### PR TITLE
v1.5.16: cross-session Permission Tray + attention flasher fix + freeze diagnostics

### DIFF
--- a/src/main/attention-source.ts
+++ b/src/main/attention-source.ts
@@ -1,0 +1,30 @@
+// src/main/attention-source.ts
+// Drives session.needsAttention for provider (claude/codex) sessions from hook
+// events instead of PTY-output scraping. Replaces the re-fire-prone pulse:
+// detection is now discrete hook events, so leaving/returning to a session does
+// nothing on its own.
+import { getGateway } from './hooks/index'
+import { pushAttention } from './ipc/channel-handlers'
+import type { HookEvent } from '../shared/hook-types'
+
+// true = raise the flasher, false = clear it, null = ignore this event.
+export function attentionForEvent(e: HookEvent): boolean | null {
+  if (e.event === 'Notification') {
+    const t = (e.payload as { notification_type?: string }).notification_type
+    return t === 'idle_prompt' || t === 'permission_prompt' ? true : null
+  }
+  if (e.event === 'UserPromptSubmit' || e.event === 'PreToolUse' || e.event === 'PostToolUse') return false
+  return null
+}
+
+let started = false
+export function startAttentionSource(): void {
+  if (started) return
+  started = true
+  const gw = getGateway()
+  if (!gw) return
+  gw.subscribe((e) => {
+    const v = attentionForEvent(e)
+    if (v !== null) pushAttention(e.sessionId, v)
+  })
+}

--- a/src/main/channel-permissions.ts
+++ b/src/main/channel-permissions.ts
@@ -5,7 +5,7 @@ import { matchApproval } from './standing-approvals-store'
 import { appendLedger } from './channel-ledger'
 import { pushPendingPermissions } from './ipc/channel-handlers'
 import { normalizePermission, decideDisposition } from './permission-core'
-import { resolveResponder } from './permission-responders'
+import { resolveResponder, deregisterResponder } from './permission-responders'
 import type { PendingPermission } from '../shared/channel-types'
 import type { HookEvent } from '../shared/hook-types'
 
@@ -23,13 +23,11 @@ export { registerResponder, deregisterResponder } from './permission-responders'
 
 function isPermissionEvent(e: HookEvent): boolean {
   if (e.event === 'PermissionRequest') return true
-  // v1.5.11: Claude Code's actual permission gate is the PreToolUse hook.
-  // Every tool call flows through; decideDisposition() auto-allows
-  // anything that isn't high-risk Bash so most fan out without UI.
   if (e.event === 'PreToolUse') return true
-  if (e.event === 'Notification' && (e.payload as { notification_type?: string }).notification_type === 'permission_prompt') return true
-  // very-old fallback: a Stop event whose payload text looks like a permission prompt
-  if (e.event === 'Stop' && /permission|allow this tool|approve/i.test(JSON.stringify(e.payload))) return true
+  // Notification(permission_prompt) is NOT a tray card: under the universal gate
+  // CCC decides before Claude would prompt, so it rarely fires; when it does
+  // (a settings ask-rule overriding a hook allow) it is an unanswerable on-screen
+  // prompt -> handled by the attention flasher (attention-source.ts), not here.
   return false
 }
 
@@ -39,14 +37,22 @@ function capture(e: HookEvent): void {
 
   const disposition = decideDisposition(p, (tool) => matchApproval(tool))
   if (disposition === 'auto-allow') {
-    appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'permission-auto-allow', summary: `${p.tool}: ${p.payloadPreview}` })
+    // Only ledger when a standing approval drove the allow (worth a record).
+    // Read-only safelist tools fire on every Read/Grep; ledgering them would
+    // hammer the disk + redactor on the hot path (spec section 4.3).
+    if (matchApproval(p.tool)) {
+      appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'permission-auto-allow', summary: `${p.tool}: ${p.payloadPreview}` })
+    }
     resolveResponder(p.requestId, 'approved')
     return
   }
 
   if (pending.size >= PENDING_CAP) {
-    appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'tray-overflow', summary: `auto-denied (tray full): ${p.tool}` })
-    resolveResponder(p.requestId, 'denied')
+    appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'tray-overflow', summary: `released to Claude (tray full): ${p.tool}` })
+    // Release to Claude's own prompt rather than denying real work. Resolving with
+    // 'approved' would auto-run it; instead drop the responder so the held-open
+    // response times out -> {} -> Claude falls back to its in-terminal prompt.
+    deregisterResponder(p.requestId)
     return
   }
 

--- a/src/main/channel-permissions.ts
+++ b/src/main/channel-permissions.ts
@@ -5,7 +5,7 @@ import { matchApproval } from './standing-approvals-store'
 import { appendLedger } from './channel-ledger'
 import { pushPendingPermissions } from './ipc/channel-handlers'
 import { normalizePermission, decideDisposition } from './permission-core'
-import { resolveResponder, deregisterResponder } from './permission-responders'
+import { resolveResponder } from './permission-responders'
 import type { PendingPermission } from '../shared/channel-types'
 import type { HookEvent } from '../shared/hook-types'
 
@@ -49,10 +49,10 @@ function capture(e: HookEvent): void {
 
   if (pending.size >= PENDING_CAP) {
     appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'tray-overflow', summary: `released to Claude (tray full): ${p.tool}` })
-    // Release to Claude's own prompt rather than denying real work. Resolving with
-    // 'approved' would auto-run it; instead drop the responder so the held-open
-    // response times out -> {} -> Claude falls back to its in-terminal prompt.
-    deregisterResponder(p.requestId)
+    // Release to Claude's own prompt rather than denying real work. 'defer' closes
+    // the held-open response with an empty body IMMEDIATELY (no 120s stall), so
+    // Claude falls back to its in-terminal prompt right away.
+    resolveResponder(p.requestId, 'defer')
     return
   }
 

--- a/src/main/channel-permissions.ts
+++ b/src/main/channel-permissions.ts
@@ -4,7 +4,7 @@ import { getSessionMeta } from './session-registry'
 import { matchApproval } from './standing-approvals-store'
 import { appendLedger } from './channel-ledger'
 import { pushPendingPermissions } from './ipc/channel-handlers'
-import { normalizePermission, decideDisposition } from './permission-core'
+import { normalizePermission, decideDisposition, isReadOnlyTool } from './permission-core'
 import { resolveResponder } from './permission-responders'
 import type { PendingPermission } from '../shared/channel-types'
 import type { HookEvent } from '../shared/hook-types'
