### PR TITLE
fix(v2-shell): UAT round 3 -- wider identity palette, GH panel animation, launch + paste fixes

### DIFF
--- a/src/main/clipboard-image.ts
+++ b/src/main/clipboard-image.ts
@@ -1,0 +1,39 @@
+import { clipboard, type NativeImage } from 'electron'
+
+/**
+ * Read an image off the clipboard, retrying briefly when the first read comes
+ * back empty.
+ *
+ * Why the retry: on Windows the clipboard advertises an externally-copied
+ * image (Snipping Tool, browser, Excalidraw, ...) via a delayed-render / DIB
+ * format. The FIRST `clipboard.readImage()` after the Electron window gains
+ * focus can return an empty NativeImage because Chromium hasn't yet
+ * materialised the bitmap for this focus session -- so a one-shot read reports
+ * "no image" even though one is present. That is the Alt+V first-attempt miss:
+ * pressing a key (which forces a focus/clipboard-sync cycle) made the SECOND
+ * attempt succeed. Re-reading a couple of times with a short async yield lets
+ * the bitmap sync land before we conclude the clipboard is empty.
+ *
+ * Deterministic and cheap: returns as soon as a non-empty image appears, and
+ * gives up after `attempts` tries (default 3, ~20ms spacing) so a genuinely
+ * empty clipboard still resolves null promptly.
+ *
+ * @param attempts total number of reads to try (>= 1)
+ * @param delayMs  delay between reads in milliseconds
+ * @param sleep    injectable timer (tests pass a no-op resolver)
+ * @returns the first non-empty NativeImage, or null if all attempts were empty
+ */
+export async function readClipboardImageWithRetry(
+  attempts = 3,
+  delayMs = 20,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<NativeImage | null> {
+  const tries = Math.max(1, attempts)
+  for (let i = 0; i < tries; i++) {
+    const img = clipboard.readImage()
+    if (!img.isEmpty()) return img
+    if (i < tries - 1) await sleep(delayMs)
+  }
+  return null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,7 @@ import { cleanupStaleHookEntries } from './hooks/boot-cleanup'
 import { DEFAULT_HOOKS_PORT } from './hooks/hooks-types'
 import { fetchModelPricing } from './tokenomics-manager'
 import { killAllAgents } from './cloud-agent-manager'
-import { startServiceStatusPoller, stopServiceStatusPoller } from './service-status'
+import { startServiceStatusPoller, stopServiceStatusPoller, getLastServiceStatus } from './service-status'
 import { initUpdateWatcher, stopUpdateWatcher, getProjectRootPath, isPackagedApp } from './update-watcher'
 import { startUpdateServer, stopUpdateServer } from './update-server'
 import { saveSessionState, loadSessionState, clearSessionState, hasSavedSessionState, SessionState } from './session-state'
@@ -698,6 +698,11 @@ if (!gotTheLock) {
 
     // Start polling Anthropic service status
     startServiceStatusPoller(getWindow)
+    // Let a freshly-mounted renderer pull the cached status immediately, rather
+    // than waiting up to a full poll interval for the next push (the title-bar
+    // status pills were blank until the next poll because the immediate poll
+    // fired before the renderer subscribed, behind the startup splash).
+    ipcMain.handle(IPC.SERVICE_STATUS_GET, () => getLastServiceStatus())
   })
 
   app.on('before-quit', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, clipboard, Menu, session, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell } from 'electron'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
@@ -35,6 +35,7 @@ import { registerGitHubHandlers } from './ipc/github-handlers'
 import { registerHooksHandlers } from './ipc/hooks-handlers'
 import { registerCodexHandlers } from './ipc/codex-handlers'
 import { registerCodexReviewHandlers } from './ipc/codex-review-handlers'
+import { readClipboardImageWithRetry } from './clipboard-image'
 import { HooksGateway } from './hooks/hooks-gateway'
 import { setGateway, getGateway } from './hooks'
 import { cleanupStaleHookEntries } from './hooks/boot-cleanup'
@@ -373,9 +374,11 @@ function createWindow(): void {
   }
 
   // Clipboard image reading (legacy — kept for compatibility, prefer saveImage)
+  // Uses readClipboardImageWithRetry so the first Alt+V after copying an image
+  // doesn't miss on Windows' delayed-render clipboard sync.
   ipcMain.handle('clipboard:readImage', async () => {
-    const img = clipboard.readImage()
-    if (img.isEmpty()) return null
+    const img = await readClipboardImageWithRetry()
+    if (!img) return null
     const resized = constrainToMaxDim(img, 1920)
     return resized.toJPEG(85).toString('base64')
   })
@@ -385,8 +388,11 @@ function createWindow(): void {
   // Returns { filename, path } so callers have both the bare name (for the MCP tool)
   // and the absolute path (for local-only flows that bypass MCP).
   ipcMain.handle('clipboard:saveImage', async () => {
-    const img = clipboard.readImage()
-    if (img.isEmpty()) return null
+    // Retry the read so the FIRST Alt+V after copying an image reliably detects
+    // it -- Windows' delayed-render clipboard can return empty on the first read
+    // after the window gains focus, which was the "no image detected" miss.
+    const img = await readClipboardImageWithRetry()
+    if (!img) return null
     const resized = constrainToMaxDim(img, 1920)
     const screenshotsDir = join(getResourcesDirectory(), 'screenshots')
     if (!existsSync(screenshotsDir)) mkdirSync(screenshotsDir, { recursive: true })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,6 +52,7 @@ import { startConductorMcpServer, stopConductorMcpServer, startBrowserAtBoot } f
 import { readConfig } from './config-manager'
 import { loadCredential, saveCredential, deleteCredential } from './credential-store'
 import { resolveConductorMcpPort } from '../shared/mcp-ports'
+import { IPC } from '../shared/ipc-channels'
 
 import { migrateRegistryKeys } from './registry'
 import { installGlobalErrorHandlers, logInfo, logError, closeDebugLogger } from './debug-logger'

--- a/src/main/service-status.ts
+++ b/src/main/service-status.ts
@@ -105,6 +105,17 @@ function fetchAllComponents(): Promise<ServiceStatusPayload | null> {
 }
 
 let timer: ReturnType<typeof setInterval> | null = null
+// Last successful payload. Cached so a renderer that mounts AFTER the immediate
+// poll has already fired (e.g. behind the startup splash) can pull the current
+// status synchronously via getLastServiceStatus() instead of waiting up to a
+// full poll interval for the next push. Fixes the title-bar status pills not
+// appearing until ~5 min after launch.
+let lastPayload: ServiceStatusPayload | null = null
+
+/** The most recent successful status payload, or null if none fetched yet. */
+export function getLastServiceStatus(): ServiceStatusPayload | null {
+  return lastPayload
+}
 
 export function startServiceStatusPoller(
   getWindow: () => BrowserWindow | null
@@ -112,6 +123,7 @@ export function startServiceStatusPoller(
   async function poll(): Promise<void> {
     const result = await fetchAllComponents()
     if (result) {
+      lastPayload = result
       const win = getWindow()
       if (win && !win.isDestroyed()) {
         win.webContents.send(IPC.SERVICE_STATUS, result)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -534,6 +534,7 @@ const electronAPI: ElectronAPI = {
     },
   },
   serviceStatus: {
+    get: () => ipcRenderer.invoke(IPC.SERVICE_STATUS_GET),
     onUpdate: (callback: (data: any) => void) => {
       const handler = (_: unknown, data: any) => callback(data)
       ipcRenderer.on(IPC.SERVICE_STATUS, handler)

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,17 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.6',
+    date: '2026-05-26',
+    highlights: "Identity colours now span the full hue wheel so sessions are instantly distinguishable, the GitHub panel slides in when shown, and a few first-launch papercuts are fixed.",
+    changes: [
+      { type: 'improvement', description: "Identity colours are re-tuned across the whole colour wheel (blues, teals, greens, ambers, oranges, roses, purples) so saved configs and active sessions are instantly distinguishable in the left rail, tabs, and inactive dots -- not all variations of purple" },
+      { type: 'improvement', description: "The GitHub panel now slides in and fades when shown, and the collapsed floating logo button fades in (both respect reduced-motion)" },
+      { type: 'fix', description: "The Claude service-status pills (Code / Claude.ai) now appear immediately on launch instead of staying blank until the first background poll minutes later" },
+      { type: 'fix', description: "Pasting an image with Alt+V now works on the first try -- previously the first attempt after copying could report 'no image detected' until you typed something (a Windows clipboard timing quirk)" },
+    ]
+  },
+  {
     version: '1.5.5',
     date: '2026-05-26',
     highlights: "Bottom-region rework from UAT: the per-session status line now sits directly above the command rows, CLI/version is a slim status bar at the bottom-left, and the GitHub panel ends above the command rows with a floating logo button when collapsed.",

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -118,10 +118,17 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
   }, [])
 
   useEffect(() => {
+    let active = true
+    // Seed from the cached payload so the pills appear immediately on mount,
+    // rather than staying blank until the next 5-min poll push (the immediate
+    // startup poll fires before this subscribes, behind the splash).
+    window.electronAPI.serviceStatus.get().then((data: ServiceStatusPayload | null) => {
+      if (active && data) setServiceStatus(data)
+    })
     const unsub = window.electronAPI.serviceStatus.onUpdate((data: ServiceStatusPayload) => {
       setServiceStatus(data)
     })
-    return unsub
+    return () => { active = false; unsub() }
   }, [])
 
   const worst = serviceStatus?.worst || 'operational'

--- a/src/renderer/components/github/GitHubPanel.tsx
+++ b/src/renderer/components/github/GitHubPanel.tsx
@@ -124,7 +124,7 @@ export default function GitHubPanel({
           onClick={() => setShowSetup(true)}
           aria-label="Configure GitHub for this session"
           title="Configure GitHub for this session"
-          className="gh-fab absolute top-2 right-2 z-20 p-1.5 rounded-lg transition-colors"
+          className="gh-fab gh-fab-in absolute top-2 right-2 z-20 p-1.5 rounded-lg transition-colors"
           style={{ background: 'var(--surface-raised)', boxShadow: 'var(--shadow-raised)' }}
         >
           <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -171,7 +171,7 @@ export default function GitHubPanel({
           window.electronPlatform === 'darwin' ? '\u2318+/' : 'Ctrl+/'
         })`}
         aria-label="Show GitHub panel"
-        className="gh-fab absolute top-2 right-2 z-20 p-1.5 rounded-lg transition-colors"
+        className="gh-fab gh-fab-in absolute top-2 right-2 z-20 p-1.5 rounded-lg transition-colors"
         style={{ background: 'var(--surface-raised)', boxShadow: 'var(--shadow-raised)' }}
       >
         <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -194,7 +194,7 @@ export default function GitHubPanel({
     : 'var(--text-muted)'
   return (
     <aside
-      className="border-l flex flex-col relative"
+      className="gh-panel-in border-l flex flex-col relative"
       style={{
         background: 'var(--surface-raised)',
         borderColor: 'var(--border-subtle)',

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -295,3 +295,28 @@ body {
   background-color: var(--surface-overlay) !important;
 }
 
+/* GitHub panel + FAB appear animations. The panel/FAB swap is otherwise an
+   instant mount; these soften the entrance so toggling Ctrl+/ or enabling a
+   session's integration reads as a deliberate slide rather than a flash.
+   React unmounts the outgoing element immediately, so this is an APPEAR-only
+   treatment (no exit animation). Respects prefers-reduced-motion -- no
+   animation when reduced, mirroring footer-update-pulse above. */
+@keyframes gh-panel-in {
+  from { opacity: 0; transform: translateX(12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.gh-panel-in {
+  animation: gh-panel-in 200ms ease-out;
+}
+@keyframes gh-fab-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
+}
+.gh-fab-in {
+  animation: gh-fab-in 200ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .gh-panel-in,
+  .gh-fab-in { animation: none; }
+}
+

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -275,6 +275,7 @@ export interface ElectronAPI {
     onRunStatusChanged: (callback: (run: TeamRun) => void) => () => void
   }
   serviceStatus: {
+    get: () => Promise<any>
     onUpdate: (callback: (data: { status: string; description: string }) => void) => () => void
   }
   cli: {

--- a/src/shared/identity-colors.ts
+++ b/src/shared/identity-colors.ts
@@ -8,22 +8,32 @@ export type IdentityColorKey =
   | 'mauve' | 'violet' | 'lavender' | 'slate-blue' | 'orchid'
   | 'indigo' | 'periwinkle' | 'plum' | 'pink' | 'rose'
 
+// Ordered so consecutively-assigned colours (email hash % 10, or any sequential
+// pick) land far apart in hue -- two sessions created back to back read as
+// instantly distinct rather than two neighbouring violets.
 export const IDENTITY_COLOR_KEYS: readonly IdentityColorKey[] = [
-  'mauve', 'violet', 'lavender', 'slate-blue', 'orchid',
-  'indigo', 'periwinkle', 'plum', 'pink', 'rose',
+  'slate-blue', 'pink', 'indigo', 'violet', 'plum',
+  'lavender', 'rose', 'orchid', 'mauve', 'periwinkle',
 ]
 
+// The KEY names are now STABLE IDENTIFIERS, not literal hues -- they are stored
+// in config (identityColorKey) and renaming would need a migration, so the
+// names are frozen while the hexes were re-tuned to span the full hue wheel for
+// differentiation in the left rail / tab row / inactive dot. The hues now
+// spread across the wheel (jewel tones, not neon) and MAY sit near status hues
+// (green/amber/red/teal); that overlap is accepted in exchange for sessions
+// being instantly distinguishable. `mauve` is unchanged (a test pins it).
 export const IDENTITY_PALETTE: Record<IdentityColorKey, { dark: string; light: string }> = {
-  'mauve':      { dark: '#9a8cf0', light: '#6d5cc0' },
-  'violet':     { dark: '#b57edc', light: '#8a4fb0' },
-  'lavender':   { dark: '#a6b4ff', light: '#5566cc' },
-  'slate-blue': { dark: '#7b68ee', light: '#5346b8' },
-  'orchid':     { dark: '#ba55d3', light: '#9333a8' },
-  'indigo':     { dark: '#7b8cff', light: '#4858c8' },
-  'periwinkle': { dark: '#8aa0ff', light: '#4a63c2' },
-  'plum':       { dark: '#c98cff', light: '#8a44c0' },
-  'pink':       { dark: '#ff6ec7', light: '#c43d92' },
-  'rose':       { dark: '#ff6b9d', light: '#c23a68' },
+  'mauve':      { dark: '#9a8cf0', light: '#6d5cc0' }, // violet  ~268 (unchanged)
+  'violet':     { dark: '#c071e0', light: '#933fb0' }, // purple-magenta ~300
+  'lavender':   { dark: '#5d8bf0', light: '#2f5cc4' }, // blue ~225
+  'slate-blue': { dark: '#3ba8d4', light: '#176b94' }, // cyan-blue ~195
+  'orchid':     { dark: '#34b39a', light: '#117a68' }, // teal-green ~168
+  'indigo':     { dark: '#46b56e', light: '#1f8a48' }, // green ~140
+  'periwinkle': { dark: '#9bbf4e', light: '#5f8420' }, // lime-olive ~95
+  'plum':       { dark: '#d9a83f', light: '#9c6e18' }, // amber-gold ~50
+  'pink':       { dark: '#e8794a', light: '#b85020' }, // orange-coral ~25
+  'rose':       { dark: '#ef5f7e', light: '#c23a54' }, // rose-red ~352
 }
 
 export function resolveIdentityColor(key: IdentityColorKey, theme: 'dark' | 'light'): string {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -170,6 +170,7 @@ export const IPC = {
 
   // Service status
   SERVICE_STATUS: 'serviceStatus:update',
+  SERVICE_STATUS_GET: 'serviceStatus:get',
 
   // CLI
   CLI_CHECK: 'cli:check',

--- a/tests/unit/main/clipboard-image.test.ts
+++ b/tests/unit/main/clipboard-image.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { clipboard } from 'electron'
+import { readClipboardImageWithRetry } from '../../../src/main/clipboard-image'
+
+// Build a fake NativeImage whose isEmpty() returns a fixed value.
+function fakeImage(empty: boolean) {
+  return { isEmpty: () => empty } as unknown as Electron.NativeImage
+}
+
+const readImage = clipboard.readImage as unknown as ReturnType<typeof vi.fn>
+// No-op sleep so the retry loop doesn't actually wait in tests.
+const noSleep = () => Promise.resolve()
+
+describe('readClipboardImageWithRetry (Alt+V first-attempt fix)', () => {
+  beforeEach(() => {
+    readImage.mockReset()
+  })
+
+  it('returns the image when the very first read is non-empty', async () => {
+    const img = fakeImage(false)
+    readImage.mockReturnValue(img)
+
+    const result = await readClipboardImageWithRetry(3, 20, noSleep)
+
+    expect(result).toBe(img)
+    expect(readImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries and succeeds when the first read is empty but a later one is not', async () => {
+    // This is the Windows delayed-render case: first read empty, then the
+    // bitmap syncs in and the second read returns the image. Pre-fix, the
+    // single-shot read reported "no image" here -- the first-attempt miss.
+    const img = fakeImage(false)
+    readImage
+      .mockReturnValueOnce(fakeImage(true))
+      .mockReturnValueOnce(img)
+
+    const result = await readClipboardImageWithRetry(3, 20, noSleep)
+
+    expect(result).toBe(img)
+    expect(readImage).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null only when every attempt is empty (genuinely no image)', async () => {
+    readImage.mockReturnValue(fakeImage(true))
+
+    const result = await readClipboardImageWithRetry(3, 20, noSleep)
+
+    expect(result).toBeNull()
+    expect(readImage).toHaveBeenCalledTimes(3)
+  })
+
+  it('respects a custom attempt count and reads at least once', async () => {
+    readImage.mockReturnValue(fakeImage(true))
+
+    expect(await readClipboardImageWithRetry(1, 20, noSleep)).toBeNull()
+    expect(readImage).toHaveBeenCalledTimes(1)
+
+    readImage.mockClear()
+    // attempts < 1 is clamped to a single read.
+    expect(await readClipboardImageWithRetry(0, 20, noSleep)).toBeNull()
+    expect(readImage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/shared/identity-colors.test.ts
+++ b/tests/unit/shared/identity-colors.test.ts
@@ -76,7 +76,9 @@ describe('bucketLegacyColorToKey -- names, passthrough, fallback', () => {
     expect(bucketLegacyColorToKey('#00ff00')).toBe('indigo')
   })
   it('routes an unknown non-status hex to the nearest identity key (pinned)', () => {
-    expect(bucketLegacyColorToKey('#8000ff')).toBe('slate-blue')
+    // Widened jewel-tone palette (UAT R3): #8000ff (a violet-purple) is now
+    // nearest to the `violet` swatch rather than the old slate-blue hex.
+    expect(bucketLegacyColorToKey('#8000ff')).toBe('violet')
   })
   it('falls back to mauve for unparseable input (empty / garbage / 3-digit)', () => {
     expect(bucketLegacyColorToKey('')).toBe('mauve')
@@ -96,7 +98,8 @@ describe('bucketLegacyColorToKeySource', () => {
     expect(bucketLegacyColorToKeySource('#00FFFF')).toEqual({ key: 'slate-blue', source: 'hex' })
   })
   it('reports source=nearest for an unknown but parseable hex', () => {
-    expect(bucketLegacyColorToKeySource('#8000ff')).toEqual({ key: 'slate-blue', source: 'nearest' })
+    // Widened jewel-tone palette (UAT R3): nearest is now `violet`.
+    expect(bucketLegacyColorToKeySource('#8000ff')).toEqual({ key: 'violet', source: 'nearest' })
   })
   it('reports source=fallback for unparseable input', () => {
     expect(bucketLegacyColorToKeySource('not-a-hex')).toEqual({ key: 'mauve', source: 'fallback' })


### PR DESCRIPTION
## Summary
Round 3 of v1.5.5-beta UAT feedback.

- **Identity palette widened across the full hue wheel** (jewel-toned) so sessions are instantly distinguishable in the rail/tabs/dots instead of all reading as purple. Keys unchanged (no migration); `IDENTITY_COLOR_KEYS` reordered so consecutive assignments land far apart. Tradeoff (intended): identity hues can now sit near status hues.
- **GitHub panel appear animation** -- slide-in + fade for the panel, fade/scale for the collapsed octocat FAB; both respect `prefers-reduced-motion`.
- **Service-status pills on launch** -- main now caches the last payload + exposes `serviceStatus.get`; the TitleBar seeds on mount, so pills show immediately instead of after the first 5-min poll. (Also fixed a startup `ReferenceError: IPC is not defined` -- `index.ts` wasn't importing `IPC`.)
- **Alt+V image paste first-attempt reliability** -- root cause was a Windows clipboard delayed-render quirk in the main process (first read after focus returns an empty bitmap). New `readClipboardImageWithRetry` re-reads a few times with a short async yield.

## Review
Double-reviewed (spec-compliance SPEC-COMPLIANT + code-quality APPROVED) over the four feature commits. The IPC-import fix is a trivial runtime-verified one-liner (caught via dev launch, gone after).

## Test Plan
- [x] `npm run typecheck` -- 0 errors
- [x] `npx vitest run` -- 1152 passed / 1 skipped
- [x] New tests: `clipboard-image.test.ts` (retry); updated `identity-colors.test.ts`
- [x] Dev launch: no `IPC is not defined`; service-status poller starts clean
- [ ] UAT in v1.5.6-beta: palette distinctness, panel slide-in, instant status pills, first-try Alt+V paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)