### PR TITLE
V2 Shell Phase 2b-2: config/session identity-colour migration + picker + notice

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -380,6 +380,11 @@ export default function App() {
 
       console.log(`[App] Restoring ${savedState.sessions.length} sessions...`)
 
+      // Idempotent session colour migration (no guard). session.clear() below wipes
+      // the on-disk copy right after restore, and migrated keys only reach disk on a
+      // graceful close (buildSessionState). So this recomputes each launch until then
+      // -- harmless: it is a no-op once keyed, raw `color` is always preserved, and the
+      // notice guard below prevents re-notifying.
       const { records: migratedSaved, summary: sessionSummary } = migrateColorRecords(savedState.sessions || [])
       console.log('[colourMigration] sessions', sessionSummary)
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -35,7 +35,7 @@ import { useSettingsStore } from './stores/settingsStore'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useThemeController } from './hooks/useThemeController'
 import { markSessionForResumePicker } from './utils/resumePicker'
-import { gatherLocalStorageData, hydrateStores } from './utils/configHydration'
+import { gatherLocalStorageData, hydrateStores, applyConfigColourMigration } from './utils/configHydration'
 import { setupCloudAgentListener } from './stores/cloudAgentStore'
 import { setupTokenomicsListener } from './stores/tokenomicsStore'
 import { setupConductorMcpListener, useConductorMcpStore } from './stores/conductorMcpStore'
@@ -224,12 +224,12 @@ export default function App() {
           await window.electronAPI.config.migrateFromLocalStorage(lsData)
           console.log('[App] Migration complete, reloading...')
           const reloaded = await window.electronAPI.config.loadAll()
-          hydrateStores(reloaded.data)
+          hydrateStores(await applyConfigColourMigration(reloaded.data))
         } else {
-          hydrateStores(result.data)
+          hydrateStores(await applyConfigColourMigration(result.data))
         }
       } else {
-        hydrateStores(result.data)
+        hydrateStores(await applyConfigColourMigration(result.data))
       }
 
       setConfigLoaded(true)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -390,6 +390,8 @@ export default function App() {
           workingDirectory: saved.workingDirectory,
           model: claude?.model ?? saved.model ?? '',
           color: saved.color,
+          identityColorKey: saved.identityColorKey,
+          legacyColor: saved.legacyColor,
           sessionType: saved.sessionType,
           shellOnly: saved.shellOnly,
           partnerTerminalPath: saved.partnerTerminalPath,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -35,6 +35,7 @@ import { useSettingsStore } from './stores/settingsStore'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useThemeController } from './hooks/useThemeController'
 import { markSessionForResumePicker } from './utils/resumePicker'
+import { migrateColorRecords } from './utils/migrateIdentityColors'
 import { gatherLocalStorageData, hydrateStores, applyConfigColourMigration } from './utils/configHydration'
 import { setupCloudAgentListener } from './stores/cloudAgentStore'
 import { setupTokenomicsListener } from './stores/tokenomicsStore'