@@ -38,9 +38,11 @@ function capture(e: HookEvent): void {
   const disposition = decideDisposition(p, (tool) => matchApproval(tool))
   if (disposition === 'auto-allow') {
     // Only ledger when a standing approval drove the allow (worth a record).
-    // Read-only safelist tools fire on every Read/Grep; ledgering them would
-    // hammer the disk + redactor on the hot path (spec section 4.3).
-    if (matchApproval(p.tool)) {
+    // A non-safelist auto-allow can ONLY have come from a standing approval, so
+    // a cheap Set check (isReadOnlyTool) avoids a second matchApproval() disk
+    // read on the hot path. Read-only safelist tools fire on every Read/Grep and
+    // are intentionally not ledgered (spec section 4.3).
+    if (!isReadOnlyTool(p.tool)) {
       appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'permission-auto-allow', summary: `${p.tool}: ${p.payloadPreview}` })
     }
     resolveResponder(p.requestId, 'approved')

--- a/src/main/clipboard-image.ts
+++ b/src/main/clipboard-image.ts
@@ -1,4 +1,5 @@
 import { clipboard, type NativeImage } from 'electron'
+import { logInfo } from './debug-logger'
 
 /**
  * Read an image off the clipboard, retrying briefly when the first read comes
@@ -29,11 +30,18 @@ export async function readClipboardImageWithRetry(
   sleep: (ms: number) => Promise<void> = (ms) =>
     new Promise((resolve) => setTimeout(resolve, ms)),
 ): Promise<NativeImage | null> {
+  const __t0 = Date.now()
   const tries = Math.max(1, attempts)
   for (let i = 0; i < tries; i++) {
     const img = clipboard.readImage()
-    if (!img.isEmpty()) return img
+    if (!img.isEmpty()) {
+      const __dt = Date.now() - __t0
+      if (__dt > 150) logInfo(`[perf] clipboard-image processing took ${__dt}ms`)
+      return img
+    }
     if (i < tries - 1) await sleep(delayMs)
   }
+  const __dt = Date.now() - __t0
+  if (__dt > 150) logInfo(`[perf] clipboard-image processing took ${__dt}ms`)
   return null
 }

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -52,6 +52,7 @@ export class HooksGateway {
   private buffers = new Map<string, RingBufferEntry[]>()
   private overflowLatched = new Set<string>()
   private subscribers = new Set<(e: HookEvent) => void>()
+  private gateActive = false
 
   constructor(opts: HooksGatewayOptions) {
     this.defaultPort = opts.defaultPort ?? DEFAULT_HOOKS_PORT
@@ -62,6 +63,11 @@ export class HooksGateway {
     this.subscribers.add(cb)
     return () => { this.subscribers.delete(cb) }
   }
+
+  // When true, the held-open + responder path applies to EVERY PreToolUse (so the
+  // tray can Allow/Deny any tool), not just Bash. Default false so a live gateway
+  // with no renderer mounted to answer does not hold tool calls open for 120s.
+  setPermissionGateActive(active: boolean): void { this.gateActive = active }
 
   // Test seam: runs the post-redaction dispatch path without HTTP.
   dispatchForTest(event: HookEvent): void { this.fanOut(event) }
@@ -243,7 +249,8 @@ export class HooksGateway {
         ? (peeked.tool_name as string)
         : typeof peeked.toolName === 'string' ? (peeked.toolName as string) : undefined
       const isPreToolUseBash = peeked.event === 'PreToolUse' && peekedToolName === 'Bash'
-      if (peeked.event === 'PermissionRequest' || isPreToolUseBash) {
+      const isHeldOpenTool = isPreToolUseBash || (this.gateActive && peeked.event === 'PreToolUse')
+      if (peeked.event === 'PermissionRequest' || isHeldOpenTool) {
         isPermissionRequest = true
         const payload = peeked.payload && typeof peeked.payload === 'object'
           ? (peeked.payload as Record<string, unknown>)

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -239,13 +239,12 @@ export class HooksGateway {
       const peeked = JSON.parse(body) as Record<string, unknown>
       // v1.5.11: Claude Code's actual permission hook fires as 'PreToolUse'
       // (legacy 'PermissionRequest' kept for forward compatibility with any
-      // future CC release that adopts the spec name). Held-open response
-      // treatment is scoped to PermissionRequest OR PreToolUse for the
-      // Bash tool -- the only tool channel-permissions classifies. Every
-      // other PreToolUse goes through the fire-and-forget ingest path, so
-      // Claude Code's own permission UI keeps gating non-Bash tools and
-      // unsubscribed environments (tests, headless smoke) don't hang on
-      // the 120s held-open timeout.
+      // future CC release that adopts the spec name). Held-open scope: Bash
+      // PreToolUse is ALWAYS held open (back-compat); v1.5.16 broadens this to
+      // EVERY PreToolUse once `gateActive` is true (see setPermissionGateActive,
+      // flipped on renderer-ready), so the tray can Allow/Deny any tool. While
+      // gateActive is false (no renderer mounted, tests, headless smoke) non-Bash
+      // PreToolUse stays fire-and-forget and nothing hangs on the 120s timeout.
       const peekedToolName = typeof peeked.tool_name === 'string'
         ? (peeked.tool_name as string)
         : typeof peeked.toolName === 'string' ? (peeked.toolName as string) : undefined
@@ -295,7 +294,12 @@ export class HooksGateway {
           clearTimeout(timeout)
           try {
             capturedRes.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'close' })
-            capturedRes.end(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: decision === 'approved' ? 'allow' : 'deny' } }))
+            // 'defer' -> empty 2xx body = no decision, Claude proceeds with its own
+            // permission flow (used on tray overflow so the call is NOT stalled for
+            // the full 120s timeout). Otherwise emit the allow/deny decision.
+            capturedRes.end(decision === 'defer'
+              ? '{}'
+              : JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: decision === 'approved' ? 'allow' : 'deny' } }))
           } catch { /* response already closed; CC falls back to its own UI */ }
           // note: responder entry deleted by resolvePending in channel-permissions.ts
         })

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -249,15 +249,26 @@ export class HooksGateway {
       const peekedToolName = typeof peeked.tool_name === 'string'
         ? (peeked.tool_name as string)
         : typeof peeked.toolName === 'string' ? (peeked.toolName as string) : undefined
-      const isPreToolUseBash = peeked.event === 'PreToolUse' && peekedToolName === 'Bash'
-      const isHeldOpenTool = isPreToolUseBash || (this.gateActive && peeked.event === 'PreToolUse')
-      if (peeked.event === 'PermissionRequest' || isHeldOpenTool) {
+      // Claude Code's real hook POST uses `hook_event_name` (not `event`) and
+      // snake_case fields; accept both so the gateway works with the live CLI as
+      // well as the spec'd PermissionRequest shape used by tests.
+      const peekedEvent = typeof peeked.hook_event_name === 'string'
+        ? (peeked.hook_event_name as string)
+        : typeof peeked.event === 'string' ? (peeked.event as string) : undefined
+      const isPreToolUseBash = peekedEvent === 'PreToolUse' && peekedToolName === 'Bash'
+      const isHeldOpenTool = isPreToolUseBash || (this.gateActive && peekedEvent === 'PreToolUse')
+      if (peekedEvent === 'PermissionRequest' || isHeldOpenTool) {
         isPermissionRequest = true
         const payload = peeked.payload && typeof peeked.payload === 'object'
           ? (peeked.payload as Record<string, unknown>)
           : peeked
-        const rid = typeof payload.requestId === 'string' ? payload.requestId : undefined
-        permissionRequestId = rid ?? `${String(peeked.sessionId ?? 'unknown')}-${Date.now()}`
+        // Prefer Claude's real per-call id `tool_use_id`; fall back to the spec'd
+        // `requestId`, then a synthetic id. Using the same field the pending card
+        // derives its id from keeps the responder key and the card key in lockstep.
+        const rid = typeof payload.tool_use_id === 'string'
+          ? (payload.tool_use_id as string)
+          : typeof payload.requestId === 'string' ? (payload.requestId as string) : undefined
+        permissionRequestId = rid ?? `${String(peeked.session_id ?? peeked.sessionId ?? 'unknown')}-${Date.now()}`
         const capturedRes = res
         const capturedId = permissionRequestId
         let done = false
@@ -372,8 +383,14 @@ export class HooksGateway {
     // is the only in-tree caller that hits this; returning early means
     // it gets dropped silently, matching the spec's "strict contract"
     // posture.
-    if (typeof parsed.event !== 'string') return
-    const event = parsed.event as HookEventKind
+    // Accept Claude Code's real `hook_event_name` as well as the spec'd `event`.
+    // Without this the gateway silently drops EVERY live hook (CC sends
+    // `hook_event_name`), which is why the events feed + tray appeared dead.
+    const eventName = typeof parsed.hook_event_name === 'string'
+      ? (parsed.hook_event_name as string)
+      : typeof parsed.event === 'string' ? (parsed.event as string) : undefined
+    if (eventName === undefined) return
+    const event = eventName as HookEventKind
     const toolName =
       typeof parsed.tool_name === 'string'
         ? (parsed.tool_name as string)

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -276,7 +276,7 @@ export class HooksGateway {
           clearTimeout(timeout)
           try {
             capturedRes.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'close' })
-            capturedRes.end(JSON.stringify({ hookSpecificOutput: { permissionDecision: decision === 'approved' ? 'approved' : 'deny' } }))
+            capturedRes.end(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: decision === 'approved' ? 'allow' : 'deny' } }))
           } catch { /* response already closed; CC falls back to its own UI */ }
           // note: responder entry deleted by resolvePending in channel-permissions.ts
         })

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -18,6 +18,7 @@ import type {
 // the old lazy-require workaround for the channel-permissions circular
 // dependency is no longer needed (#483).
 import { registerResponder, deregisterResponder } from '../permission-responders'
+import { logDebug } from '../debug-logger'
 
 // Cap the incoming HTTP body at 256 KiB. Claude Code hook payloads top out
 // around a few KB; anything beyond this is either a misbehaving client or
@@ -290,11 +291,30 @@ export class HooksGateway {
       }
     } catch { /* not valid JSON — fall through to normal path which will 400 */ }
 
+    // The held-open responder is keyed by `permissionRequestId`. Downstream, the
+    // pending tray card derives its own id from `payload.requestId` (falling back
+    // to `${sessionId}-${entry.ts}`). Claude Code's real PreToolUse hook sends NO
+    // requestId, so without this both sides would invent DIFFERENT synthetic ids
+    // (two separate Date.now() reads) and Allow/Deny would target a responder that
+    // does not exist -> the request silently stalls until the 120s timeout. Inject
+    // the resolved id into the body so ingest -> normalizePermission key the card
+    // on the SAME value we registered the responder under.
+    let ingestBody = body
+    if (isPermissionRequest && permissionRequestId) {
+      try {
+        const obj = JSON.parse(body) as Record<string, unknown>
+        const pl = (obj.payload && typeof obj.payload === 'object')
+          ? (obj.payload as Record<string, unknown>)
+          : obj
+        if (pl.requestId == null) { pl.requestId = permissionRequestId; ingestBody = JSON.stringify(obj) }
+      } catch { /* keep original body; the normal path will 400 on bad JSON */ }
+    }
+
     const result = await this._handleRequestForTest({
       remoteAddress: req.socket.remoteAddress,
       url: req.url,
       headers: req.headers as Record<string, string | string[] | undefined>,
-      body,
+      body: ingestBody,
     })
 
     // For PermissionRequest events that passed auth, the response is held open
