### PR TITLE
Intelligent tips system: 26 seed tips with transparency + platform awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test-results/
 *.ps1
 *.log
 process-snapshot-*.txt
+.tip-screenshots/

--- a/scripts/test-tips-visually.ts
+++ b/scripts/test-tips-visually.ts
@@ -1,0 +1,197 @@
+/**
+ * Visual test for the tips system. Launches the built Electron app,
+ * seeds a config to show a session header, then iterates through every
+ * tip in the library and screenshots the modal.
+ *
+ * Usage: npx tsx scripts/test-tips-visually.ts
+ */
+
+import { _electron as electron } from '@playwright/test'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import { execSync } from 'child_process'
+
+const BUILT_APP = path.join(__dirname, '..', 'out', 'main', 'index.js')
+const OUTPUT_DIR = path.join(__dirname, '..', '.tip-screenshots')
+const PLATFORM_SUFFIX = process.platform === 'darwin' ? '-mac' : '-win'
+
+function getConfigDir(): string {
+  if (process.platform === 'win32') {
+    for (const key of ['Software\\Claude Command Center', 'Software\\Claude Conductor']) {
+      try {
+        const result = execSync(`reg query "HKCU\\${key}" /v ResourcesDirectory`, { encoding: 'utf-8', timeout: 5000, windowsHide: true })
+        const match = result.match(/ResourcesDirectory\s+REG_SZ\s+(.+)/)
+        if (match) return path.join(match[1].trim(), 'CONFIG')
+      } catch {}
+    }
+    return path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Claude Conductor', 'CONFIG')
+  } else {
+    const fallbackFile = path.join(os.homedir(), '.claude-conductor', 'platform-config.json')
+    try {
+      if (fs.existsSync(fallbackFile)) {
+        const config = JSON.parse(fs.readFileSync(fallbackFile, 'utf-8'))
+        if (config.ResourcesDirectory) return path.join(config.ResourcesDirectory, 'CONFIG')
+        if (config.DataDirectory) return path.join(config.DataDirectory, 'CONFIG')
+      }
+    } catch {}
+    return path.join(os.homedir(), 'Library', 'Application Support', 'Claude Conductor', 'CONFIG')
+  }
+}
+
+async function main() {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+
+  // Seed a minimal config so session header appears
+  const configDir = getConfigDir()
+  fs.mkdirSync(configDir, { recursive: true })
+
+  const backupSuffix = '.tip-test-bak'
+  const files = {
+    'configs.json': [{ id: 'test-config', label: 'Test Session', workingDirectory: os.homedir(), model: '', color: '#89B4FA', sessionType: 'local', shellOnly: true }],
+    'settings.json': { localMachineName: 'TipTest', terminalFontSize: 14, updateChannel: 'stable', showTips: true },
+    'app-meta.json': { setupVersion: '99.99.99', lastTrainingVersion: '99.99.99', lastWhatsNewVersion: '99.99.99', lastSeenVersion: '99.99.99', hasCreatedFirstConfig: true },
+    'usage-tracking.json': { features: {}, tipsShown: {}, tipsDismissed: {}, tipsActed: {} },
+  }
+
+  const backedUp: string[] = []
+  for (const [filename, data] of Object.entries(files)) {
+    const fp = path.join(configDir, filename)
+    if (fs.existsSync(fp)) {
+      fs.copyFileSync(fp, fp + backupSuffix)
+      backedUp.push(fp)
+    }
+    fs.writeFileSync(fp, JSON.stringify(data, null, 2))
+  }
+
+  try {
+    console.log('[tips-test] Launching app...')
+    const app = await electron.launch({ args: [BUILT_APP], env: { ...process.env, NODE_ENV: 'production' } })
+    const window = await app.firstWindow()
+    await window.setViewportSize({ width: 1280, height: 800 })
+    await window.waitForTimeout(5000)
+
+    // Dismiss any modals
+    for (let i = 0; i < 4; i++) { await window.keyboard.press('Escape'); await window.waitForTimeout(300) }
+
+    // Launch the test session
+    await window.evaluate(() => {
+      const btn = document.querySelector('button[title="Launch"]')
+      if (btn) (btn as HTMLElement).click()
+    })
+    await window.waitForTimeout(3000)
+    await window.keyboard.press('Escape')
+
+    // Get all tip IDs from the library
+    const tipIds = await window.evaluate(() => {
+      // @ts-ignore
+      return (globalThis.__TIPS__ || []).map((t: any) => t.id)
+    })
+
+    // Fallback: load from the library directly via DOM import doesn't work easily.
+    // We'll iterate by forcing each tip through the store.
+    // Parse the library file to extract tip id + requires/excludes for each tip
+    const libraryFile = path.join(__dirname, '..', 'src', 'renderer', 'tips-library.ts')
+    const libraryContent = fs.readFileSync(libraryFile, 'utf-8')
+
+    // Crude parse: split by `{` blocks that start with an id
+    const tipBlocks: Array<{ id: string; requires: string[]; excludes: string[] }> = []
+    const idRegex = /id:\s*'(tip\.[^']+)'/g
+    let match
+    while ((match = idRegex.exec(libraryContent)) !== null) {
+      const id = match[1]
+      const blockStart = match.index
+      // Find the end of this tip's object (next `id:` or end of file)
+      idRegex.lastIndex = match.index + match[0].length
+      const nextMatch = idRegex.exec(libraryContent)
+      idRegex.lastIndex = match.index + match[0].length
+      const blockEnd = nextMatch ? nextMatch.index : libraryContent.length
+      const block = libraryContent.slice(blockStart, blockEnd)
+
+      const requiresMatch = block.match(/requires:\s*\[([^\]]*)\]/)
+      const excludesMatch = block.match(/excludes:\s*\[([^\]]*)\]/)
+      const parseList = (s: string) => Array.from(s.matchAll(/'([^']+)'/g), m => m[1])
+      tipBlocks.push({
+        id,
+        requires: requiresMatch ? parseList(requiresMatch[1]) : [],
+        excludes: excludesMatch ? parseList(excludesMatch[1]) : [],
+      })
+    }
+
+    console.log(`[tips-test] Found ${tipBlocks.length} tips to screenshot`)
+
+    for (const { id: tipId, requires, excludes } of tipBlocks) {
+      // Build feature state that satisfies requires but NOT excludes
+      const features: Record<string, { firstSeenAt: number; lastUsedAt: number; count: number }> = {}
+      for (const r of requires) {
+        if (!excludes.includes(r)) {
+          features[r] = { firstSeenAt: Date.now() - 1000, lastUsedAt: Date.now() - 1000, count: 1 }
+        }
+      }
+
+      await window.evaluate(([id, feats]: [string, any]) => {
+        const store = (window as any).__TIPS_STORE__
+        if (!store) return
+        store.setState({
+          currentTipId: id,
+          silencedUntilRestart: false,
+          tracking: {
+            features: feats,
+            tipsShown: { [id]: Date.now() },
+            tipsDismissed: {},
+            tipsActed: {},
+          },
+        })
+      }, [tipId, features] as any)
+      await window.waitForTimeout(300)
+
+      // Click the tip pill in the session header to open the modal
+      const pillClicked = await window.evaluate(() => {
+        const btns = document.querySelectorAll('button[title="Click for details"]')
+        if (btns.length > 0) { (btns[0] as HTMLElement).click(); return true }
+        return false
+      })
+
+      if (!pillClicked) {
+        console.log(`[tips-test] WARNING: no tip pill visible for ${tipId}`)
+        continue
+      }
+      await window.waitForTimeout(500)
+
+      const fname = `${tipId.replace(/\./g, '_')}${PLATFORM_SUFFIX}.jpg`
+      await window.screenshot({ path: path.join(OUTPUT_DIR, fname), type: 'jpeg', quality: 85 })
+      console.log(`[tips-test] Saved: ${fname}`)
+
+      // Close modal by clicking on backdrop (outside modal content)
+      await window.evaluate(() => {
+        const backdrop = document.querySelector('.fixed.inset-0.bg-black\\/60')
+        if (backdrop) {
+          const rect = backdrop.getBoundingClientRect()
+          // Click on backdrop but outside modal (top-left corner)
+          const evt = new MouseEvent('click', { bubbles: true, clientX: 10, clientY: 10 })
+          backdrop.dispatchEvent(evt)
+        }
+      })
+      await window.waitForTimeout(300)
+    }
+
+    await app.close()
+  } finally {
+    // Restore backups
+    for (const [filename] of Object.entries(files)) {
+      const fp = path.join(configDir, filename)
+      const bp = fp + backupSuffix
+      try {
+        if (fs.existsSync(bp)) { fs.copyFileSync(bp, fp); fs.unlinkSync(bp) }
+        else if (fs.existsSync(fp)) fs.unlinkSync(fp)
+      } catch {}
+    }
+  }
+
+  console.log(`\n[tips-test] Done. Screenshots in ${OUTPUT_DIR}`)
+}
+
+main().catch((err) => {
+  console.error('[tips-test]', err)
+  process.exit(1)
+})

