### PR TITLE
UAT R4: account-email chip + email->colour overrides + periodic update check

### DIFF
--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.7',
+    date: '2026-05-27',
+    highlights: "Your account email is back in the status line and session header -- coloured per account -- and you can now pin a fixed colour to any account in Settings. The Update pill also appears on its own now, without needing a restart.",
+    changes: [
+      { type: 'fix', description: "The active account email is shown again in the per-session status line and the session header, coloured per account -- it was dropped during the V2 shell refactor" },
+      { type: 'feature', description: "Assign a fixed colour to any account email in Settings > General > Account Colours. Detected accounts are listed automatically, or add one manually; the chosen colour tints that account's email everywhere it shows" },
+      { type: 'improvement', description: "The app now re-checks for updates periodically and when the window regains focus, so the Update pill appears on its own instead of only after a manual restart" },
+    ]
+  },
+  {
     version: '1.5.6',
     date: '2026-05-26',
     highlights: "Identity colours now span the full hue wheel so sessions are instantly distinguishable, the GitHub panel slides in when shown, and a few first-launch papercuts are fixed.",

--- a/src/renderer/components/AccountEmailChip.tsx
+++ b/src/renderer/components/AccountEmailChip.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import type { IdentityColorKey } from '../../shared/identity-colors'
+import { resolveIdentityColor } from '../../shared/identity-colors'
+import { resolveAccountChipColorKey, middleTruncateEmail } from '../../shared/account-chip-color'
+import { useSettingsStore } from '../stores/settingsStore'
+import { useResolvedTheme } from '../hooks/useThemeController'
+
+interface Props {
+  email?: string
+  /** Statusline-provided colour key (main computed it via colourForEmail). */
+  statuslineColour?: IdentityColorKey
+  className?: string
+  /** Max characters before middle-truncation. */
+  max?: number
+}
+
+// Coloured account-email chip (UAT R4). A small filled dot in the resolved
+// identity colour, then the email (middle-truncated, full address in title).
+// Colour precedence: user override -> statusline colour -> neutral.
+export default function AccountEmailChip({ email, statuslineColour, className, max = 28 }: Props) {
+  const overrides = useSettingsStore((s) => s.settings.accountColourOverrides)
+  const theme = useResolvedTheme()
+  if (!email) return null
+  const key = resolveAccountChipColorKey(email, statuslineColour, overrides)
+  const color = resolveIdentityColor(key, theme)
+  return (
+    <span
+      data-testid="account-chip"
+      className={`flex items-center gap-1.5 shrink-0 min-w-0 ${className ?? ''}`}
+      title={email}
+    >
+      <span
+        data-testid="account-chip-dot"
+        className="w-1.5 h-1.5 rounded-full shrink-0"
+        style={{ background: color }}
+        aria-hidden
+      />
+      <span className="truncate" style={{ color: 'var(--text-secondary)' }}>
+        {middleTruncateEmail(email, max)}
+      </span>
+    </span>
+  )
+}

--- a/src/renderer/components/BottomBar.tsx
+++ b/src/renderer/components/BottomBar.tsx
@@ -40,13 +40,32 @@ export default function BottomBar({ currentView, onViewChange, onUpdateRequested
     return () => clearInterval(interval)
   }, [])
 
-  // Update availability: one-shot check + subscribe to pushed availability.
+  // Update availability: check on mount, then re-check on a 30-min interval and
+  // when the window regains focus (debounced to <=1/5min). Without this the
+  // pill only appeared after a manual restart, so a release cut while the app
+  // is open went unnoticed. Each check is a single cheap GitHub release call.
   useEffect(() => {
-    window.electronAPI.update.check().then(setUpdateAvailable)
+    const UPDATE_INTERVAL_MS = 30 * 60 * 1000
+    const FOCUS_DEBOUNCE_MS = 5 * 60 * 1000
+    let lastCheckedAt = 0
+    const runCheck = () => {
+      lastCheckedAt = Date.now()
+      window.electronAPI.update.check().then(setUpdateAvailable)
+    }
+    runCheck()
+    const interval = setInterval(runCheck, UPDATE_INTERVAL_MS)
+    const onFocus = () => {
+      if (Date.now() - lastCheckedAt >= FOCUS_DEBOUNCE_MS) runCheck()
+    }
+    window.addEventListener('focus', onFocus)
     const off = window.electronAPI.update.onAvailable((available: boolean) => {
       setUpdateAvailable(available)
     })
-    return off
+    return () => {
+      clearInterval(interval)
+      window.removeEventListener('focus', onFocus)
+      off()
+    }
   }, [])
 
   return (

--- a/src/renderer/components/RepoBreadcrumb.tsx
+++ b/src/renderer/components/RepoBreadcrumb.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Session } from '../stores/sessionStore'
+import AccountEmailChip from './AccountEmailChip'
 
 // Passive orientation strip (spec section 8): working dir on the left, repo slug
 // + connection state on the right. NOT a toolbar -- no actions. Does not repeat
@@ -10,10 +11,11 @@ export default function RepoBreadcrumb({ session }: { session: Session }) {
   const gi = session.githubIntegration
   const slug = gi?.repoSlug
   const connected = !!gi?.enabled && !!slug
-  if (!cwd && !slug) return null
+  if (!cwd && !slug && !session.accountEmail) return null
   return (
     <div className="flex items-center gap-2 px-4 py-1 text-[11px] border-b shrink-0"
       style={{ background: 'var(--surface-panel)', borderColor: 'var(--border-subtle)', color: 'var(--text-muted)' }}>
+      <AccountEmailChip email={session.accountEmail} statuslineColour={session.accountColour} max={32} />
       <span className="font-mono truncate min-w-0" title={cwd}>{cwd}</span>
       <span className="flex-1" />
       {slug && (

--- a/src/renderer/components/SessionStatusStrip.tsx
+++ b/src/renderer/components/SessionStatusStrip.tsx
@@ -6,6 +6,7 @@ import { formatResetTime, formatTokens, formatDuration } from '../utils/terminal
 import { useCodexReviewUsage } from '../hooks/useCodexReviewUsage'
 import { useRestartSession } from '../hooks/useRestartSession'
 import ToolbarPopup from './ToolbarPopup'
+import AccountEmailChip from './AccountEmailChip'
 import {
   MODELS,
   EFFORTS,
@@ -87,6 +88,7 @@ export default function SessionStatusStrip({ sessionId }: SessionStatusStripProp
         className="flex items-center gap-3 flex-1 min-w-0 overflow-hidden"
         style={{ fontSize: `${sl.fontSize}px`, fontFamily: sl.font === 'mono' ? "'JetBrains Mono', monospace" : undefined }}
       >
+        <AccountEmailChip email={session.accountEmail} statuslineColour={session.accountColour} />
         {sl.showModel && session.modelName && (
           <span className="font-medium truncate shrink-0">
             {session.modelName}

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import GitHubConfigTab from './github/config/GitHubConfigTab'
 import { CodexSettingsTab } from './codex/CodexSettingsTab'
 import HooksGatewaySection from './github/config/HooksGatewaySection'
 import PageFrame from './PageFrame'
+import AccountColoursSection from './settings/AccountColoursSection'
 declare const __BUILD_TIME__: string
 
 export const SETTINGS_TAB_IDS = ['general', 'statusline', 'shortcuts', 'github', 'codex', 'hooks', 'about'] as const
@@ -209,6 +210,8 @@ export default function SettingsPage({ initialTab }: SettingsPageProps = {}) {
                   <span className="text-[10px] text-overlay0">(--dangerously-skip-permissions)</span>
                 </label>
               </Section>
+
+              <AccountColoursSection />
 
               <Section title="Terminal" icon={<><rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" fill="none" /><path d="M5 7l2 2-2 2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" /><line x1="9" y1="11" x2="11" y2="11" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /></>}>
                 <Field label="Font Family">

--- a/src/renderer/components/settings/AccountColoursSection.tsx
+++ b/src/renderer/components/settings/AccountColoursSection.tsx
@@ -68,7 +68,7 @@ export default function AccountColoursSection() {
         {rows.map((email) => (
           <div key={email} className="flex items-center gap-2">
             <Swatch value={overrides?.[email]} dataTestId={`swatch-${email}`} theme={theme}
-              onChange={(v) => setOverride(email, v)} />
+              onChange={(v) => setOverride(email, v)} label={email} />
             <span className="text-sm text-text truncate min-w-0" title={email}>
               {middleTruncateEmail(email, 34)}
             </span>
@@ -98,7 +98,7 @@ export default function AccountColoursSection() {
           className="bg-crust/60 border border-surface0/80 rounded-lg px-3 py-1.5 text-sm text-text flex-1 focus:outline-none focus:border-blue/50 placeholder:text-overlay0 transition-colors"
         />
         <Swatch value={addKey} dataTestId="add-email-swatch" theme={theme}
-          onChange={(v) => setAddKey((v === AUTO ? IDENTITY_COLOR_KEYS[0] : v) as IdentityColorKey)} includeAuto={false} />
+          onChange={(v) => setAddKey((v === AUTO ? IDENTITY_COLOR_KEYS[0] : v) as IdentityColorKey)} includeAuto={false} label="new account" />
         <button
           data-testid="add-email-btn"
           onClick={onAdd}
@@ -112,12 +112,13 @@ export default function AccountColoursSection() {
   )
 }
 
-function Swatch({ value, onChange, theme, dataTestId, includeAuto = true }: {
+function Swatch({ value, onChange, theme, dataTestId, includeAuto = true, label }: {
   value?: IdentityColorKey
   onChange: (v: string) => void
   theme: 'dark' | 'light'
   dataTestId: string
   includeAuto?: boolean
+  label?: string
 }) {
   return (
     <span className="flex items-center gap-1.5 shrink-0">
@@ -127,6 +128,7 @@ function Swatch({ value, onChange, theme, dataTestId, includeAuto = true }: {
         data-testid={dataTestId}
         value={value ?? (includeAuto ? '__auto__' : IDENTITY_COLOR_KEYS[0])}
         onChange={(e) => onChange(e.target.value)}
+        aria-label={label ? `Colour for ${label}` : 'Account colour'}
         className="bg-crust/60 border border-surface0/80 rounded-md px-2 py-1 text-xs text-text focus:outline-none focus:border-blue/50 transition-colors"
       >
         {includeAuto && <option value="__auto__">Auto</option>}

--- a/src/renderer/components/settings/AccountColoursSection.tsx
+++ b/src/renderer/components/settings/AccountColoursSection.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { IDENTITY_COLOR_KEYS, resolveIdentityColor } from '../../../shared/identity-colors'
+import type { IdentityColorKey } from '../../../shared/identity-colors'
+import { canonicaliseEmail, middleTruncateEmail } from '../../../shared/account-chip-color'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useResolvedTheme } from '../../hooks/useThemeController'
+
+const AUTO = '__auto__'
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+// Per-account colour overrides (UAT R4). Detected accounts come from the same
+// listKnownEmails source the attribution wizard uses; manual rows let the user
+// pre-assign a colour to an account not seen yet. Colours are identity-palette
+// KEYS, resolved per-theme, so they stay consistent with session colours.
+export default function AccountColoursSection() {
+  const overrides = useSettingsStore((s) => s.settings.accountColourOverrides)
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
+  const theme = useResolvedTheme()
+  const [detected, setDetected] = useState<string[]>([])
+  const [addEmail, setAddEmail] = useState('')
+  const [addKey, setAddKey] = useState<IdentityColorKey>(IDENTITY_COLOR_KEYS[0])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    window.electronAPI.tokenomics
+      .listKnownEmails()
+      .then((emails: string[]) => { if (active) setDetected(emails.map(canonicaliseEmail)) })
+      .catch(() => { /* listing is best-effort */ })
+    return () => { active = false }
+  }, [])
+
+  // Union of detected accounts and any manually-added override keys, deduped.
+  const rows = useMemo(() => {
+    const set = new Set<string>(detected)
+    for (const k of Object.keys(overrides ?? {})) set.add(k)
+    return Array.from(set).sort()
+  }, [detected, overrides])
+
+  const setOverride = (email: string, value: string) => {
+    const next = { ...(overrides ?? {}) }
+    if (value === AUTO) delete next[email]
+    else next[email] = value as IdentityColorKey
+    updateSettings({ accountColourOverrides: next })
+  }
+
+  const removeRow = (email: string) => {
+    const next = { ...(overrides ?? {}) }
+    delete next[email]
+    updateSettings({ accountColourOverrides: next })
+  }
+
+  const onAdd = () => {
+    const canon = canonicaliseEmail(addEmail)
+    if (!EMAIL_RE.test(canon)) { setError('Enter a valid email address'); return }
+    setError(null)
+    setOverride(canon, addKey)
+    setAddEmail('')
+  }
+
+  return (
+    <Section>
+      <p className="text-[11px] text-overlay0 mb-2 leading-relaxed">
+        Give an account a fixed colour. It tints that account's email in the status line and session header.
+        Leave a row on Auto to use the automatic colour.
+      </p>
+      <div className="space-y-1.5">
+        {rows.map((email) => (
+          <div key={email} className="flex items-center gap-2">
+            <Swatch value={overrides?.[email]} dataTestId={`swatch-${email}`} theme={theme}
+              onChange={(v) => setOverride(email, v)} />
+            <span className="text-sm text-text truncate min-w-0" title={email}>
+              {middleTruncateEmail(email, 34)}
+            </span>
+            <span className="flex-1" />
+            {detected.includes(email)
+              ? <span className="text-[10px] text-overlay0 shrink-0">detected</span>
+              : (
+                <button
+                  data-testid={`remove-${email}`}
+                  onClick={() => removeRow(email)}
+                  className="text-[11px] text-overlay0 hover:text-red transition-colors shrink-0"
+                  aria-label={`Remove ${email}`}
+                >
+                  Remove
+                </button>
+              )}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <input
+          data-testid="add-email-input"
+          value={addEmail}
+          onChange={(e) => { setAddEmail(e.target.value); if (error) setError(null) }}
+          placeholder="add account email"
+          className="bg-crust/60 border border-surface0/80 rounded-lg px-3 py-1.5 text-sm text-text flex-1 focus:outline-none focus:border-blue/50 placeholder:text-overlay0 transition-colors"
+        />
+        <Swatch value={addKey} dataTestId="add-email-swatch" theme={theme}
+          onChange={(v) => setAddKey((v === AUTO ? IDENTITY_COLOR_KEYS[0] : v) as IdentityColorKey)} includeAuto={false} />
+        <button
+          data-testid="add-email-btn"
+          onClick={onAdd}
+          className="px-3 py-1.5 text-sm bg-surface1 hover:bg-surface2 rounded-lg transition-colors shrink-0"
+        >
+          Add
+        </button>
+      </div>
+      {error && <p data-testid="add-email-error" className="mt-1 text-[11px] text-red">{error}</p>}
+    </Section>
+  )
+}
+
+function Swatch({ value, onChange, theme, dataTestId, includeAuto = true }: {
+  value?: IdentityColorKey
+  onChange: (v: string) => void
+  theme: 'dark' | 'light'
+  dataTestId: string
+  includeAuto?: boolean
+}) {
+  return (
+    <span className="flex items-center gap-1.5 shrink-0">
+      <span className="w-3 h-3 rounded-full border border-surface0/80"
+        style={{ background: value ? resolveIdentityColor(value, theme) : 'var(--text-muted)' }} aria-hidden />
+      <select
+        data-testid={dataTestId}
+        value={value ?? (includeAuto ? '__auto__' : IDENTITY_COLOR_KEYS[0])}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-crust/60 border border-surface0/80 rounded-md px-2 py-1 text-xs text-text focus:outline-none focus:border-blue/50 transition-colors"
+      >
+        {includeAuto && <option value="__auto__">Auto</option>}
+        {IDENTITY_COLOR_KEYS.map((k) => (
+          <option key={k} value={k}>{k}</option>
+        ))}
+      </select>
+    </span>
+  )
+}
+
+// Local section shell matching the General-tab card styling.
+function Section({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
+          <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.2" fill="none" />
+          <path d="M8 3a5 5 0 0 1 0 10" fill="currentColor" opacity="0.4" />
+        </svg>
+        <h3 className="text-xs font-semibold text-subtext0 uppercase tracking-wider">Account Colours</h3>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  )
+}

--- a/src/renderer/hooks/useStatuslineSubscription.ts
+++ b/src/renderer/hooks/useStatuslineSubscription.ts
@@ -27,6 +27,8 @@ export function useStatuslineSubscription(sessionId: string) {
       if (data.rateLimitWeekly != null) updates.rateLimitWeekly = data.rateLimitWeekly
       if (data.rateLimitWeeklyResets) updates.rateLimitWeeklyResets = data.rateLimitWeeklyResets
       if (data.rateLimitExtra) updates.rateLimitExtra = data.rateLimitExtra
+      if (data.accountEmail) updates.accountEmail = data.accountEmail
+      if (data.accountColour) updates.accountColour = data.accountColour
       if (Object.keys(updates).length > 0) {
         updateSession(sessionId, updates)
       }

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -56,6 +56,10 @@ export interface Session {
     usedUsd: number
     limitUsd: number
   }
+  /** Active-account email from the statusline bridge. Drives the coloured email chip. */
+  accountEmail?: string
+  /** Identity-palette KEY computed in main via colourForEmail(); resolved to a theme hex at render. */
+  accountColour?: IdentityColorKey
   legacyVersion?: {                      // Pinned Claude CLI version
     enabled: boolean
     version: string

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -80,6 +80,9 @@ export interface AppSettings {
   identityColorMigratedV2?: boolean      // one-time guard: saved-config colours migrated to identity keys
   colourMigrationNoticePending?: boolean // a colour migration changed records and the notice should show
   colourMigrationNoticeDismissed?: boolean
+  /** User-defined per-account email -> identity colour key overrides. Keyed by
+   *  canonicalised (lowercase+trim) email. Absent = use the deterministic colour. */
+  accountColourOverrides?: Record<string, import('../../shared/identity-colors').IdentityColorKey>
 }
 
 interface SettingsState {

--- a/src/shared/account-chip-color.ts
+++ b/src/shared/account-chip-color.ts
@@ -1,0 +1,42 @@
+// src/shared/account-chip-color.ts
+import type { IdentityColorKey } from './identity-colors'
+
+/** Lowercase + trim, matching colourForEmail's normalisation so override keys
+ *  and statusline emails canonicalise identically. */
+export function canonicaliseEmail(email: string): string {
+  return email.toLowerCase().trim()
+}
+
+/**
+ * Resolve the identity-palette KEY for an account's email chip.
+ * Order: user override (by canonical email) -> statusline-provided colour ->
+ * neutral 'mauve'. The hash fallback (colourForEmail) is main-only and already
+ * arrives as `statuslineColour`, so it is never recomputed here (keeps this
+ * module free of Node `crypto` and renderer-safe).
+ */
+export function resolveAccountChipColorKey(
+  email: string | undefined,
+  statuslineColour: IdentityColorKey | undefined,
+  overrides: Record<string, IdentityColorKey> | undefined,
+): IdentityColorKey {
+  if (email && overrides) {
+    const override = overrides[canonicaliseEmail(email)]
+    if (override) return override
+  }
+  if (statuslineColour) return statuslineColour
+  return 'mauve'
+}
+
+/**
+ * Truncate an email to `max` chars, removing from the MIDDLE so the local-part
+ * start and the domain end (the disambiguating parts) stay visible. Callers
+ * keep the full address in a `title` attribute.
+ */
+export function middleTruncateEmail(email: string, max = 28): string {
+  if (email.length <= max) return email
+  const ell = '...'
+  const keep = max - ell.length
+  const head = Math.ceil(keep / 2)
+  const tail = Math.floor(keep / 2)
+  return email.slice(0, head) + ell + email.slice(email.length - tail)
+}

--- a/src/shared/account-chip-color.ts
+++ b/src/shared/account-chip-color.ts
@@ -35,6 +35,7 @@ export function resolveAccountChipColorKey(
 export function middleTruncateEmail(email: string, max = 28): string {
   if (email.length <= max) return email
   const ell = '...'
+  if (max <= ell.length) return ell.slice(0, max)
   const keep = max - ell.length
   const head = Math.ceil(keep / 2)
   const tail = Math.floor(keep / 2)

--- a/tests/unit/renderer/account-colours-section.test.tsx
+++ b/tests/unit/renderer/account-colours-section.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/hooks/useThemeController', () => ({
+  useResolvedTheme: () => 'dark',
+}))
+vi.mock('../../../src/renderer/utils/config-saver', () => ({
+  saveConfigNow: vi.fn().mockResolvedValue(undefined),
+  saveConfigDebounced: vi.fn(),
+}))
+
+const { default: AccountColoursSection } = await import('../../../src/renderer/components/settings/AccountColoursSection')
+const { useSettingsStore, DEFAULT_SETTINGS } = await import('../../../src/renderer/stores/settingsStore')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS }, isLoaded: true } as any)
+  ;(window as any).electronAPI = {
+    tokenomics: { listKnownEmails: vi.fn().mockResolvedValue(['detected@x.com']) },
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+async function flush() { await act(async () => { await new Promise(r => setTimeout(r, 0)) }) }
+function renderSection() { act(() => { root.render(createElement(AccountColoursSection)) }) }
+
+function setSelect(el: HTMLSelectElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!
+  setter.call(el, value)
+  act(() => { el.dispatchEvent(new Event('change', { bubbles: true })) })
+}
+function setInput(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+  setter.call(el, value)
+  act(() => { el.dispatchEvent(new Event('input', { bubbles: true })) })
+}
+const byTestId = (id: string) => container.querySelector(`[data-testid="${id}"]`)
+
+describe('AccountColoursSection', () => {
+  it('lists detected accounts from listKnownEmails', async () => {
+    renderSection(); await flush()
+    expect(container.textContent).toContain('detected@x.com')
+  })
+
+  it('persists an override when a swatch is chosen', async () => {
+    renderSection(); await flush()
+    setSelect(byTestId('swatch-detected@x.com') as HTMLSelectElement, 'rose')
+    expect(useSettingsStore.getState().settings.accountColourOverrides?.['detected@x.com']).toBe('rose')
+  })
+
+  it('removes the override when Auto is chosen', async () => {
+    useSettingsStore.setState({
+      settings: { ...DEFAULT_SETTINGS, accountColourOverrides: { 'detected@x.com': 'rose' } }, isLoaded: true,
+    } as any)
+    renderSection(); await flush()
+    setSelect(byTestId('swatch-detected@x.com') as HTMLSelectElement, '__auto__')
+    expect(useSettingsStore.getState().settings.accountColourOverrides?.['detected@x.com']).toBeUndefined()
+  })
+
+  it('adds a manually-typed email (canonicalised) as an override', async () => {
+    renderSection(); await flush()
+    setInput(byTestId('add-email-input') as HTMLInputElement, '  New@Y.COM ')
+    setSelect(byTestId('add-email-swatch') as HTMLSelectElement, 'indigo')
+    act(() => { (byTestId('add-email-btn') as HTMLButtonElement).click() })
+    expect(useSettingsStore.getState().settings.accountColourOverrides?.['new@y.com']).toBe('indigo')
+  })
+
+  it('rejects an invalid email', async () => {
+    renderSection(); await flush()
+    setInput(byTestId('add-email-input') as HTMLInputElement, 'notanemail')
+    act(() => { (byTestId('add-email-btn') as HTMLButtonElement).click() })
+    expect(byTestId('add-email-error')).toBeTruthy()
+    expect(useSettingsStore.getState().settings.accountColourOverrides ?? {}).toEqual({})
+  })
+})

--- a/tests/unit/renderer/account-email-chip-mount.test.tsx
+++ b/tests/unit/renderer/account-email-chip-mount.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/hooks/useThemeController', () => ({
+  useResolvedTheme: () => 'dark',
+}))
+
+const { default: RepoBreadcrumb } = await import('../../../src/renderer/components/RepoBreadcrumb')
+const { useSettingsStore, DEFAULT_SETTINGS } = await import('../../../src/renderer/stores/settingsStore')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS }, isLoaded: true } as any)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+function render(session: any) {
+  act(() => { root.render(createElement(RepoBreadcrumb, { session })) })
+}
+
+describe('RepoBreadcrumb account chip', () => {
+  it('shows the account email alongside the path', () => {
+    render({ id: 's1', workingDirectory: '/home/me/proj', accountEmail: 'me@example.com', accountColour: 'violet' })
+    expect(container.textContent).toContain('me@example.com')
+    expect(container.textContent).toContain('/home/me/proj')
+  })
+
+  it('omits the chip when there is no account email', () => {
+    render({ id: 's1', workingDirectory: '/home/me/proj' })
+    expect(container.querySelector('[data-testid="account-chip"]')).toBeNull()
+    // breadcrumb itself still renders because cwd is present
+    expect(container.textContent).toContain('/home/me/proj')
+  })
+})

--- a/tests/unit/renderer/account-email-chip.test.tsx
+++ b/tests/unit/renderer/account-email-chip.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/hooks/useThemeController', () => ({
+  useResolvedTheme: () => 'dark',
+}))
+
+const { default: AccountEmailChip } = await import('../../../src/renderer/components/AccountEmailChip')
+const { useSettingsStore, DEFAULT_SETTINGS } = await import('../../../src/renderer/stores/settingsStore')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS }, isLoaded: true } as any)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+function render(props: any) {
+  act(() => { root.render(createElement(AccountEmailChip, props)) })
+}
+
+describe('AccountEmailChip', () => {
+  it('renders nothing without an email', () => {
+    render({ email: undefined, statuslineColour: undefined })
+    expect(container.querySelector('[data-testid="account-chip"]')).toBeNull()
+  })
+
+  it('renders the email text and a coloured dot', () => {
+    render({ email: 'me@example.com', statuslineColour: 'violet' })
+    expect(container.textContent).toContain('me@example.com')
+    const dot = container.querySelector('[data-testid="account-chip-dot"]') as HTMLElement
+    expect(dot).toBeTruthy()
+    expect(dot.style.background).not.toBe('')
+  })
+
+  it('uses the full email as the title even when truncated', () => {
+    const long = 'nicholas.moger@a-very-long-company-domain-name.com'
+    render({ email: long, statuslineColour: 'violet' })
+    const chip = container.querySelector('[data-testid="account-chip"]') as HTMLElement
+    expect(chip.getAttribute('title')).toBe(long)
+    // long email should be visually shortened
+    expect(chip.textContent!.length).toBeLessThan(long.length)
+  })
+})

--- a/tests/unit/renderer/bottombar-update-poll.test.ts
+++ b/tests/unit/renderer/bottombar-update-poll.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+;(globalThis as any).__APP_VERSION__ = '9.9.9-test'
+;(globalThis as any).__BUILD_TIME__ = '2026-05-25T00:00:00.000Z'
+
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings: { updateChannel: 'beta' as const, theme: 'dark' as const } }
+  const useSettingsStore: any = (selector: (s: typeof STATE) => unknown) => selector(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+
+const check = vi.fn().mockResolvedValue(false)
+;(globalThis as any).window.electronAPI = {
+  cli: { check: () => Promise.resolve(true) },
+  update: { check, onAvailable: () => () => {}, installAndRestart: vi.fn() },
+}
+
+const { default: BottomBar } = await import('../../../src/renderer/components/BottomBar')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  check.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  try { act(() => { root.unmount() }) } catch { /* already unmounted */ }
+  container.remove()
+  vi.useRealTimers()
+})
+
+async function render() {
+  await act(async () => {
+    root.render(React.createElement(BottomBar, { currentView: 'sessions', onViewChange: vi.fn() }))
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('BottomBar update polling', () => {
+  it('checks once on mount and again after the 30-min interval', async () => {
+    await render()
+    expect(check).toHaveBeenCalledTimes(1)
+    await act(async () => { vi.advanceTimersByTime(30 * 60 * 1000); await Promise.resolve() })
+    expect(check).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-checks on window focus but not more than once per 5 min', async () => {
+    await render()
+    expect(check).toHaveBeenCalledTimes(1)
+    act(() => { window.dispatchEvent(new Event('focus')) }) // within debounce -> ignored
+    expect(check).toHaveBeenCalledTimes(1)
+    await act(async () => { vi.advanceTimersByTime(5 * 60 * 1000 + 1); await Promise.resolve() })
+    act(() => { window.dispatchEvent(new Event('focus')) }) // past debounce -> fires
+    expect(check).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the interval and focus listener on unmount', async () => {
+    await render()
+    expect(check).toHaveBeenCalledTimes(1)
+    act(() => { root.unmount() })
+    await act(async () => { vi.advanceTimersByTime(60 * 60 * 1000); await Promise.resolve() })
+    act(() => { window.dispatchEvent(new Event('focus')) })
+    expect(check).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/statusline-subscription-account.test.ts
+++ b/tests/unit/renderer/statusline-subscription-account.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { useSessionStore } from '../../../src/renderer/stores/sessionStore'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// Capture the onUpdate callback the hook registers so the test can drive it.
+let pushed: ((data: any) => void) | null = null
+
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(window as any).electronAPI = {
+  statusline: {
+    onUpdate: (cb: (data: any) => void) => {
+      pushed = cb
+      return () => { pushed = null }
+    },
+  },
+}
+
+// Dynamic import AFTER mocks so the hook sees the mocked window.electronAPI
+const { useStatuslineSubscription } = await import('../../../src/renderer/hooks/useStatuslineSubscription')
+
+function HookHarness({ sessionId }: { sessionId: string }) {
+  useStatuslineSubscription(sessionId)
+  return null
+}
+
+describe('useStatuslineSubscription account fields', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    pushed = null
+    ;(window as any).electronAPI = {
+      statusline: {
+        onUpdate: (cb: (data: any) => void) => {
+          pushed = cb
+          return () => { pushed = null }
+        },
+      },
+    }
+    useSessionStore.setState({
+      sessions: [{
+        id: 's1', label: 'S1', workingDirectory: '/x', model: 'sonnet', color: 'mauve',
+        status: 'idle', createdAt: 0, sessionType: 'local',
+      } as any],
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  it('copies accountEmail + accountColour into the session', () => {
+    act(() => { root.render(React.createElement(HookHarness, { sessionId: 's1' })) })
+    act(() => { pushed!({ sessionId: 's1', accountEmail: 'me@example.com', accountColour: 'violet' }) })
+    const s = useSessionStore.getState().sessions.find((x) => x.id === 's1')!
+    expect(s.accountEmail).toBe('me@example.com')
+    expect(s.accountColour).toBe('violet')
+  })
+
+  it('leaves account fields untouched when payload omits them', () => {
+    act(() => { root.render(React.createElement(HookHarness, { sessionId: 's1' })) })
+    act(() => { pushed!({ sessionId: 's1', model: 'opus' }) })
+    const s = useSessionStore.getState().sessions.find((x) => x.id === 's1')!
+    expect(s.accountEmail).toBeUndefined()
+    expect(s.modelName).toBe('opus')
+  })
+})

--- a/tests/unit/shared/account-chip-color.test.ts
+++ b/tests/unit/shared/account-chip-color.test.ts
@@ -1,0 +1,46 @@
+// tests/unit/shared/account-chip-color.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  canonicaliseEmail,
+  resolveAccountChipColorKey,
+  middleTruncateEmail,
+} from '../../../src/shared/account-chip-color'
+
+describe('canonicaliseEmail', () => {
+  it('lowercases and trims', () => {
+    expect(canonicaliseEmail('  Me@Example.COM ')).toBe('me@example.com')
+  })
+})
+
+describe('resolveAccountChipColorKey', () => {
+  it('prefers a user override, matched by canonical email', () => {
+    const overrides = { 'me@example.com': 'rose' as const }
+    expect(resolveAccountChipColorKey('  Me@Example.com', 'violet', overrides)).toBe('rose')
+  })
+
+  it('falls back to the statusline colour when no override', () => {
+    expect(resolveAccountChipColorKey('me@example.com', 'violet', {})).toBe('violet')
+  })
+
+  it('falls back to neutral mauve when nothing is supplied', () => {
+    expect(resolveAccountChipColorKey('me@example.com', undefined, undefined)).toBe('mauve')
+  })
+
+  it('returns neutral when email is undefined', () => {
+    expect(resolveAccountChipColorKey(undefined, undefined, { 'x@y.com': 'rose' })).toBe('mauve')
+  })
+})
+
+describe('middleTruncateEmail', () => {
+  it('returns the email unchanged when within the limit', () => {
+    expect(middleTruncateEmail('a@b.com', 28)).toBe('a@b.com')
+  })
+
+  it('middle-truncates long emails keeping head and tail', () => {
+    const out = middleTruncateEmail('nicholas.moger@somecompany.com', 24)
+    expect(out.length).toBeLessThanOrEqual(24)
+    expect(out).toContain('...')
+    expect(out.startsWith('nicholas')).toBe(true)
+    expect(out.endsWith('.com')).toBe(true)
+  })
+})

--- a/tests/unit/shared/account-chip-color.test.ts
+++ b/tests/unit/shared/account-chip-color.test.ts
@@ -43,4 +43,14 @@ describe('middleTruncateEmail', () => {
     expect(out.startsWith('nicholas')).toBe(true)
     expect(out.endsWith('.com')).toBe(true)
   })
+
+  it('returns the email unchanged when max equals its length', () => {
+    expect(middleTruncateEmail('abc@d.com', 'abc@d.com'.length)).toBe('abc@d.com')
+  })
+
+  it('never exceeds max for tiny max values', () => {
+    for (const m of [0, 1, 2, 3]) {
+      expect(middleTruncateEmail('someone@example.com', m).length).toBeLessThanOrEqual(m)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
UAT Round 4 of the V2 shell. Three items, double-reviewed (spec + code quality per task) plus a final holistic review.

1. **Restore the coloured account-email chip** (regression from the V2 refactor). The active account email shows again, coloured per account, in the per-session status line (left of the model) and the session header (alongside the path). `useStatuslineSubscription` now copies `accountEmail`/`accountColour` into the session; `Session` gained both fields.
2. **New: Account Colours settings** (Settings > General). Assign a fixed identity-palette colour to any account email, overriding the deterministic hash. Detected accounts are auto-listed (reuses `tokenomics.listKnownEmails`); manual add supported. "Auto" reverts. Stored in `settings.accountColourOverrides` keyed by canonicalised email. Reach: the email chip only (Tokenomics unchanged).
3. **Periodic update check.** BottomBar now re-checks for updates on a 30-min interval and on window focus (debounced to 1/5min), so the Update pill appears without a manual restart.

New renderer-safe shared helper `src/shared/account-chip-color.ts` (`resolveAccountChipColorKey` precedence override -> statusline -> neutral; `canonicaliseEmail`; `middleTruncateEmail`) and a new `AccountEmailChip` component.

## Test Plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` -- 1176 pass, 1 skipped (gated real-Claude integration)
- [x] New tests: account-chip-color (9), statusline-subscription-account (2), account-email-chip (3), account-email-chip-mount (2), account-colours-section (5), bottombar-update-poll (3)
- [x] Existing bottom-bar.test.ts (7) still green
- [x] Manual dev UAT: email chip in status line + header; Account Colours add/override/Auto

Ships as **v1.5.7-beta**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
