### PR TITLE
V2 Shell Phase 2b-1: account colour returns an identity key

### DIFF
--- a/scripts/capture-training-screenshots.ts
+++ b/scripts/capture-training-screenshots.ts
@@ -35,7 +35,7 @@ const JPEG_QUALITY = 85
 function redactAccountInStatusline(sl: any) {
   if (sl) {
     sl.accountEmail = 'you@example.com'
-    sl.accountColour = 'blue'
+    sl.accountColour = 'periwinkle'
   }
 }
 

--- a/src/main/account-color.ts
+++ b/src/main/account-color.ts
@@ -1,18 +1,17 @@
 import { createHash } from 'crypto'
-import type { CatppuccinAccent } from '../shared/types'
-
-const PALETTE: readonly CatppuccinAccent[] = [
-  'red', 'peach', 'yellow', 'green', 'teal', 'sky',
-  'blue', 'lavender', 'mauve', 'pink', 'flamingo', 'rosewater',
-]
+import { IDENTITY_COLOR_KEYS, type IdentityColorKey } from '../shared/identity-colors'
 
 /**
- * Map an email to a stable Catppuccin palette accent. Lowercased + trimmed
- * so casing variations don't produce different colours. Deterministic
- * across machines (same email -> same colour everywhere).
+ * Map an email to a stable identity-palette KEY (V2 Shell UX spec section 5).
+ * Lowercased + trimmed so casing variations don't produce different colours.
+ * Deterministic across machines (same email -> same key everywhere). The key
+ * is resolved to a theme-specific hex at render time via resolveIdentityColor,
+ * so an account colour can never collide with reserved status / brand / link
+ * hues. This is an algorithm update, not a stored-data migration -- account
+ * colour is recomputed on every statusline update and never persisted.
  */
