### PR TITLE
v1.5.8: GH auto-detect persistence + MCP 404 diagnostics (#435 #436 #437)

### DIFF
--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -80,6 +80,78 @@ export function parseCccSessionIdFromUrl(reqUrl: string): string | null {
   }
 }
 
+/** #435: diagnostic payload for the /messages 404 branch.
+ *
+ *  When a POST /messages?sessionId=<sid> arrives but no transport is
+ *  registered under that id, the bare "Session not found" body that
+ *  used to be returned was unactionable -- the LLM consumer surfaced
+ *  it verbatim and the user had no recovery hint. This helper builds
+ *  both:
+ *
+ *    - logMessage: a single-line server-side WARN suitable for
+ *      logError(). Includes the truncated requested sid, the current
+ *      transport count, up to 3 sample sids (8-char prefixes only --
+ *      we deliberately do NOT log full sids to keep this grep-safe
+ *      against accidental sharing of logs), and the requesting
+ *      user-agent (capped at 64 chars to bound log-line size).
+ *
+ *    - body: the HTTP response body, plain ASCII (no em dashes, no
+ *      JSON wrapping), explaining the three common root causes and
+ *      the recovery path (restart the Claude session inside CCC, which
+ *      re-binds a fresh SSE connection via the per-session
+ *      --mcp-config writer).
+ *
+ *  The HTTP status stays 404 -- MCP clients (Claude CLI in particular)
+ *  rely on 404 to identify "session lost" and trigger their own
+ *  reconnect logic. Changing the code to e.g. 410 would mask real
+ *  wiring failures elsewhere in the stack.
+ *
+ *  Pure helper -- no I/O, no http types -- so it can be unit-tested
+ *  directly against a synthetic transports map. See
+ *  conductor-mcp-server-404.test.ts for the contract. */
+export interface NotFoundDiagnostic {
+  status: 404
+  body: string
+  logMessage: string
+}
+
+const SID_PREFIX_LEN = 8
+const SAMPLE_CAP = 3
+const UA_MAX_LEN = 64
+
+export function buildSessionNotFoundResponse(
+  requestedSessionId: string,
+  transports: ReadonlyMap<string, unknown>,
+  userAgent: string | undefined,
+): NotFoundDiagnostic {
+  const requestedPrefix = requestedSessionId.slice(0, SID_PREFIX_LEN)
+  const samples: string[] = []
+  for (const sid of transports.keys()) {
+    if (samples.length >= SAMPLE_CAP) break
+    samples.push(sid.slice(0, SID_PREFIX_LEN))
+  }
+  const samplesStr = samples.join(',')
+  const ua = userAgent && userAgent.length > 0
+    ? userAgent.slice(0, UA_MAX_LEN)
+    : 'unknown'
+
+  const logMessage =
+    `[vision-mcp] POST /messages 404: unknown transport sessionId=${requestedPrefix}… ` +
+    `(have ${transports.size} active transports, samples=[${samplesStr}]) ua="${ua}"`
+
+  const body =
+    `MCP transport session not found: ${requestedPrefix}…\n` +
+    `\n` +
+    `The SSE connection that owned this transport sessionId is no longer registered. This typically means:\n` +
+    `  1. Claude Code is reusing a stale sessionId from a previous SSE connection\n` +
+    `  2. The CCC MCP server restarted while Claude was idle\n` +
+    `  3. Network interruption dropped the SSE stream\n` +
+    `\n` +
+    `Recovery: restart the Claude session inside CCC (the per-session --mcp-config writer re-binds a fresh SSE connection on spawn).\n`
+
+  return { status: 404, body, logMessage }
+}
+
 // Lazy-load MCP SDK to avoid import issues in test environments
 let McpServer: any = null
 let SSEServerTransport: any = null
@@ -406,8 +478,19 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
 
         const transport = transports.get(sessionId)
         if (!transport) {
-          res.writeHead(404)
-          res.end('Session not found')
+          // #435: log a diagnostic line and return an actionable body
+          // instead of the bare "Session not found" that the LLM used
+          // to surface verbatim. The HTTP status stays 404 so MCP
+          // clients can keep their existing reconnect heuristics.
+          const ua = req.headers['user-agent']
+          const diagnostic = buildSessionNotFoundResponse(
+            sessionId,
+            transports,
+            typeof ua === 'string' ? ua : undefined,
+          )
+          logError(diagnostic.logMessage)
+          res.writeHead(diagnostic.status, { 'Content-Type': 'text/plain; charset=utf-8' })
+          res.end(diagnostic.body)
           return
         }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -50,6 +50,7 @@ import { useCodexAccountStore } from './stores/codexAccountStore'
 import GitHubPanel from './components/github/GitHubPanel'
 import OnboardingModal from './components/github/onboarding/OnboardingModal'
 import AutoDetectBanner from './components/github/AutoDetectBanner'
+import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import RepoBreadcrumb from './components/RepoBreadcrumb'
 import type { SessionState, SavedSession } from './types/electron'
 import { buildSessionState } from './session-persistence'
