### PR TITLE
V2 Shell Phase 3: sidebar + session cards

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -34,6 +34,8 @@ import { useAppMetaStore } from './stores/appMetaStore'
 import { useSettingsStore } from './stores/settingsStore'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useThemeController } from './hooks/useThemeController'
+import { useLaunchConfig } from './hooks/useLaunchConfig'
+import StageEmptyState from './components/StageEmptyState'
 import { markSessionForResumePicker } from './utils/resumePicker'
 import { migrateColorRecords } from './utils/migrateIdentityColors'
 import { gatherLocalStorageData, hydrateStores, applyConfigColourMigration } from './utils/configHydration'
@@ -122,6 +124,12 @@ export default function App() {
   const [partnerActive, setPartnerActive] = useState<Set<string>>(new Set())
   const [showMachineNamePrompt, setShowMachineNamePrompt] = useState(false)
   const [machineNameInput, setMachineNameInput] = useState('')
+  const configs = useConfigStore((s) => s.configs)
+  const launchConfig = useLaunchConfig()
+  // onCreateConfigFromStage: App owns the GuidedConfigView toggle via showGuidedConfig.
+  // Sidebar receives onShowFirstRun={() => setShowGuidedConfig(true)}, so we use the
+  // same setter here to open the real create dialog from the stage empty state.
+  const onCreateConfigFromStage = () => setShowGuidedConfig(true)
   const activeSessionId = useSessionStore((s) => s.activeSessionId)
   const sessions = useSessionStore((s) => s.sessions)
   const webviewBySession = useWebviewStore((s) => s.bySessionId)
@@ -523,14 +531,12 @@ export default function App() {
     if (!activeSessionId || sessions.length === 0 || !activeSession) {
       return (
         <div className="flex-1 flex flex-col" style={{ display: view === 'sessions' ? 'flex' : 'none' }}>
-          <div className="flex-1 flex items-center justify-center">
-            <div className="text-center text-overlay1">
-              <div className="text-5xl mb-4 font-mono">&gt;_</div>
-              <h2 className="text-xl font-semibold mb-2">Claude Command Center <span className="text-yellow/70">Beta</span></h2>
-              <p className="text-sm">Create a terminal config to get started</p>
-              <p className="text-xs text-overlay0 mt-2">Ctrl+T to create, Ctrl+Tab to switch</p>
-            </div>
-          </div>
+          <StageEmptyState
+            configs={configs}
+            onLaunch={(c) => { launchConfig(c); setView('sessions') }}
+            onShowAllConfigs={() => setView('sessions')}
+            onCreateConfig={onCreateConfigFromStage}
+          />
         </div>
       )
     }

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -11,7 +11,7 @@ import { ViewType } from '../types/views'
 import { trackUsage } from '../stores/tipsStore'
 import { generateId } from '../utils/id'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
-import { markSessionForResumePicker } from '../utils/resumePicker'
+import { useLaunchConfig } from '../hooks/useLaunchConfig'
 import SidebarNav from './sidebar/SidebarNav'
 import ConfigRow from './sidebar/ConfigRow'
 import SessionRow from './sidebar/SessionRow'
@@ -68,7 +68,8 @@ interface Props {
 }
 
 export default function Sidebar({ currentView, onViewChange, onUpdateRequested, collapsed, onShowHelp, onShowFirstRun, tourActive }: Props) {
-  const { sessions, activeSessionId, setActiveSession, removeSession, addSession, updateSession } = useSessionStore()
+  const launchConfig = useLaunchConfig()
+  const { sessions, activeSessionId, setActiveSession, removeSession, updateSession } = useSessionStore()
   const { configs, groups, sections, addConfig, updateConfig, removeConfig, addGroup, renameGroup, removeGroup, toggleGroupCollapsed, moveConfigToGroup, addSection, renameSection, removeSection, toggleSectionCollapsed, moveGroupToSection, moveConfigToSection, togglePinned, duplicateConfig, reorderConfigs } = useConfigStore()
   const appMeta = useAppMetaStore((s) => s.meta)
   const updateAppMeta = useAppMetaStore((s) => s.update)
@@ -215,49 +216,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
   }
 
   const launchFromConfig = async (config: TerminalConfig) => {
-    // Credentials are resolved in the main process at PTY spawn time — never loaded in the renderer
-    const session: Session = {
-      id: generateId(),
-      configId: config.id,
-      label: config.label,
-      workingDirectory: config.workingDirectory,
-      model: config.claudeOptions?.model ?? '',
-      color: config.color,
-      status: 'idle',
-      createdAt: Date.now(),
-      sessionType: config.sessionType,
-      shellOnly: config.shellOnly,
-      partnerTerminalPath: config.partnerTerminalPath,
-      partnerElevated: config.partnerElevated,
-      sshConfig: config.sshConfig ? {
-        host: config.sshConfig.host,
-        port: config.sshConfig.port,
-        username: config.sshConfig.username,
-        remotePath: config.sshConfig.remotePath,
-        hasPassword: config.sshConfig.hasPassword,
-        postCommand: config.sshConfig.postCommand,
-        hasSudoPassword: config.sshConfig.hasSudoPassword,
-      } : undefined,
-      legacyVersion: config.claudeOptions?.legacyVersion,
-      agentIds: config.claudeOptions?.agentIds,
-      machineName: config.machineName,
-      effortLevel: config.claudeOptions?.effortLevel,
-      disableAutoMemory: config.claudeOptions?.disableAutoMemory,
-      enableCodexReview: config.claudeOptions?.enableCodexReview,
-      provider: config.provider,
-      codexOptions: config.codexOptions,
-      // P9.3 (#280): inherit the persisted GH integration so spawning a fresh
-      // session from this config doesn't lose the user's earlier setup.
-      githubIntegration: config.githubIntegration,
-    }
-    // Both Claude and Codex sessions trigger the resume picker. The Codex picker
-    // script is deployed at boot via deployResumePickerScript; if missing on first
-    // boot, buildCodexSpawn falls back to direct codex spawn (see
-    // src/main/providers/codex/spawn.ts) so this gate cannot brick a session.
-    if (!session.shellOnly && session.sessionType === 'local') {
-      markSessionForResumePicker(session.id)
-    }
-    addSession(session)
+    launchConfig(config)
     onViewChange('sessions')
   }
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -626,8 +626,14 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
           }
         }}
       >
-        <div className="p-3 flex items-center justify-between cursor-pointer hover:bg-surface0/30 transition-colors">
-          <div className="flex items-center gap-1.5">
+        <div className="p-3 flex items-center justify-between hover:bg-surface0/30 transition-colors">
+          <button
+            type="button"
+            onClick={() => { if (!configPanelPinned) setConfigPanelOpen((o) => !o) }}
+            aria-expanded={configPanelOpen || configPanelPinned}
+            className="flex items-center gap-1.5 rounded focus-ring"
+            title="Show all saved configs"
+          >
             <svg
               width="10" height="10" viewBox="0 0 10 10" fill="currentColor"
               className="text-overlay0 transition-transform"