@@ -338,6 +358,12 @@ export class HooksGateway {
   }
 
   private ingest(sid: string, parsed: Record<string, unknown>): void {
+    // Diagnostic (verbose only): log the raw shape of every incoming hook POST
+    // BEFORE the strict `event` check below drops anything. This reveals exactly
+    // what Claude Code sends (e.g. `event` vs `hook_event_name`), which the unit
+    // tests cannot, and is the fastest way to confirm the gateway parses CC's
+    // real PreToolUse during the dev-demo permission round-trip.
+    logDebug(`[hooks] ingest sid=${sid} keys=[${Object.keys(parsed).join(',')}] event=${String(parsed.event)} hook_event_name=${String((parsed as Record<string, unknown>).hook_event_name)} tool_name=${String(parsed.tool_name)}`)
     // Reject payloads with a missing/non-string event field rather than
     // forging an 'Unknown' sentinel: the shared HookEventKind union
     // doesn't include it, so forging would propagate a type-contract

--- a/src/main/hooks/session-hooks-writer.ts
+++ b/src/main/hooks/session-hooks-writer.ts
@@ -11,6 +11,7 @@ export const MVP_EVENTS: HookEventKind[] = [
   'Notification',
   'SessionStart',
   'Stop',
+  'UserPromptSubmit',
 ]
 
 export interface InjectArgs {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import { registerChannelHandlers } from './ipc/channel-handlers'
 import { startRulesEngine } from './channel-rules'
 import { startPermissionTray } from './channel-permissions'
 import { startAttentionSource } from './attention-source'
+import { startJankDetector } from './jank-detector'
 import { readClipboardImageWithRetry } from './clipboard-image'
 import { HooksGateway } from './hooks/hooks-gateway'
 import { setGateway, getGateway } from './hooks'
@@ -650,6 +651,7 @@ if (!gotTheLock) {
     setGateway(hooksGateway)
     startPermissionTray()
     startAttentionSource()
+    startJankDetector()
     registerHooksHandlers(hooksGateway)
     if (hooksEnabled) {
       cleanupStaleHookEntries(new Set())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ import { registerCodexReviewHandlers } from './ipc/codex-review-handlers'
 import { registerChannelHandlers } from './ipc/channel-handlers'
 import { startRulesEngine } from './channel-rules'
 import { startPermissionTray } from './channel-permissions'
+import { startAttentionSource } from './attention-source'
 import { readClipboardImageWithRetry } from './clipboard-image'
 import { HooksGateway } from './hooks/hooks-gateway'
 import { setGateway, getGateway } from './hooks'
@@ -648,6 +649,7 @@ if (!gotTheLock) {
     })
     setGateway(hooksGateway)
     startPermissionTray()
+    startAttentionSource()
     registerHooksHandlers(hooksGateway)
     if (hooksEnabled) {
       cleanupStaleHookEntries(new Set())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -399,12 +399,21 @@ function createWindow(): void {
     // after the window gains focus, which was the "no image detected" miss.
     const img = await readClipboardImageWithRetry()
     if (!img) return null
+    // [perf] resize + JPEG encode is the suspected clipboard-paste freeze; time it
+    // with the source dimensions, since cost scales with input size.
+    const __t0 = Date.now()
     const resized = constrainToMaxDim(img, 1920)
+    const jpeg = resized.toJPEG(85)
+    const __dt = Date.now() - __t0
+    if (__dt > 150) {
+      const s = img.getSize()
+      logInfo(`[perf] clipboard-image resize+encode took ${__dt}ms (${s.width}x${s.height})`)
+    }
     const screenshotsDir = join(getResourcesDirectory(), 'screenshots')
     if (!existsSync(screenshotsDir)) mkdirSync(screenshotsDir, { recursive: true })
     const filename = `clipboard-${Date.now()}-${randomBytes(4).toString('hex')}.jpg`
     const filePath = join(screenshotsDir, filename)
-    writeFileSync(filePath, resized.toJPEG(85))
+    writeFileSync(filePath, jpeg)
     return filePath
   })
 

--- a/src/main/ipc/channel-handlers.ts
+++ b/src/main/ipc/channel-handlers.ts
@@ -7,11 +7,17 @@ import { loadApprovals, addApproval, removeApproval } from '../standing-approval
 import { getFeatureState, setKillSwitch, markIntroShown } from '../channel-feature-state'
 import { respondPermission } from '../channel-permissions'
 import { getCapabilityDiagnostics, forceTier } from '../channel-capability'
+import { getGateway } from '../hooks/index'
 import type { LedgerRecord, PendingPermission } from '../../shared/channel-types'
 
 // main -> renderer push helpers (broadcast to all windows)
 export function pushPendingPermissions(list: PendingPermission[]): void {
   for (const w of BrowserWindow.getAllWindows()) w.webContents.send(IPC.CHANNELS_PENDING_PERMISSIONS, list)
+}
+export function pushAttention(sessionId: string, needsAttention: boolean): void {
+  for (const w of BrowserWindow.getAllWindows()) {
+    try { w.webContents.send(IPC.CHANNELS_ATTENTION, { sessionId, needsAttention }) } catch { /* destroyed */ }
+  }
 }
 export function pushLedgerEvent(record: LedgerRecord): void {
   for (const w of BrowserWindow.getAllWindows()) w.webContents.send(IPC.CHANNELS_LEDGER_EVENT, record)
@@ -42,4 +48,11 @@ export function registerChannelHandlers(): void {
   ipcMain.handle(IPC.CHANNELS_CAPABILITY_DIAGNOSTICS, () => getCapabilityDiagnostics())
   ipcMain.handle(IPC.CHANNELS_INTRO_DISMISSED, () => { markIntroShown(); return getFeatureState() })
   ipcMain.handle(IPC.CHANNELS_KILL_SWITCH, (_e, p) => { setKillSwitch(!!p.disabled); return getFeatureState() })
+  ipcMain.handle(IPC.CHANNELS_RENDERER_READY, () => {
+    // Renderer has mounted its pending-permissions + attention listeners. Safe to
+    // make CCC the universal permission gate now (before this, non-Bash tools stay
+    // fire-and-forget so nothing holds open with no UI to answer).
+    getGateway()?.setPermissionGateActive(true)
+    return { ok: true }
+  })
 }

--- a/src/main/jank-detector.ts
+++ b/src/main/jank-detector.ts
@@ -1,0 +1,30 @@
+// src/main/jank-detector.ts
+// A self-rescheduling timer measures how late each tick is vs its scheduled
+// interval. A large gap means the event loop was blocked (a freeze). Logs via
+// logInfo so it is always captured.
+import { logInfo } from './debug-logger'
+
+const INTERVAL_MS = 250
+const STALL_FACTOR = 4   // log when actual gap > 4x expected (>1s here)
+
+export function reportIfStalled(actualGap: number, expected: number, log: (m: string) => void, label: string): void {
+  if (actualGap > expected * STALL_FACTOR) {
+    log(`[jank] main loop stalled ${Math.round(actualGap)}ms (expected ~${expected}ms) near ${label}`)
+  }
+}
+
+let timer: ReturnType<typeof setTimeout> | null = null
+let last = 0
+export function startJankDetector(now: () => number = () => performance.now()): void {
+  if (timer) return
+  last = now()
+  const tick = () => {
+    const t = now()
+    reportIfStalled(t - last, INTERVAL_MS, (m) => logInfo(m), 'tick')
+    last = t
+    timer = setTimeout(tick, INTERVAL_MS)
+    timer.unref?.()
+  }
+  timer = setTimeout(tick, INTERVAL_MS)
+  timer.unref?.()
+}

--- a/src/main/permission-core.ts
+++ b/src/main/permission-core.ts
@@ -33,12 +33,15 @@ export function normalizePermission(e: HookEvent, info: SessionInfo, transport: 
   // `command`/`arguments` fields the spec'd PermissionRequest event used.
   const pl = e.payload as {
     tool?: string; arguments?: string; command?: string; reason?: string; requestId?: string;
-    tool_input?: { command?: string }
+    tool_use_id?: string; tool_input?: { command?: string; file_path?: string }
   }
   const tool = pl.tool ?? e.toolName ?? 'unknown'
-  const preview = String(pl.arguments ?? pl.command ?? pl.tool_input?.command ?? '')
+  // Claude's tool_input carries the command (Bash) or file_path (Edit/Write/Read).
+  const preview = String(pl.arguments ?? pl.command ?? pl.tool_input?.command ?? pl.tool_input?.file_path ?? '')
   return {
-    requestId: pl.requestId ?? `${e.sessionId}-${e.ts}`,
+    // tool_use_id is Claude's real stable per-call id; it MUST match the responder
+    // key the gateway registered (hooks-gateway peek) or Allow/Deny no-ops.
+    requestId: pl.tool_use_id ?? pl.requestId ?? `${e.sessionId}-${e.ts}`,
     sessionId: e.sessionId,
     sessionLabel: info.label,
     identityColorKey: info.identityColorKey,

--- a/src/main/permission-core.ts
+++ b/src/main/permission-core.ts
@@ -54,11 +54,18 @@ export function normalizePermission(e: HookEvent, info: SessionInfo, transport: 
 }
 
 export type Disposition = 'auto-allow' | 'show'
-export function decideDisposition(p: PendingPermission, _hasStandingApproval: (tool: string) => boolean): Disposition {
-  // v1.5.11: the gateway is wired to CC's PreToolUse hook, so every tool
-  // call flows through here. Show the tray ONLY for the dangerous Bash
-  // patterns detectHighRisk recognises; auto-allow everything else so the
-  // user isn't drowned in prompts for ls/cat/Read/Edit.
-  if (p.highRisk) return 'show'
-  return 'auto-allow'
+
+// Tools with no external effect: auto-approved silently so the tray isn't a wall
+// of cards in an agent loop. TodoWrite mutates only the internal todo list (no
+// external effect) and is included deliberately. Everything not listed SHOWS
+// (err toward surfacing). High-risk is always shown regardless.
+const AUTO_ALLOW_TOOLS = new Set<string>([
+  'Read', 'Glob', 'Grep', 'LS', 'NotebookRead', 'BashOutput', 'TodoWrite',
+])
+
+export function decideDisposition(p: PendingPermission, hasStandingApproval: (tool: string) => boolean): Disposition {
+  if (p.highRisk) return 'show'                  // safety: never auto-allow a destructive payload
+  if (hasStandingApproval(p.tool)) return 'auto-allow'
+  if (AUTO_ALLOW_TOOLS.has(p.tool)) return 'auto-allow'
+  return 'show'
 }

--- a/src/main/permission-core.ts
+++ b/src/main/permission-core.ts
@@ -66,9 +66,16 @@ const AUTO_ALLOW_TOOLS = new Set<string>([
   'Read', 'Glob', 'Grep', 'LS', 'NotebookRead', 'BashOutput', 'TodoWrite',
 ])
 
+/** True for the read-only safelist (a cheap Set check; no disk IO). */
+export function isReadOnlyTool(tool: string): boolean { return AUTO_ALLOW_TOOLS.has(tool) }
+
 export function decideDisposition(p: PendingPermission, hasStandingApproval: (tool: string) => boolean): Disposition {
   if (p.highRisk) return 'show'                  // safety: never auto-allow a destructive payload
-  if (hasStandingApproval(p.tool)) return 'auto-allow'
+  // Safelist BEFORE standing approvals: the safelist is a Set lookup, while
+  // hasStandingApproval reads standing-approvals.json from disk. The hottest
+  // tools (Read/Grep/Glob) are on the safelist, so this keeps the universal
+  // gate off the disk on its hot path.
   if (AUTO_ALLOW_TOOLS.has(p.tool)) return 'auto-allow'
+  if (hasStandingApproval(p.tool)) return 'auto-allow'
   return 'show'
 }

--- a/src/main/permission-responders.ts
+++ b/src/main/permission-responders.ts
@@ -7,7 +7,10 @@
 // is a clean DAG; channel-permissions -> hooks/index back to channel-permissions
 // is what the lazy `require` in the gateway used to dodge).
 
-export type PermissionDecision = 'approved' | 'denied'
+// 'defer' = close the held-open response with an empty body so Claude Code
+// proceeds with its OWN permission flow (used when the tray is full and we
+// cannot surface another card). It is NOT an allow and NOT a deny.
+export type PermissionDecision = 'approved' | 'denied' | 'defer'
 type Responder = (decision: PermissionDecision) => void
 
 const responders = new Map<string, Responder>()

--- a/src/main/tokenomics-manager.ts
+++ b/src/main/tokenomics-manager.ts
@@ -681,6 +681,7 @@ export async function seedTokenomics(
   if (isSeeding) return loadData()
   isSeeding = true
 
+  const __t0 = Date.now()
   logInfo('[tokenomics] Starting seed...')
   const data = loadData()
 
@@ -770,6 +771,8 @@ export async function seedTokenomics(
   } catch (err) {
     logError(`[tokenomics] Seed failed: ${err}`)
   } finally {
+    const __dt = Date.now() - __t0
+    if (__dt > 250) logInfo(`[perf] tokenomics scan took ${__dt}ms`)
     isSeeding = false
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -200,6 +200,8 @@ export interface ElectronAPI {
     killSwitch: (p: unknown) => Promise<unknown>
     onPendingPermissions: (cb: (list: unknown) => void) => () => void
     onLedgerEvent: (cb: (r: unknown) => void) => () => void
+    rendererReady: () => Promise<unknown>
+    onAttention: (cb: (p: { sessionId: string; needsAttention: boolean }) => void) => () => void
   }
 }
 
@@ -695,6 +697,12 @@ const electronAPI: ElectronAPI = {
       const fn = (_e: unknown, r: unknown) => cb(r)
       ipcRenderer.on(IPC.CHANNELS_LEDGER_EVENT, fn)
       return () => ipcRenderer.removeListener(IPC.CHANNELS_LEDGER_EVENT, fn)
+    },
+    rendererReady: () => ipcRenderer.invoke(IPC.CHANNELS_RENDERER_READY),
+    onAttention: (cb: (p: { sessionId: string; needsAttention: boolean }) => void) => {
+      const fn = (_e: unknown, p: { sessionId: string; needsAttention: boolean }) => cb(p)
+      ipcRenderer.on(IPC.CHANNELS_ATTENTION, fn)
+      return () => ipcRenderer.removeListener(IPC.CHANNELS_ATTENTION, fn)
     },
   },
 }

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.16',
+    date: '2026-05-30',
+    changes: [
+      { type: 'feature', description: 'Permission tray: approve or deny any tool request from one place, across all sessions' },
+      { type: 'improvement', description: 'Attention indicator no longer re-fires when you revisit a session' },
+      { type: 'fix', description: 'Effort level now shows permanently in the status line' },
+      { type: 'fix', description: 'Settings toggles no longer overlap their labels' },
+    ],
+  },
+  {
     version: '1.5.15',
     date: '2026-05-29',
     highlights: "Removes the per-session account alias feature. Showing which Claude account a session is on is not reliable without isolating each session's config (which would fragment your shared memory and settings), so the alias label on session rows, the right-click Account tagging, and the Settings account-alias list are gone. Per-account spend tracking on the Tokenomics page is unaffected.",

--- a/src/renderer/components/SessionStatusStrip.tsx
+++ b/src/renderer/components/SessionStatusStrip.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useSessionStore } from '../stores/sessionStore'
+import { useSessionStore, type Session } from '../stores/sessionStore'
 import { useSettingsStore, DEFAULT_STATUS_LINE } from '../stores/settingsStore'
 import RateLimitBar from './terminal/RateLimitBar'
 import { formatResetTime, formatTokens, formatDuration } from '../utils/terminalFormatting'
@@ -36,6 +36,7 @@ const CONTROL_PILL =
 // THIS terminal's session -- not whatever the globally-active session is.
 export default function SessionStatusStrip({ sessionId }: SessionStatusStripProps) {
   const session = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId) || null)
+  const updateSession = useSessionStore((s) => s.updateSession)
   const sl = useSettingsStore((s) => s.settings.statusLine) || DEFAULT_STATUS_LINE
   const codexReview = useCodexReviewUsage(session?.enableCodexReview ? sessionId : null)
   const { restart } = useRestartSession(session, false)
@@ -58,6 +59,11 @@ export default function SessionStatusStrip({ sessionId }: SessionStatusStripProp
       write(`/model ${v}\n`)
     } else {
       setLastEffort(v)
+      // Persist the chosen effort on the session so it shows (and stays) in the
+      // status strip next to the model name. Without this, /effort was written to
+      // the PTY but session.effortLevel never updated, so the strip showed nothing
+      // after a mid-session effort change.
+      updateSession(sessionId, { effortLevel: v as Session['effortLevel'] })
       write(`/effort ${v}\n`)
     }
     setOpenPicker(null)

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -704,7 +704,7 @@ export function Toggle({ on, onClick, label }: { on: boolean; onClick: () => voi
       onClick={onClick}
       aria-pressed={on}
       aria-label={label}
-      className="relative w-11 h-6 rounded-full transition-colors duration-200"
+      className="relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200"
       style={{ background: on ? 'var(--status-success)' : 'var(--surface-overlay)' }}
     >
       <span

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -333,7 +333,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // #406: focus in/out + cursor/mouse reports arrive via onData too. Only a real
         // keystroke/paste should un-ack the attention pulse, else leaving a session
         // re-arms the pulse without the user typing anything.
-        if (!isControlReportOnly(data)) attentionAckedRef.current = false
+        // Shell-only sessions have no Claude hooks, so the attention flasher still
+        // comes from PTY output; un-ack on real keystrokes. Provider sessions use
+        // the hook-driven attention source (attention-source.ts) instead.
+        if (session?.shellOnly && !isControlReportOnly(data)) attentionAckedRef.current = false
         window.electronAPI.pty.write(sessionId, data)
       })
 
@@ -398,7 +401,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           // started a new task."
           if (attentionTimerRef.current) clearTimeout(attentionTimerRef.current)
           const promptPattern = /[❯$#>]\s*$|\(y\/n\)\s*$|\?\s*$|Do you want|Yes\/No|Accept\?|approve/i
-          if (promptPattern.test(stripped.trim()) && !attentionAckedRef.current) {
+          if (session?.shellOnly && promptPattern.test(stripped.trim()) && !attentionAckedRef.current) {
             attentionTimerRef.current = setTimeout(() => {
               attentionTimerRef.current = null
               // needsAttention: only for inactive tabs (controls tab notification dot)

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -336,7 +336,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // Shell-only sessions have no Claude hooks, so the attention flasher still
         // comes from PTY output; un-ack on real keystrokes. Provider sessions use
         // the hook-driven attention source (attention-source.ts) instead.
-        if (session?.shellOnly && !isControlReportOnly(data)) attentionAckedRef.current = false
+        if (shellOnly && !isControlReportOnly(data)) attentionAckedRef.current = false
         window.electronAPI.pty.write(sessionId, data)
       })
 
@@ -401,7 +401,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           // started a new task."
           if (attentionTimerRef.current) clearTimeout(attentionTimerRef.current)
           const promptPattern = /[❯$#>]\s*$|\(y\/n\)\s*$|\?\s*$|Do you want|Yes\/No|Accept\?|approve/i
-          if (session?.shellOnly && promptPattern.test(stripped.trim()) && !attentionAckedRef.current) {
+          if (shellOnly && promptPattern.test(stripped.trim()) && !attentionAckedRef.current) {
             attentionTimerRef.current = setTimeout(() => {
               attentionTimerRef.current = null
               // needsAttention: only for inactive tabs (controls tab notification dot)

--- a/src/renderer/components/channels/PermissionToast.tsx
+++ b/src/renderer/components/channels/PermissionToast.tsx
@@ -7,7 +7,7 @@ import type { PendingPermission } from '../../../shared/channel-types'
 
 interface Props {
   p: PendingPermission; focused: boolean
-  onAllow: () => void; onDeny: () => void; onAllowOnce: () => void
+  onAllow: () => void; onDeny: () => void
 }
 export function PermissionToast({ p, focused, onAllow, onDeny }: Props) {
   const theme = getResolvedTheme()

--- a/src/renderer/components/channels/PermissionToast.tsx
+++ b/src/renderer/components/channels/PermissionToast.tsx
@@ -2,13 +2,14 @@
 import React from 'react'
 import { resolveIdentityColor } from '../../../shared/identity-colors'
 import { getResolvedTheme } from '../../utils/resolvedTheme'
+import { useSessionStore } from '../../stores/sessionStore'
 import type { PendingPermission } from '../../../shared/channel-types'
 
 interface Props {
   p: PendingPermission; focused: boolean
   onAllow: () => void; onDeny: () => void; onAllowOnce: () => void
 }
-export function PermissionToast({ p, focused, onAllow, onDeny, onAllowOnce }: Props) {
+export function PermissionToast({ p, focused, onAllow, onDeny }: Props) {
   const theme = getResolvedTheme()
   const rail = p.identityColorKey ? resolveIdentityColor(p.identityColorKey as any, theme) : 'var(--text-muted)'
   const tierBadge = p.tierLabel === 'channel-relay' ? 'via channel-relay' : p.tierLabel === 'hooks' ? 'via hooks' : null
@@ -28,13 +29,16 @@ export function PermissionToast({ p, focused, onAllow, onDeny, onAllowOnce }: Pr
         <div className="mt-1.5 text-[11px] text-subtext0">{p.tool}:</div>
         <pre className="text-[11px] font-mono text-text whitespace-pre-wrap break-all max-h-16 overflow-hidden">{p.payloadPreview}</pre>
         {p.reason && <div className="mt-1 text-[11px] italic text-subtext0">{p.reason}</div>}
-        <div className="mt-2 flex gap-2">
+        <div className="mt-2 flex items-center gap-2">
           <button onClick={onAllow} autoFocus={focused && !p.highRisk}
             className="px-2 py-1 rounded text-[11px] bg-surface1 hover:bg-surface2 text-text">Allow {String.fromCodePoint(0x21B5)}</button>
           <button onClick={onDeny} autoFocus={focused && !!p.highRisk}
             className="px-2 py-1 rounded text-[11px] bg-surface1 hover:bg-surface2 text-text">Deny esc</button>
-          <button onClick={onAllowOnce}
-            className="px-2 py-1 rounded text-[11px] text-subtext0 hover:bg-surface1">Allow once</button>
+          <button onClick={() => useSessionStore.getState().setActiveSession(p.sessionId)}
+            className="px-2 py-1 rounded text-[11px] text-subtext0 hover:bg-surface1">Open</button>
+          <button onClick={() => window.electronAPI.channels.standingApprovalCRUD({ op: 'add', tool: p.tool, ttl: '1h' })}
+            className="ml-auto px-2 py-1 rounded text-[11px] text-subtext0 hover:bg-surface1"
+            title={`Stop asking about ${p.tool} for 1 hour`}>Mute 1h</button>
         </div>
       </div>
     </div>

--- a/src/renderer/components/channels/PermissionToastStack.tsx
+++ b/src/renderer/components/channels/PermissionToastStack.tsx
@@ -9,26 +9,34 @@ export default function PermissionToastStack() {
   const respond = (requestId: string, decision: 'allow' | 'deny' | 'allow-once') =>
     window.electronAPI.channels.respondPermission({ requestId, decision })
 
+  // getPending() returns insertion order (oldest first); the tray shows the
+  // newest on top. Reverse once and use the same order for rendering, focus,
+  // and the keyboard shortcuts so they all agree on which card is "primary".
+  const ordered = [...pending].reverse()
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (pending.length === 0) return
+      if (ordered.length === 0) return
       const isMac = (window as any).electronPlatform === 'darwin'
       const mod = isMac ? e.metaKey : e.ctrlKey
-      if (e.key === 'Enter' && !mod) { respond(pending[0].requestId, 'allow'); e.preventDefault() }
-      else if (e.key === 'Escape') { respond(pending[0].requestId, 'deny'); e.preventDefault() }
+      if (e.key === 'Enter' && !mod) { respond(ordered[0].requestId, 'allow'); e.preventDefault() }
+      else if (e.key === 'Escape') { respond(ordered[0].requestId, 'deny'); e.preventDefault() }
       else if (mod && /^[1-9]$/.test(e.key)) {
-        const idx = +e.key - 1; if (pending[idx]) { respond(pending[idx].requestId, 'allow'); e.preventDefault() }
+        const idx = +e.key - 1; if (ordered[idx]) { respond(ordered[idx].requestId, 'allow'); e.preventDefault() }
       }
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
   }, [pending])
 
-  if (pending.length === 0) return null
-  const visible = pending.slice(0, MAX_VISIBLE)
-  const overflow = pending.length - visible.length
+  if (ordered.length === 0) return null
+  const visible = ordered.slice(0, MAX_VISIBLE)  // newest first
+  const overflow = ordered.length - visible.length
+  // Normal column: the box is pinned at bottom-left, so it grows UPWARD and the
+  // first child (newest) sits on top while the "+N waiting" pill sits at the
+  // bottom just above the bottom bar.
   return (
-    <div className="fixed left-3 bottom-12 z-50 flex flex-col-reverse gap-2 items-start channels-tray">
+    <div className="fixed left-3 bottom-12 z-50 flex flex-col gap-2 items-start channels-tray">
       {visible.map((p, i) => (
         <PermissionToast key={p.requestId} p={p} focused={i === 0}
           onAllow={() => respond(p.requestId, 'allow')}

--- a/src/renderer/components/channels/PermissionToastStack.tsx
+++ b/src/renderer/components/channels/PermissionToastStack.tsx
@@ -6,7 +6,7 @@ import { PermissionToast } from './PermissionToast'
 const MAX_VISIBLE = 4
 export default function PermissionToastStack() {
   const pending = useChannelStore((s) => s.pending)
-  const respond = (requestId: string, decision: 'allow' | 'deny' | 'allow-once') =>
+  const respond = (requestId: string, decision: 'allow' | 'deny') =>
     window.electronAPI.channels.respondPermission({ requestId, decision })
 
   // getPending() returns insertion order (oldest first); the tray shows the
@@ -40,8 +40,7 @@ export default function PermissionToastStack() {
       {visible.map((p, i) => (
         <PermissionToast key={p.requestId} p={p} focused={i === 0}
           onAllow={() => respond(p.requestId, 'allow')}
-          onDeny={() => respond(p.requestId, 'deny')}
-          onAllowOnce={() => respond(p.requestId, 'allow-once')} />
+          onDeny={() => respond(p.requestId, 'deny')} />
       ))}
       {overflow > 0 && <div className="text-[11px] text-overlay0 bg-surface0 border border-surface1 rounded px-2 py-1">+{overflow} waiting</div>}
     </div>

--- a/src/renderer/components/channels/PermissionToastStack.tsx
+++ b/src/renderer/components/channels/PermissionToastStack.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react'
 import { useChannelStore } from '../../stores/channelStore'
 import { PermissionToast } from './PermissionToast'
 
-const MAX_VISIBLE = 5
+const MAX_VISIBLE = 4
 export default function PermissionToastStack() {
   const pending = useChannelStore((s) => s.pending)
   const respond = (requestId: string, decision: 'allow' | 'deny' | 'allow-once') =>
@@ -28,14 +28,14 @@ export default function PermissionToastStack() {
   const visible = pending.slice(0, MAX_VISIBLE)
   const overflow = pending.length - visible.length
   return (
-    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 items-end">
+    <div className="fixed left-3 bottom-12 z-50 flex flex-col-reverse gap-2 items-start channels-tray">
       {visible.map((p, i) => (
         <PermissionToast key={p.requestId} p={p} focused={i === 0}
           onAllow={() => respond(p.requestId, 'allow')}
           onDeny={() => respond(p.requestId, 'deny')}
           onAllowOnce={() => respond(p.requestId, 'allow-once')} />
       ))}
-      {overflow > 0 && <div className="text-[11px] text-overlay0 bg-surface0 border border-surface1 rounded px-2 py-1">+{overflow} more</div>}
+      {overflow > 0 && <div className="text-[11px] text-overlay0 bg-surface0 border border-surface1 rounded px-2 py-1">+{overflow} waiting</div>}
     </div>
   )
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3,6 +3,26 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles.css'
 
+// Renderer event-loop jank detector. A self-rescheduling 250ms timer measures
+// how late each tick lands vs its scheduled interval; a gap above 4x (~1s) means
+// the renderer's main thread was blocked (a freeze). Kept inline rather than
+// importing src/main/jank-detector.ts, which pulls in debug-logger (a main-only
+// module). The warning lands in the renderer console, which the debug capture
+// records.
+const JANK_INTERVAL_MS = 250
+const JANK_STALL_FACTOR = 4
+let jankLast = performance.now()
+const jankTick = () => {
+  const t = performance.now()
+  const gap = t - jankLast
+  if (gap > JANK_INTERVAL_MS * JANK_STALL_FACTOR) {
+    console.warn('[jank] renderer stalled ' + Math.round(gap) + 'ms')
+  }
+  jankLast = t
+  setTimeout(jankTick, JANK_INTERVAL_MS)
+}
+setTimeout(jankTick, JANK_INTERVAL_MS)
+
 const root = createRoot(document.getElementById('root')!)
 root.render(
   <React.StrictMode>

--- a/src/renderer/stores/channelStore.ts
+++ b/src/renderer/stores/channelStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { PendingPermission, LedgerRecord } from '../../shared/channel-types'
+import { useSessionStore } from './sessionStore'
 
 interface ChannelState {
   pending: PendingPermission[]
@@ -18,5 +19,13 @@ export const useChannelStore = create<ChannelState>((set) => ({
 export function setupChannelListeners(): () => void {
   const offP = window.electronAPI.channels.onPendingPermissions((list) => useChannelStore.getState().setPending(list as PendingPermission[]))
   const offL = window.electronAPI.channels.onLedgerEvent((r) => useChannelStore.getState().pushLedger(r as LedgerRecord))
-  return () => { offP(); offL() }
+  const offA = window.electronAPI.channels.onAttention(({ sessionId, needsAttention }) => {
+    const ss = useSessionStore.getState()
+    // Don't raise on the session you're already looking at; clears always apply.
+    if (needsAttention && ss.activeSessionId === sessionId) return
+    ss.updateSession(sessionId, { needsAttention })
+  })
+  // Tell main the listeners are mounted -> safe to make CCC the universal gate.
+  void window.electronAPI.channels.rendererReady()
+  return () => { offP(); offL(); offA() }
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -331,3 +331,8 @@ body {
   .log-list-enter { animation: none; }
 }
 
+/* Permission tray cards: slide up + fade on mount so a new card surfacing in
+   the bottom-left stack reads as a deliberate entrance rather than a flash. */
+.channels-toast { animation: ccc-tray-in 180ms ease-out; }
+@keyframes ccc-tray-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -335,4 +335,5 @@ body {
    the bottom-left stack reads as a deliberate entrance rather than a flash. */
 .channels-toast { animation: ccc-tray-in 180ms ease-out; }
 @keyframes ccc-tray-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .channels-toast { animation: none; } }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -437,6 +437,8 @@ export interface ElectronAPI {
     killSwitch: (p: { disabled: boolean }) => Promise<FeatureState>
     onPendingPermissions: (cb: (list: PendingPermission[]) => void) => () => void
     onLedgerEvent: (cb: (r: LedgerRecord) => void) => () => void
+    rendererReady: () => Promise<unknown>
+    onAttention: (cb: (p: { sessionId: string; needsAttention: boolean }) => void) => () => void
   }
   codex: {
     status: () => Promise<{

--- a/src/shared/channel-types.ts
+++ b/src/shared/channel-types.ts
@@ -92,7 +92,9 @@ export interface ChannelRule {
   lastFiredAt?: string
 }
 
-export type StandingApprovalTool = 'Bash' | 'Edit' | 'WebFetch' | '*'
+// Any Claude/Codex/MCP tool name, or '*' for all. Was a 4-tool union; widened so
+// the tray can mute Write/MultiEdit/WebSearch/Task/MCP tools too.
+export type StandingApprovalTool = string
 export type StandingApprovalTtl = '1h' | '4h' | 'until-restart'
 export interface StandingApproval {
   id: string

--- a/src/shared/hook-types.ts
+++ b/src/shared/hook-types.ts
@@ -3,6 +3,7 @@
 
 export const HOOK_EVENT_KINDS = [
   'PreToolUse', 'PostToolUse', 'Notification', 'SessionStart', 'Stop',
+  'UserPromptSubmit',
   'PreCompact', 'SubagentStart', 'SubagentStop', 'StopFailure',
   'PermissionRequest', 'FileChanged',
 ] as const

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -263,6 +263,8 @@ export const IPC = {
   CHANNELS_LEDGER_EVENT: 'channels:ledgerEvent',                    // main -> renderer: live ledger row
   CHANNELS_RULE_CRUD: 'channels:ruleCRUD',                          // renderer -> main: payload { op: 'list'|'save'|'delete', ... }
   CHANNELS_STANDING_APPROVAL_CRUD: 'channels:standingApprovalCRUD', // renderer -> main: payload { op: 'list'|'add'|'remove', ... }
+  CHANNELS_RENDERER_READY: 'channels:rendererReady',   // renderer -> main: listeners mounted, safe to gate permissions
+  CHANNELS_ATTENTION: 'channels:attention',            // main -> renderer: { sessionId, needsAttention }
   CHANNELS_CAPABILITY_DIAGNOSTICS: 'channels:capabilityDiagnostics',// renderer -> main: capability + handshake history
   CHANNELS_INTRO_DISMISSED: 'channels:introDismissed',              // renderer -> main: persist first-run dismissal
   CHANNELS_KILL_SWITCH: 'channels:killSwitch',                      // renderer -> main: toggle disableConductorChannels

--- a/tests/unit/channel-permissions.test.ts
+++ b/tests/unit/channel-permissions.test.ts
@@ -4,14 +4,20 @@ const pushed: any[][] = []
 const ledger: any[] = []
 vi.mock('../../src/main/ipc/channel-handlers', () => ({ pushPendingPermissions: (l: any[]) => pushed.push(l), pushLedgerEvent: vi.fn() }))
 vi.mock('../../src/main/channel-ledger', () => ({ appendLedger: (r: any) => { ledger.push(r); return 'l' } }))
-vi.mock('../../src/main/standing-approvals-store', () => ({ matchApproval: () => false }))
+const matchApproval = vi.fn<(tool: string) => boolean>(() => false)
+vi.mock('../../src/main/standing-approvals-store', () => ({ matchApproval: (tool: string) => matchApproval(tool) }))
 vi.mock('../../src/main/session-registry', () => ({ getSessionMeta: (id: string) => ({ id, label: id }) }))
 let hookCb!: (e: any) => void
 vi.mock('../../src/main/hooks/index', () => ({ getGateway: () => ({ subscribe: (cb: any) => { hookCb = cb; return () => {} } }) }))
-const { startPermissionTray, getPending } = await import('../../src/main/channel-permissions')
+const { startPermissionTray, getPending, resolvePending } = await import('../../src/main/channel-permissions')
 
 describe('channel-permissions', () => {
-  beforeEach(() => { pushed.length = 0; ledger.length = 0 })
+  beforeEach(() => {
+    // pending is a module-level map; drain it so each test starts clean (the
+    // overflow case otherwise leaves 50 entries behind for later tests).
+    for (const p of getPending()) resolvePending(p.requestId, 'denied')
+    pushed.length = 0; ledger.length = 0; matchApproval.mockReset(); matchApproval.mockReturnValue(false)
+  })
   it('captures a high-risk PermissionRequest, pushes it to the renderer, and ledgers permission-prompt', () => {
     startPermissionTray()
     // v2.0.0: non-high-risk now auto-allows, so the test uses a destructive
@@ -28,5 +34,23 @@ describe('channel-permissions', () => {
     for (let i = 0; i < 55; i++) hookCb({ sessionId: 's', event: 'PermissionRequest', payload: { tool: 'Bash', arguments: `rm -rf path-${i}`, requestId: `r${i}` }, ts: i })
     expect(getPending().length).toBeLessThanOrEqual(50)
     expect(ledger.some(r => r.kind === 'tray-overflow')).toBe(true)
+  })
+  it('read-only safelist tools auto-allow WITHOUT a ledger entry', () => {
+    startPermissionTray()
+    hookCb({ sessionId: 's1', event: 'PreToolUse', payload: { tool: 'Read', requestId: 'ro1' }, ts: 1 })
+    expect(getPending()).toHaveLength(0)
+    expect(ledger).toHaveLength(0)
+  })
+  it('a standing-approval auto-allow DOES ledger', () => {
+    startPermissionTray()
+    matchApproval.mockReturnValue(true)
+    hookCb({ sessionId: 's1', event: 'PreToolUse', payload: { tool: 'Edit', requestId: 'sa1' }, ts: 1 })
+    expect(getPending()).toHaveLength(0)
+    expect(ledger.some(r => r.kind === 'permission-auto-allow')).toBe(true)
+  })
+  it('an acting tool (Edit) is surfaced as pending', () => {
+    startPermissionTray()
+    hookCb({ sessionId: 's1', event: 'PreToolUse', payload: { tool: 'Edit', requestId: 'edit-surface-1' }, ts: 1 })
+    expect(getPending()).toHaveLength(1)
   })
 })

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -43,3 +43,31 @@ describe('hooks gateway permission wire value', () => {
     expect(JSON.parse(res.body)).toEqual({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } })
   })
 })
+
+describe('hold-open gating', () => {
+  let gw: HooksGateway
+  afterEach(async () => { await gw?.stop(); _resetResponders() })
+
+  it('flag OFF: a non-Bash PreToolUse is fire-and-forget (returns promptly)', async () => {
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
+    const { port } = await gw.start()
+    const secret = gw.registerSession('s2')
+    const res = await post(port!, 's2', secret, { event: 'PreToolUse', tool_name: 'Edit', payload: { requestId: 'e1' } })
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('{}')
+  })
+
+  it('flag ON: a non-Bash PreToolUse is held open until resolved', async () => {
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
+    gw.setPermissionGateActive(true)
+    const { port } = await gw.start()
+    const secret = gw.registerSession('s3')
+    const ac = new AbortController()
+    const respPromise = post(port!, 's3', secret, { event: 'PreToolUse', tool_name: 'Edit', payload: { requestId: 'e2' } }, ac.signal)
+      .then(() => 'resolved').catch(() => 'aborted')
+    const held = await Promise.race([respPromise, new Promise((r) => setTimeout(() => r('held'), 150))])
+    expect(held).toBe('held')   // still open after 150ms
+    ac.abort()                  // clean up; req.on('close') deregisters the responder
+    await respPromise
+  })
+})

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -42,6 +42,21 @@ describe('hooks gateway permission wire value', () => {
     expect(res.status).toBe(200)
     expect(JSON.parse(res.body)).toEqual({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } })
   })
+
+  it('writes an empty {} (no decision) on a defer outcome so Claude falls back to its own prompt', async () => {
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
+    const { port } = await gw.start()
+    const secret = gw.registerSession('s-defer')
+    const respPromise = post(port!, 's-defer', secret, {
+      event: 'PreToolUse', tool_name: 'Bash',
+      payload: { requestId: 'req-defer', tool_input: { command: 'rm -rf build' } },
+    })
+    await waitForResponder()
+    resolveResponder('req-defer', 'defer')
+    const res = await respPromise
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('{}')
+  })
 })
 
 describe('hold-open gating', () => {

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import http from 'node:http'
 import { HooksGateway } from '../../../src/main/hooks/hooks-gateway'
-import { resolveResponder } from '../../../src/main/permission-responders'
+import { resolveResponder, _resetResponders, _responderCount } from '../../../src/main/permission-responders'
+
+// Poll until the held-open path has registered its responder, instead of a fixed
+// sleep (deterministic under CI load). Falls through after 2s as a safety net.
+async function waitForResponder(): Promise<void> {
+  const deadline = Date.now() + 2000
+  while (_responderCount() === 0 && Date.now() < deadline) await new Promise((r) => setTimeout(r, 5))
+}
 
 function post(port: number, sid: string, token: string, body: object, signal?: AbortSignal): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
@@ -19,17 +26,17 @@ function post(port: number, sid: string, token: string, body: object, signal?: A
 
 describe('hooks gateway permission wire value', () => {
   let gw: HooksGateway
-  afterEach(async () => { await gw?.stop() })
+  afterEach(async () => { await gw?.stop(); _resetResponders() })
 
   it('writes permissionDecision "allow" (not "approved") when a Bash request is approved', async () => {
-    gw = new HooksGateway({ emit: () => {} })
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
     const { port } = await gw.start()
     const secret = gw.registerSession('sess-1')
     const respPromise = post(port!, 'sess-1', secret, {
       event: 'PreToolUse', tool_name: 'Bash',
       payload: { requestId: 'req-1', tool_input: { command: 'rm -rf build' } },
     })
-    await new Promise((r) => setTimeout(r, 50))
+    await waitForResponder()
     resolveResponder('req-1', 'approved')
     const res = await respPromise
     expect(res.status).toBe(200)

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -8,6 +8,9 @@ import { resolveResponder, _resetResponders, _responderCount } from '../../../sr
 async function waitForResponder(): Promise<void> {
   const deadline = Date.now() + 2000
   while (_responderCount() === 0 && Date.now() < deadline) await new Promise((r) => setTimeout(r, 5))
+  // Fail loudly instead of silently falling through: otherwise a real
+  // "responder never registered" bug turns into a 120s held-open hang.
+  if (_responderCount() === 0) throw new Error('responder was never registered within 2s')
 }
 
 function post(port: number, sid: string, token: string, body: object, signal?: AbortSignal): Promise<{ status: number; body: string }> {

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -90,4 +90,23 @@ describe('hold-open gating', () => {
     expect((entry.payload as { requestId: string }).requestId).toMatch(/^s4-\d+$/)
     ac.abort()
   })
+
+  // Claude Code's real hook POST uses `hook_event_name` (not `event`) and
+  // snake_case fields. Before this was handled, ingest dropped EVERY live hook
+  // -> the events feed + tray were silently dead. Lock the real shape here since
+  // the real-Claude integration test is opt-in and skipped in CI.
+  it('ingests Claude real-shape payloads (hook_event_name + tool_name)', async () => {
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
+    const { port } = await gw.start()
+    const secret = gw.registerSession('s5')
+    const res = await post(port!, 's5', secret, {
+      session_id: 's5', hook_event_name: 'PostToolUse', tool_name: 'Read',
+      tool_input: { file_path: 'F:/x/package.json' }, tool_use_id: 'toolu_abc',
+    })
+    expect(res.status).toBe(200)   // PostToolUse is fire-and-forget (not held open)
+    const buf = gw.getBuffer('s5')
+    expect(buf).toHaveLength(1)
+    expect(buf[0].event).toBe('PostToolUse')
+    expect(buf[0].toolName).toBe('Read')
+  })
 })

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -70,4 +70,24 @@ describe('hold-open gating', () => {
     ac.abort()                  // clean up; req.on('close') deregisters the responder
     await respPromise
   })
+
+  // Claude Code's real PreToolUse hook carries no requestId. The gateway must
+  // inject the SAME synthetic id it keyed the responder under into the ingested
+  // payload, so the downstream tray card resolves to that exact responder (else
+  // Allow/Deny no-ops and the call stalls 120s).
+  it('injects a synthetic requestId into the ingested payload when CC sends none', async () => {
+    gw = new HooksGateway({ emit: () => {}, defaultPort: 0 })
+    const { port } = await gw.start()
+    const secret = gw.registerSession('s4')
+    const ac = new AbortController()
+    // high-risk Bash is held open (no response); ingest still runs first
+    void post(port!, 's4', secret, { event: 'PreToolUse', sessionId: 's4', tool_name: 'Bash', payload: { tool_input: { command: 'rm -rf build' } } }, ac.signal).catch(() => {})
+    const deadline = Date.now() + 2000
+    while (gw.getBuffer('s4').length === 0 && Date.now() < deadline) await new Promise((r) => setTimeout(r, 5))
+    const entry = gw.getBuffer('s4')[0]
+    expect(entry).toBeDefined()
+    expect(typeof (entry.payload as { requestId?: unknown }).requestId).toBe('string')
+    expect((entry.payload as { requestId: string }).requestId).toMatch(/^s4-\d+$/)
+    ac.abort()
+  })
 })

--- a/tests/unit/hooks/hooks-gateway-wire.test.ts
+++ b/tests/unit/hooks/hooks-gateway-wire.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import http from 'node:http'
+import { HooksGateway } from '../../../src/main/hooks/hooks-gateway'
+import { resolveResponder } from '../../../src/main/permission-responders'
+
+function post(port: number, sid: string, token: string, body: object, signal?: AbortSignal): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body)
+    const req = http.request(
+      { host: '127.0.0.1', port, path: `/hook/${sid}`, method: 'POST',
+        headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(data), 'x-ccc-hook-token': token } },
+      (res) => { let b = ''; res.on('data', (c) => (b += c)); res.on('end', () => resolve({ status: res.statusCode ?? 0, body: b })) },
+    )
+    req.on('error', reject)
+    if (signal) signal.addEventListener('abort', () => req.destroy())
+    req.end(data)
+  })
+}
+
+describe('hooks gateway permission wire value', () => {
+  let gw: HooksGateway
+  afterEach(async () => { await gw?.stop() })
+
+  it('writes permissionDecision "allow" (not "approved") when a Bash request is approved', async () => {
+    gw = new HooksGateway({ emit: () => {} })
+    const { port } = await gw.start()
+    const secret = gw.registerSession('sess-1')
+    const respPromise = post(port!, 'sess-1', secret, {
+      event: 'PreToolUse', tool_name: 'Bash',
+      payload: { requestId: 'req-1', tool_input: { command: 'rm -rf build' } },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    resolveResponder('req-1', 'approved')
+    const res = await respPromise
+    expect(res.status).toBe(200)
+    expect(JSON.parse(res.body)).toEqual({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'allow' } })
+  })
+})

--- a/tests/unit/hooks/session-hooks-writer.test.ts
+++ b/tests/unit/hooks/session-hooks-writer.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import {
   injectHooks,
   removeHooks,
+  buildHooksBlock,
   MVP_EVENTS,
 } from '../../../src/main/hooks/session-hooks-writer'
 
@@ -83,5 +84,10 @@ describe('session-hooks-writer', () => {
     const deep = path.join(dir, 'nested', 'dir', 'settings-sid-b.json')
     injectHooks({ sessionId: 'sid-b', settingsPath: deep, port: 19335, secret: 'xyz' })
     expect(fs.existsSync(deep)).toBe(true)
+  })
+
+  it('injects a UserPromptSubmit hook (clear signal for the flasher)', () => {
+    const block = buildHooksBlock('sess', 1234, 'secret')
+    expect(block.UserPromptSubmit).toBeDefined()
   })
 })

--- a/tests/unit/main/attention-source.test.ts
+++ b/tests/unit/main/attention-source.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { attentionForEvent } from '../../../src/main/attention-source'
+import type { HookEvent } from '../../../src/shared/hook-types'
+
+const ev = (over: Partial<HookEvent>): HookEvent => ({ sessionId: 's', event: 'Stop', payload: {}, ts: 0, ...over })
+
+describe('attentionForEvent', () => {
+  it('raises on Notification(idle_prompt)', () => {
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'idle_prompt' } }))).toBe(true)
+  })
+  it('raises on Notification(permission_prompt) (unanswerable on-screen prompt)', () => {
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'permission_prompt' } }))).toBe(true)
+  })
+  it('clears on UserPromptSubmit / PreToolUse / PostToolUse', () => {
+    expect(attentionForEvent(ev({ event: 'UserPromptSubmit' }))).toBe(false)
+    expect(attentionForEvent(ev({ event: 'PreToolUse' }))).toBe(false)
+    expect(attentionForEvent(ev({ event: 'PostToolUse' }))).toBe(false)
+  })
+  it('ignores other events', () => {
+    expect(attentionForEvent(ev({ event: 'Stop' }))).toBeNull()
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'auth_success' } }))).toBeNull()
+  })
+})

--- a/tests/unit/main/jank-detector.test.ts
+++ b/tests/unit/main/jank-detector.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest'
+import { reportIfStalled } from '../../../src/main/jank-detector'
+
+describe('reportIfStalled', () => {
+  it('logs when the gap exceeds the threshold', () => {
+    const log = vi.fn()
+    reportIfStalled(1500, 250, log, 'tick')   // expected 250ms interval, actual 1500ms gap (> 4x stall threshold)
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('stalled'))
+  })
+  it('does not log a normal tick', () => {
+    const log = vi.fn()
+    reportIfStalled(260, 250, log, 'tick')
+    expect(log).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/permission-core.test.ts
+++ b/tests/unit/permission-core.test.ts
@@ -29,6 +29,9 @@ describe('permission-core', () => {
     it('high-risk always shows, even with a standing approval', () => {
       expect(decideDisposition(base({ tool: 'Bash', highRisk: { matched: 'rm -rf' } }), yesApproval)).toBe('show')
     })
+    it('high-risk with no approval shows (the plain destructive-Bash path)', () => {
+      expect(decideDisposition(base({ tool: 'Bash', highRisk: { matched: 'rm -rf' } }), noApproval)).toBe('show')
+    })
     it('standing approval auto-allows a non-high-risk tool', () => {
       expect(decideDisposition(base({ tool: 'Bash' }), yesApproval)).toBe('auto-allow')
     })

--- a/tests/unit/permission-core.test.ts
+++ b/tests/unit/permission-core.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { detectHighRisk, normalizePermission, decideDisposition } from '../../src/main/permission-core'
 import type { HookEvent } from '../../src/shared/hook-types'
+import type { PendingPermission } from '../../src/shared/channel-types'
 
 describe('permission-core', () => {
   it('flags destructive Bash payloads', () => {
@@ -18,21 +19,27 @@ describe('permission-core', () => {
     expect(p.transport).toBe('hook')
     expect(p.highRisk?.matched).toBe('rm -rf')
   })
-  it('decideDisposition: high-risk always shows even with a standing approval', () => {
-    const p = { tool: 'Bash', payloadPreview: 'rm -rf x', highRisk: { matched: 'rm -rf' } } as any
-    expect(decideDisposition(p, () => true)).toBe('show')
-  })
-  it('decideDisposition: non-high-risk Bash auto-allows regardless of standing approval (v2.0.0)', () => {
-    // v2.0.0: PreToolUse delivers every Bash call. Only the high-risk
-    // patterns (detectHighRisk) need user input; the rest auto-allow so
-    // the tray doesn't fire for ls/cat/git status.
-    const p = { tool: 'Bash', payloadPreview: 'ls', highRisk: undefined } as any
-    expect(decideDisposition(p, () => true)).toBe('auto-allow')
-    expect(decideDisposition(p, () => false)).toBe('auto-allow')
-  })
-  it('decideDisposition: non-Bash tools always auto-allow (v2.0.0)', () => {
-    const p = { tool: 'Edit', payloadPreview: 'foo', highRisk: undefined } as any
-    expect(decideDisposition(p, () => false)).toBe('auto-allow')
+  describe('decideDisposition (CCC gate policy)', () => {
+    const base = (over: Partial<PendingPermission>): PendingPermission => ({
+      requestId: 'r', sessionId: 's', sessionLabel: 'S', tool: 'Edit', payloadPreview: '',
+      capturedAt: 0, transport: 'hook', tierLabel: 'hooks', ...over,
+    })
+    const noApproval = () => false
+    const yesApproval = () => true
+    it('high-risk always shows, even with a standing approval', () => {
+      expect(decideDisposition(base({ tool: 'Bash', highRisk: { matched: 'rm -rf' } }), yesApproval)).toBe('show')
+    })
+    it('standing approval auto-allows a non-high-risk tool', () => {
+      expect(decideDisposition(base({ tool: 'Bash' }), yesApproval)).toBe('auto-allow')
+    })
+    it('read-only safelist auto-allows', () => {
+      for (const tool of ['Read', 'Glob', 'Grep', 'LS', 'NotebookRead', 'BashOutput', 'TodoWrite'])
+        expect(decideDisposition(base({ tool }), noApproval)).toBe('auto-allow')
+    })
+    it('acting tools show', () => {
+      for (const tool of ['Edit', 'Write', 'MultiEdit', 'Bash', 'WebFetch', 'Task', 'mcp__conductor__vision_click'])
+        expect(decideDisposition(base({ tool }), noApproval)).toBe('show')
+    })
   })
   it('does not flag non-Bash tools even when payload looks destructive', () => {
     expect(detectHighRisk('Edit', 'rm -rf node_modules')).toBeUndefined()


### PR DESCRIPTION
## Summary

v1.5.16 — makes CCC the cross-session **Permission Tray** and fixes the attention flasher. Bundles the done toggle/effort fixes and freeze/clipboard diagnostics.

### The headline: the tray was dead, and we found why
Probing a live Claude 2.1.158 session showed Claude's hook POST uses **`hook_event_name`** (not `event`), so the gateway's `ingest` was **silently dropping every hook** — the events feed + permission tray never received anything. Two more latent bugs compounded it: the responder wrote `permissionDecision: 'approved'` (Claude expects `'allow'`), and the responder key / pending-card key diverged because Claude sends no `requestId` (it sends `tool_use_id`). All three fixed and the opt-in real-Claude integration test now **passes** (was: 0 events received).

### What changed
- **Gateway is the universal permission gate** (behind a renderer-ready flag): holds every `PreToolUse` open, auto-allows a read-only safelist + your mutes, surfaces Allow/Deny for everything that acts (high-risk checked first).
- **Accepts Claude's real payload** (`hook_event_name`/`session_id`/`tool_use_id`/`tool_input`); emits `permissionDecision: 'allow'|'deny'`.
- **Tray** relocated bottom-left, newest-on-top, cap 4 + "+N waiting", with Allow/Deny/Open/Mute-1h.
- **Attention flasher** moved off PTY-output scraping onto `Notification(idle_prompt)` for provider sessions (kills the re-fire bug); shell-only sessions keep PTY detection.
- **Bundled:** event-loop jank detector (main + renderer), clipboard-image + tokenomics-scan timing, merged statusline-effort + settings-toggle fixes.

Spec/plan are local (gitignored). Built subagent-driven; every cluster passed independent spec + code-quality review, plus a final integration review.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 1371 passed, 1 skipped
- [x] Real-Claude hooks integration test passes (`RUN_REAL_CLAUDE_HOOKS_TEST=1`)
- [ ] Beta install: trigger a real Edit in a session; confirm the bottom-left card appears, **Allow** lets it proceed, **Deny** blocks it; confirm the flasher no longer re-fires on revisit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
