### PR TITLE
fix(v2-shell): UAT round 1 -- bottom-bar scoping, inactive identity rail, command-row tokens

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -842,68 +842,70 @@ export default function App() {
             }
           }} />
           <main className="flex-1 flex flex-col overflow-hidden titlebar-no-drag">
-            {showGuidedConfig ? (
-              <GuidedConfigView
-                onSkip={() => setShowGuidedConfig(false)}
-                onConfirm={async (configDraft, sshPassword) => {
-                  const { generateId } = await import('./utils/id')
-                  const configId = generateId()
-                  if (sshPassword) {
-                    await window.electronAPI.credentials.save(configId, sshPassword)
-                  }
-                  const newConfig = { ...configDraft, id: configId }
-                  useConfigStore.getState().addConfig(newConfig)
-                  useAppMetaStore.getState().update({ hasCreatedFirstConfig: true })
+            <div className="flex-1 flex flex-col overflow-hidden min-h-0 relative">
+              {showGuidedConfig ? (
+                <GuidedConfigView
+                  onSkip={() => setShowGuidedConfig(false)}
+                  onConfirm={async (configDraft, sshPassword) => {
+                    const { generateId } = await import('./utils/id')
+                    const configId = generateId()
+                    if (sshPassword) {
+                      await window.electronAPI.credentials.save(configId, sshPassword)
+                    }
+                    const newConfig = { ...configDraft, id: configId }
+                    useConfigStore.getState().addConfig(newConfig)
+                    useAppMetaStore.getState().update({ hasCreatedFirstConfig: true })
 
-                  // Track feature usage based on config fields set
-                  trackUsage('sessions.create-config')
-                  if (newConfig.sessionType === 'ssh') trackUsage('sessions.session-type')
-                  if (newConfig.claudeOptions?.effortLevel) trackUsage('sessions.effort-level')
-                  if (newConfig.claudeOptions?.disableAutoMemory) trackUsage('sessions.disable-auto-memory')
-                  if (newConfig.claudeOptions?.enableCodexReview) trackUsage('sessions.enable-codex-review')
-                  if (newConfig.partnerTerminalPath) trackUsage('sessions.partner-terminal')
+                    // Track feature usage based on config fields set
+                    trackUsage('sessions.create-config')
+                    if (newConfig.sessionType === 'ssh') trackUsage('sessions.session-type')
+                    if (newConfig.claudeOptions?.effortLevel) trackUsage('sessions.effort-level')
+                    if (newConfig.claudeOptions?.disableAutoMemory) trackUsage('sessions.disable-auto-memory')
+                    if (newConfig.claudeOptions?.enableCodexReview) trackUsage('sessions.enable-codex-review')
+                    if (newConfig.partnerTerminalPath) trackUsage('sessions.partner-terminal')
 
-                  const session: Session = {
-                    id: generateId(),
-                    configId: newConfig.id,
-                    label: newConfig.label,
-                    workingDirectory: newConfig.workingDirectory,
-                    model: newConfig.claudeOptions?.model ?? '',
-                    color: newConfig.color,
-                    status: 'idle',
-                    createdAt: Date.now(),
-                    sessionType: newConfig.sessionType,
-                    shellOnly: newConfig.shellOnly,
-                    sshConfig: newConfig.sshConfig,
-                    effortLevel: newConfig.claudeOptions?.effortLevel,
-                    disableAutoMemory: newConfig.claudeOptions?.disableAutoMemory,
-                    enableCodexReview: newConfig.claudeOptions?.enableCodexReview,
-                    provider: newConfig.provider,
-                    codexOptions: newConfig.codexOptions,
-                  }
-                  // Both providers support a resume picker. For Codex, the picker
-                  // script may not be deployed yet on first boot -- buildCodexSpawn
-                  // falls back to direct codex spawn (see src/main/providers/codex/spawn.ts).
-                  if (
-                    !session.shellOnly &&
-                    session.sessionType === 'local'
-                  ) {
-                    markSessionForResumePicker(session.id)
-                  }
-                  useSessionStore.getState().addSession(session)
-                  setShowGuidedConfig(false)
-                  setView('sessions')
-                }}
-              />
-            ) : (
-              <>
-                {renderSessions()}
-                {renderOverlayView()}
-              </>
-            )}
+                    const session: Session = {
+                      id: generateId(),
+                      configId: newConfig.id,
+                      label: newConfig.label,
+                      workingDirectory: newConfig.workingDirectory,
+                      model: newConfig.claudeOptions?.model ?? '',
+                      color: newConfig.color,
+                      status: 'idle',
+                      createdAt: Date.now(),
+                      sessionType: newConfig.sessionType,
+                      shellOnly: newConfig.shellOnly,
+                      sshConfig: newConfig.sshConfig,
+                      effortLevel: newConfig.claudeOptions?.effortLevel,
+                      disableAutoMemory: newConfig.claudeOptions?.disableAutoMemory,
+                      enableCodexReview: newConfig.claudeOptions?.enableCodexReview,
+                      provider: newConfig.provider,
+                      codexOptions: newConfig.codexOptions,
+                    }
+                    // Both providers support a resume picker. For Codex, the picker
+                    // script may not be deployed yet on first boot -- buildCodexSpawn
+                    // falls back to direct codex spawn (see src/main/providers/codex/spawn.ts).
+                    if (
+                      !session.shellOnly &&
+                      session.sessionType === 'local'
+                    ) {
+                      markSessionForResumePicker(session.id)
+                    }
+                    useSessionStore.getState().addSession(session)
+                    setShowGuidedConfig(false)
+                    setView('sessions')
+                  }}
+                />
+              ) : (
+                <>
+                  {renderSessions()}
+                  {renderOverlayView()}
+                </>
+              )}
+            </div>
+            <BottomBar currentView={view} onViewChange={setView} />
           </main>
         </div>
