### PR TITLE
feat(github): sync orchestrator + per-session gating (PR 3a/3c)

### DIFF
--- a/src/main/github/cache/cache-store.ts
+++ b/src/main/github/cache/cache-store.ts
@@ -54,6 +54,73 @@ export class CacheStore {
     })
   }
 
+  /**
+   * Atomic read-modify-write. Prefer this over separate `load`/`save` calls
+   * when concurrent writers are possible (e.g. the SyncOrchestrator running
+   * multiple sessions): two sessions both loading the same snapshot and
+   * saving sequentially will lose the earlier write. The mutex on `run` is
+   * re-entrant with load/save, so nested reads via await are safe.
+   */
+  async update(fn: (cache: GitHubCache) => void | Promise<void>): Promise<void> {
+    await this.mutex.run(async () => {
+      const cache = await this.readUnlocked()
+      await fn(cache)
+      await this.writeUnlocked(cache)
+    })
+  }
+
+  private async readUnlocked(): Promise<GitHubCache> {
+    let raw: string
+    try {
+      raw = await fs.readFile(this.filePath, 'utf8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return empty()
+      console.warn('[github-cache] read failed:', redactTokens(String(err)))
+      return empty()
+    }
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed.schemaVersion !== GITHUB_CACHE_SCHEMA_VERSION) {
+        await this.backupCorrupt()
+        return empty()
+      }
+      return parsed as GitHubCache
+    } catch {
+      await this.backupCorrupt()
+      return empty()
+    }
+  }
+
+  private async writeUnlocked(cache: GitHubCache): Promise<void> {
+    const lru = cache.lru.filter((s) => s in cache.repos)
+    while (Object.keys(cache.repos).length > CACHE_MAX_REPOS && lru.length > 0) {
+      const evict = lru.shift()!
+      delete cache.repos[evict]
+    }
+    cache.lru = lru
+    const tmp = `${this.filePath}.${randomUUID()}.tmp`
+    await fs.writeFile(tmp, JSON.stringify(cache), 'utf8')
+    try {
+      if (existsSync(this.filePath)) {
+        await fs.copyFile(tmp, this.filePath)
+        try {
+          await fs.unlink(tmp)
+        } catch {
+          /* ignore */
+        }
+      } else {
+        await fs.rename(tmp, this.filePath)
+      }
+    } catch (err) {
+      try {
+        await fs.unlink(tmp)
+      } catch {
+        /* ignore */
+      }
+      throw err
+    }
+  }
+
   async save(cache: GitHubCache): Promise<void> {
     await this.mutex.run(async () => {
       // LRU: drop entries no longer in repos (stale after manual edits), then

--- a/src/main/github/cache/cache-store.ts
+++ b/src/main/github/cache/cache-store.ts
@@ -58,8 +58,12 @@ export class CacheStore {
    * Atomic read-modify-write. Prefer this over separate `load`/`save` calls
    * when concurrent writers are possible (e.g. the SyncOrchestrator running
    * multiple sessions): two sessions both loading the same snapshot and
-   * saving sequentially will lose the earlier write. The mutex on `run` is
-   * re-entrant with load/save, so nested reads via await are safe.
+   * saving sequentially will lose the earlier write.
+   *
+   * IMPORTANT: AsyncMutex is NOT re-entrant. `fn` MUST NOT call load(),
+   * save(), or update() on the same CacheStore — doing so will deadlock.
+   * The internal readUnlocked / writeUnlocked helpers side-step the public
+   * API precisely because they execute inside the already-held mutex.
    */
   async update(fn: (cache: GitHubCache) => void | Promise<void>): Promise<void> {
     await this.mutex.run(async () => {

--- a/src/main/github/session/ssh-repo-detector.ts
+++ b/src/main/github/session/ssh-repo-detector.ts
@@ -1,0 +1,56 @@
+import { parseRepoUrl } from '../security/repo-url-parser'
+
+const START = '__CC_GIT_START__'
+const END = '__CC_GIT_END__'
+
+/**
+ * Sends a one-shot command to an SSH pty and returns its captured stdout.
+ *
+ * IMPORTANT: This type does NOT take a `cwd` argument. The detector builds its
+ * own `git -C <escaped cwd>` command and hands the fully-shell-escaped string
+ * to `sendOneShot`. If a helper variant ever accepts a `cwd` and interpolates
+ * it into a shell string (e.g. `cd ${cwd} && ${cmd}`), that interpolation MUST
+ * use a POSIX single-quote escape — reuse posixShellEscape below. Never pass
+ * a raw user-influenced `cwd` into any shell fragment without escaping.
+ */
+export type SendOneShotSSH = (
+  sessionId: string,
+  command: string,
+  timeoutMs?: number,
+) => Promise<string>
+
+/**
+ * POSIX single-quote shell escape. Safer than `JSON.stringify(arg)` because
+ * double-quoted shell strings still expand `$(...)`, backticks, and `$VAR`,
+ * leaving an injection path if the argument contains `$(rm -rf ~)` etc.
+ * Single-quote wrapping disables all expansion; embedded `'` are escaped
+ * as the standard `'\''` sequence.
+ */
+export function posixShellEscape(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`
+}
+
+export async function detectRepoFromSshSession(
+  sessionId: string,
+  cwd: string,
+  sendOneShot: SendOneShotSSH,
+): Promise<string | null> {
+  // Sentinels are module-local constants — safe to inline unquoted. `cwd` is
+  // attacker-influenceable (remote host path chosen by the user) so it MUST
+  // pass through posixShellEscape. JSON.stringify is not safe here: double
+  // quotes still permit $()/`` expansion on POSIX shells.
+  const cmd = `echo ${START}; git -C ${posixShellEscape(cwd)} remote get-url origin 2>/dev/null; echo ${END}`
+  let output: string
+  try {
+    // cwd is not passed separately — it's baked into cmd via escaping. This
+    // keeps the injection surface to a single, audited interpolation site.
+    output = await sendOneShot(sessionId, cmd, 5000)
+  } catch {
+    return null
+  }
+  const startIdx = output.indexOf(START)
+  const endIdx = output.indexOf(END)
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null
+  const between = output.slice(startIdx + START.length, endIdx).trim()
+  return parseRepoUrl(between)
+}

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -1,0 +1,276 @@
+import type {
+  GitHubConfig,
+  PRSnapshot,
+  RepoCache,
+  ReviewSnapshot,
+  SessionGitHubIntegration,
+  WorkflowRunSnapshot,
+} from '../../../shared/github-types'
+import type { CacheStore } from '../cache/cache-store'
+
+type FetchResult<T> =
+  | { status: 'unchanged' }
+  | { status: 'empty' }
+  | { status: 'ok'; data: T }
+
+export interface OrchestratorFetchers {
+  pr: (slug: string, branch: string) => Promise<FetchResult<unknown>>
+  runs: (slug: string, branch: string) => Promise<FetchResult<unknown[]>>
+  reviews: (slug: string, prNumber: number) => Promise<FetchResult<unknown[]>>
+}
+
+export type SyncState = 'syncing' | 'synced' | 'rate-limited' | 'error' | 'idle'
+
+export interface SyncStateEvent {
+  slug: string
+  state: SyncState
+  at: number
+  nextResetAt?: number
+}
+
+export interface SyncOrchestratorDeps {
+  cacheStore: CacheStore
+  getConfig: () => Promise<GitHubConfig | null>
+  getTokenForSession: (sessionId: string) => Promise<string | null>
+  emitData: (p: { slug: string; data: RepoCache }) => void
+  emitSyncState: (p: SyncStateEvent) => void
+  fetchers: OrchestratorFetchers
+}
+
+export interface RegisterSessionInput {
+  sessionId: string
+  slug: string
+  branch: string
+  integration: SessionGitHubIntegration
+}
+
+interface SessionState extends RegisterSessionInput {
+  timer?: NodeJS.Timeout
+  focused: boolean
+  lastSync: number
+  // Set when a RateLimitError lands; scheduleNext reads it to delay the next
+  // attempt until after the reset, then clears on the next successful sync.
+  rateLimitedUntil?: number
+}
+
+interface RateLimitErrorLike {
+  name: string
+  resetAt?: number
+}
+
+function isRateLimitError(err: unknown): err is RateLimitErrorLike {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    (err as { name?: unknown }).name === 'RateLimitError'
+  )
+}
+
+export class SyncOrchestrator {
+  private sessions = new Map<string, SessionState>()
+  private paused = false
+
+  constructor(private deps: SyncOrchestratorDeps) {}
+
+  registerSession(input: RegisterSessionInput): void {
+    this.sessions.set(input.sessionId, { ...input, focused: false, lastSync: 0 })
+    void this.scheduleNext(input.sessionId)
+  }
+
+  unregisterSession(id: string): void {
+    const s = this.sessions.get(id)
+    if (s?.timer) clearTimeout(s.timer)
+    this.sessions.delete(id)
+  }
+
+  setFocus(id: string, focused: boolean): void {
+    const s = this.sessions.get(id)
+    if (!s) return
+    s.focused = focused
+    void this.scheduleNext(id)
+  }
+
+  pause(): void {
+    this.paused = true
+  }
+
+  resume(): void {
+    this.paused = false
+    this.sessions.forEach((_, id) => void this.scheduleNext(id))
+  }
+
+  isPaused(): boolean {
+    return this.paused
+  }
+
+  async syncNow(sessionId: string): Promise<void> {
+    await this.doSync(sessionId)
+  }
+
+  private async scheduleNext(id: string): Promise<void> {
+    if (this.paused) return
+    const s = this.sessions.get(id)
+    if (!s) return
+    if (s.timer) clearTimeout(s.timer)
+
+    // Rate-limit backoff wins over normal interval. Otherwise the outer
+    // `finally(() => scheduleNext)` after doSync would replace the reset-
+    // based wait with the normal interval and defeat the shield entirely.
+    let delayMs: number
+    const now = Date.now()
+    if (s.rateLimitedUntil && now < s.rateLimitedUntil) {
+      delayMs = Math.max(s.rateLimitedUntil - now + 1000, 1000)
+    } else {
+      const cfg = await this.deps.getConfig()
+      const intervalSec = s.focused
+        ? cfg?.syncIntervals.activeSessionSec ?? 60
+        : cfg?.syncIntervals.backgroundSec ?? 300
+      delayMs = intervalSec * 1000
+    }
+
+    s.timer = setTimeout(() => {
+      void this.doSync(id).finally(() => void this.scheduleNext(id))
+    }, delayMs)
+  }
+
+  private async doSync(sessionId: string): Promise<void> {
+    const s = this.sessions.get(sessionId)
+    if (!s) return
+
+    this.deps.emitSyncState({ slug: s.slug, state: 'syncing', at: Date.now() })
+
+    const cache = await this.deps.cacheStore.load()
+    const existing: RepoCache = cache.repos[s.slug] ?? {
+      etags: {},
+      lastSynced: 0,
+      accessedAt: 0,
+    }
+
+    try {
+      const prR = await this.deps.fetchers.pr(s.slug, s.branch)
+      if (prR.status === 'ok') {
+        existing.pr = mapPR(prR.data)
+      } else if (prR.status === 'empty') {
+        // RepoCache.pr is optional; use undefined (not null) so render code
+        // only has one "no PR" sentinel to handle.
+        existing.pr = undefined
+      }
+      // 'unchanged' intentionally leaves existing.pr alone — that's the
+      // whole point of the 304 path; we preserve what the previous sync
+      // loaded rather than blanking the card while polling.
+
+      const runsR = await this.deps.fetchers.runs(s.slug, s.branch)
+      if (runsR.status === 'ok') {
+        existing.actions = mapRuns(runsR.data)
+      }
+
+      if (existing.pr) {
+        const revR = await this.deps.fetchers.reviews(s.slug, existing.pr.number)
+        if (revR.status === 'ok') {
+          existing.reviews = mapReviews(revR.data)
+        }
+      }
+
+      existing.lastSynced = Date.now()
+      existing.accessedAt = Date.now()
+      cache.repos[s.slug] = existing
+      // True access-order LRU: move the slug to the most-recent end every
+      // access. Previous impl only appended on first use, so hot repos kept
+      // their original position and were wrongly evicted as "oldest".
+      const lruIndex = cache.lru.indexOf(s.slug)
+      if (lruIndex !== -1) cache.lru.splice(lruIndex, 1)
+      cache.lru.push(s.slug)
+      await this.deps.cacheStore.save(cache)
+
+      this.deps.emitData({ slug: s.slug, data: existing })
+      this.deps.emitSyncState({ slug: s.slug, state: 'synced', at: Date.now() })
+      s.lastSync = Date.now()
+      // Clear any prior rate-limit deadline — we just succeeded.
+      s.rateLimitedUntil = undefined
+    } catch (err: unknown) {
+      if (isRateLimitError(err)) {
+        // Record the deadline; scheduleNext honors it. Don't arm a timer
+        // here directly — the outer `finally(() => scheduleNext)` would
+        // race and clobber it. rateLimitedUntil is cleared on next success.
+        s.rateLimitedUntil = err.resetAt
+        this.deps.emitSyncState({
+          slug: s.slug,
+          state: 'rate-limited',
+          at: Date.now(),
+          nextResetAt: err.resetAt,
+        })
+      } else {
+        this.deps.emitSyncState({ slug: s.slug, state: 'error', at: Date.now() })
+      }
+    }
+  }
+}
+
+interface RawPR {
+  number: number
+  title: string
+  state: PRSnapshot['state']
+  draft?: boolean
+  user?: { login?: string; avatar_url?: string }
+  created_at: string
+  updated_at: string
+  mergeable?: boolean | null
+  html_url: string
+}
+
+function mapPR(raw: unknown): PRSnapshot {
+  const r = raw as RawPR
+  return {
+    number: r.number,
+    title: r.title,
+    state: r.state,
+    draft: !!r.draft,
+    author: r.user?.login ?? 'unknown',
+    authorAvatarUrl: r.user?.avatar_url,
+    createdAt: Date.parse(r.created_at),
+    updatedAt: Date.parse(r.updated_at),
+    mergeableState:
+      r.mergeable === null || r.mergeable === undefined
+        ? 'unknown'
+        : r.mergeable
+        ? 'clean'
+        : 'conflict',
+    url: r.html_url,
+  }
+}
+
+interface RawRun {
+  id: number
+  name?: string
+  workflow_id?: number
+  status: WorkflowRunSnapshot['status']
+  conclusion?: WorkflowRunSnapshot['conclusion']
+  html_url: string
+}
+
+function mapRuns(raw: unknown[]): WorkflowRunSnapshot[] {
+  return (raw as RawRun[]).map((r) => ({
+    id: r.id,
+    workflowName: r.name ?? String(r.workflow_id ?? 'workflow'),
+    status: r.status,
+    conclusion: r.conclusion ?? null,
+    url: r.html_url,
+  }))
+}
+
+interface RawReview {
+  id: number
+  user?: { login?: string; avatar_url?: string }
+  state: ReviewSnapshot['state']
+}
+
+function mapReviews(raw: unknown[]): ReviewSnapshot[] {
+  return (raw as RawReview[]).map((rv) => ({
+    id: rv.id,
+    reviewer: rv.user?.login ?? 'unknown',
+    reviewerAvatarUrl: rv.user?.avatar_url,
+    state: rv.state,
+    threads: [],
+  }))
+}

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -13,10 +13,16 @@ type FetchResult<T> =
   | { status: 'empty' }
   | { status: 'ok'; data: T }
 
+export interface FetcherContext {
+  sessionId: string
+  slug: string
+  branch: string
+}
+
 export interface OrchestratorFetchers {
-  pr: (slug: string, branch: string) => Promise<FetchResult<unknown>>
-  runs: (slug: string, branch: string) => Promise<FetchResult<unknown[]>>
-  reviews: (slug: string, prNumber: number) => Promise<FetchResult<unknown[]>>
+  pr: (ctx: FetcherContext) => Promise<FetchResult<unknown>>
+  runs: (ctx: FetcherContext) => Promise<FetchResult<unknown[]>>
+  reviews: (ctx: FetcherContext, prNumber: number) => Promise<FetchResult<unknown[]>>
 }
 
 export type SyncState = 'syncing' | 'synced' | 'rate-limited' | 'error' | 'idle'
@@ -74,6 +80,11 @@ export class SyncOrchestrator {
   constructor(private deps: SyncOrchestratorDeps) {}
 
   registerSession(input: RegisterSessionInput): void {
+    // Clear any existing timer for this id — re-registering an already-
+    // registered session (e.g. after the user edits the slug) must not leak
+    // the previous timer, which still holds a closure on the old state.
+    const prev = this.sessions.get(input.sessionId)
+    if (prev?.timer) clearTimeout(prev.timer)
     this.sessions.set(input.sessionId, { ...input, focused: false, lastSync: 0 })
     void this.scheduleNext(input.sessionId)
   }
@@ -147,8 +158,14 @@ export class SyncOrchestrator {
       accessedAt: 0,
     }
 
+    const ctx: FetcherContext = {
+      sessionId: s.sessionId,
+      slug: s.slug,
+      branch: s.branch,
+    }
+
     try {
-      const prR = await this.deps.fetchers.pr(s.slug, s.branch)
+      const prR = await this.deps.fetchers.pr(ctx)
       if (prR.status === 'ok') {
         existing.pr = mapPR(prR.data)
       } else if (prR.status === 'empty') {
@@ -160,13 +177,13 @@ export class SyncOrchestrator {
       // whole point of the 304 path; we preserve what the previous sync
       // loaded rather than blanking the card while polling.
 
-      const runsR = await this.deps.fetchers.runs(s.slug, s.branch)
+      const runsR = await this.deps.fetchers.runs(ctx)
       if (runsR.status === 'ok') {
         existing.actions = mapRuns(runsR.data)
       }
 
       if (existing.pr) {
-        const revR = await this.deps.fetchers.reviews(s.slug, existing.pr.number)
+        const revR = await this.deps.fetchers.reviews(ctx, existing.pr.number)
         if (revR.status === 'ok') {
           existing.reviews = mapReviews(revR.data)
         }

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -64,6 +64,10 @@ interface SessionState extends RegisterSessionInput {
   // Set when a RateLimitError lands; scheduleNext reads it to delay the next
   // attempt until after the reset, then clears on the next successful sync.
   rateLimitedUntil?: number
+  // Last known PR number — cached across sync ticks so doSync doesn't have
+  // to re-read the whole cache JSON just to decide whether to follow up
+  // with a reviews fetch when the PR endpoint returns 304 (unchanged).
+  lastPRNumber?: number
 }
 
 interface RateLimitErrorLike {
@@ -93,7 +97,25 @@ export class SyncOrchestrator {
     const prev = this.sessions.get(input.sessionId)
     if (prev?.timer) clearTimeout(prev.timer)
     const isFirst = !prev
-    this.sessions.set(input.sessionId, { ...input, focused: false, lastSync: 0 })
+    const state: SessionState = { ...input, focused: false, lastSync: 0 }
+    this.sessions.set(input.sessionId, state)
+
+    // One-time warm of s.lastPRNumber from the on-disk cache. Without
+    // this, a post-restart sync that returns 304 on the PR endpoint has
+    // no way to know which PR number to request reviews for — the in-
+    // memory number starts undefined. Fire-and-forget so register stays
+    // synchronous; doSync will just skip reviews on its very first tick
+    // if the hydration hasn't resolved yet, which is harmless.
+    void this.deps.cacheStore
+      .load()
+      .then((c) => {
+        const pr = c.repos[state.slug]?.pr
+        if (pr && this.sessions.get(input.sessionId) === state) {
+          state.lastPRNumber = pr.number
+        }
+      })
+      .catch(() => {})
+
     if (isFirst && !this.paused) {
       // Kick off an immediate sync on first registration so the panel has
       // data to show instead of sitting at 'idle' for 60-300s. doSync's
@@ -213,20 +235,17 @@ export class SyncOrchestrator {
       const prR = await this.deps.fetchers.pr(ctx)
       const runsR = await this.deps.fetchers.runs(ctx)
 
-      // Peek at the current cache to know if we already have a PR number
-      // (for the reviews follow-up call when the PR fetch is 'unchanged').
-      const peeked = await this.deps.cacheStore.load()
-      const prior: RepoCache = peeked.repos[s.slug] ?? {
-        etags: {},
-        lastSynced: 0,
-        accessedAt: 0,
-      }
-
-      // Determine the PR we'll use for the reviews call. 'ok' and 'unchanged'
-      // both keep a PR; 'empty' clears it.
+      // Determine the PR we'll use for the reviews call. 'ok' and
+      // 'unchanged' both keep a PR; 'empty' clears it. Use the cached
+      // s.lastPRNumber for the 'unchanged' case instead of reading the
+      // whole cache JSON just to grab one integer — update() below runs
+      // its own load inside the mutex anyway.
       let prForReviews: number | undefined
-      if (prR.status === 'ok') prForReviews = (prR.data as { number?: number }).number
-      else if (prR.status === 'unchanged') prForReviews = prior.pr?.number
+      if (prR.status === 'ok') {
+        prForReviews = (prR.data as { number?: number }).number
+      } else if (prR.status === 'unchanged') {
+        prForReviews = s.lastPRNumber
+      }
 
       let revR: FetchResult<unknown[]> | null = null
       if (prForReviews !== undefined) {
@@ -241,12 +260,18 @@ export class SyncOrchestrator {
         }
         if (prR.status === 'ok') {
           existing.pr = mapPR(prR.data)
+          s.lastPRNumber = existing.pr.number
         } else if (prR.status === 'empty') {
           // RepoCache.pr is optional; use undefined (not null) so render
           // code only has one "no PR" sentinel. Reviews are PR-derived so
           // clear them too — otherwise a merged branch keeps stale reviews.
           existing.pr = undefined
           existing.reviews = undefined
+          s.lastPRNumber = undefined
+        } else if (prR.status === 'unchanged' && existing.pr) {
+          // Re-sync the in-memory cache from the cold-start case where
+          // lastPRNumber is undefined but disk has a PR.
+          s.lastPRNumber = existing.pr.number
         }
         // 'unchanged' intentionally leaves existing.pr alone — the point
         // of the 304 path is to preserve what the previous sync loaded.

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -37,7 +37,6 @@ export interface SyncStateEvent {
 export interface SyncOrchestratorDeps {
   cacheStore: CacheStore
   getConfig: () => Promise<GitHubConfig | null>
-  getTokenForSession: (sessionId: string) => Promise<string | null>
   emitData: (p: { slug: string; data: RepoCache }) => void
   emitSyncState: (p: SyncStateEvent) => void
   fetchers: OrchestratorFetchers
@@ -134,6 +133,12 @@ export class SyncOrchestrator {
       delayMs = Math.max(s.rateLimitedUntil - now + 1000, 1000)
     } else {
       const cfg = await this.deps.getConfig()
+      // Re-check after the await: unregisterSession could have run while
+      // getConfig was in flight. If we leaked a setTimeout here the timer
+      // would fire against a stale SessionState and the orchestrator would
+      // keep doing background work for a session that no longer exists.
+      const current = this.sessions.get(id)
+      if (!current || current !== s) return
       const intervalSec = s.focused
         ? cfg?.syncIntervals.activeSessionSec ?? 60
         : cfg?.syncIntervals.backgroundSec ?? 300
@@ -170,8 +175,11 @@ export class SyncOrchestrator {
         existing.pr = mapPR(prR.data)
       } else if (prR.status === 'empty') {
         // RepoCache.pr is optional; use undefined (not null) so render code
-        // only has one "no PR" sentinel to handle.
+        // only has one "no PR" sentinel to handle. Reviews are derived from
+        // the PR — clear them too so stale review state doesn't linger in
+        // the cache/UI after a branch loses its PR (e.g. on merge).
         existing.pr = undefined
+        existing.reviews = undefined
       }
       // 'unchanged' intentionally leaves existing.pr alone — that's the
       // whole point of the 304 path; we preserve what the previous sync

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -40,6 +40,14 @@ export interface SyncOrchestratorDeps {
   emitData: (p: { slug: string; data: RepoCache }) => void
   emitSyncState: (p: SyncStateEvent) => void
   fetchers: OrchestratorFetchers
+  /**
+   * Optional per-session branch refresher. Called immediately before each
+   * sync so a `git checkout` away from the branch registered at session-
+   * setup time doesn't leave the orchestrator polling the stale branch's
+   * PR / runs / reviews. Return `null` to keep the last known value (e.g.
+   * on transient git failure).
+   */
+  getBranch?: (sessionId: string) => Promise<string | null>
 }
 
 export interface RegisterSessionInput {
@@ -84,8 +92,18 @@ export class SyncOrchestrator {
     // the previous timer, which still holds a closure on the old state.
     const prev = this.sessions.get(input.sessionId)
     if (prev?.timer) clearTimeout(prev.timer)
+    const isFirst = !prev
     this.sessions.set(input.sessionId, { ...input, focused: false, lastSync: 0 })
-    void this.scheduleNext(input.sessionId)
+    if (isFirst && !this.paused) {
+      // Kick off an immediate sync on first registration so the panel has
+      // data to show instead of sitting at 'idle' for 60-300s. doSync's
+      // finally chains to scheduleNext which arms the normal interval.
+      void this.doSync(input.sessionId).finally(() =>
+        void this.scheduleNext(input.sessionId),
+      )
+    } else {
+      void this.scheduleNext(input.sessionId)
+    }
   }
 
   unregisterSession(id: string): void {
@@ -166,6 +184,18 @@ export class SyncOrchestrator {
     if (!s) return
 
     this.deps.emitSyncState({ slug: s.slug, state: 'syncing', at: Date.now() })
+
+    // Refresh the branch if the host provided a resolver. Without this,
+    // the orchestrator would keep polling whatever branch was active at
+    // registration time even after the user `git checkout`s elsewhere.
+    if (this.deps.getBranch) {
+      try {
+        const fresh = await this.deps.getBranch(s.sessionId)
+        if (fresh) s.branch = fresh
+      } catch {
+        /* leave s.branch alone on transient failure */
+      }
+    }
 
     const ctx: FetcherContext = {
       sessionId: s.sessionId,

--- a/src/main/github/session/sync-orchestrator.ts
+++ b/src/main/github/session/sync-orchestrator.ts
@@ -103,6 +103,17 @@ export class SyncOrchestrator {
 
   pause(): void {
     this.paused = true
+    // Cancel any in-flight timers. Without this, the last scheduleNext()
+    // already armed a setTimeout that fires even after pause() flips the
+    // flag — doSync then runs because pause is only checked before arming,
+    // not before execution. Clearing here makes "Pause syncs" effective
+    // immediately.
+    this.sessions.forEach((s) => {
+      if (s.timer) {
+        clearTimeout(s.timer)
+        s.timer = undefined
+      }
+    })
   }
 
   resume(): void {
@@ -156,62 +167,85 @@ export class SyncOrchestrator {
 
     this.deps.emitSyncState({ slug: s.slug, state: 'syncing', at: Date.now() })
 
-    const cache = await this.deps.cacheStore.load()
-    const existing: RepoCache = cache.repos[s.slug] ?? {
-      etags: {},
-      lastSynced: 0,
-      accessedAt: 0,
-    }
-
     const ctx: FetcherContext = {
       sessionId: s.sessionId,
       slug: s.slug,
       branch: s.branch,
     }
 
+    // Run the fetches outside the cache mutex — network I/O shouldn't block
+    // other sessions' cache reads — and commit the result atomically via
+    // update(). Prior impl loaded the cache, did all fetches, then saved
+    // the snapshot; two concurrent sessions could both load the same base
+    // and the later save clobbered the earlier session's updates.
+    let emitted: RepoCache | null = null
     try {
       const prR = await this.deps.fetchers.pr(ctx)
-      if (prR.status === 'ok') {
-        existing.pr = mapPR(prR.data)
-      } else if (prR.status === 'empty') {
-        // RepoCache.pr is optional; use undefined (not null) so render code
-        // only has one "no PR" sentinel to handle. Reviews are derived from
-        // the PR — clear them too so stale review state doesn't linger in
-        // the cache/UI after a branch loses its PR (e.g. on merge).
-        existing.pr = undefined
-        existing.reviews = undefined
-      }
-      // 'unchanged' intentionally leaves existing.pr alone — that's the
-      // whole point of the 304 path; we preserve what the previous sync
-      // loaded rather than blanking the card while polling.
-
       const runsR = await this.deps.fetchers.runs(ctx)
-      if (runsR.status === 'ok') {
-        existing.actions = mapRuns(runsR.data)
+
+      // Peek at the current cache to know if we already have a PR number
+      // (for the reviews follow-up call when the PR fetch is 'unchanged').
+      const peeked = await this.deps.cacheStore.load()
+      const prior: RepoCache = peeked.repos[s.slug] ?? {
+        etags: {},
+        lastSynced: 0,
+        accessedAt: 0,
       }
 
-      if (existing.pr) {
-        const revR = await this.deps.fetchers.reviews(ctx, existing.pr.number)
-        if (revR.status === 'ok') {
+      // Determine the PR we'll use for the reviews call. 'ok' and 'unchanged'
+      // both keep a PR; 'empty' clears it.
+      let prForReviews: number | undefined
+      if (prR.status === 'ok') prForReviews = (prR.data as { number?: number }).number
+      else if (prR.status === 'unchanged') prForReviews = prior.pr?.number
+
+      let revR: FetchResult<unknown[]> | null = null
+      if (prForReviews !== undefined) {
+        revR = await this.deps.fetchers.reviews(ctx, prForReviews)
+      }
+
+      await this.deps.cacheStore.update(async (cache) => {
+        const existing: RepoCache = cache.repos[s.slug] ?? {
+          etags: {},
+          lastSynced: 0,
+          accessedAt: 0,
+        }
+        if (prR.status === 'ok') {
+          existing.pr = mapPR(prR.data)
+        } else if (prR.status === 'empty') {
+          // RepoCache.pr is optional; use undefined (not null) so render
+          // code only has one "no PR" sentinel. Reviews are PR-derived so
+          // clear them too — otherwise a merged branch keeps stale reviews.
+          existing.pr = undefined
+          existing.reviews = undefined
+        }
+        // 'unchanged' intentionally leaves existing.pr alone — the point
+        // of the 304 path is to preserve what the previous sync loaded.
+
+        if (runsR.status === 'ok') {
+          existing.actions = mapRuns(runsR.data)
+        }
+
+        if (revR && revR.status === 'ok') {
           existing.reviews = mapReviews(revR.data)
         }
+
+        existing.lastSynced = Date.now()
+        existing.accessedAt = Date.now()
+        cache.repos[s.slug] = existing
+        // True access-order LRU: move the slug to the most-recent end every
+        // access. Previous impl only appended on first use, so hot repos
+        // kept their original position and got evicted as "oldest".
+        const lruIndex = cache.lru.indexOf(s.slug)
+        if (lruIndex !== -1) cache.lru.splice(lruIndex, 1)
+        cache.lru.push(s.slug)
+        emitted = existing
+      })
+
+      if (emitted) {
+        this.deps.emitData({ slug: s.slug, data: emitted })
       }
-
-      existing.lastSynced = Date.now()
-      existing.accessedAt = Date.now()
-      cache.repos[s.slug] = existing
-      // True access-order LRU: move the slug to the most-recent end every
-      // access. Previous impl only appended on first use, so hot repos kept
-      // their original position and were wrongly evicted as "oldest".
-      const lruIndex = cache.lru.indexOf(s.slug)
-      if (lruIndex !== -1) cache.lru.splice(lruIndex, 1)
-      cache.lru.push(s.slug)
-      await this.deps.cacheStore.save(cache)
-
-      this.deps.emitData({ slug: s.slug, data: existing })
       this.deps.emitSyncState({ slug: s.slug, state: 'synced', at: Date.now() })
       s.lastSync = Date.now()
-      // Clear any prior rate-limit deadline — we just succeeded.
       s.rateLimitedUntil = undefined
     } catch (err: unknown) {
       if (isRateLimitError(err)) {

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { IPC } from '../../shared/ipc-channels'
-import type { GitHubConfig, SessionGitHubIntegration } from '../../shared/github-types'
+import type { GitHubConfig, RepoCache, SessionGitHubIntegration } from '../../shared/github-types'
 import type { SavedSession } from '../session-state'
 import { GitHubConfigStore } from '../github/github-config-store'
 import { AuthProfileStore } from '../github/auth/auth-profile-store'
@@ -11,6 +11,18 @@ import { scopesToCapabilities } from '../github/auth/capability-mapper'
 import { detectRepoFromCwd, defaultGitRun } from '../github/session/repo-detector'
 import { readLocalGitState } from '../github/session/local-git-reader'
 import { validateSlug } from '../github/security/slug-validator'
+import { CacheStore } from '../github/cache/cache-store'
+import { EtagCache } from '../github/client/etag-cache'
+import { RateLimitShield } from '../github/client/rate-limit-shield'
+import {
+  fetchPRByBranch,
+  fetchPRReviews,
+  fetchWorkflowRuns,
+} from '../github/client/rest-fallback'
+import {
+  SyncOrchestrator,
+  type SyncStateEvent,
+} from '../github/session/sync-orchestrator'
 import {
   DEFAULT_FEATURE_TOGGLES,
   DEFAULT_SYNC_INTERVALS,
@@ -57,13 +69,79 @@ function emptyConfig(): GitHubConfig {
  * in PR 3. Defining them now keeps the IPC surface complete so the renderer
  * doesn't see missing-channel errors during PR 2 dev.
  */
-export function registerGitHubHandlers(deps: RegisterDeps) {
+export interface GitHubHandlersHandle {
+  orchestrator: SyncOrchestrator
+  resolveSessionIdFromWindow: () => string | null
+  setFocusedSessionResolver: (fn: () => string | null) => void
+}
+
+export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle {
   const configStore = new GitHubConfigStore(deps.resourcesDir)
   const profileStore = new AuthProfileStore({
     readConfig: () => configStore.read(),
     writeConfig: (c) => configStore.write(c),
   })
   const activeFlows = new Map<string, OAuthFlow>()
+
+  // Orchestrator dependencies. The RateLimitShield and EtagCache are shared
+  // across all syncs — the shield tracks per-bucket reset times regardless
+  // of slug, and the etag store is keyed by `METHOD path` which is already
+  // unique per endpoint/slug. Persistence of etags across restarts can come
+  // later; in-memory is fine for a running session.
+  const cacheStore = new CacheStore(deps.resourcesDir)
+  const shield = new RateLimitShield()
+  const etagStore: Record<string, string> = {}
+  const etags = new EtagCache(etagStore)
+
+  let focusedSessionResolver: () => string | null = () => null
+
+  async function getTokenForSession(sessionId: string): Promise<string | null> {
+    const sessions = await deps.loadSessions()
+    const session = sessions.find((s) => s.id === sessionId)
+    const profileId = session?.githubIntegration?.authProfileId
+    if (!profileId) return null
+    return profileStore.getToken(profileId)
+  }
+
+  // tokenFn closes over a specific sessionId — orchestrator's catch turns a
+  // throw into an 'error' sync state, which is the right UX when the user
+  // hasn't selected an auth profile yet for this session.
+  function makeTokenFn(sessionId: string) {
+    return async () => {
+      const t = await getTokenForSession(sessionId)
+      if (!t) throw new Error('no-token')
+      return t
+    }
+  }
+
+  const orchestrator = new SyncOrchestrator({
+    cacheStore,
+    getConfig: () => configStore.read(),
+    getTokenForSession,
+    emitData: (p) => deps.getWindow()?.webContents.send(IPC.GITHUB_DATA_UPDATE, p),
+    emitSyncState: (p: SyncStateEvent) =>
+      deps.getWindow()?.webContents.send(IPC.GITHUB_SYNC_STATE_UPDATE, p),
+    fetchers: {
+      pr: async (ctx) =>
+        fetchPRByBranch(ctx.slug, ctx.branch, {
+          tokenFn: makeTokenFn(ctx.sessionId),
+          shield,
+          etags,
+        }),
+      runs: async (ctx) =>
+        fetchWorkflowRuns(ctx.slug, ctx.branch, {
+          tokenFn: makeTokenFn(ctx.sessionId),
+          shield,
+          etags,
+        }),
+      reviews: async (ctx, prNumber) =>
+        fetchPRReviews(ctx.slug, prNumber, {
+          tokenFn: makeTokenFn(ctx.sessionId),
+          shield,
+          etags,
+        }),
+    },
+  })
 
   ipcMain.handle(IPC.GITHUB_CONFIG_GET, async () => {
     return (await configStore.read()) ?? null
@@ -249,11 +327,23 @@ export function registerGitHubHandlers(deps: RegisterDeps) {
         enabled: false,
         autoDetected: false,
       }
-      sessions[idx] = {
-        ...sessions[idx],
-        githubIntegration: { ...current, ...patch },
-      }
+      const merged: SessionGitHubIntegration = { ...current, ...patch }
+      sessions[idx] = { ...sessions[idx], githubIntegration: merged }
       await deps.saveSessions(sessions)
+      // Register or refresh the orchestrator's view of this session. On
+      // disable/slug-clear, unregister so its timer doesn't keep firing.
+      // registerSession already clears any prior timer for this id, so no
+      // explicit unregister-then-register dance.
+      if (merged.enabled && merged.repoSlug) {
+        orchestrator.registerSession({
+          sessionId,
+          slug: merged.repoSlug,
+          branch: 'main',
+          integration: merged,
+        })
+      } else {
+        orchestrator.unregisterSession(sessionId)
+      }
       return { ok: true }
     },
   )
@@ -263,17 +353,97 @@ export function registerGitHubHandlers(deps: RegisterDeps) {
     return { ok: true, state }
   })
 
-  // Stubs — real implementations land in PR 3 (sync orchestrator + sections).
-  // Defined here so renderer doesn't see missing-channel errors during PR 2.
-  ipcMain.handle(IPC.GITHUB_DATA_GET, async () => ({ ok: true, data: null }))
+  ipcMain.handle(IPC.GITHUB_DATA_GET, async (_e, slug: string) => {
+    const c = await cacheStore.load()
+    const data: RepoCache | null = c.repos[slug] ?? null
+    return { ok: true, data }
+  })
+
+  ipcMain.handle(IPC.GITHUB_SYNC_NOW, async (_e, sessionId: string) => {
+    // Renderer may hit this before the orchestrator saw the session (e.g.
+    // restart before restore completes, or renderer-first enable). Look up
+    // the current integration and auto-register so manual refresh always
+    // works rather than silently no-op'ing.
+    const sessions = await deps.loadSessions()
+    const session = sessions.find((s) => s.id === sessionId)
+    const integration = session?.githubIntegration
+    if (integration?.enabled && integration.repoSlug) {
+      orchestrator.registerSession({
+        sessionId,
+        slug: integration.repoSlug,
+        branch: 'main',
+        integration,
+      })
+    }
+    await orchestrator.syncNow(sessionId)
+    return { ok: true }
+  })
+
+  ipcMain.handle(IPC.GITHUB_SYNC_FOCUSED_NOW, async () => {
+    const id = focusedSessionResolver()
+    if (!id) return { ok: false, error: 'no-focused-session' }
+    await orchestrator.syncNow(id)
+    return { ok: true }
+  })
+
+  // Renderer pushes the active session id on every tab switch. We also use
+  // this value as the focused-session resolver so SYNC_FOCUSED_NOW resolves
+  // correctly without needing a separate session-state round-trip.
+  ipcMain.on(IPC.GITHUB_FOCUS_CHANGED, (_e, sessionId: string | null) => {
+    const prev = focusedSessionResolver()
+    focusedSessionResolver = () => sessionId
+    if (prev && prev !== sessionId) orchestrator.setFocus(prev, false)
+    if (sessionId) orchestrator.setFocus(sessionId, true)
+  })
+
+  ipcMain.handle(IPC.GITHUB_SYNC_PAUSE, async () => {
+    orchestrator.pause()
+    return { ok: true }
+  })
+
+  ipcMain.handle(IPC.GITHUB_SYNC_RESUME, async () => {
+    orchestrator.resume()
+    return { ok: true }
+  })
+
+  // Still stubs — real implementations require section-side machinery
+  // (transcript reader, merge/rerun/reply endpoint wrappers) that land in
+  // PR 3b alongside the populated panel sections.
   ipcMain.handle(IPC.GITHUB_SESSION_CONTEXT_GET, async () => ({ ok: true, data: null }))
-  ipcMain.handle(IPC.GITHUB_SYNC_NOW, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_SYNC_FOCUSED_NOW, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_SYNC_PAUSE, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_SYNC_RESUME, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_ACTIONS_RERUN, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_PR_MERGE, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_PR_READY, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_REVIEW_REPLY, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_NOTIF_MARK_READ, async () => ({ ok: true }))
+
+  // Kick off background registration for any session that already had
+  // integration enabled when the app was closed. Fire-and-forget because
+  // loadSessions hits disk and we don't want to block handler registration.
+  void (async () => {
+    try {
+      const sessions = await deps.loadSessions()
+      for (const s of sessions) {
+        const integ = s.githubIntegration
+        if (integ?.enabled && integ.repoSlug) {
+          orchestrator.registerSession({
+            sessionId: s.id,
+            slug: integ.repoSlug,
+            branch: 'main',
+            integration: integ,
+          })
+        }
+      }
+    } catch {
+      // Best-effort; if session state can't be read the orchestrator stays
+      // empty and syncNow / config-update will register sessions on demand.
+    }
+  })()
+
+  return {
+    orchestrator,
+    resolveSessionIdFromWindow: () => focusedSessionResolver(),
+    setFocusedSessionResolver: (fn) => {
+      focusedSessionResolver = fn
+    },
+  }
 }

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -10,6 +10,18 @@ import { verifyToken, probeRepoAccess } from '../github/auth/pat-verifier'
 import { scopesToCapabilities } from '../github/auth/capability-mapper'
 import { detectRepoFromCwd, defaultGitRun } from '../github/session/repo-detector'
 import { readLocalGitState } from '../github/session/local-git-reader'
+// Small branch-only helper for orchestrator registration. readLocalGitState
+// does too much work (status, stash, log) for this path — but reusing its
+// `run` callable keeps the git invocation consistent.
+async function readCurrentBranch(cwd: string | undefined): Promise<string> {
+  if (!cwd) return 'main'
+  try {
+    const state = await readLocalGitState(cwd, defaultGitRun())
+    return state.branch || 'main'
+  } catch {
+    return 'main'
+  }
+}
 import { validateSlug } from '../github/security/slug-validator'
 import { CacheStore } from '../github/cache/cache-store'
 import { EtagCache } from '../github/client/etag-cache'
@@ -117,7 +129,6 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
   const orchestrator = new SyncOrchestrator({
     cacheStore,
     getConfig: () => configStore.read(),
-    getTokenForSession,
     emitData: (p) => deps.getWindow()?.webContents.send(IPC.GITHUB_DATA_UPDATE, p),
     emitSyncState: (p: SyncStateEvent) =>
       deps.getWindow()?.webContents.send(IPC.GITHUB_SYNC_STATE_UPDATE, p),
@@ -335,12 +346,20 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
       // registerSession already clears any prior timer for this id, so no
       // explicit unregister-then-register dance.
       if (merged.enabled && merged.repoSlug) {
+        const branch = await readCurrentBranch(sessions[idx].workingDirectory)
         orchestrator.registerSession({
           sessionId,
           slug: merged.repoSlug,
-          branch: 'main',
+          branch,
           integration: merged,
         })
+        // If the user had this session focused before enabling integration,
+        // setFocus was a no-op because the session wasn't registered yet.
+        // Replay pending focus now so interval tiering (active vs bg) kicks
+        // in without needing another tab switch.
+        if (focusedSessionResolver() === sessionId) {
+          orchestrator.setFocus(sessionId, true)
+        }
       } else {
         orchestrator.unregisterSession(sessionId)
       }
@@ -368,12 +387,16 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     const session = sessions.find((s) => s.id === sessionId)
     const integration = session?.githubIntegration
     if (integration?.enabled && integration.repoSlug) {
+      const branch = await readCurrentBranch(session?.workingDirectory)
       orchestrator.registerSession({
         sessionId,
         slug: integration.repoSlug,
-        branch: 'main',
+        branch,
         integration,
       })
+      if (focusedSessionResolver() === sessionId) {
+        orchestrator.setFocus(sessionId, true)
+      }
     }
     await orchestrator.syncNow(sessionId)
     return { ok: true }
@@ -425,12 +448,16 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
       for (const s of sessions) {
         const integ = s.githubIntegration
         if (integ?.enabled && integ.repoSlug) {
+          const branch = await readCurrentBranch(s.workingDirectory)
           orchestrator.registerSession({
             sessionId: s.id,
             slug: integ.repoSlug,
-            branch: 'main',
+            branch,
             integration: integ,
           })
+          if (focusedSessionResolver() === s.id) {
+            orchestrator.setFocus(s.id, true)
+          }
         }
       }
     } catch {

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -140,9 +140,20 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
   // Populated at register time alongside the profile id cache.
   const cwdBySession = new Map<string, string>()
 
+  // In-memory config cache. scheduleNext() calls getConfig before every
+  // timer arm — doing a disk-read + JSON parse each time was adding
+  // filesystem I/O proportional to (sessions × tick rate). Invalidated
+  // from the CONFIG_UPDATE handler below on every write.
+  let cachedConfig: GitHubConfig | null | undefined
+  async function getCachedConfig(): Promise<GitHubConfig | null> {
+    if (cachedConfig !== undefined) return cachedConfig
+    cachedConfig = (await configStore.read()) ?? null
+    return cachedConfig
+  }
+
   const orchestrator = new SyncOrchestrator({
     cacheStore,
-    getConfig: () => configStore.read(),
+    getConfig: getCachedConfig,
     emitData: (p) => deps.getWindow()?.webContents.send(IPC.GITHUB_DATA_UPDATE, p),
     emitSyncState: (p: SyncStateEvent) =>
       deps.getWindow()?.webContents.send(IPC.GITHUB_SYNC_STATE_UPDATE, p),
@@ -187,6 +198,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     const cur = (await configStore.read()) ?? emptyConfig()
     const next = { ...cur, ...patch }
     await configStore.write(next)
+    cachedConfig = next
     return next
   })
 

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -10,14 +10,18 @@ import { verifyToken, probeRepoAccess } from '../github/auth/pat-verifier'
 import { scopesToCapabilities } from '../github/auth/capability-mapper'
 import { detectRepoFromCwd, defaultGitRun } from '../github/session/repo-detector'
 import { readLocalGitState } from '../github/session/local-git-reader'
-// Small branch-only helper for orchestrator registration. readLocalGitState
-// does too much work (status, stash, log) for this path — but reusing its
-// `run` callable keeps the git invocation consistent.
+// Lightweight branch-only read for orchestrator registration. readLocalGitState
+// runs status + stash + log + ahead/behind — far more than we need when we
+// only want the current branch. A single `git rev-parse` is ~10x faster and
+// keeps enable/startup paths snappy.
 async function readCurrentBranch(cwd: string | undefined): Promise<string> {
   if (!cwd) return 'main'
   try {
-    const state = await readLocalGitState(cwd, defaultGitRun())
-    return state.branch || 'main'
+    const run = defaultGitRun()
+    const out = (await run(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+    // Detached HEAD returns 'HEAD' — treat as 'main' so sync still targets
+    // a sensible default rather than a non-branch name.
+    return out && out !== 'HEAD' ? out : 'main'
   } catch {
     return 'main'
   }
@@ -76,10 +80,10 @@ function emptyConfig(): GitHubConfig {
  * the glue between renderer calls and the main-process modules in
  * src/main/github/**.
  *
- * Data-path handlers (GITHUB_DATA_GET, GITHUB_SYNC_*, GITHUB_SESSION_CONTEXT_GET,
- * etc.) are intentional stubs here — they're wired to the sync orchestrator
- * in PR 3. Defining them now keeps the IPC surface complete so the renderer
- * doesn't see missing-channel errors during PR 2 dev.
+ * Data-path handlers (GITHUB_DATA_GET, GITHUB_SYNC_*) now drive a live
+ * SyncOrchestrator. The remaining stubs (SESSION_CONTEXT_GET, PR_MERGE,
+ * ACTIONS_RERUN, REVIEW_REPLY, NOTIF_MARK_READ) depend on section-side
+ * machinery that lands in PR 3b alongside the populated panel sections.
  */
 export interface GitHubHandlersHandle {
   orchestrator: SyncOrchestrator
@@ -107,10 +111,15 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
 
   let focusedSessionResolver: () => string | null = () => null
 
+  // Authored-profile-id by sessionId. Populated at register-time (from
+  // SavedSession) so fetchers don't need to re-read session-state.json on
+  // every request. Previously the fetcher path did a full disk load for
+  // every GitHub API call — at 3 requests per session per sync, that was
+  // 3N reads per cycle.
+  const profileIdBySession = new Map<string, string>()
+
   async function getTokenForSession(sessionId: string): Promise<string | null> {
-    const sessions = await deps.loadSessions()
-    const session = sessions.find((s) => s.id === sessionId)
-    const profileId = session?.githubIntegration?.authProfileId
+    const profileId = profileIdBySession.get(sessionId)
     if (!profileId) return null
     return profileStore.getToken(profileId)
   }
@@ -347,6 +356,8 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
       // explicit unregister-then-register dance.
       if (merged.enabled && merged.repoSlug) {
         const branch = await readCurrentBranch(sessions[idx].workingDirectory)
+        if (merged.authProfileId) profileIdBySession.set(sessionId, merged.authProfileId)
+        else profileIdBySession.delete(sessionId)
         orchestrator.registerSession({
           sessionId,
           slug: merged.repoSlug,
@@ -361,6 +372,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
           orchestrator.setFocus(sessionId, true)
         }
       } else {
+        profileIdBySession.delete(sessionId)
         orchestrator.unregisterSession(sessionId)
       }
       return { ok: true }
@@ -388,6 +400,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     const integration = session?.githubIntegration
     if (integration?.enabled && integration.repoSlug) {
       const branch = await readCurrentBranch(session?.workingDirectory)
+      if (integration.authProfileId) profileIdBySession.set(sessionId, integration.authProfileId)
       orchestrator.registerSession({
         sessionId,
         slug: integration.repoSlug,
@@ -449,6 +462,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
         const integ = s.githubIntegration
         if (integ?.enabled && integ.repoSlug) {
           const branch = await readCurrentBranch(s.workingDirectory)
+          if (integ.authProfileId) profileIdBySession.set(s.id, integ.authProfileId)
           orchestrator.registerSession({
             sessionId: s.id,
             slug: integ.repoSlug,

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -10,22 +10,6 @@ import { verifyToken, probeRepoAccess } from '../github/auth/pat-verifier'
 import { scopesToCapabilities } from '../github/auth/capability-mapper'
 import { detectRepoFromCwd, defaultGitRun } from '../github/session/repo-detector'
 import { readLocalGitState } from '../github/session/local-git-reader'
-// Lightweight branch-only read for orchestrator registration. readLocalGitState
-// runs status + stash + log + ahead/behind — far more than we need when we
-// only want the current branch. A single `git rev-parse` is ~10x faster and
-// keeps enable/startup paths snappy.
-async function readCurrentBranch(cwd: string | undefined): Promise<string> {
-  if (!cwd) return 'main'
-  try {
-    const run = defaultGitRun()
-    const out = (await run(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
-    // Detached HEAD returns 'HEAD' — treat as 'main' so sync still targets
-    // a sensible default rather than a non-branch name.
-    return out && out !== 'HEAD' ? out : 'main'
-  } catch {
-    return 'main'
-  }
-}
 import { validateSlug } from '../github/security/slug-validator'
 import { CacheStore } from '../github/cache/cache-store'
 import { EtagCache } from '../github/client/etag-cache'
@@ -62,6 +46,23 @@ interface OAuthFlow {
   intervalSec: number
   scope: string
   cancelled: boolean
+}
+
+// Lightweight branch-only read for orchestrator registration. readLocalGitState
+// runs status + stash + log + ahead/behind — far more than we need when we
+// only want the current branch. A single `git rev-parse` is ~10x faster and
+// keeps enable / startup / sync-now paths snappy.
+async function readCurrentBranch(cwd: string | undefined): Promise<string> {
+  if (!cwd) return 'main'
+  try {
+    const run = defaultGitRun()
+    const out = (await run(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+    // Detached HEAD returns literal 'HEAD' — fall back to 'main' rather
+    // than passing a non-branch name to the sync fetchers.
+    return out && out !== 'HEAD' ? out : 'main'
+  } catch {
+    return 'main'
+  }
 }
 
 function emptyConfig(): GitHubConfig {
@@ -135,12 +136,27 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     }
   }
 
+  // Cache session cwds so getBranch doesn't hit disk on every sync tick.
+  // Populated at register time alongside the profile id cache.
+  const cwdBySession = new Map<string, string>()
+
   const orchestrator = new SyncOrchestrator({
     cacheStore,
     getConfig: () => configStore.read(),
     emitData: (p) => deps.getWindow()?.webContents.send(IPC.GITHUB_DATA_UPDATE, p),
     emitSyncState: (p: SyncStateEvent) =>
       deps.getWindow()?.webContents.send(IPC.GITHUB_SYNC_STATE_UPDATE, p),
+    getBranch: async (sessionId) => {
+      const cwd = cwdBySession.get(sessionId)
+      if (!cwd) return null
+      try {
+        const run = defaultGitRun()
+        const out = (await run(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
+        return out && out !== 'HEAD' ? out : null
+      } catch {
+        return null
+      }
+    },
     fetchers: {
       pr: async (ctx) =>
         fetchPRByBranch(ctx.slug, ctx.branch, {
@@ -358,6 +374,9 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
         const branch = await readCurrentBranch(sessions[idx].workingDirectory)
         if (merged.authProfileId) profileIdBySession.set(sessionId, merged.authProfileId)
         else profileIdBySession.delete(sessionId)
+        if (sessions[idx].workingDirectory) {
+          cwdBySession.set(sessionId, sessions[idx].workingDirectory)
+        }
         orchestrator.registerSession({
           sessionId,
           slug: merged.repoSlug,
@@ -373,6 +392,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
         }
       } else {
         profileIdBySession.delete(sessionId)
+        cwdBySession.delete(sessionId)
         orchestrator.unregisterSession(sessionId)
       }
       return { ok: true }
@@ -401,6 +421,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     if (integration?.enabled && integration.repoSlug) {
       const branch = await readCurrentBranch(session?.workingDirectory)
       if (integration.authProfileId) profileIdBySession.set(sessionId, integration.authProfileId)
+      if (session?.workingDirectory) cwdBySession.set(sessionId, session.workingDirectory)
       orchestrator.registerSession({
         sessionId,
         slug: integration.repoSlug,
@@ -418,6 +439,25 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
   ipcMain.handle(IPC.GITHUB_SYNC_FOCUSED_NOW, async () => {
     const id = focusedSessionResolver()
     if (!id) return { ok: false, error: 'no-focused-session' }
+    // Mirror SYNC_NOW: auto-register if the session has integration but
+    // isn't tracked yet. Without this, the Settings > Sync button would
+    // silently no-op when the focused session hadn't been sync-ed yet.
+    const sessions = await deps.loadSessions()
+    const session = sessions.find((s) => s.id === id)
+    const integration = session?.githubIntegration
+    if (!integration?.enabled || !integration.repoSlug) {
+      return { ok: false, error: 'not-enabled' }
+    }
+    const branch = await readCurrentBranch(session?.workingDirectory)
+    if (integration.authProfileId) profileIdBySession.set(id, integration.authProfileId)
+    if (session?.workingDirectory) cwdBySession.set(id, session.workingDirectory)
+    orchestrator.registerSession({
+      sessionId: id,
+      slug: integration.repoSlug,
+      branch,
+      integration,
+    })
+    orchestrator.setFocus(id, true)
     await orchestrator.syncNow(id)
     return { ok: true }
   })
@@ -463,6 +503,7 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
         if (integ?.enabled && integ.repoSlug) {
           const branch = await readCurrentBranch(s.workingDirectory)
           if (integ.authProfileId) profileIdBySession.set(s.id, integ.authProfileId)
+          if (s.workingDirectory) cwdBySession.set(s.id, s.workingDirectory)
           orchestrator.registerSession({
             sessionId: s.id,
             slug: integ.repoSlug,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -178,6 +178,7 @@ interface GitHubBridge {
   syncFocusedNow: () => Promise<{ ok: boolean }>
   syncPause: () => Promise<{ ok: boolean }>
   syncResume: () => Promise<{ ok: boolean }>
+  notifyFocusChanged: (sessionId: string | null) => void
   getData: (slug: string) => Promise<{ ok: boolean; data: unknown }>
   getSessionContext: (sessionId: string) => Promise<{ ok: boolean; data: unknown }>
   onDataUpdate: (cb: (p: { slug: string; data: unknown }) => void) => () => void
@@ -486,6 +487,8 @@ const electronAPI: ElectronAPI = {
     getLocalGit: (cwd) => ipcRenderer.invoke(IPC.GITHUB_LOCALGIT_GET, cwd),
     syncNow: (sessionId) => ipcRenderer.invoke(IPC.GITHUB_SYNC_NOW, sessionId),
     syncFocusedNow: () => ipcRenderer.invoke(IPC.GITHUB_SYNC_FOCUSED_NOW),
+    notifyFocusChanged: (sessionId: string | null) =>
+      ipcRenderer.send(IPC.GITHUB_FOCUS_CHANGED, sessionId),
     syncPause: () => ipcRenderer.invoke(IPC.GITHUB_SYNC_PAUSE),
     syncResume: () => ipcRenderer.invoke(IPC.GITHUB_SYNC_RESUME),
     getData: (slug) => ipcRenderer.invoke(IPC.GITHUB_DATA_GET, slug),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -84,6 +84,13 @@ export default function App() {
   const activeSession = sessions.find((s) => s.id === activeSessionId)
   const hasRestoredRef = useRef(false)
 
+  // Push focus changes to main so the sync orchestrator can shift the
+  // active session to the fast interval and the background ones to the
+  // slow interval. ipcRenderer.send, not invoke — fire-and-forget.
+  useEffect(() => {
+    window.electronAPI.github.notifyFocusChanged(activeSessionId ?? null)
+  }, [activeSessionId])
+
   // Global keyboard shortcuts
   useKeyboardShortcuts(activeSessionId, setSidebarOpen, setView)
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,7 +82,11 @@ export default function App() {
   const activeSessionId = useSessionStore((s) => s.activeSessionId)
   const sessions = useSessionStore((s) => s.sessions)
   const activeSession = sessions.find((s) => s.id === activeSessionId)
-  const githubPanelEnabled = useGitHubStore((s) => s.config?.enabledByDefault ?? false)
+  // Panel shows only when the active session has opted in. Global
+  // `enabledByDefault` is the default applied to new sessions at creation,
+  // not a runtime gate — per-session `enabled` lets users keep the panel off
+  // for sessions that don't need it (e.g. experimental terminals).
+  const githubPanelEnabled = activeSession?.githubIntegration?.enabled ?? false
   const hasRestoredRef = useRef(false)
 
   // Global keyboard shortcuts
@@ -255,6 +259,7 @@ export default function App() {
         } : undefined,
         legacyVersion: s.legacyVersion,
         agentIds: s.agentIds,
+        githubIntegration: s.githubIntegration,
       })),
       activeSessionId: state.activeSessionId,
       savedAt: Date.now(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,11 +82,6 @@ export default function App() {
   const activeSessionId = useSessionStore((s) => s.activeSessionId)
   const sessions = useSessionStore((s) => s.sessions)
   const activeSession = sessions.find((s) => s.id === activeSessionId)
-  // Panel shows only when the active session has opted in. Global
-  // `enabledByDefault` is the default applied to new sessions at creation,
-  // not a runtime gate — per-session `enabled` lets users keep the panel off
-  // for sessions that don't need it (e.g. experimental terminals).
-  const githubPanelEnabled = activeSession?.githubIntegration?.enabled ?? false
   const hasRestoredRef = useRef(false)
 
   // Global keyboard shortcuts
@@ -426,9 +421,7 @@ export default function App() {
               )
             })}
           </div>
-          {githubPanelEnabled && activeSession && (
-            <GitHubPanel sessionId={activeSession.id} />
-          )}
+          {activeSession && <GitHubPanel sessionId={activeSession.id} />}
         </div>
       </div>
     )

--- a/src/renderer/components/github/GitHubPanel.tsx
+++ b/src/renderer/components/github/GitHubPanel.tsx
@@ -52,6 +52,16 @@ export default function GitHubPanel({
     if (integrationEnabled && showSetup) setShowSetup(false)
   }, [integrationEnabled, showSetup])
 
+  // Reset the setup modal when the active session changes. App.tsx mounts a
+  // single <GitHubPanel> instance and only swaps the sessionId prop, so
+  // component state survives tab switches — without this, opening setup for
+  // session A and then switching to session B would leave the modal open
+  // but targeting B's sessionId / cwd. Clearing on id change keeps the
+  // modal strictly scoped to an explicit click.
+  useEffect(() => {
+    setShowSetup(false)
+  }, [sessionId])
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const isMac = window.electronPlatform === 'darwin'

--- a/src/renderer/components/github/GitHubPanel.tsx
+++ b/src/renderer/components/github/GitHubPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { useGitHubStore } from '../../stores/githubStore'
+import { useSessionStore } from '../../stores/sessionStore'
 import PanelHeader from './PanelHeader'
 import SessionContextSection from './sections/SessionContextSection'
 import ActivePRSection from './sections/ActivePRSection'
@@ -10,6 +11,7 @@ import IssuesSection from './sections/IssuesSection'
 import LocalGitSection from './sections/LocalGitSection'
 import NotificationsSection from './sections/NotificationsSection'
 import AgentIntentSection from './sections/AgentIntentSection'
+import SessionGitHubConfig from '../session/SessionGitHubConfig'
 
 interface Props {
   sessionId: string
@@ -33,6 +35,9 @@ export default function GitHubPanel({
   const sessionState = useGitHubStore((s) => s.sessionStates[sessionId])
   const setPanelWidth = useGitHubStore((s) => s.setPanelWidth)
   const sync = useGitHubStore((s) => (slug ? s.syncStatus[slug] : undefined))
+  const session = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId))
+  const integrationEnabled = session?.githubIntegration?.enabled ?? false
+  const [showSetup, setShowSetup] = useState(false)
   const width = sessionState?.panelWidth ?? 340
 
   useEffect(() => {
@@ -74,6 +79,47 @@ export default function GitHubPanel({
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     dragCleanupRef.current = cleanup
+  }
+
+  // Integration-not-enabled: render the rail only, with "Configure" click.
+  // The rail still answers Ctrl+/ but there's nothing to show until the user
+  // opts this session in via the setup modal.
+  if (!integrationEnabled) {
+    return (
+      <>
+        <aside
+          className="w-7 bg-mantle border-l border-surface0 flex flex-col items-center py-3"
+          aria-label="GitHub panel (integration not configured)"
+        >
+          <button
+            onClick={() => setShowSetup(true)}
+            title="Configure GitHub integration for this session"
+            className="text-subtext0 text-xs hover:text-text"
+          >
+            GH
+          </button>
+        </aside>
+        {showSetup && (
+          <div
+            className="fixed inset-0 bg-base/80 z-50 flex items-center justify-center"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="bg-mantle p-6 rounded max-w-md w-full">
+              <h3 className="text-lg mb-3 text-text">Configure GitHub for this session</h3>
+              <SessionGitHubConfig
+                sessionId={sessionId}
+                cwd={session?.workingDirectory ?? ''}
+                initial={session?.githubIntegration}
+              />
+              <button onClick={() => setShowSetup(false)} className="mt-4 text-xs text-subtext0">
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </>
+    )
   }
 
   if (!visible) {

--- a/src/renderer/components/github/GitHubPanel.tsx
+++ b/src/renderer/components/github/GitHubPanel.tsx
@@ -34,11 +34,23 @@ export default function GitHubPanel({
   const togglePanel = useGitHubStore((s) => s.togglePanel)
   const sessionState = useGitHubStore((s) => s.sessionStates[sessionId])
   const setPanelWidth = useGitHubStore((s) => s.setPanelWidth)
-  const sync = useGitHubStore((s) => (slug ? s.syncStatus[slug] : undefined))
   const session = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId))
   const integrationEnabled = session?.githubIntegration?.enabled ?? false
+  // Derive the slug from the session's integration; `slug` prop is kept for
+  // tests / future external drivers but isn't wired from App.tsx anymore.
+  // Without this fall-through the panel header would be stuck at 'idle'
+  // because syncStatus is keyed by slug.
+  const repoSlug = slug ?? session?.githubIntegration?.repoSlug
+  const sync = useGitHubStore((s) => (repoSlug ? s.syncStatus[repoSlug] : undefined))
   const [showSetup, setShowSetup] = useState(false)
   const width = sessionState?.panelWidth ?? 340
+
+  // Auto-close the setup modal once the user saves + integration flips on.
+  // Without this, disabling integration later would re-enter the rail
+  // branch with `showSetup` still true and spontaneously pop the modal.
+  useEffect(() => {
+    if (integrationEnabled && showSetup) setShowSetup(false)
+  }, [integrationEnabled, showSetup])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -93,6 +105,7 @@ export default function GitHubPanel({
         >
           <button
             onClick={() => setShowSetup(true)}
+            aria-label="Configure GitHub integration for this session"
             title="Configure GitHub integration for this session"
             className="text-subtext0 text-xs hover:text-text"
           >
@@ -104,9 +117,12 @@ export default function GitHubPanel({
             className="fixed inset-0 bg-base/80 z-50 flex items-center justify-center"
             role="dialog"
             aria-modal="true"
+            aria-labelledby="gh-setup-title"
           >
             <div className="bg-mantle p-6 rounded max-w-md w-full">
-              <h3 className="text-lg mb-3 text-text">Configure GitHub for this session</h3>
+              <h3 id="gh-setup-title" className="text-lg mb-3 text-text">
+                Configure GitHub for this session
+              </h3>
               <SessionGitHubConfig
                 sessionId={sessionId}
                 cwd={session?.workingDirectory ?? ''}
@@ -161,6 +177,8 @@ export default function GitHubPanel({
         syncedAt={sync?.at}
         nextResetAt={sync?.nextResetAt}
         onRefresh={() => void window.electronAPI.github.syncNow(sessionId)}
+        // branch / ahead / behind / dirty still come from props; PR 3b wires
+        // them to a local-git poller so the header reflects live state.
       />
       <div className="flex-1 overflow-y-auto" aria-live="polite">
         <SessionContextSection sessionId={sessionId} />

--- a/src/renderer/components/session/SessionGitHubConfig.tsx
+++ b/src/renderer/components/session/SessionGitHubConfig.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useGitHubStore } from '../../stores/githubStore'
+import { useSessionStore } from '../../stores/sessionStore'
 import { parseRepoUrlClient } from './parseRepoUrlClient'
 import type { SessionGitHubIntegration } from '../../../shared/github-types'
 
@@ -12,6 +13,7 @@ interface Props {
 export default function SessionGitHubConfig({ sessionId, cwd, initial }: Props) {
   const config = useGitHubStore((s) => s.config)
   const profiles = useGitHubStore((s) => s.profiles)
+  const updateSession = useSessionStore((s) => s.updateSession)
   const [enabled, setEnabled] = useState(initial?.enabled ?? config?.enabledByDefault ?? false)
   const [userTouchedEnabled, setUserTouchedEnabled] = useState(false)
   const [repoUrl, setRepoUrl] = useState(initial?.repoUrl ?? '')
@@ -59,6 +61,18 @@ export default function SessionGitHubConfig({ sessionId, cwd, initial }: Props) 
     }
     const r = await window.electronAPI.github.updateSessionConfig(sessionId, patch)
     setSaving(false)
+    if (r.ok) {
+      // Mirror the patch into the renderer session store so the GitHub panel's
+      // enable-gate reacts immediately — otherwise the change only shows up on
+      // the next app restart when SavedSession rehydrates.
+      const prior = useSessionStore.getState().getSession(sessionId)
+      updateSession(sessionId, {
+        githubIntegration: {
+          ...(prior?.githubIntegration ?? { enabled: false, autoDetected: false }),
+          ...patch,
+        },
+      })
+    }
     setTestResult(r.ok ? 'Saved' : `Error: ${r.error ?? 'unknown'}`)
     setTimeout(() => setTestResult(null), 2000)
   }

--- a/src/renderer/components/session/SessionGitHubConfig.tsx
+++ b/src/renderer/components/session/SessionGitHubConfig.tsx
@@ -51,6 +51,15 @@ export default function SessionGitHubConfig({ sessionId, cwd, initial }: Props) 
   const slug = parseRepoUrlClient(repoUrl)
 
   const save = async () => {
+    // Prevent save when integration is toggled on with no valid repo. The
+    // panel gate would flip true but sync registration requires a repoSlug,
+    // so the user would silently get a panel with no sync. Block it here
+    // with a visible error instead.
+    if (enabled && !slug) {
+      setTestResult('A repo URL is required to enable integration')
+      setTimeout(() => setTestResult(null), 2500)
+      return
+    }
     setSaving(true)
     const patch: Partial<SessionGitHubIntegration> = {
       enabled,
@@ -150,7 +159,7 @@ export default function SessionGitHubConfig({ sessionId, cwd, initial }: Props) 
       <div className="flex gap-2">
         <button
           onClick={save}
-          disabled={saving || (!!repoUrl && !slug)}
+          disabled={saving || (!!repoUrl && !slug) || (enabled && !slug)}
           className="bg-blue text-base px-3 py-1 rounded text-sm"
         >
           {saving ? 'Saving' : 'Save'}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -60,6 +60,10 @@ export interface Session {
   effortLevel?: 'low' | 'medium' | 'high'
   disableAutoMemory?: boolean
   machineName?: string
+  // Optional per-session GitHub integration state. Hydrated from SavedSession
+  // on restore so the panel can gate on the per-session `enabled` flag instead
+  // of the global `enabledByDefault`. Shape lives in shared/github-types.ts.
+  githubIntegration?: import('../../shared/github-types').SessionGitHubIntegration
 }
 
 interface SessionState {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -352,6 +352,7 @@ export interface ElectronAPI {
     syncFocusedNow: () => Promise<{ ok: boolean }>
     syncPause: () => Promise<{ ok: boolean }>
     syncResume: () => Promise<{ ok: boolean }>
+    notifyFocusChanged: (sessionId: string | null) => void
     getData: (
       slug: string,
     ) => Promise<{

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -209,6 +209,7 @@ export const IPC = {
   GITHUB_LOCALGIT_GET: 'github:localgit:get',
   GITHUB_SYNC_NOW: 'github:sync:now',
   GITHUB_SYNC_FOCUSED_NOW: 'github:sync:focused:now',
+  GITHUB_FOCUS_CHANGED: 'github:focus:changed',
   GITHUB_SYNC_PAUSE: 'github:sync:pause',
   GITHUB_SYNC_RESUME: 'github:sync:resume',
   GITHUB_DATA_GET: 'github:data:get',

--- a/tests/unit/github/ssh-repo-detector.test.ts
+++ b/tests/unit/github/ssh-repo-detector.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  detectRepoFromSshSession,
+  posixShellEscape,
+} from '../../../src/main/github/session/ssh-repo-detector'
+
+describe('posixShellEscape', () => {
+  it('wraps plain paths in single quotes', () => {
+    expect(posixShellEscape('/home/x/repo')).toBe(`'/home/x/repo'`)
+  })
+  it('escapes embedded single quotes', () => {
+    expect(posixShellEscape(`it's`)).toBe(`'it'\\''s'`)
+  })
+  it('neutralizes command substitution', () => {
+    // Single quotes disable $() expansion — the payload becomes a literal
+    // path string to git, never a shell command.
+    expect(posixShellEscape(`$(rm -rf ~)`)).toBe(`'$(rm -rf ~)'`)
+  })
+})
+
+describe('detectRepoFromSshSession', () => {
+  it('parses URL from between sentinels', async () => {
+    const send = vi.fn().mockResolvedValue(
+      [
+        'some terminal noise',
+        '__CC_GIT_START__',
+        'https://github.com/a/b.git',
+        '__CC_GIT_END__',
+        'more noise',
+      ].join('\n'),
+    )
+    expect(await detectRepoFromSshSession('sid', '/home/x', send)).toBe('a/b')
+  })
+
+  it('returns null when sentinel missing', async () => {
+    const send = vi.fn().mockResolvedValue('no sentinels here')
+    expect(await detectRepoFromSshSession('sid', '/x', send)).toBeNull()
+  })
+
+  it('returns null on sendOneShot rejection', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('timeout'))
+    expect(await detectRepoFromSshSession('sid', '/x', send)).toBeNull()
+  })
+
+  it('returns null when between-sentinels text is not a github url', async () => {
+    const send = vi.fn().mockResolvedValue(
+      ['__CC_GIT_START__', 'https://gitlab.com/a/b.git', '__CC_GIT_END__'].join('\n'),
+    )
+    expect(await detectRepoFromSshSession('sid', '/x', send)).toBeNull()
+  })
+
+  it('hands sendOneShot a single escaped interpolation of cwd', async () => {
+    const send = vi.fn().mockResolvedValue('__CC_GIT_START__\n\n__CC_GIT_END__')
+    await detectRepoFromSshSession('sid', `/home/x; rm -rf ~`, send)
+    const cmd = send.mock.calls[0][1] as string
+    // cwd must be single-quote wrapped so the rogue semicolon can't escape
+    // the git argument list and execute as a separate shell command.
+    expect(cmd).toContain(`'/home/x; rm -rf ~'`)
+    expect(cmd).toMatch(/^echo __CC_GIT_START__; git -C '[^']*' remote get-url origin/)
+  })
+})

--- a/tests/unit/github/sync-orchestrator.test.ts
+++ b/tests/unit/github/sync-orchestrator.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { SyncOrchestrator } from '../../../src/main/github/session/sync-orchestrator'
+import type { SyncStateEvent } from '../../../src/main/github/session/sync-orchestrator'
+import { CacheStore } from '../../../src/main/github/cache/cache-store'
+
+async function flushMicrotasks() {
+  await new Promise((r) => setImmediate(r))
+  await new Promise((r) => setImmediate(r))
+}
+
+describe('SyncOrchestrator', () => {
+  let tmp: string
+  let cacheStore: CacheStore
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gho-'))
+    cacheStore = new CacheStore(tmp)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true })
+  })
+
+  it('emits synced state on success', async () => {
+    const states: SyncStateEvent[] = []
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => 'gho_x',
+      emitData: () => {},
+      emitSyncState: (p) => states.push(p),
+      fetchers: {
+        pr: async () => ({
+          status: 'ok',
+          data: {
+            number: 1,
+            title: 't',
+            state: 'open',
+            draft: false,
+            user: { login: 'x' },
+            created_at: '2026-01-01',
+            updated_at: '2026-01-01',
+            mergeable: true,
+            html_url: 'https://github.com/a/b/pull/1',
+          },
+        }),
+        runs: async () => ({ status: 'ok', data: [] }),
+        reviews: async () => ({ status: 'ok', data: [] }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'main',
+      integration: { enabled: true, autoDetected: false },
+    })
+    await orch.syncNow('s1')
+    expect(states.some((s) => s.state === 'synced')).toBe(true)
+    orch.unregisterSession('s1')
+  })
+
+  it('preserves cached PR on "unchanged" (304 path)', async () => {
+    const cache = await cacheStore.load()
+    cache.repos['a/b'] = {
+      etags: {},
+      lastSynced: 100,
+      accessedAt: 100,
+      pr: {
+        number: 99,
+        title: 'cached',
+        state: 'open',
+        draft: false,
+        author: 'x',
+        createdAt: 0,
+        updatedAt: 0,
+        mergeableState: 'clean',
+        url: 'u',
+      },
+    }
+    cache.lru.push('a/b')
+    await cacheStore.save(cache)
+
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => 'gho_x',
+      emitData: () => {},
+      emitSyncState: () => {},
+      fetchers: {
+        pr: async () => ({ status: 'unchanged' }),
+        runs: async () => ({ status: 'unchanged' }),
+        reviews: async () => ({ status: 'unchanged' }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'x',
+      integration: { enabled: true, autoDetected: false },
+    })
+    await orch.syncNow('s1')
+    const after = await cacheStore.load()
+    expect(after.repos['a/b'].pr?.number).toBe(99)
+    orch.unregisterSession('s1')
+  })
+
+  it('blanks PR on "empty" (no PR for branch)', async () => {
+    const cache = await cacheStore.load()
+    cache.repos['a/b'] = {
+      etags: {},
+      lastSynced: 100,
+      accessedAt: 100,
+      pr: {
+        number: 99,
+        title: 'cached',
+        state: 'open',
+        draft: false,
+        author: 'x',
+        createdAt: 0,
+        updatedAt: 0,
+        mergeableState: 'clean',
+        url: 'u',
+      },
+    }
+    cache.lru.push('a/b')
+    await cacheStore.save(cache)
+
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => null,
+      emitData: () => {},
+      emitSyncState: () => {},
+      fetchers: {
+        pr: async () => ({ status: 'empty' }),
+        runs: async () => ({ status: 'ok', data: [] }),
+        reviews: async () => ({ status: 'ok', data: [] }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'x',
+      integration: { enabled: true, autoDetected: false },
+    })
+    await orch.syncNow('s1')
+    const after = await cacheStore.load()
+    expect(after.repos['a/b'].pr).toBeUndefined()
+    orch.unregisterSession('s1')
+  })
+
+  it('emits rate-limited with nextResetAt from RateLimitError', async () => {
+    const states: SyncStateEvent[] = []
+    const resetAt = Date.now() + 3_000
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => 'gho_x',
+      emitData: () => {},
+      emitSyncState: (p) => states.push(p),
+      fetchers: {
+        pr: async () => {
+          const e = new Error('rate limited') as Error & { resetAt: number }
+          e.name = 'RateLimitError'
+          e.resetAt = resetAt
+          throw e
+        },
+        runs: async () => ({ status: 'ok', data: [] }),
+        reviews: async () => ({ status: 'ok', data: [] }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'x',
+      integration: { enabled: true, autoDetected: false },
+    })
+    await orch.syncNow('s1')
+    expect(states.some((s) => s.state === 'rate-limited' && s.nextResetAt === resetAt)).toBe(true)
+    orch.unregisterSession('s1')
+  })
+
+  it('pause blocks new scheduling; resume rearms it', async () => {
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => null,
+      emitData: () => {},
+      emitSyncState: () => {},
+      fetchers: {
+        pr: async () => ({ status: 'empty' }),
+        runs: async () => ({ status: 'ok', data: [] }),
+        reviews: async () => ({ status: 'ok', data: [] }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'x',
+      integration: { enabled: true, autoDetected: false },
+    })
+    orch.pause()
+    expect(orch.isPaused()).toBe(true)
+    orch.resume()
+    expect(orch.isPaused()).toBe(false)
+    orch.unregisterSession('s1')
+  })
+
+  it('LRU moves a slug to the most-recent end on every sync', async () => {
+    const cache = await cacheStore.load()
+    cache.repos['other/repo'] = { etags: {}, lastSynced: 0, accessedAt: 0 }
+    cache.lru.push('other/repo', 'a/b', 'stale/repo')
+    cache.repos['a/b'] = { etags: {}, lastSynced: 0, accessedAt: 0 }
+    cache.repos['stale/repo'] = { etags: {}, lastSynced: 0, accessedAt: 0 }
+    await cacheStore.save(cache)
+
+    const orch = new SyncOrchestrator({
+      cacheStore,
+      getConfig: async () => null,
+      getTokenForSession: async () => null,
+      emitData: () => {},
+      emitSyncState: () => {},
+      fetchers: {
+        pr: async () => ({ status: 'empty' }),
+        runs: async () => ({ status: 'ok', data: [] }),
+        reviews: async () => ({ status: 'ok', data: [] }),
+      },
+    })
+    orch.registerSession({
+      sessionId: 's1',
+      slug: 'a/b',
+      branch: 'x',
+      integration: { enabled: true, autoDetected: false },
+    })
+    await orch.syncNow('s1')
+    await flushMicrotasks()
+    const after = await cacheStore.load()
+    expect(after.lru[after.lru.length - 1]).toBe('a/b')
+    orch.unregisterSession('s1')
+  })
+})

--- a/tests/unit/github/sync-orchestrator.test.ts
+++ b/tests/unit/github/sync-orchestrator.test.ts
@@ -29,7 +29,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => 'gho_x',
       emitData: () => {},
       emitSyncState: (p) => states.push(p),
       fetchers: {
@@ -86,7 +85,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => 'gho_x',
       emitData: () => {},
       emitSyncState: () => {},
       fetchers: {
@@ -131,7 +129,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => null,
       emitData: () => {},
       emitSyncState: () => {},
       fetchers: {
@@ -158,7 +155,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => 'gho_x',
       emitData: () => {},
       emitSyncState: (p) => states.push(p),
       fetchers: {
@@ -187,7 +183,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => null,
       emitData: () => {},
       emitSyncState: () => {},
       fetchers: {
@@ -220,7 +215,6 @@ describe('SyncOrchestrator', () => {
     const orch = new SyncOrchestrator({
       cacheStore,
       getConfig: async () => null,
-      getTokenForSession: async () => null,
       emitData: () => {},
       emitSyncState: () => {},
       fetchers: {


### PR DESCRIPTION
## Summary

Second slice of the GitHub sidebar rollout. PR 2 landed the UI; this
wires the backend sync loop and replaces the global \`enabledByDefault\`
panel gate with per-session opt-in.

- \`Session.githubIntegration\` carried into the renderer store and
  hydrated from \`SavedSession\` on restore; panel gate switched from
  \`config.enabledByDefault\` to \`session.githubIntegration?.enabled\`.
- \`GitHubPanel\` always mounts next to the terminal. If the session
  hasn't opted in, it renders a 28px rail whose 'GH' chip opens a
  setup modal containing \`SessionGitHubConfig\`. Replaces the
  previously-deferred SessionDialog integration (dialog is
  batch-on-confirm over TerminalConfig; the component needs a live
  session id and persists immediately, so the lifecycles never matched).
- \`ssh-repo-detector.ts\` + tests. Uses posixShellEscape for the cwd
  interpolation so remote paths like \`/home/x; rm -rf ~\` can't escape
  the git argument list.
- \`sync-orchestrator.ts\` + tests. Per-session polling, focus-aware
  interval tiering (active vs background), 304 preserves cached PR,
  'empty' clears it (assigns \`undefined\`, not \`null\` — single sentinel
  for 'no PR'), RateLimitError backs off until reset via
  \`rateLimitedUntil\` rather than racing an inline timer with
  scheduleNext.
- Data-path IPC stubs replaced with real orchestrator wiring
  (\`GITHUB_DATA_GET\`, \`SYNC_NOW\`, \`SYNC_FOCUSED_NOW\`, \`SYNC_PAUSE\`,
  \`SYNC_RESUME\`). Fetchers close over \`ctx.sessionId\` so background
  syncs never borrow another session's token.
- \`GITHUB_FOCUS_CHANGED\` IPC: renderer pushes active session id on
  every tab switch; main toggles setFocus on prev/new so interval
  tiering tracks the user's focus in real time.
- On-save auto-register + startup-time auto-register so sync resumes
  without manual intervention after a restart.

## Out of scope (PR 3b, 3c)

Section bodies (LocalGit, SessionContext, ActivePR, CI, Reviews with
the sanitized markdown render site, Issues, Notifications), session-
context service, PR merge/rerun/reply/notif-mark-read real
implementations, onboarding modal, tour step, tips, banners, a11y
sweep, E2E tests.

## Depends on

PR 2 (#15) merged to beta.

## Test plan

- [x] 470 unit tests pass (14 new across ssh-repo-detector and
      sync-orchestrator)
- [x] Typecheck clean
- [x] Production build clean
- [ ] Enable integration on a session -> panel mounts, sync timer
      starts, GitHubStore receives data/sync state updates
- [ ] Disable on a session -> orchestrator unregisters, rail remains
      with 'Configure' entry point
- [ ] Restart the app with an enabled session -> sync resumes
      automatically from SavedSession
- [ ] Focus change between two integrated sessions -> background
      session shifts to slow interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)