--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -28,6 +28,7 @@ const CONFIG_FILES = {
   accounts: 'accounts.json',
   visionGlobal: 'vision-global.json',
   commandSections: 'command-sections.json',
+  usageTracking: 'usage-tracking.json',
 } as const
 
 export type ConfigKey = keyof typeof CONFIG_FILES

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,8 @@ import SetupDialog from './components/SetupDialog'
 import WhatsNewModal, { shouldShowWhatsNew, markWhatsNewSeen } from './components/WhatsNewModal'
 import TrainingWalkthrough, { shouldShowTraining, isFirstInstall } from './components/TrainingWalkthrough'
 import GuidedConfigView from './components/GuidedConfigView'
+import TipModal from './components/TipModal'
+import { useTipsStore, trackUsage } from './stores/tipsStore'
 import ErrorBoundary from './components/ErrorBoundary'
 import CloseDialog from './components/CloseDialog'
 import { useSessionStore, Session } from './stores/sessionStore'
@@ -45,7 +47,22 @@ declare const __APP_VERSION__: string
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [view, setView] = useState<ViewType>('sessions')
+  const [viewRaw, setViewRaw] = useState<ViewType>('sessions')
+  const view = viewRaw
+  const setView = (v: ViewType) => {
+    setViewRaw(v)
+    // Track view usage for the tips system
+    const map: Record<string, string> = {
+      'memory': 'memory.memory-page',
+      'tokenomics': 'tokenomics.dashboard',
+      'vision': 'vision.toggle-vision',
+      'insights': 'advanced.insights',
+      'logs': 'advanced.log-viewer',
+      'cloud-agents': 'agents.cloud-agent-dispatch',
+    }
+    const featureId = map[v]
+    if (featureId) trackUsage(featureId)
+  }
   const [setupComplete, setSetupComplete] = useState<boolean | null>(null)
   const [configLoaded, setConfigLoaded] = useState(false)
   const [needsCliSetup, setNeedsCliSetup] = useState(false)
@@ -56,6 +73,7 @@ export default function App() {
   const [showTraining, setShowTraining] = useState(false)
   const [showTrainingAll, setShowTrainingAll] = useState(false)
   const [showGuidedConfig, setShowGuidedConfig] = useState(false)
+  const [showTipModal, setShowTipModal] = useState(false)
   const [partnerActive, setPartnerActive] = useState<Set<string>>(new Set())
   const [showMachineNamePrompt, setShowMachineNamePrompt] = useState(false)
   const [machineNameInput, setMachineNameInput] = useState('')
@@ -165,6 +183,11 @@ export default function App() {
           else if (shouldShowTraining()) setShowTraining(true)
         }
       }, 500)
+
+      // Pick a tip for this session (one per app launch)
+      setTimeout(() => {
+        useTipsStore.getState().pickNextTip()
+      }, 2000)
     }
 
     postConfigInit()
