### PR TITLE
V2 Shell UX Phase 2a: identity-colour palette keys + bucketing (logic only)

### DIFF
--- a/src/shared/identity-colors.ts
+++ b/src/shared/identity-colors.ts
@@ -30,3 +30,68 @@ export function resolveIdentityColor(key: IdentityColorKey, theme: 'dark' | 'lig
   const entry = IDENTITY_PALETTE[key] ?? IDENTITY_PALETTE.mauve
   return theme === 'light' ? entry.light : entry.dark
 }
+
+// Exact legacy hexes from the previous 24-swatch picker (spec section 12 table).
+const LEGACY_HEX_TO_KEY: Record<string, IdentityColorKey> = {
+  '#FF3366': 'rose', '#FF7F50': 'rose', '#FFA07A': 'rose', '#FF4500': 'rose',
+  '#FFFF00': 'violet', '#FF9933': 'violet', '#FFB347': 'violet', '#FFD700': 'violet',
+  '#00FF7F': 'indigo', '#32CD32': 'indigo', '#7FFF00': 'indigo', '#00FA9A': 'indigo',
+  '#00FFFF': 'slate-blue', '#33FFCC': 'slate-blue', '#20B2AA': 'slate-blue', '#00CED1': 'slate-blue',
+  '#00BFFF': 'periwinkle', '#4169E1': 'periwinkle',
+  '#FF00FF': 'orchid', '#FF6EC7': 'pink', '#FF6B9D': 'rose',
+  '#7B68EE': 'slate-blue', '#BA55D3': 'orchid', '#FF1493': 'pink',
+}
+
+const LEGACY_NAME_TO_KEY: Record<string, IdentityColorKey> = {
+  red: 'rose', maroon: 'rose', peach: 'violet', yellow: 'violet', gold: 'violet',
+  green: 'indigo', teal: 'slate-blue', cyan: 'slate-blue', sky: 'periwinkle', blue: 'periwinkle', sapphire: 'periwinkle',
+  lavender: 'lavender', mauve: 'mauve', pink: 'pink', flamingo: 'rose', rosewater: 'pink',
+}
+
+const RESERVED_ANCHORS: Array<{ hex: string; key: IdentityColorKey }> = [
+  { hex: '#FF0000', key: 'rose' },
+  { hex: '#FFBF00', key: 'violet' },
+  { hex: '#00C000', key: 'indigo' },
+  { hex: '#00B0B0', key: 'slate-blue' },
+  { hex: '#2E7BFF', key: 'periwinkle' },
+]
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return null
+  const n = parseInt(m[1], 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+function dist2(a: [number, number, number], b: [number, number, number]): number {
+  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
+}
+
+/**
+ * Map a legacy stored colour (raw hex, colour name, or already-a-key) to a
+ * curated IdentityColorKey. Priority: existing key -> known name -> exact legacy
+ * hex -> nearest-colour fallback (which routes reserved-ish hues to their bucket
+ * key, otherwise the nearest identity key). Deterministic.
+ */
+export function bucketLegacyColorToKey(value: string): IdentityColorKey {
+  const raw = value.trim()
+  const lower = raw.toLowerCase()
+  if ((IDENTITY_COLOR_KEYS as readonly string[]).includes(lower)) return lower as IdentityColorKey
+  if (LEGACY_NAME_TO_KEY[lower]) return LEGACY_NAME_TO_KEY[lower]
+
+  const norm = (raw.startsWith('#') ? raw : '#' + raw).toUpperCase()
+  if (LEGACY_HEX_TO_KEY[norm]) return LEGACY_HEX_TO_KEY[norm]
+
+  const rgb = hexToRgb(norm)
+  if (!rgb) return 'mauve'
+
+  let best: { key: IdentityColorKey; d: number } | null = null
+  for (const a of RESERVED_ANCHORS) {
+    const d = dist2(rgb, hexToRgb(a.hex)!)
+    if (!best || d < best.d) best = { key: a.key, d }
+  }
+  for (const k of IDENTITY_COLOR_KEYS) {
+    const d = dist2(rgb, hexToRgb(IDENTITY_PALETTE[k].dark)!)
+    if (!best || d < best.d) best = { key: k, d }
+  }
+  return best!.key
+}

--- a/src/shared/identity-colors.ts
+++ b/src/shared/identity-colors.ts
@@ -38,10 +38,15 @@ const LEGACY_HEX_TO_KEY: Record<string, IdentityColorKey> = {
   '#00FF7F': 'indigo', '#32CD32': 'indigo', '#7FFF00': 'indigo', '#00FA9A': 'indigo',
   '#00FFFF': 'slate-blue', '#33FFCC': 'slate-blue', '#20B2AA': 'slate-blue', '#00CED1': 'slate-blue',
   '#00BFFF': 'periwinkle', '#4169E1': 'periwinkle',
+  // Non-colliding legacy hues kept as their identity equivalent; FF6EC7 / FF6B9D /
+  // 7B68EE are themselves palette dark hexes, so they round-trip exactly.
   '#FF00FF': 'orchid', '#FF6EC7': 'pink', '#FF6B9D': 'rose',
   '#7B68EE': 'slate-blue', '#BA55D3': 'orchid', '#FF1493': 'pink',
 }
 
+// Colour names from older configs + the prior account palette. Includes names
+// beyond the spec's explicit list (maroon / sapphire / gold / cyan) because they
+// appear in real saved configs and must bucket deterministically too.
 const LEGACY_NAME_TO_KEY: Record<string, IdentityColorKey> = {
   red: 'rose', maroon: 'rose', peach: 'violet', yellow: 'violet', gold: 'violet',
   green: 'indigo', teal: 'slate-blue', cyan: 'slate-blue', sky: 'periwinkle', blue: 'periwinkle', sapphire: 'periwinkle',

--- a/src/shared/identity-colors.ts
+++ b/src/shared/identity-colors.ts
@@ -1,0 +1,32 @@
+// Curated identity-colour palette (V2 Shell UX spec section 5). Identity is
+// stored by stable KEY and resolved to a theme hex at render time, so re-tuning
+// a hue edits one table entry -- never stored data. Deliberately excludes every
+// reserved semantic hue (status success/warning/danger/info, accent teal, brand
+// copper, link/info blue) so identity can never be mistaken for state.
+
+export type IdentityColorKey =
+  | 'mauve' | 'violet' | 'lavender' | 'slate-blue' | 'orchid'
+  | 'indigo' | 'periwinkle' | 'plum' | 'pink' | 'rose'
+
+export const IDENTITY_COLOR_KEYS: readonly IdentityColorKey[] = [
+  'mauve', 'violet', 'lavender', 'slate-blue', 'orchid',
+  'indigo', 'periwinkle', 'plum', 'pink', 'rose',
+]
+
+export const IDENTITY_PALETTE: Record<IdentityColorKey, { dark: string; light: string }> = {
+  'mauve':      { dark: '#9a8cf0', light: '#6d5cc0' },
+  'violet':     { dark: '#b57edc', light: '#8a4fb0' },
+  'lavender':   { dark: '#a6b4ff', light: '#5566cc' },
+  'slate-blue': { dark: '#7b68ee', light: '#5346b8' },
+  'orchid':     { dark: '#ba55d3', light: '#9333a8' },
+  'indigo':     { dark: '#7b8cff', light: '#4858c8' },
+  'periwinkle': { dark: '#8aa0ff', light: '#4a63c2' },
+  'plum':       { dark: '#c98cff', light: '#8a44c0' },
+  'pink':       { dark: '#ff6ec7', light: '#c43d92' },
+  'rose':       { dark: '#ff6b9d', light: '#c23a68' },
+}
+
+export function resolveIdentityColor(key: IdentityColorKey, theme: 'dark' | 'light'): string {
+  const entry = IDENTITY_PALETTE[key] ?? IDENTITY_PALETTE.mauve
+  return theme === 'light' ? entry.light : entry.dark
+}

--- a/tests/unit/shared/identity-colors.test.ts
+++ b/tests/unit/shared/identity-colors.test.ts
@@ -5,6 +5,7 @@ import {
   resolveIdentityColor,
   type IdentityColorKey,
 } from '../../../src/shared/identity-colors'
+import { bucketLegacyColorToKey } from '../../../src/shared/identity-colors'
 
 describe('identity palette + resolver', () => {
   it('has 10 keys, all lowercase, no status/brand/link hues by name', () => {
@@ -32,5 +33,48 @@ describe('identity palette + resolver', () => {
   it('falls back to mauve for an unknown key (defensive)', () => {
     expect(resolveIdentityColor('not-a-key' as IdentityColorKey, 'dark'))
       .toBe(IDENTITY_PALETTE.mauve.dark)
+  })
+})
+
+describe('bucketLegacyColorToKey -- legacy 24-swatch picker hexes', () => {
+  const cases: Array<[string, IdentityColorKey]> = [
+    ['#FF3366', 'rose'], ['#FF7F50', 'rose'], ['#FFA07A', 'rose'], ['#FF4500', 'rose'],
+    ['#FFFF00', 'violet'], ['#FF9933', 'violet'], ['#FFB347', 'violet'], ['#FFD700', 'violet'],
+    ['#00FF7F', 'indigo'], ['#32CD32', 'indigo'], ['#7FFF00', 'indigo'], ['#00FA9A', 'indigo'],
+    ['#00FFFF', 'slate-blue'], ['#33FFCC', 'slate-blue'], ['#20B2AA', 'slate-blue'], ['#00CED1', 'slate-blue'],
+    ['#00BFFF', 'periwinkle'], ['#4169E1', 'periwinkle'],
+    ['#FF00FF', 'orchid'], ['#FF6EC7', 'pink'], ['#FF6B9D', 'rose'],
+    ['#7B68EE', 'slate-blue'], ['#BA55D3', 'orchid'], ['#FF1493', 'pink'],
+  ]
+  it.each(cases)('maps %s -> %s', (hex, key) => {
+    expect(bucketLegacyColorToKey(hex)).toBe(key)
+  })
+  it('is case-insensitive and tolerates missing #', () => {
+    expect(bucketLegacyColorToKey('ff3366')).toBe('rose')
+    expect(bucketLegacyColorToKey('#ff3366')).toBe('rose')
+  })
+})
+
+describe('bucketLegacyColorToKey -- names, passthrough, fallback', () => {
+  const names: Array<[string, IdentityColorKey]> = [
+    ['red', 'rose'], ['peach', 'violet'], ['yellow', 'violet'], ['green', 'indigo'],
+    ['teal', 'slate-blue'], ['sky', 'periwinkle'], ['blue', 'periwinkle'],
+    ['lavender', 'lavender'], ['mauve', 'mauve'], ['pink', 'pink'],
+    ['flamingo', 'rose'], ['rosewater', 'pink'],
+  ]
+  it.each(names)('maps catppuccin name %s -> %s', (name, key) => {
+    expect(bucketLegacyColorToKey(name)).toBe(key)
+  })
+  it('passes through an existing identity key', () => {
+    expect(bucketLegacyColorToKey('indigo')).toBe('indigo')
+    expect(bucketLegacyColorToKey('slate-blue')).toBe('slate-blue')
+  })
+  it('routes an unknown reserved-ish hex to the reserved bucket key', () => {
+    expect(bucketLegacyColorToKey('#ff0000')).toBe('rose')
+    expect(bucketLegacyColorToKey('#00ff00')).toBe('indigo')
+  })
+  it('routes an unknown non-status hex to the nearest identity key', () => {
+    const k = bucketLegacyColorToKey('#8000ff')
+    expect(IDENTITY_COLOR_KEYS).toContain(k)
   })
 })

--- a/tests/unit/shared/identity-colors.test.ts
+++ b/tests/unit/shared/identity-colors.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IDENTITY_COLOR_KEYS,
+  IDENTITY_PALETTE,
+  resolveIdentityColor,
+  type IdentityColorKey,
+} from '../../../src/shared/identity-colors'
+
+describe('identity palette + resolver', () => {
+  it('has 10 keys, all lowercase, no status/brand/link hues by name', () => {
+    expect(IDENTITY_COLOR_KEYS.length).toBe(10)
+    for (const k of IDENTITY_COLOR_KEYS) expect(k).toMatch(/^[a-z-]+$/)
+    for (const banned of ['red', 'green', 'teal', 'amber', 'yellow', 'sky', 'blue', 'copper']) {
+      expect(IDENTITY_COLOR_KEYS).not.toContain(banned)
+    }
+  })
+  it('every key resolves to a 6-digit hex in both themes', () => {
+    for (const k of IDENTITY_COLOR_KEYS) {
+      expect(resolveIdentityColor(k, 'dark')).toMatch(/^#[0-9a-fA-F]{6}$/)
+      expect(resolveIdentityColor(k, 'light')).toMatch(/^#[0-9a-fA-F]{6}$/)
+    }
+  })
+  it('dark and light differ for each key (theme-specific)', () => {
+    for (const k of IDENTITY_COLOR_KEYS) {
+      expect(resolveIdentityColor(k, 'dark')).not.toBe(resolveIdentityColor(k, 'light'))
+    }
+  })
+  it('resolves the documented mauve values', () => {
+    expect(resolveIdentityColor('mauve', 'dark')).toBe('#9a8cf0')
+    expect(resolveIdentityColor('mauve', 'light')).toBe('#6d5cc0')
+  })
+  it('falls back to mauve for an unknown key (defensive)', () => {
+    expect(resolveIdentityColor('not-a-key' as IdentityColorKey, 'dark'))
+      .toBe(IDENTITY_PALETTE.mauve.dark)
+  })
+})

--- a/tests/unit/shared/identity-colors.test.ts
+++ b/tests/unit/shared/identity-colors.test.ts
@@ -3,9 +3,9 @@ import {
   IDENTITY_COLOR_KEYS,
   IDENTITY_PALETTE,
   resolveIdentityColor,
+  bucketLegacyColorToKey,
   type IdentityColorKey,
 } from '../../../src/shared/identity-colors'
-import { bucketLegacyColorToKey } from '../../../src/shared/identity-colors'
 
 describe('identity palette + resolver', () => {
   it('has 10 keys, all lowercase, no status/brand/link hues by name', () => {
@@ -61,6 +61,7 @@ describe('bucketLegacyColorToKey -- names, passthrough, fallback', () => {
     ['teal', 'slate-blue'], ['sky', 'periwinkle'], ['blue', 'periwinkle'],
     ['lavender', 'lavender'], ['mauve', 'mauve'], ['pink', 'pink'],
     ['flamingo', 'rose'], ['rosewater', 'pink'],
+    ['maroon', 'rose'], ['sapphire', 'periwinkle'], ['gold', 'violet'], ['cyan', 'slate-blue'],
   ]
   it.each(names)('maps catppuccin name %s -> %s', (name, key) => {
     expect(bucketLegacyColorToKey(name)).toBe(key)
@@ -73,8 +74,12 @@ describe('bucketLegacyColorToKey -- names, passthrough, fallback', () => {
     expect(bucketLegacyColorToKey('#ff0000')).toBe('rose')
     expect(bucketLegacyColorToKey('#00ff00')).toBe('indigo')
   })
-  it('routes an unknown non-status hex to the nearest identity key', () => {
-    const k = bucketLegacyColorToKey('#8000ff')
-    expect(IDENTITY_COLOR_KEYS).toContain(k)
+  it('routes an unknown non-status hex to the nearest identity key (pinned)', () => {
+    expect(bucketLegacyColorToKey('#8000ff')).toBe('slate-blue')
+  })
+  it('falls back to mauve for unparseable input (empty / garbage / 3-digit)', () => {
+    expect(bucketLegacyColorToKey('')).toBe('mauve')
+    expect(bucketLegacyColorToKey('not-a-hex')).toBe('mauve')
+    expect(bucketLegacyColorToKey('#fff')).toBe('mauve')
   })
 })


### PR DESCRIPTION
**Phase 2a of V2 Shell UX** (spec §5, §12; plan `2026-05-25-v2-shell-phase2a`). Pure logic module, **no wiring yet** (adoption is Phase 2b) -- mirrors how Phase 1 defined tokens before adoption.

## What changed
- New `src/shared/identity-colors.ts`: `IdentityColorKey` + `IDENTITY_COLOR_KEYS` (10 curated non-status hues), `IDENTITY_PALETTE` (per-theme hexes), `resolveIdentityColor(key, theme)`, and deterministic `bucketLegacyColorToKey(value)` (existing-key → catppuccin name → exact legacy hex → nearest-colour fallback routing reserved hues to their bucket).
- New `tests/unit/shared/identity-colors.test.ts`: 50 cases (palette/resolver + all 24 legacy hexes + names + passthrough + fallback + garbage input).

## Tests
- 50/50 in the new file; full suite **1045 pass / 1 skip**; `tsc --noEmit` 0.

## Reviews
- Spec compliance ✅ (all 20 hexes + 24 mappings exact, scope clean).
- Code quality: actioned (pinned nearest-colour test, garbage-input coverage, comment clarity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)