### PR TITLE
V2 Shell Phase 7: acceptance QA + closure

### DIFF
--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Session } from '../stores/sessionStore'
 import NotesBar from './NotesBar'
 import TipPill from './TipPill'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
+import { useResolvedTheme } from '../hooks/useThemeController'
 
 interface Props {
   session: Session
@@ -9,6 +11,10 @@ interface Props {
 }
 
 export default function SessionHeader({ session, onShowTip }: Props) {
+  const theme = useResolvedTheme()
+  // Resolve identity per-theme (like every other migrated surface) so the accent
+  // theme-shifts and a pre-migration reserved hue never leaks through.
+  const identity = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
   return (
     <div
       className="flex items-center gap-3 px-4 py-2 border-b shrink-0 relative"
@@ -19,11 +25,11 @@ export default function SessionHeader({ session, onShowTip }: Props) {
           colour reads strong on the left and dissolves toward the right. */}
       <div
         className="absolute top-0 left-0 right-0 h-[2px] pointer-events-none"
-        style={{ background: `linear-gradient(to right, ${session.color} 0%, ${session.color}80 15%, transparent 55%)` }}
+        style={{ background: `linear-gradient(to right, ${identity} 0%, ${identity}80 15%, transparent 55%)` }}
         aria-hidden
       />
       {/* Color dot: at-a-glance session identifier (name lives in the tab strip above) */}
-      <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: session.color }} />
+      <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: identity }} />
 
       {session.sessionType === 'ssh' && session.sshConfig && (
         <span className="text-xs text-mauve">SSH: {session.sshConfig.username}@{session.sshConfig.host}</span>


### PR DESCRIPTION
## Summary
Phase 7 (final) of the V2 Shell UX redesign: acceptance QA against spec §14 + closure.

**Acceptance QA result: SHELL V2 ACCEPTANCE -- PASS WITH NOTES.** All 18 §14 criteria pass (token blocks both themes; monochrome-readable selection; 3-zone bottom bar; keyboard nav + distinct focus ring; icon-only tooltips; status never used as identity; context-aware empty state; single-row clip-not-wrap; keyboard config disclosure; single runtime source; collapsible CommandBar; Mode/Model relocated with no false "current"; colour migration bucket mapping + guarded one-time notice; health-never-recolours-identity state model). No must-fix gaps.

**This closure commit** fixes the one real QA finding: `SessionHeader` was the lone migrated surface still reading raw `session.color` for its accent line + dot -- now uses the per-theme `resolveIdentityColor(...)` resolver like every other surface, so it theme-shifts and no pre-migration reserved hue leaks through.

**Deferred (follow-up, not blockers):** CommandBar overflow `Commands` menu; BottomBar staged responsive collapse (currently clip-not-wrap, which meets §14); StageEmptyState "Show all configs" opening the sidebar disclosure (it's already keyboard-reachable).

**All six shell build phases (3, 4, 4b, 5, 6) + this closure are merged; #417/#398/#418/#406 all resolved.** The 8 action-bar pages remain a separate Pages wave (still raw `--color-*`; needs its own design pass).

## Test plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- 1126 pass / 1 skip
- [ ] CI green (Windows + macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)