@@ -323,7 +346,7 @@ export default function App() {
     return (
       <div className="flex-1 flex flex-col" style={{ display: view === 'sessions' ? 'flex' : 'none', minHeight: 0 }}>
         <TabBar />
-        <SessionHeader session={activeSession} isShowingPartner={partnerActive.has(activeSession.id)} sidebarCollapsed={!sidebarOpen} />
+        <SessionHeader session={activeSession} isShowingPartner={partnerActive.has(activeSession.id)} sidebarCollapsed={!sidebarOpen} onShowTip={() => setShowTipModal(true)} />
         {sessions.map((session) => {
           const isShowingPartner = partnerActive.has(session.id)
           const hasPartner = !!session.partnerTerminalPath
@@ -430,6 +453,7 @@ export default function App() {
     <ErrorBoundary>
       <div className="flex flex-col h-screen bg-base text-text">
         {showWhatsNew && <WhatsNewModal onClose={handleWhatsNewClose} />}
+        {showTipModal && <TipModal onClose={() => setShowTipModal(false)} onNavigate={(v) => setView(v)} />}
 
         {showMachineNamePrompt && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -521,6 +545,14 @@ export default function App() {
                   const newConfig = { ...configDraft, id: configId }
                   useConfigStore.getState().addConfig(newConfig)
                   useAppMetaStore.getState().update({ hasCreatedFirstConfig: true })
+
+                  // Track feature usage based on config fields set
+                  trackUsage('sessions.create-config')
+                  if (newConfig.sessionType === 'ssh') trackUsage('sessions.session-type')
+                  if (newConfig.flickerFree) trackUsage('sessions.flicker-free')
+                  if (newConfig.effortLevel) trackUsage('sessions.effort-level')
+                  if (newConfig.disableAutoMemory) trackUsage('sessions.disable-auto-memory')
+                  if (newConfig.powershellTool) trackUsage('sessions.powershell-tool')
 
                   const session: Session = {
                     id: generateId(),

--- a/src/renderer/components/NotesBar.tsx
+++ b/src/renderer/components/NotesBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import NoteDialog from './NoteDialog'
+import { trackUsage } from '../stores/tipsStore'
 
 interface NoteEntry {
   id: string
@@ -35,6 +36,7 @@ export default function NotesBar({ configId }: Props) {
 
   const handleSave = async (id: string, label: string, content: string, color: string, noteConfigId?: string) => {
     await window.electronAPI.notes.save(id, label, content, color, noteConfigId)
+    trackUsage('security.encrypted-notes')
     setShowDialog(false)
     setEditingNote(null)
     loadNotes()

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -3,14 +3,16 @@ import { Session, useSessionStore } from '../stores/sessionStore'
 import { killSessionPty, clearSpawned } from '../ptyTracker'
 import { markSessionForResumePicker } from '../utils/resumePicker'
 import NotesBar from './NotesBar'
+import TipPill from './TipPill'
 
 interface Props {
   session: Session
   isShowingPartner?: boolean
   sidebarCollapsed?: boolean
+  onShowTip?: () => void
 }
 
-export default function SessionHeader({ session, isShowingPartner, sidebarCollapsed }: Props) {
+export default function SessionHeader({ session, isShowingPartner, sidebarCollapsed, onShowTip }: Props) {
   const updateSession = useSessionStore((s) => s.updateSession)
   const [recoverMenu, setRecoverMenu] = useState<{ x: number; y: number } | null>(null)
 
@@ -117,6 +119,8 @@ export default function SessionHeader({ session, isShowingPartner, sidebarCollap
       <NotesBar configId={session.configId} />
 
       <div className="flex-1" />
+
+      {onShowTip && <TipPill onClick={onShowTip} />}
 
       <button
         onClick={handleRestart}

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -128,6 +128,16 @@ export default function SettingsPage() {
                     <option value="beta">Beta (pre-release builds)</option>
                   </select>
                 </Field>
+                <label className="flex items-center gap-2 text-sm text-subtext0 cursor-pointer mt-3">
+                  <input
+                    type="checkbox"
+                    checked={settings.showTips}
+                    onChange={(e) => save({ showTips: e.target.checked })}
+                    className="rounded border-surface1"
+                  />
+                  Show intelligent tips
+                  <span className="text-[10px] text-overlay0">(Contextual feature discovery in session header)</span>
+                </label>
               </Section>
 
               <Section title="Security" icon={<path d="M8 2L3 5v4c0 3.5 2.1 6.4 5 7.5 2.9-1.1 5-4 5-7.5V5L8 2z" stroke="currentColor" strokeWidth="1.2" fill="none" />}>

--- a/src/renderer/components/TipModal.tsx
+++ b/src/renderer/components/TipModal.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import { useTipsStore } from '../stores/tipsStore'
+import type { ViewType } from '../types/views'
+import { resolveBody, resolveFocusHint } from '../tips-library'
+
+interface Props {
+  onClose: () => void
+  onNavigate?: (view: ViewType) => void
+}
+
+/** Render a tip body with **bold** markdown segments and line breaks */
+function renderBody(body: string): React.ReactNode {
+  return body.split('\n').map((line, i) => {
+    if (line.trim() === '') return <div key={i} className="h-2" />
+    const parts = line.split(/(\*\*[^*]+\*\*|`[^`]+`)/)
+    return (
+      <p key={i} className="text-sm text-subtext0 leading-relaxed mb-2">
+        {parts.map((part, j) => {
+          if (part.startsWith('**') && part.endsWith('**')) {
+            return <strong key={j} className="text-text font-semibold">{part.slice(2, -2)}</strong>
+          }
+          if (part.startsWith('`') && part.endsWith('`')) {
+            return <code key={j} className="text-mauve bg-surface0/50 px-1 py-0.5 rounded text-[0.82rem]">{part.slice(1, -1)}</code>
+          }
+          return <span key={j}>{part}</span>
+        })}
+      </p>
+    )
+  })
+}
+
+export default function TipModal({ onClose, onNavigate }: Props) {
+  // Subscribe to currentTipId so the modal re-renders when it changes
+  const currentTipId = useTipsStore((s) => s.currentTipId)
+  const dismissTip = useTipsStore((s) => s.dismissTip)
+  const markTipActed = useTipsStore((s) => s.markTipActed)
+  const pickNextTip = useTipsStore((s) => s.pickNextTip)
+  const silenceUntilRestart = useTipsStore((s) => s.silenceUntilRestart)
+
+  const current = useTipsStore.getState().getCurrentTip()
+  if (!current) return null
+  const { tip, content } = current
+  const isMac = typeof window !== 'undefined' && window.electronPlatform === 'darwin'
+  const body = resolveBody(content, isMac)
+  const focusHint = resolveFocusHint(content, isMac)
+
+  const handleAction = () => {
+    markTipActed(tip.id)
+    if (content.actionTarget && onNavigate) {
+      onNavigate(content.actionTarget as ViewType)
+    }
+    onClose()
+  }
+
+  const handleDismiss = () => {
+    dismissTip(tip.id)
+    pickNextTip()
+    onClose()
+  }
+
+  const handleNext = () => {
+    pickNextTip()
+    onClose()
+  }
+
+  const handleSilence = () => {
+    silenceUntilRestart()
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="bg-mantle rounded-lg shadow-2xl border border-surface0 w-full max-w-lg flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-6 pt-5 pb-3 flex items-start justify-between gap-4 border-b border-surface0">
+          <div className="flex items-start gap-3 flex-1 min-w-0">
+            <div className="text-mauve text-2xl mt-0.5" aria-hidden>💡</div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-overlay0 mb-0.5">
+                {tip.category} · {tip.complexity}
+              </div>
+              <h2 className="text-base font-bold text-text">{content.title}</h2>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-overlay0 hover:text-text text-xl leading-none -mt-1 -mr-2 px-2 py-1"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 max-h-[50vh] overflow-y-auto">
+          {renderBody(body)}
+
+          {focusHint && (
+            <div className="mt-3 p-2.5 rounded border border-mauve/30 bg-mauve/5 text-xs text-subtext0">
+              <strong className="text-mauve">📍 Where to look:</strong> {focusHint}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-surface0 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-3 text-xs">
+            <button
+              onClick={handleSilence}
+              className="text-overlay0 hover:text-text transition-colors"
+              title="Don't show tips again until next app restart"
+            >
+              Silence until restart
+            </button>
+            <span className="text-surface1">·</span>
+            <button
+              onClick={handleDismiss}
+              className="text-overlay0 hover:text-red transition-colors"
+              title="Never show this specific tip again"
+            >
+              Don't show this again
+            </button>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleNext}
+              className="px-3 py-1.5 text-sm text-overlay1 hover:text-text transition-colors"
+            >
+              Next tip
+            </button>
+            {content.actionLabel ? (
+              <button
+                onClick={handleAction}
+                className="px-4 py-1.5 bg-mauve hover:bg-pink text-base font-medium rounded text-sm transition-colors"
+              >
+                {content.actionLabel}
+              </button>
+            ) : (
+              <button
+                onClick={onClose}
+                className="px-4 py-1.5 bg-mauve hover:bg-pink text-base font-medium rounded text-sm transition-colors"
+              >
+                Got it
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/TipPill.tsx
+++ b/src/renderer/components/TipPill.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react'
+import { useTipsStore } from '../stores/tipsStore'
+import { useSettingsStore } from '../stores/settingsStore'
+
+interface Props {
+  onClick: () => void
+}
+
+/**
+ * Animated pill shown to the left of the Restart button in session header.
+ * Shows the current tip's shortText. Pulses subtly to draw attention.
+ */
+export default function TipPill({ onClick }: Props) {
+  const currentTipId = useTipsStore((s) => s.currentTipId)
+  const silenced = useTipsStore((s) => s.silencedUntilRestart)
+  const showTips = useSettingsStore((s) => s.settings.showTips)
+
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setMounted(true), 200)
+    return () => clearTimeout(t)
+  }, [currentTipId])
+
+  if (!showTips || silenced || !currentTipId) return null
+
+  const current = useTipsStore.getState().getCurrentTip()
+  if (!current) return null
+
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-xs
+        bg-gradient-to-r from-mauve/20 to-blue/10
+        border border-mauve/40
+        text-subtext1 hover:text-text hover:border-mauve
+        transition-all max-w-[340px] truncate
+        ${mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-1'}
+        hover:scale-[1.02]`}
+      style={{
+        animation: mounted ? 'tip-pulse 4s ease-in-out infinite' : undefined,
+      }}
+      title="Click for details"
+    >
+      <span className="text-mauve shrink-0" aria-hidden>💡</span>
+      <span className="truncate">{current.content.shortText}</span>
+    </button>
+  )
+}
+
+// Inject keyframes once
+const TIP_STYLE_ID = 'tip-pulse-keyframes'
+if (typeof document !== 'undefined' && !document.getElementById(TIP_STYLE_ID)) {
+  const style = document.createElement('style')
+  style.id = TIP_STYLE_ID
+  style.textContent = `
+    @keyframes tip-pulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(203, 166, 247, 0); }
+      50% { box-shadow: 0 0 12px 2px rgba(203, 166, 247, 0.25); }
+    }
+  `
+  document.head.appendChild(style)
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -36,6 +36,7 @@ export interface AppSettings {
   localMachineName: string
   updateChannel: 'stable' | 'beta'
   skipPermissionsForAgents: boolean
+  showTips: boolean
 }
 
 interface SettingsState {
@@ -56,7 +57,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   statusLine: { ...DEFAULT_STATUS_LINE },
   localMachineName: '',
   updateChannel: 'stable' as const,
-  skipPermissionsForAgents: true
+  skipPermissionsForAgents: true,
+  showTips: true
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({

--- a/src/renderer/stores/tipsStore.ts
+++ b/src/renderer/stores/tipsStore.ts
@@ -1,0 +1,186 @@
+/**
+ * Tips Store — tracks feature usage and manages the intelligent tip display.
+ *
+ * Persisted to usage-tracking.json via saveConfigNow.
+ */
+import { create } from 'zustand'
+import { saveConfigNow } from '../utils/config-saver'
+import { TIPS_LIBRARY, Tip, TipContent } from '../tips-library'
+
+/** Single feature usage event */
+export interface FeatureUsage {
+  firstSeenAt: number
+  lastUsedAt: number
+  count: number
+}
+
+/** Complete usage tracking state (persisted) */
+export interface UsageTracking {
+  /** Feature ID → usage event */
+  features: Record<string, FeatureUsage>
+  /** Tip ID → timestamp first shown */
+  tipsShown: Record<string, number>
+  /** Tip ID → timestamp user dismissed permanently */
+  tipsDismissed: Record<string, number>
+  /** Tip ID → timestamp user acted on (clicked action button) */
+  tipsActed: Record<string, number>
+}
+
+export interface TipsState {
+  tracking: UsageTracking
+  isLoaded: boolean
+
+  /** In-memory session state (not persisted) */
+  currentTipId: string | null
+  silencedUntilRestart: boolean
+
+  hydrate: (tracking: UsageTracking) => void
+  recordUsage: (featureId: string) => void
+  dismissTip: (tipId: string) => void
+  markTipActed: (tipId: string) => void
+  silenceUntilRestart: () => void
+  pickNextTip: () => void
+  getCurrentTip: () => { tip: Tip; content: TipContent } | null
+}
+
+const EMPTY_TRACKING: UsageTracking = {
+  features: {},
+  tipsShown: {},
+  tipsDismissed: {},
+  tipsActed: {},
+}
+
+/** Decide which content variant to show for a tip given usage state */
+function resolveContent(tip: Tip, tracking: UsageTracking): TipContent | null {
+  // Check excludes — if the user has done something that makes this tip irrelevant
+  if (tip.excludes && tip.excludes.some((f) => tracking.features[f])) {
+    return tip.variants.postUse ?? null
+  }
+  // Check requires — user must have done prerequisite
+  if (tip.requires && !tip.requires.every((f) => tracking.features[f])) {
+    return null
+  }
+  return tip.variants.primary
+}
+
+/** Pick the best tip to show given current state */
+function selectNextTip(tracking: UsageTracking, excludeId?: string): Tip | null {
+  const MIN_REPEAT_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+  const candidates = TIPS_LIBRARY.filter((tip) => {
+    if (excludeId && tip.id === excludeId) return false
+    // Skip permanently dismissed
+    if (tracking.tipsDismissed[tip.id]) return false
+    // Skip recently shown unless it's been 7+ days
+    const shownAt = tracking.tipsShown[tip.id]
+    if (shownAt && Date.now() - shownAt < MIN_REPEAT_MS) return false
+    // Must have resolvable content (passes requires/excludes)
+    const content = resolveContent(tip, tracking)
+    if (!content) return false
+    return true
+  })
+
+  if (candidates.length === 0) return null
+
+  // Sort by: (1) priority, (2) simple before advanced, (3) random
+  const complexityWeight = { simple: 0, intermediate: 1, advanced: 2 }
+  candidates.sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority
+    const cw = complexityWeight[a.complexity] - complexityWeight[b.complexity]
+    if (cw !== 0) return cw
+    return Math.random() - 0.5
+  })
+
+  return candidates[0]
+}
+
+export const useTipsStore = create<TipsState>((set, get) => ({
+  tracking: EMPTY_TRACKING,
+  isLoaded: false,
+  currentTipId: null,
+  silencedUntilRestart: false,
+
+  hydrate: (tracking) => set({ tracking: tracking || EMPTY_TRACKING, isLoaded: true }),
+
+  recordUsage: (featureId) => {
+    set((state) => {
+      const now = Date.now()
+      const existing = state.tracking.features[featureId]
+      const features = {
+        ...state.tracking.features,
+        [featureId]: existing
+          ? { ...existing, lastUsedAt: now, count: existing.count + 1 }
+          : { firstSeenAt: now, lastUsedAt: now, count: 1 },
+      }
+      const tracking = { ...state.tracking, features }
+      saveConfigNow('usageTracking', tracking)
+      return { tracking }
+    })
+  },
+
+  dismissTip: (tipId) => {
+    set((state) => {
+      const tracking = {
+        ...state.tracking,
+        tipsDismissed: { ...state.tracking.tipsDismissed, [tipId]: Date.now() },
+      }
+      saveConfigNow('usageTracking', tracking)
+      return { tracking, currentTipId: state.currentTipId === tipId ? null : state.currentTipId }
+    })
+  },
+
+  markTipActed: (tipId) => {
+    set((state) => {
+      const tracking = {
+        ...state.tracking,
+        tipsActed: { ...state.tracking.tipsActed, [tipId]: Date.now() },
+      }
+      saveConfigNow('usageTracking', tracking)
+      return { tracking }
+    })
+  },
+
+  silenceUntilRestart: () => set({ silencedUntilRestart: true, currentTipId: null }),
+
+  pickNextTip: () => {
+    const state = get()
+    if (state.silencedUntilRestart) return
+    const excludeId = state.currentTipId || undefined
+    const tip = selectNextTip(state.tracking, excludeId)
+    if (tip) {
+      set((s) => {
+        const tracking = {
+          ...s.tracking,
+          tipsShown: { ...s.tracking.tipsShown, [tip.id]: Date.now() },
+        }
+        saveConfigNow('usageTracking', tracking)
+        return { tracking, currentTipId: tip.id }
+      })
+    } else {
+      set({ currentTipId: null })
+    }
+  },
+
+  getCurrentTip: () => {
+    const state = get()
+    if (!state.currentTipId) return null
+    const tip = TIPS_LIBRARY.find((t) => t.id === state.currentTipId)
+    if (!tip) return null
+    const content = resolveContent(tip, state.tracking)
+    if (!content) return null
+    return { tip, content }
+  },
+}))
+
+/**
+ * Helper: call this in key places throughout the app to track feature usage.
+ * Example: trackUsage('sessions.create-config') after addConfig()
+ */
+export function trackUsage(featureId: string): void {
+  useTipsStore.getState().recordUsage(featureId)
+}
+
+// Expose for dev/test access via window.__TIPS_STORE__
+if (typeof window !== 'undefined') {
+  ;(window as any).__TIPS_STORE__ = useTipsStore
+}

--- a/src/renderer/tips-library.ts
+++ b/src/renderer/tips-library.ts
@@ -1,0 +1,532 @@
+/**
+ * Tips Library — seed set of intelligent tips.
+ *
+ * Each tip has a primary variant (for users who haven't done the thing)
+ * and optionally a postUse variant (for users who have).
+ *
+ * Priority: higher = shown sooner (0-100).
+ * Platform-specific body copy: use `bodyMac` / `bodyWin` to override `body`.
+ * Focus hints describe WHERE in the UI to look.
+ *
+ * Categories:
+ *   - discovery — non-obvious features users should know about
+ *   - power-user — shortcuts and advanced uses
+ *   - transparency — what the app does behind the scenes (privacy-relevant)
+ */
+
+export type TipCategory =
+  | 'sessions'
+  | 'commands'
+  | 'agents'
+  | 'vision'
+  | 'memory'
+  | 'tokenomics'
+  | 'security'
+  | 'productivity'
+  | 'ui-navigation'
+  | 'advanced'
+  | 'transparency'
+
+export type TipComplexity = 'simple' | 'intermediate' | 'advanced'
+
+export interface TipContent {
+  /** Short text shown in the header pill (keep under 60 chars) */
+  shortText: string
+  /** Full modal title */
+  title: string
+  /** Full modal body — plain text with **bold** and `code` segments */
+  body: string
+  /** Optional platform-specific body overrides */
+  bodyMac?: string
+  bodyWin?: string
+  /** Optional call-to-action button label */
+  actionLabel?: string
+  /** Where the action navigates (matches a ViewType or custom handler key) */
+  actionTarget?: string
+  /** Optional highlight region hint — shown in a callout at bottom of modal */
+  focusHint?: string
+  focusHintMac?: string
+  focusHintWin?: string
+}
+
+export interface Tip {
+  id: string
+  category: TipCategory
+  complexity: TipComplexity
+  /** Higher = more important, shown sooner */
+  priority: number
+  /** Feature IDs that must be used before this tip is relevant */
+  requires?: string[]
+  /** Feature IDs that if used, make the primary variant irrelevant */
+  excludes?: string[]
+  variants: {
+    primary: TipContent
+    postUse?: TipContent
+  }
+}
+
+/** Resolve content body for the current platform */
+export function resolveBody(content: TipContent, isMac: boolean): string {
+  if (isMac && content.bodyMac) return content.bodyMac
+  if (!isMac && content.bodyWin) return content.bodyWin
+  return content.body
+}
+
+/** Resolve focus hint for the current platform */
+export function resolveFocusHint(content: TipContent, isMac: boolean): string | undefined {
+  if (isMac && content.focusHintMac) return content.focusHintMac
+  if (!isMac && content.focusHintWin) return content.focusHintWin
+  return content.focusHint
+}
+
+export const TIPS_LIBRARY: Tip[] = [
+  // ── Discovery: low-barrier, high-value features ────────────────────────
+
+  {
+    id: 'tip.notes',
+    category: 'security',
+    complexity: 'simple',
+    priority: 85,
+    excludes: ['security.encrypted-notes'],
+    variants: {
+      primary: {
+        shortText: '🔒 Stash secrets alongside your session',
+        title: 'Encrypted Notes',
+        body: 'Every session can hold **encrypted notes** — API keys, SQL snippets, DB connection strings, URLs, anything you want one-click access to without committing it to the repo.\n\nClick the small **lock+ icon** in the session header (next to Restart) to add a note. You can create multiple notes per config with different colors to tell them apart at a glance.\n\nContent is encrypted at rest using your OS credential store — DPAPI on Windows, Keychain on macOS. The renderer never sees plaintext; decryption happens in the main process only.',
+        actionLabel: 'Got it',
+        focusHint: 'Session header — small lock icon with a + next to it',
+      },
+      postUse: {
+        shortText: '🔒 Right-click a note to edit or duplicate',
+        title: 'Organize Your Notes',
+        body: 'Nice — you already use notes. A few things you might not know:\n\n• **Right-click a note** to edit, duplicate, change color, or delete\n• **Drag notes** to reorder them in the bar\n• Notes can be **config-scoped** (only shown for one config) or **global** (shown in every session)\n• Each note shows a **lock icon** indicating encrypted-at-rest status',
+      },
+    },
+  },
+
+  {
+    id: 'tip.memory-visualiser',
+    category: 'memory',
+    complexity: 'simple',
+    priority: 80,
+    excludes: ['memory.memory-page'],
+    variants: {
+      primary: {
+        shortText: '🧠 Browse what Claude remembers about your projects',
+        title: 'Memory Visualiser',
+        body: 'Claude Code writes **auto-memory** files to `~/.claude/projects/*/memory/` to remember things across sessions — your preferences, past feedback, project context, references to external systems.\n\nClick the **brain icon** in the sidebar to browse them visually. Drill down: all projects → project card → type groups (user / feedback / project / reference) → individual memories with rendered markdown.\n\nYou can search across all memories, edit frontmatter, and delete stale entries.',
+        actionLabel: 'Open Memory',
+        actionTarget: 'memory',
+        focusHint: 'Sidebar — brain icon (between Vision and Logs)',
+      },
+    },
+  },
+
+  // ── Commands ────────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.command-args-ctrl-click',
+    category: 'commands',
+    complexity: 'intermediate',
+    priority: 75,
+    requires: ['commands.create-command'],
+    excludes: ['commands.ctrl-click-args'],
+    variants: {
+      primary: {
+        shortText: '⌨ Ctrl+click a command button to customize args',
+        title: 'Customize Command Arguments',
+        body: 'You\'ve got commands set up — here\'s a power move: **Ctrl+click** any command button to pop open an arguments editor. Override the defaults for one run without changing the command itself.\n\nThe last custom args are remembered, so next time you Ctrl+click the same button they pre-fill.\n\nPerfect for a `run tests` command where sometimes you want `--watch`, sometimes `--filter foo`, sometimes nothing.',
+        bodyMac: 'You\'ve got commands set up — here\'s a power move: **Ctrl+click** any command button to pop open an arguments editor (on Mac this is still Ctrl, not Cmd — the app uses the same binding on both platforms). Override the defaults for one run without changing the command itself.\n\nThe last custom args are remembered, so next time you Ctrl+click the same button they pre-fill.\n\nPerfect for a `run tests` command where sometimes you want `--watch`, sometimes `--filter foo`, sometimes nothing.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.command-sections',
+    category: 'commands',
+    complexity: 'simple',
+    priority: 60,
+    requires: ['commands.create-command'],
+    excludes: ['commands.command-sections'],
+    variants: {
+      primary: {
+        shortText: '📂 Group command buttons into named sections',
+        title: 'Command Sections',
+        body: 'Once you have more than 4-5 command buttons they start to get cluttered. Organize them into **named sections** — right-click in the command bar to create one, then drag commands into it.\n\nSections are collapsible, so you can hide rarely-used commands until you need them.\n\nExamples: "Testing", "Deploy", "DB Ops", "Claude prompts".',
+      },
+    },
+  },
+
+  {
+    id: 'tip.command-target',
+    category: 'commands',
+    complexity: 'intermediate',
+    priority: 55,
+    requires: ['commands.create-command', 'sessions.partner-terminal'],
+    variants: {
+      primary: {
+        shortText: '🎯 Target commands at your partner terminal',
+        title: 'Command Targeting',
+        body: 'You use partner terminals — did you know **each command button can target a specific terminal**?\n\nWhen editing a command, set **Target** to:\n• **Claude** — always runs in the Claude pane\n• **Partner** — always runs in your partner shell\n• **Any** (default) — runs in whichever pane is active\n\nGreat for `git status`, `npm test`, `docker ps` — commands you want in the shell, not typed into Claude\'s prompt.',
+      },
+    },
+  },
+
+  // ── Sessions & Configs ──────────────────────────────────────────────────
+
+  {
+    id: 'tip.pin-config',
+    category: 'sessions',
+    complexity: 'simple',
+    priority: 70,
+    requires: ['sessions.create-config'],
+    excludes: ['sessions.pin-config'],
+    variants: {
+      primary: {
+        shortText: '📌 Pin your most-used configs to the top',
+        title: 'Pinned Configs',
+        body: 'Right-click any config in the sidebar and choose **Pin** to move it to a dedicated pinned panel at the top. Pinned configs stay visible even when you scroll through dozens of others.\n\nPerfect for your main project that you launch a dozen times a day. You can also access pinned configs from the Sessions view when the sidebar is collapsed.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.partner-terminal',
+    category: 'sessions',
+    complexity: 'intermediate',
+    priority: 65,
+    requires: ['sessions.create-config'],
+    excludes: ['sessions.partner-terminal'],
+    variants: {
+      primary: {
+        shortText: '🔀 Add a partner shell next to Claude',
+        title: 'Partner Terminal',
+        body: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set a Partner Terminal Path. Path examples below.',
+        bodyMac: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set Partner Terminal Path to `/bin/zsh` or `/bin/bash`.',
+        bodyWin: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set Partner Terminal Path to `powershell.exe` or `cmd.exe`. You can also tick **Elevated** to run it as admin (requires `gsudo`).',
+      },
+      postUse: {
+        shortText: '🎯 Route command buttons to your partner shell',
+        title: 'Target Commands at Partner',
+        body: 'Now that you use partner terminals: **each command button can target a specific terminal**. When editing a command, set **Target: Partner** and it\'ll always run in the partner shell.\n\nGreat for `git status`, `npm test`, `docker ps` — anything you want in the shell instead of sent as a Claude prompt.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.effort-level',
+    category: 'sessions',
+    complexity: 'intermediate',
+    priority: 60,
+    requires: ['sessions.create-config'],
+    excludes: ['sessions.effort-level'],
+    variants: {
+      primary: {
+        shortText: '🧠 Dial Claude\'s thinking depth per config',
+        title: 'Effort Level',
+        body: '**Effort level** passes `--effort` to Claude Code, controlling how hard Claude thinks before responding:\n\n• **Low** — Quick responses, less reasoning, cheapest\n• **Medium** — Balanced (close to default)\n• **High** — Deep thinking, slower, most expensive\n\nSet it per-config. A common pattern is to have two configs for the same project: "Quick" (low effort) for refactors and docs, "Deep" (high effort) for architecture and debugging.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.ssh-config',
+    category: 'sessions',
+    complexity: 'intermediate',
+    priority: 55,
+    excludes: ['sessions.session-type'],
+    variants: {
+      primary: {
+        shortText: '🌐 Run Claude on a remote machine over SSH',
+        title: 'SSH Sessions',
+        body: 'Create a config with **SSH** as the session type, enter host/port/user/remote path, and Claude runs on the remote with full file access. Your terminal stays local.\n\nThe Vision system even sets up automatic reverse SSH tunnels so Claude on the remote can control browsers running on your local machine — useful for testing staging apps.\n\nPasswords (if you don\'t use key auth) are encrypted with your OS credential store and only decrypted in the main process, never in the renderer.',
+      },
+      postUse: {
+        shortText: '🐳 Run Claude inside a Docker container via SSH',
+        title: 'Docker-in-SSH',
+        body: 'You\'re already using SSH sessions. Next level: target a **Docker container** on the remote. Edit your SSH config and set a Docker Container name.\n\nThe app will wrap commands with `docker exec -it <container>` so Claude runs inside the container. Screenshots also go through `docker cp`. Great for reproducible builds.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.duplicate-config',
+    category: 'sessions',
+    complexity: 'simple',
+    priority: 45,
+    requires: ['sessions.create-config'],
+    excludes: ['sessions.duplicate-config'],
+    variants: {
+      primary: {
+        shortText: '📋 Duplicate a config instead of recreating it',
+        title: 'Duplicate Config',
+        body: 'Right-click any config in the sidebar and choose **Duplicate** to create a copy with all its settings. Useful for:\n\n• Creating a "Quick" + "Deep" pair of the same project\n• Testing a config change without losing the original\n• Making dev/staging/prod variants\n\nThe duplicate gets `(copy)` appended to the label — rename it from the context menu.',
+      },
+    },
+  },
+
+  // ── Vision ──────────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.vision-system',
+    category: 'vision',
+    complexity: 'intermediate',
+    priority: 50,
+    excludes: ['vision.toggle-vision'],
+    variants: {
+      primary: {
+        shortText: '👁 Give Claude a browser to drive',
+        title: 'Vision System',
+        body: '**Vision** gives Claude a real browser it can control — screenshot, navigate, click, type, scroll, evaluate JS. Perfect for testing web apps, scraping docs, or just showing Claude what\'s on screen.\n\nClick the **eye icon** in the sidebar and press Start. It runs a local MCP server on `127.0.0.1:19333` (localhost only) and 17 tools become available to every Claude session automatically.\n\nThe MCP server is registered in `~/.claude/settings.json` under `mcpServers.conductor-vision`. When you stop Vision, the entry is cleanly removed.',
+        actionLabel: 'Open Vision',
+        actionTarget: 'vision',
+        focusHint: 'Sidebar — eye icon',
+      },
+    },
+  },
+
+  // ── Tokenomics ──────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.tokenomics',
+    category: 'tokenomics',
+    complexity: 'simple',
+    priority: 50,
+    excludes: ['tokenomics.dashboard'],
+    variants: {
+      primary: {
+        shortText: '💰 See where your Claude money is going',
+        title: 'Tokenomics',
+        body: 'The **Tokenomics** page tracks your token usage and costs across every Claude session — today, this week, all time.\n\nIt parses your Claude CLI JSONL transcripts to give you historical data going back months, and syncs live as you work. You get:\n\n• Cost breakdown by model\n• Daily spend charts\n• Rate limit utilization (5-hour & 7-day)\n• Per-session burn rate\n\nModel pricing is fetched from BerriAI\'s LiteLLM repo on GitHub (cached for 24h) so costs stay accurate.',
+        actionLabel: 'Open Tokenomics',
+        actionTarget: 'tokenomics',
+      },
+    },
+  },
+
+  // ── Productivity ────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.cycle-sessions',
+    category: 'productivity',
+    complexity: 'simple',
+    priority: 50,
+    requires: ['sessions.create-config'],
+    variants: {
+      primary: {
+        shortText: '⌨ Ctrl+Tab to flip between sessions',
+        title: 'Session Shortcuts',
+        body: 'Fast switching between sessions:\n\n• **Ctrl+Tab** — next session\n• **Ctrl+Shift+Tab** — previous session\n• **Ctrl+1** through **Ctrl+9** — jump directly to session N\n• **Ctrl+T** — new config\n• **Ctrl+W** — close current session\n• **Ctrl+B** — toggle sidebar\n\nAll customizable in Settings > Shortcuts. Learn Ctrl+Tab and Ctrl+1-9 and you\'ll rarely touch the mouse.',
+        bodyMac: 'Fast switching between sessions (note: on Mac, these still use **Ctrl**, not Cmd — the app keeps the same bindings on both platforms):\n\n• **Ctrl+Tab** — next session\n• **Ctrl+Shift+Tab** — previous session\n• **Ctrl+1** through **Ctrl+9** — jump directly to session N\n• **Ctrl+T** — new config\n• **Ctrl+W** — close current session\n• **Ctrl+B** — toggle sidebar\n\nAll customizable in Settings > Shortcuts.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.paste-image',
+    category: 'productivity',
+    complexity: 'simple',
+    priority: 45,
+    variants: {
+      primary: {
+        shortText: '🖼 Paste clipboard images with Alt+V',
+        title: 'Paste Image from Clipboard',
+        body: 'Image on your clipboard? Press **Alt+V** in any session and the app saves it to a temp file and pastes the file path into Claude\'s prompt.\n\nWorks with screenshots, images copied from browser, diagrams from Excalidraw, anything in clipboard image format. No more "let me save this to disk first and drag it in".',
+      },
+    },
+  },
+
+  {
+    id: 'tip.statusline-customize',
+    category: 'productivity',
+    complexity: 'intermediate',
+    priority: 40,
+    excludes: ['productivity.statusline-config'],
+    variants: {
+      primary: {
+        shortText: '📊 Customize which metrics show in the status line',
+        title: 'Status Line Customization',
+        body: 'The status line at the bottom of the screen shows session metrics — model, context %, tokens, cost, lines changed, duration, rate limits, peak hours indicator. You can toggle each one individually.\n\nGo to **Settings > Status Line** and enable just the metrics you care about. Minimalists can hide everything but model + cost. Power users can show all eight fields.',
+        actionLabel: 'Open Settings',
+        actionTarget: 'settings',
+      },
+    },
+  },
+
+  // ── Agents ──────────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.cloud-agents',
+    category: 'agents',
+    complexity: 'intermediate',
+    priority: 40,
+    excludes: ['agents.cloud-agent-dispatch'],
+    variants: {
+      primary: {
+        shortText: '☁ Dispatch Claude to work in the background',
+        title: 'Cloud Agents',
+        body: '**Cloud agents** run headless Claude sessions in the background. You give them a task, they run, you come back later for the result.\n\nPerfect for:\n• Running tests across a large codebase\n• Generating documentation for every file\n• Security audits\n• Long refactors\n\nClick the **cloud icon** in the sidebar and press "New Agent". Monitor progress from the dashboard — see status, elapsed time, token usage, and output for each.',
+        actionLabel: 'Open Agent Hub',
+        actionTarget: 'cloud-agents',
+      },
+    },
+  },
+
+  {
+    id: 'tip.agent-teams',
+    category: 'agents',
+    complexity: 'advanced',
+    priority: 30,
+    requires: ['agents.cloud-agent-dispatch'],
+    excludes: ['agents.agent-teams'],
+    variants: {
+      primary: {
+        shortText: '🤖 Chain agents into multi-step pipelines',
+        title: 'Agent Teams',
+        body: 'You\'ve used cloud agents — ready for the next level? **Agent Teams** orchestrate multiple agents in sequence or parallel, like a mini CI/CD pipeline for Claude.\n\nExample team: [analyze codebase] → [write tests] → [run tests] → [fix failures]. Each step uses a different agent template with different tools.\n\nGo to Agent Hub > **Teams** tab to create your first one.',
+      },
+    },
+  },
+
+  // ── Advanced ────────────────────────────────────────────────────────────
+
+  {
+    id: 'tip.storyboard',
+    category: 'advanced',
+    complexity: 'intermediate',
+    priority: 35,
+    excludes: ['advanced.storyboard'],
+    variants: {
+      primary: {
+        shortText: '🎬 Record a sequence of screenshots',
+        title: 'Storyboard Capture',
+        body: '**Storyboard** records timed screenshots of a screen region — perfect for showing Claude a UI flow you want to replicate or a bug you\'re trying to reproduce.\n\nClick the Storyboard button in the command bar, pick an interval (1-5s), select a region, and let it roll. Review the captured frames, annotate each, deselect noise frames, and send a structured prompt with numbered frames to Claude.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.insights',
+    category: 'advanced',
+    complexity: 'advanced',
+    priority: 25,
+    variants: {
+      primary: {
+        shortText: '📈 AI-powered analysis of your Claude usage',
+        title: 'Insights',
+        body: '**Insights** runs a Claude-powered analysis of your session history to find big wins, friction points, and regressions over time.\n\nClick the **pulse icon** in the sidebar. You\'ll get KPI trends (sessions/day, avg cost, lines changed) plus qualitative analysis of what\'s working and what\'s not in your Claude usage patterns.\n\nReports are saved to `resources/insights/` so you can look back at past runs.',
+        actionLabel: 'Open Insights',
+        actionTarget: 'insights',
+      },
+    },
+  },
+
+  {
+    id: 'tip.flicker-free',
+    category: 'sessions',
+    complexity: 'intermediate',
+    priority: 25,
+    requires: ['sessions.create-config'],
+    excludes: ['sessions.flicker-free'],
+    variants: {
+      primary: {
+        shortText: '✨ Smoother terminal rendering',
+        title: 'Flicker-Free Rendering',
+        body: 'Enable **flicker-free rendering** on a config to reduce terminal flicker during long streaming outputs. The app sets `CLAUDE_CODE_NO_FLICKER=1` and Claude uses the terminal\'s alternate screen buffer, which updates smoothly.\n\nTradeoff: you lose Ctrl+F search and scrollback **while Claude is running**. Exit Claude and scrollback comes back.\n\nMost useful for long outputs with lots of updates — e.g., running tests with a watcher.',
+      },
+    },
+  },
+
+  // ── Transparency: what the app does behind the scenes ──────────────────
+
+  {
+    id: 'tip.transparency.statusline-injection',
+    category: 'transparency',
+    complexity: 'intermediate',
+    priority: 20,
+    variants: {
+      primary: {
+        shortText: 'ℹ How we power the statusline metrics',
+        title: 'Statusline Script Injection',
+        body: 'Heads up — you should know how the rich statusline (tokens, cost, rate limits, context %) actually works:\n\n1. The app deploys a small Node.js script to `~/.claude/claude-multi-statusline.js`\n2. It adds a `statusLine` entry to `~/.claude/settings.json` pointing to that script\n3. Claude Code runs the script on each command and displays its output\n4. The script reads your Claude OAuth token from `~/.claude/.credentials.json` to fetch rate limits from `api.anthropic.com/api/oauth/usage`\n\n**What the app does NOT do**: store your token, send data anywhere else, or modify anything in the Claude CLI itself. The injection is reversible — delete the `statusLine` key from settings.json and the feature turns off.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.transparency.vision-mcp',
+    category: 'transparency',
+    complexity: 'intermediate',
+    priority: 18,
+    requires: ['vision.toggle-vision'],
+    variants: {
+      primary: {
+        shortText: 'ℹ How Vision injects into Claude settings',
+        title: 'Vision MCP Registration',
+        body: 'When you start Vision, the app:\n\n1. Launches a local MCP server bound to `127.0.0.1:19333` (**localhost only** — not exposed to the network)\n2. Adds an `mcpServers.conductor-vision` entry to `~/.claude/settings.json` pointing to the SSE endpoint\n3. Claude Code picks up 17 vision tools automatically (screenshot, navigate, click, type, etc.)\n\nWhen you stop Vision, the entry is removed cleanly. For SSH sessions, the app sets up a reverse tunnel (`-R 19333:localhost:19333`) automatically so remote Claude can reach the local MCP server.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.transparency.session-logs',
+    category: 'transparency',
+    complexity: 'intermediate',
+    priority: 17,
+    variants: {
+      primary: {
+        shortText: 'ℹ Your session output is logged locally',
+        title: 'Session Activity Logging',
+        body: 'The app records **all PTY output** from every session to `resources/logs/<config-label>/<session-id>/session.jsonl`. This includes:\n\n• Prompts you send to Claude\n• Claude\'s responses\n• Terminal commands and their output\n• File contents Claude reads\n\nThese logs stay **100% local** — they\'re never uploaded or transmitted. They exist so you can audit sessions after the fact or recover lost context. Logs rotate when they exceed 10MB per session.\n\nTo clean them up: open the Logs view in the sidebar, or delete them manually from `resources/logs/`.',
+        bodyMac: 'The app records **all PTY output** from every session to `~/Library/Application Support/Claude Conductor/resources/logs/<config-label>/<session-id>/session.jsonl`. This includes:\n\n• Prompts you send to Claude\n• Claude\'s responses\n• Terminal commands and their output\n• File contents Claude reads\n\nThese logs stay **100% local** — they\'re never uploaded or transmitted. Logs rotate when they exceed 10MB per session.\n\nTo clean them up: open the Logs view in the sidebar, or delete them manually.',
+        bodyWin: 'The app records **all PTY output** from every session to `%LOCALAPPDATA%\\Claude Conductor\\resources\\logs\\<config-label>\\<session-id>\\session.jsonl`. This includes:\n\n• Prompts you send to Claude\n• Claude\'s responses\n• Terminal commands and their output\n• File contents Claude reads\n\nThese logs stay **100% local** — they\'re never uploaded or transmitted. Logs rotate when they exceed 10MB per session.\n\nTo clean them up: open the Logs view in the sidebar, or delete them manually.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.transparency.credential-storage',
+    category: 'transparency',
+    complexity: 'advanced',
+    priority: 16,
+    variants: {
+      primary: {
+        shortText: 'ℹ How your SSH passwords are encrypted',
+        title: 'Credential Storage',
+        body: 'SSH passwords and OAuth account tokens are encrypted using **Electron\'s `safeStorage` API**, which wraps your OS credential store:\n\n• **Windows** — DPAPI (Data Protection API), tied to your Windows user account\n• **macOS** — Keychain\n• **Linux** — libsecret (Secret Service)\n\nEncrypted blobs are stored in `resources/CONFIG/ssh-credentials.json` with an `enc:` prefix. The renderer process **never** sees plaintext — decryption happens only in the main process, right before the credential is needed.\n\nIf you move the app to a new machine, encrypted credentials won\'t work there — you\'ll need to re-enter them (they\'re tied to the old OS\'s credential store).',
+        bodyMac: 'SSH passwords and OAuth account tokens are encrypted using **Electron\'s `safeStorage` API** which wraps macOS **Keychain**.\n\nEncrypted blobs are stored in `~/Library/Application Support/Claude Conductor/resources/CONFIG/ssh-credentials.json` with an `enc:` prefix. The renderer process **never** sees plaintext — decryption happens only in the main process.\n\nIf you move the app to a new machine, encrypted credentials won\'t work there — you\'ll need to re-enter them (they\'re tied to the old Keychain).',
+        bodyWin: 'SSH passwords and OAuth account tokens are encrypted using **Electron\'s `safeStorage` API** which wraps **Windows DPAPI** (Data Protection API), tied to your Windows user account.\n\nEncrypted blobs are stored in `%LOCALAPPDATA%\\Claude Conductor\\resources\\CONFIG\\ssh-credentials.json` with an `enc:` prefix. The renderer process **never** sees plaintext — decryption happens only in the main process.\n\nIf you move the app to a new Windows machine or reinstall the OS, encrypted credentials won\'t decrypt there — you\'ll need to re-enter them.',
+      },
+    },
+  },
+
+  {
+    id: 'tip.transparency.resources-folder',
+    category: 'transparency',
+    complexity: 'intermediate',
+    priority: 15,
+    variants: {
+      primary: {
+        shortText: 'ℹ Where the app stores everything',
+        title: 'Resources Folder',
+        body: 'The app uses a **Resources Directory** for all user data. Configurable at first-run setup.\n\nContents:\n• `CONFIG/` — JSON files for your configs, commands, settings, encrypted credentials, tokenomics, usage tracking\n• `logs/` — per-session JSONL activity logs\n• `screenshots/` — any screenshots captured by the Snap / Storyboard features\n• `insights/` — AI-generated usage reports\n• `status/` — real-time session metrics (written by the statusline script)\n• `scripts/` — deployed helper scripts like the statusline\n• `claude-versions/` — installed legacy Claude CLI versions\n\nBack up the whole `resources/` folder to move to a new machine (note: encrypted credentials won\'t transfer — see the credential tip).',
+        bodyMac: 'The app stores everything under `~/Library/Application Support/Claude Conductor/resources/`:\n\n• `CONFIG/` — JSON files for configs, commands, settings, encrypted credentials, tokenomics, usage tracking\n• `logs/` — per-session JSONL activity logs\n• `screenshots/` — captured by Snap / Storyboard features\n• `insights/` — AI usage reports\n• `status/` — real-time session metrics (from statusline script)\n• `scripts/` — deployed helper scripts\n• `claude-versions/` — installed legacy Claude CLI versions\n\nBack up the whole `resources/` folder to move to a new machine (encrypted credentials won\'t transfer since they\'re tied to Keychain).',
+        bodyWin: 'The app stores everything under `%LOCALAPPDATA%\\Claude Conductor\\resources\\`:\n\n• `CONFIG\\` — JSON files for configs, commands, settings, encrypted credentials, tokenomics, usage tracking\n• `logs\\` — per-session JSONL activity logs\n• `screenshots\\` — captured by Snap / Storyboard features\n• `insights\\` — AI usage reports\n• `status\\` — real-time session metrics (from statusline script)\n• `scripts\\` — deployed helper scripts\n• `claude-versions\\` — installed legacy Claude CLI versions\n\nBack up the whole `resources\\` folder to move to a new machine (encrypted credentials won\'t transfer since they\'re tied to DPAPI).',
+      },
+    },
+  },
+
+  {
+    id: 'tip.transparency.network-activity',
+    category: 'transparency',
+    complexity: 'intermediate',
+    priority: 14,
+    variants: {
+      primary: {
+        shortText: 'ℹ What the app sends over the network',
+        title: 'Network Activity',
+        body: 'In the interest of transparency, here\'s every network call the app makes:\n\n• **Rate limits** (`api.anthropic.com/api/oauth/usage`) — once per Claude Code command, only when statusline is enabled. Uses YOUR Claude OAuth token (read from `~/.claude/.credentials.json`).\n\n• **Update check** (`api.github.com`) — via `gh` CLI, checks for new releases when you explicitly trigger an update check or on app start.\n\n• **Model pricing** (`raw.githubusercontent.com/BerriAI/litellm`) — once per 24 hours, to get current Claude model pricing for cost calculations. Cached locally.\n\n• **Vision MCP server** — listens on `127.0.0.1:19333` only. Localhost-only, never exposed to the network.\n\n**The app sends NO telemetry, analytics, or usage data.** Everything else stays on your machine.',
+      },
+    },
+  },
+]

--- a/src/renderer/utils/configHydration.ts
+++ b/src/renderer/utils/configHydration.ts
@@ -3,6 +3,7 @@ import { useConfigStore } from '../stores/configStore'
 import { useMagicButtonStore } from '../stores/magicButtonStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useAppMetaStore } from '../stores/appMetaStore'
+import { useTipsStore, UsageTracking } from '../stores/tipsStore'
 import { useCloudAgentStore } from '../stores/cloudAgentStore'
 import { useAgentLibraryStore } from '../stores/agentLibraryStore'
 import { useTeamStore } from '../stores/teamStore'
@@ -174,6 +175,9 @@ export function hydrateStores(configData: Record<string, unknown>): void {
   const agentTeams = (configData.agentTeams as any[]) || []
   const agentTeamRuns = (configData.agentTeamRuns as any[]) || []
   useTeamStore.getState().hydrate(agentTeams, agentTeamRuns)
+
+  const usageTracking = (configData.usageTracking as UsageTracking) || undefined
+  useTipsStore.getState().hydrate(usageTracking as UsageTracking)
 
   console.log('[App] All stores hydrated from CONFIG/')
 }


### PR DESCRIPTION
## Summary

Adds a contextual tips system that surfaces non-obvious features and explains what the app does behind the scenes. A pill appears to the left of the Restart button in the session header showing a bite-sized tip; clicking it opens a full modal with platform-aware content.

## What's in this PR

### Architecture
- **`tipsStore`** — Zustand store tracking feature usage, tip show/dismiss/act events, with `silenceUntilRestart` session state. Persists to `CONFIG/usage-tracking.json`.
- **`tips-library.ts`** — 26 seed tips with `requires`/`excludes` gating, priority + complexity weighting, optional `postUse` variants for "did you know" copy after the user has done the thing, and platform-specific body/focus-hint overrides.
- **`TipPill`** — animated header badge with subtle mauve glow pulse.
- **`TipModal`** — full modal with category label, markdown-lite body rendering (`**bold**` and `` `code` ``), focus-hint callout, optional action button, and footer controls (Next tip / Silence until restart / Don't show again).
- **`window.electronPlatform`** wired into modal for Mac vs Windows content.

### Seed tips (26 total)

**Discovery** — Encrypted Notes, Memory Visualiser, SSH Sessions, Vision System, Tokenomics, Cloud Agents, Storyboard, Insights, Flicker-Free

**Power user** — Ctrl+click command args, Command sections, Command targeting, Pin config, Partner terminal, Effort level, Duplicate config, Cycle sessions, Paste image, Statusline customize, Agent Teams

**Transparency** (new category) — explicit disclosure of what the app does behind the scenes:
- Statusline script injection (`~/.claude/claude-multi-statusline.js` + `settings.json` entry)
- Vision MCP registration in `settings.json` + SSH reverse tunnels
- Session activity logging (all PTY output, local-only)
- Credential encryption via OS safeStorage (DPAPI / Keychain / libsecret)
- Resources folder structure with per-platform paths
- Every network call the app makes (rate limits, GitHub releases, LiteLLM pricing, Vision MCP localhost-only)

### Platform awareness

- Partner Terminal tip: `powershell.exe`/`cmd.exe`/`gsudo` on Win, `/bin/zsh`/`/bin/bash` on Mac
- Credential Storage tip: DPAPI vs Keychain, with correct data dir paths
- Resources Folder tip: `%LOCALAPPDATA%\Claude Conductor\resources\` on Win, `~/Library/Application Support/Claude Conductor/resources/` on Mac
- Session Logs tip: same path awareness
- Cycle Sessions tip: notes that Mac also uses Ctrl (not Cmd) since the app keeps the same bindings

### Usage tracking hooks

Wired at the call sites to avoid circular imports:
- `App.tsx` GuidedConfigView onConfirm — tracks `create-config`, `session-type`, `flicker-free`, `effort-level`, `disable-auto-memory`, `powershell-tool`
- `App.tsx` setView wrapper — tracks memory, tokenomics, vision, insights, logs, cloud-agents
- `NotesBar.tsx` handleSave — tracks `encrypted-notes`

More hooks coming in follow-up PR (config pinning, partner terminal, command args, etc).

### Settings integration

New `showTips: boolean` in AppSettings (default `true`). Toggle appears in **Settings > General** as "Show intelligent tips".

### Dev tooling

`scripts/test-tips-visually.ts` — Playwright harness that launches the built app and captures a screenshot of each tip's modal for visual review. Satisfies each tip's `requires`/`excludes` state per-iteration to test all 26 tips end-to-end. Saves to `.tip-screenshots/` (gitignored). Used to audit copy accuracy and catch visual regressions.

## Test plan

- [x] All 26 tips render without errors (verified via test-tips-visually.ts)
- [x] Platform-aware tips show correct paths on Windows (verified in screenshots)
- [ ] Test on macOS — spot-check the Mac-specific copy in Partner Terminal, Credential Storage, Resources Folder, Session Logs tips
- [ ] Toggle "Show intelligent tips" in settings — pill should disappear
- [ ] Click "Silence until restart" — pill should disappear for rest of session
- [ ] Click "Don't show this again" — that tip should never come back
- [ ] Click "Next tip" — modal should show a different tip
- [ ] Click an action button (e.g., "Open Memory") — should navigate and close modal
- [ ] Verify tracking works — create a config, open Memory page, then restart — the relevant tips should be excluded from rotation
- [ ] Verify `CONFIG/usage-tracking.json` is created and populated
- [ ] Verify `postUse` variant shows for users who have used the excluded feature (e.g., use partner terminal → next launch, Partner Terminal tip should show the "Target commands at partner" variant)

## Screenshots

Captured via `scripts/test-tips-visually.ts`. Per-tip Windows screenshots available in `.tip-screenshots/` during development.

## Follow-ups (future PRs)

- Add tracking hooks at remaining call sites (vision start, storyboard, command create, pin config, etc)
- Expand tip library to cover all ~50 tip-worthy features from the catalogue
- Add "Tour mode" — rotate through N tips in sequence
- Add analytics on which tips are clicked vs dismissed (local only)
- Screenshots/GIFs embedded in tips where useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)