### PR TITLE
Beta v1.2.166 → stable promotion candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "1.2.165",
+  "version": "1.2.166",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",
@@ -15,6 +15,7 @@
     "test:unit": "vitest run",
     "test:e2e": "npx playwright test",
     "release": "node scripts/release.js",
+    "promote": "node scripts/promote.js",
     "update-server": "node scripts/update-server.js",
     "postinstall": "npx @electron/rebuild --only node-pty --only better-sqlite3",
     "rebuild": "npx @electron/rebuild",

--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -81,7 +81,11 @@ if (currentBranch !== 'beta') {
 }
 ok(`On beta branch`)
 
-// Clean tree — promoting with uncommitted changes would be ambiguous
+// Clean tree — promoting with uncommitted changes would be ambiguous.
+// If the status check itself fails (git unavailable, corrupt repo, etc.),
+// treat it as a hard failure: we can't safely promote without confirming
+// the working tree is clean, since later steps (checkout main, push) could
+// either fail mid-flow or accidentally promote uncommitted work.
 try {
   const status = run('git status --porcelain')
   if (status.length > 0) {
@@ -93,7 +97,7 @@ try {
   ok('Working tree clean')
 } catch (err) {
   if (err.message.includes('Working tree has')) throw err
-  warn(`Could not check git status: ${err.message}`)
+  fail(`Could not check git status: ${err.message}`)
 }
 
 // gh auth
@@ -129,13 +133,32 @@ try {
   fail(`Could not compare beta refs: ${err.message}`)
 }
 
-// Verify main exists locally
+// Ensure local main exists and is in sync with origin/main before we touch it.
+// A stale or diverged local main can break the ancestry check or result in a
+// surprising push (promoting an unexpected history). We hard-reset local main
+// to origin/main — this is safe because the promote flow only ever
+// fast-forwards main to beta; there should never be local-only commits on main
+// that we want to preserve. If a user has made local commits to main they
+// didn't push, that's a workflow violation the reset cleanly recovers from.
 try {
   run('git rev-parse --verify main')
 } catch {
-  // Create local main tracking origin/main if it doesn't exist
-  run('git branch main origin/main')
+  // Create a local main tracking origin/main if it doesn't exist yet
+  run('git branch --track main origin/main')
   ok('Created local main branch tracking origin/main')
+}
+
+try {
+  const localMain = run('git rev-parse main')
+  const originMain = run('git rev-parse origin/main')
+  if (localMain !== originMain) {
+    run('git branch -f main origin/main')
+    ok(`Reset local main from ${localMain.slice(0, 7)} to origin/main (${originMain.slice(0, 7)})`)
+  } else {
+    ok('Local main matches origin/main')
+  }
+} catch (err) {
+  fail(`Could not synchronize main with origin/main: ${err.message}`)
 }
 
 // --- Step 3: Verify main is strictly behind beta ---

--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Promote the current beta to a stable release.
+ *
+ * Branching model:
+ *   - `beta` is the working branch where all features land.
+ *   - `main` is stable-only — it only receives fast-forwards from beta.
+ *
+ * What this script does:
+ *   1. Verifies you're on `beta`, tree is clean, `main` is a strict ancestor.
+ *   2. Fetches the latest state of both branches from origin.
+ *   3. Fast-forwards local `main` to match `beta`.
+ *   4. Pushes `main` to origin.
+ *   5. Optionally runs `node scripts/release.js --stable --no-bump` from main
+ *      to ship a stable release at the same version as the current beta.
+ *
+ * Usage:
+ *   npm run promote           (interactive — asks before running release)
+ *   npm run promote -- --yes  (no prompts, immediately releases stable)
+ *   npm run promote -- --ff-only  (just FF main, don't run release)
+ *
+ * After this script runs, you'll be left on `main` with the stable release
+ * either shipped (default) or ready to ship (--ff-only). In either case,
+ * remember to `git checkout beta` before continuing feature work.
+ */
+
+const { execSync } = require('child_process')
+const path = require('path')
+const readline = require('readline')
+
+const PROJECT_ROOT = path.resolve(__dirname, '..')
+
+const args = process.argv.slice(2)
+const AUTO_YES = args.includes('--yes') || args.includes('-y')
+const FF_ONLY = args.includes('--ff-only')
+
+function run(cmd, opts = {}) {
+  return execSync(cmd, { cwd: PROJECT_ROOT, encoding: 'utf-8', ...opts }).trim()
+}
+
+function runInherit(cmd) {
+  execSync(cmd, { cwd: PROJECT_ROOT, stdio: 'inherit' })
+}
+
+function ok(msg) { console.log(`      OK  ${msg}`) }
+function warn(msg) { console.log(`      WARN  ${msg}`) }
+function fail(msg) { console.error(`      FAIL  ${msg}`); process.exit(1) }
+function step(num, total, msg) { console.log(`\n[${num}/${total}] ${msg}`) }
+
+function ask(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve((answer || '').trim().toLowerCase())
+    })
+  })
+}
+
+;(async () => {
+
+const TOTAL = FF_ONLY ? 5 : 6
+
+console.log('')
+console.log('  ===========================================')
+console.log('    Promote beta → main (stable release)')
+console.log('  ===========================================')
+
+// --- Step 1: Validate starting state ---
+step(1, TOTAL, 'Validating starting state...')
+
+let currentBranch
+try {
+  currentBranch = run('git rev-parse --abbrev-ref HEAD')
+} catch {
+  fail('Not a git repository')
+}
+
+if (currentBranch !== 'beta') {
+  fail(`Must be on the 'beta' branch to promote — currently on '${currentBranch}'. Run: git checkout beta`)
+}
+ok(`On beta branch`)
+
+// Clean tree — promoting with uncommitted changes would be ambiguous
+try {
+  const status = run('git status --porcelain')
+  if (status.length > 0) {
+    fail(
+      `Working tree has uncommitted changes. Either commit them on beta (then re-run promote) ` +
+      `or stash them:\n${status.split('\n').map((l) => '         ' + l).join('\n')}`
+    )
+  }
+  ok('Working tree clean')
+} catch (err) {
+  if (err.message.includes('Working tree has')) throw err
+  warn(`Could not check git status: ${err.message}`)
+}
+
+// gh auth
+try {
+  run('gh auth status 2>&1')
+  ok('GitHub CLI authenticated')
+} catch {
+  fail('GitHub CLI not authenticated. Run: gh auth login')
+}
+
+// --- Step 2: Fetch latest from origin ---
+step(2, TOTAL, 'Fetching latest from origin...')
+try {
+  run('git fetch origin beta main --tags')
+  ok('Fetched origin/beta, origin/main, and tags')
+} catch (err) {
+  fail(`git fetch failed: ${err.message}`)
+}
+
+// Verify local beta is in sync with origin/beta
+try {
+  const localBeta = run('git rev-parse beta')
+  const originBeta = run('git rev-parse origin/beta')
+  if (localBeta !== originBeta) {
+    fail(
+      `Local beta (${localBeta.slice(0, 7)}) does not match origin/beta (${originBeta.slice(0, 7)}). ` +
+      `Push or reset beta first.`
+    )
+  }
+  ok('Local beta matches origin/beta')
+} catch (err) {
+  if (err.message.includes('Local beta')) throw err
+  fail(`Could not compare beta refs: ${err.message}`)
+}
+
+// Verify main exists locally
+try {
+  run('git rev-parse --verify main')
+} catch {
+  // Create local main tracking origin/main if it doesn't exist
+  run('git branch main origin/main')
+  ok('Created local main branch tracking origin/main')
+}
+
+// --- Step 3: Verify main is strictly behind beta ---
+step(3, TOTAL, 'Checking that main is a strict ancestor of beta...')
+try {
+  const mainSha = run('git rev-parse main')
+  const betaSha = run('git rev-parse beta')
+
+  if (mainSha === betaSha) {
+    warn('main is already at beta — nothing to promote')
+    if (FF_ONLY) process.exit(0)
+    // Fall through to release step — maybe they want to re-ship stable
+  } else {
+    // Check: is main an ancestor of beta? (i.e. can we fast-forward?)
+    try {
+      run(`git merge-base --is-ancestor main beta`)
+      const ahead = run('git rev-list --count main..beta')
+      ok(`Main can fast-forward to beta (${ahead} commit(s) ahead)`)
+    } catch {
+      fail(
+        `Cannot fast-forward: beta has diverged from main. This means main has commits ` +
+        `not on beta (e.g. a hotfix landed directly on main). Resolve by merging main ` +
+        `into beta first: git checkout beta && git merge main && git push`
+      )
+    }
+  }
+} catch (err) {
+  if (err.message.includes('Cannot fast-forward')) throw err
+  fail(`Ancestry check failed: ${err.message}`)
+}
+
+// --- Step 4: Fast-forward main to beta ---
+step(4, TOTAL, 'Fast-forwarding main to beta...')
+try {
+  run('git checkout main')
+  run('git merge --ff-only beta')
+  ok('Fast-forwarded main → beta')
+} catch (err) {
+  fail(`Fast-forward failed: ${err.message}`)
+}
+
+// --- Step 5: Push main ---
+step(5, TOTAL, 'Pushing main to origin...')
+try {
+  run('git push origin main 2>&1', { timeout: 60000 })
+  ok('Pushed main to origin')
+} catch (err) {
+  fail(`Push failed: ${err.message}`)
+}
+
+if (FF_ONLY) {
+  console.log('')
+  console.log('  ===========================================')
+  console.log('    Main is promoted. Run the release manually:')
+  console.log('      npm run release -- --stable --no-bump')
+  console.log('    Then: git checkout beta')
+  console.log('  ===========================================')
+  process.exit(0)
+}
+
+// --- Step 6: Ship stable release ---
+step(6, TOTAL, 'Shipping stable release from main...')
+
+let confirm = 'y'
+if (!AUTO_YES) {
+  confirm = await ask('      Run `npm run release -- --stable --no-bump` now? (y/N): ')
+}
+
+if (confirm === 'y' || confirm === 'yes') {
+  try {
+    runInherit('node scripts/release.js --stable --no-bump')
+    ok('Stable release dispatched')
+  } catch {
+    fail('Release failed — check the output above')
+  }
+} else {
+  console.log('')
+  console.log('  Skipped release. To ship stable manually:')
+  console.log('    npm run release -- --stable --no-bump')
+}
+
+console.log('')
+console.log('  ===========================================')
+console.log('    Promote complete. Remember to:')
+console.log('      git checkout beta')
+console.log('    ... before continuing feature work.')
+console.log('  ===========================================')
+
+})()

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -20,17 +20,25 @@
  *   8. Watch the workflow run to completion
  *   9. Verify the final release has both .exe and .dmg attached
  *
