### PR TITLE
Beta v1.4.2 → stable promotion candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/main/memory-scanner.ts
+++ b/src/main/memory-scanner.ts
@@ -395,13 +395,17 @@ export async function writeMemoryFrontmatter(
   if (frontmatter.description !== undefined) merged.description = frontmatter.description
   if (frontmatter.type !== undefined) merged.type = frontmatter.type
 
-  // Build YAML block
+  // Build YAML block. For values that need quoting (colons, special YAML
+  // chars, embedded newlines/quotes/backslashes), emit via JSON.stringify —
+  // YAML 1.2 double-quoted flow scalars accept JSON's full escape vocabulary
+  // (\\, \", \n, \t, \uXXXX, …), so this round-trips cleanly. The previous
+  // hand-rolled `value.replace(/"/g, '\\"')` only escaped quotes, leaving
+  // backslashes and newlines as malformed YAML on read-back.
   const yamlLines: string[] = []
   for (const [key, value] of Object.entries(merged)) {
     if (value) {
-      // Quote values that contain colons or special YAML characters
-      const needsQuotes = /[:#\[\]{}&*!|>'"%@`]/.test(value) || value.includes('\n')
-      yamlLines.push(needsQuotes ? `${key}: "${value.replace(/"/g, '\\"')}"` : `${key}: ${value}`)
+      const needsQuotes = /[:#\[\]{}&*!|>'"%@`\\]/.test(value) || /[\r\n\t]/.test(value)
+      yamlLines.push(needsQuotes ? `${key}: ${JSON.stringify(value)}` : `${key}: ${value}`)
     }
   }
 

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,12 +15,13 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
-    version: '1.4.1',
+    version: '1.4.2',
     date: '2026-04-28',
     highlights: "Safety-net daily backups of your CONFIG directory — never lose a session list to a corrupted write again",
     changes: [
       { type: 'feature', description: "Daily auto-backup of CONFIG/*.json under CONFIG/_backups/YYYY-MM-DD/ on every app launch. Last 7 days kept, prunes older. Recovery is a manual copy back into CONFIG/ — but the data is always there if anything goes sideways" },
       { type: 'fix', description: "Capture-training script no longer destroys real config data on cleanup. PID lock prevents concurrent captures; cleanup only restores files it explicitly backed up; never blind-deletes by filename match" },
+      { type: 'fix', description: "Memory frontmatter writer now produces valid YAML for values containing backslashes, newlines, and other control chars. Previously only escaped quotes — anything else round-tripped as malformed YAML. Switched to JSON-stringify which is a strict subset of YAML 1.2's double-quoted scalar grammar" },
     ]
   },
   {


### PR DESCRIPTION
## What this is

This PR tracks everything on the `beta` branch that is a candidate for the next stable release.

**Current beta release**: [v1.4.2-beta](https://github.com/nubbymong/claude-command-center/releases/tag/v1.4.2-beta)

Merging this PR promotes all these changes to the stable channel.

## How to promote

Run `npm run promote` from the `beta` branch. It will merge this PR and cut a stable release.