-        <BottomBar currentView={view} onViewChange={setView} />
         {showTraining && (
           <TrainingWalkthrough
             onClose={handleTrainingClose}

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -499,7 +499,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
   return (
     <div className="flex flex-col shrink-0" onContextMenu={(e) => handleContextMenu(e, undefined, 'claude')}>
       {/* Row 1: Magic buttons */}
-      <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0">
+      <div className="flex items-center gap-1 px-2 py-0.5 border-t" style={{ background: 'var(--surface-chrome)', borderColor: 'var(--border-subtle)' }}>
         {/* Collapse toggle -- chevron + "Commands" + visible-command count.
             Collapsing hides the command rows (2/3) so the strip becomes a
             single slim row. Replaces the old static Tools sparkle icon. */}
@@ -596,7 +596,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
         <div className="flex flex-col overflow-hidden animate-[commandbar-expand_0.22s_ease-out]">
           {/* Row 2: Claude commands */}
           {claudeCommands.length > 0 && (
-            <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'claude') }}>
+            <div className="flex items-center gap-1 px-2 py-0.5 border-t overflow-x-auto" style={{ background: 'var(--surface-chrome)', borderColor: 'var(--border-subtle)' }} onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'claude') }}>
               {/* Section icon: Claude asterisk */}
               <div className="shrink-0 text-peach/60" title="Claude Commands">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
@@ -610,7 +610,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
 
           {/* Row 3: Partner commands */}
           {showPartnerRow && (
-            <div className="flex items-center gap-1 px-2 py-0.5 bg-crust border-t border-surface0 overflow-x-auto" onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'partner') }}>
+            <div className="flex items-center gap-1 px-2 py-0.5 border-t overflow-x-auto" style={{ background: 'var(--surface-chrome)', borderColor: 'var(--border-subtle)' }} onContextMenu={(e) => { e.stopPropagation(); handleContextMenu(e, undefined, 'partner') }}>
               {/* Section icon: </> code */}
               <div className="shrink-0 text-green/60" title="Partner Terminal Commands">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -73,19 +73,24 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
     )
   }
 
