### PR TITLE
feat(v1.5.12): Ultracode effort + Disable Workflows toggle + tour/tips

### DIFF
--- a/src/main/hooks/per-session-settings.ts
+++ b/src/main/hooks/per-session-settings.ts
@@ -33,7 +33,15 @@ export function getLocalSessionMcpConfigPath(sessionId: string): string {
  * the docs are ambiguous. Copying every top-level key (not just the keys
  * CCC cares about) is safe under both semantics.
  */
-export function writeLocalSessionSettings(sessionId: string): string {
+export interface WriteSessionSettingsOptions {
+  /** v1.5.12: when true, force `disableWorkflows: true` into the per-session
+   *  settings so Claude Code's dynamic-workflow feature is disabled at boot.
+   *  Caller (pty-manager) reads the CCC AppSettings.disableClaudeWorkflows
+   *  flag and passes it through. */
+  disableWorkflows?: boolean
+}
+
+export function writeLocalSessionSettings(sessionId: string, opts: WriteSessionSettingsOptions = {}): string {
   const claudeDir = path.join(os.homedir(), '.claude')
   try {
     fs.mkdirSync(claudeDir, { recursive: true })
@@ -53,10 +61,17 @@ export function writeLocalSessionSettings(sessionId: string): string {
     /* shared settings may not exist yet (fresh install) -- start empty */
   }
 
-  // Clone every top-level key from shared so injectHooks (when re-enabled)
-  // can overlay the `hooks` key without dropping the user's outputStyle,
-  // permissions, etc.
+  // Clone every top-level key from shared so injectHooks can overlay the
+  // `hooks` key without dropping the user's outputStyle, permissions, etc.
   const sesCfg: Record<string, unknown> = { ...shared }
+
+  // v1.5.12: opt-in disable of CC's dynamic workflows feature. Overrides any
+  // existing value in the shared settings.json -- the CCC toggle is the
+  // authoritative source for newly spawned sessions. Set to undefined would
+  // leave the shared value alone, which is what we want for the off path.
+  if (opts.disableWorkflows) {
+    sesCfg.disableWorkflows = true
+  }
 
   const sesPath = getLocalSessionSettingsPath(sessionId)
   return atomicJsonWrite(sesPath, sesCfg)

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -30,6 +30,7 @@ import { disposeSession as disposeCodexReviewUsage } from './codex-review-usage'
 import { readCodexAccountEmail } from './account-identity'
 import type { AccountIdentity } from '../shared/types'
 import { updateSessionMeta, clearSessionMeta } from './session-registry'
+import { readConfig } from './config-manager'
 
 import * as path from 'path'
 import * as fs from 'fs'
@@ -905,7 +906,14 @@ export function spawnPty(
       const quoteForShell = (p: string): string =>
         os.platform() === 'win32' ? p.replace(/'/g, "''") : p.replace(/'/g, "'\\''")
       try {
-        const sesPath = writeLocalSessionSettings(sessionId)
+        // v1.5.12: thread the CCC AppSettings.disableClaudeWorkflows flag
+        // through so Claude Code's dynamic-workflow feature can be killed
+        // at the per-session level without the user hand-editing
+        // ~/.claude/settings.json. Read fresh on every spawn so a Settings
+        // toggle takes effect on the next session without an app restart.
+        const appSettings = readConfig<{ disableClaudeWorkflows?: boolean }>('settings')
+        const disableWorkflows = !!appSettings?.disableClaudeWorkflows
+        const sesPath = writeLocalSessionSettings(sessionId, { disableWorkflows })
         // Re-enabled in v1.5.11: the permission tray (CC P7-P9, shipped in
         // v1.5.10) is the consumer that was missing when the original
         // disable comment was written. injectHooks rewrites the per-session

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,18 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.12',
+    date: '2026-05-29',
+    highlights: "Day-two Opus 4.8 polish: Ultracode effort level (xhigh + automatic dynamic workflows), a global Disable Claude Code dynamic workflows toggle in Settings > Security, and new tour + tips entries for the Permission Attention Tray and Dynamic Workflows so they actually show up in /help.",
+    changes: [
+      { type: 'feature', description: "Effort dropdown: **Ultracode** option added. Sets `--effort ultracode` so Claude Code (2.1.154+) automatically plans dynamic workflows for every substantive task. Resets when you start a new session" },
+      { type: 'feature', description: "Settings > Security: **Disable Claude Code dynamic workflows** toggle writes `disableWorkflows: true` into the per-session Claude settings so workflows are off for newly spawned sessions. Applies on next spawn; existing sessions keep their setting" },
+      { type: 'feature', description: "Tour: dedicated **Permission Attention Tray** step covering the high-risk Bash patterns, the 50-entry cap, and how the gateway intercepts before Claude runs the command" },
+      { type: 'feature', description: "Tour: dedicated **Dynamic Workflows** step covering the three ways to invoke (workflow keyword, Ultracode, /deep-research), the /workflows progress view, the 1000-subagent cap, and the global disable" },
+      { type: 'improvement', description: "Tips: new entries for the Permission Tray and Dynamic Workflows so the contextual tip system surfaces them after first use" },
+    ],
+  },
+  {
     version: '1.5.11',
     date: '2026-05-29',
     highlights: "Opus 4.8 lands as the new default, with Extra high effort and a Fast mode toggle (2.5x speed at 2x cost). The Permission Attention Tray from v1.5.10 is now actually wired -- v1.5.10 shipped the toast stack but the hook injection was disabled, so no toast ever fired; v1.5.11 fixes the wiring and ties it to Claude Code's real PreToolUse hook.",

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -100,7 +100,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const agentUserTemplates = useAgentLibraryStore(s => s.templates)
   const allAgentTemplates = [...agentUserTemplates, ...BUILTIN_TEMPLATES]
   const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(new Set(initialClaude?.agentIds ?? initial?.agentIds ?? []))
-  type EffortLevelOpt = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | ''
+  type EffortLevelOpt = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode' | ''
   const [effortLevel, setEffortLevel] = useState<EffortLevelOpt>(
     (initialClaude?.effortLevel ?? initial?.effortLevel ?? '') as EffortLevelOpt
   )
@@ -624,6 +624,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                   <option value="high">High -- deep reasoning</option>
                   <option value="xhigh">Extra high -- Opus 4.8 hardest tasks</option>
                   <option value="max">Max -- maximum reasoning budget</option>
+                  <option value="ultracode">Ultracode -- xhigh + automatic workflows (research preview)</option>
                 </select>
               </div>
             )}

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -195,6 +195,16 @@ export default function SettingsPage({ initialTab }: SettingsPageProps = {}) {
                   Skip permission prompts for headless agents
                   <span className="text-[10px] text-overlay0">(--dangerously-skip-permissions)</span>
                 </label>
+                <label className="flex items-center gap-2 text-sm text-subtext0 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={!!settings.disableClaudeWorkflows}
+                    onChange={(e) => save({ disableClaudeWorkflows: e.target.checked })}
+                    className="rounded border-surface1"
+                  />
+                  Disable Claude Code dynamic workflows
+                  <span className="text-[10px] text-overlay0">(applies to new sessions; CC fans out up to 1000 subagents per workflow)</span>
+                </label>
               </Section>
 
               <AccountAliasesSection />

--- a/src/renderer/lib/claude-cli-options.ts
+++ b/src/renderer/lib/claude-cli-options.ts
@@ -24,6 +24,7 @@ export const EFFORTS: OptionItem[] = [
   { label: 'High', value: 'high' },
   { label: 'Extra high', value: 'xhigh' },
   { label: 'Max', value: 'max' },
+  { label: 'Ultracode', value: 'ultracode', hint: 'xhigh + automatic dynamic workflows (Opus 4.8)' },
 ]
 
 export const PERMISSION_MODES: OptionItem[] = [

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -90,6 +90,12 @@ export interface AppSettings {
    *  is canonicalised at write time and is the lookup key into SavedSession
    *  /Session.accountAliasEmail. */
   accountAliases?: import('../../shared/account-alias').AccountAlias[]
+  /** v1.5.12: when true, CCC writes `disableWorkflows: true` into every
+   *  per-session Claude settings file so Claude Code's dynamic-workflow
+   *  feature is disabled at session boot. Affects newly spawned sessions
+   *  only -- in-flight sessions keep whatever setting they started with.
+   *  Off by default; CC's own /config toggle still wins per-session. */
+  disableClaudeWorkflows?: boolean
 }
 
 interface SettingsState {

--- a/src/renderer/tips-library.ts
+++ b/src/renderer/tips-library.ts
@@ -621,6 +621,37 @@ export const TIPS_LIBRARY: Tip[] = [
   },
 
   {
+    id: 'tip.permission-tray',
+    category: 'security',
+    complexity: 'simple',
+    priority: 70,
+    variants: {
+      primary: {
+        shortText: 'High-risk Bash now stacks as a toast',
+        title: 'Permission Attention Tray',
+        body: 'When Claude tries to run a high-risk Bash command -- **rm -rf**, **sudo**, **dd if=**, **chmod 777**, **--force / --force-with-lease**, fork bombs -- it surfaces as a toast in the top-right corner so you can approve or reject without scrolling back through the terminal.\n\nEverything else (Read, Edit, Grep, ls, git status) **auto-allows** so the tray only fires when it matters. Catches commands from dynamic-workflow subagents too.\n\nTray caps at 50 entries; overflow auto-denies so a runaway agent cannot bury you in prompts.',
+        focusHint: 'Top-right corner of the window',
+      },
+    },
+  },
+
+  {
+    id: 'tip.dynamic-workflows',
+    category: 'productivity',
+    complexity: 'advanced',
+    priority: 55,
+    variants: {
+      primary: {
+        shortText: 'Opus 4.8 can orchestrate hundreds of subagents',
+        title: 'Dynamic Workflows',
+        body: 'Opus 4.8 ships **dynamic workflows** -- Claude writes a JavaScript orchestration script on the fly and fans out up to 1,000 parallel subagents in the background while your session stays free.\n\n**Three ways to invoke:**\n- Include the word **workflow** in your prompt\n- Set effort to **Ultracode** in Session Config (auto-orchestrates every task)\n- Run **/deep-research <question>** -- the bundled example\n\nWatch with **/workflows**. Save a run with **s** -- it becomes /<name> in future sessions.\n\nCCC: if you want it off globally, toggle **Disable Claude Code dynamic workflows** in Settings > Security.',
+        actionLabel: 'Open Settings',
+        actionTarget: 'settings',
+      },
+    },
+  },
+
+  {
     id: 'tip.transparency.network-activity',
     category: 'transparency',
     complexity: 'intermediate',

--- a/src/renderer/training-steps.ts
+++ b/src/renderer/training-steps.ts
@@ -446,6 +446,64 @@ export const trainingSteps: TrainingStep[] = [
     screenshotFilename: 'step-tips.jpg',
   },
   {
+    id: 'permission-tray',
+    title: 'Permission Attention Tray',
+    sinceVersion: '1.5.12',
+    section: 'admin',
+    summary:
+      'High-risk Bash commands -- rm -rf, sudo, force-push, dd, mkfs, chmod 777, fork bombs -- stack as toasts in the top-right corner. Approve or reject without scrolling back through the terminal. Everything else auto-allows so the tray only fires when it should.',
+    highlights: [
+      'Toast stack tops out at 50 entries; overflow auto-denies',
+      'Detection runs on Claude Code\'s PreToolUse hook -- the gateway intercepts before Claude executes',
+      'Auto-allow path handles non-Bash tools (Read, Edit, Grep, Write) silently',
+      'High-risk patterns: rm -rf / rm -fr, sudo, dd if=, chmod 777, --force / --force-with-lease, fork bombs',
+      'Toast survives session focus changes -- you can approve from any view',
+    ],
+    howToTrigger: [
+      { label: 'Spawn a Claude session', value: 'Saved Configs → +' },
+      { label: 'Trigger', value: 'Ask Claude to delete files, force-push, sudo, etc.' },
+      { label: 'Approve / reject', value: 'Top-right toast → click or keyboard' },
+    ],
+    proTip:
+      'The tray catches commands that come from dynamic-workflow subagents too -- if a 1000-agent run tries to rm -rf something, the high-risk detection still gates it.',
+    bullets: [
+      '**Toast stack** for high-risk Bash; everything else auto-allows',
+      'Hooks into **PreToolUse** so it fires before Claude actually runs the command',
+      'Patterns: **rm -rf, sudo, force-push, dd, mkfs, chmod 777, fork bombs**',
+      'Overflow (>50) auto-denies so a runaway agent can\'t bury you in prompts',
+    ],
+    screenshotFilename: 'step-security.jpg',
+  },
+  {
+    id: 'dynamic-workflows',
+    title: 'Dynamic Workflows',
+    sinceVersion: '1.5.12',
+    section: 'productivity',
+    summary:
+      'Opus 4.8\'s dynamic workflows orchestrate tens to hundreds of parallel subagents from a JavaScript script Claude writes for you. Run `workflow` in your prompt, set effort to `ultracode`, or use the bundled `/deep-research`. Watch progress via `/workflows`. Caps: 16 concurrent agents, 1000 total per run.',
+    highlights: [
+      'Ask in the prompt: include the word **workflow** and Claude writes one for the task',
+      'Auto-mode: **Ultracode** effort in Session Config + `/effort ultracode` enables auto-orchestration',
+      'Bundled: **`/deep-research <question>`** is the headline preview workflow',
+      'Watch with **`/workflows`** -- per-phase agent counts, token totals, drill-down per agent',
+      'Save with **`s`** in the `/workflows` view -- becomes `/<name>` in future sessions',
+    ],
+    howToTrigger: [
+      { label: 'One-off', value: "include 'workflow' in your prompt" },
+      { label: 'Auto every task', value: 'Session Config → Effort → Ultracode' },
+      { label: 'Disable globally', value: 'Settings → General → Security → Disable Claude Code dynamic workflows' },
+    ],
+    proTip:
+      'Workflows can burn 1000-agent tokens fast. CCC\'s tokenomics still tracks the spend per session and the permission tray still catches any high-risk Bash a subagent tries.',
+    bullets: [
+      '**Background orchestration** -- subagents run in parallel while your session stays free',
+      '**Ultracode** in the effort dropdown enables it automatically for every task',
+      '**/deep-research** is the bundled example; **/workflows** lists active runs',
+      'CCC: **Disable Claude Code dynamic workflows** in Settings -> Security if you want it off',
+    ],
+    screenshotFilename: 'step-agent-hub.jpg',
+  },
+  {
     id: 'github-sidebar',
     title: 'GitHub Sidebar',
     sinceVersion: '1.4.0',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -65,7 +65,7 @@ export interface AccountIdentity {
 
 export interface ClaudeOptions {
   model?: string
-  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
   legacyVersion?: LegacyVersion
   disableAutoMemory?: boolean
   flickerFree?: boolean
@@ -122,7 +122,7 @@ export interface SavedSession {
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   powershellTool?: boolean
   /** @deprecated read from claudeOptions; removed in P1.2+ */
-  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   disableAutoMemory?: boolean
   /**

--- a/tests/unit/training-steps.test.ts
+++ b/tests/unit/training-steps.test.ts
@@ -8,8 +8,9 @@ import {
 
 describe('training-steps', () => {
   describe('trainingSteps array', () => {
-    it('has exactly 15 steps', () => {
-      expect(trainingSteps).toHaveLength(15)
+    it('has exactly 17 steps', () => {
+      // v1.5.12: added permission-tray + dynamic-workflows steps
+      expect(trainingSteps).toHaveLength(17)
     })
 
     it('every step has required fields', () => {


### PR DESCRIPTION
## Summary

Day-two Opus 4.8 polish, all small + scoped.

- **Ultracode** option in the effort dropdown (sets \`--effort ultracode\` so CC 2.1.154+ auto-orchestrates dynamic workflows for every substantive task).
- **Disable Claude Code dynamic workflows** toggle in Settings > Security. Writes \`disableWorkflows: true\` into the per-session Claude settings JSON so workflows are off for newly spawned sessions. Read fresh on every spawn -- flipping it takes effect on the next session.
- **Tour: Permission Attention Tray step** -- the v1.5.11 headline feature didn't have its own tour entry, now does.
- **Tour: Dynamic Workflows step** -- covers the three ways to invoke (workflow keyword, Ultracode, /deep-research), the /workflows progress view, and the 1000-subagent cap.
- **Tips library**: matching primary tips for both features so they surface in the bottom-bar tips system after first use.

## Test plan
- [x] 1338/1338 unit tests pass.
- [x] \`npm run typecheck\` clean.
- [ ] CI green via ci-run.
- [ ] Manual smoke: spawn a Claude session with Ultracode effort and confirm \`/effort\` shows \`ultracode\` active.
- [ ] Manual smoke: toggle Disable Workflows in Settings and verify the next spawned session has \`disableWorkflows: true\` in its \`~/.claude/settings-<sid>.json\`.

## Deferred
- Tokenomics workflow-aware breakdown (separating workflow spend from interactive spend) -- needs visibility into CC 2.1.154's actual JSONL shape for workflow turns. Filed as a follow-up after some real-world tracing.
- Front-facing screenshot recapture + GitHub repo hero polish -- a separate session of work.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>