### PR TITLE
V2 Shell Phase 4b: collapsible CommandBar quick-actions strip

### DIFF
--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useCommandStore, CustomCommand, CommandSection } from '../stores/commandStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useCommandBarStore } from '../stores/commandBarStore'
@@ -7,16 +7,8 @@ import ScreenshotButton from './ScreenshotButton'
 import ExcalidrawButton from './ExcalidrawButton'
 import WebviewButton from './WebviewButton'
 import { useWebviewStore, pollUrlForContent, probeWebviewUrls } from '../stores/webviewStore'
-import ToolbarPopup from './ToolbarPopup'
 import { generateId } from '../utils/id'
 import { trackUsage } from '../stores/tipsStore'
-import {
-  MODELS,
-  EFFORTS,
-  PERMISSION_MODES,
-  shortModelName as resolveModelName,
-  isModelActive,
-} from '../lib/claude-cli-options'
 import { CODEX_MODELS } from '../codex-models'
 
 // -- Codex toolbar sub-components --
@@ -104,38 +96,17 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
   // persistent when bouncing back to the original side.
   const collapsedSectionIds = useCommandBarStore((s) => s.state.collapsedSectionIds)
   const toggleSectionCollapse = useCommandBarStore((s) => s.toggleSection)
+  // Whole-bar collapse -- shared + persisted, same store as section collapse.
+  // Defaults to expanded so existing users are not surprised on upgrade.
+  const barCollapsed = useCommandBarStore((s) => s.state.barCollapsed)
+  const toggleBar = useCommandBarStore((s) => s.toggleBar)
   const [sectionInput, setSectionInput] = useState<{ x: number; y: number; editSection?: CommandSection; rowTarget?: 'claude' | 'partner' } | null>(null)
 
-  // --- Model/Effort/Mode pickers ---
-  // Effort and permission mode are NOT present in Claude Code's statusline
-  // JSON schema (code.claude.com/docs/en/statusline), so there's no authoritative
-  // way to display the current value. We track the last-clicked value in memory
-  // only — used for the dropdown checkmark, never shown as an always-visible
-  // label. Reloading the app or changing via terminal clears the checkmark.
-  const [openPicker, setOpenPicker] = useState<'model' | 'mode' | null>(null)
-  const [lastEffort, setLastEffort] = useState<string | null>(null)
-  const [lastMode, setLastMode] = useState<string | null>(null)
+  // Claude Mode/Model/Effort pickers used to live here. They were removed in
+  // P4b -- the app-level BottomBar now owns those controls (Claude only).
+  // Codex sessions keep their inline option dropdowns below.
   const activeSession = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
   const updateSession = useSessionStore((s) => s.updateSession)
-
-  const shortModelName = (fullName?: string): string =>
-    resolveModelName(fullName || activeSession?.model)
-
-  const handleModelSelect = useCallback((si: number, value: string) => {
-    if (si === 0) {
-      window.electronAPI.pty.write(sessionId, `/model ${value}\n`)
-    } else {
-      setLastEffort(value)
-      window.electronAPI.pty.write(sessionId, `/effort ${value}\n`)
-    }
-    setOpenPicker(null)
-  }, [sessionId])
-
-  const handleModeSelect = useCallback((_si: number, value: string) => {
-    setLastMode(value)
-    window.electronAPI.pty.write(sessionId, `/permission-mode ${value}\n`)
-    setOpenPicker(null)
-  }, [sessionId])
 
   const visibleCommands = commands
     .filter((c) => c.scope === 'global' || (c.scope === 'config' && c.configId === configId))
@@ -151,6 +122,11 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
   // Split commands by target — no 'any' concept, default is 'claude'
   const claudeCommands = visibleCommands.filter((c) => !c.target || c.target === 'claude' || c.target === 'any')
   const partnerCommands = visibleCommands.filter((c) => c.target === 'partner')
+
+  // Count of command chips actually shown in the strip -- drives the collapse
+  // toggle's badge. Partner commands only count when the partner row renders.
+  const showPartnerRow = !!partnerEnabled && partnerCommands.length > 0
+  const visibleCommandCount = claudeCommands.length + (showPartnerRow ? partnerCommands.length : 0)
 
   /** Build the full command string (prompt + default args) */
   const buildFullCommand = (cmd: CustomCommand, args?: string[]): string => {
@@ -379,7 +355,13 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
     toggleSectionCollapse(sectionId)
   }
 
