### PR TITLE
V2 Shell UX Phase 1: expanded tokens + light-theme AA contrast

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -56,6 +56,12 @@
   --surface-stage: #171e27;
   --surface-stage-gutter: #141b24;
   --surface-raised: #1c2430;
+  --surface-base: #0d131b;
+  --surface-sunken: #0c121a;
+  --surface-overlay: #222c39;
+
+  --border-subtle: #1f2731;
+  --border-strong: #33404f;
 
   --text-primary: #eef2f7;
   --text-secondary: #a8b2c0;
@@ -127,6 +133,12 @@
   --surface-stage: #e8ecf3;
   --surface-stage-gutter: #dee3eb;
   --surface-raised: #eff2f7;
+  --surface-base: #dfe4ec;
+  --surface-sunken: #d6dce6;
+  --surface-overlay: #f6f8fb;
+
+  --border-subtle: #c2cad6;
+  --border-strong: #a7b2c2;
 
   --text-primary: #11161f;
   --text-secondary: #404c5b;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -48,8 +48,9 @@
 /* -- Semantic design tokens -- V2 "Command Workbench" (spec §12) --
    Explicit per-theme values (NOT palette aliases). Touched chrome consumes
    these; raw --color-* stays for migration compatibility only.
-   Surface ladder darkest -> brightest stage -> raised:
-   chrome < panel < stage < raised. Default = E5 Dark. */
+   Surface ladder by absolute darkness:
+   chrome < sunken < base < panel < stage < raised. overlay sits above all
+   (popovers/menus, with shadow), not part of the depth ramp. Default = E5 Dark. */
 :root {
   --surface-chrome: #0a0e13;
   --surface-panel: #111720;
@@ -142,7 +143,7 @@
 
   --text-primary: #11161f;
   --text-secondary: #404c5b;
-  --text-muted: #545e6b;
+  --text-muted: #4e5865;
   --text-on-chrome: #11161f;
 
   --terminal-foreground: #11161f;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -142,7 +142,7 @@
 
   --text-primary: #11161f;
   --text-secondary: #404c5b;
-  --text-muted: #6f7b89;
+  --text-muted: #545e6b;
   --text-on-chrome: #11161f;
 
   --terminal-foreground: #11161f;

--- a/tests/unit/styles/design-tokens.test.ts
+++ b/tests/unit/styles/design-tokens.test.ts
@@ -34,6 +34,8 @@ describe('V2 shell design tokens', () => {
   it.each(NEW_TOKENS)('defines %s in the light ([data-theme=light]) block', (t) => {
     expect(tokenNames(light).has(t)).toBe(true)
   })
+  // Covers --surface-*/--border-* only; --text-* drift is a separate concern,
+  // add a guard when text tokens are systematically managed.
   it('defines the same --surface-*/--border-* token set in both themes (no drift)', () => {
     const surfBorder = (s: Set<string>) =>
       [...s].filter((t) => t.startsWith('--surface-') || t.startsWith('--border-')).sort()
@@ -41,6 +43,8 @@ describe('V2 shell design tokens', () => {
   })
 })
 
+// Reads a token value from a single theme block. Assumes no duplicate token
+// names within a block (returns the first match).
 function tokenValue(block: string, name: string): string {
   const m = block.match(new RegExp(name + '\\s*:\\s*([^;]+);'))
   if (!m) throw new Error('token not found: ' + name)
@@ -63,9 +67,10 @@ function contrast(a: string, b: string): number {
   return (hi + 0.05) / (lo + 0.05)
 }
 
-describe('TL2.1 light theme text contrast (WCAG AA)', () => {
+describe('TL2.1 light theme text contrast (WCAG AA/AAA)', () => {
   const panel = tokenValue(light, '--surface-panel')
   const stage = tokenValue(light, '--surface-stage')
+  // AAA threshold (7:1) -- primary body text on the lightest surface.
   it('primary text on stage >= 7:1', () => {
     expect(contrast(tokenValue(light, '--text-primary'), stage)).toBeGreaterThanOrEqual(7)
   })

--- a/tests/unit/styles/design-tokens.test.ts
+++ b/tests/unit/styles/design-tokens.test.ts
@@ -40,3 +40,39 @@ describe('V2 shell design tokens', () => {
     expect(surfBorder(tokenNames(light))).toEqual(surfBorder(tokenNames(dark)))
   })
 })
+
+function tokenValue(block: string, name: string): string {
+  const m = block.match(new RegExp(name + '\\s*:\\s*([^;]+);'))
+  if (!m) throw new Error('token not found: ' + name)
+  return m[1].trim()
+}
+// WCAG 2.1 relative luminance + contrast ratio.
+function srgbToLin(c: number): number {
+  const s = c / 255
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+}
+function luminance(hex: string): number {
+  const n = parseInt(hex.replace('#', ''), 16)
+  return 0.2126 * srgbToLin((n >> 16) & 255)
+    + 0.7152 * srgbToLin((n >> 8) & 255)
+    + 0.0722 * srgbToLin(n & 255)
+}
+function contrast(a: string, b: string): number {
+  const l1 = luminance(a), l2 = luminance(b)
+  const hi = Math.max(l1, l2), lo = Math.min(l1, l2)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+describe('TL2.1 light theme text contrast (WCAG AA)', () => {
+  const panel = tokenValue(light, '--surface-panel')
+  const stage = tokenValue(light, '--surface-stage')
+  it('primary text on stage >= 7:1', () => {
+    expect(contrast(tokenValue(light, '--text-primary'), stage)).toBeGreaterThanOrEqual(7)
+  })
+  it('secondary text on panel >= 4.5:1', () => {
+    expect(contrast(tokenValue(light, '--text-secondary'), panel)).toBeGreaterThanOrEqual(4.5)
+  })
+  it('muted text on panel >= 4.5:1 (the "washed out" fix)', () => {
+    expect(contrast(tokenValue(light, '--text-muted'), panel)).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/tests/unit/styles/design-tokens.test.ts
+++ b/tests/unit/styles/design-tokens.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const css = readFileSync(resolve(__dirname, '../../../src/renderer/styles.css'), 'utf8')
+
+// Return the body of the rule for `selector` that defines the semantic tokens
+// (identified by containing --surface-chrome). There are two `:root` blocks
+// in the file -- the raw --color-* palette and the semantic block; this picks
+// the semantic one. CSS custom-property blocks have no nested braces, so a
+// non-greedy [^}]* body match is safe.
+function themeBlock(selector: string): string {
+  const re = new RegExp(selector + '\\s*\\{([^}]*)\\}', 'g')
+  for (const m of css.matchAll(re)) {
+    if (m[1].includes('--surface-chrome')) return m[1]
+  }
+  throw new Error('semantic block not found for ' + selector)
+}
+function tokenNames(block: string): Set<string> {
+  return new Set([...block.matchAll(/(--[\w-]+)\s*:/g)].map((m) => m[1]))
+}
+
+const NEW_TOKENS = [
+  '--surface-base', '--surface-sunken', '--surface-overlay',
+  '--border-subtle', '--border-strong',
+]
+const dark = themeBlock(':root')
+const light = themeBlock('\\[data-theme="light"\\]')
+
+describe('V2 shell design tokens', () => {
+  it.each(NEW_TOKENS)('defines %s in the dark (:root) semantic block', (t) => {
+    expect(tokenNames(dark).has(t)).toBe(true)
+  })
+  it.each(NEW_TOKENS)('defines %s in the light ([data-theme=light]) block', (t) => {
+    expect(tokenNames(light).has(t)).toBe(true)
+  })
+  it('defines the same --surface-*/--border-* token set in both themes (no drift)', () => {
+    const surfBorder = (s: Set<string>) =>
+      [...s].filter((t) => t.startsWith('--surface-') || t.startsWith('--border-')).sort()
+    expect(surfBorder(tokenNames(light))).toEqual(surfBorder(tokenNames(dark)))
+  })
+})


### PR DESCRIPTION
**Phase 1 of the V2 Shell UX redesign** (spec `docs/superpowers/specs/2026-05-25-v2-shell-ux-design.md` §4-5; plan `docs/superpowers/plans/2026-05-25-v2-shell-phase1-tokens.md`). Visual/structural foundation only -- no behaviour changes, no component adoption yet.

## What changed
- **New semantic tokens** in both theme blocks (`:root` E5 Dark + `[data-theme="light"]` TL2.1): `--surface-base`, `--surface-sunken`, `--surface-overlay`, `--border-subtle`, `--border-strong`. Consumed by later phases.
- **Light-theme contrast fix:** `--text-muted` was ~3.0:1 on `--surface-panel` (the "washed out" complaint) -> darkened to `#4e5865` (~5:1, WCAG AA with headroom).

## Tests
- New `tests/unit/styles/design-tokens.test.ts`: structural no-drift guard (both themes define the same `--surface-*`/`--border-*` set) + WCAG contrast gate computed from the token values.
- Full suite: **1000 passed / 1 skipped**. `tsc --noEmit`: 0 errors.

## Reviews
- Independent spec-compliance review: ✅
- Independent code-quality review: actioned (AA/AAA naming, muted headroom, comment annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)