+ * Branching model:
+ *   - Work on the `beta` branch. Beta/dev releases cut from there.
+ *   - When a beta is stable, use `npm run promote` to fast-forward main and
+ *     cut a stable release at the SAME version (no bump — the code is identical).
+ *   - Hotfixes can land directly on main and release as stable from there.
+ *
  * Usage:
  *   npm run release                 (interactive channel prompt, patch bump)
- *   npm run release -- --beta       (force beta channel)
- *   npm run release -- --stable     (force stable channel)
- *   npm run release -- --dev        (force dev channel — experimental)
+ *   npm run release -- --beta       (force beta channel — must be on beta branch)
+ *   npm run release -- --stable     (force stable channel — must be on main branch)
+ *   npm run release -- --dev        (force dev channel — must be on beta branch)
  *   npm run release -- --minor      (minor version bump)
  *   npm run release -- --major      (major version bump)
+ *   npm run release -- --no-bump    (reuse current version — used by promote flow)
  *   npm run release -- --skip-tests (skip local typecheck + vitest)
  *   npm run release -- --skip-build (skip local build smoke test)
  *   npm run release -- --skip-watch (don't wait for workflow to finish)
  *   npm run release -- --skip-push  (everything except commit/push/dispatch)
+ *   npm run release -- --skip-branch-check  (bypass branch ↔ channel enforcement)
  *
  * Notes:
  *   - VirusTotal scanning is part of the GitHub Actions workflow, not local.
@@ -53,11 +61,30 @@ const SKIP_TESTS = args.includes('--skip-tests')
 const SKIP_BUILD = args.includes('--skip-build')
 const SKIP_WATCH = args.includes('--skip-watch')
 const SKIP_PUSH = args.includes('--skip-push')
+const SKIP_BRANCH_CHECK = args.includes('--skip-branch-check')
+const NO_BUMP = args.includes('--no-bump')
 const BUMP_MINOR = args.includes('--minor')
 const BUMP_MAJOR = args.includes('--major')
 const FORCE_BETA = args.includes('--beta')
 const FORCE_STABLE = args.includes('--stable')
 const FORCE_DEV = args.includes('--dev')
+
+/**
+ * Branching model:
+ *   - `main`  : stable-only branch. Only stable releases are cut here.
+ *   - `beta`  : default working branch. All features land here first.
+ *               Beta and dev releases are cut from beta.
+ *
+ * Channel → required branch:
+ *   stable → main  (release must be reviewed + promoted from beta)
+ *   beta   → beta  (daily releases)
+ *   dev    → beta  (experimental, released from the same branch as beta)
+ */
+const CHANNEL_BRANCH = {
+  stable: 'main',
+  beta: 'beta',
+  dev: 'beta',
+}
 
 // ============================================================
 // HELPERS
@@ -177,10 +204,23 @@ try {
 } catch {
   warn('Could not detect current branch, defaulting to main')
 }
-if (currentBranch !== 'main') {
-  warn(`On branch '${currentBranch}' — workflow will dispatch on this branch, not main`)
-}
 ok(`Current branch: ${currentBranch}`)
+
+// Enforce branch ↔ channel correspondence to prevent shipping beta code as
+// stable (or vice versa). `--skip-branch-check` exists for emergencies but
+// should not be used in normal operation.
+const requiredBranch = CHANNEL_BRANCH[channel]
+if (!SKIP_BRANCH_CHECK && currentBranch !== requiredBranch) {
+  fail(
+    `Channel '${channel}' must be released from the '${requiredBranch}' branch, ` +
+    `but current branch is '${currentBranch}'.\n      ` +
+    `Run: git checkout ${requiredBranch}\n      ` +
+    `(or pass --skip-branch-check to bypass — not recommended)`
+  )
+}
+if (SKIP_BRANCH_CHECK && currentBranch !== requiredBranch) {
+  warn(`Branch check skipped: releasing ${channel} from '${currentBranch}' instead of '${requiredBranch}'`)
+}
 
 // Git status (uncommitted changes will be included in the release commit)
 try {
@@ -195,30 +235,36 @@ try {
   warn('Git status check failed (non-fatal)')
 }
 
-// --- Step 2: Version bump ---
-step(2, TOTAL_STEPS, 'Incrementing version...')
+// --- Step 2: Version bump (or reuse) ---
+step(2, TOTAL_STEPS, NO_BUMP ? 'Reusing current version (--no-bump)...' : 'Incrementing version...')
 
 const pkgPath = path.join(PROJECT_ROOT, 'package.json')
 const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
 const oldVersion = pkg.version
-const parts = oldVersion.split('.').map(Number)
 
-if (BUMP_MAJOR) {
-  parts[0] += 1; parts[1] = 0; parts[2] = 0
-} else if (BUMP_MINOR) {
-  parts[1] += 1; parts[2] = 0
+let version
+if (NO_BUMP) {
+  // Used by the promote flow: stable release reuses the beta's version so
+  // v1.2.166-beta → v1.2.166 (same code, different tag, no version drift).
+  version = oldVersion
 } else {
-  parts[2] = (parts[2] || 0) + 1
+  const parts = oldVersion.split('.').map(Number)
+  if (BUMP_MAJOR) {
+    parts[0] += 1; parts[1] = 0; parts[2] = 0
+  } else if (BUMP_MINOR) {
+    parts[1] += 1; parts[2] = 0
+  } else {
+    parts[2] = (parts[2] || 0) + 1
+  }
+  version = parts.join('.')
+  pkg.version = version
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
 }
-
-const version = parts.join('.')
-pkg.version = version
-fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
 
 const tag = tagFor(version, channel)
 
 console.log('')
-console.log(`      v${oldVersion} → v${version}  (tag: ${tag}, channel: ${channel})`)
+console.log(`      ${NO_BUMP ? `v${version} (reused)` : `v${oldVersion} → v${version}`}  (tag: ${tag}, channel: ${channel})`)
 
 // --- Step 3: Sync changelog version ---
 step(3, TOTAL_STEPS, 'Aligning changelog version with bumped version...')

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,18 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.2.166',
+    date: '2026-04-08',
+    highlights: "Branching model: beta + main with promote flow",
+    changes: [
+      { type: 'improvement', description: "New branching model: all feature work happens on the `beta` branch; the `main` branch is stable-only and receives fast-forwards from beta" },
+      { type: 'improvement', description: "Release script now enforces branch ↔ channel correspondence — --stable must run on main, --beta/--dev must run on beta (bypass with --skip-branch-check in emergencies)" },
+      { type: 'feature', description: "New `npm run promote` command fast-forwards main to beta and ships a stable release at the same version as the current beta (so v1.2.166-beta and v1.2.166 stable are literally the same code, different tags)" },
+      { type: 'feature', description: "New --no-bump flag on the release script reuses the current package.json version instead of incrementing — used by the promote flow to keep beta and stable version numbers aligned" },
+      { type: 'feature', description: "New --ff-only and --yes flags on the promote script for partial/automated runs" },
+    ]
+  },
+  {
     version: '1.2.165',
     date: '2026-04-08',
     highlights: "Release script hotfix: cross-platform sleep + proper workflow watching",


### PR DESCRIPTION
## What this is

This PR tracks everything on the `beta` branch that is a candidate for the next stable release.

**Current beta release**: [v1.2.166-beta](https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.166-beta)

Merging this PR promotes all these changes to the stable channel as v1.2.166.

## How it works

- Beta releases ship from the `beta` branch via \`npm run release -- --beta\`.
- This PR auto-updates as new beta releases land (same PR, more commits).
- When ready, \`npm run promote\` merges this PR and cuts a stable release at the same version.

## Changes since last stable

### v1.2.166-beta (this release)
**Branching model: beta + main with promote flow**
- New branching model: all feature work happens on \`beta\`; \`main\` is stable-only and receives fast-forwards from beta
- Release script now enforces branch ↔ channel correspondence
- New \`npm run promote\` command fast-forwards main to beta and ships a stable release
- New \`--no-bump\` flag reuses current version (used by promote flow)

### v1.2.165-beta
- Release script hotfix: cross-platform sleep + proper workflow watching

### v1.2.164-beta
- Unified release pipeline + channel label on update button

### v1.2.163-beta
- SSH statusline (OSC sentinel approach)
- Unified MCP image transport for clipboard paste, snap, storyboard (local + SSH)
- Dual service status indicator in title bar
- MCP server now auto-starts independent of browser vision config
- 'Got it' tip button now clears the pill
- Aspect ratio fix for snap/storyboard resize