-  // Render a single command button with full-color styling
+  // Render a single command button as a NEUTRAL chip.
+  // The command's colour reads as a small dot in front of the label rather
+  // than tinting the whole button (P4b + the 2026-04-25 pass). A saturated
+  // chip-per-button row dominated the strip and clashed with the active-tab
+  // marker; the neutral surface chip mirrors the tool-button style and the
+  // dot carries identity. Drag-over still uses the blue ring -- a transient
+  // affordance, not the command colour.
   const renderCommandButton = (cmd: CustomCommand) => {
     const color = cmd.color || '#89B4FA'
     const isDragging = dragId === cmd.id
@@ -387,13 +369,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
     const hasArgs = (cmd.defaultArgs && cmd.defaultArgs.length > 0) || (cmd.lastCustomArgs && cmd.lastCustomArgs.length > 0)
     const argsTitle = cmd.defaultArgs?.length
       ? `${cmd.prompt}\nArgs: ${cmd.defaultArgs.join(' ')}\nCtrl+click to customize args`
-      : cmd.prompt
-    // Sophistication pass 2026-04-25: command-button colour now reads as a
-     // small dot in front of the label rather than tinting the whole button.
-     // The previous saturated chip-per-button row dominated the bottom strip
-     // visually and clashed with the active-tab marker. Buttons now inherit
-     // a neutral surface chip; the dot carries identity. Drag-over still
-     // uses the blue ring for clarity since that's a transient affordance.
+      : (cmd.label || cmd.prompt)
     return (
       <button
         key={cmd.id}
@@ -404,10 +380,10 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
         onDragEnd={handleDragEnd}
         onClick={(e) => handleClick(cmd, e)}
         onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, cmd.id) }}