-export function colourForEmail(email: string): CatppuccinAccent {
+export function colourForEmail(email: string): IdentityColorKey {
   const normalised = email.toLowerCase().trim()
   const hash = createHash('sha256').update(normalised).digest()
-  return PALETTE[hash[0] % PALETTE.length]
+  return IDENTITY_COLOR_KEYS[hash[0] % IDENTITY_COLOR_KEYS.length]
 }

--- a/src/main/tokenomics-manager.ts
+++ b/src/main/tokenomics-manager.ts
@@ -9,7 +9,8 @@ import * as path from 'path'
 import { getConfigDir, ensureConfigDir } from './config-manager'
 import { getResourcesDirectory } from './ipc/setup-handlers'
 import { logInfo, logError } from './debug-logger'
-import type { TokenomicsData, TokenomicsSessionRecord, TokenomicsDailyAggregate, TokenomicsSyncProgress, AccountIdentity, StatuslineData, CatppuccinAccent, AttributionPayload, UnattributedSessionGroup } from '../shared/types'
+import type { TokenomicsData, TokenomicsSessionRecord, TokenomicsDailyAggregate, TokenomicsSyncProgress, AccountIdentity, StatuslineData, AttributionPayload, UnattributedSessionGroup } from '../shared/types'
+import type { IdentityColorKey } from '../shared/identity-colors'
 import { IPC } from '../shared/ipc-channels'
 import { colourForEmail } from './account-color'
 import {
@@ -823,7 +824,7 @@ let cachedData: TokenomicsData | null = null
  */
 export function decorateStatuslineWithColour<T extends { accountEmail?: string }>(
   sl: T,
-): T & { accountColour?: CatppuccinAccent } {
+): T & { accountColour?: IdentityColorKey } {
   if (typeof sl.accountEmail === 'string' && sl.accountEmail.trim().length > 0) {
     return { ...sl, accountColour: colourForEmail(sl.accountEmail) }
   }

--- a/src/renderer/components/terminal/ContextBar.tsx
+++ b/src/renderer/components/terminal/ContextBar.tsx
@@ -3,7 +3,9 @@ import { formatTokens, formatDuration, formatResetTime } from '../../utils/termi
 import RateLimitBar from './RateLimitBar'
 import { useSettingsStore, DEFAULT_STATUS_LINE } from '../../stores/settingsStore'
 import { useCodexReviewUsage } from '../../hooks/useCodexReviewUsage'
-import type { CatppuccinAccent } from '../../../shared/types'
+import { resolveIdentityColor } from '../../../shared/identity-colors'
+import type { IdentityColorKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
 
 interface ContextBarProps {
   modelName?: string
@@ -29,8 +31,9 @@ interface ContextBarProps {
   enableCodexReview?: boolean
   /** P8.11: active-account email rendered as the leftmost Row 1 slot. Omit to hide. */
   accountEmail?: string
-  /** P8.11: Catppuccin accent used to colour the account email. Computed main-side. */
-  accountColour?: CatppuccinAccent
+  /** P8.11 / v2 shell: identity-palette KEY for the account email, computed main-side.
+   *  Resolved to a theme hex here via resolveIdentityColor(). */
+  accountColour?: IdentityColorKey
 }
 
 export default function ContextBar({
@@ -45,6 +48,7 @@ export default function ContextBar({
   accountColour,
 }: ContextBarProps) {
   const sl = useSettingsStore((s) => s.settings.statusLine) || DEFAULT_STATUS_LINE
+  const theme = useResolvedTheme()
   const codexReviewUsage = useCodexReviewUsage(enableCodexReview ? sessionId ?? null : null)
   const showCodexReviewRow = enableCodexReview && codexReviewUsage && codexReviewUsage.reviewCount > 0
 
@@ -69,7 +73,7 @@ export default function ContextBar({
         {accountEmail && (
           <span
             className="text-xs font-medium tabular-nums"
-            style={{ color: `var(--color-${accountColour ?? 'subtext0'})` }}
+            style={{ color: accountColour ? resolveIdentityColor(accountColour, theme) : 'var(--color-subtext0)' }}
             title={accountEmail}
           >
             {accountEmail}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,8 @@
  * This is the canonical source — other files should import from here.
  */
 
+import type { IdentityColorKey } from './identity-colors'
+
 // ── Vision ──
 
 /** @deprecated Use GlobalVisionConfig instead — vision is now global, not per-session */
@@ -159,8 +161,9 @@ export interface StatuslineData {
   rateLimitExtra?: RateLimitExtra
   /** Active-account email surfaced by the bridge script. Renderer displays it left of the model name. */
   accountEmail?: string
-  /** Pre-computed by main process via `colourForEmail()`; renderer consumes directly. */
-  accountColour?: CatppuccinAccent
+  /** Pre-computed by main process via `colourForEmail()` as an identity-palette KEY;
+   *  the renderer resolves it to a theme hex via resolveIdentityColor(). */
+  accountColour?: IdentityColorKey
 }
 
 // ── Agent Templates ──

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,10 +56,6 @@ export interface LegacyVersion {
 
 export type ProviderId = 'claude' | 'codex'
 
-export type CatppuccinAccent =
-  | 'red' | 'peach' | 'yellow' | 'green' | 'teal' | 'sky'
-  | 'blue' | 'lavender' | 'mauve' | 'pink' | 'flamingo' | 'rosewater'
-
 export interface AccountIdentity {
   email: string
   name?: string

--- a/tests/unit/main/account-color.test.ts
+++ b/tests/unit/main/account-color.test.ts
@@ -7,10 +7,13 @@ describe('colourForEmail', () => {
     expect(IDENTITY_COLOR_KEYS).toContain(colourForEmail('alice@example.com'))
   })
 
-  it('never returns a reserved status/brand/link hue', () => {
-    const reserved = ['red', 'peach', 'yellow', 'green', 'teal', 'sky', 'blue', 'copper', 'flamingo', 'rosewater']
-    for (const e of ['a@x.com', 'b@y.com', 'c@z.com', 'd@w.com', 'e@v.com', 'f@u.com']) {
-      expect(reserved).not.toContain(colourForEmail(e))
+  it('stays inside the curated identity palette across a large sample', () => {
+    // The curation guarantee: every output is a member of the curated palette,
+    // which by construction excludes every reserved status / brand / link hue.
+    // Sampling many distinct emails exercises the full modulo index range and
+    // proves the implementation never produces an out-of-range / undefined key.
+    for (let i = 0; i < 200; i++) {
+      expect(IDENTITY_COLOR_KEYS).toContain(colourForEmail(`sample${i}@example.com`))
     }
   })
 

--- a/tests/unit/main/account-color.test.ts
+++ b/tests/unit/main/account-color.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from 'vitest'
 import { colourForEmail } from '../../../src/main/account-color'
+import { IDENTITY_COLOR_KEYS } from '../../../src/shared/identity-colors'
 
 describe('colourForEmail', () => {
-  it('returns a value from the Catppuccin palette', () => {
-    const PALETTE = ['red','peach','yellow','green','teal','sky','blue','lavender','mauve','pink','flamingo','rosewater']
-    expect(PALETTE).toContain(colourForEmail('alice@example.com'))
+  it('returns a key from the curated identity palette', () => {
+    expect(IDENTITY_COLOR_KEYS).toContain(colourForEmail('alice@example.com'))
   })
 
-  it('is deterministic: same email always returns same colour', () => {
+  it('never returns a reserved status/brand/link hue', () => {
+    const reserved = ['red', 'peach', 'yellow', 'green', 'teal', 'sky', 'blue', 'copper', 'flamingo', 'rosewater']
+    for (const e of ['a@x.com', 'b@y.com', 'c@z.com', 'd@w.com', 'e@v.com', 'f@u.com']) {
+      expect(reserved).not.toContain(colourForEmail(e))
+    }
+  })
+
+  it('is deterministic: same email always returns same key', () => {
     const e = 'alice@example.com'
     expect(colourForEmail(e)).toBe(colourForEmail(e))
   })
@@ -20,12 +27,9 @@ describe('colourForEmail', () => {
     expect(colourForEmail('  alice@example.com  ')).toBe(colourForEmail('alice@example.com'))
   })
 
-  it('produces palette coverage: 10 distinct emails yield at least 5 distinct colours', () => {
-    const emails = [
-      'a@x.com', 'b@x.com', 'c@x.com', 'd@x.com', 'e@x.com',
-      'f@x.com', 'g@x.com', 'h@x.com', 'i@x.com', 'j@x.com',
-    ]
-    const colours = new Set(emails.map(colourForEmail))
-    expect(colours.size).toBeGreaterThanOrEqual(5)
+  it('produces palette coverage: 20 distinct emails yield at least 5 distinct keys', () => {
+    const emails = Array.from({ length: 20 }, (_, i) => `user${i}@example.com`)
+    const keys = new Set(emails.map(colourForEmail))
+    expect(keys.size).toBeGreaterThanOrEqual(5)
   })
 })

--- a/tests/unit/main/statusline-colour-forwarding.test.ts
+++ b/tests/unit/main/statusline-colour-forwarding.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import { decorateStatuslineWithColour } from '../../../src/main/tokenomics-manager'
+import { IDENTITY_COLOR_KEYS } from '../../../src/shared/identity-colors'
 import type { StatuslineData } from '../../../src/shared/types'
 
 describe('decorateStatuslineWithColour', () => {
-  it('computes accountColour from accountEmail', () => {
+  it('computes accountColour as an identity key from accountEmail', () => {
     const sl: StatuslineData = { sessionId: 's', accountEmail: 'alice@example.com' } as any
     const out = decorateStatuslineWithColour(sl)
     expect(out.accountColour).toBeDefined()
-    expect(['red','peach','yellow','green','teal','sky','blue','lavender','mauve','pink','flamingo','rosewater']).toContain(out.accountColour)
+    expect(IDENTITY_COLOR_KEYS).toContain(out.accountColour)
   })
 
   it('returns same colour for same email (deterministic)', () => {

--- a/tests/unit/renderer/contextbar-account-slot.test.ts
+++ b/tests/unit/renderer/contextbar-account-slot.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment jsdom
 /**
- * P8.11: ContextBar exposes an optional leftmost slot for the active-account
- * email, coloured with the Catppuccin accent computed main-side.
+ * P8.11 + V2 shell 2b-1: ContextBar exposes an optional leftmost slot for the
+ * active-account email, coloured by resolving the identity-palette KEY computed
+ * main-side to a theme hex via resolveIdentityColor().
  *
- * Uses React.createElement (not JSX) so the file stays under the
- * vitest include pattern (*.test.ts) -- matches sibling contextbar tests.
+ * Uses React.createElement (not JSX) so the file stays under the vitest include
+ * pattern (*.test.ts) -- matches sibling contextbar tests.
  */
 import React from 'react'
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
 // --- mock useSettingsStore before component import ---
+// Must provide settings.statusLine (ContextBar) AND settings.theme + getState
+// (useResolvedTheme, used to resolve the identity key to a theme hex).
 vi.mock('../../../src/renderer/stores/settingsStore', () => {
   const DEFAULT_STATUS_LINE = {
     showModel: true,
@@ -27,15 +31,15 @@ vi.mock('../../../src/renderer/stores/settingsStore', () => {
     font: 'sans',
     fontSize: 12,
   }
-  return {
-    DEFAULT_STATUS_LINE,
-    useSettingsStore: (selector: (s: { settings: { statusLine: typeof DEFAULT_STATUS_LINE } }) => unknown) =>
-      selector({ settings: { statusLine: DEFAULT_STATUS_LINE } }),
-  }
+  const STATE = { settings: { statusLine: DEFAULT_STATUS_LINE, theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { DEFAULT_STATUS_LINE, useSettingsStore }
 })
 
 // Import after mock is registered
 const { default: ContextBar } = await import('../../../src/renderer/components/terminal/ContextBar')
+const { resolveIdentityColor } = await import('../../../src/shared/identity-colors')
 
 const baseProps = {
   modelName: 'sonnet',
@@ -51,6 +55,12 @@ const baseProps = {
   rateLimitWeekly: null,
   rateLimitWeeklyResets: null,
   rateLimitExtra: null,
+}
+
+function emailSpan(container: HTMLElement): HTMLElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLElement>('span')).find(
+    (s) => s.textContent === 'alice@example.com',
+  )
 }
 
 describe('ContextBar account slot', () => {
@@ -73,7 +83,7 @@ describe('ContextBar account slot', () => {
       root.render(React.createElement(ContextBar, {
         ...(baseProps as any),
         accountEmail: 'alice@example.com',
-        accountColour: 'blue',
+        accountColour: 'mauve',
       }))
     })
     expect(container.textContent).toContain('alice@example.com')
@@ -86,20 +96,30 @@ describe('ContextBar account slot', () => {
     expect(container.textContent).not.toContain('@')
   })
 
-  it('applies a Catppuccin colour class derived from accountColour', () => {
+  it('resolves the identity key to a concrete colour (not a CSS var), keyed by the value', () => {
     act(() => {
       root.render(React.createElement(ContextBar, {
         ...(baseProps as any),
         accountEmail: 'alice@example.com',
-        accountColour: 'peach',
+        accountColour: 'mauve',
       }))
     })
-    const emailEl = Array.from(container.querySelectorAll<HTMLElement>('span')).find(
-      (s) => s.textContent === 'alice@example.com',
-    )
-    expect(emailEl).toBeDefined()
-    const cls = emailEl?.className || ''
-    const style = emailEl?.getAttribute('style') || ''
-    expect(cls.includes('text-peach') || style.includes('--color-peach')).toBe(true)
+    const colourMauve = emailSpan(container)?.style.color || ''
+    expect(colourMauve).toBeTruthy()
+    // No longer a Catppuccin CSS variable -- it is the resolved palette hex.
+    expect(colourMauve).not.toContain('var(')
+
+    act(() => {
+      root.render(React.createElement(ContextBar, {
+        ...(baseProps as any),
+        accountEmail: 'alice@example.com',
+        accountColour: 'rose',
+      }))
+    })
+    const colourRose = emailSpan(container)?.style.color || ''
+    // Different identity key resolves to a different colour (resolver is wired).
+    expect(colourRose).not.toBe(colourMauve)
+    // Sanity: resolveIdentityColor returns distinct hexes for these keys in dark theme.
+    expect(resolveIdentityColor('mauve', 'dark')).not.toBe(resolveIdentityColor('rose', 'dark'))
   })
 })

--- a/tests/unit/renderer/contextbar-account-slot.test.ts
+++ b/tests/unit/renderer/contextbar-account-slot.test.ts
@@ -8,8 +8,7 @@
  * pattern (*.test.ts) -- matches sibling contextbar tests.
  */
 import React from 'react'
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 
@@ -94,6 +93,17 @@ describe('ContextBar account slot', () => {
       root.render(React.createElement(ContextBar, baseProps as any))
     })
     expect(container.textContent).not.toContain('@')
+  })
+
+  it('falls back to the neutral token when accountColour is absent but email is present', () => {
+    act(() => {
+      root.render(React.createElement(ContextBar, {
+        ...(baseProps as any),
+        accountEmail: 'alice@example.com',
+      }))
+    })
+    const style = emailSpan(container)?.getAttribute('style') || ''
+    expect(style).toContain('var(--color-subtext0)')
   })
 
   it('resolves the identity key to a concrete colour (not a CSS var), keyed by the value', () => {

--- a/tests/unit/renderer/contextbar-codex-compat.test.ts
+++ b/tests/unit/renderer/contextbar-codex-compat.test.ts
@@ -25,11 +25,12 @@ vi.mock('../../../src/renderer/stores/settingsStore', () => {
     font: 'sans',
     fontSize: 12,
   }
-  return {
-    DEFAULT_STATUS_LINE,
-    useSettingsStore: (selector: (s: { settings: { statusLine: typeof DEFAULT_STATUS_LINE } }) => unknown) =>
-      selector({ settings: { statusLine: DEFAULT_STATUS_LINE } }),
-  }
+  // STATE carries theme + getState so useResolvedTheme (called by ContextBar)
+  // resolves the identity key without touching window.matchMedia.
+  const STATE = { settings: { statusLine: DEFAULT_STATUS_LINE, theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { DEFAULT_STATUS_LINE, useSettingsStore }
 })
 
 // Import after mock is registered

--- a/tests/unit/renderer/contextbar-codex-firstturn.test.ts
+++ b/tests/unit/renderer/contextbar-codex-firstturn.test.ts
@@ -28,11 +28,12 @@ vi.mock('../../../src/renderer/stores/settingsStore', () => {
     font: 'sans',
     fontSize: 12,
   }
-  return {
-    DEFAULT_STATUS_LINE,
-    useSettingsStore: (selector: (s: { settings: { statusLine: typeof DEFAULT_STATUS_LINE } }) => unknown) =>
-      selector({ settings: { statusLine: DEFAULT_STATUS_LINE } }),
-  }
+  // STATE carries theme + getState so useResolvedTheme (called by ContextBar)
+  // resolves the identity key without touching window.matchMedia.
+  const STATE = { settings: { statusLine: DEFAULT_STATUS_LINE, theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { DEFAULT_STATUS_LINE, useSettingsStore }
 })
 
 // Import after mock is registered

--- a/tests/unit/renderer/contextbar-codex-review.test.ts
+++ b/tests/unit/renderer/contextbar-codex-review.test.ts
@@ -31,11 +31,12 @@ vi.mock('../../../src/renderer/stores/settingsStore', () => {
     font: 'sans',
     fontSize: 12,
   }
-  return {
-    DEFAULT_STATUS_LINE,
-    useSettingsStore: (selector: (s: { settings: { statusLine: typeof DEFAULT_STATUS_LINE } }) => unknown) =>
-      selector({ settings: { statusLine: DEFAULT_STATUS_LINE } }),
-  }
+  // STATE carries theme + getState so useResolvedTheme (called by ContextBar)
+  // resolves the identity key without touching window.matchMedia.
+  const STATE = { settings: { statusLine: DEFAULT_STATUS_LINE, theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { DEFAULT_STATUS_LINE, useSettingsStore }
 })
 
 const { default: ContextBar } = await import('../../../src/renderer/components/terminal/ContextBar')


### PR DESCRIPTION
## Summary
Phase 2b-1 of the V2 Shell UX redesign (spec sections 5 + 12). Migrates the deterministic per-account colour off the legacy Catppuccin palette onto the curated identity-colour key model shipped in Phase 2a, so account colours can never collide with reserved status / brand / link hues.

- `colourForEmail` now returns an `IdentityColorKey` (indexes `IDENTITY_COLOR_KEYS`), keeping the same SHA-256 + lowercase/trim determinism. Algorithm update only -- account colour is recomputed per statusline update and never persisted, so there is **no stored-data migration**.
- `StatuslineData.accountColour` and `decorateStatuslineWithColour` carry the key across the IPC boundary.
- `ContextBar` resolves the key to a dark/light hex via `resolveIdentityColor(key, theme)` using the existing reactive `useResolvedTheme()` hook (with a neutral `--color-subtext0` fallback).
- Removes the now-dead `CatppuccinAccent` type; fixes the demo-seed literal (`blue` -> `periwinkle`).

Out of scope (Phase 2b-2): session/config `identityColorKey`, the legacy `session.color` migration + guard flag + one-time notice, and the picker swatches. The dormant `ContextBar` account-slot wiring in `TerminalView` is also untouched (pre-existing gap).

## Reviews
- Spec-compliance review: COMPLIANT (matches plan + spec sections 5/12; no scope creep).
- Code-quality review: APPROVED (no Critical/Important). Minor test-quality findings applied as a follow-up commit.

## Test Plan
- [x] `npm run typecheck` -> 0 errors
- [x] `npx vitest run` -> 1052 passed / 1 skipped (pre-existing skip)
- [x] Account-colour + statusline-forwarding + ContextBar account-slot tests assert identity keys and the resolved-hex render path
- [x] 3 sibling ContextBar tests updated for the new `useResolvedTheme()` dependency (test-mock-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)