-  // Selection (isActive) = identity rail + tint + identity border + elevation + bold + chip.
-  // Health and focus are separate channels and never touch these.
+  // Selection channel: inset box-shadow rail -- no layout shift (no padding math).
+  // inactive: muted 3px rail only. multi-select: muted rail + light tint.
+  // active: full identity rail + tint + border + elevation.
+  const identityMuted = `color-mix(in srgb, ${identity} 55%, transparent)`
   const selectedStyle: React.CSSProperties = isActive
     ? {
         backgroundColor: identity + '20',
-        borderColor: `color-mix(in srgb, ${identity} 55%, transparent)`,
-        borderLeft: `4px solid ${identity}`,
-        paddingLeft: 7,
-        boxShadow: '0 2px 8px rgba(0,0,0,.22)',
+        borderColor: identityMuted,
+        boxShadow: `inset 4px 0 0 ${identity}, 0 2px 8px rgba(0,0,0,.22)`,
       }
     : isSelected
-    ? { backgroundColor: identity + '12' }
-    : {}
+    ? {
+        backgroundColor: identity + '12',
+        boxShadow: `inset 3px 0 0 ${identityMuted}`,
+      }
+    : {
+        boxShadow: `inset 3px 0 0 ${identityMuted}`,
+      }
 
   return (
     <button

--- a/tests/unit/renderer/commandbar-row-tokens.test.ts
+++ b/tests/unit/renderer/commandbar-row-tokens.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/**
+ * Fix 3 -- command-strip rows must NOT carry bg-crust (UAT round 1).
+ * The magic-buttons row (row 1) always renders. Rows 2/3 only render when
+ * there are commands; this test keeps it simple and checks row 1 + the
+ * overall DOM for bg-crust on divs that are command-strip containers.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: (sel: any) =>
+    sel({
+      sessions: [{ id: 's-1', label: 't', workingDirectory: '/', color: '#89b4fa',
+        sessionType: 'local', provider: 'claude', model: 'sonnet' }],
+      activeSessionId: 's-1',
+      updateSession: vi.fn(),
+    }),
+}))
+
+vi.mock('../../../src/renderer/stores/commandStore', () => ({
+  useCommandStore: () => ({
+    commands: [],
+    sections: [],
+    addCommand: vi.fn(),
+    updateCommand: vi.fn(),
+    removeCommand: vi.fn(),
+    reorderCommands: vi.fn(),
+    updateSection: vi.fn(),
+    removeSection: vi.fn(),
+    reorderSections: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/renderer/stores/commandBarStore', () => ({
+  useCommandBarStore: (sel: any) =>
+    sel({ state: { collapsedSectionIds: [] }, toggleSection: vi.fn() }),
+}))
+
+vi.mock('../../../src/renderer/stores/webviewStore', () => ({
+  useWebviewStore: (sel: any) =>
+    sel({ startActivation: vi.fn(() => 0), markAvailable: vi.fn(),
+          markFailed: vi.fn(), bySessionId: {} }),
+  pollUrlForContent: vi.fn(() => Promise.resolve(false)),
+  probeWebviewUrls: vi.fn(() => Promise.resolve(false)),
+}))
+
+vi.mock('../../../src/renderer/stores/tipsStore', () => ({ trackUsage: vi.fn() }))
+vi.mock('../../../src/renderer/utils/id', () => ({ generateId: () => 'test-id' }))
+vi.mock('../../../src/renderer/components/ScreenshotButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/ExcalidrawButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/WebviewButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/CommandDialog', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/ToolbarPopup', () => ({ default: () => null }))
+
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(globalThis as any).window.electronAPI = { pty: { write: vi.fn() } }
+
+const { default: CommandBar } = await import('../../../src/renderer/components/CommandBar')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+describe('CommandBar row surface tokens (Fix 3)', () => {
+  it('command-strip rows do not carry bg-crust class', () => {
+    act(() => {
+      root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1' }))
+    })
+    // Strip rows are flex divs with border-t. Input fields also carry bg-crust but
+    // those are <input> elements, not <div>. Assert no <div> has bg-crust.
+    const crustedDivs = Array.from(container.querySelectorAll('div.bg-crust'))
+    expect(crustedDivs).toHaveLength(0)
+  })
+})

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -58,11 +58,25 @@ describe('SessionRow card', () => {
     expect(container.querySelector('.card-focus')).toBeTruthy()
   })
 
-  it('selected card uses the identity colour for its 4px left rail (not teal var)', () => {
+  it('active card uses an inset box-shadow rail with the identity colour', () => {
     render(root, {}, { isActive: true })
     const card = container.querySelector('.session-card') as HTMLElement
-    expect(card.style.borderLeftWidth).toBe('4px')
-    expect(card.getAttribute('style') || '').toContain('rgb(')
+    const style = card.getAttribute('style') || ''
+    expect(style).toContain('inset 4px')
+  })
+
+  it('inactive row has a muted inset box-shadow rail (identity colour visible)', () => {
+    render(root, {}, { isActive: false, isSelected: false })
+    const card = container.querySelector('.session-card') as HTMLElement
+    const style = card.getAttribute('style') || ''
+    expect(style).toContain('inset')
+  })
+
+  it('active row box-shadow contains "inset 4px" (stronger rail than inactive)', () => {
+    render(root, {}, { isActive: true })
+    const card = container.querySelector('.session-card') as HTMLElement
+    const style = card.getAttribute('style') || ''
+    expect(style).toContain('inset 4px')
   })
 
   it('context meter turns danger above 85%', () => {

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -65,11 +65,12 @@ describe('SessionRow card', () => {
     expect(style).toContain('inset 4px')
   })
 
-  it('inactive row has a muted inset box-shadow rail (identity colour visible)', () => {
+  it('inactive row has a muted 3px inset box-shadow rail (identity colour visible, narrower than active)', () => {
     render(root, {}, { isActive: false, isSelected: false })
     const card = container.querySelector('.session-card') as HTMLElement
     const style = card.getAttribute('style') || ''
-    expect(style).toContain('inset')
+    expect(style).toContain('inset 3px')
+    expect(style).not.toContain('inset 4px')
   })
 
   it('active row box-shadow contains "inset 4px" (stronger rail than inactive)', () => {


### PR DESCRIPTION
## Summary
Fixes the three P1 UAT regressions reported against the v1.5.3-beta V2 shell:

1. **A' bottom bar scoped to the content column.** It was rendering full-app-width and running *under* the sidebar. `<BottomBar>` is now inside `<main>`; the view content is wrapped in a `flex-1 flex flex-col overflow-hidden min-h-0 relative` column with `<BottomBar>` as its sibling below. Exactly one BottomBar in App.tsx; it now shows on overlay views (Settings/Tokenomics/etc.) too. (App.tsx diff is large but mostly re-indentation from the new wrapper div.)
2. **Persistent inactive identity rail.** Inactive session rows had lost all identity colour. SessionRow now shows the identity colour via an inset box-shadow rail in every state: inactive `inset 3px` muted, multi-select muted rail + light tint, active `inset 4px` full + tint + border + elevation. Old `borderLeft`/padding approach removed. Health dots/pills and focus ring untouched.
3. **Command rows tokenised.** The three CommandBar row containers moved from raw `bg-crust border-surface0` to `var(--surface-chrome)` / `var(--border-subtle)`, matching the chrome-token pattern used across BottomBar/TitleBar/SessionHeader. The two `bg-crust` *inputs* (ArgsPopover, SectionNameInput) are intentionally left.

## Review
Double-reviewed before push: spec-compliance (SPEC-COMPLIANT, no scope creep) + code-quality (APPROVED). Inactive-rail test tightened to assert the muted 3px rail per the code review.

## Test Plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- 1129 passed / 1 skipped
- [x] New/updated unit tests: `sessionrow-card.test.ts` (active/inactive rail), `commandbar-row-tokens.test.ts`
- [ ] UAT in v1.5.4-beta build: confirm bottom bar sits under terminal only, inactive rows show identity colour, command rows follow theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)