### PR TITLE
feat(github): panel sections + action handlers (PR 3b/3c)

### DIFF
--- a/src/main/github/session/transcript-loader.ts
+++ b/src/main/github/session/transcript-loader.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import type { TranscriptToolCall } from './tool-call-inspector'
+import type { TranscriptMessage } from './transcript-scanner'
+
+/**
+ * Loads the most-recently-touched JSONL transcript under
+ * ~/.claude/projects/<cwd-mangled>/ and returns a small, typed view of
+ * its contents.
+ *
+ * Conductor's internal session id is NOT the same as Claude CLI's
+ * sessionId (the CLI picks its own UUID). We therefore locate the right
+ * transcript by:
+ *   1. Mapping the session's cwd to Claude's project-folder naming
+ *      convention (same mapping as src/main/ipc/setup-handlers.ts).
+ *   2. Picking the JSONL with the most recent mtime — for an active
+ *      session that's overwhelmingly the running conversation.
+ *
+ * Returns an empty result (rather than throwing) if anything fails:
+ *   - cwd has no Claude project folder yet
+ *   - folder has no JSONL files
+ *   - JSONL parse errors (best-effort line-by-line)
+ */
+
+function pathToClaudeProjectFolder(fsPath: string): string {
+  return fsPath.replace(/:/g, '-').replace(/[\\/]+/g, '-')
+}
+
+const MAX_LINES = 500
+
+export interface TranscriptEvents {
+  messages: TranscriptMessage[]
+  toolCalls: TranscriptToolCall[]
+}
+
+interface ContentPart {
+  type?: string
+  text?: string
+  name?: string
+  input?: Record<string, unknown>
+}
+
+interface JsonlEntry {
+  type?: string
+  timestamp?: string
+  message?:
+    | string
+    | {
+        role?: string
+        content?: string | ContentPart[]
+      }
+}
+
+export async function loadTranscriptEvents(cwd: string | undefined): Promise<TranscriptEvents> {
+  const empty: TranscriptEvents = { messages: [], toolCalls: [] }
+  if (!cwd) return empty
+
+  const projectsDir = path.join(homedir(), '.claude', 'projects')
+  const folder = path.join(projectsDir, pathToClaudeProjectFolder(cwd))
+
+  let entries: string[]
+  try {
+    entries = await fs.readdir(folder)
+  } catch {
+    return empty
+  }
+  const jsonl = entries.filter((e) => e.endsWith('.jsonl'))
+  if (jsonl.length === 0) return empty
+
+  let newestFile: string | null = null
+  let newestMtime = 0
+  for (const name of jsonl) {
+    const full = path.join(folder, name)
+    try {
+      const st = await fs.stat(full)
+      if (st.mtimeMs > newestMtime) {
+        newestMtime = st.mtimeMs
+        newestFile = full
+      }
+    } catch {
+      /* skip */
+    }
+  }
+  if (!newestFile) return empty
+
+  let raw: string
+  try {
+    raw = await fs.readFile(newestFile, 'utf8')
+  } catch {
+    return empty
+  }
+
+  const lines = raw.split('\n').filter((l) => l.trim())
+  // Cap at the last MAX_LINES — older history is unlikely to influence the
+  // current session's GitHub context and parsing is O(n) in both bytes
+  // read + JSON.parse calls.
+  const tail = lines.slice(-MAX_LINES)
+
+  const messages: TranscriptMessage[] = []
+  const toolCalls: TranscriptToolCall[] = []
+
+  for (const line of tail) {
+    let obj: JsonlEntry
+    try {
+      obj = JSON.parse(line) as JsonlEntry
+    } catch {
+      continue
+    }
+    const ts = obj.timestamp ? new Date(obj.timestamp).getTime() : 0
+    if (!obj.message || typeof obj.message === 'string') continue
+
+    const content = obj.message.content
+    const role = obj.message.role ?? (obj.type === 'human' ? 'user' : obj.type)
+
+    if (typeof content === 'string') {
+      if (role === 'user' || role === 'assistant') {
+        messages.push({ role, text: content, ts })
+      }
+      continue
+    }
+    if (!Array.isArray(content)) continue
+
+    for (const part of content) {
+      if (part.type === 'text' && typeof part.text === 'string') {
+        if (role === 'user' || role === 'assistant') {
+          messages.push({ role, text: part.text, ts })
+        }
+      } else if (part.type === 'tool_use' && typeof part.name === 'string') {
+        toolCalls.push({
+          type: 'tool_call',
+          tool: part.name,
+          args: (part.input ?? {}) as Record<string, unknown>,
+          timestamp: ts,
+        })
+      }
+    }
+  }
+
+  return { messages, toolCalls }
+}

--- a/src/main/github/session/transcript-loader.ts
+++ b/src/main/github/session/transcript-loader.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 import type { TranscriptToolCall } from './tool-call-inspector'
 import type { TranscriptMessage } from './transcript-scanner'
+import { pathToClaudeProjectFolder } from '../../utils/claude-project-path'
 
 /**
  * Loads the most-recently-touched JSONL transcript under
@@ -23,11 +24,11 @@ import type { TranscriptMessage } from './transcript-scanner'
  *   - JSONL parse errors (best-effort line-by-line)
  */
 
-function pathToClaudeProjectFolder(fsPath: string): string {
-  return fsPath.replace(/:/g, '-').replace(/[\\/]+/g, '-')
-}
-
 const MAX_LINES = 500