-        className={`flex items-center gap-1.5 px-2.5 py-0.5 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
+        className={`flex items-center gap-1.5 px-2.5 py-0.5 text-xs rounded border whitespace-nowrap shrink-0 transition-colors focus-ring ${
           isDragOver
             ? 'border-blue/50 bg-surface0/70 text-text'
-            : 'border-surface1/60 bg-surface0/40 text-subtext0 hover:bg-surface0 hover:text-text hover:border-surface1'
+            : 'bg-surface0/50 hover:bg-surface0 border-surface1/40 hover:border-surface1 text-subtext0 hover:text-text'
         }`}
         style={{
           opacity: isDragging ? 0.4 : 1,
@@ -524,13 +500,28 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
     <div className="flex flex-col shrink-0" onContextMenu={(e) => handleContextMenu(e, undefined, 'claude')}>
       {/* Row 1: Magic buttons */}
       <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0">
-        {/* Section icon: sparkle/wand */}
-        <div className="shrink-0 text-overlay0" title="Tools">
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M8 1v3M8 12v3M1 8h3M12 8h3" />
-            <path d="M3.5 3.5l2 2M10.5 10.5l2 2M12.5 3.5l-2 2M5.5 10.5l-2 2" />
+        {/* Collapse toggle -- chevron + "Commands" + visible-command count.
+            Collapsing hides the command rows (2/3) so the strip becomes a
+            single slim row. Replaces the old static Tools sparkle icon. */}
+        <button
+          onClick={toggleBar}
+          aria-expanded={!barCollapsed}
+          title={barCollapsed ? 'Show commands' : 'Hide commands'}
+          className="flex items-center gap-1 px-1.5 py-0.5 text-xs text-overlay0 hover:text-text rounded hover:bg-surface0/60 transition-colors shrink-0 focus-ring cursor-pointer"
+        >
+          <svg
+            width="9" height="9" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.4"
+            className="shrink-0 transition-transform duration-200"
+            style={{ transform: barCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)' }}
+            aria-hidden
+          >
+            <path d="M2.5 4l2.5 2.5L7.5 4" />
           </svg>
-        </div>
+          <span className="font-medium">Commands</span>
+          {visibleCommandCount > 0 && (
+            <span className="text-[9px] text-overlay0 font-normal tabular-nums">{visibleCommandCount}</span>
+          )}
+        </button>
         <div className="w-px h-4 bg-surface1 mx-0.5" />
         <ScreenshotButton sessionId={sessionId} sessionType={sessionType} />
         <ExcalidrawButton sessionId={sessionId} />
@@ -541,7 +532,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
             <div className="w-px h-4 bg-surface1 mx-0.5" />
             <button
               onClick={onTogglePartner}
-              className="flex items-center gap-1.5 px-2 py-0.5 text-xs rounded bg-surface0/60 border border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text transition-colors whitespace-nowrap shrink-0"
+              className="flex items-center gap-1.5 px-2 py-0.5 text-xs rounded bg-surface0/60 border border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text transition-colors whitespace-nowrap shrink-0 focus-ring"
               title={isPartnerActive ? 'Switch back to Claude terminal' : 'Switch to partner terminal'}
             >
               {isPartnerActive ? (
@@ -562,135 +553,76 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
         {/* Spacer */}
         <div className="flex-1" />
 
-        {/* Permission mode picker -- Claude only */}
-        {(activeSession?.provider ?? 'claude') === 'claude' && (
-          <div className="relative shrink-0">
-            <button
-              onClick={() => setOpenPicker(openPicker === 'mode' ? null : 'mode')}
-              className="flex items-center gap-1 px-2 py-0.5 text-xs text-subtext0 hover:text-text rounded bg-surface0/50 hover:bg-surface0 border border-surface1/40 hover:border-surface1 transition-colors shrink-0 cursor-pointer"
-            >
-              Mode
-              <svg width="8" height="8" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.4" className="opacity-50">
-                <path d="M2.5 4l2.5 2.5L7.5 4" />
-              </svg>
-            </button>
-            {openPicker === 'mode' && (
-              <ToolbarPopup
-                sections={[{
-                  title: 'Mode',
-                  shortcut: 'Shift+Ctrl+M',
-                  items: PERMISSION_MODES.map((m) => ({ ...m, active: m.value === lastMode })),
-                }]}
-                onSelect={handleModeSelect}
-                onClose={() => setOpenPicker(null)}
-              />
-            )}
-          </div>
-        )}
-
-        {/* Codex: permissions preset inline dropdown */}
+        {/* Codex inline option dropdowns -- BottomBar owns the Claude Mode/Model
+            controls now, so the Claude pickers that used to live here were
+            removed (P4b). Codex sessions keep these because BottomBar's
+            Mode/Model cockpit is Claude-only. */}
         {(activeSession?.provider ?? 'claude') === 'codex' && activeSession?.codexOptions && (
-          <PermissionsPresetDropdown
-            value={activeSession.codexOptions.permissionsPreset ?? 'standard'}
-            onChange={(next) =>
-              updateSession(activeSession.id, {
-                codexOptions: { ...activeSession.codexOptions!, permissionsPreset: next },
-              })
-            }
-          />
+          <>
+            <PermissionsPresetDropdown
+              value={activeSession.codexOptions.permissionsPreset ?? 'standard'}
+              onChange={(next) =>
+                updateSession(activeSession.id, {
+                  codexOptions: { ...activeSession.codexOptions!, permissionsPreset: next },
+                })
+              }
+            />
+            <CodexModelDropdown
+              value={activeSession.codexOptions.model ?? 'gpt-5.5'}
+              onChange={(next) =>
+                updateSession(activeSession.id, {
+                  codexOptions: { ...activeSession.codexOptions!, model: next },
+                })
+              }
+            />
+            <div className="w-px h-4 bg-surface1 mx-0.5" />
+          </>
         )}
 
-        <div className="w-px h-4 bg-surface1 mx-0.5" />
-
-        {/* Model + Effort picker -- Claude only */}
-        {(activeSession?.provider ?? 'claude') === 'claude' && (
-          <div className="relative shrink-0">
-            <button
-              onClick={() => setOpenPicker(openPicker === 'model' ? null : 'model')}
-              className="flex items-center gap-1 px-2 py-0.5 text-xs text-subtext0 hover:text-text rounded bg-surface0/50 hover:bg-surface0 border border-surface1/40 hover:border-surface1 transition-colors shrink-0 cursor-pointer"
-            >
-              <span className="text-blue">{shortModelName(activeSession?.modelName)}</span>
-              <svg width="8" height="8" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.4" className="opacity-50">
-                <path d="M2.5 4l2.5 2.5L7.5 4" />
-              </svg>
-            </button>
-            {openPicker === 'model' && (
-              <ToolbarPopup
-                alignRight
-                sections={[
-                  {
-                    title: 'Models',
-                    shortcut: 'Shift+Ctrl+I',
-                    items: MODELS.map((m) => ({
-                      ...m,
-                      active: isModelActive(
-                        m.value,
-                        activeSession?.modelName || activeSession?.model || '',
-                      ),
-                    })),
-                  },
-                  {
-                    title: 'Effort',
-                    shortcut: 'Shift+Ctrl+E',
-                    items: EFFORTS.map((e) => ({ ...e, active: e.value === lastEffort })),
-                  },
-                ]}
-                onSelect={handleModelSelect}
-                onClose={() => setOpenPicker(null)}
-              />
-            )}
-          </div>
-        )}
-
-        {/* Codex: GPT model inline dropdown */}
-        {(activeSession?.provider ?? 'claude') === 'codex' && activeSession?.codexOptions && (
-          <CodexModelDropdown
-            value={activeSession.codexOptions.model ?? 'gpt-5.5'}
-            onChange={(next) =>
-              updateSession(activeSession.id, {
-                codexOptions: { ...activeSession.codexOptions!, model: next },
-              })
-            }
-          />
-        )}
-
-        <div className="w-px h-4 bg-surface1 mx-0.5" />
         <button
           onClick={() => setShowDialog(true)}
-          className="px-1.5 py-0.5 text-xs text-overlay0 hover:text-text rounded hover:bg-surface0 shrink-0"
+          className="px-1.5 py-0.5 text-xs text-overlay0 hover:text-text rounded hover:bg-surface0 shrink-0 focus-ring"
           title="Add command"
         >
           +
         </button>
       </div>
 
-      {/* Row 2: Claude commands */}
-      {claudeCommands.length > 0 && (
-        <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'claude') }}>
-          {/* Section icon: Claude asterisk */}
-          <div className="shrink-0 text-peach/60" title="Claude Commands">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <path d="M12 2v8.5M12 13.5V22M2 12h8.5M13.5 12H22M4.93 4.93l6.01 6.01M13.06 13.06l6.01 6.01M19.07 4.93l-6.01 6.01M10.94 13.06l-6.01 6.01" />
-            </svg>
-          </div>
-          <div className="w-px h-4 bg-surface1 mx-0.5" />
-          {renderGroupedCommands(claudeCommands, 'claude')}
-        </div>
-      )}
+      {/* Command rows (2/3) -- hidden when the bar is collapsed. The wrapper
+          animates open via a max-height + opacity transition (220ms); when
+          collapsed the rows are removed from the DOM entirely so collapsed
+          chips are not focusable/clickable behind a clipped container. */}
+      {!barCollapsed && (
+        <div className="flex flex-col overflow-hidden animate-[commandbar-expand_0.22s_ease-out]">
+          {/* Row 2: Claude commands */}
+          {claudeCommands.length > 0 && (
+            <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'claude') }}>
+              {/* Section icon: Claude asterisk */}
+              <div className="shrink-0 text-peach/60" title="Claude Commands">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                  <path d="M12 2v8.5M12 13.5V22M2 12h8.5M13.5 12H22M4.93 4.93l6.01 6.01M13.06 13.06l6.01 6.01M19.07 4.93l-6.01 6.01M10.94 13.06l-6.01 6.01" />
+                </svg>
+              </div>
+              <div className="w-px h-4 bg-surface1 mx-0.5" />
+              {renderGroupedCommands(claudeCommands, 'claude')}
+            </div>
+          )}
 
-      {/* Row 3: Partner commands */}
-      {partnerEnabled && partnerCommands.length > 0 && (
-        <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'partner') }}>
-          {/* Section icon: </> code */}
-          <div className="shrink-0 text-green/60" title="Partner Terminal Commands">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="7 8 3 12 7 16" />
-              <polyline points="17 8 21 12 17 16" />
-              <line x1="14" y1="4" x2="10" y2="20" />
-            </svg>
-          </div>
-          <div className="w-px h-4 bg-surface1 mx-0.5" />
-          {renderGroupedCommands(partnerCommands, 'partner')}
+          {/* Row 3: Partner commands */}
+          {showPartnerRow && (
+            <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'partner') }}>
+              {/* Section icon: </> code */}
+              <div className="shrink-0 text-green/60" title="Partner Terminal Commands">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="7 8 3 12 7 16" />
+                  <polyline points="17 8 21 12 17 16" />
+                  <line x1="14" y1="4" x2="10" y2="20" />
+                </svg>
+              </div>
+              <div className="w-px h-4 bg-surface1 mx-0.5" />
+              {renderGroupedCommands(partnerCommands, 'partner')}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/renderer/stores/commandBarStore.ts
+++ b/src/renderer/stores/commandBarStore.ts
@@ -13,6 +13,12 @@ import { saveConfigDebounced } from '../utils/config-saver'
 
 export interface CommandBarUiState {
   collapsedSectionIds: string[]
+  // Whole-bar collapse -- when true the CommandBar renders only its slim
+  // toggle row and hides the command rows. Shared (like collapsedSectionIds)
+  // so the Claude and Partner CommandBar instances within one config agree,
+  // and persisted so the choice survives restarts. Defaults to false
+  // (expanded) to avoid surprising existing users on upgrade.
+  barCollapsed: boolean
 }
 
 interface CommandBarStore {
@@ -21,10 +27,13 @@ interface CommandBarStore {
   hydrate: (state: Partial<CommandBarUiState>) => void
   isCollapsed: (sectionId: string) => boolean
   toggleSection: (sectionId: string) => void
+  toggleBar: () => void
+  setBarCollapsed: (value: boolean) => void
 }
 
 const DEFAULTS: CommandBarUiState = {
   collapsedSectionIds: [],
+  barCollapsed: false,
 }
 
 export const useCommandBarStore = create<CommandBarStore>((set, get) => ({
@@ -42,6 +51,9 @@ export const useCommandBarStore = create<CommandBarStore>((set, get) => ({
         collapsedSectionIds: Array.isArray(next.collapsedSectionIds)
           ? next.collapsedSectionIds
           : [],
+        // Defend against a corrupted commandBarUi.json where barCollapsed
+        // came back as a non-boolean; default to expanded.
+        barCollapsed: typeof next.barCollapsed === 'boolean' ? next.barCollapsed : false,
       },
       isLoaded: true,
     }),
@@ -59,6 +71,21 @@ export const useCommandBarStore = create<CommandBarStore>((set, get) => ({
       // Debounced — rapid expand/collapse spam shouldn't write to
       // disk on every click. config-saver coalesces successive calls
       // within 300 ms.
+      saveConfigDebounced('commandBarUi', nextState)
+      return { state: nextState }
+    }),
+
+  toggleBar: () =>
+    set((s) => {
+      const nextState = { ...s.state, barCollapsed: !s.state.barCollapsed }
+      saveConfigDebounced('commandBarUi', nextState)
+      return { state: nextState }
+    }),
+
+  setBarCollapsed: (value) =>
+    set((s) => {
+      if (s.state.barCollapsed === value) return s
+      const nextState = { ...s.state, barCollapsed: value }
       saveConfigDebounced('commandBarUi', nextState)
       return { state: nextState }
     }),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -256,3 +256,11 @@ body {
 .meter-warn    { background: var(--status-warning); }
 .meter-danger  { background: var(--status-danger); }
 
+/* CommandBar quick-actions strip: expand-in for the command rows when the
+   bar is un-collapsed. Kept inside the 150-300ms project window. The rows are
+   removed from the DOM when collapsed, so only the open direction animates. */
+@keyframes commandbar-expand {
+  from { max-height: 0; opacity: 0; }
+  to   { max-height: 240px; opacity: 1; }
+}
+

--- a/src/renderer/utils/configHydration.ts
+++ b/src/renderer/utils/configHydration.ts
@@ -182,7 +182,7 @@ export function hydrateStores(configData: Record<string, unknown>): void {
   const usageTracking = (configData.usageTracking as UsageTracking) || undefined
   useTipsStore.getState().hydrate(usageTracking as UsageTracking)
 
-  const commandBarUi = (configData.commandBarUi as { collapsedSectionIds?: string[] }) || {}
+  const commandBarUi = (configData.commandBarUi as { collapsedSectionIds?: string[]; barCollapsed?: boolean }) || {}
   useCommandBarStore.getState().hydrate(commandBarUi)
 
   const excalidraw = (configData.excalidraw as { bySessionId?: Record<string, unknown> }) || { bySessionId: {} }

--- a/tests/unit/renderer/commandbar-codex-toolbar.test.ts
+++ b/tests/unit/renderer/commandbar-codex-toolbar.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 /**
  * P5.5: CommandBar Codex toolbar -- model + permissions preset.
- * Asserts that Codex sessions see model/preset dropdowns (not the Claude
- * Mode picker), and that Claude sessions still see the Mode picker.
+ * Asserts that Codex sessions see model/preset dropdowns. The Claude Mode
+ * picker was removed from the CommandBar in P4b (it lives in the app-level
+ * BottomBar now), so neither provider renders a "Mode" button here.
  */
 import React from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -169,13 +170,17 @@ describe('CommandBar Codex toolbar (P5.5)', () => {
     expect(hasPreset).toBe(true)
   })
 
-  it('Claude sessions: Mode dropdown still visible', () => {
+  it('Claude sessions: Mode dropdown is HIDDEN (moved to BottomBar in P4b)', () => {
     mockSessions = [mkClaude()]
     mockActiveSessionId = 's-1'
     act(() => {
       root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
     })
-    // "Mode" is the literal button label rendered for Claude sessions
-    expect(container.textContent ?? '').toContain('Mode')
+    // P4b removed the transitional Claude Mode picker from the CommandBar --
+    // the app-level BottomBar owns Mode/Model now. No button labelled "Mode".
+    const modeBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => (b.textContent ?? '').trim() === 'Mode',
+    )
+    expect(modeBtn).toBeUndefined()
   })
 })

--- a/tests/unit/renderer/commandbar-quickactions.test.ts
+++ b/tests/unit/renderer/commandbar-quickactions.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+/**
+ * P4b: CommandBar collapsible quick-actions strip + neutral chips.
+ *
+ * Verifies the Phase-4 cleanup of the transitional CommandBar:
+ *  1. The Claude Mode picker + Claude Model/Effort picker are GONE
+ *     (BottomBar owns those now -- this strip is Claude-mode-agnostic).
+ *  2. The Codex inline dropdowns STAY (BottomBar is Claude-only there).
+ *  3. A collapse toggle exists and hides the command rows when collapsed.
+ *  4. Command chips are neutral -- colour is a dot, not a button tint.
+ *
+ * React.createElement (not JSX) so the file stays *.test.ts under the
+ * vitest include glob -- matches the sibling commandbar-codex-toolbar test.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// --- store mocks (must precede component import) ---
+
+let mockSessions: Array<any> = []
+let mockActiveSessionId: string | null = null
+const mockUpdate = vi.fn()
+
+vi.mock('../../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: (sel: any) =>
+    sel({
+      sessions: mockSessions,
+      activeSessionId: mockActiveSessionId,
+      updateSession: mockUpdate,
+    }),
+}))
+
+// One custom Claude command so a chip renders.
+const mockCommand = {
+  id: 'cmd-1',
+  label: 'Deploy',
+  prompt: '/deploy',
+  color: '#f38ba8',
+  scope: 'global' as const,
+  target: 'claude' as const,
+}
+
+vi.mock('../../../src/renderer/stores/commandStore', () => ({
+  useCommandStore: Object.assign(
+    () => ({
+      commands: [mockCommand],
+      sections: [],
+      addCommand: vi.fn(),
+      updateCommand: vi.fn(),
+      removeCommand: vi.fn(),
+      reorderCommands: vi.fn(),
+      updateSection: vi.fn(),
+      removeSection: vi.fn(),
+      reorderSections: vi.fn(),
+    }),
+    { getState: () => ({ addSection: vi.fn() }) },
+  ),
+}))
+
+// Mutable bar-collapse state so a test can flip it between renders.
+let mockBarCollapsed = false
+const mockToggleBar = vi.fn(() => { mockBarCollapsed = !mockBarCollapsed })
+
+vi.mock('../../../src/renderer/stores/commandBarStore', () => ({
+  useCommandBarStore: (sel: any) =>
+    sel({
+      state: { collapsedSectionIds: [], barCollapsed: mockBarCollapsed },
+      toggleSection: vi.fn(),
+      toggleBar: mockToggleBar,
+      setBarCollapsed: vi.fn(),
+    }),
+}))
+
+vi.mock('../../../src/renderer/stores/webviewStore', () => ({
+  useWebviewStore: (sel: any) =>
+    sel({
+      startActivation: vi.fn(() => 0),
+      markAvailable: vi.fn(),
+      markFailed: vi.fn(),
+      bySessionId: {},
+    }),
+  pollUrlForContent: vi.fn(() => Promise.resolve(false)),
+  probeWebviewUrls: vi.fn(() => Promise.resolve(false)),
+}))
+
+vi.mock('../../../src/renderer/stores/tipsStore', () => ({
+  trackUsage: vi.fn(),
+}))
+
+vi.mock('../../../src/renderer/utils/id', () => ({
+  generateId: () => 'test-id',
+}))
+
+// Stub child components that would need full Electron context
+vi.mock('../../../src/renderer/components/ScreenshotButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/ExcalidrawButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/WebviewButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/CommandDialog', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/ToolbarPopup', () => ({ default: () => null }))
+
+// Mock window.electronAPI
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(globalThis as any).window.electronAPI = {
+  pty: { write: vi.fn() },
+}
+
+// Import component AFTER all mocks
+const { default: CommandBar } = await import('../../../src/renderer/components/CommandBar')
+
+// --- Session factories ---
+
+const mkClaude = () => ({
+  id: 's-1',
+  label: 't',
+  workingDirectory: '/',
+  color: '#89b4fa',
+  sessionType: 'local' as const,
+  provider: 'claude' as const,
+  model: 'claude-opus-4-5',
+  modelName: 'claude-opus-4-5',
+})
+
+const mkCodex = () => ({
+  id: 's-1',
+  label: 't',
+  workingDirectory: '/',
+  color: '#89b4fa',
+  sessionType: 'local' as const,
+  provider: 'codex' as const,
+  model: 'codex',
+  codexOptions: { model: 'gpt-5.5', permissionsPreset: 'standard' as const },
+})
+
+// --- helpers ---
+
+function buttons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+}
+function buttonByAccessibleName(container: HTMLElement, needle: string): HTMLButtonElement | undefined {
+  const n = needle.toLowerCase()
+  return buttons(container).find((b) => {
+    const title = (b.getAttribute('title') ?? '').toLowerCase()
+    const aria = (b.getAttribute('aria-label') ?? '').toLowerCase()
+    return title.includes(n) || aria.includes(n)
+  })
+}
+
+// --- Test setup ---
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  mockUpdate.mockClear()
+  mockToggleBar.mockClear()
+  mockBarCollapsed = false
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+// --- Tests ---
+
+describe('CommandBar quick-actions strip (P4b)', () => {
+  it('does NOT render the Claude Mode button or the Claude model-picker trigger', () => {
+    mockSessions = [mkClaude()]
+    mockActiveSessionId = 's-1'
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    // No button whose trimmed text is exactly "Mode".
+    const modeBtn = buttons(container).find((b) => (b.textContent ?? '').trim() === 'Mode')
+    expect(modeBtn).toBeUndefined()
+    // The Claude model picker trigger displayed the short model name + a caret.
+    // shortModelName('claude-opus-4-5') -> "Opus"; assert that trigger is gone.
+    const modelTrigger = buttons(container).find((b) => (b.textContent ?? '').includes('Opus'))
+    expect(modelTrigger).toBeUndefined()
+  })
+
+  it('keeps the Codex inline dropdowns for a codex session', () => {
+    mockSessions = [mkCodex()]
+    mockActiveSessionId = 's-1'
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    const text = container.textContent ?? ''
+    // CodexModelDropdown exposes the gpt-5.x option list.
+    expect(text).toContain('gpt-5.5')
+    // PermissionsPresetDropdown exposes the preset list.
+    const hasPreset = ['read-only', 'standard', 'auto', 'unrestricted'].some((p) => text.includes(p))
+    expect(hasPreset).toBe(true)
+  })
+
+  it('has a collapse toggle that hides the command rows when barCollapsed flips', () => {
+    mockSessions = [mkClaude()]
+    mockActiveSessionId = 's-1'
+
+    // Expanded: the command chip is present.
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    const expandedHasChip = buttons(container).some((b) => (b.textContent ?? '').includes('Deploy'))
+    expect(expandedHasChip).toBe(true)
+
+    // The toggle has an accessible name mentioning "command".
+    const toggle = buttonByAccessibleName(container, 'command')
+    expect(toggle).toBeDefined()
+    expect(toggle!.getAttribute('aria-expanded')).toBe('true')
+
+    // Collapse and re-render: the command chip is gone.
+    mockBarCollapsed = true
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    const collapsedHasChip = buttons(container).some((b) => (b.textContent ?? '').includes('Deploy'))
+    expect(collapsedHasChip).toBe(false)
+    // Toggle still present and now reports collapsed.
+    const toggle2 = buttonByAccessibleName(container, 'command')
+    expect(toggle2).toBeDefined()
+    expect(toggle2!.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('renders the command colour as a dot, not as a chip background/border tint', () => {
+    mockSessions = [mkClaude()]
+    mockActiveSessionId = 's-1'
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    const chip = buttons(container).find((b) => (b.textContent ?? '').includes('Deploy'))
+    expect(chip).toBeDefined()
+
+    // The chip itself must NOT paint its own background/border with the colour.
+    expect(chip!.style.backgroundColor).toBe('')
+    expect(chip!.style.borderColor).toBe('')
+
+    // A descendant dot carries the colour as inline backgroundColor.
+    const dot = Array.from(chip!.querySelectorAll<HTMLElement>('span')).find(
+      (s) => s.style.backgroundColor !== '',
+    )
+    expect(dot).toBeDefined()
+    // #f38ba8 -> rgb(243, 139, 168)
+    expect(dot!.style.backgroundColor.replace(/\s/g, '')).toBe('rgb(243,139,168)')
+  })
+})


### PR DESCRIPTION
## Summary
Phase 4b of the V2 Shell redesign (spec §7b). Restyles `CommandBar.tsx` as a collapsible per-session quick-actions strip and removes the transitional Claude Mode/Model pickers (now owned by the A' bottom bar from Phase 4).

- **Removed** the Claude Mode picker + Model/Effort picker + their handlers/state/now-unused imports. Codex inline dropdowns (`PermissionsPresetDropdown`, `CodexModelDropdown`) retained (A' is Claude-only for those).
- **Collapsible strip:** a keyboard-accessible "Commands" toggle (`aria-expanded`, focus-ring, 220ms animation) hides the command rows; shared `barCollapsed` state in `commandBarStore` (mirrors the existing section-collapse pattern, persisted + hydrate-guarded). Default expanded.
- **Neutral chips:** per-command colour is a small dot, the chip is a neutral surface (no full-button tint); tooltips + focus-ring on every chip/control.
- **Preserved:** add/edit/delete, sections + section-collapse, drag-reorder, args popover, command targets, webview activation, context menu, Snap/Draw/Web/partner buttons.
- **Deferred to Phase 6 audit:** overflow `Commands` menu; heavy/destructive separation (no destructive flag on `CustomCommand` -- a data-model change, out of scope here).

## Review
Internal double-review (combined spec + code-quality): PASS. One Minor (hydration cast type drift) fixed in `c9c139a`.

## Test plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- green (new `commandbar-quickactions.test.ts` 4 cases; `commandbar-codex-toolbar.test.ts` reconciled to the new design)
- [ ] CI green (Windows + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)