@@ -561,33 +562,36 @@ export default function App() {
             <AutoDetectBanner
               cwd={activeSession.workingDirectory!}
               onAccept={async (slug) => {
-                // Persist the detected repo onto the session BEFORE
-                // navigating so the GitHub config tab reflects the
-                // auto-filled value. Without this write the slug was
-                // silently discarded and the user had to re-enter it.
-                try {
-                  const patch = {
-                    repoUrl: `https://github.com/${slug}`,
-                    repoSlug: slug,
-                    autoDetected: true,
-                  }
-                  await window.electronAPI.github.updateSessionConfig(
-                    activeSession.id,
-                    patch,
-                  )
-                  useSessionStore.getState().updateSession(activeSession.id, {
-                    githubIntegration: {
-                      ...(gi ?? { enabled: false, autoDetected: false }),
-                      ...patch,
+                // Logic lives in utils/githubAutoDetectAccept so it is unit-
+                // testable (App.tsx is enormous). It fixes two bugs the
+                // inline version had:
+                //   #436 -- now writes the patch to the parent CONFIG too,
+                //   so the GH repo selection persists across app restarts.
+                //   #437 -- if the user already has at least one auth
+                //   profile, the click auto-enables the integration, picks
+                //   a profile by slug owner, and stays on the session
+                //   view. The legacy "send to Settings" path only fires
+                //   for unauthed users.
+                await handleAutoDetectAccept(
+                  slug,
+                  {
+                    id: activeSession.id,
+                    configId: activeSession.configId,
+                    githubIntegration: gi,
+                  },
+                  {
+                    electronAPI: window.electronAPI,
+                    updateSession: (id, patch) =>
+                      useSessionStore.getState().updateSession(id, patch),
+                    updateConfig: (id, patch) =>
+                      useConfigStore.getState().updateConfig(id, patch),
+                    profiles: useGitHubStore.getState().profiles,
+                    navigateToGitHubSettings: () => {
+                      setPendingSettingsTab('github')
+                      setView('settings')
                     },
-                  })
-                } catch {
-                  // Fall through: we still send the user to the GitHub
-                  // tab so they can configure manually. Losing the write
-                  // is fine; losing the navigation would be worse.
-                }
-                setPendingSettingsTab('github')
-                setView('settings')
+                  },
+                )
               }}
               onEdit={() => {
                 setPendingSettingsTab('github')

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.8',
+    date: '2026-05-27',
+    highlights: "Three bug fixes: 'Use this repo' in the auto-detect banner now persists across restarts and skips the Settings detour when you are already authed; the Codex MCP server's 'Session not found' 404 now logs diagnostics and returns an actionable recovery message.",
+    changes: [
+      { type: 'fix', description: "Clicking 'Use this repo' in the auto-detect banner now writes the repo to the parent saved config (not just the live session), so the selection survives an app restart" },
+      { type: 'fix', description: "When at least one GitHub auth profile already exists, 'Use this repo' enables the integration in place and auto-picks a matching profile by repo or username -- no more bounce to the Settings tab" },
+      { type: 'improvement', description: "Conductor MCP /messages 404 now logs the requested transport id, active-transport count, sample ids and user-agent, and returns a multi-line recovery message instead of a bare 'Session not found' (helps when Claude reports the Codex review tool as unavailable mid-session)" },
+    ]
+  },
+  {
     version: '1.5.7',
     date: '2026-05-27',
     highlights: "Your account email is back in the status line and session header -- coloured per account -- and you can now pin a fixed colour to any account in Settings. The Update pill also appears on its own now, without needing a restart.",

--- a/src/renderer/utils/githubAutoDetectAccept.ts
+++ b/src/renderer/utils/githubAutoDetectAccept.ts
@@ -1,0 +1,145 @@
+import type { SessionGitHubIntegration } from '../../shared/github-types'
+
+/**
+ * Minimal session shape the helper needs. Defined locally instead of importing
+ * the full Session type so the helper is easy to call from tests without
+ * having to construct unrelated session fields.
+ */
+export interface AutoDetectAcceptSession {
+  id: string
+  configId?: string
+  githubIntegration?: SessionGitHubIntegration
+}
+
+/**
+ * Minimal profile shape -- mirrors useGitHubStore profiles but kept local so
+ * tests don't have to pull the full AuthProfile (with createdAt, scopes, etc).
+ */
+export interface AutoDetectAcceptProfile {
+  id: string
+  username: string
+  allowedRepos?: string[]
+}
+
+export interface AutoDetectAcceptDeps {
+  /**
+   * Subset of window.electronAPI we touch. Typed loose so tests can pass a
+   * minimal stub without recreating the full electron.d.ts surface.
+   */
+  electronAPI: {
+    github: {
+      updateSessionConfig: (
+        sessionId: string,
+        patch: Partial<SessionGitHubIntegration>,
+      ) => Promise<{ ok: boolean; error?: string }>
+    }
+  }
+  /** Mirror onto the live session in the renderer store. */
+  updateSession: (
+    id: string,
+    patch: { githubIntegration: SessionGitHubIntegration },
+  ) => void
+  /**
+   * Mirror onto the parent CONFIG so re-spawned sessions inherit the setup.
+   * Bug #436: previously this write was missing and the GH repo selection
+   * was forgotten across app restarts.
+   */
+  updateConfig: (
+    id: string,
+    patch: { githubIntegration: SessionGitHubIntegration },
+  ) => void
+  profiles: ReadonlyArray<AutoDetectAcceptProfile>
+  /**
+   * Called only when no profiles exist, to send the user to Settings so they
+   * can sign in. Bug #437: previously this fired unconditionally even when
+   * the user was already authed.
+   */
+  navigateToGitHubSettings: () => void
+}
+
+/**
+ * Picks a profile to auto-assign based on the slug owner. Mirrors the intent
+ * of SessionGitHubConfig.tsx's auto-match useEffect (the comment there says
+ * "allowedRepos takes priority over username because fine-grained PATs are
+ * scoped per repo, not per owner") but does it as a two-pass scan so the
+ * priority is real -- the form's single find() with an OR was first-match
+ * wins, which would let a username-only profile listed earlier in the array
+ * beat a properly-scoped fine-grained PAT.
+ *
+ *  - prefer a profile whose allowedRepos contains the exact slug
+ *  - else a profile whose username matches the slug owner (case-insensitive)
+ *  - else undefined -- capability routing handles the no-match path
+ */
+export function pickProfileIdForSlug(
+  slug: string,
+  profiles: ReadonlyArray<AutoDetectAcceptProfile>,
+): string | undefined {
+  if (!slug) return undefined
+  const [owner] = slug.split('/')
+  const scoped = profiles.find((p) => p.allowedRepos?.includes(slug))
+  if (scoped) return scoped.id
+  const byUsername = profiles.find(
+    (p) => p.username.toLowerCase() === owner.toLowerCase(),
+  )
+  return byUsername?.id
+}
+
+/**
+ * Handles the "Use this repo" click on the AutoDetectBanner.
+ *
+ * Behaviour:
+ *  - Writes the detected repo to BOTH the session AND the parent config
+ *    (#436 fix: parent config write was missing -- selection was lost on
+ *    restart because re-spawned sessions inherit from the config, not from
+ *    the previous SavedSession's mirror).
+ *  - If at least one auth profile exists, auto-enable the integration and
+ *    auto-pick a profile by slug owner, then STAY on the session view
+ *    (#437 fix: previously routed to Settings even when authed).
+ *  - If no profiles exist, route to GitHub Settings so the user can sign in
+ *    (today's behaviour for the unauthed path).
+ *
+ * The patch is best-effort: if the IPC write throws, we still navigate the
+ * unauthed user to Settings so they can configure manually. Losing the write
+ * is fine; losing the navigation would be worse.
+ */
+export async function handleAutoDetectAccept(
+  slug: string,
+  session: AutoDetectAcceptSession,
+  deps: AutoDetectAcceptDeps,
+): Promise<void> {
+  const hasAuth = deps.profiles.length > 0
+  const basePatch: Partial<SessionGitHubIntegration> = {
+    repoUrl: `https://github.com/${slug}`,
+    repoSlug: slug,
+    autoDetected: true,
+  }
+  // Authed path: also flip enabled on + pick a profile so the integration is
+  // live without an extra trip through Settings.
+  const patch: Partial<SessionGitHubIntegration> = hasAuth
+    ? {
+        ...basePatch,
+        enabled: true,
+        authProfileId: pickProfileIdForSlug(slug, deps.profiles),
+      }
+    : basePatch
+
+  const prior = session.githubIntegration ?? { enabled: false, autoDetected: false }
+  const merged: SessionGitHubIntegration = { ...prior, ...patch }
+
+  try {
+    await deps.electronAPI.github.updateSessionConfig(session.id, patch)
+    deps.updateSession(session.id, { githubIntegration: merged })
+    if (session.configId) {
+      deps.updateConfig(session.configId, { githubIntegration: merged })
+    }
+  } catch {
+    // Swallow IPC errors. The unauthed user still gets routed to Settings
+    // below so they can finish setup manually. For the authed path there is
+    // nothing useful to do here -- the next save attempt will surface a real
+    // error to the user.
+  }
+
+  if (!hasAuth) {
+    deps.navigateToGitHubSettings()
+  }
+}

--- a/src/renderer/utils/githubAutoDetectAccept.ts
+++ b/src/renderer/utils/githubAutoDetectAccept.ts
@@ -127,7 +127,16 @@ export async function handleAutoDetectAccept(
   const merged: SessionGitHubIntegration = { ...prior, ...patch }
 
   try {
-    await deps.electronAPI.github.updateSessionConfig(session.id, patch)
+    const res = await deps.electronAPI.github.updateSessionConfig(session.id, patch)
+    if (!res.ok) {
+      // Main-side write failed (missing session / persistence error). Do NOT
+      // mirror to the stores -- that would leave the in-memory view out of
+      // sync with disk. Unauthed users still get routed to Settings so they
+      // can finish setup manually; authed users get no mirror + no nav and
+      // the next click of the banner will retry naturally.
+      if (!hasAuth) deps.navigateToGitHubSettings()
+      return
+    }
     deps.updateSession(session.id, { githubIntegration: merged })
     if (session.configId) {
       deps.updateConfig(session.configId, { githubIntegration: merged })

--- a/tests/unit/main/conductor-mcp-server-404.test.ts
+++ b/tests/unit/main/conductor-mcp-server-404.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #435 regression: when a /messages POST arrives with a sessionId that
+ * isn't registered in the transports map (SSE dropped, server restarted,
+ * Claude reusing a stale sid), we want:
+ *
+ *   1. The 404 response body to be actionable -- includes a recovery
+ *      hint instead of the bare "Session not found" that the LLM
+ *      currently surfaces.
+ *   2. A WARN-level server-side log line with diagnostics (requested sid
+ *      prefix, count of active transports, sample sids, user-agent) so
+ *      we can correlate user reports against the in-process state when
+ *      the bug recurs.
+ *
+ * The helper is pure (no I/O, no http types) so we can unit-test it
+ * directly without spinning up a real http.Server.
+ *
+ * Note: we deliberately do NOT fix the underlying SSE-reconnect race
+ * here -- this PR is diagnostic + UX only. The recovery investigation
+ * is deferred to a follow-up cycle.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildSessionNotFoundResponse } from '../../../src/main/conductor-mcp-server'
+
+describe('buildSessionNotFoundResponse (#435)', () => {
+  it('returns status 404', () => {
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.status).toBe(404)
+  })
+
+  it('reports 0 active transports and empty samples when map is empty', () => {
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.logMessage).toContain('have 0 active transports')
+    expect(result.logMessage).toContain('samples=[]')
+  })
+
+  it('includes the truncated requested sid prefix in the log line and body', () => {
+    const result = buildSessionNotFoundResponse(
+      'abc12345-this-is-the-full-id-and-we-do-not-want-to-leak-it',
+      new Map(),
+      undefined,
+    )
+    // First 8 chars then ellipsis.
+    expect(result.logMessage).toContain('sessionId=abc12345')
+    expect(result.body).toContain('abc12345')
+    // Full id MUST NOT leak into the body (LLM-visible) or log.
+    expect(result.body).not.toContain('this-is-the-full-id')
+    expect(result.logMessage).not.toContain('this-is-the-full-id')
+  })
+
+  it('handles short requested sids without crashing (less than 8 chars)', () => {
+    // Defensive: a malformed POST might pass a 3-char sid; truncate-to-8
+    // shouldn't blow up.
+    const result = buildSessionNotFoundResponse('abc', new Map(), undefined)
+    expect(result.status).toBe(404)
+    expect(result.logMessage).toContain('sessionId=abc')
+  })
+
+  it('includes the recovery instructions in the body', () => {
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.body).toContain('MCP transport session not found')
+    expect(result.body).toContain('restart the Claude session inside CCC')
+    expect(result.body).toContain('SSE connection')
+    // No JSON wrapping -- plain text.
+    expect(result.body.trim().startsWith('{')).toBe(false)
+  })
+
+  it('uses ASCII double-dash (not em dash) in the body', () => {
+    // User-facing copy convention: no em dashes (obvious AI tell + the
+    // LLM consumer is going to relay this text verbatim).
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.body).not.toContain('—')
+  })
+
+  it('lists samples (truncated to first 8 chars) when 2 transports are present', () => {
+    const transports = new Map<string, unknown>([
+      ['first-transport-sid-aaa', {}],
+      ['second-transport-sid-bbb', {}],
+    ])
+    const result = buildSessionNotFoundResponse('missing-sid', transports, undefined)
+    expect(result.logMessage).toContain('have 2 active transports')
+    expect(result.logMessage).toContain('first-tr')
+    expect(result.logMessage).toContain('second-t')
+    // Full sids must NOT appear -- we only log the 8-char prefixes.
+    expect(result.logMessage).not.toContain('first-transport-sid-aaa')
+    expect(result.logMessage).not.toContain('second-transport-sid-bbb')
+  })
+
+  it('caps samples at 3 when more than 3 transports are present', () => {
+    const transports = new Map<string, unknown>([
+      ['aaaaaaaa-one', {}],
+      ['bbbbbbbb-two', {}],
+      ['cccccccc-three', {}],
+      ['dddddddd-four', {}],
+      ['eeeeeeee-five', {}],
+    ])
+    const result = buildSessionNotFoundResponse('missing-sid', transports, undefined)
+    expect(result.logMessage).toContain('have 5 active transports')
+    // First three should appear (Map iteration is insertion-ordered).
+    expect(result.logMessage).toContain('aaaaaaaa')
+    expect(result.logMessage).toContain('bbbbbbbb')
+    expect(result.logMessage).toContain('cccccccc')
+    // Fourth and fifth must NOT appear.
+    expect(result.logMessage).not.toContain('dddddddd')
+    expect(result.logMessage).not.toContain('eeeeeeee')
+  })
+
+  it('uses ua="unknown" when the user-agent header is absent', () => {
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.logMessage).toContain('ua="unknown"')
+  })
+
+  it('includes the verbatim user-agent header when present', () => {
+    const result = buildSessionNotFoundResponse(
+      'abc12345xyz',
+      new Map(),
+      'claude-cli/2.0.13',
+    )
+    expect(result.logMessage).toContain('ua="claude-cli/2.0.13"')
+  })
+
+  it('caps the user-agent at 64 chars to keep log lines bounded', () => {
+    // Defensive: a malicious / runaway client could send a multi-kB UA.
+    // We don't want a single bad request to spam multi-line log entries.
+    const longUa = 'x'.repeat(200)
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), longUa)
+    // Extract the ua="..." substring and assert its inner length is <= 64.
+    const match = result.logMessage.match(/ua="([^"]*)"/)
+    expect(match).not.toBeNull()
+    expect(match![1].length).toBeLessThanOrEqual(64)
+  })
+
+  it('begins the log line with the [vision-mcp] prefix used by neighbours', () => {
+    // Consistency with the surrounding logInfo/logError calls in this
+    // file -- the rebrand to "conductor" happened but the log prefix was
+    // intentionally kept as [vision-mcp].
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.logMessage.startsWith('[vision-mcp]')).toBe(true)
+  })
+
+  it('mentions POST /messages 404 in the log line for greppability', () => {
+    const result = buildSessionNotFoundResponse('abc12345xyz', new Map(), undefined)
+    expect(result.logMessage).toContain('POST /messages 404')
+  })
+})

