### PR TITLE
fix(github): wire session-context-seen trackUsage call

### DIFF
--- a/src/renderer/components/github/sections/SessionContextSection.tsx
+++ b/src/renderer/components/github/sections/SessionContextSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import SectionFrame from '../SectionFrame'
 import type { SessionContextResult } from '../../../../shared/github-types'
 import { relativeTime } from '../../../utils/relativeTime'
+import { trackUsage } from '../../../stores/tipsStore'
 
 interface Props {
   sessionId: string
@@ -32,6 +33,14 @@ export default function SessionContextSection({ sessionId }: Props) {
   const empty =
     !ctx || (!ctx.primaryIssue && !ctx.activePR && ctx.recentFiles.length === 0)
   const summary = ctx?.primaryIssue ? `#${ctx.primaryIssue.number}` : undefined
+
+  // Fire the tracking tag once the section has genuinely-useful data.
+  // The corresponding tip in TIPS_LIBRARY excludes on this key, so it
+  // stops surfacing once the user has actually seen session-context
+  // work. Guarded by `empty` so the empty-state render doesn't count.
+  useEffect(() => {
+    if (!empty) trackUsage('github.session-context-seen')
+  }, [empty])
 
   return (
     <SectionFrame


### PR DESCRIPTION
## Summary

Release-readiness gap discovered while auditing PR 3c outputs: the `session-context` tip in TIPS_LIBRARY uses `excludes: ['github.session-context-seen']`, but no component ever fired the matching `trackUsage` call. The tip would have kept surfacing in rotation even after the user had clearly seen session-context working.

## Fix

`SessionContextSection.tsx` now imports `trackUsage` and fires `github.session-context-seen` in a `useEffect` that's guarded by `!empty` — so empty-state renders (no repo configured yet) don't silently mark the tip seen.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npx vitest run` — 487 / 487 tests pass
- [ ] Manual: enable integration on a real repo, confirm the session-context tip stops appearing after one render with content

🤖 Generated with [Claude Code](https://claude.com/claude-code)