### PR TITLE
V2 Shell Phase 6: terminal framing + global cleanup + #406

### DIFF
--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -363,7 +363,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
   // dot carries identity. Drag-over still uses the blue ring -- a transient
   // affordance, not the command colour.
   const renderCommandButton = (cmd: CustomCommand) => {
-    const color = cmd.color || '#89B4FA'
+    const color = cmd.color || 'var(--accent)'
     const isDragging = dragId === cmd.id
     const isDragOver = dragOverId === cmd.id
     const hasArgs = (cmd.defaultArgs && cmd.defaultArgs.length > 0) || (cmd.lastCustomArgs && cmd.lastCustomArgs.length > 0)
@@ -389,7 +389,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           opacity: isDragging ? 0.4 : 1,
           cursor: isDragging ? 'grabbing' : 'grab',
           borderLeftWidth: isDragOver ? '2px' : undefined,
-          borderLeftColor: isDragOver ? '#89B4FA' : undefined,
+          borderLeftColor: isDragOver ? 'var(--status-info)' : undefined,
         }}
         title={argsTitle}
       >

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -11,7 +11,8 @@ interface Props {
 export default function SessionHeader({ session, onShowTip }: Props) {
   return (
     <div
-      className="flex items-center gap-3 px-4 py-2 border-b border-surface0 bg-mantle shrink-0 relative"
+      className="flex items-center gap-3 px-4 py-2 border-b shrink-0 relative"
+      style={{ background: 'var(--surface-panel)', borderColor: 'var(--border-subtle)' }}
     >
       {/* Session-color accent line that fades out toward the right --
           the gradient stops before fully transparent at ~70% so the

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -593,7 +593,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
                   return !prev
                 })
               }}
-              className={`w-6 h-6 flex items-center justify-center rounded transition-colors ${configPanelPinned ? 'bg-blue/20 text-blue' : 'hover:bg-surface0 text-overlay1 hover:text-text'}`}
+              className={`w-6 h-6 flex items-center justify-center rounded transition-colors focus-ring ${configPanelPinned ? 'bg-blue/20 text-blue' : 'hover:bg-surface0 text-overlay1 hover:text-text'}`}
               title={configPanelPinned ? 'Unpin config panel' : 'Pin config panel open'}
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -602,7 +602,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); setShowNewSectionInput(true); setConfigPanelOpen(true); setTimeout(() => newSectionInputRef.current?.focus(), 0) }}
-              className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface0 text-overlay1 hover:text-text transition-colors"
+              className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface0 text-overlay1 hover:text-text transition-colors focus-ring"
               title="New section"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.2">
@@ -614,7 +614,7 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); setShowNewDialog(true) }}
-              className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface0 text-overlay1 hover:text-text transition-colors"
+              className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface0 text-overlay1 hover:text-text transition-colors focus-ring"
               title="New config (Ctrl+T)"
             >
               <svg width="14" height="14" viewBox="0 0 14 14"><line x1="7" y1="2" x2="7" y2="12" stroke="currentColor" strokeWidth="1.5"/><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.5"/></svg>
@@ -825,13 +825,13 @@ export default function Sidebar({ currentView, onViewChange, onUpdateRequested, 
             <span className="text-[10px] text-overlay0">{selectedSessionIds.size} selected</span>
             <button
               onClick={handleBulkClose}
-              className="px-1.5 py-0.5 rounded text-[10px] bg-red/20 text-red hover:bg-red/30 transition-colors"
+              className="px-1.5 py-0.5 rounded text-[10px] bg-red/20 text-red hover:bg-red/30 transition-colors focus-ring"
             >
               Close All
             </button>
             <button
               onClick={() => setSelectedSessionIds(new Set())}
-              className="px-1.5 py-0.5 rounded text-[10px] bg-surface1 text-overlay1 hover:bg-surface1/80 transition-colors"
+              className="px-1.5 py-0.5 rounded text-[10px] bg-surface1 text-overlay1 hover:bg-surface1/80 transition-colors focus-ring"
             >
               Clear
             </button>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -10,6 +10,7 @@ import CommandBar from './CommandBar'
 import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { stripCursorSequences } from '../utils/terminalFormatting'
+import { isControlReportOnly } from '../utils/terminalInput'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
 import { ScrollToBottomButton } from './terminal'
@@ -340,7 +341,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // new work", so when Claude next hits a prompt we should re-surface
       // it if they've tabbed away by then.
       term.onData((data) => {
-        attentionAckedRef.current = false
+        // #406: focus in/out + cursor/mouse reports arrive via onData too. Only a real
+        // keystroke/paste should un-ack the attention pulse, else leaving a session
+        // re-arms the pulse without the user typing anything.
+        if (!isControlReportOnly(data)) attentionAckedRef.current = false
         window.electronAPI.pty.write(sessionId, data)
       })
 
@@ -564,9 +568,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     <div className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative" style={{ minHeight: 0 }}>
       <div
         ref={xtermContainerRef}
-        className="flex-1 p-1 overflow-hidden"
+        className="flex-1 overflow-hidden"
         style={{
           minHeight: 0,
+          padding: '8px 10px 8px 18px',
           background: 'linear-gradient(90deg, var(--surface-stage-gutter) 0, var(--surface-stage-gutter) 12px, var(--surface-stage) 12px)',
           boxShadow: 'inset 16px 0 20px -16px rgba(0,0,0,.5)',
         }}

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -193,13 +193,13 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
         <ThemeToggle />
         <button
           onClick={() => window.electronAPI.window.minimize()}
-          className="p-2 hover:bg-surface0 rounded transition-colors text-overlay1 hover:text-text"
+          className="p-2 hover:bg-surface0 rounded transition-colors text-overlay1 hover:text-text focus-ring"
         >
           <svg width="12" height="12" viewBox="0 0 12 12"><line x1="1" y1="6" x2="11" y2="6" stroke="currentColor" strokeWidth="1.2"/></svg>
         </button>
         <button
           onClick={() => window.electronAPI.window.maximize()}
-          className="p-2 hover:bg-surface0 rounded transition-colors text-overlay1 hover:text-text"
+          className="p-2 hover:bg-surface0 rounded transition-colors text-overlay1 hover:text-text focus-ring"
         >
           {maximized ? (
             <svg width="12" height="12" viewBox="0 0 12 12"><rect x="2" y="3.5" width="7" height="7" rx="0.5" stroke="currentColor" strokeWidth="1.2" fill="none"/><path d="M3.5 3.5V2.5C3.5 2.22 3.72 2 4 2H9.5C9.78 2 10 2.22 10 2.5V8C10 8.28 9.78 8.5 9.5 8.5H9" stroke="currentColor" strokeWidth="1.2" fill="none"/></svg>
@@ -209,7 +209,7 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
         </button>
         <button
           onClick={() => window.electronAPI.window.close()}
-          className="p-2 hover:bg-red rounded transition-colors text-overlay1 hover:text-white"
+          className="p-2 hover:bg-red rounded transition-colors text-overlay1 hover:text-text focus-ring"
         >
           <svg width="12" height="12" viewBox="0 0 12 12"><line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" strokeWidth="1.2"/><line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" strokeWidth="1.2"/></svg>
         </button>

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -43,10 +43,10 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
       <span className="text-xs text-text truncate flex-1">{config.label}</span>
       {config.sessionType === 'ssh' && <SshBadge />}
       {config.shellOnly && <ShellBadge />}
-      <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
         <button
           onClick={onLaunch}
-          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text"
+          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text focus-ring"
           title="Launch"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><polygon points="3,1 10,6 3,11" /></svg>
@@ -54,7 +54,7 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
         {onPin && (
           <button
             onClick={onPin}
-            className={`p-1 rounded hover:bg-surface1 transition-colors ${config.pinned ? 'text-blue' : 'text-overlay1 hover:text-text'}`}
+            className={`p-1 rounded hover:bg-surface1 transition-colors focus-ring ${config.pinned ? 'text-blue' : 'text-overlay1 hover:text-text'}`}
             title={config.pinned ? 'Unpin' : 'Pin to top'}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -64,14 +64,14 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
         )}
         <button
           onClick={onEdit}
-          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text"
+          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text focus-ring"
           title="Edit"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M8.5 1.5l2 2-7 7H1.5v-2z"/></svg>
         </button>
         <button
           onClick={onDelete}
-          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-red"
+          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-red focus-ring"
           title="Delete"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg>

--- a/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
+++ b/src/renderer/components/sidebar/PinnedConfigsPanel.tsx
@@ -27,14 +27,14 @@ export default function PinnedConfigsPanel({ configs, onLaunch }: PinnedConfigsP
           <span className="text-xs text-text truncate flex-1">{config.label}</span>
           <button
             onClick={() => onLaunch(config)}
-            className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-text opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-0.5 rounded hover:bg-surface1 text-overlay1 hover:text-text opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity focus-ring"
             title="Launch"
           >
             <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="2,1 8,5 2,9" /></svg>
           </button>
           <button
             onClick={() => togglePinned(config.id)}
-            className="p-0.5 rounded hover:bg-surface1 text-overlay0 hover:text-text opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-0.5 rounded hover:bg-surface1 text-overlay0 hover:text-text opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity focus-ring"
             title="Unpin"
           >
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>

--- a/src/renderer/components/sidebar/SessionGroupHeader.tsx
+++ b/src/renderer/components/sidebar/SessionGroupHeader.tsx
@@ -13,6 +13,7 @@ export default function SessionGroupHeader({ group, collapsed, onToggleCollapse,
     <div className="flex items-center gap-1 py-1 px-1 rounded hover:bg-surface0/30 transition-colors group/sheader">
       <button
         onClick={onToggleCollapse}
+        aria-label={collapsed ? 'Expand group' : 'Collapse group'}
         className="p-0.5 text-overlay0 hover:text-text transition-colors focus-ring"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"

--- a/src/renderer/components/sidebar/SessionSectionHeader.tsx
+++ b/src/renderer/components/sidebar/SessionSectionHeader.tsx
@@ -13,6 +13,7 @@ export default function SessionSectionHeader({ section, collapsed, onToggleColla
     <div className="flex items-center gap-1 py-1.5 px-1 rounded hover:bg-surface0/20 transition-colors group/ssection">
       <button
         onClick={onToggleCollapse}
+        aria-label={collapsed ? 'Expand section' : 'Collapse section'}
         className="p-0.5 text-overlay0 hover:text-text transition-colors focus-ring"
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"

--- a/src/renderer/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/components/sidebar/SidebarNav.tsx
@@ -106,10 +106,10 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
   isCollapsed: boolean
 }) {
   const isInsightsActive = item.view === 'insights' && !!insightsStatus
-  const insightsDotColor = insightsStatus === 'running' ? '#89B4FA'
-    : insightsStatus === 'extracting_kpis' ? '#F9E2AF'
-    : insightsStatus === 'complete' ? '#A6E3A1'
-    : insightsStatus === 'failed' ? '#F38BA8'
+  const insightsDotColor = insightsStatus === 'running' ? 'var(--status-info)'
+    : insightsStatus === 'extracting_kpis' ? 'var(--status-warning)'
+    : insightsStatus === 'complete' ? 'var(--status-success)'
+    : insightsStatus === 'failed' ? 'var(--status-danger)'
     : null
   const isInsightsAnimating = insightsStatus === 'running' || insightsStatus === 'extracting_kpis'
   const isCloudAgentsRunning = item.view === 'cloud-agents' && cloudAgentRunning > 0
@@ -166,7 +166,7 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
           className={`absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ${isInsightsAnimating ? 'insights-pulse-dot' : ''}`}
           style={{
             backgroundColor: insightsDotColor,
-            boxShadow: `0 0 6px 2px ${insightsDotColor}60`,
+            boxShadow: `0 0 6px 2px color-mix(in srgb, ${insightsDotColor} 38%, transparent)`,
           }}
         />
       )}
@@ -174,8 +174,8 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
         <span
           className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full insights-pulse-dot"
           style={{
-            backgroundColor: '#89B4FA',
-            boxShadow: '0 0 6px 2px #89B4FA60',
+            backgroundColor: 'var(--status-info)',
+            boxShadow: '0 0 6px 2px color-mix(in srgb, var(--status-info) 38%, transparent)',
           }}
         />
       )}
@@ -187,8 +187,8 @@ function NavButton({ item, currentView, onViewChange, insightsStatus, insightsMe
           title={serverRunning ? 'Conductor MCP server running' : 'Conductor MCP server stopped'}
           className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full"
           style={{
-            backgroundColor: serverRunning ? '#A6E3A1' : '#F38BA8',
-            boxShadow: `0 0 6px 2px ${serverRunning ? '#A6E3A160' : '#F38BA860'}`,
+            backgroundColor: serverRunning ? 'var(--status-success)' : 'var(--status-danger)',
+            boxShadow: `0 0 6px 2px color-mix(in srgb, ${serverRunning ? 'var(--status-success)' : 'var(--status-danger)'} 38%, transparent)`,
           }}
         />
       )}

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -1,0 +1,12 @@
+// Detects xterm onData payloads that are terminal CONTROL REPORTS only (focus
+// in/out, cursor-position report, mouse report) -- NOT genuine user input.
+// Fixes #406: the attention-ack must not reset when the user merely focuses or
+// blurs a session (xterm emits focus reports through onData), only when they
+// actually type. If anything other than control reports remains, it's input.
+const CONTROL_REPORT = /\x1b\[(?:I|O|\d*(?:;\d*)*R|M[\s\S]{0,3}|<\d+;\d+;\d+[Mm])/g
+
+export function isControlReportOnly(data: string): boolean {
+  if (!data) return true
+  const stripped = data.replace(CONTROL_REPORT, '')
+  return stripped.length === 0
+}

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { isControlReportOnly } from '../../../src/renderer/utils/terminalInput'
+
+describe('isControlReportOnly', () => {
+  it('treats focus in/out reports as control-only (not input)', () => {
+    expect(isControlReportOnly('\x1b[I')).toBe(true)
+    expect(isControlReportOnly('\x1b[O')).toBe(true)
+  })
+  it('treats cursor-position reports as control-only', () => {
+    expect(isControlReportOnly('\x1b[12;40R')).toBe(true)
+  })
+  it('treats SGR mouse reports as control-only', () => {
+    expect(isControlReportOnly('\x1b[<0;10;20M')).toBe(true)
+    expect(isControlReportOnly('\x1b[<0;10;20m')).toBe(true)
+  })
+  it('treats genuine typed characters as input', () => {
+    expect(isControlReportOnly('a')).toBe(false)
+    expect(isControlReportOnly('\r')).toBe(false)
+    expect(isControlReportOnly('ls -la')).toBe(false)
+  })
+  it('treats a control report followed by typed input as input', () => {
+    expect(isControlReportOnly('\x1b[Ohello')).toBe(false)
+  })
+  it('empty string is not input', () => {
+    expect(isControlReportOnly('')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Phase 6 of the V2 Shell redesign (spec §9/§11/§6).

- **Terminal container framing (§9):** the xterm host div now has intentional padding (`8px 10px 8px 18px`) so terminal text insets PAST the 12px left gutter band with comfortable breathing room (was `p-1`/4px, overlapping the gutter). FitAddon reflows automatically -- no PTY-text change.
- **#406 fix:** the session attention pulse no longer re-fires when you merely LEAVE a session. Root cause: xterm emits focus in/out (and cursor/mouse) control reports through `onData`, and the code treated those as "user typed", wiping the attention ack. New pure `isControlReportOnly()` predicate gates the ack-reset so only genuine keystrokes/pastes un-ack; all data still forwards to the PTY; clear-on-enter is unchanged.
- **Cross-surface cleanup (§11 audit):** focus rings on the previously-bare TitleBar window/sidebar controls, ConfigRow/PinnedConfigsPanel action buttons (+ `group-focus-within` so Tab reveals them), Sidebar header + multi-select buttons; accessible names on the session group/section collapse chevrons; SidebarNav status dots + CommandBar system affordances + SessionHeader surface moved from hardcoded Catppuccin hex to semantic `--status-*`/`--surface-*` tokens; `hover:text-white` -> `hover:text-text`.

**Deferred (follow-up, noted):** CommandBar overflow `Commands` menu + heavy/destructive command separation (needs a `CustomCommand` flag).

## Review
Internal double-review (combined spec + code-quality): PASS, no findings. The #406 predicate was verified safe (no keystroke-suppression).

## Test plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- green (new `terminal-input.test.ts` 6 cases)
- [ ] CI green (Windows + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)