--- a/tests/unit/renderer/auto-detect-banner-accept.test.tsx
+++ b/tests/unit/renderer/auto-detect-banner-accept.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+/**
+ * Covers the AutoDetectBanner "Use this repo" click path.
+ *
+ *   #436 -- the patch must be written to BOTH the live session AND the parent
+ *           CONFIG so the GH repo selection survives an app restart.
+ *   #437 -- when at least one auth profile exists, the click should auto-enable
+ *           the integration, auto-pick a profile, and STAY on the session view.
+ *           When no profiles exist, the legacy "send to Settings" behaviour
+ *           should fire so the user can sign in.
+ *
+ * Strategy: the click handler lives in App.tsx as an inline closure, but its
+ * logic is extracted into src/renderer/utils/githubAutoDetectAccept.ts. We
+ * exercise the helper directly with stubbed deps for the unit assertions, then
+ * also mount the real AutoDetectBanner with a wrapper that wires the helper
+ * exactly like App.tsx does -- so a future refactor that drops the helper
+ * import would break the harness test too.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import {
+  handleAutoDetectAccept,
+  pickProfileIdForSlug,
+} from '../../../src/renderer/utils/githubAutoDetectAccept'
+import type {
+  AutoDetectAcceptDeps,
+  AutoDetectAcceptProfile,
+} from '../../../src/renderer/utils/githubAutoDetectAccept'
+import AutoDetectBanner from '../../../src/renderer/components/github/AutoDetectBanner'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+interface BuildDepsOpts {
+  profiles?: AutoDetectAcceptProfile[]
+  ipcOk?: boolean
+  throwOnIpc?: boolean
+}
+
+function buildDeps(opts: BuildDepsOpts = {}) {
+  const profiles = opts.profiles ?? []
+  const updateSessionConfig = vi.fn(async () => {
+    if (opts.throwOnIpc) throw new Error('boom')
+    return { ok: opts.ipcOk ?? true }
+  })
+  const updateSession = vi.fn()
+  const updateConfig = vi.fn()
+  const navigateToGitHubSettings = vi.fn()
+  const deps: AutoDetectAcceptDeps = {
+    electronAPI: { github: { updateSessionConfig } },
+    updateSession,
+    updateConfig,
+    profiles,
+    navigateToGitHubSettings,
+  }
+  return { deps, updateSessionConfig, updateSession, updateConfig, navigateToGitHubSettings }
+}
+
+describe('pickProfileIdForSlug', () => {
+  it('prefers allowedRepos exact match over username', () => {
+    const profiles: AutoDetectAcceptProfile[] = [
+      { id: 'p-name', username: 'octocat' },
+      { id: 'p-scoped', username: 'someone-else', allowedRepos: ['octocat/hello'] },
+    ]
+    expect(pickProfileIdForSlug('octocat/hello', profiles)).toBe('p-scoped')
+  })
+
+  it('falls back to case-insensitive username match', () => {
+    const profiles: AutoDetectAcceptProfile[] = [
+      { id: 'p-other', username: 'someone-else' },
+      { id: 'p-owner', username: 'OctoCat' },
+    ]
+    expect(pickProfileIdForSlug('octocat/hello', profiles)).toBe('p-owner')
+  })
+
+  it('returns undefined when no profile matches the owner', () => {
+    const profiles: AutoDetectAcceptProfile[] = [
+      { id: 'p-other', username: 'someone-else' },
+    ]
+    expect(pickProfileIdForSlug('octocat/hello', profiles)).toBeUndefined()
+  })
+
+  it('returns undefined for an empty slug', () => {
+    const profiles: AutoDetectAcceptProfile[] = [{ id: 'p-1', username: 'octocat' }]
+    expect(pickProfileIdForSlug('', profiles)).toBeUndefined()
+  })
+})
+
+describe('handleAutoDetectAccept -- #436 / #437', () => {
+  const baseSession = {
+    id: 'sess-1',
+    configId: 'cfg-1',
+    githubIntegration: undefined,
+  }
+
+  it('with profiles present: writes to session AND config, enables, picks profile, does NOT navigate', async () => {
+    const profiles: AutoDetectAcceptProfile[] = [
+      { id: 'p-owner', username: 'octocat' },
+    ]
+    const { deps, updateSessionConfig, updateSession, updateConfig, navigateToGitHubSettings } =
+      buildDeps({ profiles })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    // IPC patch -- enabled true, profile resolved
+    expect(updateSessionConfig).toHaveBeenCalledTimes(1)
+    const [sentSessionId, sentPatch] = updateSessionConfig.mock.calls[0]
+    expect(sentSessionId).toBe('sess-1')
+    expect(sentPatch).toEqual({
+      repoUrl: 'https://github.com/octocat/hello',
+      repoSlug: 'octocat/hello',
+      autoDetected: true,
+      enabled: true,
+      authProfileId: 'p-owner',
+    })
+
+    // Session mirror
+    expect(updateSession).toHaveBeenCalledTimes(1)
+    expect(updateSession.mock.calls[0][0]).toBe('sess-1')
+    expect(updateSession.mock.calls[0][1]).toEqual({
+      githubIntegration: {
+        enabled: true,
+        autoDetected: true,
+        repoUrl: 'https://github.com/octocat/hello',
+        repoSlug: 'octocat/hello',
+        authProfileId: 'p-owner',
+      },
+    })
+
+    // #436 -- parent CONFIG mirror is the previously-missing write
+    expect(updateConfig).toHaveBeenCalledTimes(1)
+    expect(updateConfig.mock.calls[0][0]).toBe('cfg-1')
+    expect(updateConfig.mock.calls[0][1].githubIntegration.enabled).toBe(true)
+    expect(updateConfig.mock.calls[0][1].githubIntegration.repoSlug).toBe('octocat/hello')
+
+    // #437 -- already authed, do NOT navigate to Settings
+    expect(navigateToGitHubSettings).not.toHaveBeenCalled()
+  })
+
+  it('with profiles present but no owner match: enables, leaves authProfileId undefined, no nav', async () => {
+    const profiles: AutoDetectAcceptProfile[] = [
+      { id: 'p-other', username: 'someone-else' },
+    ]
+    const { deps, updateSessionConfig, navigateToGitHubSettings } = buildDeps({ profiles })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    const sentPatch = updateSessionConfig.mock.calls[0][1]
+    expect(sentPatch.enabled).toBe(true)
+    expect(sentPatch.authProfileId).toBeUndefined()
+    expect(navigateToGitHubSettings).not.toHaveBeenCalled()
+  })
+
+  it('with NO profiles: still writes session + config patch, then navigates to Settings (#437 fallback)', async () => {
+    const { deps, updateSessionConfig, updateSession, updateConfig, navigateToGitHubSettings } =
+      buildDeps({ profiles: [] })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    // Patch shape -- enabled is NOT flipped on; only the detected slug fields
+    const sentPatch = updateSessionConfig.mock.calls[0][1]
+    expect(sentPatch).toEqual({
+      repoUrl: 'https://github.com/octocat/hello',
+      repoSlug: 'octocat/hello',
+      autoDetected: true,
+    })
+    expect(sentPatch.enabled).toBeUndefined()
+
+    expect(updateSession).toHaveBeenCalledTimes(1)
+    expect(updateConfig).toHaveBeenCalledTimes(1) // #436 mirror still happens
+
+    // #437 fallback: legacy nav fires when there's no auth to use
+    expect(navigateToGitHubSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('patch always contains repoUrl, repoSlug, autoDetected (authed and unauthed)', async () => {
+    // Authed
+    const a = buildDeps({ profiles: [{ id: 'p1', username: 'octocat' }] })
+    await handleAutoDetectAccept('octocat/hello', baseSession, a.deps)
+    const authedPatch = a.updateSessionConfig.mock.calls[0][1]
+    expect(authedPatch.repoUrl).toBe('https://github.com/octocat/hello')
+    expect(authedPatch.repoSlug).toBe('octocat/hello')
+    expect(authedPatch.autoDetected).toBe(true)
+
+    // Unauthed
+    const u = buildDeps({ profiles: [] })
+    await handleAutoDetectAccept('octocat/hello', baseSession, u.deps)
+    const unauthedPatch = u.updateSessionConfig.mock.calls[0][1]
+    expect(unauthedPatch.repoUrl).toBe('https://github.com/octocat/hello')
+    expect(unauthedPatch.repoSlug).toBe('octocat/hello')
+    expect(unauthedPatch.autoDetected).toBe(true)
+  })
+
+  it('skips parent-config write when the session has no configId (orphan session)', async () => {
+    const orphan = { id: 'sess-2', configId: undefined, githubIntegration: undefined }
+    const { deps, updateConfig } = buildDeps({ profiles: [{ id: 'p1', username: 'octocat' }] })
+
+    await handleAutoDetectAccept('octocat/hello', orphan, deps)
+    expect(updateConfig).not.toHaveBeenCalled()
+  })
+
+  it('still navigates unauthed users to Settings when the IPC write throws', async () => {
+    const { deps, updateSession, updateConfig, navigateToGitHubSettings } = buildDeps({
+      profiles: [],
+      throwOnIpc: true,
+    })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    // Mirrors were skipped because the IPC threw, but the user still ends up
+    // on Settings so they can configure manually -- losing the write is fine,
+    // losing the navigation would be worse.
+    expect(updateSession).not.toHaveBeenCalled()
+    expect(updateConfig).not.toHaveBeenCalled()
+    expect(navigateToGitHubSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('merges over a pre-existing integration record without dropping prior fields', async () => {
+    const session = {
+      id: 'sess-1',
+      configId: 'cfg-1',
+      githubIntegration: {
+        enabled: false,
+        autoDetected: false,
+        panelWidth: 320,
+      },
+    }
+    const { deps, updateSession } = buildDeps({ profiles: [{ id: 'p1', username: 'octocat' }] })
+
+    await handleAutoDetectAccept('octocat/hello', session, deps)
+
+    const merged = updateSession.mock.calls[0][1].githubIntegration
+    expect(merged.panelWidth).toBe(320) // prior field preserved
+    expect(merged.enabled).toBe(true)
+    expect(merged.repoSlug).toBe('octocat/hello')
+  })
+})
+
+// --- DOM-level harness: confirms the click on the real banner button flows
+// into the helper exactly the way App.tsx wires it up. ---
+describe('AutoDetectBanner + handleAutoDetectAccept end-to-end click', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    // The banner detects the slug via window.electronAPI.github.repoDetect.
+    ;(globalThis as any).window.electronAPI = {
+      github: {
+        repoDetect: vi.fn().mockResolvedValue({ ok: true, slug: 'octocat/hello' }),
+        updateSessionConfig: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    }
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  async function flush() {
+    // Two microtask drains: one for the repoDetect promise, one for the
+    // post-resolve setState in the banner.
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  it('authed user clicking "Use this repo" stays on the session view', async () => {
+    const navigate = vi.fn()
+    const updateSession = vi.fn()
+    const updateConfig = vi.fn()
+    const profiles: AutoDetectAcceptProfile[] = [{ id: 'p-owner', username: 'octocat' }]
+
+    const Harness: React.FC = () => (
+      <AutoDetectBanner
+        cwd="F:/repo"
+        onAccept={async (slug) => {
+          await handleAutoDetectAccept(
+            slug,
+            { id: 'sess-1', configId: 'cfg-1', githubIntegration: undefined },
+            {
+              electronAPI: (globalThis as any).window.electronAPI,
+              updateSession,
+              updateConfig,
+              profiles,
+              navigateToGitHubSettings: navigate,
+            },
+          )
+        }}
+        onEdit={() => {}}
+        onDismiss={() => {}}
+      />
+    )
+
+    await act(async () => {
+      root.render(<Harness />)
+      await flush()
+    })
+
+    const useBtn = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (b) => (b.textContent ?? '').includes('Use this repo'),
+    )
+    expect(useBtn).toBeTruthy()
+
+    await act(async () => {
+      useBtn!.click()
+      await flush()
+    })
+
+    expect(updateSession).toHaveBeenCalledTimes(1)
+    expect(updateConfig).toHaveBeenCalledTimes(1)
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('unauthed user clicking "Use this repo" navigates to Settings', async () => {
+    const navigate = vi.fn()
+    const updateSession = vi.fn()
+    const updateConfig = vi.fn()
+
+    const Harness: React.FC = () => (
+      <AutoDetectBanner
+        cwd="F:/repo"
+        onAccept={async (slug) => {
+          await handleAutoDetectAccept(
+            slug,
+            { id: 'sess-1', configId: 'cfg-1', githubIntegration: undefined },
+            {
+              electronAPI: (globalThis as any).window.electronAPI,
+              updateSession,
+              updateConfig,
+              profiles: [],
+              navigateToGitHubSettings: navigate,
+            },
+          )
+        }}
+        onEdit={() => {}}
+        onDismiss={() => {}}
+      />
+    )
+
+    await act(async () => {
+      root.render(<Harness />)
+      await flush()
+    })
+
+    const useBtn = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (b) => (b.textContent ?? '').includes('Use this repo'),
+    )
+    expect(useBtn).toBeTruthy()
+
+    await act(async () => {
+      useBtn!.click()
+      await flush()
+    })
+
+    expect(navigate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/auto-detect-banner-accept.test.tsx
+++ b/tests/unit/renderer/auto-detect-banner-accept.test.tsx
@@ -216,6 +216,37 @@ describe('handleAutoDetectAccept -- #436 / #437', () => {
     expect(navigateToGitHubSettings).toHaveBeenCalledTimes(1)
   })
 
+  it('when IPC returns ok=false (authed), helper does NOT mirror to stores and does NOT navigate', async () => {
+    const { deps, updateSession, updateConfig, navigateToGitHubSettings } = buildDeps({
+      profiles: [{ id: 'p-owner', username: 'octocat' }],
+      ipcOk: false,
+    })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    // Main reported a write failure -- don't desync the stores from disk.
+    expect(updateSession).not.toHaveBeenCalled()
+    expect(updateConfig).not.toHaveBeenCalled()
+    // Authed user stays put; the next click of the banner will retry.
+    expect(navigateToGitHubSettings).not.toHaveBeenCalled()
+  })
+
+  it('when IPC returns ok=false (unauthed), helper does NOT mirror to stores AND DOES navigate to Settings', async () => {
+    const { deps, updateSession, updateConfig, navigateToGitHubSettings } = buildDeps({
+      profiles: [],
+      ipcOk: false,
+    })
+
+    await handleAutoDetectAccept('octocat/hello', baseSession, deps)
+
+    // Same desync-prevention as the authed case.
+    expect(updateSession).not.toHaveBeenCalled()
+    expect(updateConfig).not.toHaveBeenCalled()
+    // Unauthed user still gets routed so they can finish setup manually --
+    // losing the write is fine, losing the nav would be worse.
+    expect(navigateToGitHubSettings).toHaveBeenCalledTimes(1)
+  })
+
   it('merges over a pre-existing integration record without dropping prior fields', async () => {
     const session = {
       id: 'sess-1',


### PR DESCRIPTION
## Three bug fixes for v1.5.8-beta

### #436 + #437 -- GH auto-detect 'Use this repo'
The `AutoDetectBanner.onAccept` closure in `App.tsx` was writing the patch only to the live session (via IPC), never to the parent `TerminalConfig.githubIntegration`. So the next spawn from the saved config lost the repo selection. Also, the handler always navigated to Settings, even when the user already had an auth profile.

Extracted the logic into `src/renderer/utils/githubAutoDetectAccept.ts` and fixed both:
- The helper writes to **both** the session AND the parent config (mirroring `SessionGitHubConfig.save`).
- When `profiles.length > 0`, it auto-enables the integration in place with a two-pass profile match (`allowedRepos` exact match, else case-insensitive username); no navigation.
- When no profiles exist, behaviour is unchanged: navigate to Settings to sign in.
- Bails on `ok=false` from the IPC (pre-existing parity bug surfaced by code review).

15 new unit tests covering authed-match, authed-no-match, unauthed-with-nav, IPC failure (resolve + throw), pre-existing field merge, and a DOM click harness.

### #435 -- Codex MCP /messages 404 diagnostics
`POST /messages?sessionId=<sid>` was returning a bare `Session not found` with no logging. When the SSE transport for that sid had been GC'd / dropped / never registered, Claude surfaced the unactionable error mid-session.

Added a pure helper `buildSessionNotFoundResponse` to `conductor-mcp-server.ts` that returns `{ status: 404, body, logMessage }`. The handler now:
- Calls `logError` with the requested sid (8-char prefix), active-transport count, up to 3 sample sid prefixes, and user-agent (capped at 64 chars).
- Returns a multi-line plain-text body with three likely causes and the recovery path ('restart the Claude session inside CCC').
- Adds `Content-Type: text/plain; charset=utf-8` (was previously unset).

13 new unit tests. Underlying connection-recovery work is explicitly deferred; this commit improves diagnostics so the next encounter is debuggable.

## Verification
- `npm run typecheck` clean
- Full vitest sweep: **1204 pass / 1 skip** (gated real-Claude integration test)
- Spec-compliance review: APPROVED on both fixes
- Code-quality review: APPROVED on MCP fix; one IMPORTANT (IPC ok=false bail) addressed in `c56f7da`

## Commits
- `abfc1fc` fix(mcp): diagnostic logging + actionable body on /messages 404 (#435)
- `fcf4154` fix(github): auto-detect "Use this repo" persists to parent config + skips Settings nav when authed (#436 #437)
- `c56f7da` fix(github): bail when updateSessionConfig IPC returns ok=false (review follow-up)
- `d41924e` docs(changelog): v1.5.8 -- GH auto-detect persistence + MCP 404 diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)