@@ -379,7 +380,10 @@ export default function App() {
 
       console.log(`[App] Restoring ${savedState.sessions.length} sessions...`)
 
-      const restoredSessions: Session[] = savedState.sessions.map((saved: SavedSession) => {
+      const { records: migratedSaved, summary: sessionSummary } = migrateColorRecords(savedState.sessions || [])
+      console.log('[colourMigration] sessions', sessionSummary)
+
+      const restoredSessions: Session[] = migratedSaved.map((saved: SavedSession) => {
         // v1.5 provider-shape: read Claude fields from claudeOptions, fall back to
         // legacy top-level fields for un-migrated files (belt-and-braces).
         const claude = saved.claudeOptions
@@ -424,6 +428,13 @@ export default function App() {
 
       useSessionStore.getState().restoreSessions(restoredSessions, savedState.activeSessionId)
       await window.electronAPI.session.clear()
+
+      if (sessionSummary.changed > 0) {
+        const s = useSettingsStore.getState()
+        if (!s.settings.colourMigrationNoticeDismissed && !s.settings.colourMigrationNoticePending) {
+          s.updateSettings({ colourMigrationNoticePending: true })
+        }
+      }
 
       console.log('[App] Sessions restored')
     } catch (err) {

--- a/src/renderer/components/ColourMigrationNotice.tsx
+++ b/src/renderer/components/ColourMigrationNotice.tsx
@@ -1,0 +1,103 @@
+import { useSettingsStore } from '../stores/settingsStore'
+import { useConfigStore } from '../stores/configStore'
+import { useSessionStore } from '../stores/sessionStore'
+import { pickColourReviewTarget } from '../utils/migrateIdentityColors'
+
+interface Props {
+  /**
+   * Opens the app's existing config-edit dialog for the given config id. Wired
+   * by the parent to the SAME handler ConfigRow's onEdit ultimately calls
+   * (Sidebar's setEditingConfig). Optional: when absent, Review colours still
+   * dismisses and warns rather than dead-ending.
+   */
+  onOpenConfigEditor?: (configId: string) => void
+}
+
+/**
+ * One-time, dismissible info notice for the V2 identity-colour migration. Shows
+ * once when a migration changed saved records (pending && !dismissed) and gives
+ * a safe "Review colours" shortcut that resolves to a still-existing config (or
+ * warns + dismisses if there is nothing safe to open). Quiet info tone -- this
+ * is informational, not a warning. Uses per-field Zustand selectors to avoid
+ * re-render cascades (codebase convention).
+ */
+export default function ColourMigrationNotice({ onOpenConfigEditor }: Props) {
+  const pending = useSettingsStore((s) => s.settings.colourMigrationNoticePending)
+  const dismissed = useSettingsStore((s) => s.settings.colourMigrationNoticeDismissed)
+
+  if (pending !== true || dismissed === true) return null
+
+  const dismiss = () => {
+    // getState() (not the hook value) so this never depends on a fresh render.
+    void useSettingsStore.getState().updateSettings({ colourMigrationNoticeDismissed: true })
+  }
+
+  const handleReview = () => {
+    try {
+      const target = pickColourReviewTarget(
+        useConfigStore.getState().configs,
+        useSessionStore.getState().sessions,
+      )
+      if (target.kind === 'config') {
+        onOpenConfigEditor?.(target.configId)
+      } else {
+        console.warn('[colourMigration] Review colours: no editable target found')
+      }
+    } catch (err) {
+      // Never let the shortcut throw -- it is a convenience, not load-bearing.
+      console.warn('[colourMigration] Review colours failed', err)
+    } finally {
+      // Always dismiss after a Review action, regardless of outcome.
+      dismiss()
+    }
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mx-2 mb-2 rounded-lg border border-blue/30 bg-mantle p-3"
+    >
+      <div className="flex items-start gap-2 mb-2">
+        <div className="text-blue mt-0.5 shrink-0">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="16" x2="12" y2="12" />
+            <line x1="12" y1="8" x2="12.01" y2="8" />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-semibold text-text">Session colours refreshed</div>
+          <div className="text-[11px] text-subtext0 leading-snug mt-0.5">
+            Some saved config and session colours were moved out of reserved status colours so
+            running, warning, error and focus states stay readable.
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleReview}
+          className="px-2 py-1 bg-surface0 hover:bg-surface1 text-text rounded text-xs transition-colors"
+        >
+          Review colours
+        </button>
+        <button
+          onClick={dismiss}
+          className="px-2 py-1 text-overlay1 hover:text-text rounded text-xs transition-colors"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/GuidedConfigView.tsx
+++ b/src/renderer/components/GuidedConfigView.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { TerminalConfig } from '../stores/configStore'
-import { COLOR_SWATCHES } from './SessionDialog'
+import { IDENTITY_SWATCHES } from './SessionDialog'
+import { resolveIdentityColor, bucketLegacyColorToKey, type IdentityColorKey } from '../../shared/identity-colors'
+import { useResolvedTheme } from '../hooks/useThemeController'
 
 type SessionType = 'local' | 'ssh'
 type SectionKey = 'identity' | 'directory' | 'connection' | 'claude' | 'advanced'
@@ -18,7 +20,8 @@ export default function GuidedConfigView({ onConfirm, onSkip }: Props) {
   // Form state
   const [label, setLabel] = useState('')
   const [workingDir, setWorkingDir] = useState('')
-  const [color, setColor] = useState(COLOR_SWATCHES[0])
+  const [colorKey, setColorKey] = useState<IdentityColorKey>(bucketLegacyColorToKey(''))
+  const theme = useResolvedTheme()
   const [sessionType, setSessionType] = useState<SessionType>('local')
   const [sshHost, setSshHost] = useState('')
   const [sshPort, setSshPort] = useState(22)
@@ -64,7 +67,8 @@ export default function GuidedConfigView({ onConfirm, onSkip }: Props) {
       provider: 'claude',
       label: label.trim(),
       workingDirectory: dir,
-      color,
+      identityColorKey: colorKey,
+      color: resolveIdentityColor(colorKey, 'dark'),  // back-compat shadow; render prefers the key
       sessionType,
       sshConfig: sessionType === 'ssh' ? {
         host: sshHost.trim(),
@@ -130,13 +134,14 @@ export default function GuidedConfigView({ onConfirm, onSkip }: Props) {
                     className="flex flex-wrap gap-1.5"
                     onMouseDown={focusSection('identity')}
                   >
-                    {COLOR_SWATCHES.slice(0, 16).map((c) => (
+                    {IDENTITY_SWATCHES.map((k) => (
                       <button
-                        key={c}
+                        key={k}
                         type="button"
-                        onClick={() => setColor(c)}
-                        className={`w-6 h-6 rounded transition-all ${color === c ? 'ring-2 ring-text scale-110' : 'hover:scale-105'}`}
-                        style={{ backgroundColor: c }}
+                        onClick={() => setColorKey(k)}
+                        className={`w-6 h-6 rounded transition-all ${colorKey === k ? 'ring-2 ring-text scale-110' : 'hover:scale-105'}`}
+                        style={{ backgroundColor: resolveIdentityColor(k, theme) }}
+                        title={k}
                       />
                     ))}
                   </div>

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -3,6 +3,8 @@ import { TerminalConfig, ConfigGroup, ConfigSection, ProviderId, CodexOptions, u
 import { useAgentLibraryStore, BUILTIN_TEMPLATES } from '../stores/agentLibraryStore'
 import { ProviderSegmentedControl } from './SessionDialog/ProviderSegmentedControl'
 import { CodexFormFields } from './SessionDialog/CodexFormFields'
+import { IDENTITY_COLOR_KEYS, resolveIdentityColor, bucketLegacyColorToKey, type IdentityColorKey } from '../../shared/identity-colors'
+import { useResolvedTheme } from '../hooks/useThemeController'
 
 export type SessionType = 'local' | 'ssh'
 
@@ -13,7 +15,13 @@ export interface SSHConfig {
   remotePath: string
 }
 
-// Neon / Claude UX style color palette
+// Identity-colour swatches: stable palette keys (resolved to a theme hex at render).
+// Reserved status/brand/link hues are intentionally absent -- identity can never collide with state.
+export const IDENTITY_SWATCHES: readonly IdentityColorKey[] = IDENTITY_COLOR_KEYS
+
+// Legacy 24-hex palette retained for non-identity pickers (screenshot button,
+// custom commands, notes, project-browser auto-assign) that still store a raw
+// hex string. Identity pickers use IDENTITY_SWATCHES above.
 export const COLOR_SWATCHES = [
   // Neon electric
   '#00FFFF', '#FF00FF', '#00FF7F', '#FF6EC7',
@@ -49,7 +57,10 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const [label, setLabel] = useState(initial?.label ?? '')
   const [workingDir, setWorkingDir] = useState(initial?.workingDirectory ?? '')
   const [model, setModel] = useState(initialClaude?.model ?? initial?.model ?? '')
-  const [color, setColor] = useState(initial?.color ?? COLOR_SWATCHES[0])
+  const [colorKey, setColorKey] = useState<IdentityColorKey>(
+    (initial?.identityColorKey as IdentityColorKey) ?? bucketLegacyColorToKey(initial?.color ?? '')
+  )
+  const theme = useResolvedTheme()
   const [sessionType, setSessionType] = useState<SessionType>(initial?.sessionType ?? 'local')
   const [shellOnly, setShellOnly] = useState(initial?.shellOnly ?? false)
   const [groupId, setGroupId] = useState<string | undefined>(initial?.groupId)
@@ -245,7 +256,8 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       provider,
       label: label.trim(),
       workingDirectory: dir,
-      color,
+      identityColorKey: colorKey,
+      color: resolveIdentityColor(colorKey, 'dark'),  // back-compat shadow; render prefers the key
       sessionType,
       shellOnly,
       groupId,
@@ -347,16 +359,16 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
             <div>
               <label className="block text-xs text-subtext0 mb-1">Color</label>
               <div className="flex flex-wrap gap-1.5">
-                {COLOR_SWATCHES.map((c) => (
+                {IDENTITY_SWATCHES.map((k) => (
                   <button
-                    key={c}
+                    key={k}
                     type="button"
-                    onClick={() => setColor(c)}
+                    onClick={() => setColorKey(k)}
                     className={`w-6 h-6 rounded-md border-2 transition-all ${
-                      color === c ? 'border-text scale-110' : 'border-transparent hover:border-overlay0'
+                      colorKey === k ? 'border-text scale-110' : 'border-transparent hover:border-overlay0'
                     }`}
-                    style={{ backgroundColor: c }}
-                    title={c}
+                    style={{ backgroundColor: resolveIdentityColor(k, theme) }}
+                    title={k}
                   />
                 ))}
               </div>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import SessionGroupHeader from './sidebar/SessionGroupHeader'
 import UpdatePanel from './sidebar/UpdatePanel'
 import PinnedConfigsPanel from './sidebar/PinnedConfigsPanel'
 import FirstRunCard from './FirstRunCard'
+import ColourMigrationNotice from './ColourMigrationNotice'
 import { useAppMetaStore } from '../stores/appMetaStore'
 
 // Inject keyframes for attention pulse animation (shared with TabBar)
@@ -917,6 +918,15 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
           }
         }}
       >
+        {/* One-time colour-migration notice. Wires Review colours to the SAME
+            edit dialog ConfigRow.onEdit uses (setEditingConfig below). */}
+        <ColourMigrationNotice
+          onOpenConfigEditor={(configId) => {
+            const cfg = configs.find((c) => c.id === configId)
+            if (cfg) setEditingConfig(cfg)
+          }}
+        />
+
         {showFirstRunCard && onShowFirstRun && (
           <FirstRunCard
             onGetStarted={onShowFirstRun}

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { useSessionStore } from '../stores/sessionStore'
 import { killSessionPty } from './TerminalView'
 import HeaderCluster from './HeaderCluster'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
+import { useResolvedTheme } from '../hooks/useThemeController'
 
 // Inject keyframes for attention pulse animation
 const ATTENTION_STYLES_ID = 'attention-pulse-styles'
@@ -23,6 +25,7 @@ function injectAttentionStyles() {
 
 export default function TabBar() {
   const { sessions, activeSessionId, setActiveSession, removeSession } = useSessionStore()
+  const theme = useResolvedTheme()
 
   // Inject styles on first render
   React.useEffect(() => {
@@ -37,7 +40,7 @@ export default function TabBar() {
       {sessions.map((session) => {
         const needsAttention = session.needsAttention && activeSessionId !== session.id
         const isActive = activeSessionId === session.id
-        const color = session.color
+        const color = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
 
         return (
           <button

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { TerminalConfig } from '../../stores/configStore'
 import { ClaudeBadge, ShellBadge, SshBadge } from './Badges'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
 
 interface ConfigRowProps {
   config: TerminalConfig
@@ -21,6 +23,8 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
   // Identity now lives in a small color dot — no row fill at rest, no
   // heavy left border. Hover just lifts to a neutral surface tint;
   // colour is held in the dot and badges only.
+  const theme = useResolvedTheme()
+  const dotColour = resolveIdentityColor(config.identityColorKey ?? bucketLegacyColorToKey(config.color), theme)
   return (
     <div
       className={`flex items-center gap-1.5 rounded py-1 px-2 group transition-colors hover:bg-surface0/50 ${isDragOver ? 'border-t-2 border-blue' : ''}`}
@@ -33,7 +37,7 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
     >
       <span
         className="w-1.5 h-1.5 rounded-full shrink-0"
-        style={{ backgroundColor: config.color }}
+        style={{ backgroundColor: dotColour }}
         aria-hidden
       />
       <span className="text-xs text-text truncate flex-1">{config.label}</span>

--- a/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
+++ b/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { TerminalConfig, useConfigStore } from '../../stores/configStore'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
 
 interface PinnedConfigsPanelProps {
   configs: TerminalConfig[]
@@ -8,17 +10,20 @@ interface PinnedConfigsPanelProps {
 
 export default function PinnedConfigsPanel({ configs, onLaunch }: PinnedConfigsPanelProps) {
   const togglePinned = useConfigStore((s) => s.togglePinned)
+  const theme = useResolvedTheme()
 
   if (configs.length === 0) return null
 
   return (
     <div className="px-2 pb-1 space-y-0.5">
-      {configs.map((config) => (
+      {configs.map((config) => {
+        const dotColour = resolveIdentityColor(config.identityColorKey ?? bucketLegacyColorToKey(config.color), theme)
+        return (
         <div
           key={config.id}
           className="flex items-center gap-2 rounded-md py-1 px-2 group transition-colors hover:bg-surface0/40"
         >
-          <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: config.color }} />
+          <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: dotColour }} />
           <span className="text-xs text-text truncate flex-1">{config.label}</span>
           <button
             onClick={() => onLaunch(config)}
@@ -35,7 +40,8 @@ export default function PinnedConfigsPanel({ configs, onLaunch }: PinnedConfigsP
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>
           </button>
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Session } from '../../stores/sessionStore'
 import { ClaudeBadge, CodexBadge, ShellBadge, SshBadge } from './Badges'
 import { StatusDot, type SessionState } from '../ui/StatusDot'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
 
 interface SessionRowProps {
   session: Session
@@ -45,7 +47,8 @@ function toSessionState(status: Session['status'], needsAttention: boolean): Ses
 }
 
 export default function SessionRow({ session, isActive, needsAttention, isRenaming, renameValue, renameRef, onRenameChange, onRenameFinish, onRenameCancel, onClick, onContextMenu, isSelected, isFocused }: SessionRowProps) {
-  const tintColor = session.color
+  const theme = useResolvedTheme()
+  const tintColor = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
   const st = toSessionState(session.status, needsAttention)
 
   // Priority: error > awaiting > active (spec §10). toSessionState never

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -15,6 +15,8 @@ export function buildSessionState(): SessionState {
     label: s.label,
     workingDirectory: s.workingDirectory,
     color: s.color,
+    identityColorKey: s.identityColorKey,
+    legacyColor: s.legacyColor,
     sessionType: s.sessionType,
     shellOnly: s.shellOnly,
     partnerTerminalPath: s.partnerTerminalPath,

--- a/src/renderer/stores/configStore.ts
+++ b/src/renderer/stores/configStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { saveConfigNow, saveConfigDebounced } from '../utils/config-saver'
 import type { ProviderId, ClaudeOptions, CodexOptions } from '../../shared/types'
+import type { IdentityColorKey } from '../../shared/identity-colors'
 
 // Re-export provider types so callers can import from a single place
 export type { ProviderId, ClaudeOptions, CodexOptions }
@@ -10,6 +11,10 @@ export interface TerminalConfig {
   label: string
   workingDirectory: string
   color: string
+  /** V2 identity colour: stable palette key. Authoritative over `color` at render time. */
+  identityColorKey?: IdentityColorKey
+  /** Pre-migration raw `color`, retained only when this record was migrated. */
+  legacyColor?: string
   sessionType: 'local' | 'ssh'
   shellOnly?: boolean  // Don't run Claude, just open a shell
   groupId?: string     // Group this config belongs to

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { ProviderId, CodexOptions } from '../../shared/types'
+import type { IdentityColorKey } from '../../shared/identity-colors'
 
 export type SessionStatus = 'idle' | 'working' | 'complete' | 'error' | 'disconnected'
 export type SessionType = 'local' | 'ssh'
@@ -22,6 +23,10 @@ export interface Session {
   workingDirectory: string
   model: string
   color: string
+  /** V2 identity colour: stable palette key. Authoritative over `color` at render time. */
+  identityColorKey?: IdentityColorKey
+  /** Pre-migration raw `color`, retained only when this record was migrated. */
+  legacyColor?: string
   status: SessionStatus
   createdAt: number
   sessionType: SessionType

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -77,6 +77,9 @@ export interface AppSettings {
   theme: ThemeMode
   tokenomicsAccountFilter?: string  // 'all' | '__mixed__' | '__unknown__' | <email>
   fontMigratedV2?: boolean  // one-time guard: existing installs moved off the old Cascadia Code/14 default
+  identityColorMigratedV2?: boolean      // one-time guard: saved-config colours migrated to identity keys
+  colourMigrationNoticePending?: boolean // a colour migration changed records and the notice should show
+  colourMigrationNoticeDismissed?: boolean
 }
 
 interface SettingsState {

--- a/src/renderer/utils/configHydration.ts
+++ b/src/renderer/utils/configHydration.ts
@@ -9,6 +9,7 @@ import { useAgentLibraryStore } from '../stores/agentLibraryStore'
 import { useTeamStore } from '../stores/teamStore'
 import { useCommandBarStore } from '../stores/commandBarStore'
 import { useExcalidrawStore } from '../stores/excalidrawStore'
+import { migrateColorRecords } from './migrateIdentityColors'
 
 /**
  * Gather all relevant localStorage keys for migration to CONFIG/.
@@ -188,4 +189,55 @@ export function hydrateStores(configData: Record<string, unknown>): void {
   useExcalidrawStore.getState().hydrate(excalidraw as never)
 
   console.log('[App] All stores hydrated from CONFIG/')
+}
+
+/**
+ * One-time, idempotent, partial-failure-safe migration of saved config colours
+ * to identity keys. Returns possibly-updated configData to hydrate from. Never
+ * sets the guard unless the relevant persist actually succeeded.
+ */
+export async function applyConfigColourMigration(
+  configData: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const rawSettings = { ...((configData.settings as any) || {}) }
+  if (rawSettings.identityColorMigratedV2) return configData            // guard set: fast path
+
+  const configs = (configData.configs as any[]) || []
+  const { records, summary } = migrateColorRecords(configs)
+  console.log('[colourMigration] configs', summary)
+
+  const changedNow = summary.changed > 0
+  // A prior run may have persisted migrated configs but failed to persist the
+  // guard. Detect by migrated records already carrying legacyColor.
+  const hasPriorMigrated = configs.some((c: any) => c?.identityColorKey && c?.legacyColor)
+
+  // Genuine no-op (clean install / natively keyed): set guard, never notify.
+  if (!changedNow && !hasPriorMigrated) {
+    try {
+      const newSettings = { ...rawSettings, identityColorMigratedV2: true }
+      await window.electronAPI.config.save('settings', newSettings)
+      return { ...configData, settings: newSettings }
+    } catch (e) {
+      console.error('[colourMigration] guard persist failed (no-op case); will retry', e)
+      return configData
+    }
+  }
+
+  // Something changed now, OR a prior partial success left migrated records.
+  try {
+    if (changedNow) {
+      await window.electronAPI.config.save('configs', records)          // 1) persist configs FIRST
+    }
+    const dismissed = rawSettings.colourMigrationNoticeDismissed === true
+    const newSettings = {
+      ...rawSettings,
+      identityColorMigratedV2: true,
+      colourMigrationNoticePending: dismissed ? rawSettings.colourMigrationNoticePending : true,
+    }
+    await window.electronAPI.config.save('settings', newSettings)       // 2) guard + pending SECOND
+    return { ...configData, configs: changedNow ? records : configs, settings: newSettings }
+  } catch (e) {
+    console.error('[colourMigration] persist failed; guard NOT set, hydrating original data', e)
+    return configData                                                   // safe original; retry next launch
+  }
 }

--- a/src/renderer/utils/migrateIdentityColors.ts
+++ b/src/renderer/utils/migrateIdentityColors.ts
@@ -45,3 +45,24 @@ export function migrateColorRecords<T extends ColourRecord>(
   })
   return { records: out, summary: { scanned: records.length, changed, skipped, fallback } }
 }
+
+interface ReviewConfigRef { id: string; legacyColor?: string }
+interface ReviewSessionRef { configId?: string; legacyColor?: string }
+
+/**
+ * Choose the target for the notice's "Review colours" action (safety fallback
+ * chain): first migrated config -> a migrated session's still-existing config
+ * -> none. Never throws; returns 'none' when there is nothing safe to open
+ * (e.g. the migrated config was deleted, or only sessions changed with no
+ * resolvable config).
+ */
+export function pickColourReviewTarget(
+  configs: readonly ReviewConfigRef[],
+  sessions: readonly ReviewSessionRef[],
+): { kind: 'config'; configId: string } | { kind: 'none' } {
+  const cfg = configs.find((c) => c.legacyColor)
+  if (cfg) return { kind: 'config', configId: cfg.id }
+  const sess = sessions.find((s) => s.legacyColor && s.configId && configs.some((c) => c.id === s.configId))
+  if (sess && sess.configId) return { kind: 'config', configId: sess.configId }
+  return { kind: 'none' }
+}

--- a/src/renderer/utils/migrateIdentityColors.ts
+++ b/src/renderer/utils/migrateIdentityColors.ts
@@ -1,0 +1,47 @@
+import {
+  IDENTITY_COLOR_KEYS,
+  bucketLegacyColorToKeySource,
+  type IdentityColorKey,
+} from '../../shared/identity-colors'
+
+export interface ColourMigrationSummary {
+  scanned: number
+  changed: number
+  skipped: number
+  fallback: number
+}
+
+interface ColourRecord {
+  color?: string
+  identityColorKey?: IdentityColorKey
+  legacyColor?: string
+}
+
+const isValidKey = (k: unknown): k is IdentityColorKey =>
+  typeof k === 'string' && (IDENTITY_COLOR_KEYS as readonly string[]).includes(k)
+
+/**
+ * Idempotent, non-destructive migration of legacy raw `color` to an identity
+ * KEY. Never overwrites a valid existing identityColorKey; never deletes
+ * `color`. Sets identityColorKey + legacyColor only on records that change.
+ * Pure (no I/O). `fallback` counts records that needed the nearest/neutral
+ * path rather than an exact key/name/hex match.
+ */
+export function migrateColorRecords<T extends ColourRecord>(
+  records: readonly T[],
+): { records: T[]; summary: ColourMigrationSummary } {
+  let changed = 0
+  let skipped = 0
+  let fallback = 0
+  const out = records.map((r) => {
+    if (isValidKey(r.identityColorKey)) {
+      skipped++
+      return r
+    }
+    const { key, source } = bucketLegacyColorToKeySource(r.color ?? '')
+    if (source === 'fallback' || source === 'nearest') fallback++
+    changed++
+    return { ...r, identityColorKey: key, legacyColor: r.color }
+  })
+  return { records: out, summary: { scanned: records.length, changed, skipped, fallback } }
+}

--- a/src/shared/identity-colors.ts
+++ b/src/shared/identity-colors.ts
@@ -71,23 +71,27 @@ function dist2(a: [number, number, number], b: [number, number, number]): number
   return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
 }
 
+/** How bucketLegacyColorToKeySource arrived at its key, for migration counting. */
+export type LegacyColorSource = 'key' | 'name' | 'hex' | 'nearest' | 'fallback'
+
 /**
  * Map a legacy stored colour (raw hex, colour name, or already-a-key) to a
- * curated IdentityColorKey. Priority: existing key -> known name -> exact legacy
- * hex -> nearest-colour fallback (which routes reserved-ish hues to their bucket
- * key, otherwise the nearest identity key). Deterministic.
+ * curated IdentityColorKey, also reporting how the match was made. Priority:
+ * existing key -> known name -> exact legacy hex -> nearest-colour fallback
+ * (which routes reserved-ish hues to their bucket key, otherwise the nearest
+ * identity key) -> neutral fallback for unparseable input. Deterministic.
  */
-export function bucketLegacyColorToKey(value: string): IdentityColorKey {
+export function bucketLegacyColorToKeySource(value: string): { key: IdentityColorKey; source: LegacyColorSource } {
   const raw = value.trim()
   const lower = raw.toLowerCase()
-  if ((IDENTITY_COLOR_KEYS as readonly string[]).includes(lower)) return lower as IdentityColorKey
-  if (LEGACY_NAME_TO_KEY[lower]) return LEGACY_NAME_TO_KEY[lower]
+  if ((IDENTITY_COLOR_KEYS as readonly string[]).includes(lower)) return { key: lower as IdentityColorKey, source: 'key' }
+  if (LEGACY_NAME_TO_KEY[lower]) return { key: LEGACY_NAME_TO_KEY[lower], source: 'name' }
 
   const norm = (raw.startsWith('#') ? raw : '#' + raw).toUpperCase()
-  if (LEGACY_HEX_TO_KEY[norm]) return LEGACY_HEX_TO_KEY[norm]
+  if (LEGACY_HEX_TO_KEY[norm]) return { key: LEGACY_HEX_TO_KEY[norm], source: 'hex' }
 
   const rgb = hexToRgb(norm)
-  if (!rgb) return 'mauve'
+  if (!rgb) return { key: 'mauve', source: 'fallback' }
 
   let best: { key: IdentityColorKey; d: number } | null = null
   for (const a of RESERVED_ANCHORS) {
@@ -98,5 +102,13 @@ export function bucketLegacyColorToKey(value: string): IdentityColorKey {
     const d = dist2(rgb, hexToRgb(IDENTITY_PALETTE[k].dark)!)
     if (!best || d < best.d) best = { key: k, d }
   }
-  return best!.key
+  return { key: best!.key, source: 'nearest' }
+}
+
+/**
+ * Map a legacy stored colour to a curated IdentityColorKey. Thin wrapper over
+ * bucketLegacyColorToKeySource that drops the match-source detail.
+ */
+export function bucketLegacyColorToKey(value: string): IdentityColorKey {
+  return bucketLegacyColorToKeySource(value).key
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,6 +92,10 @@ export interface SavedSession {
   label: string
   workingDirectory: string
   color: string
+  /** V2 identity colour: stable palette key. Authoritative over `color` at render time. */
+  identityColorKey?: IdentityColorKey
+  /** Pre-migration raw `color`, retained only when this record was migrated. */
+  legacyColor?: string
   sessionType: 'local' | 'ssh'
   shellOnly?: boolean
   partnerTerminalPath?: string

--- a/tests/unit/renderer/colour-migration-hydration.test.ts
+++ b/tests/unit/renderer/colour-migration-hydration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { applyConfigColourMigration } from '../../../src/renderer/utils/configHydration'
+
+function setupSave(impl?: (key: string, data: any) => Promise<unknown>) {
+  const calls: Array<{ key: string; data: any }> = []
+  const save = vi.fn((key: string, data: any) => {
+    calls.push({ key, data })
+    return impl ? impl(key, data) : Promise.resolve()
+  })
+  ;(globalThis as any).window = { electronAPI: { config: { save } } }
+  return { calls, save }
+}
+
+describe('applyConfigColourMigration', () => {
+  beforeEach(() => { (globalThis as any).window = undefined })
+
+  it('fast-path: guard already set -> no saves, returns input unchanged', async () => {
+    const { save } = setupSave()
+    const data = { settings: { identityColorMigratedV2: true }, configs: [{ color: '#FF3366' }] }
+    const out = await applyConfigColourMigration(data)
+    expect(save).not.toHaveBeenCalled()
+    expect(out).toBe(data)
+  })
+
+  it('changed configs: awaits configs save BEFORE settings save, sets guard + pending', async () => {
+    const { calls } = setupSave()
+    const data = { settings: {}, configs: [{ color: '#FF3366' }, { color: '#00FFFF' }] }
+    const out: any = await applyConfigColourMigration(data)
+    expect(calls.map((c) => c.key)).toEqual(['configs', 'settings'])
+    expect(out.configs[0].identityColorKey).toBe('rose')
+    expect(out.settings.identityColorMigratedV2).toBe(true)
+    expect(out.settings.colourMigrationNoticePending).toBe(true)
+  })
+
+  it('clean / all-keyed: no configs save, guard set, pending NOT set', async () => {
+    const { calls } = setupSave()
+    const data = { settings: {}, configs: [{ color: '#FF3366', identityColorKey: 'rose' }] }
+    const out: any = await applyConfigColourMigration(data)
+    expect(calls.map((c) => c.key)).toEqual(['settings'])
+    expect(out.settings.identityColorMigratedV2).toBe(true)
+    expect(out.settings.colourMigrationNoticePending).toBeUndefined()
+  })
+
+  it('config save rejects: guard NOT set, returns original', async () => {
+    const data = { settings: {}, configs: [{ color: '#FF3366' }] }
+    setupSave((key) => key === 'configs' ? Promise.reject(new Error('disk')) : Promise.resolve())
+    const out: any = await applyConfigColourMigration(data)
+    expect(out).toBe(data)
+  })
+
+  it('config save ok but settings save rejects: returns original (retry next launch)', async () => {
+    const data = { settings: {}, configs: [{ color: '#FF3366' }] }
+    setupSave((key) => key === 'settings' ? Promise.reject(new Error('disk')) : Promise.resolve())
+    const out: any = await applyConfigColourMigration(data)
+    expect(out).toBe(data)
+  })
+
+  it('partial-success recovery: guard false, changed 0, records already keyed+legacy -> guard + pending', async () => {
+    const { calls } = setupSave()
+    const data = { settings: {}, configs: [{ color: '#FF3366', identityColorKey: 'rose', legacyColor: '#FF3366' }] }
+    const out: any = await applyConfigColourMigration(data)
+    expect(calls.map((c) => c.key)).toEqual(['settings'])
+    expect(out.settings.identityColorMigratedV2).toBe(true)
+    expect(out.settings.colourMigrationNoticePending).toBe(true)
+  })
+
+  it('partial-success recovery respects prior dismissal', async () => {
+    setupSave()
+    const data = { settings: { colourMigrationNoticeDismissed: true }, configs: [{ color: '#FF3366', identityColorKey: 'rose', legacyColor: '#FF3366' }] }
+    const out: any = await applyConfigColourMigration(data)
+    expect(out.settings.colourMigrationNoticePending).toBeUndefined()
+  })
+})

--- a/tests/unit/renderer/colour-migration-notice.test.ts
+++ b/tests/unit/renderer/colour-migration-notice.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * Task 8 (V2 shell P2b2): one-time colour-migration notice.
+ *
+ * Uses React.createElement (not JSX) so the file stays under the vitest include
+ * pattern (*.test.ts) -- matches sibling renderer component tests
+ * (e.g. contextbar-account-slot.test.ts).
+ *
+ * Focus here: visibility (pending/dismissed gating) + the Dismiss action.
+ * The Review colours target-picker logic is covered in
+ * colour-review-target.test.ts.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// Mutable settings the mocked store reads from, plus a spy for updateSettings.
+const STATE: { settings: Record<string, unknown> } = { settings: {} }
+const updateSettings = vi.fn(() => Promise.resolve())
+
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => ({ ...STATE, updateSettings })
+  return { useSettingsStore }
+})
+
+// Review handler reads configs/sessions via getState; provide empty defaults.
+vi.mock('../../../src/renderer/stores/configStore', () => {
+  const useConfigStore: any = (selector: (s: any) => unknown) => selector({ configs: [] })
+  useConfigStore.getState = () => ({ configs: [] })
+  return { useConfigStore }
+})
+vi.mock('../../../src/renderer/stores/sessionStore', () => {
+  const useSessionStore: any = (selector: (s: any) => unknown) => selector({ sessions: [] })
+  useSessionStore.getState = () => ({ sessions: [] })
+  return { useSessionStore }
+})
+
+const { default: ColourMigrationNotice } = await import(
+  '../../../src/renderer/components/ColourMigrationNotice'
+)
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (b) => b.textContent === label,
+  )
+}
+
+describe('ColourMigrationNotice', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    STATE.settings = {}
+    updateSettings.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  it('renders nothing when pending is false', () => {
+    STATE.settings = { colourMigrationNoticePending: false }
+    act(() => { root.render(React.createElement(ColourMigrationNotice, {})) })
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing when pending && dismissed', () => {
+    STATE.settings = { colourMigrationNoticePending: true, colourMigrationNoticeDismissed: true }
+    act(() => { root.render(React.createElement(ColourMigrationNotice, {})) })
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders the title when pending && !dismissed', () => {
+    STATE.settings = { colourMigrationNoticePending: true }
+    act(() => { root.render(React.createElement(ColourMigrationNotice, {})) })
+    expect(container.textContent).toContain('Session colours refreshed')
+  })
+
+  it('Dismiss persists colourMigrationNoticeDismissed: true', () => {
+    STATE.settings = { colourMigrationNoticePending: true }
+    act(() => { root.render(React.createElement(ColourMigrationNotice, {})) })
+    const btn = findButton(container, 'Dismiss')
+    expect(btn).toBeTruthy()
+    act(() => { btn!.click() })
+    expect(updateSettings).toHaveBeenCalledWith({ colourMigrationNoticeDismissed: true })
+  })
+})

--- a/tests/unit/renderer/colour-review-target.test.ts
+++ b/tests/unit/renderer/colour-review-target.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { pickColourReviewTarget } from '../../../src/renderer/utils/migrateIdentityColors'
+
+describe('pickColourReviewTarget', () => {
+  it('picks the first migrated config', () => {
+    expect(pickColourReviewTarget([{ id: 'a' }, { id: 'b', legacyColor: '#FF3366' }], []))
+      .toEqual({ kind: 'config', configId: 'b' })
+  })
+  it('falls back to a migrated session mapped to an existing config', () => {
+    expect(pickColourReviewTarget([{ id: 'a' }], [{ configId: 'a', legacyColor: '#00FFFF' }]))
+      .toEqual({ kind: 'config', configId: 'a' })
+  })
+  it('returns none when the migrated session config no longer exists', () => {
+    expect(pickColourReviewTarget([{ id: 'a' }], [{ configId: 'gone', legacyColor: '#00FFFF' }]))
+      .toEqual({ kind: 'none' })
+  })
+  it('returns none when nothing was migrated', () => {
+    expect(pickColourReviewTarget([{ id: 'a' }], [{ configId: 'a' }])).toEqual({ kind: 'none' })
+  })
+})

--- a/tests/unit/renderer/configrow-identity-colour.test.ts
+++ b/tests/unit/renderer/configrow-identity-colour.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+/**
+ * Task 7 (V2 shell colour migration): ConfigRow's identity dot resolves its
+ * colour through resolveIdentityColor(identityColorKey ?? bucketLegacyColorToKey(color), theme),
+ * so a migrated record (has identityColorKey) and an un-migrated one (legacy
+ * raw hex only) both render a concrete theme hex -- never a CSS var.
+ *
+ * Uses React.createElement (not JSX) so the file stays a *.test.ts under the
+ * vitest include pattern -- matches sibling renderer tests. The settings-store
+ * mock mirrors contextbar-account-slot.test.ts (selector + getState, theme:'dark').
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// --- mock useSettingsStore before component import ---
+// useResolvedTheme reads settings.theme via both a selector call and getState().
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings: { theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+
+// Import after mock is registered
+const { default: ConfigRow } = await import('../../../src/renderer/components/sidebar/ConfigRow')
+const { resolveIdentityColor, bucketLegacyColorToKey } = await import('../../../src/shared/identity-colors')
+
+const THEME = 'dark' as const
+
+const baseConfig = {
+  id: 'c1',
+  provider: 'claude' as const,
+  label: 'Test Config',
+  workingDirectory: '.',
+  sessionType: 'local' as const,
+}
+
+const rowProps = {
+  onLaunch: () => {},
+  onEdit: () => {},
+  onDelete: () => {},
+  onContextMenu: () => {},
+}
+
+function dot(container: HTMLElement): HTMLElement | null {
+  // The identity dot is the aria-hidden span carrying the inline backgroundColor.
+  return container.querySelector<HTMLElement>('span[aria-hidden]')
+}
+
+describe('ConfigRow identity colour', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  it('renders the dot using resolveIdentityColor for a config with identityColorKey', () => {
+    act(() => {
+      root.render(React.createElement(ConfigRow, {
+        ...(rowProps as any),
+        config: { ...baseConfig, identityColorKey: 'rose', color: '#ffffff' },
+      }))
+    })
+    const el = dot(container)
+    expect(el).toBeTruthy()
+    expect(el!.style.backgroundColor).toBe(toRgb(resolveIdentityColor('rose', THEME)))
+  })
+
+  it('renders the same colour from a legacy raw hex (no key) as the bucketed key would', () => {
+    act(() => {
+      root.render(React.createElement(ConfigRow, {
+        ...(rowProps as any),
+        config: { ...baseConfig, color: '#00FFFF' },
+      }))
+    })
+    const el = dot(container)
+    const expectedKey = bucketLegacyColorToKey('#00FFFF')
+    expect(el!.style.backgroundColor).toBe(toRgb(resolveIdentityColor(expectedKey, THEME)))
+  })
+
+  it('does not render the dot colour as a CSS var', () => {
+    act(() => {
+      root.render(React.createElement(ConfigRow, {
+        ...(rowProps as any),
+        config: { ...baseConfig, identityColorKey: 'mauve', color: '' },
+      }))
+    })
+    const style = dot(container)?.getAttribute('style') || ''
+    expect(style).not.toContain('var(')
+  })
+})
+
+// jsdom normalises inline style colours to rgb(...) form; convert our hex
+// expectation the same way so the assertions compare like-for-like.
+function toRgb(hex: string): string {
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex)
+  if (!m) return hex
+  const r = parseInt(m[1], 16)
+  const g = parseInt(m[2], 16)
+  const b = parseInt(m[3], 16)
+  return `rgb(${r}, ${g}, ${b})`
+}

--- a/tests/unit/renderer/identity-swatches.test.ts
+++ b/tests/unit/renderer/identity-swatches.test.ts
@@ -1,0 +1,15 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { IDENTITY_SWATCHES } from '../../../src/renderer/components/SessionDialog'
+import { IDENTITY_COLOR_KEYS } from '../../../src/shared/identity-colors'
+
+describe('IDENTITY_SWATCHES', () => {
+  it('offers exactly the curated identity keys', () => {
+    expect([...IDENTITY_SWATCHES]).toEqual([...IDENTITY_COLOR_KEYS])
+  })
+  it('offers no reserved status/brand/link hue', () => {
+    for (const banned of ['red', 'green', 'teal', 'amber', 'yellow', 'sky', 'blue', 'copper']) {
+      expect(IDENTITY_SWATCHES).not.toContain(banned as any)
+    }
+  })
+})

--- a/tests/unit/renderer/migrate-identity-colors.test.ts
+++ b/tests/unit/renderer/migrate-identity-colors.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { migrateColorRecords } from '../../../src/renderer/utils/migrateIdentityColors'
+
+describe('migrateColorRecords', () => {
+  it('maps each status-collision bucket to its key', () => {
+    const { records } = migrateColorRecords([
+      { color: '#FF3366' }, // red -> rose
+      { color: '#FFD700' }, // gold -> violet
+      { color: '#32CD32' }, // green -> indigo
+      { color: '#00FFFF' }, // teal/cyan -> slate-blue
+      { color: '#4169E1' }, // link blue -> periwinkle
+    ])
+    expect(records.map((r) => r.identityColorKey)).toEqual(['rose', 'violet', 'indigo', 'slate-blue', 'periwinkle'])
+  })
+
+  it('keeps a non-colliding colour as its equivalent identity hue', () => {
+    const { records } = migrateColorRecords([{ color: '#FF00FF' }]) // -> orchid
+    expect(records[0].identityColorKey).toBe('orchid')
+  })
+
+  it('routes unknown/invalid colour to the neutral fallback (mauve)', () => {
+    const { records, summary } = migrateColorRecords([{ color: 'not-a-hex' }, { color: '' }])
+    expect(records[0].identityColorKey).toBe('mauve')
+    expect(records[1].identityColorKey).toBe('mauve')
+    expect(summary.fallback).toBe(2)
+  })
+
+  it('does NOT overwrite an existing valid identityColorKey (skips it)', () => {
+    const { records, summary } = migrateColorRecords([{ color: '#FF3366', identityColorKey: 'pink' }])
+    expect(records[0].identityColorKey).toBe('pink')        // unchanged
+    expect(records[0].legacyColor).toBeUndefined()          // not touched
+    expect(summary.skipped).toBe(1)
+    expect(summary.changed).toBe(0)
+  })
+
+  it('retains legacyColor only on records it actually changed', () => {
+    const { records } = migrateColorRecords([
+      { color: '#FF3366' },                          // changed -> legacyColor set
+      { color: '#FF3366', identityColorKey: 'rose' }, // skipped -> no legacyColor
+    ])
+    expect(records[0].legacyColor).toBe('#FF3366')
+    expect(records[1].legacyColor).toBeUndefined()
+  })
+
+  it('preserves other fields and does not delete color', () => {
+    const { records } = migrateColorRecords([{ color: '#FF3366', label: 'web' } as any])
+    expect((records[0] as any).label).toBe('web')
+    expect(records[0].color).toBe('#FF3366')
+  })
+
+  it('is idempotent: a second pass changes nothing', () => {
+    const first = migrateColorRecords([{ color: '#FF3366' }])
+    const second = migrateColorRecords(first.records)
+    expect(second.summary.changed).toBe(0)
+    expect(second.summary.skipped).toBe(1)
+    expect(second.records[0].identityColorKey).toBe('rose')
+  })
+
+  it('reports accurate summary counts', () => {
+    const { summary } = migrateColorRecords([
+      { color: '#FF3366' },                           // changed (hex)
+      { color: 'not-a-hex' },                         // changed + fallback
+      { color: '#FF3366', identityColorKey: 'rose' }, // skipped
+    ])
+    expect(summary).toEqual({ scanned: 3, changed: 2, skipped: 1, fallback: 1 })
+  })
+
+  it('counts nearest-match (parseable unknown hex) as fallback', () => {
+    const { summary } = migrateColorRecords([{ color: '#8000ff' }]) // nearest
+    expect(summary.fallback).toBe(1)
+    expect(summary.changed).toBe(1)
+  })
+})

--- a/tests/unit/shared/identity-colors.test.ts
+++ b/tests/unit/shared/identity-colors.test.ts
@@ -4,6 +4,7 @@ import {
   IDENTITY_PALETTE,
   resolveIdentityColor,
   bucketLegacyColorToKey,
+  bucketLegacyColorToKeySource,
   type IdentityColorKey,
 } from '../../../src/shared/identity-colors'
 
@@ -81,5 +82,26 @@ describe('bucketLegacyColorToKey -- names, passthrough, fallback', () => {
     expect(bucketLegacyColorToKey('')).toBe('mauve')
     expect(bucketLegacyColorToKey('not-a-hex')).toBe('mauve')
     expect(bucketLegacyColorToKey('#fff')).toBe('mauve')
+  })
+})
+
+describe('bucketLegacyColorToKeySource', () => {
+  it('reports source=key for an existing key', () => {
+    expect(bucketLegacyColorToKeySource('indigo')).toEqual({ key: 'indigo', source: 'key' })
+  })
+  it('reports source=name for a known colour name', () => {
+    expect(bucketLegacyColorToKeySource('teal')).toEqual({ key: 'slate-blue', source: 'name' })
+  })
+  it('reports source=hex for a known legacy swatch hex', () => {
+    expect(bucketLegacyColorToKeySource('#00FFFF')).toEqual({ key: 'slate-blue', source: 'hex' })
+  })
+  it('reports source=nearest for an unknown but parseable hex', () => {
+    expect(bucketLegacyColorToKeySource('#8000ff')).toEqual({ key: 'slate-blue', source: 'nearest' })
+  })
+  it('reports source=fallback for unparseable input', () => {
+    expect(bucketLegacyColorToKeySource('not-a-hex')).toEqual({ key: 'mauve', source: 'fallback' })
+  })
+  it('bucketLegacyColorToKey still returns the same key', () => {
+    expect(bucketLegacyColorToKey('#00FFFF')).toBe('slate-blue')
   })
 })


### PR DESCRIPTION
## Summary
Phase 2b-2 of the V2 Shell UX redesign (spec sections 5 + 12). Stores per-config/per-session colour as a stable `identityColorKey`, migrates every existing `config.color` / `session.color` to a key exactly once (guarded, reversible, idempotent), switches the colour picker to identity keys, resolves all colour surfaces through `resolveIdentityColor(key, theme)`, and shows a single non-alarming "Session colours refreshed" notice only when something actually changed.

Plan: `docs/superpowers/plans/2026-05-25-v2-shell-phase2b2-color-migration.md` (approved with 3 safety edits).

### Safety design (this PR mutates persisted user data)
- **Render fallback** `identityColorKey ?? bucketLegacyColorToKey(color)` everywhere -> the displayed colour is identical before and after the stored migration; no half-migrated visual state.
- **Strict awaited persist-then-guard:** `applyConfigColourMigration` awaits `save('configs')` BEFORE `save('settings', guard+pending)`. A persist failure never sets the guard (next launch retries idempotently). Runs as an awaited pre-step before `hydrateStores`.
- **Partial-success recovery:** if a prior run keyed configs but failed to persist the guard, the guard + notice are restored next launch.
- **Idempotent, non-destructive migration:** never overwrites a valid key, never deletes `color`, sets `legacyColor` only on changed records. Sessions migrate idempotently at restore (no guard).
- **Account colour:** no stored migration (Phase 2b-1 already keys it; recomputed at render).

### Scope notes
- The 4 unrelated `COLOR_SWATCHES` importers (CommandDialog / NoteDialog / ProjectBrowser / MagicButtonSettingsDialog) are non-identity raw-hex pickers and are intentionally untouched; `IDENTITY_SWATCHES` is the new identity picker constant.
- Phase 3 items (dense card, empty state, nav model) not started.

## Reviews
- Spec-compliance: COMPLIANT (13/13 incl. all 3 safety edits; §12 bucket table verified hex-by-hex; notice copy exact).
- Code-quality: APPROVED (no Critical/Important; full data-loss/guard-correctness trace clean). One Minor doc-clarification applied.

## Test Plan
- [x] `npm run typecheck` -> 0
- [x] `npx vitest run` -> 1087 passed / 1 skipped (pre-existing skip)
- [x] Unit-tested: migration helper (buckets, idempotent, no-overwrite, legacyColor, fallback counts); `applyConfigColourMigration` (await order, config-save-reject -> guard unset, settings-save-reject -> safe original, partial-success recovery, clean install no-notice); picker swatch set == identity keys (no reserved hue); render resolves key->hex (not a CSS var); review-target fallback chain; notice visibility + dismiss persistence
- [ ] Manual in-app soak (recommended before stable promote): seed colliding colours -> launch -> colours visually unchanged + notice once + dismiss persists across restart; clean install -> no notice; re-launch -> guard skips; light+dark resolve; edit migrated config -> sensible swatch selected, reserved hues absent; `Review colours` opens the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)