+// Cap the bytes we read off disk so a long-lived transcript doesn't turn
+// the Session Context poll into an O(N bytes) hit every 20s. ~1MB is
+// plenty of tail for issue references + recent tool calls.
+const MAX_BYTES = 1_000_000
 
 export interface TranscriptEvents {
   messages: TranscriptMessage[]
@@ -86,7 +87,27 @@ export async function loadTranscriptEvents(cwd: string | undefined): Promise<Tra
 
   let raw: string
   try {
-    raw = await fs.readFile(newestFile, 'utf8')
+    // Tail-read when the file is huge so we don't load tens of MB into
+    // memory every poll. The first partial line (before the first \n) is
+    // dropped when we slice — newline-delimited JSON tolerates it.
+    const st = await fs.stat(newestFile)
+    if (st.size > MAX_BYTES) {
+      const fh = await fs.open(newestFile, 'r')
+      try {
+        const buf = Buffer.alloc(MAX_BYTES)
+        const start = st.size - MAX_BYTES
+        await fh.read(buf, 0, MAX_BYTES, start)
+        const tail = buf.toString('utf8')
+        // Drop whatever precedes the first newline — it's almost certainly
+        // a partial JSON line that can't parse.
+        const nl = tail.indexOf('\n')
+        raw = nl >= 0 ? tail.slice(nl + 1) : tail
+      } finally {
+        await fh.close()
+      }
+    } else {
+      raw = await fs.readFile(newestFile, 'utf8')
+    }
   } catch {
     return empty
   }

--- a/src/main/github/session/transcript-loader.ts
+++ b/src/main/github/session/transcript-loader.ts
@@ -96,8 +96,11 @@ export async function loadTranscriptEvents(cwd: string | undefined): Promise<Tra
       try {
         const buf = Buffer.alloc(MAX_BYTES)
         const start = st.size - MAX_BYTES
-        await fh.read(buf, 0, MAX_BYTES, start)
-        const tail = buf.toString('utf8')
+        // Slice by bytesRead so a short read (file shrank, filesystem
+        // quirk, etc.) doesn't leave trailing zero bytes in the decoded
+        // string that would corrupt line splitting / JSON parsing.
+        const { bytesRead } = await fh.read(buf, 0, MAX_BYTES, start)
+        const tail = buf.subarray(0, bytesRead).toString('utf8')
         // Drop whatever precedes the first newline — it's almost certainly
         // a partial JSON line that can't parse.
         const nl = tail.indexOf('\n')

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -582,6 +582,12 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     IPC.GITHUB_ACTIONS_RERUN,
     async (_e, slug: string, runId: number) => {
       if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      // Fail fast on non-finite IDs — GitHub returns HTML error pages for
+      // malformed paths which the shield-aware fetch would then parse as
+      // a generic HTTP failure. Validating here gives a clearer error.
+      if (!Number.isFinite(runId) || runId <= 0) {
+        return { ok: false, error: 'invalid-run-id' }
+      }
       const id = focusedSessionResolver()
       if (!id) return { ok: false, error: 'no-focused-session' }
       try {
@@ -613,6 +619,9 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
       if (!['merge', 'squash', 'rebase'].includes(method)) {
         return { ok: false, error: 'invalid-method' }
       }
+      if (!Number.isFinite(prNumber) || prNumber <= 0) {
+        return { ok: false, error: 'invalid-pr-number' }
+      }
       const id = focusedSessionResolver()
       if (!id) return { ok: false, error: 'no-focused-session' }
       try {
@@ -636,6 +645,9 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     IPC.GITHUB_PR_READY,
     async (_e, slug: string, prNumber: number) => {
       if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      if (!Number.isFinite(prNumber) || prNumber <= 0) {
+        return { ok: false, error: 'invalid-pr-number' }
+      }
       const id = focusedSessionResolver()
       if (!id) return { ok: false, error: 'no-focused-session' }
       try {

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -503,7 +503,13 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     const sessions = await deps.loadSessions()
     const session = sessions.find((s) => s.id === sessionId)
     const integration = session?.githubIntegration
-    if (!integration?.repoSlug) return { ok: true, data: null }
+    // Validate slug shape before interpolating into REST paths (enrichIssue,
+    // below). session-state.json is author-trusted but has been machine-
+    // round-tripped; a corrupted or hand-edited slug could otherwise build
+    // an arbitrary API URL.
+    if (!integration?.repoSlug || !validateSlug(integration.repoSlug)) {
+      return { ok: true, data: null }
+    }
 
     // Transcript scanning is opt-in per spec §10 — default off. Tool-call
     // signals (recent files edited via Read/Edit/Bash) come from a

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -552,14 +552,170 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     return { ok: true, data: ctx }
   })
 
-  // Still stubs — PR 3b action handlers below cover merge/rerun/reply; the
-  // mark-read call still needs per-profile notification plumbing that
-  // piggybacks on a dedicated PR 3b step (task 78).
-  ipcMain.handle(IPC.GITHUB_ACTIONS_RERUN, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_PR_MERGE, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_PR_READY, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_REVIEW_REPLY, async () => ({ ok: true }))
-  ipcMain.handle(IPC.GITHUB_NOTIF_MARK_READ, async () => ({ ok: true }))
+  // Helper: resolve a token for an action IPC. Every action needs a token
+  // scoped to SOMETHING — the focused session for merge / rerun / reply, or
+  // a specific profile id for notification mark-read. Missing token falls
+  // back to error:'no-token' so the renderer surfaces the auth gap.
+  function tokenFnForSession(sessionId: string) {
+    return async () => {
+      const t = await getTokenForSession(sessionId)
+      if (!t) throw new Error('no-token')
+      return t
+    }
+  }
+
+  function tokenFnForProfile(profileId: string) {
+    return async () => {
+      const t = await profileStore.getToken(profileId)
+      if (!t) throw new Error('no-token')
+      return t
+    }
+  }
+
+  ipcMain.handle(
+    IPC.GITHUB_ACTIONS_RERUN,
+    async (_e, slug: string, runId: number) => {
+      if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      const id = focusedSessionResolver()
+      if (!id) return { ok: false, error: 'no-focused-session' }
+      try {
+        // rerun-failed-jobs re-runs only the failed jobs from the run, which
+        // is the action users click 'Re-run' for 99% of the time. Use /rerun
+        // (full re-run) instead if we later want a separate control.
+        const r = await githubFetch(
+          `/repos/${slug}/actions/runs/${runId}/rerun-failed-jobs`,
+          { tokenFn: tokenFnForSession(id), shield, etags, method: 'POST' },
+        )
+        return r.ok
+          ? { ok: true }
+          : { ok: false, error: `http-${r.status}` }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC.GITHUB_PR_MERGE,
+    async (
+      _e,
+      slug: string,
+      prNumber: number,
+      method: 'merge' | 'squash' | 'rebase',
+    ) => {
+      if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      if (!['merge', 'squash', 'rebase'].includes(method)) {
+        return { ok: false, error: 'invalid-method' }
+      }
+      const id = focusedSessionResolver()
+      if (!id) return { ok: false, error: 'no-focused-session' }
+      try {
+        const r = await githubFetch(`/repos/${slug}/pulls/${prNumber}/merge`, {
+          tokenFn: tokenFnForSession(id),
+          shield,
+          etags,
+          method: 'PUT',
+          body: { merge_method: method },
+        })
+        return r.ok
+          ? { ok: true }
+          : { ok: false, error: `http-${r.status}` }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC.GITHUB_PR_READY,
+    async (_e, slug: string, prNumber: number) => {
+      if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      const id = focusedSessionResolver()
+      if (!id) return { ok: false, error: 'no-focused-session' }
+      try {
+        // Draft→ready canonically lives behind the GraphQL mutation
+        // markPullRequestReadyForReview. First resolve the PR's GraphQL
+        // node id via REST, then run the mutation.
+        const prGet = await githubFetch(`/repos/${slug}/pulls/${prNumber}`, {
+          tokenFn: tokenFnForSession(id),
+          shield,
+          etags,
+        })
+        if (!prGet.ok) return { ok: false, error: `http-${prGet.status}` }
+        const prJson = (await prGet.json()) as { node_id?: string }
+        if (!prJson.node_id) return { ok: false, error: 'no-node-id' }
+        const gql = await githubFetch('/graphql', {
+          tokenFn: tokenFnForSession(id),
+          shield,
+          etags,
+          method: 'POST',
+          bucket: 'graphql',
+          baseUrl: 'https://api.github.com',
+          body: {
+            query: `mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){clientMutationId}}`,
+            variables: { id: prJson.node_id },
+          },
+        })
+        return gql.ok
+          ? { ok: true }
+          : { ok: false, error: `http-${gql.status}` }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC.GITHUB_REVIEW_REPLY,
+    async (_e, slug: string, threadId: string, body: string) => {
+      if (!validateSlug(slug)) return { ok: false, error: 'invalid-slug' }
+      if (!body || typeof body !== 'string') return { ok: false, error: 'empty-body' }
+      const id = focusedSessionResolver()
+      if (!id) return { ok: false, error: 'no-focused-session' }
+      // threadId here is the root-comment id of the review thread (the shape
+      // populated by PR 3c when fetchPRReviewComments is wired in). The
+      // /comments/{id}/replies endpoint posts under the same thread.
+      const commentId = Number(threadId)
+      if (!Number.isFinite(commentId)) return { ok: false, error: 'invalid-thread-id' }
+      try {
+        const r = await githubFetch(
+          `/repos/${slug}/pulls/comments/${commentId}/replies`,
+          {
+            tokenFn: tokenFnForSession(id),
+            shield,
+            etags,
+            method: 'POST',
+            body: { body },
+          },
+        )
+        return r.ok
+          ? { ok: true }
+          : { ok: false, error: `http-${r.status}` }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    IPC.GITHUB_NOTIF_MARK_READ,
+    async (_e, profileId: string, threadId: string) => {
+      if (!profileId || !threadId) return { ok: false, error: 'missing-args' }
+      try {
+        const r = await githubFetch(`/notifications/threads/${threadId}`, {
+          tokenFn: tokenFnForProfile(profileId),
+          shield,
+          etags,
+          method: 'PATCH',
+        })
+        return r.ok
+          ? { ok: true }
+          : { ok: false, error: `http-${r.status}` }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
 
   // Kick off background registration for any session that already had
   // integration enabled when the app was closed. Fire-and-forget because

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -14,6 +14,7 @@ import { validateSlug } from '../github/security/slug-validator'
 import { CacheStore } from '../github/cache/cache-store'
 import { EtagCache } from '../github/client/etag-cache'
 import { RateLimitShield } from '../github/client/rate-limit-shield'
+import { githubFetch } from '../github/client/github-fetch'
 import {
   fetchPRByBranch,
   fetchPRReviews,
@@ -23,6 +24,10 @@ import {
   SyncOrchestrator,
   type SyncStateEvent,
 } from '../github/session/sync-orchestrator'
+import { buildSessionContext } from '../github/session/session-context-service'
+import { extractFileSignals } from '../github/session/tool-call-inspector'
+import { scanTranscriptMessages } from '../github/session/transcript-scanner'
+import { loadTranscriptEvents } from '../github/session/transcript-loader'
 import {
   DEFAULT_FEATURE_TOGGLES,
   DEFAULT_SYNC_INTERVALS,
@@ -494,10 +499,62 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     return { ok: true }
   })
 
-  // Still stubs — real implementations require section-side machinery
-  // (transcript reader, merge/rerun/reply endpoint wrappers) that land in
-  // PR 3b alongside the populated panel sections.
-  ipcMain.handle(IPC.GITHUB_SESSION_CONTEXT_GET, async () => ({ ok: true, data: null }))
+  ipcMain.handle(IPC.GITHUB_SESSION_CONTEXT_GET, async (_e, sessionId: string) => {
+    const sessions = await deps.loadSessions()
+    const session = sessions.find((s) => s.id === sessionId)
+    const integration = session?.githubIntegration
+    if (!integration?.repoSlug) return { ok: true, data: null }
+
+    // Transcript scanning is opt-in per spec §10 — default off. Tool-call
+    // signals (recent files edited via Read/Edit/Bash) come from a
+    // separate, narrower inspector that never reads message bodies.
+    const cfg = await getCachedConfig()
+    const events = await loadTranscriptEvents(session?.workingDirectory)
+    const recentFiles = extractFileSignals(events.toolCalls)
+    const transcriptRefs = cfg?.transcriptScanningOptIn
+      ? scanTranscriptMessages(events.messages)
+      : []
+    const branchName = await readCurrentBranch(session?.workingDirectory)
+    const repoSlug = integration.repoSlug
+
+    const ctx = await buildSessionContext({
+      branchName,
+      transcriptRefs,
+      // prBodyRefs needs the PR body text — not stored on RepoCache yet.
+      // Deferred to a PR-body-scan follow-up; empty array keeps the priority
+      // algorithm well-defined in the meantime.
+      prBodyRefs: [],
+      recentFiles,
+      sessionRepo: repoSlug,
+      enrichIssue: async (repo, n) => {
+        try {
+          const r = await githubFetch(`/repos/${repo}/issues/${n}`, {
+            tokenFn: makeTokenFn(sessionId),
+            shield,
+            etags,
+          })
+          if (!r.ok) return null
+          const j = (await r.json()) as {
+            title?: string
+            state?: 'open' | 'closed'
+            assignee?: { login?: string } | null
+          }
+          return {
+            title: j.title,
+            state: j.state,
+            assignee: j.assignee?.login,
+          }
+        } catch {
+          return null
+        }
+      },
+    })
+    return { ok: true, data: ctx }
+  })
+
+  // Still stubs — PR 3b action handlers below cover merge/rerun/reply; the
+  // mark-read call still needs per-profile notification plumbing that
+  // piggybacks on a dedicated PR 3b step (task 78).
   ipcMain.handle(IPC.GITHUB_ACTIONS_RERUN, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_PR_MERGE, async () => ({ ok: true }))
   ipcMain.handle(IPC.GITHUB_PR_READY, async () => ({ ok: true }))

--- a/src/main/ipc/github-handlers.ts
+++ b/src/main/ipc/github-handlers.ts
@@ -719,6 +719,10 @@ export function registerGitHubHandlers(deps: RegisterDeps): GitHubHandlersHandle
     IPC.GITHUB_NOTIF_MARK_READ,
     async (_e, profileId: string, threadId: string) => {
       if (!profileId || !threadId) return { ok: false, error: 'missing-args' }
+      // threadId is string-typed on the wire; reject anything other than a
+      // strict positive integer to avoid path-traversal into unintended
+      // endpoints. GitHub's notification thread ids are numeric.
+      if (!/^[1-9]\d*$/.test(threadId)) return { ok: false, error: 'invalid-thread-id' }
       try {
         const r = await githubFetch(`/notifications/threads/${threadId}`, {
           tokenFn: tokenFnForProfile(profileId),

--- a/src/main/ipc/setup-handlers.ts
+++ b/src/main/ipc/setup-handlers.ts
@@ -107,16 +107,11 @@ function setDataDirectory(dataDir: string): boolean {
   }
 }
 
-/**
- * Convert a filesystem path to Claude's project folder name convention.
- * e.g. C:\Users\jane\AppData\Local\Programs\claude-conductor
- *   -> C--Users-jane-AppData-Local-Programs-claude-conductor
- */
-function pathToClaudeProjectFolder(fsPath: string): string {
-  return fsPath
-    .replace(/:/g, '-')     // Colons become hyphens (C: -> C-)
-    .replace(/[\\/]+/g, '-') // Path separators become hyphens
-}
+// Shared helper lives in utils/claude-project-path. Both this module and the
+// GitHub transcript loader map cwd → Claude's ~/.claude/projects/<folder>/
+// convention; keeping one source of truth avoids drift if the convention
+// ever changes upstream.
+import { pathToClaudeProjectFolder } from '../utils/claude-project-path'
 
 /**
  * Check if the install path is already trusted by Claude CLI.

--- a/src/main/screenshot-capture.ts
+++ b/src/main/screenshot-capture.ts
@@ -100,7 +100,17 @@ async function _captureRectangleImpl(mainWindow: BrowserWindow): Promise<string 
       alwaysOnTop: true,
       skipTaskbar: true,
       resizable: false,
-      fullscreen: true,
+      // NO `fullscreen: true` on Windows: combining fullscreen + transparent
+      // drops this window into the exclusive-compositor path that doesn't
+      // route mouse/keyboard input reliably after another window was just
+      // minimized. The explicit x/y/width/height already fills the display.
+      // `show: false` delays the first paint until we can `focus()` the
+      // window ourselves — on Windows, minimize() of the prior window can
+      // leave focus on the desktop, and a same-tick construction doesn't
+      // grab it back, which is why the crosshair rendered but drag / escape
+      // were dead until you Ctrl+Alt+Del'd out of it.
+      show: false,
+      focusable: true,
       webPreferences: {
         preload: join(__dirname, '../preload/screenshot-overlay.js'),
         contextIsolation: true,
@@ -110,7 +120,18 @@ async function _captureRectangleImpl(mainWindow: BrowserWindow): Promise<string 
     })
 
     let resolved = false
+    // Safety net: if for any reason the overlay still fails to capture
+    // input (OS compositor edge case, focus-stealer race), auto-cancel
+    // after 2 minutes so the user can never get stuck needing task
+    // manager to dismiss a ghost crosshair window.
+    const safetyTimer = setTimeout(() => {
+      if (resolved) return
+      console.warn('[screenshot] overlay safety timeout — auto-cancelling')
+      handleCancel()
+    }, 120_000)
+
     const cleanup = () => {
+      clearTimeout(safetyTimer)
       if (!overlay.isDestroyed()) overlay.destroy()
       mainWindow.restore()
       mainWindow.focus()
@@ -179,7 +200,20 @@ async function _captureRectangleImpl(mainWindow: BrowserWindow): Promise<string 
       }
     })
 
-    // Load inline HTML for the overlay
+    // Show + focus only after the page is ready. Showing before load can
+    // leave the window in the Windows "created but unfocused" state where
+    // input events never reach the renderer; waiting for did-finish-load
+    // gives Chromium time to register input handlers before we ask the
+    // OS to focus it. Also force-elevate to 'screen-saver' so the overlay
+    // sits above taskbar popups and always-on-top apps on Windows.
+    overlay.once('ready-to-show', () => {
+      if (overlay.isDestroyed()) return
+      overlay.setAlwaysOnTop(true, 'screen-saver')
+      overlay.show()
+      overlay.focus()
+      overlay.moveTop()
+    })
+
     const html = getOverlayHtml()
     overlay.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
   })
@@ -347,7 +381,12 @@ export async function startStoryboard(mainWindow: BrowserWindow): Promise<{ x: n
       alwaysOnTop: true,
       skipTaskbar: true,
       resizable: false,
-      fullscreen: true,
+      // See matching comment in captureRectangle: fullscreen + transparent
+      // on Windows breaks input capture when opened right after a
+      // minimize(). Explicit sizing fills the display; show/focus happen
+      // after ready-to-show so the OS has a chance to route input here.
+      show: false,
+      focusable: true,
       webPreferences: {
         preload: join(__dirname, '../preload/screenshot-overlay.js'),
         contextIsolation: true,
@@ -357,7 +396,16 @@ export async function startStoryboard(mainWindow: BrowserWindow): Promise<{ x: n
     })
 
     let resolved = false
+    // Same safety net as captureRectangle: auto-cancel after 2 min so
+    // the overlay can never get stuck as a ghost window.
+    const safetyTimer = setTimeout(() => {
+      if (resolved) return
+      console.warn('[storyboard] overlay safety timeout — auto-cancelling')
+      handleCancel()
+    }, 120_000)
+
     const cleanup = () => {
+      clearTimeout(safetyTimer)
       if (!overlay.isDestroyed()) overlay.destroy()
       mainWindow.restore()
       mainWindow.focus()
@@ -395,6 +443,14 @@ export async function startStoryboard(mainWindow: BrowserWindow): Promise<{ x: n
         mainWindow.focus()
         resolve(null)
       }
+    })
+
+    overlay.once('ready-to-show', () => {
+      if (overlay.isDestroyed()) return
+      overlay.setAlwaysOnTop(true, 'screen-saver')
+      overlay.show()
+      overlay.focus()
+      overlay.moveTop()
     })
 
     const html = getOverlayHtml()

--- a/src/main/utils/claude-project-path.ts
+++ b/src/main/utils/claude-project-path.ts
@@ -1,0 +1,19 @@
+/**
+ * Maps a filesystem path to Claude CLI's project-folder naming convention
+ * under ~/.claude/projects/. This is used by both the setup handler
+ * (to check whether a project is trusted) and the GitHub transcript
+ * loader (to locate the active session's JSONL).
+ *
+ * e.g. C:\Users\jane\repos\app  ->  C--Users-jane-repos-app
+ * e.g. /home/jane/repos/app     ->  -home-jane-repos-app
+ *
+ * Both colons (drive letters on Windows) and path separators collapse to
+ * hyphens; repeated separators flatten rather than producing empty
+ * segments because the original convention runs the replacements in
+ * sequence on the raw string.
+ */
+export function pathToClaudeProjectFolder(fsPath: string): string {
+  return fsPath
+    .replace(/:/g, '-')
+    .replace(/[\\/]+/g, '-')
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -190,15 +190,19 @@ interface GitHubBridge {
       nextResetAt?: number
     }) => void,
   ) => () => void
-  rerunActionsRun: (slug: string, runId: number) => Promise<{ ok: boolean }>
+  rerunActionsRun: (slug: string, runId: number) => Promise<{ ok: boolean; error?: string }>
   mergePR: (
     slug: string,
     prNumber: number,
     method: 'merge' | 'squash' | 'rebase',
-  ) => Promise<{ ok: boolean }>
-  readyPR: (slug: string, prNumber: number) => Promise<{ ok: boolean }>
-  replyToReview: (slug: string, threadId: string, body: string) => Promise<{ ok: boolean }>
-  markNotifRead: (profileId: string, notifId: string) => Promise<{ ok: boolean }>
+  ) => Promise<{ ok: boolean; error?: string }>
+  readyPR: (slug: string, prNumber: number) => Promise<{ ok: boolean; error?: string }>
+  replyToReview: (
+    slug: string,
+    threadId: string,
+    body: string,
+  ) => Promise<{ ok: boolean; error?: string }>
+  markNotifRead: (profileId: string, notifId: string) => Promise<{ ok: boolean; error?: string }>
 }
 
 const electronAPI: ElectronAPI = {

--- a/src/renderer/components/github/GitHubPanel.tsx
+++ b/src/renderer/components/github/GitHubPanel.tsx
@@ -192,11 +192,11 @@ export default function GitHubPanel({
       />
       <div className="flex-1 overflow-y-auto" aria-live="polite">
         <SessionContextSection sessionId={sessionId} />
-        <ActivePRSection sessionId={sessionId} />
-        <CISection sessionId={sessionId} />
-        <ReviewsSection sessionId={sessionId} />
-        <IssuesSection sessionId={sessionId} />
-        <LocalGitSection sessionId={sessionId} />
+        <ActivePRSection sessionId={sessionId} slug={repoSlug} />
+        <CISection sessionId={sessionId} slug={repoSlug} />
+        <ReviewsSection sessionId={sessionId} slug={repoSlug} />
+        <IssuesSection sessionId={sessionId} slug={repoSlug} />
+        <LocalGitSection sessionId={sessionId} cwd={session?.workingDirectory} />
         <NotificationsSection sessionId={sessionId} />
         <AgentIntentSection sessionId={sessionId} />
       </div>

--- a/src/renderer/components/github/sections/ActivePRSection.tsx
+++ b/src/renderer/components/github/sections/ActivePRSection.tsx
@@ -46,6 +46,13 @@ export default function ActivePRSection({ sessionId, slug }: Props) {
         setActionError(r.error ?? `${kind} failed`)
         setTimeout(() => setActionError(null), 4000)
       }
+    } catch (err) {
+      // IPC rejection (handler threw, main-side network error surfaced as
+      // a throw, renderer navigating). Surface to the user rather than
+      // letting it propagate as an unhandled promise rejection from the
+      // click callback.
+      setActionError(err instanceof Error ? err.message : `${kind} failed`)
+      setTimeout(() => setActionError(null), 4000)
     } finally {
       setPending(null)
     }

--- a/src/renderer/components/github/sections/ActivePRSection.tsx
+++ b/src/renderer/components/github/sections/ActivePRSection.tsx
@@ -1,13 +1,90 @@
 import SectionFrame from '../SectionFrame'
+import { useGitHubStore } from '../../../stores/githubStore'
+import { relativeTime } from '../../../utils/relativeTime'
 
 interface Props {
   sessionId: string
+  slug?: string
 }
 
-export default function ActivePRSection({ sessionId }: Props) {
+export default function ActivePRSection({ sessionId, slug }: Props) {
+  const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
+  const pr = data?.pr
+
+  if (!slug) {
+    return (
+      <SectionFrame sessionId={sessionId} id="activePR" title="Active PR" emptyIndicator>
+        <div className="text-xs text-overlay0">No repo configured</div>
+      </SectionFrame>
+    )
+  }
+  if (!pr) {
+    return (
+      <SectionFrame sessionId={sessionId} id="activePR" title="Active PR" emptyIndicator>
+        <div className="text-xs text-overlay0">No PR for this branch</div>
+      </SectionFrame>
+    )
+  }
+
+  // The app denies window.open via setWindowOpenHandler, so external links
+  // must route through shell.openExternal (https-only enforcement lives
+  // in the main-side handler).
+  const open = () => void window.electronAPI.shell.openExternal(pr.url)
+  const ready = async () => {
+    await window.electronAPI.github.readyPR(slug, pr.number)
+  }
+  const merge = async (method: 'merge' | 'squash' | 'rebase') => {
+    await window.electronAPI.github.mergePR(slug, pr.number, method)
+  }
+
   return (
-    <SectionFrame sessionId={sessionId} id="activePR" title="Active PR" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame sessionId={sessionId} id="activePR" title="Active PR" summary={`#${pr.number}`}>
+      <div className="text-xs space-y-1">
+        <div className="text-text">{pr.title}</div>
+        <div className="text-overlay1">
+          @{pr.author} · {pr.draft ? 'draft' : pr.state} · {relativeTime(pr.updatedAt)}
+        </div>
+        <div className="text-subtext0">
+          Mergeable:{' '}
+          <span
+            className={
+              pr.mergeableState === 'clean'
+                ? 'text-green'
+                : pr.mergeableState === 'conflict'
+                ? 'text-red'
+                : 'text-overlay1'
+            }
+          >
+            {pr.mergeableState}
+          </span>
+        </div>
+        <div className="flex gap-1 pt-2 flex-wrap">
+          <button
+            onClick={open}
+            className="bg-surface0 hover:bg-surface1 px-2 py-0.5 rounded text-xs"
+          >
+            Open in GitHub
+          </button>
+          {pr.draft && (
+            <button
+              onClick={ready}
+              className="bg-surface0 hover:bg-surface1 px-2 py-0.5 rounded text-xs"
+            >
+              Ready for review
+            </button>
+          )}
+          {pr.mergeableState === 'clean' &&
+            pr.allowedMergeMethods?.map((m) => (
+              <button
+                key={m}
+                onClick={() => merge(m)}
+                className="bg-blue/20 hover:bg-blue/40 text-blue px-2 py-0.5 rounded text-xs capitalize"
+              >
+                {m}
+              </button>
+            ))}
+        </div>
+      </div>
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/ActivePRSection.tsx
+++ b/src/renderer/components/github/sections/ActivePRSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import SectionFrame from '../SectionFrame'
 import { useGitHubStore } from '../../../stores/githubStore'
 import { relativeTime } from '../../../utils/relativeTime'
@@ -10,6 +11,8 @@ interface Props {
 export default function ActivePRSection({ sessionId, slug }: Props) {
   const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
   const pr = data?.pr
+  const [pending, setPending] = useState<'ready' | 'merge' | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
 
   if (!slug) {
     return (
@@ -30,12 +33,27 @@ export default function ActivePRSection({ sessionId, slug }: Props) {
   // must route through shell.openExternal (https-only enforcement lives
   // in the main-side handler).
   const open = () => void window.electronAPI.shell.openExternal(pr.url)
-  const ready = async () => {
-    await window.electronAPI.github.readyPR(slug, pr.number)
+
+  const runAction = async (
+    kind: 'ready' | 'merge',
+    fn: () => Promise<{ ok: boolean; error?: string }>,
+  ) => {
+    setPending(kind)
+    setActionError(null)
+    try {
+      const r = await fn()
+      if (!r.ok) {
+        setActionError(r.error ?? `${kind} failed`)
+        setTimeout(() => setActionError(null), 4000)
+      }
+    } finally {
+      setPending(null)
+    }
   }
-  const merge = async (method: 'merge' | 'squash' | 'rebase') => {
-    await window.electronAPI.github.mergePR(slug, pr.number, method)
-  }
+  const ready = () =>
+    runAction('ready', () => window.electronAPI.github.readyPR(slug, pr.number))
+  const merge = (method: 'merge' | 'squash' | 'rebase') =>
+    runAction('merge', () => window.electronAPI.github.mergePR(slug, pr.number, method))
 
   return (
     <SectionFrame sessionId={sessionId} id="activePR" title="Active PR" summary={`#${pr.number}`}>
@@ -68,9 +86,10 @@ export default function ActivePRSection({ sessionId, slug }: Props) {
           {pr.draft && (
             <button
               onClick={ready}
-              className="bg-surface0 hover:bg-surface1 px-2 py-0.5 rounded text-xs"
+              disabled={pending === 'ready'}
+              className="bg-surface0 hover:bg-surface1 px-2 py-0.5 rounded text-xs disabled:opacity-50"
             >
-              Ready for review
+              {pending === 'ready' ? 'Marking' : 'Ready for review'}
             </button>
           )}
           {pr.mergeableState === 'clean' &&
@@ -78,12 +97,14 @@ export default function ActivePRSection({ sessionId, slug }: Props) {
               <button
                 key={m}
                 onClick={() => merge(m)}
-                className="bg-blue/20 hover:bg-blue/40 text-blue px-2 py-0.5 rounded text-xs capitalize"
+                disabled={pending === 'merge'}
+                className="bg-blue/20 hover:bg-blue/40 text-blue px-2 py-0.5 rounded text-xs capitalize disabled:opacity-50"
               >
                 {m}
               </button>
             ))}
         </div>
+        {actionError && <div className="text-red text-[10px]">{actionError}</div>}
       </div>
     </SectionFrame>
   )

--- a/src/renderer/components/github/sections/CISection.tsx
+++ b/src/renderer/components/github/sections/CISection.tsx
@@ -1,13 +1,79 @@
+import { useState } from 'react'
 import SectionFrame from '../SectionFrame'
+import { useGitHubStore } from '../../../stores/githubStore'
+import type { WorkflowRunSnapshot } from '../../../../shared/github-types'
 
 interface Props {
   sessionId: string
+  slug?: string
 }
 
-export default function CISection({ sessionId }: Props) {
+function runIcon(r: WorkflowRunSnapshot): string {
+  if (r.conclusion === 'success') return String.fromCodePoint(0x2713)
+  if (r.conclusion === 'failure') return String.fromCodePoint(0x2717)
+  if (r.status === 'in_progress' || r.status === 'queued') return String.fromCodePoint(0x25cc)
+  return String.fromCodePoint(0x2014)
+}
+
+function runColor(r: WorkflowRunSnapshot): string {
+  if (r.conclusion === 'success') return 'text-green'
+  if (r.conclusion === 'failure') return 'text-red'
+  if (r.status !== 'completed') return 'text-yellow'
+  return 'text-overlay1'
+}
+
+export default function CISection({ sessionId, slug }: Props) {
+  const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
+  const runs = data?.actions ?? []
+  const [rerunning, setRerunning] = useState<number | null>(null)
+  const empty = runs.length === 0
+
+  const rerun = async (id: number) => {
+    if (!slug) return
+    setRerunning(id)
+    await window.electronAPI.github.rerunActionsRun(slug, id)
+    setRerunning(null)
+  }
+
+  const failed = runs.filter((r) => r.conclusion === 'failure').length
+  const summary = empty ? undefined : failed > 0 ? `${failed} failed` : 'all passing'
+
   return (
-    <SectionFrame sessionId={sessionId} id="ci" title="CI / Actions" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="ci"
+      title="CI / Actions"
+      summary={summary}
+      emptyIndicator={empty}
+    >
+      <div className="space-y-1 text-xs">
+        {runs.map((r) => (
+          <div key={r.id} className="flex items-center gap-2">
+            <span className={runColor(r)} aria-label={r.conclusion ?? r.status}>
+              {runIcon(r)}
+            </span>
+            <span className="text-text truncate flex-1" title={r.workflowName}>
+              {r.workflowName}
+            </span>
+            <button
+              onClick={() => void window.electronAPI.shell.openExternal(r.url)}
+              className="text-overlay1 hover:text-text"
+              aria-label="Open run in GitHub"
+            >
+              {String.fromCodePoint(0x2197)}
+            </button>
+            {r.conclusion === 'failure' && slug && (
+              <button
+                onClick={() => rerun(r.id)}
+                disabled={rerunning === r.id}
+                className="bg-surface0 hover:bg-surface1 px-1.5 py-0.5 rounded text-xs"
+              >
+                {rerunning === r.id ? '...' : 'Re-run'}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/CISection.tsx
+++ b/src/renderer/components/github/sections/CISection.tsx
@@ -39,6 +39,11 @@ export default function CISection({ sessionId, slug }: Props) {
         setRerunError(r.error ?? 'Re-run failed')
         setTimeout(() => setRerunError(null), 4000)
       }
+    } catch (err) {
+      // Catch IPC rejections so they don't bubble up as unhandled promise
+      // rejections from the click handler. try/finally alone re-throws.
+      setRerunError(err instanceof Error ? err.message : 'Re-run failed')
+      setTimeout(() => setRerunError(null), 4000)
     } finally {
       // Always clear, even on rejection — otherwise a network error leaves
       // the Re-run button permanently disabled.

--- a/src/renderer/components/github/sections/CISection.tsx
+++ b/src/renderer/components/github/sections/CISection.tsx
@@ -26,13 +26,19 @@ export default function CISection({ sessionId, slug }: Props) {
   const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
   const runs = data?.actions ?? []
   const [rerunning, setRerunning] = useState<number | null>(null)
+  const [rerunError, setRerunError] = useState<string | null>(null)
   const empty = runs.length === 0
 
   const rerun = async (id: number) => {
     if (!slug) return
     setRerunning(id)
+    setRerunError(null)
     try {
-      await window.electronAPI.github.rerunActionsRun(slug, id)
+      const r = await window.electronAPI.github.rerunActionsRun(slug, id)
+      if (!r.ok) {
+        setRerunError(r.error ?? 'Re-run failed')
+        setTimeout(() => setRerunError(null), 4000)
+      }
     } finally {
       // Always clear, even on rejection — otherwise a network error leaves
       // the Re-run button permanently disabled.
@@ -52,6 +58,7 @@ export default function CISection({ sessionId, slug }: Props) {
       emptyIndicator={empty}
     >
       <div className="space-y-1 text-xs">
+        {rerunError && <div className="text-red text-[10px]">{rerunError}</div>}
         {runs.map((r) => (
           <div key={r.id} className="flex items-center gap-2">
             <span className={runColor(r)} aria-label={r.conclusion ?? r.status}>

--- a/src/renderer/components/github/sections/CISection.tsx
+++ b/src/renderer/components/github/sections/CISection.tsx
@@ -31,8 +31,13 @@ export default function CISection({ sessionId, slug }: Props) {
   const rerun = async (id: number) => {
     if (!slug) return
     setRerunning(id)
-    await window.electronAPI.github.rerunActionsRun(slug, id)
-    setRerunning(null)
+    try {
+      await window.electronAPI.github.rerunActionsRun(slug, id)
+    } finally {
+      // Always clear, even on rejection — otherwise a network error leaves
+      // the Re-run button permanently disabled.
+      setRerunning(null)
+    }
   }
 
   const failed = runs.filter((r) => r.conclusion === 'failure').length

--- a/src/renderer/components/github/sections/IssuesSection.tsx
+++ b/src/renderer/components/github/sections/IssuesSection.tsx
@@ -1,13 +1,48 @@
 import SectionFrame from '../SectionFrame'
+import { useGitHubStore } from '../../../stores/githubStore'
 
 interface Props {
   sessionId: string
+  slug?: string
 }
 
-export default function IssuesSection({ sessionId }: Props) {
+export default function IssuesSection({ sessionId, slug }: Props) {
+  const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
+  const issues = data?.issues ?? []
+  const empty = issues.length === 0
+
   return (
-    <SectionFrame sessionId={sessionId} id="issues" title="Issues" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="issues"
+      title="Issues"
+      summary={empty ? undefined : `${issues.length}`}
+      emptyIndicator={empty}
+    >
+      <ul className="space-y-1 text-xs">
+        {issues.map((i) => (
+          <li key={i.number} className="flex items-start gap-2">
+            <button
+              onClick={() => void window.electronAPI.shell.openExternal(i.url)}
+              className="text-blue hover:underline"
+            >
+              #{i.number}
+            </button>
+            {i.primary && (
+              <span className="bg-mauve/20 text-mauve text-[10px] px-1 rounded">
+                primary
+              </span>
+            )}
+            <span className={i.state === 'open' ? 'text-green' : 'text-overlay0'}>
+              {i.state}
+            </span>
+            <span className="text-text truncate flex-1" title={i.title}>
+              {i.title}
+            </span>
+            {i.assignee && <span className="text-overlay1">@{i.assignee}</span>}
+          </li>
+        ))}
+      </ul>
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/LocalGitSection.tsx
+++ b/src/renderer/components/github/sections/LocalGitSection.tsx
@@ -19,8 +19,14 @@ export default function LocalGitSection({ sessionId, cwd }: Props) {
     if (!cwd) return
     let alive = true
     const poll = async () => {
-      const r = await window.electronAPI.github.getLocalGit(cwd)
-      if (alive && r.ok) setState(r.state as LocalGitState)
+      try {
+        const r = await window.electronAPI.github.getLocalGit(cwd)
+        if (alive && r.ok) setState(r.state as LocalGitState)
+      } catch {
+        // Keep the previous state; a transient IPC failure shouldn't
+        // flip the section to empty, and swallowing here prevents an
+        // unhandled rejection every poll tick.
+      }
     }
     void poll()
     const t = setInterval(poll, 15_000)
@@ -47,8 +53,11 @@ export default function LocalGitSection({ sessionId, cwd }: Props) {
   }
 
   const dirtyCount = state.staged.length + state.unstaged.length + state.untracked.length
-  const summary = dirtyCount > 0 ? `${dirtyCount} changes` : 'clean'
   const empty = !state.branch
+  // Suppress summary when there's no branch — "clean" against a missing
+  // repo would mislead the user. The empty indicator in the section
+  // header already conveys the "no git here" state at a glance.
+  const summary = empty ? undefined : dirtyCount > 0 ? `${dirtyCount} changes` : 'clean'
 
   return (
     <SectionFrame

--- a/src/renderer/components/github/sections/LocalGitSection.tsx
+++ b/src/renderer/components/github/sections/LocalGitSection.tsx
@@ -1,13 +1,133 @@
+import { useEffect, useState } from 'react'
 import SectionFrame from '../SectionFrame'
+import type { LocalGitState } from '../../../../shared/github-types'
+import { relativeTime } from '../../../utils/relativeTime'
 
 interface Props {
   sessionId: string
+  cwd?: string
 }
 
-export default function LocalGitSection({ sessionId }: Props) {
+export default function LocalGitSection({ sessionId, cwd }: Props) {
+  const [state, setState] = useState<LocalGitState | null>(null)
+
+  useEffect(() => {
+    if (!cwd) return
+    let alive = true
+    const poll = async () => {
+      const r = await window.electronAPI.github.getLocalGit(cwd)
+      if (alive && r.ok) setState(r.state as LocalGitState)
+    }
+    void poll()
+    const t = setInterval(poll, 15_000)
+    return () => {
+      alive = false
+      clearInterval(t)
+    }
+  }, [cwd])
+
+  if (!cwd) {
+    return (
+      <SectionFrame sessionId={sessionId} id="localGit" title="Local Git" emptyIndicator>
+        <div className="text-xs text-overlay0">No working directory</div>
+      </SectionFrame>
+    )
+  }
+
+  if (!state) {
+    return (
+      <SectionFrame sessionId={sessionId} id="localGit" title="Local Git" emptyIndicator>
+        <div className="text-xs text-overlay0">Loading</div>
+      </SectionFrame>
+    )
+  }
+
+  const dirtyCount = state.staged.length + state.unstaged.length + state.untracked.length
+  const summary = dirtyCount > 0 ? `${dirtyCount} changes` : 'clean'
+  const empty = !state.branch
+
   return (
-    <SectionFrame sessionId={sessionId} id="localGit" title="Local Git" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="localGit"
+      title="Local Git"
+      summary={summary}
+      emptyIndicator={empty}
+    >
+      {state.branch && (
+        <div className="space-y-2 text-xs">
+          <div className="text-subtext0">
+            On <span className="text-text">{state.branch}</span>
+            {state.ahead > 0 && (
+              <span className="text-green ml-2">
+                {String.fromCodePoint(0x2191)}
+                {state.ahead}
+              </span>
+            )}
+            {state.behind > 0 && (
+              <span className="text-teal ml-1">
+                {String.fromCodePoint(0x2193)}
+                {state.behind}
+              </span>
+            )}
+          </div>
+          {state.staged.length > 0 && (
+            <details>
+              <summary className="cursor-pointer text-green">
+                Staged ({state.staged.length})
+              </summary>
+              <ul className="ml-4 text-overlay1">
+                {state.staged.map((f) => (
+                  <li key={f}>{f}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+          {state.unstaged.length > 0 && (
+            <details>
+              <summary className="cursor-pointer text-peach">
+                Unstaged ({state.unstaged.length})
+              </summary>
+              <ul className="ml-4 text-overlay1">
+                {state.unstaged.map((f) => (
+                  <li key={f}>{f}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+          {state.untracked.length > 0 && (
+            <details>
+              <summary className="cursor-pointer text-overlay1">
+                Untracked ({state.untracked.length})
+              </summary>
+              <ul className="ml-4 text-overlay1">
+                {state.untracked.map((f) => (
+                  <li key={f}>{f}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+          {state.recentCommits.length > 0 && (
+            <div className="pt-2 border-t border-surface0">
+              <div className="text-subtext0 mb-1">Recent commits</div>
+              <ul className="space-y-0.5">
+                {state.recentCommits.map((c) => (
+                  <li key={c.sha} className="flex gap-2">
+                    <code className="text-mauve">{c.sha}</code>
+                    <span className="text-overlay1 truncate flex-1" title={c.subject}>
+                      {c.subject}
+                    </span>
+                    <span className="text-overlay0 shrink-0">{relativeTime(c.at)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {state.stashCount > 0 && (
+            <div className="text-overlay1 pt-1">Stash: {state.stashCount}</div>
+          )}
+        </div>
+      )}
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/LocalGitSection.tsx
+++ b/src/renderer/components/github/sections/LocalGitSection.tsx
@@ -12,6 +12,10 @@ export default function LocalGitSection({ sessionId, cwd }: Props) {
   const [state, setState] = useState<LocalGitState | null>(null)
 
   useEffect(() => {
+    // Reset to loading state on cwd change so the section doesn't briefly
+    // render the previous repo's branch/status while the first new poll
+    // is in flight.
+    setState(null)
     if (!cwd) return
     let alive = true
     const poll = async () => {

--- a/src/renderer/components/github/sections/NotificationsSection.tsx
+++ b/src/renderer/components/github/sections/NotificationsSection.tsx
@@ -1,13 +1,91 @@
+import { useState } from 'react'
 import SectionFrame from '../SectionFrame'
+import type { NotificationSummary } from '../../../../shared/github-types'
+import { useGitHubStore } from '../../../stores/githubStore'
 
 interface Props {
   sessionId: string
 }
 
 export default function NotificationsSection({ sessionId }: Props) {
+  const profiles = useGitHubStore((s) => s.profiles)
+  const notifCapable = profiles.filter((p) => p.capabilities.includes('notifications'))
+  const [selectedId, setSelectedId] = useState(notifCapable[0]?.id ?? '')
+  // Local-only for now — main's notifications fetch pushes through the
+  // data channel in a follow-up. The empty state below is the correct
+  // UX until that lands: "no notifications right now" with no fake data.
+  const items: NotificationSummary[] = []
+
+  if (notifCapable.length === 0) {
+    return (
+      <SectionFrame
+        sessionId={sessionId}
+        id="notifications"
+        title="Notifications"
+        emptyIndicator
+      >
+        <div className="text-xs text-overlay0">
+          Add an auth profile with the notifications scope to enable this.
+        </div>
+      </SectionFrame>
+    )
+  }
+
+  const unread = items.filter((i) => i.unread).length
   return (
-    <SectionFrame sessionId={sessionId} id="notifications" title="Notifications" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="notifications"
+      title="Notifications"
+      summary={unread > 0 ? `${unread} unread` : undefined}
+      emptyIndicator={items.length === 0}
+    >
+      {notifCapable.length > 1 && (
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          className="bg-surface0 p-1 rounded text-xs mb-2"
+        >
+          {notifCapable.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.label} ({p.username})
+            </option>
+          ))}
+        </select>
+      )}
+      <ul className="space-y-1 text-xs">
+        {items.map((i) => (
+          <li key={i.id} className="flex gap-2">
+            {i.unread && (
+              <span className="text-peach w-2" aria-label="unread">
+                {String.fromCodePoint(0x25cf)}
+              </span>
+            )}
+            <button
+              onClick={() => void window.electronAPI.shell.openExternal(i.url)}
+              className="text-blue hover:underline"
+            >
+              {i.repo}
+            </button>
+            <span className="text-text truncate flex-1" title={i.title}>
+              {i.title}
+            </span>
+            {i.unread && (
+              <button
+                onClick={() =>
+                  void window.electronAPI.github.markNotifRead(selectedId, i.id)
+                }
+                className="text-overlay1 text-[10px]"
+              >
+                mark read
+              </button>
+            )}
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="text-overlay0">No notifications right now</li>
+        )}
+      </ul>
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/NotificationsSection.tsx
+++ b/src/renderer/components/github/sections/NotificationsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import SectionFrame from '../SectionFrame'
 import type { NotificationSummary } from '../../../../shared/github-types'
 import { useGitHubStore } from '../../../stores/githubStore'
@@ -11,6 +11,19 @@ export default function NotificationsSection({ sessionId }: Props) {
   const profiles = useGitHubStore((s) => s.profiles)
   const notifCapable = profiles.filter((p) => p.capabilities.includes('notifications'))
   const [selectedId, setSelectedId] = useState(notifCapable[0]?.id ?? '')
+  // Re-sync the selection when profiles hydrate after mount (or when the
+  // previously-selected profile is removed). useState's initializer only
+  // fires once — without this, selectedId can stay '' and markNotifRead
+  // would fire with an empty profile id.
+  useEffect(() => {
+    if (notifCapable.length === 0) {
+      if (selectedId !== '') setSelectedId('')
+      return
+    }
+    if (!notifCapable.some((p) => p.id === selectedId)) {
+      setSelectedId(notifCapable[0].id)
+    }
+  }, [notifCapable, selectedId])
   // Local-only for now — main's notifications fetch pushes through the
   // data channel in a follow-up. The empty state below is the correct
   // UX until that lands: "no notifications right now" with no fake data.
@@ -41,17 +54,20 @@ export default function NotificationsSection({ sessionId }: Props) {
       emptyIndicator={items.length === 0}
     >
       {notifCapable.length > 1 && (
-        <select
-          value={selectedId}
-          onChange={(e) => setSelectedId(e.target.value)}
-          className="bg-surface0 p-1 rounded text-xs mb-2"
-        >
-          {notifCapable.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.label} ({p.username})
-            </option>
-          ))}
-        </select>
+        <label className="mb-2 flex items-center gap-2 text-xs text-text">
+          <span className="text-subtext0">Profile</span>
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="bg-surface0 p-1 rounded text-xs"
+          >
+            {notifCapable.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label} ({p.username})
+              </option>
+            ))}
+          </select>
+        </label>
       )}
       <ul className="space-y-1 text-xs">
         {items.map((i) => (

--- a/src/renderer/components/github/sections/NotificationsSection.tsx
+++ b/src/renderer/components/github/sections/NotificationsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import SectionFrame from '../SectionFrame'
 import type { NotificationSummary } from '../../../../shared/github-types'
 import { useGitHubStore } from '../../../stores/githubStore'
@@ -9,7 +9,13 @@ interface Props {
 
 export default function NotificationsSection({ sessionId }: Props) {
   const profiles = useGitHubStore((s) => s.profiles)
-  const notifCapable = profiles.filter((p) => p.capabilities.includes('notifications'))
+  // Memoize so the filtered list has stable identity between renders.
+  // Without this, the hydration effect below depends on a new array
+  // every render and runs on every render tick.
+  const notifCapable = useMemo(
+    () => profiles.filter((p) => p.capabilities.includes('notifications')),
+    [profiles],
+  )
   const [selectedId, setSelectedId] = useState(notifCapable[0]?.id ?? '')
   // Re-sync the selection when profiles hydrate after mount (or when the
   // previously-selected profile is removed). useState's initializer only

--- a/src/renderer/components/github/sections/ReviewsSection.tsx
+++ b/src/renderer/components/github/sections/ReviewsSection.tsx
@@ -18,11 +18,31 @@ export default function ReviewsSection({ sessionId, slug }: Props) {
   const unresolved = allThreads.filter((t) => !t.resolved)
   const empty = allThreads.length === 0 && reviews.length === 0
 
+  const [replyError, setReplyError] = useState<string | null>(null)
+  const [replySending, setReplySending] = useState(false)
+
   const send = async (threadId: string) => {
     if (!slug) return
-    await window.electronAPI.github.replyToReview(slug, threadId, replyText)
-    setReplyingTo(null)
-    setReplyText('')
+    const trimmed = replyText.trim()
+    if (!trimmed) {
+      setReplyError('Reply cannot be empty')
+      return
+    }
+    setReplyError(null)
+    setReplySending(true)
+    try {
+      const r = await window.electronAPI.github.replyToReview(slug, threadId, trimmed)
+      if (r.ok) {
+        setReplyingTo(null)
+        setReplyText('')
+      } else {
+        // Keep the composer open + preserve the typed text so the user
+        // can retry instead of losing their reply to a transient failure.
+        setReplyError(r.error ?? 'Failed to send')
+      }
+    } finally {
+      setReplySending(false)
+    }
   }
 
   return (
@@ -74,22 +94,34 @@ export default function ReviewsSection({ sessionId, slug }: Props) {
                 anchor clicks would otherwise be inert. */}
             <SanitizedMarkdown source={t.bodyMarkdown} />
             {replyingTo === t.id ? (
-              <div className="flex gap-1">
-                <input
-                  value={replyText}
-                  onChange={(e) => setReplyText(e.target.value)}
-                  className="flex-1 bg-surface0 p-1 rounded text-xs"
-                  placeholder="Reply"
-                />
-                <button
-                  onClick={() => send(t.id)}
-                  className="bg-blue text-base px-2 py-0.5 rounded text-xs"
-                >
-                  Send
-                </button>
-                <button onClick={() => setReplyingTo(null)} className="text-overlay1">
-                  {String.fromCodePoint(0x00d7)}
-                </button>
+              <div className="space-y-1">
+                <div className="flex gap-1">
+                  <input
+                    value={replyText}
+                    onChange={(e) => setReplyText(e.target.value)}
+                    className="flex-1 bg-surface0 p-1 rounded text-xs"
+                    placeholder="Reply"
+                    aria-label="Reply to review comment"
+                  />
+                  <button
+                    onClick={() => send(t.id)}
+                    disabled={replySending || replyText.trim().length === 0}
+                    className="bg-blue text-base px-2 py-0.5 rounded text-xs disabled:opacity-50"
+                  >
+                    {replySending ? 'Sending' : 'Send'}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setReplyingTo(null)
+                      setReplyError(null)
+                    }}
+                    className="text-overlay1"
+                    aria-label="Cancel reply"
+                  >
+                    {String.fromCodePoint(0x00d7)}
+                  </button>
+                </div>
+                {replyError && <div className="text-red text-[10px]">{replyError}</div>}
               </div>
             ) : (
               <button

--- a/src/renderer/components/github/sections/ReviewsSection.tsx
+++ b/src/renderer/components/github/sections/ReviewsSection.tsx
@@ -1,13 +1,107 @@
+import { useState } from 'react'
 import SectionFrame from '../SectionFrame'
+import { useGitHubStore } from '../../../stores/githubStore'
+import { SanitizedMarkdown } from '../SanitizedMarkdown'
 
 interface Props {
   sessionId: string
+  slug?: string
 }
 
-export default function ReviewsSection({ sessionId }: Props) {
+export default function ReviewsSection({ sessionId, slug }: Props) {
+  const data = useGitHubStore((s) => (slug ? s.repoData[slug] : undefined))
+  const reviews = data?.reviews ?? []
+  const [replyingTo, setReplyingTo] = useState<string | null>(null)
+  const [replyText, setReplyText] = useState('')
+
+  const allThreads = reviews.flatMap((r) => r.threads)
+  const unresolved = allThreads.filter((t) => !t.resolved)
+  const empty = allThreads.length === 0 && reviews.length === 0
+
+  const send = async (threadId: string) => {
+    if (!slug) return
+    await window.electronAPI.github.replyToReview(slug, threadId, replyText)
+    setReplyingTo(null)
+    setReplyText('')
+  }
+
   return (
-    <SectionFrame sessionId={sessionId} id="reviews" title="Reviews & Comments" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="reviews"
+      title="Reviews & Comments"
+      summary={empty ? undefined : `${unresolved.length} open`}
+      emptyIndicator={empty}
+    >
+      <div className="space-y-3 text-xs">
+        {reviews.map((r) => (
+          <div key={r.id} className="flex items-center gap-2 text-overlay1">
+            {/* Initials monogram per spec §9 avatar strategy — CSP blocks
+                remote https <img>, and the PR 2 plan captured avatarUrl
+                for a future main-process data: URL proxy. */}
+            <div
+              className="w-5 h-5 rounded-full bg-surface0 text-text flex items-center justify-center text-[9px] font-semibold shrink-0"
+              aria-hidden="true"
+            >
+              {r.reviewer.trim().slice(0, 2).toUpperCase()}
+            </div>
+            <span>@{r.reviewer}</span>
+            <span
+              className={
+                r.state === 'APPROVED'
+                  ? 'text-green'
+                  : r.state === 'CHANGES_REQUESTED'
+                  ? 'text-red'
+                  : 'text-overlay1'
+              }
+            >
+              {r.state.toLowerCase().replace('_', ' ')}
+            </span>
+          </div>
+        ))}
+        {unresolved.map((t) => (
+          <div key={t.id} className="border-l-2 border-surface0 pl-2 space-y-1">
+            <div className="text-overlay0">
+              @{t.commenter} on{' '}
+              <code className="text-peach">
+                {t.file}:{t.line}
+              </code>
+            </div>
+            {/* Spec §9: SanitizedMarkdown is the ONLY dangerouslySetInnerHTML
+                render site in this feature. It routes <a href=https://...>
+                clicks through window.electronAPI.shell.openExternal because
+                the app blocks will-navigate and denies window.open — raw
+                anchor clicks would otherwise be inert. */}
+            <SanitizedMarkdown source={t.bodyMarkdown} />
+            {replyingTo === t.id ? (
+              <div className="flex gap-1">
+                <input
+                  value={replyText}
+                  onChange={(e) => setReplyText(e.target.value)}
+                  className="flex-1 bg-surface0 p-1 rounded text-xs"
+                  placeholder="Reply"
+                />
+                <button
+                  onClick={() => send(t.id)}
+                  className="bg-blue text-base px-2 py-0.5 rounded text-xs"
+                >
+                  Send
+                </button>
+                <button onClick={() => setReplyingTo(null)} className="text-overlay1">
+                  {String.fromCodePoint(0x00d7)}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setReplyingTo(t.id)}
+                className="text-blue text-xs"
+              >
+                Reply
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/ReviewsSection.tsx
+++ b/src/renderer/components/github/sections/ReviewsSection.tsx
@@ -40,6 +40,11 @@ export default function ReviewsSection({ sessionId, slug }: Props) {
         // can retry instead of losing their reply to a transient failure.
         setReplyError(r.error ?? 'Failed to send')
       }
+    } catch (err) {
+      // IPC rejection path — without this, a main-side throw leaves the
+      // button click as an unhandled promise rejection and the user gets
+      // no feedback. Preserve composer state so retry is one click.
+      setReplyError(err instanceof Error ? err.message : 'Failed to send reply')
     } finally {
       setReplySending(false)
     }

--- a/src/renderer/components/github/sections/SessionContextSection.tsx
+++ b/src/renderer/components/github/sections/SessionContextSection.tsx
@@ -13,8 +13,13 @@ export default function SessionContextSection({ sessionId }: Props) {
   useEffect(() => {
     let alive = true
     const poll = async () => {
-      const r = await window.electronAPI.github.getSessionContext(sessionId)
-      if (alive && r.ok) setCtx(r.data as SessionContextResult | null)
+      try {
+        const r = await window.electronAPI.github.getSessionContext(sessionId)
+        if (alive && r.ok) setCtx(r.data as SessionContextResult | null)
+      } catch {
+        // Swallow — preserve the last good context rather than crashing
+        // the poll loop on a transient IPC failure.
+      }
     }
     void poll()
     const t = setInterval(poll, 20_000)
@@ -36,26 +41,28 @@ export default function SessionContextSection({ sessionId }: Props) {
       summary={summary}
       emptyIndicator={empty}
     >
-      {ctx?.primaryIssue ? (
+      {ctx && !empty ? (
         <div className="text-xs space-y-2">
-          <div>
-            <span className="text-subtext0">Working on: </span>
-            <span className="text-blue">#{ctx.primaryIssue.number}</span>
-            {ctx.primaryIssue.title && (
-              <span className="text-text ml-1">{ctx.primaryIssue.title}</span>
-            )}
-            {ctx.primaryIssue.state && (
-              <span
-                className={`ml-2 text-[10px] px-1 rounded ${
-                  ctx.primaryIssue.state === 'open'
-                    ? 'bg-green/20 text-green'
-                    : 'bg-overlay0/20 text-overlay1'
-                }`}
-              >
-                {ctx.primaryIssue.state}
-              </span>
-            )}
-          </div>
+          {ctx.primaryIssue && (
+            <div>
+              <span className="text-subtext0">Working on: </span>
+              <span className="text-blue">#{ctx.primaryIssue.number}</span>
+              {ctx.primaryIssue.title && (
+                <span className="text-text ml-1">{ctx.primaryIssue.title}</span>
+              )}
+              {ctx.primaryIssue.state && (
+                <span
+                  className={`ml-2 text-[10px] px-1 rounded ${
+                    ctx.primaryIssue.state === 'open'
+                      ? 'bg-green/20 text-green'
+                      : 'bg-overlay0/20 text-overlay1'
+                  }`}
+                >
+                  {ctx.primaryIssue.state}
+                </span>
+              )}
+            </div>
+          )}
           {ctx.otherSignals.length > 0 && (
             <details className="text-overlay1">
               <summary className="cursor-pointer">

--- a/src/renderer/components/github/sections/SessionContextSection.tsx
+++ b/src/renderer/components/github/sections/SessionContextSection.tsx
@@ -1,13 +1,103 @@
+import { useEffect, useState } from 'react'
 import SectionFrame from '../SectionFrame'
+import type { SessionContextResult } from '../../../../shared/github-types'
+import { relativeTime } from '../../../utils/relativeTime'
 
 interface Props {
   sessionId: string
 }
 
 export default function SessionContextSection({ sessionId }: Props) {
+  const [ctx, setCtx] = useState<SessionContextResult | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    const poll = async () => {
+      const r = await window.electronAPI.github.getSessionContext(sessionId)
+      if (alive && r.ok) setCtx(r.data as SessionContextResult | null)
+    }
+    void poll()
+    const t = setInterval(poll, 20_000)
+    return () => {
+      alive = false
+      clearInterval(t)
+    }
+  }, [sessionId])
+
+  const empty =
+    !ctx || (!ctx.primaryIssue && !ctx.activePR && ctx.recentFiles.length === 0)
+  const summary = ctx?.primaryIssue ? `#${ctx.primaryIssue.number}` : undefined
+
   return (
-    <SectionFrame sessionId={sessionId} id="sessionContext" title="Session Context" emptyIndicator>
-      <div className="text-xs text-overlay0">Populated in PR 3</div>
+    <SectionFrame
+      sessionId={sessionId}
+      id="sessionContext"
+      title="Session Context"
+      summary={summary}
+      emptyIndicator={empty}
+    >
+      {ctx?.primaryIssue ? (
+        <div className="text-xs space-y-2">
+          <div>
+            <span className="text-subtext0">Working on: </span>
+            <span className="text-blue">#{ctx.primaryIssue.number}</span>
+            {ctx.primaryIssue.title && (
+              <span className="text-text ml-1">{ctx.primaryIssue.title}</span>
+            )}
+            {ctx.primaryIssue.state && (
+              <span
+                className={`ml-2 text-[10px] px-1 rounded ${
+                  ctx.primaryIssue.state === 'open'
+                    ? 'bg-green/20 text-green'
+                    : 'bg-overlay0/20 text-overlay1'
+                }`}
+              >
+                {ctx.primaryIssue.state}
+              </span>
+            )}
+          </div>
+          {ctx.otherSignals.length > 0 && (
+            <details className="text-overlay1">
+              <summary className="cursor-pointer">
+                Other signals ({ctx.otherSignals.length})
+              </summary>
+              <ul className="ml-4">
+                {ctx.otherSignals.map((s, i) => (
+                  <li key={i}>
+                    #{s.number} <span className="text-overlay0">({s.source})</span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+          {ctx.activePR && (
+            <div>
+              <span className="text-subtext0">Related PR: </span>
+              <span className="text-mauve">#{ctx.activePR.number}</span>
+              <span className="text-overlay0 ml-1">
+                {ctx.activePR.draft ? 'draft' : ctx.activePR.state}
+              </span>
+            </div>
+          )}
+          {ctx.recentFiles.length > 0 && (
+            <div>
+              <div className="text-subtext0">Claude recently edited:</div>
+              <ul className="ml-3">
+                {ctx.recentFiles.slice(0, 5).map((f) => (
+                  <li key={f.filePath} className="flex gap-2">
+                    <code className="text-peach truncate" title={f.filePath}>
+                      {f.filePath}
+                    </code>
+                    <span className="text-overlay0 shrink-0">{relativeTime(f.at)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="text-xs text-overlay0">No session context yet</div>
+      )}
     </SectionFrame>
   )
 }

--- a/src/renderer/components/github/sections/SessionContextSection.tsx
+++ b/src/renderer/components/github/sections/SessionContextSection.tsx
@@ -62,8 +62,8 @@ export default function SessionContextSection({ sessionId }: Props) {
                 Other signals ({ctx.otherSignals.length})
               </summary>
               <ul className="ml-4">
-                {ctx.otherSignals.map((s, i) => (
-                  <li key={i}>
+                {ctx.otherSignals.map((s) => (
+                  <li key={`${s.source}:${s.repo ?? ''}:${s.number}`}>
                     #{s.number} <span className="text-overlay0">({s.source})</span>
                   </li>
                 ))}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -379,15 +379,19 @@ export interface ElectronAPI {
         nextResetAt?: number
       }) => void,
     ) => () => void
-    rerunActionsRun: (slug: string, runId: number) => Promise<{ ok: boolean }>
+    rerunActionsRun: (slug: string, runId: number) => Promise<{ ok: boolean; error?: string }>
     mergePR: (
       slug: string,
       prNumber: number,
       method: 'merge' | 'squash' | 'rebase',
-    ) => Promise<{ ok: boolean }>
-    readyPR: (slug: string, prNumber: number) => Promise<{ ok: boolean }>
-    replyToReview: (slug: string, threadId: string, body: string) => Promise<{ ok: boolean }>
-    markNotifRead: (profileId: string, notifId: string) => Promise<{ ok: boolean }>
+    ) => Promise<{ ok: boolean; error?: string }>
+    readyPR: (slug: string, prNumber: number) => Promise<{ ok: boolean; error?: string }>
+    replyToReview: (
+      slug: string,
+      threadId: string,
+      body: string,
+    ) => Promise<{ ok: boolean; error?: string }>
+    markNotifRead: (profileId: string, notifId: string) => Promise<{ ok: boolean; error?: string }>
   }
 }
 

--- a/tests/unit/github/transcript-loader.test.ts
+++ b/tests/unit/github/transcript-loader.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { pathToClaudeProjectFolder } from '../../../src/main/utils/claude-project-path'
 
 // loadTranscriptEvents reads from ~/.claude/projects/. os.homedir() reads
 // HOME (POSIX) and USERPROFILE (Windows), so we stub both via vi.stubEnv
@@ -21,8 +22,9 @@ afterEach(async () => {
 })
 
 async function writeProjectJsonl(cwd: string, filename: string, lines: string[], mtime?: number) {
-  // Mirror the convention in src/main/utils/claude-project-path.ts.
-  const folder = cwd.replace(/:/g, '-').replace(/[\\/]+/g, '-')
+  // Reuse the shared helper so the test can't drift from the production
+  // mapping if Claude CLI's folder convention ever changes.
+  const folder = pathToClaudeProjectFolder(cwd)
   const dir = path.join(fakeHome, '.claude', 'projects', folder)
   await fs.mkdir(dir, { recursive: true })
   const full = path.join(dir, filename)

--- a/tests/unit/github/transcript-loader.test.ts
+++ b/tests/unit/github/transcript-loader.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+// loadTranscriptEvents reads from ~/.claude/projects/. os.homedir() reads
+// HOME (POSIX) and USERPROFILE (Windows), so we stub both via vi.stubEnv
+// — which respects vitest's per-test isolation and won't bleed into
+// parallel workers the way raw process.env mutations can.
+let fakeHome: string
+
+beforeEach(async () => {
+  fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-tx-'))
+  vi.stubEnv('HOME', fakeHome)
+  vi.stubEnv('USERPROFILE', fakeHome)
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await fs.rm(fakeHome, { recursive: true, force: true })
+})
+
+async function writeProjectJsonl(cwd: string, filename: string, lines: string[], mtime?: number) {
+  // Mirror the convention in src/main/utils/claude-project-path.ts.
+  const folder = cwd.replace(/:/g, '-').replace(/[\\/]+/g, '-')
+  const dir = path.join(fakeHome, '.claude', 'projects', folder)
+  await fs.mkdir(dir, { recursive: true })
+  const full = path.join(dir, filename)
+  await fs.writeFile(full, lines.join('\n'), 'utf8')
+  if (mtime !== undefined) {
+    await fs.utimes(full, new Date(mtime), new Date(mtime))
+  }
+  return full
+}
+
+describe('loadTranscriptEvents', () => {
+  it('returns empty when cwd is undefined', async () => {
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents(undefined)
+    expect(r).toEqual({ messages: [], toolCalls: [] })
+  })
+
+  it('returns empty when project folder does not exist', async () => {
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents('/nonexistent/path')
+    expect(r).toEqual({ messages: [], toolCalls: [] })
+  })
+
+  it('picks the most recently modified jsonl when multiple exist', async () => {
+    const cwd = '/home/x/app'
+    await writeProjectJsonl(
+      cwd,
+      'old.jsonl',
+      [
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-01-01T00:00:00Z',
+          message: { role: 'user', content: 'old file' },
+        }),
+      ],
+      Date.now() - 60_000,
+    )
+    await writeProjectJsonl(
+      cwd,
+      'new.jsonl',
+      [
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-01-02T00:00:00Z',
+          message: { role: 'user', content: 'new file wins' },
+        }),
+      ],
+      Date.now(),
+    )
+
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents(cwd)
+    expect(r.messages).toHaveLength(1)
+    expect(r.messages[0].text).toBe('new file wins')
+  })
+
+  it('tolerates invalid JSON lines', async () => {
+    const cwd = '/home/x/app'
+    await writeProjectJsonl(cwd, 'a.jsonl', [
+      'not json at all',
+      JSON.stringify({
+        message: { role: 'user', content: 'good line' },
+        timestamp: '2026-01-01T00:00:00Z',
+      }),
+      '{"half": ',
+    ])
+
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents(cwd)
+    expect(r.messages).toHaveLength(1)
+    expect(r.messages[0].text).toBe('good line')
+  })
+
+  it('extracts tool calls from content parts', async () => {
+    const cwd = '/home/x/app'
+    await writeProjectJsonl(cwd, 'a.jsonl', [
+      JSON.stringify({
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'ok' },
+            { type: 'tool_use', name: 'Edit', input: { file_path: '/home/x/a.ts' } },
+          ],
+        },
+        timestamp: '2026-01-01T00:00:00Z',
+      }),
+    ])
+
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents(cwd)
+    expect(r.messages.map((m) => m.text)).toEqual(['ok'])
+    expect(r.toolCalls).toHaveLength(1)
+    expect(r.toolCalls[0].tool).toBe('Edit')
+    expect(r.toolCalls[0].args).toEqual({ file_path: '/home/x/a.ts' })
+  })
+
+  it('caps at MAX_LINES (tails the newest lines)', async () => {
+    const cwd = '/home/x/app'
+    const many: string[] = []
+    for (let i = 0; i < 600; i++) {
+      many.push(
+        JSON.stringify({
+          message: { role: 'user', content: `msg-${i}` },
+          timestamp: '2026-01-01T00:00:00Z',
+        }),
+      )
+    }
+    await writeProjectJsonl(cwd, 'a.jsonl', many)
+
+    const { loadTranscriptEvents } = await import(
+      '../../../src/main/github/session/transcript-loader'
+    )
+    const r = await loadTranscriptEvents(cwd)
+    expect(r.messages).toHaveLength(500)
+    // The tail should include the newest 500 — i.e. msg-599 down to msg-100.
+    expect(r.messages[r.messages.length - 1].text).toBe('msg-599')
+    expect(r.messages[0].text).toBe('msg-100')
+  })
+})


### PR DESCRIPTION
## Summary

Populates all seven GitHub panel sections and wires the remaining action
IPCs to real GitHub REST/GraphQL calls. After this PR the feature is
functionally complete end-to-end for anyone who's enabled integration
on a session — PR 3c adds onboarding polish and E2E tests.

Sections:
- **LocalGit** — 15s poll of getLocalGit IPC; branch, ahead/behind,
  staged/unstaged/untracked file drawers, last 5 commits, stash count.
- **SessionContext** — 20s poll of SESSION_CONTEXT_GET. Runs the spec
  §6.1 priority algorithm (branch issue number > most recent transcript
  ref > first PR-body ref) and renders the primary issue with title,
  state, related PR, and recently-edited files. Transcript scanning is
  still opt-in per spec §10.
- **ActivePR** — PR title, author, mergeable state, merge buttons gated
  on pr.allowedMergeMethods; 'Ready for review' shows only for drafts.
- **CI** — workflow runs with conclusion-colored glyphs; re-run button
  appears only on failed runs.
- **Reviews** — threaded review comments. Introduces the ONE dangerously-
  SetInnerHTML render site in the feature via the PR-2 SanitizedMarkdown
  wrapper (marked + DOMPurify, https-only URLs). Reply composer posts
  via replyToReview IPC.
- **Issues** — linked issues with 'primary' badge matching session-
  context's resolved primary.
- **Notifications** — per-profile selector + mark-read action. Empty
  state surfaces until the notifications fetch push lands.

Backend:
- New \`transcript-loader.ts\` reads the most-recently-touched JSONL
  under \`~/.claude/projects/<cwd-mangled>/\` and returns typed
  {messages, toolCalls}. Caps at 500 lines for parse cost.
- SESSION_CONTEXT_GET handler: feeds transcript scanner + tool-call
  inspector into buildSessionContext with a REST enrichIssue resolver.
- Action handlers (ACTIONS_RERUN, PR_MERGE, PR_READY, REVIEW_REPLY,
  NOTIF_MARK_READ) each validate inputs, resolve the right actor's
  token, and return discriminated errors on non-2xx.
- PR_READY uses GraphQL markPullRequestReadyForReview since REST has
  no direct draft→ready endpoint.

## Out of scope (PR 3c)

Onboarding modal, post-update trigger, screenshots (Win + Mac), tour
step, tips seed, banners (auto-detect / rate-limit / expiry),
accessibility sweep, E2E tests for OAuth UI + panel states, notifications
fetch push pipeline, PR-body reference scanning.

## Depends on

PR 3a (#16) merged to beta.

## Test plan

- [x] 470 unit tests pass
- [x] Typecheck clean
- [x] Production build clean
- [ ] Sections render real data when a session is enabled with a valid
      repoSlug + auth profile
- [ ] LocalGit poll picks up local git mutations within 15s
- [ ] SessionContext surfaces a branch-named issue (e.g. \`fix/247-x\`)
- [ ] PR merge succeeds when mergeable state is 'clean'
- [ ] Re-run failed jobs returns ok:true for a failed run
- [ ] Ready-for-review flips a draft via the GraphQL mutation
- [ ] Reviews renders sanitized markdown (<script>, javascript:, onclick
      all stripped); anchor clicks route through shell.openExternal

🤖 Generated with [Claude Code](https://claude.com/claude-code)