### PR TITLE
feat(permission-tray): active-session suppression + enrichment fix + mouse-only + disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Conduct dozens of Claude and Codex sessions in parallel. Orchestrate up to **1,0
 
 <br/>
 
+<sub>An independent, community-built project &middot; not affiliated with, endorsed by, or sponsored by Anthropic. See [Disclaimer](#disclaimer-and-trademarks).</sub>
+
+<br/>
+
 <img src="docs/screenshots/v2-shell-hero.jpg" alt="Claude Command Center v2.0 -- multi-session shell with Opus 4.8 and the permission tray" width="100%" />
 
 </div>
@@ -251,6 +255,16 @@ Per-release detail lives in [`src/renderer/changelog.ts`](src/renderer/changelog
 ## Contributing
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding standards, and the PR process.
+
+---
+
+## Disclaimer and trademarks
+
+Claude and Claude Code are trademarks of Anthropic, PBC. OpenAI and Codex are trademarks of OpenAI. This project is an independent, community-built tool. It is **not affiliated with, endorsed by, sponsored by, or supported by Anthropic or OpenAI**.
+
+All references to "Claude", "Claude Code", "Codex", "Anthropic", or "OpenAI" are nominative, used solely to identify the third-party software this tool interoperates with. Claude Command Center is a separate work that wraps and orchestrates the official Claude Code and Codex CLIs. It does not include, modify, or redistribute their code, and it requires you to install and authenticate those tools yourself under their own terms.
+
+If you are a rights holder with a concern about this project's use of a name or mark, please open a [GitHub issue](../../issues) or contact the maintainer and it will be addressed promptly.
 
 ---
 

--- a/src/main/channel-permissions.ts
+++ b/src/main/channel-permissions.ts
@@ -8,21 +8,29 @@ import { detectHighRisk } from './permission-core'
 import type { PendingPermission } from '../shared/channel-types'
 import type { HookEvent } from '../shared/hook-types'
 
-// Genuine-only tray (v1.5.17). CCC is NOT the permission gate; Claude's own
+// Genuine-only tray (v1.5.17+). CCC is NOT the permission gate; Claude's own
 // settings decide. We surface ONLY `Notification(permission_prompt)` events
-// (fire only when settings did NOT auto-approve), enriched with the session's
-// pending tool. Cards deep-link or dismiss -- they never answer Claude.
+// (they fire only when settings did NOT auto-approve), enriched with the
+// session's blocked tool. Cards deep-link or dismiss -- they never answer Claude.
 const PENDING_CAP = 50
 const pending = new Map<string, PendingPermission>()
-// Per session: the most recent PreToolUse with no following PostToolUse/Stop.
-// On a permission_prompt (which carries no tool detail) this IS the blocked tool.
-const lastPendingTool = new Map<string, { tool: string; preview: string }>()
+// Per session: tools that fired PreToolUse with no matching PostToolUse yet,
+// keyed by Claude's `tool_use_id` (insertion-ordered). A permission_prompt
+// Notification carries NO tool detail, so the still-in-flight tool is the
+// blocked one and is used to enrich the card. v1.5.18: keying by tool_use_id
+// (instead of a single per-session slot) means an auto-approved SIBLING tool
+// completing no longer wipes the blocked tool's detail -- that was the v1.5.17
+// "Claude needs your permission" generic-message bug under parallel tool calls.
+const inflight = new Map<string, Map<string, { tool: string; preview: string }>>()
+// cardRequestId -> the tool_use_id we enriched it from, so the MATCHING
+// PostToolUse dismisses exactly that card and a sibling's PostToolUse does not.
+const cardTool = new Map<string, string | undefined>()
 let started = false
 
 export function getPending(): PendingPermission[] { return [...pending.values()] }
 
 /** Test seam: reset module state between cases. */
-export function _resetPending(): void { pending.clear(); lastPendingTool.clear() }
+export function _resetPending(): void { pending.clear(); inflight.clear(); cardTool.clear() }
 
 function trayEnabled(): boolean {
   // Mirror cloud-agent-manager.ts -- read AppSettings fresh; default ON.
@@ -34,26 +42,50 @@ function isPermissionPrompt(e: HookEvent): boolean {
     (e.payload as { notification_type?: string }).notification_type === 'permission_prompt'
 }
 
+function toolUseId(e: HookEvent): string | undefined {
+  const id = (e.payload as { tool_use_id?: unknown }).tool_use_id
+  return typeof id === 'string' ? id : undefined
+}
+
 function previewFor(e: HookEvent): { tool: string; preview: string } {
   const pl = e.payload as {
     tool?: string; command?: string; arguments?: string
-    tool_input?: { command?: string; file_path?: string }
+    tool_input?: { command?: string; file_path?: string; url?: string; query?: string }
   }
   const tool = e.toolName ?? pl.tool ?? 'tool'
-  const preview = String(pl.tool_input?.command ?? pl.tool_input?.file_path ?? pl.command ?? pl.arguments ?? '')
+  // Bash -> command, Edit/Write/Read -> file_path, WebFetch -> url, WebSearch -> query.
+  const preview = String(
+    pl.tool_input?.command ?? pl.tool_input?.file_path ?? pl.tool_input?.url ??
+    pl.tool_input?.query ?? pl.command ?? pl.arguments ?? '',
+  )
   return { tool, preview }
 }
 
 function dismissForSession(sessionId: string): void {
   let changed = false
-  for (const [id, p] of pending) if (p.sessionId === sessionId) { pending.delete(id); changed = true }
+  for (const [id, p] of pending) if (p.sessionId === sessionId) { pending.delete(id); cardTool.delete(id); changed = true }
+  if (changed) pushPendingPermissions(getPending())
+}
+
+// Dismiss exactly the card(s) enriched from this tool_use_id (the approve path:
+// the blocked tool ran, so its PostToolUse arrives and the prompt is resolved).
+function dismissCardByTool(sessionId: string, tuid: string): void {
+  let changed = false
+  for (const [id, p] of pending) {
+    if (p.sessionId === sessionId && cardTool.get(id) === tuid) {
+      pending.delete(id); cardTool.delete(id); changed = true
+    }
+  }
   if (changed) pushPendingPermissions(getPending())
 }
 
 function captureNotification(e: HookEvent): void {
   if (!trayEnabled()) return
   const meta = getSessionMeta(e.sessionId)
-  const enrich = lastPendingTool.get(e.sessionId)
+  // The blocked tool is whatever is still in-flight; pick the most recent.
+  const m = inflight.get(e.sessionId)
+  const entries = m ? [...m.entries()] : []
+  const [enrichTuid, enrich] = entries.length ? entries[entries.length - 1] : [undefined, undefined]
   const id = `${e.sessionId}-${e.ts}`
   const p: PendingPermission = {
     requestId: id,
@@ -70,17 +102,33 @@ function captureNotification(e: HookEvent): void {
   }
   if (pending.size >= PENDING_CAP) {
     const oldest = pending.keys().next().value
-    if (oldest) pending.delete(oldest)
+    if (oldest) { pending.delete(oldest); cardTool.delete(oldest) }
   }
   pending.set(id, p)
+  cardTool.set(id, enrichTuid)
   appendLedger({ source: 'permission', target: p.sessionLabel, transport: null, kind: 'permission-prompt', summary: `${p.tool}: ${p.payloadPreview}` })
   pushPendingPermissions(getPending())
 }
 
 function track(e: HookEvent): void {
-  if (e.event === 'PreToolUse') { lastPendingTool.set(e.sessionId, previewFor(e)); return }
-  if (e.event === 'PostToolUse' || e.event === 'Stop') {
-    lastPendingTool.delete(e.sessionId)
+  if (e.event === 'PreToolUse') {
+    const tuid = toolUseId(e) ?? `${e.sessionId}-${e.ts}`
+    const m = inflight.get(e.sessionId) ?? new Map<string, { tool: string; preview: string }>()
+    m.set(tuid, previewFor(e))
+    inflight.set(e.sessionId, m)
+    return
+  }
+  if (e.event === 'PostToolUse') {
+    const tuid = toolUseId(e)
+    const m = inflight.get(e.sessionId)
+    if (m && tuid) { m.delete(tuid); if (m.size === 0) inflight.delete(e.sessionId) }
+    // Approve path: the blocked tool ran -> dismiss exactly its card.
+    if (tuid) dismissCardByTool(e.sessionId, tuid)
+    return
+  }
+  if (e.event === 'Stop') {
+    // Turn ended -> any still-open prompt is moot; clear tracking + cards.
+    inflight.delete(e.sessionId)
     dismissForSession(e.sessionId)
     return
   }
@@ -102,6 +150,7 @@ export function dismissPermission(p: { requestId: string }): { ok: boolean } {
   const card = pending.get(p.requestId)
   if (!card) return { ok: false }
   pending.delete(p.requestId)
+  cardTool.delete(p.requestId)
   appendLedger({ source: 'permission', target: card.sessionLabel, transport: null, kind: 'permission-dismiss', summary: `ignored ${card.tool}` })
   pushPendingPermissions(getPending())
   return { ok: true }

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,15 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.18',
+    date: '2026-05-31',
+    changes: [
+      { type: 'improvement', description: 'Permission tray no longer shows a card for the session you are currently viewing (Claude prompts you right there). The card appears if you switch to another session while the prompt is still waiting.' },
+      { type: 'fix', description: 'Permission cards now reliably show which tool and command Claude is asking about, even when several tools run at once.' },
+      { type: 'improvement', description: 'Added a footer note clarifying this is an independent project, not affiliated with or endorsed by Anthropic.' },
+    ],
+  },
+  {
     version: '1.5.17',
     date: '2026-05-31',
     changes: [

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -20,6 +20,7 @@ export const changelog: ChangelogEntry[] = [
     changes: [
       { type: 'improvement', description: 'Permission tray no longer shows a card for the session you are currently viewing (Claude prompts you right there). The card appears if you switch to another session while the prompt is still waiting.' },
       { type: 'fix', description: 'Permission cards now reliably show which tool and command Claude is asking about, even when several tools run at once.' },
+      { type: 'fix', description: 'Permission cards are now mouse-only: they never steal keyboard focus or interrupt your typing, and a stray Enter or Escape can no longer action a card.' },
       { type: 'improvement', description: 'Added a footer note clarifying this is an independent project, not affiliated with or endorsed by Anthropic.' },
     ],
   },

--- a/src/renderer/components/BottomBar.tsx
+++ b/src/renderer/components/BottomBar.tsx
@@ -109,6 +109,16 @@ export default function BottomBar({ currentView, onViewChange, onUpdateRequested
         )}
       </div>
 
+      {/* Independent-project disclaimer, pinned bottom-right. Nominative use of
+          "Anthropic"/"Claude" only; this app is not an Anthropic product. */}
+      <span
+        className="ml-auto shrink truncate italic text-[10px]"
+        style={{ color: 'var(--text-muted)' }}
+        title="Claude and Claude Code are trademarks of Anthropic, PBC. This is an independent community project."
+      >
+        Not affiliated with or endorsed by Anthropic
+      </span>
+
       {/* CLI help modal -- ported verbatim from StatusBar so the
           "CLI not found -- click for help" path still works. */}
       {showCliHelp && (

--- a/src/renderer/components/channels/PermissionToast.tsx
+++ b/src/renderer/components/channels/PermissionToast.tsx
@@ -32,10 +32,13 @@ export function PermissionToast({ p, onGoToSession, onIgnore }: Props) {
               <pre className="text-[11px] font-mono text-text whitespace-pre-wrap break-all max-h-16 overflow-hidden">{p.payloadPreview}</pre>
             </>)
           : (<div className="mt-1.5 text-[11px] text-subtext0">{p.payloadPreview}</div>)}
+        {/* MOUSE ONLY. No autoFocus (a card must never steal focus from the
+            terminal and interrupt typing) and tabIndex=-1 (so a stray Enter /
+            Space while typing can never activate an action). Click only. */}
         <div className="mt-2 flex items-center gap-2">
-          <button onClick={onGoToSession} autoFocus
+          <button onClick={onGoToSession} tabIndex={-1}
             className="px-2 py-1 rounded text-[11px] bg-surface1 hover:bg-surface2 text-text">Go to session</button>
-          <button onClick={onIgnore}
+          <button onClick={onIgnore} tabIndex={-1}
             className="ml-auto px-2 py-1 rounded text-[11px] text-subtext0 hover:bg-surface1"
             title="Dismiss this card -- Claude's own prompt stays in the session">Ignore</button>
         </div>

--- a/src/renderer/components/channels/PermissionToastStack.tsx
+++ b/src/renderer/components/channels/PermissionToastStack.tsx
@@ -4,17 +4,31 @@ import { useChannelStore } from '../../stores/channelStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { PermissionToast } from './PermissionToast'
+import type { PendingPermission } from '../../../shared/channel-types'
 
 const MAX_VISIBLE = 4
+
+// Newest on top (the box is pinned bottom-left and grows upward), and suppress
+// the session the user is CURRENTLY viewing -- Claude's own prompt is already on
+// screen there, so a card would be redundant. The card is NOT discarded: it
+// stays in the store, and when the user switches away `activeSessionId` changes,
+// this re-runs, and the card reappears. Pure reactive render -- no polling.
+export function visiblePermissionCards(
+  pending: PendingPermission[],
+  activeSessionId: string | null,
+): PendingPermission[] {
+  return [...pending].reverse().filter((p) => p.sessionId !== activeSessionId)
+}
+
 export default function PermissionToastStack() {
   const enabled = useSettingsStore((s) => s.settings.permissionTrayEnabled !== false)
   const pending = useChannelStore((s) => s.pending)
+  const activeSessionId = useSessionStore((s) => s.activeSessionId)
 
   const ignore = (requestId: string) => window.electronAPI.channels.dismissPermission({ requestId })
   const goTo = (sessionId: string) => useSessionStore.getState().setActiveSession(sessionId)
 
-  // Newest on top (the box is pinned bottom-left and grows upward).
-  const ordered = [...pending].reverse()
+  const ordered = visiblePermissionCards(pending, activeSessionId)
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -23,7 +37,7 @@ export default function PermissionToastStack() {
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [pending])
+  }, [pending, activeSessionId])
 
   if (!enabled || ordered.length === 0) return null
   const visible = ordered.slice(0, MAX_VISIBLE)

--- a/src/renderer/components/channels/PermissionToastStack.tsx
+++ b/src/renderer/components/channels/PermissionToastStack.tsx
@@ -1,5 +1,5 @@
 // src/renderer/components/channels/PermissionToastStack.tsx
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useChannelStore } from '../../stores/channelStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
@@ -30,14 +30,9 @@ export default function PermissionToastStack() {
 
   const ordered = visiblePermissionCards(pending, activeSessionId)
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (ordered.length === 0) return
-      if (e.key === 'Escape') { ignore(ordered[0].requestId); e.preventDefault() }   // Esc dismisses the top card
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  }, [pending, activeSessionId])
+  // MOUSE ONLY -- deliberately NO keyboard handler. A global keydown listener
+  // here would intercept the user's typing (e.g. swallow Escape mid-edit) and
+  // let a stray key act on a card. The card is dismissed only by clicking Ignore.
 
   if (!enabled || ordered.length === 0) return null
   const visible = ordered.slice(0, MAX_VISIBLE)

--- a/tests/unit/channel-permissions.test.ts
+++ b/tests/unit/channel-permissions.test.ts
@@ -13,13 +13,14 @@ const mod = await import('../../src/main/channel-permissions')
 const { startPermissionTray, getPending, dismissPermission, _resetPending } = mod as any
 
 const notif = (sid: string, ts = 1) => ({ sessionId: sid, event: 'Notification', payload: { notification_type: 'permission_prompt', message: 'Claude needs your permission' }, ts })
-const pre = (sid: string, tool: string, input: any, ts = 1) => ({ sessionId: sid, event: 'PreToolUse', toolName: tool, payload: { tool_name: tool, tool_input: input }, ts })
+const pre = (sid: string, tool: string, input: any, tuid: string, ts = 1) => ({ sessionId: sid, event: 'PreToolUse', toolName: tool, payload: { tool_name: tool, tool_input: input, tool_use_id: tuid }, ts })
+const post = (sid: string, tuid: string, ts = 1) => ({ sessionId: sid, event: 'PostToolUse', payload: { tool_use_id: tuid }, ts })
 
 describe('channel-permissions (genuine-only)', () => {
   beforeEach(() => { _resetPending(); pushMock.mockClear(); readConfigMock.mockReturnValue({}) ; startPermissionTray() })
 
   it('PreToolUse alone never creates a card (it only tracks)', () => {
-    hookCb(pre('s1', 'Bash', { command: 'whoami' }))
+    hookCb(pre('s1', 'Bash', { command: 'whoami' }, 't1'))
     expect(getPending()).toHaveLength(0)
   })
 
@@ -29,30 +30,59 @@ describe('channel-permissions (genuine-only)', () => {
     expect(getPending()[0].sessionId).toBe('s1')
   })
 
-  it('enriches the card from the session pending PreToolUse', () => {
-    hookCb(pre('s1', 'Bash', { command: 'whoami' }))
+  it('enriches the card from the blocked in-flight PreToolUse', () => {
+    hookCb(pre('s1', 'Bash', { command: 'whoami' }, 't1'))
     hookCb(notif('s1', 2))
     const card = getPending()[0]
     expect(card.tool).toBe('Bash')
     expect(card.payloadPreview).toBe('whoami')
   })
 
-  it('falls back to the generic message when no pending tool', () => {
+  it('enriches WebFetch from the url', () => {
+    hookCb(pre('s1', 'WebFetch', { url: 'https://example.com' }, 't1'))
+    hookCb(notif('s1', 2))
+    expect(getPending()[0].tool).toBe('WebFetch')
+    expect(getPending()[0].payloadPreview).toBe('https://example.com')
+  })
+
+  it('a sibling tool completing does NOT wipe the blocked tool detail (parallel calls)', () => {
+    // Read (t1) and Glob (t2) both fire; Read auto-approves and completes; Glob
+    // is the blocked one. The notification must still enrich from Glob.
+    hookCb(pre('s1', 'Read', { file_path: '/a' }, 't1'))
+    hookCb(pre('s1', 'Glob', { query: '**/x' }, 't2'))
+    hookCb(post('s1', 't1', 3))           // Read completes
+    hookCb(notif('s1', 4))
+    const card = getPending()[0]
+    expect(card.tool).toBe('Glob')
+    expect(card.payloadPreview).toBe('**/x')
+  })
+
+  it('falls back to the generic message when no tool is in-flight', () => {
     hookCb(notif('s1'))
     expect(getPending()[0].payloadPreview).toBe('Claude needs your permission')
   })
 
   it('flags a destructive pending command as high-risk', () => {
-    hookCb(pre('s1', 'Bash', { command: 'rm -rf /tmp/x' }))
+    hookCb(pre('s1', 'Bash', { command: 'rm -rf /tmp/x' }, 't1'))
     hookCb(notif('s1', 2))
     expect(getPending()[0].highRisk?.matched).toBe('rm -rf')
   })
 
-  it('PostToolUse for the session auto-dismisses its card and clears tracking', () => {
-    hookCb(pre('s1', 'Bash', { command: 'whoami' }))
+  it('the matching PostToolUse auto-dismisses the card (approve path)', () => {
+    hookCb(pre('s1', 'Bash', { command: 'whoami' }, 't1'))
     hookCb(notif('s1', 2))
     expect(getPending()).toHaveLength(1)
-    hookCb({ sessionId: 's1', event: 'PostToolUse', toolName: 'Bash', payload: {}, ts: 3 })
+    hookCb(post('s1', 't1', 3))
+    expect(getPending()).toHaveLength(0)
+  })
+
+  it('a SIBLING PostToolUse does NOT dismiss the card; the matching one does', () => {
+    hookCb(pre('s1', 'Bash', { command: 'whoami' }, 't1'))
+    hookCb(notif('s1', 2))                // card enriched from t1
+    hookCb(pre('s1', 'Read', { file_path: '/b' }, 't2'))
+    hookCb(post('s1', 't2', 3))           // sibling completes -> card stays
+    expect(getPending()).toHaveLength(1)
+    hookCb(post('s1', 't1', 4))           // matching -> dismiss
     expect(getPending()).toHaveLength(0)
   })
 

--- a/tests/unit/renderer/permission-toast-stack.test.tsx
+++ b/tests/unit/renderer/permission-toast-stack.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { visiblePermissionCards } from '../../../src/renderer/components/channels/PermissionToastStack'
+import type { PendingPermission } from '../../../src/shared/channel-types'
+
+const card = (requestId: string, sessionId: string): PendingPermission => ({
+  requestId, sessionId, sessionLabel: sessionId, tool: 'Bash', payloadPreview: 'x',
+  capturedAt: 0, transport: 'hook', tierLabel: 'hooks',
+})
+
+describe('visiblePermissionCards (active-session suppression)', () => {
+  it('newest card is first (reversed insertion order)', () => {
+    const out = visiblePermissionCards([card('a', 's1'), card('b', 's2')], null)
+    expect(out.map((c) => c.requestId)).toEqual(['b', 'a'])
+  })
+
+  it('suppresses the card for the session the user is currently viewing', () => {
+    const out = visiblePermissionCards([card('a', 's1'), card('b', 's2')], 's1')
+    expect(out.map((c) => c.sessionId)).toEqual(['s2'])
+  })
+
+  it('reappears when the active session changes away from it', () => {
+    const pending = [card('a', 's1')]
+    expect(visiblePermissionCards(pending, 's1')).toHaveLength(0)   // viewing s1 -> hidden
+    expect(visiblePermissionCards(pending, 's2')).toHaveLength(1)   // switched away -> shown
+  })
+
+  it('shows everything when no session is active', () => {
+    expect(visiblePermissionCards([card('a', 's1'), card('b', 's2')], null)).toHaveLength(2)
+  })
+})

--- a/tests/unit/renderer/permission-toast.test.tsx
+++ b/tests/unit/renderer/permission-toast.test.tsx
@@ -25,4 +25,10 @@ describe('PermissionToast', () => {
     const html = renderToStaticMarkup(<PermissionToast p={generic} onGoToSession={vi.fn()} onIgnore={vi.fn()} />)
     expect(html).toContain('Claude needs your permission')
   })
+  it('is mouse-only: both action buttons are out of the keyboard tab order (tabIndex -1)', () => {
+    // Guards against a card stealing focus from the terminal or a stray key
+    // activating an action while the user is typing. Click only.
+    const html = renderToStaticMarkup(<PermissionToast p={base} onGoToSession={vi.fn()} onIgnore={vi.fn()} />)
+    expect(html.split('tabindex="-1"').length - 1).toBe(2)
+  })
 })


### PR DESCRIPTION
## Summary
v1.5.18-beta. Follow-ups to the genuine-only tray (v1.5.17), plus an independent-project disclaimer.

- **Active-session suppression:** a permission card is hidden for the session you are currently viewing (Claude's own prompt is already on screen there) and reappears reactively if you switch away while it is still pending. Pure render-time filter (`visiblePermissionCards`), no polling -- main holds the card the whole time.
- **Robust enrichment:** track in-flight tools by `tool_use_id` instead of a single per-session slot, so an auto-approved sibling completing no longer wipes the blocked tool's detail (the v1.5.17 generic "Claude needs your permission" bug under parallel tool calls). The matching `PostToolUse` dismisses exactly that card; a sibling's does not; `Stop` clears all. WebFetch (url) and WebSearch (query) previews added.
- **Mouse-only:** the card no longer steals keyboard focus (removed `autoFocus`) or installs a global keydown handler, and both buttons are out of the tab order (`tabIndex=-1`). A card appearing mid-type can no longer interrupt typing, and a stray Enter/Escape/Space can no longer action a card.
- **Disclaimer:** bottom-bar italic "Not affiliated with or endorsed by Anthropic"; README header sub-line + a Disclaimer and trademarks section (nominative use, independent project, rights-holder contact path).

## Verification
- `npm run typecheck`: clean. `npx vitest run`: 1384 passed, 1 opt-in skipped, 0 failed.
- Two independent reviews: APPROVED (suppression reappear-without-loss, per-tool dismiss, mouse-only focus removal all verified).

## Test Plan
- [ ] Install v1.5.18-beta.
- [ ] While viewing a session, trigger a genuine prompt -> NO card. Switch to another session -> the card appears. Switch back -> it hides.
- [ ] Trigger a prompt while several tools run -> card shows the correct blocked tool + command.
- [ ] Start typing in the terminal, trigger a prompt -> typing is not interrupted; Enter/Escape do nothing to the card; only clicking Go to session / Ignore acts on it.
- [ ] Footer shows the disclaimer bottom-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)