### PR TITLE
fix(terminal): bracketed-paste support for right-click paste

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -333,10 +333,15 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           navigator.clipboard.writeText(sel)
         } else {
           navigator.clipboard.readText().then((text) => {
-            if (text) {
-              // Paste directly into the PTY (like real Claude Code terminal)
-              window.electronAPI.pty.write(sessionId, text)
-            }
+            if (!text) return
+            // Route through xterm's paste() so bracketed-paste mode is
+            // respected. Writing the raw text straight to the PTY skipped
+            // the \x1b[200~...\x1b[201~ wrapping that apps like Claude
+            // Code CLI use to distinguish pastes from keystrokes, causing
+            // embedded \n to submit the first line and strand the rest
+            // in the input buffer. xterm emits the (possibly wrapped)
+            // payload via onData, which already forwards to pty.write.
+            term?.paste(text)
           })
         }
       }

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -325,24 +325,31 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       document.addEventListener('keydown', handleKeyDownCopy)
 
       // Right-click: copy selection or paste from clipboard
-      handleContextMenu = (e: MouseEvent) => {
+      handleContextMenu = async (e: MouseEvent) => {
         e.preventDefault()
         e.stopPropagation()
         const sel = term?.getSelection()
         if (sel) {
-          navigator.clipboard.writeText(sel)
-        } else {
-          navigator.clipboard.readText().then((text) => {
-            if (!text) return
-            // Route through xterm's paste() so bracketed-paste mode is
-            // respected. Writing the raw text straight to the PTY skipped
-            // the \x1b[200~...\x1b[201~ wrapping that apps like Claude
-            // Code CLI use to distinguish pastes from keystrokes, causing
-            // embedded \n to submit the first line and strand the rest
-            // in the input buffer. xterm emits the (possibly wrapped)
-            // payload via onData, which already forwards to pty.write.
-            term?.paste(text)
-          })
+          try {
+            await navigator.clipboard.writeText(sel)
+          } catch {
+            // clipboard access denied (insecure context / not focused)
+          }
+          return
+        }
+        try {
+          const text = await navigator.clipboard.readText()
+          if (!text) return
+          // Route through xterm's paste() so bracketed-paste mode is
+          // respected. Writing the raw text straight to the PTY skipped
+          // the \x1b[200~...\x1b[201~ wrapping that apps like Claude
+          // Code CLI use to distinguish pastes from keystrokes, causing
+          // embedded \n to submit the first line and strand the rest
+          // in the input buffer. xterm emits the (possibly wrapped)
+          // payload via onData, which already forwards to pty.write.
+          term?.paste(text)
+        } catch {
+          // clipboard access denied (insecure context / not focused)
         }
       }
       container.addEventListener('contextmenu', handleContextMenu, true)


### PR DESCRIPTION
## Summary

Right-click paste was bypassing xterm.js and writing the clipboard text straight to the PTY, so bracketed-paste-mode wrapping (`\x1b[200~`...`\x1b[201~`) was never applied. Apps that opt into the mode — Claude Code CLI being the user-facing case — treated embedded `\n` as Enter and submitted the first line, leaving the rest of the paste stranded in their input box.

## Fix

One-line change in `src/renderer/components/TerminalView.tsx`: route the clipboard text through `term.paste(text)` instead of `window.electronAPI.pty.write(sessionId, text)`. xterm.js then:
- Detects whether the remote app has enabled bracketed paste (CSI 2004h).
- Wraps the payload with the bracket delimiters if yes, passes through as-is if no.
- Emits the (possibly wrapped) payload via its existing `onData` handler, which already forwards to `pty.write`.

No main-process changes needed. Ctrl+V already worked correctly because xterm.js handles it through its own DOM paste event on the hidden textarea; only the right-click path bypassed it.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npx vitest run` — 487 / 487 tests pass
- [x] `npm run build` — clean
- [ ] Manual: right-click paste a multi-line block into an SSH Claude Code session, verify whole thing lands in the prompt as one submission
- [ ] Manual: right-click paste a single-line command at a plain bash SSH shell, verify it still executes normally (no regression for apps that don't enable bracketed paste)
- [ ] Manual: Ctrl+V paste in both contexts as a sanity check (was already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)