@@ -637,7 +643,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
             </svg>
             <span className="text-xs font-semibold text-subtext0 uppercase tracking-wider">Saved Configs</span>
             <span className="text-[10px] text-overlay0">{configs.length}</span>
-          </div>
+          </button>
           <div className="flex gap-0.5">
             <button
               onClick={(e) => {
@@ -870,7 +876,10 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
 
       {/* Active Sessions */}
       <div className="p-3 flex items-center justify-between border-t border-surface0 mt-2">
-        <span className="text-xs font-semibold text-subtext0 uppercase tracking-wider">Active Sessions</span>
+        <span className="flex items-center gap-1.5">
+          <span className="text-xs font-semibold text-subtext0 uppercase tracking-wider">Active Sessions</span>
+          <span className="text-[10px] text-overlay0">{sessions.length}</span>
+        </span>
         {selectedSessionIds.size > 1 && (
           <div className="flex items-center gap-1.5">
             <span className="text-[10px] text-overlay0">{selectedSessionIds.size} selected</span>
@@ -956,7 +965,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
               }}
             />
             {!sessionSectionCollapsed[section.id] && (
-              <div className="ml-2 space-y-0.5">
+              <div className="space-y-0.5">
                 {sectionGroups.map(({ group, sessions: groupSessions }) => (
                   <div key={group.id} className="mb-1">
                     <SessionGroupHeader
@@ -966,7 +975,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
                       onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
                     />
                     {!sessionGroupCollapsed[group.id] && (
-                      <div className="ml-3 space-y-0.5">
+                      <div className="space-y-0.5">
                         {groupSessions.map(renderSessionRow)}
                       </div>
                     )}
@@ -988,7 +997,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
               onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
             />
             {!sessionGroupCollapsed[group.id] && (
-              <div className="ml-3 space-y-0.5">
+              <div className="space-y-0.5">
                 {groupSessions.map(renderSessionRow)}
               </div>
             )}

--- a/src/renderer/components/StageEmptyState.tsx
+++ b/src/renderer/components/StageEmptyState.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { TerminalConfig } from '../stores/configStore'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
+import { useResolvedTheme } from '../hooks/useThemeController'
+
+interface Props {
+  configs: TerminalConfig[]
+  onLaunch: (config: TerminalConfig) => void
+  onShowAllConfigs: () => void
+  onCreateConfig: () => void
+}
+
+// Context-aware centre cold-open (spec section 6). Configs exist -> invite
+// launching one (pinned first, else first few) + "Show all configs". None ->
+// invite creating one.
+export default function StageEmptyState({ configs, onLaunch, onShowAllConfigs, onCreateConfig }: Props) {
+  const theme = useResolvedTheme()
+  const hasConfigs = configs.length > 0
+  const pinned = configs.filter((c) => c.pinned)
+  const launchers = (pinned.length > 0 ? pinned : configs).slice(0, 6)
+
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center max-w-md px-6">
+        <div className="text-5xl mb-4 font-mono text-overlay1">&gt;_</div>
+        <h2 className="text-xl font-semibold mb-1 text-text">
+          {hasConfigs ? 'Start a saved config' : 'Claude Command Center'}
+        </h2>
+        <p className="text-sm text-subtext0 mb-5">
+          {hasConfigs ? 'Pick a config to launch a new session.' : 'Create a terminal config to get started.'}
+        </p>
+
+        {hasConfigs ? (
+          <>
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {launchers.map((c) => {
+                const color = resolveIdentityColor(c.identityColorKey ?? bucketLegacyColorToKey(c.color), theme)
+                return (
+                  <button
+                    key={c.id}
+                    onClick={() => onLaunch(c)}
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg border border-surface1 hover:border-surface2 hover:bg-surface0/40 transition-colors text-left focus-ring"
+                    title={`Launch ${c.label}`}
+                  >
+                    <span className="w-2 h-2 rounded-[2px] shrink-0" style={{ backgroundColor: color }} aria-hidden />
+                    <span className="text-xs text-text truncate">{c.label}</span>
+                  </button>
+                )
+              })}
+            </div>
+            <button
+              onClick={onShowAllConfigs}
+              className="text-xs text-subtext0 hover:text-text underline-offset-2 hover:underline focus-ring rounded px-1"
+            >
+              Show all configs
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={onCreateConfig}
+            className="px-4 py-2 rounded-lg bg-mauve hover:bg-pink text-base text-xs font-medium transition-colors focus-ring"
+          >
+            Create a terminal config
+          </button>
+        )}
+        <p className="text-xs text-overlay0 mt-4">Ctrl+T to create, Ctrl+Tab to switch</p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -20,7 +20,7 @@ interface ConfigRowProps {
 }
 
 export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, onContextMenu, draggable, onDragStart, onDragOver, onDrop, onDragEnd, isDragOver }: ConfigRowProps) {
-  // Identity now lives in a small color dot — no row fill at rest, no
+  // Identity now lives in a small color square -- no row fill at rest, no
   // heavy left border. Hover just lifts to a neutral surface tint;
   // colour is held in the dot and badges only.
   const theme = useResolvedTheme()

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TerminalConfig } from '../../stores/configStore'
-import { ClaudeBadge, ShellBadge, SshBadge } from './Badges'
+import { ShellBadge, SshBadge } from './Badges'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
 import { useResolvedTheme } from '../../hooks/useThemeController'
 
@@ -36,17 +36,17 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
       onDragEnd={onDragEnd}
     >
       <span
-        className="w-1.5 h-1.5 rounded-full shrink-0"
+        className="w-1.5 h-1.5 rounded-[2px] shrink-0"
         style={{ backgroundColor: dotColour }}
         aria-hidden
       />
       <span className="text-xs text-text truncate flex-1">{config.label}</span>
       {config.sessionType === 'ssh' && <SshBadge />}
-      {config.shellOnly ? <ShellBadge /> : <ClaudeBadge needsAttention={false} />}
+      {config.shellOnly && <ShellBadge />}
       <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
         <button
           onClick={onLaunch}
-          className="p-1 rounded hover:bg-surface1 text-green"
+          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text"
           title="Launch"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><polygon points="3,1 10,6 3,11" /></svg>

--- a/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
+++ b/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
@@ -23,11 +23,11 @@ export default function PinnedConfigsPanel({ configs, onLaunch }: PinnedConfigsP
           key={config.id}
           className="flex items-center gap-2 rounded-md py-1 px-2 group transition-colors hover:bg-surface0/40"
         >
-          <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: dotColour }} />
+          <div className="w-2 h-2 rounded-[2px] shrink-0" style={{ backgroundColor: dotColour }} />
           <span className="text-xs text-text truncate flex-1">{config.label}</span>
           <button
             onClick={() => onLaunch(config)}
-            className="p-0.5 rounded hover:bg-surface1 text-green opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-text opacity-0 group-hover:opacity-100 transition-opacity"
             title="Launch"
           >
             <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="2,1 8,5 2,9" /></svg>

--- a/src/renderer/components/sidebar/SessionGroupHeader.tsx
+++ b/src/renderer/components/sidebar/SessionGroupHeader.tsx
@@ -13,7 +13,7 @@ export default function SessionGroupHeader({ group, collapsed, onToggleCollapse,
     <div className="flex items-center gap-1 py-1 px-1 rounded hover:bg-surface0/30 transition-colors group/sheader">
       <button
         onClick={onToggleCollapse}
-        className="p-0.5 text-overlay0 hover:text-text transition-colors"
+        className="p-0.5 text-overlay0 hover:text-text transition-colors focus-ring"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"
           style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
@@ -23,7 +23,7 @@ export default function SessionGroupHeader({ group, collapsed, onToggleCollapse,
       <span className="text-xs font-medium text-subtext1 truncate flex-1">{group.name}</span>
       <button
         onClick={onCloseAll}
-        className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-red opacity-0 group-hover/sheader:opacity-100 transition-opacity"
+        className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-red opacity-0 group-hover/sheader:opacity-100 transition-opacity focus-ring"
         title="Close all sessions in group"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -118,16 +118,19 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
         {isActive && <span data-testid="identity-chip"><IdentityChip color={identity} title="Selected session" /></span>}
       </span>
 
-      {/* Line 2: model meta + context meter + right-aligned % column */}
-      <span className="meta relative z-10 row-start-2 truncate">{metaLine}</span>
-      <div className="relative z-10 row-start-2 col-start-2 flex items-center gap-1.5">
+      {/* Line 2: model meta + context meter + right-aligned %. One grid child
+          spanning the name+meta columns (2 / 4) so the meta does NOT auto-place
+          into the 9px dot column (col 1) and get clipped. The dot column stays
+          empty on line 2, so line 2 aligns under the name. */}
+      <div className="relative z-10 row-start-2 flex items-center gap-2" style={{ gridColumn: '2 / 4' }} data-testid="card-line2">
+        <span className="meta truncate">{metaLine}</span>
         <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
           <div className={`meter-fill ${meterClass(pct)}`} style={{ width: `${pct}%` }} />
         </div>
+        <span className="meta w-9 text-right tabular-nums shrink-0">
+          {session.contextPercent != null ? `${Math.round(pct)}%` : ''}
+        </span>
       </div>
-      <span className="meta relative z-10 row-start-2 col-start-3 w-9 text-right tabular-nums">
-        {session.contextPercent != null ? `${Math.round(pct)}%` : ''}
-      </span>
     </button>
   )
 }

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Session } from '../../stores/sessionStore'
-import { ClaudeBadge, CodexBadge, ShellBadge, SshBadge } from './Badges'
+import { CodexBadge, ShellBadge, SshBadge } from './Badges'
 import { StatusDot, type SessionState } from '../ui/StatusDot'
+import { StatusPill } from '../ui/StatusPill'
+import { IdentityChip } from '../ui/IdentityChip'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
 import { useResolvedTheme } from '../../hooks/useThemeController'
 
@@ -21,20 +23,9 @@ interface SessionRowProps {
   isFocused?: boolean
 }
 
-/** Map the store's SessionStatus (5 values) to the UI SessionState (7 values).
- *  Source field: session.status (type SessionStatus = 'idle'|'working'|'complete'|'error'|'disconnected')
- *  needsAttention boolean overrides to 'awaiting' when true (no 'awaiting'/'blocked' in store).
- *
- *  Mapping:
- *    needsAttention=true                -> 'awaiting'
- *    status 'working'                   -> 'running'
- *    status 'idle'                      -> 'idle'
- *    status 'complete'                  -> 'idle'   (done/ready = idle)
- *    status 'error'                     -> 'error'
- *    status 'disconnected'              -> 'background'
- */
+// Map store SessionStatus -> UI SessionState (see ui/StatusDot). error wins over
+// needsAttention (spec section 10 priority: error > awaiting > running).
 function toSessionState(status: Session['status'], needsAttention: boolean): SessionState {
-  // error wins over needsAttention (spec §10 priority: error > awaiting)
   if (status === 'error') return 'error'
   if (needsAttention) return 'awaiting'
   switch (status) {
@@ -46,104 +37,97 @@ function toSessionState(status: Session['status'], needsAttention: boolean): Ses
   }
 }
 
+function meterClass(pct: number): string {
+  if (pct > 85) return 'meter-danger'
+  if (pct >= 70) return 'meter-warn'
+  return 'meter-neutral'
+}
+
 export default function SessionRow({ session, isActive, needsAttention, isRenaming, renameValue, renameRef, onRenameChange, onRenameFinish, onRenameCancel, onClick, onContextMenu, isSelected, isFocused }: SessionRowProps) {
   const theme = useResolvedTheme()
-  const tintColor = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
+  const identity = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
   const st = toSessionState(session.status, needsAttention)
+  const pct = session.contextPercent ?? 0
+  const providerLabel = session.shellOnly ? 'shell' : (session.provider ?? 'claude')
+  const metaLine = `${session.modelName ?? session.model ?? ''}${providerLabel ? ` · ${providerLabel}` : ''}`.trim()
 
-  // Priority: error > awaiting > active (spec §10). toSessionState never
-  // emits 'blocked' (no store signal yet); wire it here + there together if added.
-  const rowStateClass =
-    st === 'error' ? 'row-error'
-    : st === 'awaiting' ? 'row-awaiting'
-    : isActive ? 'row-active' : ''
+  // #398: when renaming, render a plain <div> (NOT a <button>) so the text input
+  // is never nested inside interactive button content (invalid HTML / a11y).
+  if (isRenaming) {
+    return (
+      <div className="session-card" style={{ gridTemplateColumns: '1fr' }}>
+        <input
+          ref={renameRef}
+          value={renameValue}
+          onChange={(e) => onRenameChange(e.target.value)}
+          onBlur={onRenameFinish}
+          onKeyDown={(e) => {
+            e.stopPropagation()
+            if (e.key === 'Enter') onRenameFinish()
+            if (e.key === 'Escape') onRenameCancel()
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="w-full bg-base border border-blue rounded px-1.5 py-0.5 text-xs text-text outline-none min-w-0"
+        />
+      </div>
+    )
+  }
+
+  // Selection (isActive) = identity rail + tint + identity border + elevation + bold + chip.
+  // Health and focus are separate channels and never touch these.
+  const selectedStyle: React.CSSProperties = isActive
+    ? {
+        backgroundColor: identity + '20',
+        borderColor: `color-mix(in srgb, ${identity} 55%, transparent)`,
+        borderLeft: `4px solid ${identity}`,
+        paddingLeft: 7,
+        boxShadow: '0 2px 8px rgba(0,0,0,.22)',
+      }
+    : isSelected
+    ? { backgroundColor: identity + '12' }
+    : {}
 
   return (
     <button
       onClick={onClick}
       onContextMenu={onContextMenu}
-      className={`session-row w-full text-left transition-all duration-150 group relative overflow-hidden ${rowStateClass} ${
-        isActive
-          ? 'text-text'
-          : 'text-subtext0 hover:text-text'
-      } ${isSelected ? 'ring-1 ring-blue/50' : ''} ${isFocused ? 'ring-1 ring-blue/30' : ''}`}
-      style={{
-        backgroundColor: isActive && !rowStateClass ? tintColor + '20' : isSelected && !rowStateClass ? tintColor + '15' : undefined,
-      }}
-      onMouseEnter={(e) => { if (!isActive && !isSelected && !rowStateClass) (e.currentTarget as HTMLElement).style.backgroundColor = tintColor + '12' }}
-      onMouseLeave={(e) => { if (!isActive && !isSelected && !rowStateClass) (e.currentTarget as HTMLElement).style.backgroundColor = '' }}
+      className={`session-card w-full text-left transition-all duration-150 group relative overflow-hidden ${
+        isActive ? 'text-text' : 'text-subtext0 hover:text-text'
+      } ${isFocused ? 'card-focus' : ''}`}
+      style={selectedStyle}
+      onMouseEnter={(e) => { if (!isActive && !isSelected) (e.currentTarget as HTMLElement).style.backgroundColor = identity + '12' }}
+      onMouseLeave={(e) => { if (!isActive && !isSelected) (e.currentTarget as HTMLElement).style.backgroundColor = '' }}
     >
       {st === 'awaiting' && (
-        <div
-          className="absolute inset-0 rounded-md attention-pulse-bg"
-          style={{ backgroundColor: tintColor }}
-        />
+        <div className="absolute inset-0 rounded-md attention-pulse-bg" style={{ backgroundColor: identity }} />
       )}
 
-      {/* Col 1: status dot (hidden during rename to keep input flush) */}
-      <span className="relative z-10" style={{ display: isRenaming ? 'none' : undefined }}>
-        <StatusDot state={st} />
+      {/* Line 1, col 1: health dot */}
+      <span className="relative z-10 row-start-1"><StatusDot state={st} /></span>
+
+      {/* Line 1, col 2: name + (non-default) provider/ssh badges */}
+      <span className="nm relative z-10 row-start-1 flex items-center gap-1.5">
+        <span className="text-[13px] truncate" style={{ fontWeight: isActive ? 700 : 600 }}>{session.label}</span>
+        {session.sessionType === 'ssh' && <SshBadge />}
+        {session.shellOnly ? <ShellBadge /> : (session.provider ?? 'claude') === 'codex' ? <CodexBadge needsAttention={needsAttention} /> : null}
       </span>
 
-      {/* Col 2: name / rename input + badges */}
-      <span className="nm relative z-10 flex items-center gap-1.5" style={isRenaming ? { gridColumn: '1 / -1' } : undefined}>
-        {isRenaming ? (
-          <input
-            ref={renameRef}
-            value={renameValue}
-            onChange={(e) => onRenameChange(e.target.value)}
-            onBlur={onRenameFinish}
-            onKeyDown={(e) => {
-              e.stopPropagation()
-              if (e.key === 'Enter') onRenameFinish()
-              if (e.key === 'Escape') onRenameCancel()
-            }}
-            onClick={(e) => e.stopPropagation()}
-            className="flex-1 bg-base border border-blue rounded px-1.5 py-0.5 text-xs text-text outline-none min-w-0"
-          />
-        ) : (
-          <>
-            <span className="text-xs font-medium truncate">{session.label}</span>
-            {session.sessionType === 'ssh' && <SshBadge />}
-            {session.shellOnly ? (
-              <ShellBadge />
-            ) : (session.provider ?? 'claude') === 'codex' ? (
-              <CodexBadge needsAttention={needsAttention} />
-            ) : (
-              <ClaudeBadge needsAttention={needsAttention} />
-            )}
-          </>
-        )}
+      {/* Line 1, col 3: status pill + identity chip (chip selected-only) */}
+      <span className="relative z-10 row-start-1 flex items-center gap-1.5 justify-self-end">
+        <StatusPill state={st} />
+        {isActive && <span data-testid="identity-chip"><IdentityChip color={identity} title="Selected session" /></span>}
       </span>
 
-      {/* Col 3: model meta (right-aligned) -- hidden during rename */}
-      {!isRenaming && (
-        <span className="meta relative z-10">
-          {session.modelName ?? session.model ?? ''}
-        </span>
-      )}
-
-      {/* Context bar: spans all 3 columns */}
-      <div className="relative z-10" style={{ gridColumn: '1 / -1', marginTop: 2 }}>
-        <div className="flex items-center gap-1.5">
-          <div className="flex-1 h-1.5 bg-surface1 rounded-full overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-500"
-              style={{
-                width: `${session.contextPercent ?? 0}%`,
-                backgroundColor: (session.contextPercent ?? 0) > 80
-                  ? tintColor
-                  : (session.contextPercent ?? 0) > 50
-                  ? tintColor + 'CC'
-                  : tintColor + '99'
-              }}
-            />
-          </div>
-          <span className="text-[10px] text-overlay0 w-7 text-right">
-            {session.contextPercent != null ? `${Math.round(session.contextPercent)}%` : ''}
-          </span>
+      {/* Line 2: model meta + context meter + right-aligned % column */}
+      <span className="meta relative z-10 row-start-2 truncate">{metaLine}</span>
+      <div className="relative z-10 row-start-2 col-start-2 flex items-center gap-1.5">
+        <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
+          <div className={`meter-fill ${meterClass(pct)}`} style={{ width: `${pct}%` }} />
         </div>
       </div>
+      <span className="meta relative z-10 row-start-2 col-start-3 w-9 text-right tabular-nums">
+        {session.contextPercent != null ? `${Math.round(pct)}%` : ''}
+      </span>
     </button>
   )
 }

--- a/src/renderer/components/sidebar/SessionSectionHeader.tsx
+++ b/src/renderer/components/sidebar/SessionSectionHeader.tsx
@@ -13,7 +13,7 @@ export default function SessionSectionHeader({ section, collapsed, onToggleColla
     <div className="flex items-center gap-1 py-1.5 px-1 rounded hover:bg-surface0/20 transition-colors group/ssection">
       <button
         onClick={onToggleCollapse}
-        className="p-0.5 text-overlay0 hover:text-text transition-colors"
+        className="p-0.5 text-overlay0 hover:text-text transition-colors focus-ring"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"
           style={{ transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
@@ -25,7 +25,7 @@ export default function SessionSectionHeader({ section, collapsed, onToggleColla
       </span>
       <button
         onClick={onCloseAll}
-        className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-red opacity-0 group-hover/ssection:opacity-100 transition-opacity"
+        className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-red opacity-0 group-hover/ssection:opacity-100 transition-opacity focus-ring"
         title="Close all sessions in section"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>

--- a/src/renderer/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/components/sidebar/SidebarNav.tsx
@@ -150,18 +150,17 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
       style={currentView === item.view ? { color: 'var(--accent)' } : undefined}
     >
       {item.icon}
-      {/* Fast inline tooltip — appears immediately on hover instead of waiting
+      {/* Fast inline tooltip -- appears immediately on hover instead of waiting
           for the OS native `title` delay. Pointer-events:none so it doesn't
-          block clicks. Only rendered for the collapsed/icon-strip layout
-          where the label isn't already visible. */}
-      {isCollapsed && (
-        <span
-          className="pointer-events-none absolute left-full ml-2 z-40 px-2 py-0.5 text-[11px] rounded bg-surface1 text-text border border-surface2 shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-100"
-          aria-hidden="true"
-        >
-          {title}
-        </span>
-      )}
+          block clicks. Position adapts: collapsed = right of icon; expanded = below. */}
+      <span
+        className={`pointer-events-none absolute z-40 px-2 py-0.5 text-[11px] rounded bg-surface1 text-text border border-surface2 shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-100 ${
+          isCollapsed ? 'left-full ml-2 top-1/2 -translate-y-1/2' : 'top-full mt-1 left-1/2 -translate-x-1/2'
+        }`}
+        aria-hidden="true"
+      >
+        {title}
+      </span>
       {isInsightsActive && insightsDotColor && (
         <span
           className={`absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ${isInsightsAnimating ? 'insights-pulse-dot' : ''}`}
@@ -182,6 +181,10 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
       )}
       {showServerDot && (
         <span
+          data-testid="conductor-mcp-dot"
+          role="img"
+          aria-label={serverRunning ? 'Conductor MCP server running' : 'Conductor MCP server stopped'}
+          title={serverRunning ? 'Conductor MCP server running' : 'Conductor MCP server stopped'}
           className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full"
           style={{
             backgroundColor: serverRunning ? '#A6E3A1' : '#F38BA8',
@@ -206,16 +209,24 @@ export default function SidebarNav({ currentView, onViewChange, insightsStatus, 
         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
         <line x1="12" y1="17" x2="12.01" y2="17" />
       </svg>
-      {collapsed && (
-        <span
-          className="pointer-events-none absolute left-full ml-2 z-40 px-2 py-0.5 text-[11px] rounded bg-surface1 text-text border border-surface2 shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-100"
-          aria-hidden="true"
-        >
-          Feature Guide
-        </span>
-      )}
+      <span
+        className={`pointer-events-none absolute z-40 px-2 py-0.5 text-[11px] rounded bg-surface1 text-text border border-surface2 shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-100 ${
+          collapsed ? 'left-full ml-2 top-1/2 -translate-y-1/2' : 'top-full mt-1 left-1/2 -translate-x-1/2'
+        }`}
+        aria-hidden="true"
+      >
+        Feature Guide
+      </span>
     </button>
   ) : null
+
+  const primary = navItems.filter(i => ['cloud-agents', 'insights', 'tokenomics'].includes(i.view))
+  const system = navItems.filter(i => !['cloud-agents', 'insights', 'tokenomics'].includes(i.view))
+  const renderItem = (item: typeof navItems[0]) => (
+    <NavButton key={item.view} item={item} currentView={currentView} onViewChange={onViewChange}
+      insightsStatus={insightsStatus} insightsMessage={insightsMessage} cloudAgentRunning={cloudAgentRunning}
+      visionRunning={visionRunning} serverRunning={serverRunning} isCollapsed={false} />
+  )
 
   if (collapsed) {
     return (
@@ -223,19 +234,16 @@ export default function SidebarNav({ currentView, onViewChange, insightsStatus, 
         className="flex flex-col items-center gap-1 py-2 border-b border-surface0"
         style={{ background: 'var(--surface-chrome)', color: 'var(--text-on-chrome)' }}
       >
-        {navItems.map(item => (
-          <NavButton
-            key={item.view}
-            item={item}
-            currentView={currentView}
-            onViewChange={onViewChange}
-            insightsStatus={insightsStatus}
-            insightsMessage={insightsMessage}
-            cloudAgentRunning={cloudAgentRunning}
-            visionRunning={visionRunning}
-            serverRunning={serverRunning}
-            isCollapsed
-          />
+        {navItems.filter(i => ['cloud-agents', 'insights', 'tokenomics'].includes(i.view)).map(item => (
+          <NavButton key={item.view} item={item} currentView={currentView} onViewChange={onViewChange}
+            insightsStatus={insightsStatus} insightsMessage={insightsMessage} cloudAgentRunning={cloudAgentRunning}
+            visionRunning={visionRunning} serverRunning={serverRunning} isCollapsed />
+        ))}
+        <span className="h-px w-6 my-1 bg-surface1" aria-hidden />
+        {navItems.filter(i => !['cloud-agents', 'insights', 'tokenomics'].includes(i.view)).map(item => (
+          <NavButton key={item.view} item={item} currentView={currentView} onViewChange={onViewChange}
+            insightsStatus={insightsStatus} insightsMessage={insightsMessage} cloudAgentRunning={cloudAgentRunning}
+            visionRunning={visionRunning} serverRunning={serverRunning} isCollapsed />
         ))}
         {helpButton}
       </div>
@@ -244,23 +252,12 @@ export default function SidebarNav({ currentView, onViewChange, insightsStatus, 
 
   return (
     <div
-      className="px-2 pt-2 flex gap-1 border-b border-surface0 pb-2"
+      className="px-2 pt-2 flex gap-1 items-center border-b border-surface0 pb-2"
       style={{ background: 'var(--surface-chrome)', color: 'var(--text-on-chrome)' }}
     >
-      {navItems.map(item => (
-        <NavButton
-          key={item.view}
-          item={item}
-          currentView={currentView}
-          onViewChange={onViewChange}
-          insightsStatus={insightsStatus}
-          insightsMessage={insightsMessage}
-          cloudAgentRunning={cloudAgentRunning}
-          visionRunning={visionRunning}
-          serverRunning={serverRunning}
-          isCollapsed={false}
-        />
-      ))}
+      {primary.map(renderItem)}
+      <span className="w-px self-stretch my-1 bg-surface1 shrink-0" aria-hidden />
+      {system.map(renderItem)}
       {helpButton}
     </div>
   )

--- a/src/renderer/components/ui/IdentityChip.tsx
+++ b/src/renderer/components/ui/IdentityChip.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+// Shown on the SELECTED card only (spec section 6 line 1, far right). A small
+// rounded square in the session identity colour -- a non-status, structural
+// "this is the selected identity" marker. Square (not a dot) so it never reads
+// as a health dot.
+export function IdentityChip({ color, title }: { color: string; title?: string }) {
+  return (
+    <span
+      className="w-2.5 h-2.5 rounded-[3px] shrink-0"
+      style={{ backgroundColor: color, boxShadow: `0 0 0 1px color-mix(in srgb, ${color} 45%, transparent)` }}
+      role={title ? 'img' : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      title={title}
+    />
+  )
+}

--- a/src/renderer/components/ui/StatusPill.tsx
+++ b/src/renderer/components/ui/StatusPill.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import type { SessionState } from './StatusDot'
+
+// Health pill -- secondary to the name. Only emitted for states that carry a
+// meaningful health signal; idle/background stay quiet (no pill) so the row
+// reads calm. Colour is a status token; never an identity hue (spec section 6).
+const PILL: Partial<Record<SessionState, { label: string; color: string }>> = {
+  running:    { label: 'running',    color: 'var(--status-success)' },
+  awaiting:   { label: 'attention',  color: 'var(--status-warning)' },
+  error:      { label: 'stopped',    color: 'var(--status-danger)' },
+  compacting: { label: 'compacting', color: 'var(--status-info)' },
+}
+
+export function StatusPill({ state }: { state: SessionState }) {
+  const p = PILL[state]
+  if (!p) return null
+  return (
+    <span
+      className="text-[9px] font-medium uppercase tracking-wide px-1.5 py-px rounded-full shrink-0 leading-none"
+      style={{ color: p.color, background: `color-mix(in srgb, ${p.color} 15%, transparent)` }}
+    >
+      {p.label}
+    </span>
+  )
+}

--- a/src/renderer/hooks/useLaunchConfig.ts
+++ b/src/renderer/hooks/useLaunchConfig.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { Session, useSessionStore } from '../stores/sessionStore'
+import { TerminalConfig } from '../stores/configStore'
+import { generateId } from '../utils/id'
+import { markSessionForResumePicker } from '../utils/resumePicker'
+
+/**
+ * Shared "launch a saved config into a new active session" action. Extracted
+ * verbatim from Sidebar.launchFromConfig so the centre empty state reuses the
+ * EXACT same launch path (no behaviour drift). Returns the new session id.
+ * Credentials are resolved in the main process at PTY spawn time, never here.
+ * addSession() sets the new session active (sessionStore), so callers only need
+ * to ensure the 'sessions' view is shown.
+ */
+export function useLaunchConfig(): (config: TerminalConfig) => string {
+  const addSession = useSessionStore((s) => s.addSession)
+  return useCallback((config: TerminalConfig) => {
+    const session: Session = {
+      id: generateId(),
+      configId: config.id,
+      label: config.label,
+      workingDirectory: config.workingDirectory,
+      model: config.claudeOptions?.model ?? '',
+      color: config.color,
+      status: 'idle',
+      createdAt: Date.now(),
+      sessionType: config.sessionType,
+      shellOnly: config.shellOnly,
+      partnerTerminalPath: config.partnerTerminalPath,
+      partnerElevated: config.partnerElevated,
+      sshConfig: config.sshConfig ? {
+        host: config.sshConfig.host,
+        port: config.sshConfig.port,
+        username: config.sshConfig.username,
+        remotePath: config.sshConfig.remotePath,
+        hasPassword: config.sshConfig.hasPassword,
+        postCommand: config.sshConfig.postCommand,
+        hasSudoPassword: config.sshConfig.hasSudoPassword,
+      } : undefined,
+      legacyVersion: config.claudeOptions?.legacyVersion,
+      agentIds: config.claudeOptions?.agentIds,
+      machineName: config.machineName,
+      effortLevel: config.claudeOptions?.effortLevel,
+      disableAutoMemory: config.claudeOptions?.disableAutoMemory,
+      enableCodexReview: config.claudeOptions?.enableCodexReview,
+      provider: config.provider,
+      codexOptions: config.codexOptions,
+      githubIntegration: config.githubIntegration,
+    }
+    if (!session.shellOnly && session.sessionType === 'local') {
+      markSessionForResumePicker(session.id)
+    }
+    addSession(session)
+    return session.id
+  }, [addSession])
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -220,29 +220,39 @@ body {
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 60%, transparent);
 }
-/* Active session row: soft fill + 2px accent left edge, no border. */
-.row-active {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  box-shadow: inset 2px 0 0 var(--accent), 0 1px 5px rgba(0,0,0,.28);
-}
-/* Attention treatments -- louder than identity (spec §10). */
-.row-awaiting {
-  background: color-mix(in srgb, var(--status-warning) 12%, transparent);
-  box-shadow: inset 3px 0 0 var(--status-warning);
-}
-.row-error {
-  background: color-mix(in srgb, var(--status-danger) 13%, transparent);
-  box-shadow: inset 3px 0 0 var(--status-danger);
-}
 /* Active rail icon glow (eased). */
 .rail-active {
   box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 43%, transparent);
 }
-/* Session row: 3-col grid [dot | name | meta]. */
-.session-row {
-  display: grid; grid-template-columns: 9px 1fr auto; align-items: center; gap: 9px;
-  padding: 7px 10px; border-radius: 9px;
+/* Session card (V2 Phase 3): two-line dense card. Selection, health, and focus
+   are three independent channels (spec section 3.2/6):
+     - selection (isActive)  -> identity rail + tint + identity border + elevation
+                                 + bold name + chip (driven by inline styles, since
+                                 the identity hue is per-session, not a token)
+     - health (dot/pill)     -> never recolours rail/tint/name
+     - keyboard focus        -> quiet teal DASHED ring, distinct from selection */
+.session-card {
+  display: grid;
+  grid-template-columns: 9px 1fr auto;
+  align-items: center;
+  column-gap: 9px;
+  row-gap: 2px;
+  padding: 7px 10px;
+  border-radius: 9px;
+  border: 1px solid transparent;
 }
-.session-row .nm { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.session-row .meta { font-family: 'JetBrains Mono', monospace; font-size: 10px; color: var(--text-muted); justify-self: end; }
+.session-card .nm { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-card .meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+.card-focus {
+  outline: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 3px;
+}
+.meter-fill { height: 100%; border-radius: 9999px; transition: width 500ms ease, background-color 200ms ease; }
+.meter-neutral { background: var(--text-muted); }
+.meter-warn    { background: var(--status-warning); }
+.meter-danger  { background: var(--status-danger); }
 

--- a/tests/unit/renderer/codex-mini-icon.test.ts
+++ b/tests/unit/renderer/codex-mini-icon.test.ts
@@ -53,9 +53,10 @@ describe('SessionRow provider mini-icon', () => {
     })
   }
 
-  it('Claude session renders the Claude badge', () => {
+  it('Claude session renders no provider badge (quiet launcher)', () => {
     mountWith('claude')
-    expect(container.querySelector('[title^="Claude"]')).not.toBeNull()
+    // Claude is the default provider -- no badge rendered (quiet launcher design)
+    expect(container.querySelector('[title^="Claude"]')).toBeNull()
     expect(container.querySelector('[title^="Codex"]')).toBeNull()
   })
 

--- a/tests/unit/renderer/configrow-quiet-launcher.test.ts
+++ b/tests/unit/renderer/configrow-quiet-launcher.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings: { theme: 'dark' as const } }
+  const useSettingsStore: any = (sel: (s: typeof STATE) => unknown) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+const { default: ConfigRow } = await import('../../../src/renderer/components/sidebar/ConfigRow')
+
+const baseConfig = { id: 'c1', provider: 'claude' as const, label: 'My Config', workingDirectory: '.', sessionType: 'local' as const, identityColorKey: 'mauve' as const, color: '' }
+const rowProps = { onLaunch: () => {}, onEdit: () => {}, onDelete: () => {}, onContextMenu: () => {} }
+
+describe('ConfigRow quiet launcher', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('does NOT render a Claude badge for the default provider', () => {
+    act(() => root.render(React.createElement(ConfigRow, { ...(rowProps as any), config: baseConfig })))
+    expect(container.querySelector('[title="Claude is working"]')).toBeNull()
+  })
+
+  it('launch button is not status-green (neutral affordance)', () => {
+    act(() => root.render(React.createElement(ConfigRow, { ...(rowProps as any), config: baseConfig })))
+    const launch = container.querySelector('[title="Launch"]') as HTMLElement
+    expect(launch).toBeTruthy()
+    expect(launch.className).not.toContain('text-green')
+  })
+
+  it('keeps the SSH pill for ssh configs', () => {
+    act(() => root.render(React.createElement(ConfigRow, { ...(rowProps as any), config: { ...baseConfig, sessionType: 'ssh' } })))
+    expect(container.querySelector('[title="SSH session"]')).toBeTruthy()
+  })
+})

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -78,4 +78,16 @@ describe('SessionRow card', () => {
     expect(input).toBeTruthy()
     expect(input.closest('button')).toBeNull()
   })
+
+  it('line 2 spans out of the 9px dot column so the model meta is not clipped', () => {
+    // jsdom cannot compute CSS grid, so lock the structural intent: the line-2
+    // content lives in ONE child that spans grid columns 2 / 4 (never auto-placed
+    // into the dot column), and the model meta text lives inside that wrapper.
+    render(root, { model: 'sonnet', provider: 'claude' })
+    const line2 = container.querySelector('[data-testid="card-line2"]') as HTMLElement
+    expect(line2).toBeTruthy()
+    expect(line2.style.gridColumn).toBe('2 / 4')
+    expect(line2.textContent).toContain('sonnet')
+    expect(line2.textContent).toContain('claude')
+  })
 })

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings: { theme: 'dark' as const } }
+  const useSettingsStore: any = (sel: (s: typeof STATE) => unknown) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+const { default: SessionRow } = await import('../../../src/renderer/components/sidebar/SessionRow')
+
+const base = {
+  id: 's1', label: 'web-frontend', model: 'sonnet', identityColorKey: 'mauve' as const,
+  color: '', status: 'working' as const, createdAt: 0, provider: 'claude' as const,
+  sessionType: 'local' as const, contextPercent: 40,
+}
+const props = {
+  isActive: false, needsAttention: false, isRenaming: false, renameValue: '',
+  renameRef: { current: null }, onRenameChange: () => {}, onRenameFinish: () => {},
+  onRenameCancel: () => {}, onClick: () => {}, onContextMenu: () => {},
+}
+
+function render(root: Root, sessionOverrides: any, propOverrides: any = {}) {
+  act(() => root.render(React.createElement(SessionRow, { ...(props as any), ...propOverrides, session: { ...base, ...sessionOverrides } })))
+}
+
+describe('SessionRow card', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('does NOT render a Claude provider badge for the default (claude) provider', () => {
+    render(root, { provider: 'claude' })
+    expect(container.querySelector('[title="Claude is working"]')).toBeNull()
+    expect(container.querySelector('[title="Waiting for input"]')).toBeNull()
+  })
+
+  it('renders a Codex glyph for codex provider (non-default)', () => {
+    render(root, { provider: 'codex' })
+    expect(container.querySelector('[title="Codex is working"]')).toBeTruthy()
+  })
+
+  it('shows an identity chip only when selected (isActive)', () => {
+    render(root, {}, { isActive: false })
+    const before = container.querySelectorAll('[data-testid="identity-chip"]').length
+    render(root, {}, { isActive: true })
+    const after = container.querySelectorAll('[data-testid="identity-chip"]').length
+    expect(before).toBe(0)
+    expect(after).toBe(1)
+  })
+
+  it('applies the quiet dashed focus ring class when focused', () => {
+    render(root, {}, { isFocused: true })
+    expect(container.querySelector('.card-focus')).toBeTruthy()
+  })
+
+  it('selected card uses the identity colour for its 4px left rail (not teal var)', () => {
+    render(root, {}, { isActive: true })
+    const card = container.querySelector('.session-card') as HTMLElement
+    expect(card.style.borderLeftWidth).toBe('4px')
+    expect(card.getAttribute('style') || '').toContain('rgb(')
+  })
+
+  it('context meter turns danger above 85%', () => {
+    render(root, { contextPercent: 90 })
+    expect(container.querySelector('.meter-danger')).toBeTruthy()
+    render(root, { contextPercent: 50 })
+    expect(container.querySelector('.meter-neutral')).toBeTruthy()
+  })
+
+  it('rename input is NOT nested inside a <button> (a11y #398)', () => {
+    render(root, {}, { isRenaming: true, renameValue: 'x' })
+    const input = container.querySelector('input') as HTMLElement
+    expect(input).toBeTruthy()
+    expect(input.closest('button')).toBeNull()
+  })
+})

--- a/tests/unit/renderer/sidebar-config-disclosure.test.ts
+++ b/tests/unit/renderer/sidebar-config-disclosure.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const settings = { configPanelPinned: false, theme: 'dark', keyboardShortcuts: undefined }
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings, updateSettings: () => {} }
+  const useSettingsStore: any = (sel: any) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+vi.mock('../../../src/renderer/stores/sessionStore', () => {
+  const STATE = { sessions: [], activeSessionId: null, setActiveSession: () => {}, removeSession: () => {}, addSession: () => {}, updateSession: () => {} }
+  const useSessionStore: any = (sel?: any) => (sel ? sel(STATE) : STATE)
+  useSessionStore.getState = () => STATE
+  return { useSessionStore }
+})
+vi.mock('../../../src/renderer/stores/configStore', () => {
+  const STATE: any = { configs: [], groups: [], sections: [] }
+  ;['addConfig','updateConfig','removeConfig','addGroup','renameGroup','removeGroup','toggleGroupCollapsed','moveConfigToGroup','addSection','renameSection','removeSection','toggleSectionCollapsed','moveGroupToSection','moveConfigToSection','togglePinned','duplicateConfig','reorderConfigs'].forEach(k => STATE[k] = () => {})
+  const useConfigStore: any = (sel?: any) => (sel ? sel(STATE) : STATE)
+  useConfigStore.getState = () => STATE
+  return { useConfigStore }
+})
+vi.mock('../../../src/renderer/stores/insightsStore', () => ({ useInsightsStore: (sel: any) => sel({ status: null, statusMessage: null }) }))
+vi.mock('../../../src/renderer/stores/cloudAgentStore', () => ({ useCloudAgentStore: (sel: any) => sel({ agents: [] }) }))
+vi.mock('../../../src/renderer/stores/conductorMcpStore', () => ({ useConductorMcpStore: (sel: any) => sel({ browserRunning: false, serverRunning: true }) }))
+vi.mock('../../../src/renderer/stores/appMetaStore', () => ({ useAppMetaStore: (sel: any) => sel({ meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }) }))
+;(globalThis as any).window.electronAPI = { update: { check: () => Promise.resolve(false), onAvailable: () => () => {}, getVersion: () => Promise.resolve('') } }
+
+const { default: Sidebar } = await import('../../../src/renderer/components/Sidebar')
+
+describe('Sidebar config disclosure', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('exposes a keyboard-focusable "Saved Configs" disclosure button with aria-expanded', () => {
+    act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {} } as any)))
+    const btn = Array.from(container.querySelectorAll('button')).find(b => /saved configs/i.test(b.textContent || ''))
+    expect(btn).toBeTruthy()
+    expect(btn!.getAttribute('aria-expanded')).not.toBeNull()
+  })
+})

--- a/tests/unit/renderer/sidebarnav-rail.test.ts
+++ b/tests/unit/renderer/sidebarnav-rail.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { default: SidebarNav } = await import('../../../src/renderer/components/sidebar/SidebarNav')
+
+const props = { currentView: 'sessions' as any, onViewChange: () => {}, insightsStatus: null, insightsMessage: null, cloudAgentRunning: 0 }
+
+describe('SidebarNav rail', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('every nav button has an accessible name (aria-label/title)', () => {
+    act(() => root.render(React.createElement(SidebarNav, props as any)))
+    const buttons = Array.from(container.querySelectorAll('button'))
+    expect(buttons.length).toBeGreaterThan(0)
+    for (const b of buttons) {
+      const named = b.getAttribute('aria-label') || b.getAttribute('title')
+      expect(named, `button "${b.textContent}" needs an accessible name`).toBeTruthy()
+    }
+  })
+
+  it('labels the Conductor-MCP server dot when serverRunning is defined', () => {
+    act(() => root.render(React.createElement(SidebarNav, { ...props, serverRunning: true } as any)))
+    const dot = container.querySelector('[data-testid="conductor-mcp-dot"]') as HTMLElement
+    expect(dot).toBeTruthy()
+    expect(dot.getAttribute('title') || dot.getAttribute('aria-label')).toMatch(/conductor|mcp|server/i)
+  })
+})

--- a/tests/unit/renderer/stage-empty-state.test.ts
+++ b/tests/unit/renderer/stage-empty-state.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings: { theme: 'dark' as const } }
+  const useSettingsStore: any = (sel: any) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+const { default: StageEmptyState } = await import('../../../src/renderer/components/StageEmptyState')
+
+const cfg = (id: string, label: string) => ({ id, label, provider: 'claude', workingDirectory: '.', sessionType: 'local', identityColorKey: 'mauve', color: '', pinned: true })
+
+describe('StageEmptyState', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('configs exist -> "Start a saved config" + a launch card + "Show all configs"', () => {
+    const onLaunch = vi.fn(); const onShowAll = vi.fn(); const onCreate = vi.fn()
+    act(() => root.render(React.createElement(StageEmptyState, { configs: [cfg('a','Alpha')] as any, onLaunch, onShowAllConfigs: onShowAll, onCreateConfig: onCreate })))
+    expect(container.textContent).toContain('Start a saved config')
+    const card = Array.from(container.querySelectorAll('button')).find(b => /Alpha/.test(b.textContent || ''))
+    expect(card).toBeTruthy()
+    act(() => card!.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onLaunch).toHaveBeenCalledTimes(1)
+    expect(Array.from(container.querySelectorAll('button')).some(b => /show all configs/i.test(b.textContent || ''))).toBe(true)
+  })
+
+  it('no configs -> "Create a terminal config" primary action', () => {
+    const onLaunch = vi.fn(); const onShowAll = vi.fn(); const onCreate = vi.fn()
+    act(() => root.render(React.createElement(StageEmptyState, { configs: [] as any, onLaunch, onShowAllConfigs: onShowAll, onCreateConfig: onCreate })))
+    expect(container.textContent).toContain('Create a terminal config')
+    const create = Array.from(container.querySelectorAll('button')).find(b => /create a terminal config/i.test(b.textContent || ''))
+    expect(create).toBeTruthy()
+    act(() => create!.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/statuspill-identitychip.test.ts
+++ b/tests/unit/renderer/statuspill-identitychip.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { StatusPill } = await import('../../../src/renderer/components/ui/StatusPill')
+const { IdentityChip } = await import('../../../src/renderer/components/ui/IdentityChip')
+
+describe('StatusPill', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('renders a label for running', () => {
+    act(() => root.render(React.createElement(StatusPill, { state: 'running' })))
+    expect(container.textContent).toContain('running')
+  })
+  it('renders "stopped" for error and "attention" for awaiting', () => {
+    act(() => root.render(React.createElement(StatusPill, { state: 'error' })))
+    expect(container.textContent).toContain('stopped')
+    act(() => root.render(React.createElement(StatusPill, { state: 'awaiting' })))
+    expect(container.textContent).toContain('attention')
+  })
+  it('renders nothing for idle (quiet)', () => {
+    act(() => root.render(React.createElement(StatusPill, { state: 'idle' })))
+    expect(container.textContent).toBe('')
+  })
+})
+
+describe('IdentityChip', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+
+  it('applies the colour and is not a CSS var', () => {
+    act(() => root.render(React.createElement(IdentityChip, { color: '#9a8cf0' })))
+    const el = container.querySelector('span') as HTMLElement
+    expect(el.style.backgroundColor).toBe('rgb(154, 140, 240)')
+    expect(el.getAttribute('style') || '').not.toContain('var(')
+  })
+})


### PR DESCRIPTION
## Summary
Phase 3 of the V2 Shell UX redesign (spec `docs/superpowers/specs/2026-05-25-v2-shell-ux-design.md` §6/§3.2/§10). Renderer-only restyle + one pure refactor; no PTY/IPC/store behaviour change.

- **Dense two-line session card** with the locked state model: selection = per-session identity rail (4px) + tint + identity border + elevation + bold name + chip; health = dot + new `StatusPill` only (never recolours rail/tint/name); keyboard focus = quiet teal **dashed** ring (replaces the old solid ring). Context meter thresholds <70 neutral / 70-85 warn / >85 danger.
- **Quiet saved-config launchers** (`ConfigRow`, `PinnedConfigsPanel`): identity square, no default-provider Claude badge (glyph only for non-default), SSH pill kept, neutral (non-green) launch affordance.
- **Keyboard-accessible "Saved Configs" disclosure** (`aria-expanded`), not hover-only; "Active Sessions" gains a count.
- **#417** uniform session-card left edge (de-indented session lanes; config-panel indentation untouched; no fake "Ungrouped" header).
- **Context-aware cold-open empty state** (`StageEmptyState`): configs exist -> "Start a saved config" + pinned launchers + "Show all configs"; none -> "Create a terminal config". Launches via a shared `useLaunchConfig` hook extracted verbatim from `Sidebar.launchFromConfig`.
- **Icon rail** grouped (primary/system + divider), tooltips in both layouts, and the persistent Conductor-MCP green dot now has an accessible label.
- **#398** rename input no longer nested inside a `<button>`.

## Review
Internal double-review: spec-compliance PASS; code-quality found one Critical (line-2 meta clipped into the 9px dot column, verified in Chromium) -- fixed in `db6fa43` with a layout-locking test.

## Test plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- 1107 pass / 1 skip / 0 fail (6 new test files: primitives, card, quiet launcher, disclosure, empty state, icon rail)
- [ ] CI green (Windows + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)