### PR TITLE
Conductor D1a: supervised out-of-process hooks gateway backbone

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       outDir: 'out/main',
       rollupOptions: {
         input: {
-          index: resolve(__dirname, 'src/main/index.ts')
+          index: resolve(__dirname, 'src/main/index.ts'),
+          'hooks-host': resolve(__dirname, 'src/main/services/hooks-host.ts')
         }
       }
     }

--- a/src/main/claude-account-identity.ts
+++ b/src/main/claude-account-identity.ts
@@ -171,20 +171,25 @@ export async function recheckSessionIdentityAsync(
  *  the synchronous hot path. Mirrors recheckAll logic but uses fsp.stat. */
 export async function recheckAllAsync(): Promise<void> {
   for (const [sessionId, profileId] of [...watched]) {
-    const before = bySession.get(sessionId) ?? null
-    let changed: string | null = null
-    try { changed = await recheckSessionIdentityAsync(sessionId, profileId) } catch { /* best-effort */ }
-    if (!changed) continue
-    pushAccountIdentity(sessionId)
-    if (!profileId) continue // bare-global/default session: no profile context to detect against
-    const known = listProfiles().map((p) => p.accountEmail).filter((e): e is string => !!e)
-    if (classifyIdentityChange(sessionId, changed, before, known).kind === 'capture') {
-      if (detectedByProfile.get(profileId) === changed) continue
-      detectedByProfile.set(profileId, changed)
-      broadcastNewAccountDetected(sessionId, profileId, changed)
-    } else {
-      detectedByProfile.delete(profileId)
-    }
+    // Guard the WHOLE per-session body (not just the stat) so a throw in
+    // pushAccountIdentity/listProfiles/classify/broadcast can never abort the poll
+    // or reject this promise (it's void'd in a setInterval -> would be an unhandled
+    // rejection). One bad session is skipped; the rest still poll.
+    try {
+      const before = bySession.get(sessionId) ?? null
+      const changed = await recheckSessionIdentityAsync(sessionId, profileId)
+      if (!changed) continue
+      pushAccountIdentity(sessionId)
+      if (!profileId) continue // bare-global/default session: no profile context to detect against
+      const known = listProfiles().map((p) => p.accountEmail).filter((e): e is string => !!e)
+      if (classifyIdentityChange(sessionId, changed, before, known).kind === 'capture') {
+        if (detectedByProfile.get(profileId) === changed) continue
+        detectedByProfile.set(profileId, changed)
+        broadcastNewAccountDetected(sessionId, profileId, changed)
+      } else {
+        detectedByProfile.delete(profileId)
+      }
+    } catch { /* best-effort per-session; never abort the poll or reject */ }
   }
 }
 

--- a/src/main/claude-account-identity.ts
+++ b/src/main/claude-account-identity.ts
@@ -3,7 +3,7 @@
 // RELIABLE + drift-immune: read once at spawn from the session's profile (or the
 // default ~/.claude.json for single-account sessions), never re-read. Fixes the
 // v1.5.9 chip removal (whose source was the GLOBAL last-login at tick time).
-import fs from 'node:fs'; import path from 'node:path'
+import fs, { promises as fsp } from 'node:fs'; import path from 'node:path'
 import { BrowserWindow } from 'electron'
 import { readProfileAccountEmail, getProfileConfigDir, sharedRoot, listProfiles } from './account-profiles'
 import { IPC } from '../shared/ipc-channels'
@@ -145,11 +145,54 @@ export function getWatchedProfileId(sessionId: string): string | undefined {
   return watched.get(sessionId)
 }
 
+/**
+ * Async variant of recheckSessionIdentity. Uses fsp.stat (async) for the
+ * per-tick mtime check so the Electron main event loop is not blocked.
+ * The expensive JSON parse only runs on a real mtime change (rare) and may
+ * remain synchronous -- it is not on the hot path.
+ */
+export async function recheckSessionIdentityAsync(
+  sessionId: string,
+  profileId: string | undefined,
+): Promise<string | null> {
+  const file = identityFilePath(profileId)
+  let mtime: number
+  try { mtime = (await fsp.stat(file)).mtimeMs } catch { return null }
+  if (lastMtimeMs.get(sessionId) === mtime) return null
+  lastMtimeMs.set(sessionId, mtime)
+  let email: string | null = null
+  try { email = profileId ? readProfileAccountEmail(profileId) : getDefaultAccountEmail() } catch { return null }
+  if (!email || bySession.get(sessionId) === email) return null
+  bySession.set(sessionId, email) // mid-session change: bypass the first-capture guard
+  return email
+}
+
+/** Async poll loop: iterates all watched sessions with async mtime checks off
+ *  the synchronous hot path. Mirrors recheckAll logic but uses fsp.stat. */
+export async function recheckAllAsync(): Promise<void> {
+  for (const [sessionId, profileId] of [...watched]) {
+    const before = bySession.get(sessionId) ?? null
+    let changed: string | null = null
+    try { changed = await recheckSessionIdentityAsync(sessionId, profileId) } catch { /* best-effort */ }
+    if (!changed) continue
+    pushAccountIdentity(sessionId)
+    if (!profileId) continue // bare-global/default session: no profile context to detect against
+    const known = listProfiles().map((p) => p.accountEmail).filter((e): e is string => !!e)
+    if (classifyIdentityChange(sessionId, changed, before, known).kind === 'capture') {
+      if (detectedByProfile.get(profileId) === changed) continue
+      detectedByProfile.set(profileId, changed)
+      broadcastNewAccountDetected(sessionId, profileId, changed)
+    } else {
+      detectedByProfile.delete(profileId)
+    }
+  }
+}
+
 /** Start polling a live session's identity file for mid-session account changes. */
 export function startWatchingAccountIdentity(sessionId: string, profileId: string | undefined): void {
   watched.set(sessionId, profileId)
   if (!pollTimer) {
-    pollTimer = setInterval(recheckAll, POLL_MS)
+    pollTimer = setInterval(() => { void recheckAllAsync() }, POLL_MS)
     // Never keep the process alive just for this poll.
     if (typeof (pollTimer as { unref?: () => void }).unref === 'function') (pollTimer as { unref: () => void }).unref()
   }
@@ -189,3 +232,6 @@ export function _resetClaudeAccounts(): void {
   detectedByProfile.clear()
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null }
 }
+
+/** Alias for the async-poll test suite (same semantics, shorter name). */
+export const _resetForTest = _resetClaudeAccounts

--- a/src/main/claude-account-identity.ts
+++ b/src/main/claude-account-identity.ts
@@ -167,9 +167,24 @@ export async function recheckSessionIdentityAsync(
   return email
 }
 
+// In-flight guard: a slow disk can make a 5s poll tick outlast the interval, so
+// the next tick must not start a second concurrent fan-out (overlapping stat
+// storms + duplicate broadcasts). Set on entry, cleared in `finally`.
+let recheckInFlight = false
+
 /** Async poll loop: iterates all watched sessions with async mtime checks off
  *  the synchronous hot path. Mirrors recheckAll logic but uses fsp.stat. */
 export async function recheckAllAsync(): Promise<void> {
+  if (recheckInFlight) return
+  recheckInFlight = true
+  try {
+    await recheckAllAsyncInner()
+  } finally {
+    recheckInFlight = false
+  }
+}
+
+async function recheckAllAsyncInner(): Promise<void> {
   for (const [sessionId, profileId] of [...watched]) {
     // Guard the WHOLE per-session body (not just the stat) so a throw in
     // pushAccountIdentity/listProfiles/classify/broadcast can never abort the poll
@@ -235,8 +250,13 @@ export function _resetClaudeAccounts(): void {
   watched.clear()
   lastMtimeMs.clear()
   detectedByProfile.clear()
+  recheckInFlight = false
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null }
 }
 
 /** Alias for the async-poll test suite (same semantics, shorter name). */
 export const _resetForTest = _resetClaudeAccounts
+
+/** Test seam: exposes the in-flight guard state so a test can assert overlapping
+ *  poll ticks do not run concurrently. */
+export function __isRecheckInFlightForTest(): boolean { return recheckInFlight }

--- a/src/main/data-paths.ts
+++ b/src/main/data-paths.ts
@@ -4,7 +4,10 @@ import { homedir } from 'os'
 import { readRegistry, writeRegistry } from './registry'
 import { logInfo } from './debug-logger'
 
-// Lazy getter for default data dir — can't call at module load time
+// Default data dir. Uses os.homedir() (not Electron's app.getPath('home')) so
+// this module stays electron-free and can run inside the hooks utilityProcess.
+// Resolved lazily via getDataDirectory() so downstream lazy-initializers
+// (e.g. debug-logger) can call it without a module-load-order constraint.
 function getDefaultDataDir(): string {
   if (process.platform === 'darwin') {
     return path.join(homedir(), 'Library', 'Application Support', 'Claude Conductor')

--- a/src/main/data-paths.ts
+++ b/src/main/data-paths.ts
@@ -1,0 +1,104 @@
+import * as path from 'path'
+import * as fs from 'fs'
+import { homedir } from 'os'
+import { readRegistry, writeRegistry } from './registry'
+import { logInfo } from './debug-logger'
+
+// Lazy getter for default data dir — can't call at module load time
+function getDefaultDataDir(): string {
+  if (process.platform === 'darwin') {
+    return path.join(homedir(), 'Library', 'Application Support', 'Claude Conductor')
+  }
+  if (process.platform === 'linux') {
+    return path.join(homedir(), '.claude-conductor', 'data')
+  }
+  // Windows: derive %LOCALAPPDATA% from the env var,
+  // falling back to <home>\AppData\Local.
+  const localAppData = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local')
+  return path.join(localAppData, 'Claude Command Center')
+}
+
+// Cache registry values — they don't change during the app's lifetime
+// (only set during installer wizard or setup dialog, which restarts the app)
+let cachedDataDir: string | null = null
+let cachedResourcesDir: string | null = null
+let dataDirFromRegistry = false // true if DataDirectory was found in registry
+
+// Read data directory from registry (cached after first call)
+export function getDataDirectory(): string {
+  if (cachedDataDir) return cachedDataDir
+
+  const regVal = readRegistry('DataDirectory')
+  if (regVal) {
+    cachedDataDir = regVal
+    dataDirFromRegistry = true
+    logInfo(`[setup] Data directory from registry: ${cachedDataDir}`)
+    return cachedDataDir
+  }
+
+  cachedDataDir = getDefaultDataDir()
+  logInfo(`[setup] Data directory default: ${cachedDataDir}`)
+  return cachedDataDir
+}
+
+// Read resources directory from registry (cached after first call)
+export function getResourcesDirectory(): string {
+  if (cachedResourcesDir) return cachedResourcesDir
+
+  const regVal = readRegistry('ResourcesDirectory')
+  if (regVal) {
+    cachedResourcesDir = regVal
+    logInfo(`[setup] Resources directory from registry: ${cachedResourcesDir}`)
+    return cachedResourcesDir
+  }
+
+  cachedResourcesDir = path.join(getDataDirectory(), 'resources')
+  logInfo(`[setup] Resources directory fallback: ${cachedResourcesDir}`)
+  return cachedResourcesDir
+}
+
+// Set data directory in registry and create folders
+export function setDataDirectory(dataDir: string): boolean {
+  try {
+    // Create directory structure
+    fs.mkdirSync(path.join(dataDir, 'sessions'), { recursive: true })
+    fs.mkdirSync(path.join(dataDir, 'logs'), { recursive: true })
+    fs.mkdirSync(path.join(dataDir, 'debug'), { recursive: true })
+    fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
+
+    writeRegistry('DataDirectory', dataDir)
+
+    cachedDataDir = dataDir // Update cache
+    dataDirFromRegistry = true
+    logInfo(`[setup] Data directory set to: ${dataDir}`)
+    return true
+  } catch (err) {
+    logInfo(`[setup] Failed to set data directory: ${err}`)
+    return false
+  }
+}
+
+// Set resources directory in registry and create folders
+export function setResourcesDirectory(resourcesDir: string): boolean {
+  try {
+    fs.mkdirSync(path.join(resourcesDir, 'insights'), { recursive: true })
+    fs.mkdirSync(path.join(resourcesDir, 'screenshots'), { recursive: true })
+    fs.mkdirSync(path.join(resourcesDir, 'skills'), { recursive: true })
+    fs.mkdirSync(path.join(resourcesDir, 'scripts'), { recursive: true })
+    fs.mkdirSync(path.join(resourcesDir, 'status'), { recursive: true })
+
+    writeRegistry('ResourcesDirectory', resourcesDir)
+
+    cachedResourcesDir = resourcesDir // Update cache
+    logInfo(`[setup] Resources directory set to: ${resourcesDir}`)
+    return true
+  } catch (err) {
+    logInfo(`[setup] Failed to set resources directory: ${err}`)
+    return false
+  }
+}
+
+// Accessor for the dataDirFromRegistry flag (used by isSetupComplete in the IPC layer)
+export function isDataDirFromRegistry(): boolean {
+  return dataDirFromRegistry
+}

--- a/src/main/debug-logger.ts
+++ b/src/main/debug-logger.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { getDataDirectory } from './ipc/setup-handlers'
+import { getDataDirectory } from './data-paths'
 
 // Lazy-initialized: can't call getDataDirectory() at module load time
 let LOG_DIR: string | null = null

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -17,7 +17,7 @@ import type {
 // Responder registry lives in its own module so we can import it directly --
 // the old lazy-require workaround for the channel-permissions circular
 // dependency is no longer needed (#483).
-import { registerResponder, deregisterResponder } from '../permission-responders'
+import { registerResponder as defaultRegister, deregisterResponder as defaultDeregister } from '../permission-responders'
 import { logTrace, logWarn, logError } from '../debug-logger'
 
 // Diagnostics (opt-in, verbose-gated): module-level in-flight counter for the
@@ -36,6 +36,10 @@ const MAX_REQUEST_BODY_BYTES = 256 * 1024
 export interface HooksGatewayOptions {
   defaultPort?: number
   emit: (channel: string, payload: unknown) => void
+  permissionResponders?: {
+    register: (id: string, cb: (decision: string) => void) => void
+    deregister: (id: string) => void
+  }
 }
 
 interface HandleArgs {
@@ -64,6 +68,11 @@ export class HooksGateway {
   private defaultPort: number
   private emit: HooksGatewayOptions['emit']
 
+  public readonly permissionRegister: (id: string, cb: (decision: string) => void) => void
+  public readonly permissionDeregister: (id: string) => void
+  private _eventsTotal = 0
+  private _dropsTotal = 0
+
   private secrets = new Map<string, string>()
   private buffers = new Map<string, RingBufferEntry[]>()
   private overflowLatched = new Set<string>()
@@ -73,6 +82,8 @@ export class HooksGateway {
   constructor(opts: HooksGatewayOptions) {
     this.defaultPort = opts.defaultPort ?? DEFAULT_HOOKS_PORT
     this.emit = opts.emit
+    this.permissionRegister = opts.permissionResponders?.register ?? defaultRegister
+    this.permissionDeregister = opts.permissionResponders?.deregister ?? defaultDeregister
   }
 
   subscribe(cb: (e: HookEvent) => void): () => void {
@@ -145,6 +156,18 @@ export class HooksGateway {
     const secret = randomUUID()
     this.secrets.set(sessionId, secret)
     return secret
+  }
+
+  registerSessionWithSecret(sessionId: string, secret: string): void {
+    this.secrets.set(sessionId, secret)
+  }
+
+  hasSecret(sessionId: string): boolean {
+    return this.secrets.has(sessionId)
+  }
+
+  metrics(): { inFlight: number; eventsTotal: number; dropsTotal: number } {
+    return { inFlight: hooksInFlight, eventsTotal: this._eventsTotal, dropsTotal: this._dropsTotal }
   }
 
   unregisterSession(sessionId: string): void {
@@ -322,7 +345,7 @@ export class HooksGateway {
           if (done) return
           done = true
           clearTimeout(timeout)
-          deregisterResponder(capturedId)
+          this.permissionDeregister(capturedId)
         }
         const timeout = setTimeout(() => {
           if (done) return
@@ -331,11 +354,11 @@ export class HooksGateway {
             capturedRes.writeHead(200, { 'Content-Type': 'application/json', 'Connection': 'close' })
             capturedRes.end('{}')
           } catch { /* response already closed */ }
-          deregisterResponder(capturedId)
+          this.permissionDeregister(capturedId)
         }, 120_000)
         timeout.unref?.()
         req.on('close', () => cleanup())
-        registerResponder(capturedId, (decision) => {
+        this.permissionRegister(capturedId, (decision) => {
           if (done) return  // timeout already fired or client aborted
           done = true
           clearTimeout(timeout)
@@ -484,11 +507,13 @@ export class HooksGateway {
       payload: redacted,
       ts: Date.now(),
     }
+    this._eventsTotal++
 
     const buf = this.buffers.get(sid) ?? []
     buf.push(entry)
     if (buf.length > RING_BUFFER_CAP) {
       buf.splice(0, buf.length - RING_BUFFER_CAP)
+      this._dropsTotal++
       if (!this.overflowLatched.has(sid)) {
         this.overflowLatched.add(sid)
         try {

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -109,10 +109,10 @@ export class HooksGateway {
     return { ...this._status }
   }
 
-  async start(): Promise<HooksGatewayStatus> {
+  async start(portOverride?: number): Promise<HooksGatewayStatus> {
     if (this.server) return this.status()
     this._status = { ...this._status, enabled: true }
-    const port = await this.bindWithRetry(this.defaultPort)
+    const port = await this.bindWithRetry(portOverride ?? this.defaultPort)
     if (port === null) {
       this._status = {
         enabled: false,

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -158,6 +158,8 @@ export class HooksGateway {
     return secret
   }
 
+  // Used by the proxy to replay an existing (known) secret into a fail-open
+  // in-process gateway, vs registerSession which mints a fresh UUID.
   registerSessionWithSecret(sessionId: string, secret: string): void {
     this.secrets.set(sessionId, secret)
   }
@@ -166,6 +168,11 @@ export class HooksGateway {
     return this.secrets.has(sessionId)
   }
 
+  // NB: inFlight reads the module-scoped `hooksInFlight` (process-global) -- by
+  // design there is exactly one gateway per process (the prod singleton, or the
+  // in-process fail-open instance; the child runs in its own process with its own
+  // module scope). eventsTotal/dropsTotal are per-instance. If two gateways are
+  // ever instantiated in ONE process, inFlight would be shared across them.
   metrics(): { inFlight: number; eventsTotal: number; dropsTotal: number } {
     return { inFlight: hooksInFlight, eventsTotal: this._eventsTotal, dropsTotal: this._dropsTotal }
   }

--- a/src/main/hooks/index.ts
+++ b/src/main/hooks/index.ts
@@ -1,12 +1,27 @@
-import type { HooksGateway } from './hooks-gateway'
+import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
+import type { RingBufferEntry } from './hooks-types'
 
-let singleton: HooksGateway | null = null
+/** The gateway surface consumers use via getGateway(). Implemented by both the
+ *  in-process HooksGateway and the out-of-process HooksGatewayProxy, so either can
+ *  back the singleton without casts. */
+export interface HooksGatewayLike {
+  registerSession(sessionId: string): string
+  unregisterSession(sessionId: string): void
+  getBuffer(sessionId: string): RingBufferEntry[]
+  status(): HooksGatewayStatus
+  start(): Promise<HooksGatewayStatus>
+  stop(): Promise<void>
+  setPermissionGateActive(active: boolean): void
+  subscribe(cb: (e: HookEvent) => void): () => void
+}
 
-export function setGateway(gw: HooksGateway): void {
+let singleton: HooksGatewayLike | null = null
+
+export function setGateway(gw: HooksGatewayLike): void {
   singleton = gw
 }
 
-export function getGateway(): HooksGateway | null {
+export function getGateway(): HooksGatewayLike | null {
   return singleton
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,6 +48,8 @@ import { startJankDetector } from './jank-detector'
 import { readClipboardImageWithRetry } from './clipboard-image'
 import { HooksGateway } from './hooks/hooks-gateway'
 import { setGateway, getGateway } from './hooks'
+import { ServiceSupervisor } from './services/service-supervisor'
+import { forkHooksChild } from './services/fork-hooks-child'
 import { cleanupStaleHookEntries } from './hooks/boot-cleanup'
 import { DEFAULT_HOOKS_PORT } from './hooks/hooks-types'
 import { fetchModelPricing } from './tokenomics-manager'
@@ -117,6 +119,8 @@ function saveWindowState(win: BrowserWindow): void {
 
 let mainWindow: BrowserWindow | null = null
 let splashWindow: BrowserWindow | null = null
+let _hooksSupervisor: ServiceSupervisor | null = null
+function setHooksSupervisor(s: ServiceSupervisor): void { _hooksSupervisor = s }
 
 function getSplashImagePath(): { path: string; mime: string } | null {
   // In dev: repo root. In production: resources/ directory inside app.
@@ -692,26 +696,31 @@ if (!gotTheLock) {
     const hooksSettings = readConfig<{ hooksEnabled?: boolean; hooksPort?: number }>('settings')
     const hooksEnabled = hooksSettings?.hooksEnabled !== false
     const hooksPort = hooksSettings?.hooksPort ?? DEFAULT_HOOKS_PORT
-    const hooksGateway = new HooksGateway({
-      defaultPort: hooksPort,
-      emit: (channel, payload) => {
-        const win = getWindow()
-        if (win && !win.isDestroyed()) {
-          try { win.webContents.send(channel, payload) } catch { /* destroyed */ }
-        }
-      },
-    })
-    setGateway(hooksGateway)
+    const emitToWindow = (channel: string, payload: unknown) => {
+      const win = getWindow()
+      if (win && !win.isDestroyed()) {
+        try { win.webContents.send(channel, payload) } catch { /* destroyed */ }
+      }
+    }
+    if (hooksEnabled) {
+      // Supervised out-of-process gateway: a utilityProcess child runs the HooksGateway,
+      // crash-isolated from the main thread, with restart/backoff + fail-open-to-in-process.
+      const hooksSupervisor = new ServiceSupervisor({ forkChild: forkHooksChild, defaultPort: hooksPort, emit: emitToWindow })
+      const hooksProxy = hooksSupervisor.start()   // forks the child + posts start (S1 replay-before-listen inside)
+      setGateway(hooksProxy)                        // B1: consumers + handlers all use the proxy
+      setHooksSupervisor(hooksSupervisor)           // module-scope ref for before-quit (S5)
+    } else {
+      // Hooks disabled: today's exact behavior — an in-process gateway exists (so
+      // registerSession still mints secrets) but never binds; no child is forked.
+      setGateway(new HooksGateway({ defaultPort: hooksPort, emit: emitToWindow }))
+    }
     startPermissionTray()
     startEffortTracker()
     startAttentionSource()
     startJankDetector()
-    registerHooksHandlers(hooksGateway)
+    registerHooksHandlers(getGateway()!)   // B1: handlers get whatever gateway backs the singleton
     if (hooksEnabled) {
-      cleanupStaleHookEntries(new Set())
-      hooksGateway.start().catch((err) => {
-        logError(`[hooks] Gateway failed to start: ${err?.message ?? err}`)
-      })
+      cleanupStaleHookEntries(new Set())   // supervisor.start() already fired proxy.start()
     }
 
     // Shell — open URLs in system browser
@@ -778,6 +787,9 @@ if (!gotTheLock) {
 
   app.on('before-quit', () => {
     logInfo('App quitting...')
+    // S5: mark the supervisor shutting-down BEFORE killAllPty() so a hooks-child
+    // exit during teardown does NOT trigger a restart (race-free shutdown).
+    try { _hooksSupervisor?.shutdown() } catch { /* never started / hooks disabled */ }
     stopServiceStatusPoller()
     stopUpdateWatcher()
     stopUpdateServer()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import { registerTokenomicsHandlers } from './ipc/tokenomics-handlers'
 import { registerAccountAttributionHandlers } from './ipc/account-attribution-handlers'
 import { registerGitHubHandlers } from './ipc/github-handlers'
 import { registerHooksHandlers } from './ipc/hooks-handlers'
+import { registerServiceHealthHandlers } from './ipc/service-health-handlers'
 import { registerCodexHandlers } from './ipc/codex-handlers'
 import { registerCodexReviewHandlers } from './ipc/codex-review-handlers'
 import { registerChannelHandlers } from './ipc/channel-handlers'
@@ -121,6 +122,7 @@ let mainWindow: BrowserWindow | null = null
 let splashWindow: BrowserWindow | null = null
 let _hooksSupervisor: ServiceSupervisor | null = null
 function setHooksSupervisor(s: ServiceSupervisor): void { _hooksSupervisor = s }
+function getHooksSupervisor(): ServiceSupervisor | null { return _hooksSupervisor }
 
 function getSplashImagePath(): { path: string; mime: string } | null {
   // In dev: repo root. In production: resources/ directory inside app.
@@ -719,6 +721,9 @@ if (!gotTheLock) {
     startAttentionSource()
     startJankDetector()
     registerHooksHandlers(getGateway()!)   // B1: handlers get whatever gateway backs the singleton
+    // D1b: diagnostics IPC. The getter returns null in the hooks-disabled branch
+    // (supervisor never set) -> the handler serves an honest synthetic "hooks off" snapshot.
+    registerServiceHealthHandlers(() => getHooksSupervisor())
     if (hooksEnabled) {
       cleanupStaleHookEntries(new Set())   // supervisor.start() already fired proxy.start()
     }

--- a/src/main/ipc/hooks-handlers.ts
+++ b/src/main/ipc/hooks-handlers.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, ipcMain } from 'electron'
 import { IPC } from '../../shared/ipc-channels'
-import type { HooksGateway } from '../hooks/hooks-gateway'
+import type { HooksGatewayLike } from '../hooks'
 import type { HooksToggleRequest, HooksGetBufferRequest, HooksGatewayStatus } from '../../shared/hook-types'
 import { getActivePtySessionIds } from '../pty-manager'
 import { removeHooks } from '../hooks/session-hooks-writer'
@@ -14,7 +14,7 @@ function broadcastStatus(status: HooksGatewayStatus): void {
   }
 }
 
-export function registerHooksHandlers(gateway: HooksGateway): void {
+export function registerHooksHandlers(gateway: HooksGatewayLike): void {
   ipcMain.handle(IPC.HOOKS_TOGGLE, async (_e, req: HooksToggleRequest) => {
     let status: HooksGatewayStatus
     if (req.enabled) {

--- a/src/main/ipc/service-health-handlers.ts
+++ b/src/main/ipc/service-health-handlers.ts
@@ -1,0 +1,35 @@
+import { ipcMain } from 'electron'
+import { IPC } from '../../shared/ipc-channels'
+import { createInitialHealth } from '../../shared/service-health'
+import type { DiagnosticsSnapshot } from '../../shared/service-health'
+import type { ServiceSupervisor } from '../services/service-supervisor'
+
+type SupGetter = () => Pick<ServiceSupervisor, 'getDiagnosticsSnapshot' | 'manualRestart'> | null
+
+/** Pure: returns the live supervisor snapshot, or an honest synthetic "hooks off"
+ *  snapshot (state:'stopped') when no supervisor exists (hooksEnabled=false). */
+export function buildHealthGet(getSup: SupGetter): () => DiagnosticsSnapshot {
+  return () => {
+    const sup = getSup()
+    if (sup) return sup.getDiagnosticsSnapshot()
+    const h = { ...createInitialHealth('hooks', 'Hooks gateway'), state: 'stopped' as const }
+    return { capturedAt: Date.now(), services: [h], log: [] }
+  }
+}
+
+/** Pure: delegates to the supervisor's manualRestart, or declines honestly when
+ *  there is no supervisor. */
+export function buildRestart(getSup: SupGetter): (serviceId: string) => { ok: boolean; reason?: string } {
+  return (serviceId) => {
+    const sup = getSup()
+    if (!sup) return { ok: false, reason: 'no-supervisor' }
+    return sup.manualRestart(serviceId)
+  }
+}
+
+export function registerServiceHealthHandlers(getSup: SupGetter): void {
+  const get = buildHealthGet(getSup)
+  const restart = buildRestart(getSup)
+  ipcMain.handle(IPC.SERVICE_HEALTH_GET, async () => get())
+  ipcMain.handle(IPC.SERVICE_RESTART, async (_e, serviceId: string) => restart(serviceId))
+}

--- a/src/main/ipc/setup-handlers.ts
+++ b/src/main/ipc/setup-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app, dialog, BrowserWindow } from 'electron'
+import { ipcMain, dialog, BrowserWindow } from 'electron'
 import * as path from 'path'
 import * as fs from 'fs'
 import { homedir } from 'os'
@@ -6,109 +6,21 @@ import * as pty from 'node-pty'
 import { logInfo } from '../debug-logger'
 import { getInstallPath } from '../update-watcher'
 import { resolveClaudeForPty } from '../pty-manager'
-import { readRegistry, writeRegistry } from '../registry'
+import {
+  getDataDirectory,
+  getResourcesDirectory,
+  setDataDirectory,
+  setResourcesDirectory,
+  isDataDirFromRegistry,
+} from '../data-paths'
 
-// Lazy getter for default data dir - can't call app.getPath() at module load time
-function getDefaultDataDir(): string {
-  if (process.platform === 'darwin') {
-    return path.join(app.getPath('home'), 'Library', 'Application Support', 'Claude Conductor')
-  }
-  if (process.platform === 'linux') {
-    return path.join(app.getPath('home'), '.claude-conductor', 'data')
-  }
-  // Windows: Electron's app.getPath() has NO 'localAppData' key and throws on it,
-  // which broke first-run on any machine without the registry DataDirectory set
-  // (e.g. a clean install before the setup wizard writes it). Derive %LOCALAPPDATA%
-  // from the env var, falling back to <home>\AppData\Local.
-  const localAppData = process.env.LOCALAPPDATA || path.join(homedir(), 'AppData', 'Local')
-  return path.join(localAppData, 'Claude Command Center')
-}
-
-// Cache registry values — they don't change during the app's lifetime
-// (only set during installer wizard or setup dialog, which restarts the app)
-let cachedDataDir: string | null = null
-let cachedResourcesDir: string | null = null
-let dataDirFromRegistry = false // true if DataDirectory was found in registry
-
-// Read data directory from registry (cached after first call)
-export function getDataDirectory(): string {
-  if (cachedDataDir) return cachedDataDir
-
-  const regVal = readRegistry('DataDirectory')
-  if (regVal) {
-    cachedDataDir = regVal
-    dataDirFromRegistry = true
-    logInfo(`[setup] Data directory from registry: ${cachedDataDir}`)
-    return cachedDataDir
-  }
-
-  cachedDataDir = getDefaultDataDir()
-  logInfo(`[setup] Data directory default: ${cachedDataDir}`)
-  return cachedDataDir
-}
-
-// Read resources directory from registry (cached after first call)
-export function getResourcesDirectory(): string {
-  if (cachedResourcesDir) return cachedResourcesDir
-
-  const regVal = readRegistry('ResourcesDirectory')
-  if (regVal) {
-    cachedResourcesDir = regVal
-    logInfo(`[setup] Resources directory from registry: ${cachedResourcesDir}`)
-    return cachedResourcesDir
-  }
-
-  cachedResourcesDir = path.join(getDataDirectory(), 'resources')
-  logInfo(`[setup] Resources directory fallback: ${cachedResourcesDir}`)
-  return cachedResourcesDir
-}
-
-// Set resources directory in registry and create folders
-function setResourcesDirectory(resourcesDir: string): boolean {
-  try {
-    fs.mkdirSync(path.join(resourcesDir, 'insights'), { recursive: true })
-    fs.mkdirSync(path.join(resourcesDir, 'screenshots'), { recursive: true })
-    fs.mkdirSync(path.join(resourcesDir, 'skills'), { recursive: true })
-    fs.mkdirSync(path.join(resourcesDir, 'scripts'), { recursive: true })
-    fs.mkdirSync(path.join(resourcesDir, 'status'), { recursive: true })
-
-    writeRegistry('ResourcesDirectory', resourcesDir)
-
-    cachedResourcesDir = resourcesDir // Update cache
-    logInfo(`[setup] Resources directory set to: ${resourcesDir}`)
-    return true
-  } catch (err) {
-    logInfo(`[setup] Failed to set resources directory: ${err}`)
-    return false
-  }
-}
+export { getDataDirectory, getResourcesDirectory } from '../data-paths'
 
 // Check if setup is complete (uses cached registry/config check)
 export function isSetupComplete(): boolean {
   // Ensure getDataDirectory() has been called at least once to populate cache
   getDataDirectory()
-  return dataDirFromRegistry
-}
-
-// Set data directory in registry and create folders
-function setDataDirectory(dataDir: string): boolean {
-  try {
-    // Create directory structure
-    fs.mkdirSync(path.join(dataDir, 'sessions'), { recursive: true })
-    fs.mkdirSync(path.join(dataDir, 'logs'), { recursive: true })
-    fs.mkdirSync(path.join(dataDir, 'debug'), { recursive: true })
-    fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
-
-    writeRegistry('DataDirectory', dataDir)
-
-    cachedDataDir = dataDir // Update cache
-    dataDirFromRegistry = true
-    logInfo(`[setup] Data directory set to: ${dataDir}`)
-    return true
-  } catch (err) {
-    logInfo(`[setup] Failed to set data directory: ${err}`)
-    return false
-  }
+  return isDataDirFromRegistry()
 }
 
 // Shared helper lives in utils/claude-project-path. Both this module and the

--- a/src/main/services/fork-hooks-child.ts
+++ b/src/main/services/fork-hooks-child.ts
@@ -13,5 +13,5 @@ export function forkHooksChild(): ForkedChild {
     onMessage: (handler: (m: FromChildMessage) => void) => proc.on('message', (m) => handler(m as FromChildMessage)),
     kill: () => { try { proc.kill() } catch { /* already dead */ } },
   }
-  return { transport, kill: () => transport.kill(), onExit: (cb) => proc.once('exit', cb) }
+  return { transport, kill: transport.kill, onExit: (cb) => proc.once('exit', cb) }
 }

--- a/src/main/services/fork-hooks-child.ts
+++ b/src/main/services/fork-hooks-child.ts
@@ -1,0 +1,17 @@
+import { utilityProcess } from 'electron'
+import { join } from 'node:path'
+import type { ForkedChild } from './service-supervisor'
+import type { ChildTransport, FromChildMessage, ToChildMessage } from './service-transport'
+
+/** Fork the hooks gateway child (out/main/hooks-host.js) as an Electron
+ *  utilityProcess and adapt it to the ChildTransport the supervisor expects. */
+export function forkHooksChild(): ForkedChild {
+  const entry = join(__dirname, 'hooks-host.js')
+  const proc = utilityProcess.fork(entry, [], { serviceName: 'ccc-hooks-gateway' })
+  const transport: ChildTransport = {
+    post: (msg: ToChildMessage) => proc.postMessage(msg),
+    onMessage: (handler: (m: FromChildMessage) => void) => proc.on('message', (m) => handler(m as FromChildMessage)),
+    kill: () => { try { proc.kill() } catch { /* already dead */ } },
+  }
+  return { transport, kill: () => transport.kill(), onExit: (cb) => proc.once('exit', cb) }
+}

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -32,6 +32,16 @@ export class HooksGatewayProxy implements HooksGatewayLike {
   // Presence-tracking only — the actual held-open responder lives in the child;
   // resolvePermission routes the decision back over the transport.
   private openPermissionRequests = new Set<string>()
+  // start() (utility mode) returns only once the child announces `bound`, so the
+  // hooks toggle persists the REAL listening status (not a premature listening:false).
+  // An UNREF'd timeout fallback guarantees a bind failure can't hang the toggle.
+  private static BOUND_WAIT_MS = 4000
+  private boundWaiters: Array<{ resolve: (s: HooksGatewayStatus) => void; timer: ReturnType<typeof setTimeout> }> = []
+
+  private resolveBoundWaiters(): void {
+    const waiters = this.boundWaiters.splice(0)
+    for (const w of waiters) { clearTimeout(w.timer); w.resolve(this.status()) }
+  }
 
   constructor(opts: HooksGatewayProxyOptions) {
     this.transport = opts.transport
@@ -94,7 +104,10 @@ export class HooksGatewayProxy implements HooksGatewayLike {
   private onChildMessage(m: FromChildMessage): void {
     switch (m.type) {
       case 'bound':
-        this._status = { enabled: true, listening: true, port: m.port }; break
+        this._status = { enabled: true, listening: true, port: m.port }
+        try { this.emit(IPC.HOOKS_STATUS, { ...this._status }) } catch { /* destroyed */ }
+        this.resolveBoundWaiters()
+        break
       case 'event': {
         const entry = m.entry
         const buf = this.buffers.get(entry.sessionId) ?? []
@@ -125,7 +138,18 @@ export class HooksGatewayProxy implements HooksGatewayLike {
     if (this.inProcess) { await this.inProcessReady; return this.inProcess.start() }
     this.transport.post({ type: 'start', port: this.port })
     this._status = { ...this._status, enabled: true }
-    return this.status()
+    if (this._status.listening) return this.status()   // already bound (e.g. re-enable)
+    return new Promise<HooksGatewayStatus>((resolve) => {
+      const waiter = {
+        resolve,
+        timer: setTimeout(() => {
+          this.boundWaiters = this.boundWaiters.filter((w) => w !== waiter)
+          resolve(this.status())   // timed out — return whatever we have
+        }, HooksGatewayProxy.BOUND_WAIT_MS),
+      }
+      if (typeof (waiter.timer as { unref?: () => void }).unref === 'function') (waiter.timer as { unref: () => void }).unref()
+      this.boundWaiters.push(waiter)
+    })
   }
 
   /** Disable the gateway. Awaits the in-process bind first (if fail-open) so a

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -25,8 +25,10 @@ export class HooksGatewayProxy {
   // and every consumer method delegates to it so the proxy stays a faithful drop-in.
   private inProcess: HooksGateway | null = null
   private inProcessReady: Promise<unknown> | null = null
-  // Permission bridge: child-opened request ids awaiting a main-side decision.
-  private responders = new Map<string, (decision: string) => void>()
+  // Permission bridge: ids of child-opened requests awaiting a main-side decision.
+  // Presence-tracking only — the actual held-open responder lives in the child;
+  // resolvePermission routes the decision back over the transport.
+  private openPermissionRequests = new Set<string>()
 
   constructor(opts: HooksGatewayProxyOptions) {
     this.transport = opts.transport
@@ -71,8 +73,12 @@ export class HooksGatewayProxy {
     return { ...this._status }
   }
 
-  /** Test/seam parity with HooksGateway. */
-  dispatchForTest(event: HookEvent): void { this.fanOut(event) }
+  /** Test/seam parity with HooksGateway. After fail-open the in-process gateway
+   *  owns fan-out, so delegate there (matches the other read-path delegations). */
+  dispatchForTest(event: HookEvent): void {
+    if (this.inProcess) { this.inProcess.dispatchForTest(event); return }
+    this.fanOut(event)
+  }
 
   /** Public entry the supervisor uses when it owns the transport subscription. */
   handleChildMessage(m: FromChildMessage): void { this.onChildMessage(m) }
@@ -103,7 +109,7 @@ export class HooksGatewayProxy {
       case 'permission-open':
         // Record the open request so a later resolvePermission(requestId, ...)
         // is meaningful (we route the decision back to the child).
-        this.responders.set(m.requestId, () => { /* decision routed via transport.post */ })
+        this.openPermissionRequests.add(m.requestId)
         break
       default: break
     }
@@ -149,7 +155,7 @@ export class HooksGatewayProxy {
    *  handles it (no-op here). Utility-process: route the decision back to the child. */
   resolvePermission(requestId: string, decision: string): void {
     if (this.inProcess) return
-    this.responders.delete(requestId)
+    this.openPermissionRequests.delete(requestId)
     this.transport.post({ type: 'permission-respond', requestId, decision })
   }
 

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -20,8 +20,7 @@ export class HooksGatewayProxy {
   private buffers = new Map<string, RingBufferEntry[]>()
   private subscribers = new Set<(e: HookEvent) => void>()
   private _status: HooksGatewayStatus = { enabled: true, listening: false, port: null }
-  // permission bridge map — populated in Task 8
-  private responders = new Map<string, (decision: string) => void>()
+  // (the permission-bridge responder map lands in Task 8 alongside the logic that uses it)
 
   constructor(opts: HooksGatewayProxyOptions) {
     this.transport = opts.transport
@@ -77,6 +76,8 @@ export class HooksGatewayProxy {
         break
       }
       case 'dropped':
+        // The child's gateway latches HOOKS_DROPPED once per session (overflowLatched),
+        // so we receive at most one 'dropped' per session and don't need a local latch.
         try { this.emit(IPC.HOOKS_DROPPED, { sessionId: m.sessionId }) } catch { /* destroyed */ }
         break
       case 'permission-open':

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto'
+import { IPC } from '../../shared/ipc-channels'
+import { RING_BUFFER_CAP } from '../hooks/hooks-types'
+import type { RingBufferEntry } from '../hooks/hooks-types'
+import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
+import type { ChildTransport, FromChildMessage } from './service-transport'
+
+export interface HooksGatewayProxyOptions {
+  transport: ChildTransport
+  defaultPort: number
+  emit?: (channel: string, payload: unknown) => void   // to renderer
+  selfSubscribe?: boolean   // default true; supervisor passes false and drives handleChildMessage
+}
+
+export class HooksGatewayProxy {
+  private transport: ChildTransport
+  private port: number
+  private emit: (channel: string, payload: unknown) => void
+  private secrets = new Map<string, string>()
+  private buffers = new Map<string, RingBufferEntry[]>()
+  private subscribers = new Set<(e: HookEvent) => void>()
+  private _status: HooksGatewayStatus = { enabled: true, listening: false, port: null }
+  // permission bridge map — populated in Task 8
+  private responders = new Map<string, (decision: string) => void>()
+
+  constructor(opts: HooksGatewayProxyOptions) {
+    this.transport = opts.transport
+    this.port = opts.defaultPort
+    this.emit = opts.emit ?? (() => {})
+    if (opts.selfSubscribe !== false) this.transport.onMessage((m) => this.onChildMessage(m))
+  }
+
+  subscribe(cb: (e: HookEvent) => void): () => void {
+    this.subscribers.add(cb); return () => { this.subscribers.delete(cb) }
+  }
+
+  /** SYNCHRONOUS: secret minted in main (keeps pty-manager's spawn path sync),
+   *  registration fire-and-forget to the child. */
+  registerSession(sessionId: string): string {
+    const secret = randomUUID()
+    this.secrets.set(sessionId, secret)
+    this.transport.post({ type: 'register', sid: sessionId, secret })
+    return secret
+  }
+
+  unregisterSession(sessionId: string): void {
+    this.secrets.delete(sessionId); this.buffers.delete(sessionId)
+    this.transport.post({ type: 'unregister', sid: sessionId })
+    try { this.emit(IPC.HOOKS_SESSION_ENDED, sessionId) } catch { /* webContents destroyed */ }
+  }
+
+  getBuffer(sessionId: string): RingBufferEntry[] { return [...(this.buffers.get(sessionId) ?? [])] }
+  status(): HooksGatewayStatus { return { ...this._status } }
+
+  /** Test/seam parity with HooksGateway. */
+  dispatchForTest(event: HookEvent): void { this.fanOut(event) }
+
+  /** Public entry the supervisor uses when it owns the transport subscription. */
+  handleChildMessage(m: FromChildMessage): void { this.onChildMessage(m) }
+
+  private fanOut(event: HookEvent): void {
+    for (const cb of [...this.subscribers]) { try { cb(event) } catch { /* bad subscriber */ } }
+  }
+
+  private onChildMessage(m: FromChildMessage): void {
+    switch (m.type) {
+      case 'bound':
+        this._status = { enabled: true, listening: true, port: m.port }; break
+      case 'event': {
+        const entry = m.entry
+        const buf = this.buffers.get(entry.sessionId) ?? []
+        buf.push(entry as RingBufferEntry)
+        if (buf.length > RING_BUFFER_CAP) buf.splice(0, buf.length - RING_BUFFER_CAP)
+        this.buffers.set(entry.sessionId, buf)
+        this.fanOut(entry)
+        try { this.emit(IPC.HOOKS_EVENT, entry) } catch { /* destroyed */ }
+        break
+      }
+      case 'dropped':
+        try { this.emit(IPC.HOOKS_DROPPED, { sessionId: m.sessionId }) } catch { /* destroyed */ }
+        break
+      case 'permission-open':
+        // Task 8 fills this in (main-side responder registry)
+        break
+      default: break
+    }
+  }
+
+  // start/stop/setPermissionGateActive/failOpen/isInProcessFallback/resolvePermission/
+  // rebindTransport/replaySecretsTo: Task 8 + Task 10.
+}

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -38,11 +38,12 @@ export class HooksGatewayProxy {
   }
 
   subscribe(cb: (e: HookEvent) => void): () => void {
+    // After fail-open the in-process gateway owns fan-out, so a new subscriber goes
+    // straight there. this.subscribers stays dormant once inProcess is set (the
+    // pre-failOpen subscribers were already copied into the gateway by failOpen()).
+    if (this.inProcess) return this.inProcess.subscribe(cb)
     this.subscribers.add(cb)
-    // After fail-open the in-process gateway is the real event source, so the
-    // subscriber must be registered there too; unsubscribe removes from both.
-    const offInProc = this.inProcess?.subscribe(cb)
-    return () => { this.subscribers.delete(cb); offInProc?.() }
+    return () => { this.subscribers.delete(cb) }
   }
 
   /** SYNCHRONOUS: secret minted in main (keeps pty-manager's spawn path sync),
@@ -154,8 +155,8 @@ export class HooksGatewayProxy {
   /** Renderer Allow/Deny path. In-process: the module responder registry already
    *  handles it (no-op here). Utility-process: route the decision back to the child. */
   resolvePermission(requestId: string, decision: string): void {
-    if (this.inProcess) return
-    this.openPermissionRequests.delete(requestId)
+    this.openPermissionRequests.delete(requestId)   // clear regardless of host
+    if (this.inProcess) return   // in-process: the module responder registry already resolved it
     this.transport.post({ type: 'permission-respond', requestId, decision })
   }
 
@@ -165,6 +166,9 @@ export class HooksGatewayProxy {
     this._status = { ...this._status, listening: false }
   }
 
+  // Precondition: utility-process mode only (called on child restart, before any
+  // fail-open). this.secrets is the source of truth there; after failOpen() it goes
+  // stale because registerSession delegates to the in-process gateway.
   replaySecretsTo(t: ChildTransport): void {
     for (const [sid, secret] of this.secrets) t.post({ type: 'register', sid, secret })
   }

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -138,7 +138,11 @@ export class HooksGatewayProxy implements HooksGatewayLike {
     if (this.inProcess) { await this.inProcessReady; return this.inProcess.start() }
     this.transport.post({ type: 'start', port: this.port })
     this._status = { ...this._status, enabled: true }
-    if (this._status.listening) return this.status()   // already bound (e.g. re-enable)
+    // Already listening (e.g. a re-enable). Safe because the supervisor resets
+    // listening:false via rebindTransport() on every child restart, so a dead
+    // child can't leave this stale-true — and we already posted `start` above, so
+    // a live child re-receives it regardless.
+    if (this._status.listening) return this.status()
     return new Promise<HooksGatewayStatus>((resolve) => {
       const waiter = {
         resolve,
@@ -158,6 +162,7 @@ export class HooksGatewayProxy implements HooksGatewayLike {
     if (this.inProcess) { await this.inProcessReady; await this.inProcess.stop(); return }
     this.transport.post({ type: 'stop' })
     this._status = { enabled: false, listening: false, port: null }
+    this.resolveBoundWaiters()   // a start()->stop() race must not wait out the 4s bound fallback
   }
 
   setPermissionGateActive(active: boolean): void {
@@ -176,7 +181,11 @@ export class HooksGatewayProxy implements HooksGatewayLike {
     for (const [sid, secret] of this.secrets) gw.registerSessionWithSecret(sid, secret)
     for (const cb of this.subscribers) gw.subscribe(cb)
     this.inProcess = gw
-    this.inProcessReady = gw.start()   // tracked so stop() can await it (no socket leak / race)
+    // Tracked so stop() can await it (no socket leak / race). Draining the bound
+    // waiters only AFTER the in-process gateway binds lets a start() awaited across
+    // the fail-open transition resolve with the real listening status (via
+    // status()->inProcess) instead of waiting out the 4s bound fallback.
+    this.inProcessReady = gw.start().then((s) => { this.resolveBoundWaiters(); return s })
   }
 
   /** Renderer Allow/Deny path. In-process: the module responder registry already
@@ -191,6 +200,7 @@ export class HooksGatewayProxy implements HooksGatewayLike {
   rebindTransport(t: ChildTransport): void {
     this.transport = t
     this._status = { ...this._status, listening: false }
+    this.resolveBoundWaiters()   // drop any waiter (and its timer) tied to the previous child
   }
 
   // Precondition: utility-process mode only (called on child restart, before any

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -4,6 +4,7 @@ import { RING_BUFFER_CAP } from '../hooks/hooks-types'
 import { HooksGateway } from '../hooks/hooks-gateway'
 import type { RingBufferEntry } from '../hooks/hooks-types'
 import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
+import type { HooksGatewayLike } from '../hooks'
 import type { ChildTransport, FromChildMessage } from './service-transport'
 
 export interface HooksGatewayProxyOptions {
@@ -13,7 +14,9 @@ export interface HooksGatewayProxyOptions {
   selfSubscribe?: boolean   // default true; supervisor passes false and drives handleChildMessage
 }
 
-export class HooksGatewayProxy {
+// `implements HooksGatewayLike` enforces the drop-in contract at compile time: if a
+// method is added to the consumed gateway surface, the proxy must implement it too.
+export class HooksGatewayProxy implements HooksGatewayLike {
   private transport: ChildTransport
   private port: number
   private emit: (channel: string, payload: unknown) => void

--- a/src/main/services/hooks-gateway-proxy.ts
+++ b/src/main/services/hooks-gateway-proxy.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { IPC } from '../../shared/ipc-channels'
 import { RING_BUFFER_CAP } from '../hooks/hooks-types'
+import { HooksGateway } from '../hooks/hooks-gateway'
 import type { RingBufferEntry } from '../hooks/hooks-types'
 import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
 import type { ChildTransport, FromChildMessage } from './service-transport'
@@ -20,7 +21,12 @@ export class HooksGatewayProxy {
   private buffers = new Map<string, RingBufferEntry[]>()
   private subscribers = new Set<(e: HookEvent) => void>()
   private _status: HooksGatewayStatus = { enabled: true, listening: false, port: null }
-  // (the permission-bridge responder map lands in Task 8 alongside the logic that uses it)
+  // Fail-open: when set, the gateway runs IN-PROCESS (today's exact HooksGateway)
+  // and every consumer method delegates to it so the proxy stays a faithful drop-in.
+  private inProcess: HooksGateway | null = null
+  private inProcessReady: Promise<unknown> | null = null
+  // Permission bridge: child-opened request ids awaiting a main-side decision.
+  private responders = new Map<string, (decision: string) => void>()
 
   constructor(opts: HooksGatewayProxyOptions) {
     this.transport = opts.transport
@@ -30,12 +36,18 @@ export class HooksGatewayProxy {
   }
 
   subscribe(cb: (e: HookEvent) => void): () => void {
-    this.subscribers.add(cb); return () => { this.subscribers.delete(cb) }
+    this.subscribers.add(cb)
+    // After fail-open the in-process gateway is the real event source, so the
+    // subscriber must be registered there too; unsubscribe removes from both.
+    const offInProc = this.inProcess?.subscribe(cb)
+    return () => { this.subscribers.delete(cb); offInProc?.() }
   }
 
   /** SYNCHRONOUS: secret minted in main (keeps pty-manager's spawn path sync),
-   *  registration fire-and-forget to the child. */
+   *  registration fire-and-forget to the child. After fail-open it delegates to
+   *  the in-process gateway (still synchronous) instead of posting to a dead child. */
   registerSession(sessionId: string): string {
+    if (this.inProcess) return this.inProcess.registerSession(sessionId)
     const secret = randomUUID()
     this.secrets.set(sessionId, secret)
     this.transport.post({ type: 'register', sid: sessionId, secret })
@@ -43,13 +55,21 @@ export class HooksGatewayProxy {
   }
 
   unregisterSession(sessionId: string): void {
+    if (this.inProcess) { this.inProcess.unregisterSession(sessionId); return }
     this.secrets.delete(sessionId); this.buffers.delete(sessionId)
     this.transport.post({ type: 'unregister', sid: sessionId })
     try { this.emit(IPC.HOOKS_SESSION_ENDED, sessionId) } catch { /* webContents destroyed */ }
   }
 
-  getBuffer(sessionId: string): RingBufferEntry[] { return [...(this.buffers.get(sessionId) ?? [])] }
-  status(): HooksGatewayStatus { return { ...this._status } }
+  getBuffer(sessionId: string): RingBufferEntry[] {
+    if (this.inProcess) return this.inProcess.getBuffer(sessionId)
+    return [...(this.buffers.get(sessionId) ?? [])]
+  }
+
+  status(): HooksGatewayStatus {
+    if (this.inProcess) return this.inProcess.status()
+    return { ...this._status }
+  }
 
   /** Test/seam parity with HooksGateway. */
   dispatchForTest(event: HookEvent): void { this.fanOut(event) }
@@ -81,12 +101,70 @@ export class HooksGatewayProxy {
         try { this.emit(IPC.HOOKS_DROPPED, { sessionId: m.sessionId }) } catch { /* destroyed */ }
         break
       case 'permission-open':
-        // Task 8 fills this in (main-side responder registry)
+        // Record the open request so a later resolvePermission(requestId, ...)
+        // is meaningful (we route the decision back to the child).
+        this.responders.set(m.requestId, () => { /* decision routed via transport.post */ })
         break
       default: break
     }
   }
 
-  // start/stop/setPermissionGateActive/failOpen/isInProcessFallback/resolvePermission/
-  // rebindTransport/replaySecretsTo: Task 8 + Task 10.
+  /** Enable the gateway. Utility-process mode posts `start` to the child;
+   *  after fail-open it drives the in-process gateway directly. */
+  async start(): Promise<HooksGatewayStatus> {
+    if (this.inProcess) { await this.inProcessReady; return this.inProcess.start() }
+    this.transport.post({ type: 'start', port: this.port })
+    this._status = { ...this._status, enabled: true }
+    return this.status()
+  }
+
+  /** Disable the gateway. Awaits the in-process bind first (if fail-open) so a
+   *  start->stop race can't leak the listening socket. */
+  async stop(): Promise<void> {
+    if (this.inProcess) { await this.inProcessReady; await this.inProcess.stop(); return }
+    this.transport.post({ type: 'stop' })
+    this._status = { enabled: false, listening: false, port: null }
+  }
+
+  setPermissionGateActive(active: boolean): void {
+    if (this.inProcess) { this.inProcess.setPermissionGateActive(active); return }
+    this.transport.post({ type: 'setGate', active })
+  }
+
+  isInProcessFallback(): boolean { return this.inProcess !== null }
+
+  /** Tear down the child path and run the gateway in-process (today's exact code).
+   *  Replays known secrets + current subscribers so live sessions keep working.
+   *  PRECONDITION: the supervisor has already killed the child (no double bind). */
+  failOpen(): void {
+    if (this.inProcess) return
+    const gw = new HooksGateway({ defaultPort: this.port, emit: this.emit })
+    for (const [sid, secret] of this.secrets) gw.registerSessionWithSecret(sid, secret)
+    for (const cb of this.subscribers) gw.subscribe(cb)
+    this.inProcess = gw
+    this.inProcessReady = gw.start()   // tracked so stop() can await it (no socket leak / race)
+  }
+
+  /** Renderer Allow/Deny path. In-process: the module responder registry already
+   *  handles it (no-op here). Utility-process: route the decision back to the child. */
+  resolvePermission(requestId: string, decision: string): void {
+    if (this.inProcess) return
+    this.responders.delete(requestId)
+    this.transport.post({ type: 'permission-respond', requestId, decision })
+  }
+
+  // Supervisor helpers (used in Task 10):
+  rebindTransport(t: ChildTransport): void {
+    this.transport = t
+    this._status = { ...this._status, listening: false }
+  }
+
+  replaySecretsTo(t: ChildTransport): void {
+    for (const [sid, secret] of this.secrets) t.post({ type: 'register', sid, secret })
+  }
+
+  /** Test-only: reflects whichever store currently owns the session secret. */
+  hasSecretForTest(sid: string): boolean {
+    return this.inProcess ? this.inProcess.hasSecret(sid) : this.secrets.has(sid)
+  }
 }

--- a/src/main/services/hooks-host-core.ts
+++ b/src/main/services/hooks-host-core.ts
@@ -1,12 +1,35 @@
 import { HooksGateway } from '../hooks/hooks-gateway'
 import { IPC } from '../../shared/ipc-channels'
+import type { HooksGatewayOptions } from '../hooks/hooks-gateway'
 import type { HostTransport } from './service-transport'
-import type { HookEvent } from '../../shared/hook-types'
+import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
 
 export interface HooksHost {
   _gatewayHasSecret(sid: string): boolean
   _ingestForTest(sid: string, secret: string): Promise<void>
   _registerResponderForTest(id: string, cb: (decision: string) => void): void
+}
+
+/** The minimal gateway surface `createHooksHost` depends on. The default
+ *  `createGateway` builds a real `HooksGateway`; tests inject a stub (e.g. one
+ *  whose `start()` resolves to a bind failure) to exercise the bind-failed path
+ *  deterministically. */
+export interface HooksGatewayHostFace {
+  registerSessionWithSecret(sid: string, secret: string): void
+  unregisterSession(sid: string): void
+  start(portOverride?: number): Promise<HooksGatewayStatus>
+  stop(): Promise<void>
+  setPermissionGateActive(active: boolean): void
+  metrics(): { inFlight: number; eventsTotal: number; dropsTotal: number }
+  hasSecret(sid: string): boolean
+  _handleRequestForTest(args: Parameters<HooksGateway['_handleRequestForTest']>[0]): Promise<{ status: number; body: string }>
+  permissionRegister(id: string, cb: (decision: string) => void): void
+}
+
+export interface CreateHooksHostOptions {
+  healthBeat?: boolean
+  /** Injection seam (default builds a real HooksGateway). */
+  createGateway?: (o: HooksGatewayOptions) => HooksGatewayHostFace
 }
 
 /**
@@ -17,10 +40,11 @@ export interface HooksHost {
  *   (permission-respond) -- B2: the gateway must NOT import permission-responders.
  * - control messages from parent drive register/unregister/start/stop/setGate.
  */
-export function createHooksHost(transport: HostTransport, opts?: { healthBeat?: boolean }): HooksHost {
+export function createHooksHost(transport: HostTransport, opts?: CreateHooksHostOptions): HooksHost {
   const localResponders = new Map<string, (decision: string) => void>()
 
-  const gateway = new HooksGateway({
+  const createGateway = opts?.createGateway ?? ((o: HooksGatewayOptions) => new HooksGateway(o))
+  const gateway = createGateway({
     emit: (channel, payload) => {
       if (channel === IPC.HOOKS_EVENT) {
         transport.post({ type: 'event', entry: payload as HookEvent })
@@ -43,7 +67,11 @@ export function createHooksHost(transport: HostTransport, opts?: { healthBeat?: 
       case 'unregister': gateway.unregisterSession(msg.sid); break
       case 'start':
         void gateway.start(msg.port).then((s) => {
-          if (s.listening && s.port != null) transport.post({ type: 'bound', port: s.port, pid: process.pid })
+          if (s.listening && s.port != null) {
+            transport.post({ type: 'bound', port: s.port, pid: process.pid })
+          } else {
+            transport.post({ type: 'bind-failed', error: s.error ?? 'bind-failed' })
+          }
         })
         break
       case 'stop': void gateway.stop(); break

--- a/src/main/services/hooks-host-core.ts
+++ b/src/main/services/hooks-host-core.ts
@@ -61,6 +61,12 @@ export function createHooksHost(transport: HostTransport, opts?: CreateHooksHost
     },
   })
 
+  // Forward a small set of operationally-useful child events to the diagnostics
+  // ring. Metadata-only (never hook bodies). `Date.now()` is fine here -- this is
+  // a real child process, NOT a workflow script.
+  const postLog = (level: 'info' | 'warn' | 'error', code: string, message: string) =>
+    transport.post({ type: 'log', entry: { ts: Date.now(), serviceId: 'hooks', level, code, message } })
+
   transport.onMessage((msg) => {
     switch (msg.type) {
       case 'register': gateway.registerSessionWithSecret(msg.sid, msg.secret); break
@@ -70,11 +76,12 @@ export function createHooksHost(transport: HostTransport, opts?: CreateHooksHost
           if (s.listening && s.port != null) {
             transport.post({ type: 'bound', port: s.port, pid: process.pid })
           } else {
+            postLog('error', 'bind-failed', s.error ?? 'bind-failed')
             transport.post({ type: 'bind-failed', error: s.error ?? 'bind-failed' })
           }
         })
         break
-      case 'stop': void gateway.stop(); break
+      case 'stop': postLog('info', 'child-stop', 'gateway stop requested'); void gateway.stop(); break
       case 'setGate': gateway.setPermissionGateActive(msg.active); break
       case 'permission-respond': localResponders.get(msg.requestId)?.(msg.decision); break
       default: break

--- a/src/main/services/hooks-host-core.ts
+++ b/src/main/services/hooks-host-core.ts
@@ -41,7 +41,11 @@ export function createHooksHost(transport: HostTransport, opts?: { healthBeat?: 
     switch (msg.type) {
       case 'register': gateway.registerSessionWithSecret(msg.sid, msg.secret); break
       case 'unregister': gateway.unregisterSession(msg.sid); break
-      case 'start': void gateway.start(); break
+      case 'start':
+        void gateway.start(msg.port).then((s) => {
+          if (s.listening && s.port != null) transport.post({ type: 'bound', port: s.port, pid: process.pid })
+        })
+        break
       case 'stop': void gateway.stop(); break
       case 'setGate': gateway.setPermissionGateActive(msg.active); break
       case 'permission-respond': localResponders.get(msg.requestId)?.(msg.decision); break

--- a/src/main/services/hooks-host-core.ts
+++ b/src/main/services/hooks-host-core.ts
@@ -1,0 +1,73 @@
+import { HooksGateway } from '../hooks/hooks-gateway'
+import { IPC } from '../../shared/ipc-channels'
+import type { HostTransport } from './service-transport'
+import type { HookEvent } from '../../shared/hook-types'
+
+export interface HooksHost {
+  _gatewayHasSecret(sid: string): boolean
+  _ingestForTest(sid: string, secret: string): Promise<void>
+  _registerResponderForTest(id: string, cb: (decision: string) => void): void
+}
+
+/**
+ * Run the HooksGateway inside a child process, bridged to `transport`.
+ * - gateway emit (HOOKS_EVENT/HOOKS_DROPPED) -> post digested message to parent
+ * - held-open responders live HERE (the socket is here) but their existence is
+ *   announced to MAIN (permission-open) and MAIN's decision is routed back
+ *   (permission-respond) -- B2: the gateway must NOT import permission-responders.
+ * - control messages from parent drive register/unregister/start/stop/setGate.
+ */
+export function createHooksHost(transport: HostTransport, opts?: { healthBeat?: boolean }): HooksHost {
+  const localResponders = new Map<string, (decision: string) => void>()
+
+  const gateway = new HooksGateway({
+    emit: (channel, payload) => {
+      if (channel === IPC.HOOKS_EVENT) {
+        transport.post({ type: 'event', entry: payload as HookEvent })
+      } else if (channel === IPC.HOOKS_DROPPED) {
+        transport.post({ type: 'dropped', sessionId: (payload as { sessionId: string }).sessionId })
+      }
+    },
+    permissionResponders: {
+      register: (id, cb) => {
+        localResponders.set(id, cb)
+        transport.post({ type: 'permission-open', requestId: id, sid: '' })
+      },
+      deregister: (id) => { localResponders.delete(id) },
+    },
+  })
+
+  transport.onMessage((msg) => {
+    switch (msg.type) {
+      case 'register': gateway.registerSessionWithSecret(msg.sid, msg.secret); break
+      case 'unregister': gateway.unregisterSession(msg.sid); break
+      case 'start': void gateway.start(); break
+      case 'stop': void gateway.stop(); break
+      case 'setGate': gateway.setPermissionGateActive(msg.active); break
+      case 'permission-respond': localResponders.get(msg.requestId)?.(msg.decision); break
+      default: break
+    }
+  })
+
+  if (opts?.healthBeat !== false) {
+    const beat = setInterval(() => {
+      const m = gateway.metrics()
+      transport.post({
+        type: 'health',
+        inFlight: m.inFlight, eventsTotal: m.eventsTotal, dropsTotal: m.dropsTotal, stallsLastMin: 0,
+      })
+    }, 1000)
+    if (typeof (beat as { unref?: () => void }).unref === 'function') (beat as { unref: () => void }).unref()
+  }
+
+  return {
+    _gatewayHasSecret: (sid) => gateway.hasSecret(sid),
+    _ingestForTest: (sid, secret) => gateway._handleRequestForTest({
+      remoteAddress: '127.0.0.1',
+      url: '/hook/' + sid,
+      headers: { 'x-ccc-hook-token': secret },
+      body: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Glob' }),
+    }).then(() => undefined),
+    _registerResponderForTest: (id, cb) => gateway.permissionRegister(id, cb),
+  }
+}

--- a/src/main/services/hooks-host.ts
+++ b/src/main/services/hooks-host.ts
@@ -1,0 +1,20 @@
+// Runs INSIDE an Electron utilityProcess. MUST NOT import any electron main-API.
+// The MessagePort arrives via the Electron global process.parentPort.
+import type { HostTransport, FromChildMessage, ToChildMessage } from './service-transport'
+import { createHooksHost } from './hooks-host-core'
+
+// process.parentPort is an Electron utilityProcess global not present on Node's
+// process type — localize the cast here.
+const parentPort = (process as unknown as {
+  parentPort: {
+    on(ev: 'message', cb: (e: { data: ToChildMessage }) => void): void
+    postMessage(msg: FromChildMessage): void
+  }
+}).parentPort
+
+const transport: HostTransport = {
+  post: (msg) => parentPort.postMessage(msg),
+  onMessage: (handler) => parentPort.on('message', (e) => handler(e.data)),
+}
+
+createHooksHost(transport)

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -82,7 +82,10 @@ export class ServiceSupervisor {
       this.log.push(m.entry)
       if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
     }
-    if (m.type === 'event' || m.type === 'dropped' || m.type === 'permission-open') {
+    // Forward `bound` to the proxy too so its status/HOOKS_STATUS broadcast and
+    // start()-await-bound resolve in the production (supervisor-driven) path, not
+    // just when the proxy self-subscribes.
+    if (m.type === 'bound' || m.type === 'event' || m.type === 'dropped' || m.type === 'permission-open') {
       this.proxy?.handleChildMessage(m)
     }
   }

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -1,0 +1,95 @@
+import { HooksGatewayProxy } from './hooks-gateway-proxy'
+import { createInitialHealth } from '../../shared/service-health'
+import type { ServiceHealth, ServiceLogEntry, DiagnosticsSnapshot } from '../../shared/service-health'
+import type { ChildTransport, FromChildMessage } from './service-transport'
+
+export interface ForkedChild {
+  transport: ChildTransport
+  kill: () => void
+  onExit: (cb: () => void) => void
+}
+
+export interface ServiceSupervisorOptions {
+  forkChild: () => ForkedChild
+  defaultPort: number
+  emit: (channel: string, payload: unknown) => void
+  now?: () => number   // injectable clock for tests
+}
+
+const LOG_CAP = 200
+
+export class ServiceSupervisor {
+  private opts: ServiceSupervisorOptions
+  private now: () => number
+  private health: ServiceHealth = createInitialHealth('hooks', 'Hooks gateway')
+  private log: ServiceLogEntry[] = []
+  private child: ForkedChild | null = null
+  private proxy: HooksGatewayProxy | null = null
+  // shuttingDown is used by Task 10 lifecycle extension
+  private shuttingDown = false
+
+  constructor(opts: ServiceSupervisorOptions) {
+    this.opts = opts
+    this.now = opts.now ?? (() => Date.now())
+  }
+
+  getDiagnosticsSnapshot(): DiagnosticsSnapshot {
+    return { capturedAt: this.now(), services: [{ ...this.health }], log: [...this.log] }
+  }
+
+  getProxy(): HooksGatewayProxy | null { return this.proxy }
+
+  private appendLog(level: ServiceLogEntry['level'], code: string, message: string): void {
+    this.log.push({ ts: this.now(), serviceId: 'hooks', level, code, message })
+    if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
+  }
+
+  // The supervisor owns the SINGLE transport subscription (ChildTransport.onMessage
+  // is last-writer-wins). It consumes bound/health/log itself and forwards the
+  // proxy-relevant messages (event/dropped/permission-open) via handleChildMessage.
+  private onChildMessage(m: FromChildMessage): void {
+    if (m.type === 'bound') {
+      this.health = {
+        ...this.health,
+        state: 'listening',
+        host: 'utility-process',
+        port: m.port,
+        pid: m.pid,
+        startedAt: this.health.startedAt ?? this.now(),
+      }
+      this.appendLog('info', 'bound', `bound :${m.port} pid=${m.pid}`)
+    } else if (m.type === 'health') {
+      this.health = {
+        ...this.health,
+        inFlight: m.inFlight,
+        eventsTotal: m.eventsTotal,
+        dropsTotal: m.dropsTotal,
+        childLoopStallsLastMin: m.stallsLastMin,
+        lastHeartbeatAt: this.now(),
+      }
+    } else if (m.type === 'log') {
+      this.log.push(m.entry)
+      if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
+    }
+    if (m.type === 'event' || m.type === 'dropped' || m.type === 'permission-open') {
+      this.proxy?.handleChildMessage(m)
+    }
+  }
+
+  start(): HooksGatewayProxy {
+    const c = this.opts.forkChild()
+    this.child = c
+    this.proxy = new HooksGatewayProxy({
+      transport: c.transport,
+      defaultPort: this.opts.defaultPort,
+      emit: this.opts.emit,
+      selfSubscribe: false,
+    })
+    c.transport.onMessage((m) => this.onChildMessage(m))
+    this.appendLog('info', 'child-up', 'hooks child forked')
+    void this.proxy.start()
+    return this.proxy
+  }
+
+  // Task 10 extends this with spawnChild/restart/backoff/failOpen/shutdown.
+}

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -1,5 +1,6 @@
 import { HooksGatewayProxy } from './hooks-gateway-proxy'
 import { createInitialHealth } from '../../shared/service-health'
+import { IPC } from '../../shared/ipc-channels'
 import type { ServiceHealth, ServiceLogEntry, DiagnosticsSnapshot } from '../../shared/service-health'
 import type { ChildTransport, FromChildMessage } from './service-transport'
 
@@ -55,6 +56,14 @@ export class ServiceSupervisor {
     if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
   }
 
+  // Push the live diagnostics snapshot to the renderer. Called after every
+  // health mutation (and after a forwarded child log lands) so the health pill +
+  // services console reflect reality without polling. Guarded: the window may be
+  // gone during teardown.
+  private pushHealth(): void {
+    try { this.opts.emit(IPC.SERVICE_HEALTH_UPDATE, this.getDiagnosticsSnapshot()) } catch { /* window gone */ }
+  }
+
   // The supervisor owns the SINGLE transport subscription (ChildTransport.onMessage
   // is last-writer-wins). It consumes bound/health/log itself and forwards the
   // proxy-relevant messages (event/dropped/permission-open) via handleChildMessage.
@@ -73,6 +82,7 @@ export class ServiceSupervisor {
         startedAt: this.health.startedAt ?? this.now(),
       }
       this.appendLog('info', 'bound', `bound :${m.port} pid=${m.pid}`)
+      this.pushHealth()
     } else if (m.type === 'health') {
       this.health = {
         ...this.health,
@@ -82,9 +92,11 @@ export class ServiceSupervisor {
         childLoopStallsLastMin: m.stallsLastMin,
         lastHeartbeatAt: this.now(),
       }
+      this.pushHealth()
     } else if (m.type === 'log') {
       this.log.push(m.entry)
       if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
+      this.pushHealth()
     }
     // Forward `bound` to the proxy too so its status/HOOKS_STATUS broadcast and
     // start()-await-bound resolve in the production (supervisor-driven) path, not
@@ -120,8 +132,9 @@ export class ServiceSupervisor {
     this.proxy.replaySecretsTo(c.transport)
     this.health = { ...this.health, state: this.restarts > 0 ? 'restarting' : 'starting' }
     this.appendLog('info', 'child-up', `hooks child forked (restart ${this.restarts})`)
+    this.pushHealth()
     void this.proxy.start()
-    c.onExit(() => this.onChildExit())
+    c.onExit(() => { if (this.child === c) this.onChildExit() })
   }
 
   private onChildExit(): void {
@@ -130,6 +143,7 @@ export class ServiceSupervisor {
     if (this.shuttingDown || this.fellOpen) return
     this.health = { ...this.health, state: 'crashed', lastError: { message: 'child exited', ts: this.now() } }
     this.appendLog('error', 'crashed', 'hooks child exited unexpectedly')
+    this.pushHealth()
     if (this.restarts >= (this.opts.maxRestarts ?? 5)) { this.activateFallback(); return }
     const delay = ServiceSupervisor.BACKOFFS[Math.min(this.backoffIdx, ServiceSupervisor.BACKOFFS.length - 1)]
     this.backoffIdx++
@@ -149,6 +163,7 @@ export class ServiceSupervisor {
     this.child?.kill()   // free the port BEFORE the in-process gateway binds (mutual exclusion)
     this.health = { ...this.health, host: 'in-process-fallback', state: 'degraded', restartCount: this.restarts }
     this.proxy?.failOpen()
+    this.pushHealth()
   }
 
   shutdown(): void {

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -26,10 +26,13 @@ export class ServiceSupervisor {
   private log: ServiceLogEntry[] = []
   private child: ForkedChild | null = null
   private proxy: HooksGatewayProxy | null = null
-  // shuttingDown is used by Task 10 lifecycle extension
   private shuttingDown = false
   private restarts = 0
+  // backoffIdx only advances (never reset on a healthy bind) — a conservative
+  // D1a choice: slower escalation toward fail-open is safer than restart thrash.
+  // A "healthy for N seconds -> reset the counters" policy is a hardening follow-up.
   private backoffIdx = 0
+  private restartTimer: ReturnType<typeof setTimeout> | null = null
   private static BACKOFFS = [250, 1000, 4000, 4000, 4000]
 
   constructor(opts: ServiceSupervisorOptions) {
@@ -52,6 +55,10 @@ export class ServiceSupervisor {
   // is last-writer-wins). It consumes bound/health/log itself and forwards the
   // proxy-relevant messages (event/dropped/permission-open) via handleChildMessage.
   private onChildMessage(m: FromChildMessage): void {
+    // Once we've failed open (or are shutting down) the child is dead; ignore any
+    // messages still draining out of the pipe so a stale `bound`/`health` can't
+    // flip the host back to utility-process and clobber the `degraded` state.
+    if (this.shuttingDown || this.proxy?.isInProcessFallback()) return
     if (m.type === 'bound') {
       this.health = {
         ...this.health,
@@ -114,25 +121,29 @@ export class ServiceSupervisor {
     if (this.shuttingDown) return
     this.health = { ...this.health, state: 'crashed', lastError: { message: 'child exited', ts: this.now() } }
     this.appendLog('error', 'crashed', 'hooks child exited unexpectedly')
-    if (this.restarts >= (this.opts.maxRestarts ?? 5)) { this.failOpen(); return }
+    if (this.restarts >= (this.opts.maxRestarts ?? 5)) { this.activateFallback(); return }
     const delay = ServiceSupervisor.BACKOFFS[Math.min(this.backoffIdx, ServiceSupervisor.BACKOFFS.length - 1)]
     this.backoffIdx++
-    setTimeout(() => {
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null
+      if (this.shuttingDown) return   // shutdown() raced the backoff — do not resurrect the child
       this.restarts++
       this.health = { ...this.health, restartCount: this.restarts }
       this.spawnChild()
     }, delay)
   }
 
-  private failOpen(): void {
+  /** Tear down the child path and run the gateway in-process (proxy.failOpen). */
+  private activateFallback(): void {
     this.appendLog('warn', 'fallback', 'falling open to in-process gateway')
     this.child?.kill()   // free the port BEFORE the in-process gateway binds (mutual exclusion)
-    this.health = { ...this.health, host: 'in-process-fallback', state: 'degraded' }
+    this.health = { ...this.health, host: 'in-process-fallback', state: 'degraded', restartCount: this.restarts }
     this.proxy?.failOpen()
   }
 
   shutdown(): void {
     this.shuttingDown = true
+    if (this.restartTimer !== null) { clearTimeout(this.restartTimer); this.restartTimer = null }
     try { this.child?.kill() } catch { /* best-effort */ }
   }
 }

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -97,6 +97,15 @@ export class ServiceSupervisor {
       this.log.push(m.entry)
       if (this.log.length > LOG_CAP) this.log.splice(0, this.log.length - LOG_CAP)
       this.pushHealth()
+    } else if (m.type === 'bind-failed') {
+      this.health = { ...this.health, state: 'crashed', lastError: { message: m.error, ts: this.now() } }
+      this.appendLog('error', 'bind-failed', `hooks child failed to bind: ${m.error}`)
+      this.pushHealth()
+      // Escalate like an exit: the child is alive but useless. Kill it so the normal
+      // exit-driven restart/backoff -> fail-open path runs (single-owner of that logic).
+      // Do NOT forward bind-failed to the proxy.
+      try { this.child?.kill() } catch { /* best-effort */ }
+      return
     }
     // Forward `bound` to the proxy too so its status/HOOKS_STATUS broadcast and
     // start()-await-bound resolve in the production (supervisor-driven) path, not

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -27,6 +27,10 @@ export class ServiceSupervisor {
   private child: ForkedChild | null = null
   private proxy: HooksGatewayProxy | null = null
   private shuttingDown = false
+  // Set once we commit to fail-open. activateFallback()'s own child.kill() fires an
+  // exit event; this flag (set BEFORE the kill) stops that exit re-entering
+  // onChildExit and logging a spurious second 'falling open'.
+  private fellOpen = false
   private restarts = 0
   // backoffIdx only advances (never reset on a healthy bind) — a conservative
   // D1a choice: slower escalation toward fail-open is safer than restart thrash.
@@ -121,7 +125,9 @@ export class ServiceSupervisor {
   }
 
   private onChildExit(): void {
-    if (this.shuttingDown) return
+    // Ignore exits once shutting down OR once we've committed to fail-open (the
+    // latter so activateFallback()'s own child.kill() can't re-enter and re-run).
+    if (this.shuttingDown || this.fellOpen) return
     this.health = { ...this.health, state: 'crashed', lastError: { message: 'child exited', ts: this.now() } }
     this.appendLog('error', 'crashed', 'hooks child exited unexpectedly')
     if (this.restarts >= (this.opts.maxRestarts ?? 5)) { this.activateFallback(); return }
@@ -138,6 +144,7 @@ export class ServiceSupervisor {
 
   /** Tear down the child path and run the gateway in-process (proxy.failOpen). */
   private activateFallback(): void {
+    this.fellOpen = true   // BEFORE kill() so the kill's exit event can't re-enter onChildExit
     this.appendLog('warn', 'fallback', 'falling open to in-process gateway')
     this.child?.kill()   // free the port BEFORE the in-process gateway binds (mutual exclusion)
     this.health = { ...this.health, host: 'in-process-fallback', state: 'degraded', restartCount: this.restarts }

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -111,6 +111,29 @@ export class ServiceSupervisor {
     return this.proxy!
   }
 
+  /** User-requested restart of a service. In utility-process mode this kills the
+   *  current child and immediately respawns, resetting the restart/backoff/fail-open
+   *  counters so a manual restart is a clean slate (not counted against the fail-open
+   *  budget). Declines in in-process fallback (live un-fail-open is deferred, spec §7)
+   *  and during shutdown. The old child's kill fires its onExit, but the spawnChild
+   *  guard (`this.child === c`) ignores a non-current child's exit so no spurious
+   *  extra spawn occurs. */
+  manualRestart(serviceId: string): { ok: boolean; reason?: string } {
+    if (serviceId !== 'hooks') return { ok: false, reason: 'unknown-service' }
+    if (this.shuttingDown) return { ok: false, reason: 'shutting-down' }
+    if (this.proxy?.isInProcessFallback()) return { ok: false, reason: 'fallback' } // live revert deferred (spec §7)
+    this.appendLog('info', 'manual-restart', 'manual restart requested')
+    if (this.restartTimer !== null) { clearTimeout(this.restartTimer); this.restartTimer = null }
+    this.restarts = 0
+    this.backoffIdx = 0
+    this.fellOpen = false
+    this.health = { ...this.health, restartCount: 0 }
+    try { this.child?.kill() } catch { /* best-effort */ }
+    this.spawnChild()   // rebinds the long-lived proxy to the fresh child + replays secrets + start
+    this.pushHealth()
+    return { ok: true }
+  }
+
   private spawnChild(): void {
     const c = this.opts.forkChild()
     this.child = c

--- a/src/main/services/service-supervisor.ts
+++ b/src/main/services/service-supervisor.ts
@@ -14,6 +14,7 @@ export interface ServiceSupervisorOptions {
   defaultPort: number
   emit: (channel: string, payload: unknown) => void
   now?: () => number   // injectable clock for tests
+  maxRestarts?: number // fail open to in-process after this many failed restarts (default 5)
 }
 
 const LOG_CAP = 200
@@ -27,6 +28,9 @@ export class ServiceSupervisor {
   private proxy: HooksGatewayProxy | null = null
   // shuttingDown is used by Task 10 lifecycle extension
   private shuttingDown = false
+  private restarts = 0
+  private backoffIdx = 0
+  private static BACKOFFS = [250, 1000, 4000, 4000, 4000]
 
   constructor(opts: ServiceSupervisorOptions) {
     this.opts = opts
@@ -77,19 +81,58 @@ export class ServiceSupervisor {
   }
 
   start(): HooksGatewayProxy {
-    const c = this.opts.forkChild()
-    this.child = c
-    this.proxy = new HooksGatewayProxy({
-      transport: c.transport,
-      defaultPort: this.opts.defaultPort,
-      emit: this.opts.emit,
-      selfSubscribe: false,
-    })
-    c.transport.onMessage((m) => this.onChildMessage(m))
-    this.appendLog('info', 'child-up', 'hooks child forked')
-    void this.proxy.start()
-    return this.proxy
+    this.spawnChild()
+    return this.proxy!
   }
 
-  // Task 10 extends this with spawnChild/restart/backoff/failOpen/shutdown.
+  private spawnChild(): void {
+    const c = this.opts.forkChild()
+    this.child = c
+    if (!this.proxy) {
+      this.proxy = new HooksGatewayProxy({
+        transport: c.transport,
+        defaultPort: this.opts.defaultPort,
+        emit: this.opts.emit,
+        selfSubscribe: false,
+      })
+    } else {
+      this.proxy.rebindTransport(c.transport)   // point the long-lived proxy at the NEW child
+    }
+    c.transport.onMessage((m) => this.onChildMessage(m))
+    // S1 replay-before-listen: register the known secrets on the new child BEFORE it
+    // binds/announces, so a request landing right after bind validates against a
+    // populated secret map. The child applies `register` synchronously on receipt and
+    // only binds on `start`, so the ordering holds.
+    this.proxy.replaySecretsTo(c.transport)
+    this.health = { ...this.health, state: this.restarts > 0 ? 'restarting' : 'starting' }
+    this.appendLog('info', 'child-up', `hooks child forked (restart ${this.restarts})`)
+    void this.proxy.start()
+    c.onExit(() => this.onChildExit())
+  }
+
+  private onChildExit(): void {
+    if (this.shuttingDown) return
+    this.health = { ...this.health, state: 'crashed', lastError: { message: 'child exited', ts: this.now() } }
+    this.appendLog('error', 'crashed', 'hooks child exited unexpectedly')
+    if (this.restarts >= (this.opts.maxRestarts ?? 5)) { this.failOpen(); return }
+    const delay = ServiceSupervisor.BACKOFFS[Math.min(this.backoffIdx, ServiceSupervisor.BACKOFFS.length - 1)]
+    this.backoffIdx++
+    setTimeout(() => {
+      this.restarts++
+      this.health = { ...this.health, restartCount: this.restarts }
+      this.spawnChild()
+    }, delay)
+  }
+
+  private failOpen(): void {
+    this.appendLog('warn', 'fallback', 'falling open to in-process gateway')
+    this.child?.kill()   // free the port BEFORE the in-process gateway binds (mutual exclusion)
+    this.health = { ...this.health, host: 'in-process-fallback', state: 'degraded' }
+    this.proxy?.failOpen()
+  }
+
+  shutdown(): void {
+    this.shuttingDown = true
+    try { this.child?.kill() } catch { /* best-effort */ }
+  }
 }

--- a/src/main/services/service-transport.ts
+++ b/src/main/services/service-transport.ts
@@ -1,0 +1,44 @@
+import type { ServiceLogEntry } from '../../shared/service-health'
+import type { HookEvent } from '../../shared/hook-types'
+
+/** main -> child */
+export type ToChildMessage =
+  | { type: 'register'; sid: string; secret: string }
+  | { type: 'unregister'; sid: string }
+  | { type: 'start'; port: number }
+  | { type: 'stop' }
+  | { type: 'setGate'; active: boolean }
+  | { type: 'permission-respond'; requestId: string; decision: string }
+
+/** child -> main */
+export type FromChildMessage =
+  | { type: 'bound'; port: number; pid: number }
+  | { type: 'event'; entry: HookEvent }
+  | { type: 'dropped'; sessionId: string }
+  | { type: 'permission-open'; requestId: string; sid: string }
+  | { type: 'health'; inFlight: number; eventsTotal: number; dropsTotal: number; stallsLastMin: number }
+  | { type: 'log'; entry: ServiceLogEntry }
+
+/** The transport the main-side proxy/supervisor use to talk to the child. */
+export interface ChildTransport {
+  post(msg: ToChildMessage): void
+  onMessage(handler: (msg: FromChildMessage) => void): void
+  kill(): void
+}
+
+/** In-memory fake: `post`/`onMessage` carry main->child; `emitToParent`/`parentMessages`
+ *  simulate child->main so tests can drive both directions without a real process. */
+export class FakeChildTransport implements ChildTransport {
+  private childHandler: ((m: ToChildMessage) => void) | null = null
+  private parentHandler: ((m: FromChildMessage) => void) | null = null
+  killed = false
+  parentMessages: FromChildMessage[] = []
+
+  post(msg: ToChildMessage): void { this.childHandler?.(msg) }
+  onMessage(handler: (m: FromChildMessage) => void): void { this.parentHandler = handler }
+  kill(): void { this.killed = true }
+
+  // test helpers
+  onChild(handler: (m: ToChildMessage) => void): void { this.childHandler = handler }
+  emitToParent(msg: FromChildMessage): void { this.parentMessages.push(msg); this.parentHandler?.(msg) }
+}

--- a/src/main/services/service-transport.ts
+++ b/src/main/services/service-transport.ts
@@ -19,7 +19,11 @@ export type FromChildMessage =
   | { type: 'health'; inFlight: number; eventsTotal: number; dropsTotal: number; stallsLastMin: number }
   | { type: 'log'; entry: ServiceLogEntry }
 
-/** The transport the main-side proxy/supervisor use to talk to the child. */
+/** The transport the main-side proxy/supervisor use to talk to the child.
+ *  NOTE: `onMessage` is SINGLE-HANDLER — the last registration wins. When both the
+ *  supervisor and the proxy need child messages, the supervisor owns the single
+ *  subscription and forwards to the proxy via `proxy.handleChildMessage` (the proxy
+ *  is constructed with `selfSubscribe: false`). */
 export interface ChildTransport {
   post(msg: ToChildMessage): void
   onMessage(handler: (msg: FromChildMessage) => void): void

--- a/src/main/services/service-transport.ts
+++ b/src/main/services/service-transport.ts
@@ -26,6 +26,13 @@ export interface ChildTransport {
   kill(): void
 }
 
+/** Child-side transport: the host posts FromChildMessage to its parent and
+ *  receives ToChildMessage from it (the inverse of ChildTransport). */
+export interface HostTransport {
+  post(msg: FromChildMessage): void
+  onMessage(handler: (msg: ToChildMessage) => void): void
+}
+
 /** In-memory fake: `post`/`onMessage` carry main->child; `emitToParent`/`parentMessages`
  *  simulate child->main so tests can drive both directions without a real process. */
 export class FakeChildTransport implements ChildTransport {
@@ -41,4 +48,13 @@ export class FakeChildTransport implements ChildTransport {
   // test helpers
   onChild(handler: (m: ToChildMessage) => void): void { this.childHandler = handler }
   emitToParent(msg: FromChildMessage): void { this.parentMessages.push(msg); this.parentHandler?.(msg) }
+
+  /** View this fake from the CHILD side: post() -> parent (emitToParent),
+   *  onMessage() receives what main posted (onChild). */
+  asHostTransport(): HostTransport {
+    return {
+      post: (m: FromChildMessage) => this.emitToParent(m),
+      onMessage: (h: (m: ToChildMessage) => void) => this.onChild(h),
+    }
+  }
 }

--- a/src/main/services/service-transport.ts
+++ b/src/main/services/service-transport.ts
@@ -13,6 +13,7 @@ export type ToChildMessage =
 /** child -> main */
 export type FromChildMessage =
   | { type: 'bound'; port: number; pid: number }
+  | { type: 'bind-failed'; error: string }
   | { type: 'event'; entry: HookEvent }
   | { type: 'dropped'; sessionId: string }
   | { type: 'permission-open'; requestId: string; sid: string }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -603,6 +603,17 @@ const electronAPI: ElectronAPI = {
       return () => ipcRenderer.removeListener(IPC.SERVICE_STATUS, handler)
     }
   },
+  serviceHealth: {
+    get: (): Promise<import('../shared/service-health').DiagnosticsSnapshot> =>
+      ipcRenderer.invoke(IPC.SERVICE_HEALTH_GET),
+    restart: (serviceId: string): Promise<{ ok: boolean; reason?: string }> =>
+      ipcRenderer.invoke(IPC.SERVICE_RESTART, serviceId),
+    onUpdate: (callback: (snap: import('../shared/service-health').DiagnosticsSnapshot) => void) => {
+      const handler = (_: unknown, snap: import('../shared/service-health').DiagnosticsSnapshot) => callback(snap)
+      ipcRenderer.on(IPC.SERVICE_HEALTH_UPDATE, handler)
+      return () => ipcRenderer.removeListener(IPC.SERVICE_HEALTH_UPDATE, handler)
+    }
+  },
   cli: {
     check: () => ipcRenderer.invoke(IPC.CLI_CHECK)
   },

--- a/src/renderer/components/ConductorHealthPill.tsx
+++ b/src/renderer/components/ConductorHealthPill.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react'
+import type { DiagnosticsSnapshot, ServiceHealth } from '../../shared/service-health'
+
+// No \u{...} escapes in JSX (esbuild doesn't support them). U+25C6 BLACK DIAMOND.
+const DIAMOND = String.fromCodePoint(0x25c6)
+
+type Tone = 'green' | 'amber' | 'red' | 'grey'
+
+function worst(services: ServiceHealth[]): { tone: Tone; word: string | null; tip: string } {
+  if (!services.length) return { tone: 'grey', word: null, tip: 'Services: unknown' }
+  // Hooks is the only supervised service today; generalize to worst-of when >1.
+  const s = services[0]
+  const tip = `Hooks: ${s.host} ${s.state}${s.port ? ' :' + s.port : ''} - ${s.inFlight} in-flight`
+  switch (s.state) {
+    case 'listening':
+      return { tone: 'green', word: null, tip }
+    case 'crashed':
+      return { tone: 'red', word: 'Down', tip }
+    case 'stopped':
+      return { tone: 'grey', word: null, tip: 'Hooks: off' }
+    default:
+      // starting / restarting / degraded
+      return {
+        tone: 'amber',
+        word: s.host === 'in-process-fallback' ? 'Fallback' : 'Degraded',
+        tip,
+      }
+  }
+}
+
+const DOT: Record<Tone, string> = {
+  green: 'bg-green',
+  amber: 'bg-yellow',
+  red: 'bg-red',
+  grey: 'bg-overlay0',
+}
+const TXT: Record<Tone, string> = {
+  green: 'text-overlay1',
+  amber: 'text-yellow',
+  red: 'text-red',
+  grey: 'text-overlay0',
+}
+
+interface Props {
+  open: boolean
+  onOpen: () => void
+}
+
+export default function ConductorHealthPill({ open, onOpen }: Props) {
+  const [snap, setSnap] = useState<DiagnosticsSnapshot | null>(null)
+
+  useEffect(() => {
+    let active = true
+    window.electronAPI.serviceHealth.get().then((s) => {
+      if (active) setSnap(s)
+    })
+    const unsub = window.electronAPI.serviceHealth.onUpdate((s) => setSnap(s))
+    return () => {
+      active = false
+      unsub()
+    }
+  }, [])
+
+  const w = worst(snap?.services ?? [])
+
+  return (
+    <button
+      onClick={onOpen}
+      className={`titlebar-no-drag flex items-center gap-1 px-1.5 py-0.5 rounded border transition-colors focus-ring ${
+        open ? 'border-current bg-surface0/70' : 'border-surface0/60 bg-surface0/40'
+      }`}
+      title={w.tip}
+      aria-expanded={open}
+      aria-label="Services health"
+    >
+      <span className={`w-1.5 h-1.5 rounded-full ${DOT[w.tone]}`} />
+      <span className={`text-[10px] font-medium leading-none ${TXT[w.tone]}`}>
+        {DIAMOND} Services
+      </span>
+      {w.word && (
+        <span className={`text-[10px] font-semibold leading-none ${TXT[w.tone]}`}>{w.word}</span>
+      )}
+    </button>
+  )
+}

--- a/src/renderer/components/ConductorHealthPill.tsx
+++ b/src/renderer/components/ConductorHealthPill.tsx
@@ -66,6 +66,7 @@ export default function ConductorHealthPill({ open, onOpen }: Props) {
   return (
     <button
       onClick={onOpen}
+      data-conductor-pill
       className={`titlebar-no-drag flex items-center gap-1 px-1.5 py-0.5 rounded border transition-colors focus-ring ${
         open ? 'border-current bg-surface0/70' : 'border-surface0/60 bg-surface0/40'
       }`}

--- a/src/renderer/components/ConductorServicesPanel.tsx
+++ b/src/renderer/components/ConductorServicesPanel.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useRef, useState } from 'react'
+import type {
+  DiagnosticsSnapshot,
+  ServiceHealth,
+  ServiceLogEntry,
+} from '../../shared/service-health'
+
+// No \u{...} escapes in JSX (esbuild). U+21BB CLOCKWISE OPEN CIRCLE ARROW,
+// U+29C9 TWO JOINED SQUARES, U+25CB WHITE CIRCLE.
+const RESTART_GLYPH = String.fromCodePoint(0x21bb)
+const COPY_GLYPH = String.fromCodePoint(0x29c9)
+const HOLLOW = String.fromCodePoint(0x25cb)
+
+const STATE_DOT: Record<string, string> = {
+  listening: 'bg-green',
+  starting: 'bg-yellow',
+  restarting: 'bg-yellow',
+  degraded: 'bg-yellow',
+  crashed: 'bg-red',
+  stopped: 'bg-overlay0',
+}
+const LOG_TXT: Record<string, string> = {
+  info: 'text-subtext0',
+  warn: 'text-yellow',
+  error: 'text-red',
+}
+
+function uptime(startedAt: number | null): string {
+  if (!startedAt) return '-'
+  const s = Math.max(0, Math.floor((Date.now() - startedAt) / 1000))
+  if (s < 60) return `${s}s`
+  if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`
+  return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`
+}
+
+function Metric({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-px">
+      <span className="text-[9px] uppercase tracking-wide text-overlay1">{label}</span>
+      <span className="text-[11px] text-text tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+function ServiceCard({ s }: { s: ServiceHealth }) {
+  return (
+    <div className="rounded border border-surface0 bg-crust/50 p-2.5">
+      <div className="flex items-center gap-1.5 mb-2">
+        <span className={`w-2 h-2 rounded-full ${STATE_DOT[s.state] ?? 'bg-overlay0'}`} />
+        <span className="text-[12px] font-semibold text-text">{s.label}</span>
+        <span className="text-[10px] text-subtext0">
+          {s.host}
+          {s.port ? ` :${s.port}` : ''}
+          {s.state !== 'listening' ? ` (${s.state})` : ''}
+        </span>
+      </div>
+      <div className="grid grid-cols-4 gap-x-2 gap-y-1.5">
+        <Metric label="PID" value={s.pid ?? '-'} />
+        <Metric label="Uptime" value={uptime(s.startedAt)} />
+        <Metric label="In-flight" value={s.inFlight} />
+        <Metric label="Restarts" value={s.restartCount} />
+        <Metric label="Events" value={s.eventsTotal} />
+        <Metric label="Drops" value={s.dropsTotal} />
+        <Metric label="Thrput/s" value={s.throughputPerSec} />
+        <Metric label="Jank m/c" value={`${s.mainLoopStallsLastMin}/${s.childLoopStallsLastMin}`} />
+      </div>
+      {s.lastError && (
+        <div className="mt-2 text-[10px] text-red break-words">
+          last error: {s.lastError.message}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LogTail({ log }: { log: ServiceLogEntry[] }) {
+  return (
+    <div className="rounded border border-surface0 bg-crust/50 max-h-32 overflow-y-auto p-1.5 font-mono text-[10px] leading-snug">
+      {log.length === 0 ? (
+        <div className="text-overlay1">no log entries</div>
+      ) : (
+        log.map((e, i) => (
+          <div key={i} className={`${LOG_TXT[e.level] ?? 'text-subtext0'} whitespace-pre-wrap break-words`}>
+            <span className="text-overlay1">{e.code} </span>
+            {e.message}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+
+export default function ConductorServicesPanel({ onClose }: { onClose: () => void }) {
+  const [snap, setSnap] = useState<DiagnosticsSnapshot | null>(null)
+  const [entered, setEntered] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let active = true
+    window.electronAPI.serviceHealth.get().then((s) => { if (active) setSnap(s) })
+    const unsub = window.electronAPI.serviceHealth.onUpdate((s) => setSnap(s))
+    // Trigger the enter transition on the next frame.
+    const t = setTimeout(() => setEntered(true), 0)
+    return () => { active = false; unsub(); clearTimeout(t) }
+  }, [])
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      // The pill button owns its own open/close toggle; ignore clicks on it so
+      // the toggle isn't fought by this close-on-outside handler.
+      if (target.closest?.('[data-conductor-pill]')) return
+      if (ref.current && !ref.current.contains(target)) onClose()
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [onClose])
+
+  const services = snap?.services ?? []
+  const inFallback = services[0]?.host === 'in-process-fallback'
+
+  const handleRestart = () => { void window.electronAPI.serviceHealth.restart('hooks') }
+  const handleCopy = () => {
+    if (snap) void navigator.clipboard?.writeText(JSON.stringify(snap, null, 2))
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Services diagnostics"
+      className={`absolute right-0 top-full mt-1.5 z-50 w-80 rounded-lg border border-surface0 bg-mantle shadow-xl p-3 flex flex-col gap-2.5 transition-all duration-200 ease-out ${
+        entered ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'
+      }`}
+    >
+      {services.map((s) => (
+        <ServiceCard key={s.id} s={s} />
+      ))}
+      <LogTail log={snap?.log ?? []} />
+      <div
+        className="rounded border border-surface0/60 bg-crust/30 px-2.5 py-1.5 text-[11px] text-overlay1 flex items-center gap-1.5"
+        title="MCP relocation is a future phase"
+      >
+        <span>{HOLLOW}</span>
+        <span>MCP server</span>
+        <span className="text-overlay0">in-process :19333 (next phase)</span>
+      </div>
+      <div className="flex items-center gap-2 pt-0.5">
+        <button
+          onClick={handleRestart}
+          disabled={inFallback}
+          title={inFallback ? 'Relaunch the app to retry the supervised gateway' : 'Restart the hooks gateway'}
+          className="flex-1 px-2 py-1 rounded border border-surface0 bg-surface0/40 text-[11px] text-text transition-colors hover:bg-surface0/70 disabled:opacity-40 disabled:cursor-not-allowed focus-ring"
+        >
+          {RESTART_GLYPH} Restart
+        </button>
+        <button
+          onClick={handleCopy}
+          title="Copy the full diagnostics snapshot as JSON"
+          className="flex-1 px-2 py-1 rounded border border-surface0 bg-surface0/40 text-[11px] text-text transition-colors hover:bg-surface0/70 focus-ring"
+        >
+          {COPY_GLYPH} Copy diagnostics
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ConductorServicesPanel.tsx
+++ b/src/renderer/components/ConductorServicesPanel.tsx
@@ -49,9 +49,9 @@ function ServiceCard({ s }: { s: ServiceHealth }) {
         <span className={`w-2 h-2 rounded-full ${STATE_DOT[s.state] ?? 'bg-overlay0'}`} />
         <span className="text-[12px] font-semibold text-text">{s.label}</span>
         <span className="text-[10px] text-subtext0">
-          {s.host}
-          {s.port ? ` :${s.port}` : ''}
-          {s.state !== 'listening' ? ` (${s.state})` : ''}
+          {s.state === 'stopped'
+            ? 'disabled'
+            : `${s.host}${s.port ? ` :${s.port}` : ''}${s.state !== 'listening' ? ` (${s.state})` : ''}`}
         </span>
       </div>
       <div className="grid grid-cols-4 gap-x-2 gap-y-1.5">
@@ -61,8 +61,11 @@ function ServiceCard({ s }: { s: ServiceHealth }) {
         <Metric label="Restarts" value={s.restartCount} />
         <Metric label="Events" value={s.eventsTotal} />
         <Metric label="Drops" value={s.dropsTotal} />
-        <Metric label="Thrput/s" value={s.throughputPerSec} />
-        <Metric label="Jank m/c" value={`${s.mainLoopStallsLastMin}/${s.childLoopStallsLastMin}`} />
+        {/* throughputPerSec + mainLoopStallsLastMin are not yet instrumented in the
+            backbone (always 0) -> show '-' rather than a dishonest 0. Child-loop
+            jank IS live. Wire these in a follow-up when the supervisor computes them. */}
+        <Metric label="Thrput/s" value={'-'} />
+        <Metric label="Jank m/c" value={`-/${s.childLoopStallsLastMin}`} />
       </div>
       {s.lastError && (
         <div className="mt-2 text-[10px] text-red break-words">
@@ -90,7 +93,7 @@ function LogTail({ log }: { log: ServiceLogEntry[] }) {
   )
 }
 
-export default function ConductorServicesPanel({ onClose }: { onClose: () => void }) {
+export default function ConductorServicesPanel({ open = true, onClose }: { open?: boolean; onClose: () => void }) {
   const [snap, setSnap] = useState<DiagnosticsSnapshot | null>(null)
   const [entered, setEntered] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -99,10 +102,16 @@ export default function ConductorServicesPanel({ onClose }: { onClose: () => voi
     let active = true
     window.electronAPI.serviceHealth.get().then((s) => { if (active) setSnap(s) })
     const unsub = window.electronAPI.serviceHealth.onUpdate((s) => setSnap(s))
-    // Trigger the enter transition on the next frame.
-    const t = setTimeout(() => setEntered(true), 0)
-    return () => { active = false; unsub(); clearTimeout(t) }
+    return () => { active = false; unsub() }
   }, [])
+
+  // Drive BOTH the enter and leave transitions off `open`. TitleBar keeps us
+  // mounted for ~200ms after open flips false so the closing animation plays
+  // (feedback_animations: all panel changes animated), then unmounts.
+  useEffect(() => {
+    if (open) { const t = setTimeout(() => setEntered(true), 0); return () => clearTimeout(t) }
+    setEntered(false)
+  }, [open])
 
   useEffect(() => {
     const onDown = (e: MouseEvent) => {
@@ -117,7 +126,17 @@ export default function ConductorServicesPanel({ onClose }: { onClose: () => voi
   }, [onClose])
 
   const services = snap?.services ?? []
-  const inFallback = services[0]?.host === 'in-process-fallback'
+  const svc = services[0]
+  // A 'stopped' service (hooks off in Settings) defaults to host 'in-process-fallback'
+  // but is NOT a crash-fallback — distinguish so we don't tell the user to relaunch.
+  const stopped = svc?.state === 'stopped'
+  const inFallback = !stopped && svc?.host === 'in-process-fallback'
+  const restartDisabled = stopped || inFallback
+  const restartTitle = stopped
+    ? 'Hooks are disabled in Settings'
+    : inFallback
+      ? 'Relaunch the app to retry the supervised gateway'
+      : 'Restart the hooks gateway'
 
   const handleRestart = () => { void window.electronAPI.serviceHealth.restart('hooks') }
   const handleCopy = () => {
@@ -148,8 +167,8 @@ export default function ConductorServicesPanel({ onClose }: { onClose: () => voi
       <div className="flex items-center gap-2 pt-0.5">
         <button
           onClick={handleRestart}
-          disabled={inFallback}
-          title={inFallback ? 'Relaunch the app to retry the supervised gateway' : 'Restart the hooks gateway'}
+          disabled={restartDisabled}
+          title={restartTitle}
           className="flex-1 px-2 py-1 rounded border border-surface0 bg-surface0/40 text-[11px] text-text transition-colors hover:bg-surface0/70 disabled:opacity-40 disabled:cursor-not-allowed focus-ring"
         >
           {RESTART_GLYPH} Restart

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import ThemeToggle from './ThemeToggle'
 import ConductorHealthPill from './ConductorHealthPill'
+import ConductorServicesPanel from './ConductorServicesPanel'
 
 interface Props {
   sidebarOpen: boolean
@@ -181,6 +182,7 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
         {/* Conductor services health pill + anchored diagnostics console (D1b) */}
         <div className="relative mr-2">
           <ConductorHealthPill open={panelOpen} onOpen={() => setPanelOpen((o) => !o)} />
+          {panelOpen && <ConductorServicesPanel onClose={() => setPanelOpen(false)} />}
         </div>
         {/* Claude service status — two pills (Claude Code + Claude.ai) with API in tooltip */}
         {serviceStatus && (

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import ThemeToggle from './ThemeToggle'
+import ConductorHealthPill from './ConductorHealthPill'
 
 interface Props {
   sidebarOpen: boolean
@@ -110,6 +111,7 @@ function StatusPill({ label, status, highlight }: StatusPillProps) {
 export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
   const [maximized, setMaximized] = useState(false)
   const [serviceStatus, setServiceStatus] = useState<ServiceStatusPayload | null>(null)
+  const [panelOpen, setPanelOpen] = useState(false)
 
   useEffect(() => {
     window.electronAPI.window.isMaximized().then(setMaximized)
@@ -176,6 +178,10 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
       </div>
 
       <div className="titlebar-no-drag flex items-center gap-1">
+        {/* Conductor services health pill + anchored diagnostics console (D1b) */}
+        <div className="relative mr-2">
+          <ConductorHealthPill open={panelOpen} onOpen={() => setPanelOpen((o) => !o)} />
+        </div>
         {/* Claude service status — two pills (Claude Code + Claude.ai) with API in tooltip */}
         {serviceStatus && (
           <div

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import ThemeToggle from './ThemeToggle'
 import ConductorHealthPill from './ConductorHealthPill'
@@ -112,7 +112,21 @@ function StatusPill({ label, status, highlight }: StatusPillProps) {
 export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
   const [maximized, setMaximized] = useState(false)
   const [serviceStatus, setServiceStatus] = useState<ServiceStatusPayload | null>(null)
+  // panelOpen drives the open/closed visual state; panelMounted keeps the panel in
+  // the DOM through its ~200ms closing transition before unmount (so close is animated).
   const [panelOpen, setPanelOpen] = useState(false)
+  const [panelMounted, setPanelMounted] = useState(false)
+  const panelCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const openPanel = () => {
+    if (panelCloseTimer.current) { clearTimeout(panelCloseTimer.current); panelCloseTimer.current = null }
+    setPanelMounted(true)
+    setPanelOpen(true)
+  }
+  const closePanel = () => {
+    setPanelOpen(false)
+    panelCloseTimer.current = setTimeout(() => { setPanelMounted(false); panelCloseTimer.current = null }, 200)
+  }
 
   useEffect(() => {
     window.electronAPI.window.isMaximized().then(setMaximized)
@@ -181,8 +195,8 @@ export default function TitleBar({ sidebarOpen, onToggleSidebar }: Props) {
       <div className="titlebar-no-drag flex items-center gap-1">
         {/* Conductor services health pill + anchored diagnostics console (D1b) */}
         <div className="relative mr-2">
-          <ConductorHealthPill open={panelOpen} onOpen={() => setPanelOpen((o) => !o)} />
-          {panelOpen && <ConductorServicesPanel onClose={() => setPanelOpen(false)} />}
+          <ConductorHealthPill open={panelOpen} onOpen={() => (panelOpen ? closePanel() : openPanel())} />
+          {panelMounted && <ConductorServicesPanel open={panelOpen} onClose={closePanel} />}
         </div>
         {/* Claude service status — two pills (Claude Code + Claude.ai) with API in tooltip */}
         {serviceStatus && (

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -312,6 +312,11 @@ export interface ElectronAPI {
     get: () => Promise<any>
     onUpdate: (callback: (data: { status: string; description: string }) => void) => () => void
   }
+  serviceHealth: {
+    get: () => Promise<import('../../shared/service-health').DiagnosticsSnapshot>
+    restart: (serviceId: string) => Promise<{ ok: boolean; reason?: string }>
+    onUpdate: (callback: (snap: import('../../shared/service-health').DiagnosticsSnapshot) => void) => () => void
+  }
   cli: {
     check: () => Promise<boolean>
   }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -174,6 +174,9 @@ export const IPC = {
   // Service status
   SERVICE_STATUS: 'serviceStatus:update',
   SERVICE_STATUS_GET: 'serviceStatus:get',
+  SERVICE_HEALTH_GET: 'serviceHealth:get',
+  SERVICE_HEALTH_UPDATE: 'serviceHealth:update',
+  SERVICE_RESTART: 'serviceHealth:restart',
 
   // CLI
   CLI_CHECK: 'cli:check',

--- a/src/shared/service-health.ts
+++ b/src/shared/service-health.ts
@@ -1,0 +1,46 @@
+export type ServiceState =
+  | 'starting' | 'listening' | 'degraded' | 'restarting' | 'crashed' | 'stopped'
+export type ServiceHost = 'utility-process' | 'in-process-fallback'
+
+export interface ServiceHealth {
+  id: string
+  label: string
+  host: ServiceHost
+  state: ServiceState
+  port: number | null
+  pid: number | null
+  startedAt: number | null
+  inFlight: number
+  eventsTotal: number
+  dropsTotal: number
+  throughputPerSec: number
+  restartCount: number
+  lastError: { message: string; ts: number } | null
+  mainLoopStallsLastMin: number
+  childLoopStallsLastMin: number
+  lastHeartbeatAt: number
+}
+
+export interface ServiceLogEntry {
+  ts: number
+  serviceId: string
+  level: 'info' | 'warn' | 'error'
+  code: string
+  message: string
+}
+
+export interface DiagnosticsSnapshot {
+  capturedAt: number
+  services: ServiceHealth[]
+  log: ServiceLogEntry[]
+}
+
+export function createInitialHealth(id: string, label: string): ServiceHealth {
+  return {
+    id, label, host: 'in-process-fallback', state: 'starting',
+    port: null, pid: null, startedAt: null,
+    inFlight: 0, eventsTotal: 0, dropsTotal: 0, throughputPerSec: 0,
+    restartCount: 0, lastError: null,
+    mainLoopStallsLastMin: 0, childLoopStallsLastMin: 0, lastHeartbeatAt: 0,
+  }
+}

--- a/tests/unit/hooks/hooks-gateway-seams.test.ts
+++ b/tests/unit/hooks/hooks-gateway-seams.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { HooksGateway } from '../../../src/main/hooks/hooks-gateway'
+
+describe('HooksGateway seams', () => {
+  it('uses an injected responder registry instead of the module import', () => {
+    const register = vi.fn(); const deregister = vi.fn()
+    const gw = new HooksGateway({ emit: () => {}, permissionResponders: { register, deregister } })
+    expect(gw.permissionRegister).toBe(register)
+    expect(gw.permissionDeregister).toBe(deregister)
+  })
+
+  it('defaults the responder registry to the module functions (in-process behavior unchanged)', () => {
+    const gw = new HooksGateway({ emit: () => {} })
+    expect(typeof gw.permissionRegister).toBe('function')
+    expect(typeof gw.permissionDeregister).toBe('function')
+  })
+
+  it('registerSessionWithSecret stores a caller-supplied secret; hasSecret reflects it', () => {
+    const gw = new HooksGateway({ emit: () => {} })
+    expect(gw.hasSecret('s1')).toBe(false)
+    gw.registerSessionWithSecret('s1', 'sekret')
+    expect(gw.hasSecret('s1')).toBe(true)
+  })
+
+  it('metrics().eventsTotal increments on a real ingest', async () => {
+    const gw = new HooksGateway({ emit: () => {} })
+    const secret = gw.registerSession('s1')
+    await gw._handleRequestForTest({
+      remoteAddress: '127.0.0.1',
+      url: '/hook/s1',
+      headers: { 'x-ccc-hook-token': secret },
+      body: JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Glob' }),
+    })
+    expect(gw.metrics().eventsTotal).toBe(1)
+    expect(gw.metrics().dropsTotal).toBe(0)
+  })
+})

--- a/tests/unit/main/claude-account-identity-async-poll.test.ts
+++ b/tests/unit/main/claude-account-identity-async-poll.test.ts
@@ -5,9 +5,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }))
 
 // The async poll must do its per-tick mtime check WITHOUT calling the sync fs API.
+// We also make the ASYNC stat slow + counted so the concurrency guard is observable:
+// two overlapping recheckAllAsync calls must only fan out ONE stat.
+// `vi.hoisted` so the spy exists before the hoisted vi.mock factory runs.
+const { asyncStat } = vi.hoisted(() => ({
+  asyncStat: vi.fn(async () => { await new Promise((r) => setTimeout(r, 20)); throw new Error('ENOENT') }),
+}))
 vi.mock('fs', async (orig) => {
   const real = await orig<typeof import('fs')>()
-  return { ...real, statSync: vi.fn(() => { throw new Error('statSync must not run on the poll tick') }) }
+  return {
+    ...real,
+    statSync: vi.fn(() => { throw new Error('statSync must not run on the poll tick') }),
+    promises: { ...real.promises, stat: asyncStat },
+  }
 })
 
 import * as identity from '../../../src/main/claude-account-identity'
@@ -18,5 +28,20 @@ describe('recheckAllAsync', () => {
   it('exists and resolves without calling statSync on the tick path', async () => {
     identity.startWatchingAccountIdentity('s1', undefined)
     await expect(identity.recheckAllAsync()).resolves.toBeUndefined()
+  })
+
+  it('does not run recheckAllAsync concurrently (in-flight guard)', async () => {
+    identity.startWatchingAccountIdentity('s1', undefined)
+    asyncStat.mockClear()
+    expect(identity.__isRecheckInFlightForTest()).toBe(false)
+    // Two overlapping calls without awaiting the first; the second must short-circuit
+    // (return immediately) so only the first iterates the watched sessions.
+    const first = identity.recheckAllAsync()
+    const second = identity.recheckAllAsync()
+    expect(identity.__isRecheckInFlightForTest()).toBe(true)
+    await Promise.all([first, second])
+    expect(identity.__isRecheckInFlightForTest()).toBe(false)
+    // The slow stat ran exactly ONCE (the second call short-circuited at the guard).
+    expect(asyncStat).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/main/claude-account-identity-async-poll.test.ts
+++ b/tests/unit/main/claude-account-identity-async-poll.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Stub Electron so the module resolves; pushAccountIdentity becomes a no-op
+// (no identity file exists during this test, so it is never reached anyway).
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }))
+
+// The async poll must do its per-tick mtime check WITHOUT calling the sync fs API.
+vi.mock('fs', async (orig) => {
+  const real = await orig<typeof import('fs')>()
+  return { ...real, statSync: vi.fn(() => { throw new Error('statSync must not run on the poll tick') }) }
+})
+
+import * as identity from '../../../src/main/claude-account-identity'
+
+describe('recheckAllAsync', () => {
+  beforeEach(() => identity._resetForTest?.())
+
+  it('exists and resolves without calling statSync on the tick path', async () => {
+    identity.startWatchingAccountIdentity('s1', undefined)
+    await expect(identity.recheckAllAsync()).resolves.toBeUndefined()
+  })
+})

--- a/tests/unit/main/data-paths.test.ts
+++ b/tests/unit/main/data-paths.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// The global setup mocks both setup-handlers and debug-logger.
+// This suite tests the REAL data-paths functions, so unmock both.
+vi.unmock('../../../src/main/ipc/setup-handlers')
+vi.unmock('../../../src/main/data-paths')
+vi.unmock('../../../src/main/debug-logger')
+
+// Test 1: Re-export identity
+import {
+  getDataDirectory as getDataDirFromDataPaths,
+  getResourcesDirectory as getResourcesDirFromDataPaths,
+} from '../../../src/main/data-paths'
+import {
+  getDataDirectory as getDataDirFromSetupHandlers,
+  getResourcesDirectory as getResourcesDirFromSetupHandlers,
+} from '../../../src/main/ipc/setup-handlers'
+
+describe('data-paths module', () => {
+  describe('re-export identity', () => {
+    it('getDataDirectory from data-paths and setup-handlers are the same function reference', () => {
+      expect(getDataDirFromDataPaths).toBe(getDataDirFromSetupHandlers)
+    })
+
+    it('getResourcesDirectory from data-paths and setup-handlers are the same function reference', () => {
+      expect(getResourcesDirFromDataPaths).toBe(getResourcesDirFromSetupHandlers)
+    })
+  })
+
+  describe('behavior', () => {
+    it('getDataDirectory() returns a non-empty string', () => {
+      const dir = getDataDirFromDataPaths()
+      expect(typeof dir).toBe('string')
+      expect(dir.length).toBeGreaterThan(0)
+    })
+
+    it('getDataDirectory() returns the same value on a second call (cache)', () => {
+      const first = getDataDirFromDataPaths()
+      const second = getDataDirFromDataPaths()
+      expect(first).toBe(second)
+    })
+  })
+
+  describe('electron-free source guard', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../../src/main/data-paths.ts'),
+      'utf-8'
+    )
+
+    it('does not import from electron', () => {
+      expect(src).not.toMatch(/from ['"]electron['"]/)
+    })
+
+    it('does not import from setup-handlers', () => {
+      expect(src).not.toMatch(/setup-handlers/)
+    })
+  })
+})

--- a/tests/unit/main/data-paths.test.ts
+++ b/tests/unit/main/data-paths.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-// The global setup mocks both setup-handlers and debug-logger.
-// This suite tests the REAL data-paths functions, so unmock both.
+// The global setup mocks setup-handlers and debug-logger. This suite tests the
+// REAL data-paths + setup-handlers re-export, so unmock those two. We KEEP
+// debug-logger mocked so getDataDirectory()'s logInfo() stays a no-op and the
+// test never touches the real log dir on disk (CI hygiene).
 vi.unmock('../../../src/main/ipc/setup-handlers')
 vi.unmock('../../../src/main/data-paths')
-vi.unmock('../../../src/main/debug-logger')
 
 // Test 1: Re-export identity
 import {
@@ -49,8 +50,9 @@ describe('data-paths module', () => {
       'utf-8'
     )
 
-    it('does not import from electron', () => {
-      expect(src).not.toMatch(/from ['"]electron['"]/)
+    it('does not import from electron (incl. subpaths / require)', () => {
+      expect(src).not.toMatch(/from ['"]electron(\/[^'"]*)?['"]/)
+      expect(src).not.toMatch(/require\(['"]electron(\/[^'"]*)?['"]\)/)
     })
 
     it('does not import from setup-handlers', () => {

--- a/tests/unit/renderer/conductor-health-pill.test.tsx
+++ b/tests/unit/renderer/conductor-health-pill.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * ConductorHealthPill unit tests (Conductor D1b, Task 9).
+ *
+ * Verifies the aggregate-colour mapping + label rules from spec §2:
+ *   - green + no state word when the hooks service is `listening`
+ *   - amber + "Fallback" when host is `in-process-fallback`
+ *   - amber + "Degraded" for degraded/starting/restarting (utility host)
+ *   - red + "Down" when crashed
+ *   - grey + no state word when stopped (hooks off — not an alarm)
+ *   - the label always renders "<diamond> Services"
+ *   - clicking the pill invokes onOpen
+ *
+ * jsdom logs a benign "Not implemented: HTMLCanvasElement.getContext" — unrelated.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import type {
+  DiagnosticsSnapshot,
+  ServiceState,
+  ServiceHost,
+} from '../../../src/shared/service-health'
+import { createInitialHealth } from '../../../src/shared/service-health'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+function mkSnap(state: ServiceState, host: ServiceHost = 'utility-process'): DiagnosticsSnapshot {
+  const h = { ...createInitialHealth('hooks', 'Hooks gateway'), state, host, port: 19431 }
+  return { capturedAt: 1, services: [h], log: [] }
+}
+
+function mockApi(snap: DiagnosticsSnapshot): void {
+  ;(globalThis as any).window.electronAPI = {
+    serviceHealth: {
+      get: vi.fn().mockResolvedValue(snap),
+      restart: vi.fn(),
+      onUpdate: vi.fn().mockReturnValue(() => {}),
+    },
+  }
+}
+
+const { default: ConductorHealthPill } = await import(
+  '../../../src/renderer/components/ConductorHealthPill'
+)
+
+async function renderPill(props: { open: boolean; onOpen: () => void }): Promise<{
+  container: HTMLElement
+  unmount: () => void
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  await act(async () => {
+    root.render(React.createElement(ConductorHealthPill, props))
+  })
+  // Let the seeding get().then() resolve and re-render.
+  await act(async () => { await Promise.resolve() })
+  return {
+    container,
+    unmount: () => {
+      act(() => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+describe('ConductorHealthPill', () => {
+  let unmount: () => void
+
+  afterEach(() => {
+    unmount?.()
+    vi.clearAllMocks()
+  })
+
+  it('always renders the "Services" label', async () => {
+    mockApi(mkSnap('listening'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    expect(r.container.textContent).toContain('Services')
+  })
+
+  it('renders green and no state word when listening', async () => {
+    mockApi(mkSnap('listening'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    const dot = r.container.querySelector('span.rounded-full') as HTMLElement
+    expect(dot.className).toContain('bg-green')
+    expect(r.container.textContent).not.toMatch(/Degraded|Down|Fallback/)
+  })
+
+  it('shows amber + "Fallback" when in in-process fallback', async () => {
+    mockApi(mkSnap('degraded', 'in-process-fallback'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    const dot = r.container.querySelector('span.rounded-full') as HTMLElement
+    expect(dot.className).toContain('bg-yellow')
+    expect(r.container.textContent).toContain('Fallback')
+  })
+
+  it('shows amber + "Degraded" for a starting/utility transition', async () => {
+    mockApi(mkSnap('starting'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    const dot = r.container.querySelector('span.rounded-full') as HTMLElement
+    expect(dot.className).toContain('bg-yellow')
+    expect(r.container.textContent).toContain('Degraded')
+  })
+
+  it('shows red + "Down" when crashed', async () => {
+    mockApi(mkSnap('crashed'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    const dot = r.container.querySelector('span.rounded-full') as HTMLElement
+    expect(dot.className).toContain('bg-red')
+    expect(r.container.textContent).toContain('Down')
+  })
+
+  it('shows neutral grey and no state word when stopped (hooks off)', async () => {
+    mockApi(mkSnap('stopped'))
+    const r = await renderPill({ open: false, onOpen: () => {} })
+    unmount = r.unmount
+    const dot = r.container.querySelector('span.rounded-full') as HTMLElement
+    expect(dot.className).toContain('bg-overlay0')
+    expect(r.container.textContent).not.toMatch(/Degraded|Down|Fallback/)
+  })
+
+  it('calls onOpen when clicked', async () => {
+    const onOpen = vi.fn()
+    mockApi(mkSnap('listening'))
+    const r = await renderPill({ open: false, onOpen })
+    unmount = r.unmount
+    const btn = r.container.querySelector('button') as HTMLButtonElement
+    await act(async () => { btn.click() })
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/renderer/conductor-services-panel.test.tsx
+++ b/tests/unit/renderer/conductor-services-panel.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+/**
+ * ConductorServicesPanel unit tests (Conductor D1b, Task 10).
+ *
+ * Verifies (spec §3.7 / §6):
+ *   - renders the per-service metrics (port, pid, in-flight, events, drops,
+ *     throughput, jank, restarts, lastError) + a level-coloured log tail
+ *   - "Copy diagnostics" writes the full DiagnosticsSnapshot JSON to the clipboard
+ *   - "Restart" calls serviceHealth.restart('hooks') in utility mode
+ *   - "Restart" is disabled when host is in-process-fallback
+ *   - a disabled "next phase" MCP row is shown
+ *   - click-outside calls onClose
+ *
+ * jsdom logs a benign "Not implemented: HTMLCanvasElement.getContext" — unrelated.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import type { DiagnosticsSnapshot, ServiceState, ServiceHost } from '../../../src/shared/service-health'
+import { createInitialHealth } from '../../../src/shared/service-health'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+function mkSnap(state: ServiceState, host: ServiceHost = 'utility-process'): DiagnosticsSnapshot {
+  const h = { ...createInitialHealth('hooks', 'Hooks gateway'), state, host }
+  return { capturedAt: 1, services: [h], log: [] }
+}
+
+const restartMock = vi.fn().mockResolvedValue({ ok: true })
+
+function mockApi(snap: DiagnosticsSnapshot): void {
+  ;(globalThis as any).window.electronAPI = {
+    serviceHealth: {
+      get: vi.fn().mockResolvedValue(snap),
+      restart: restartMock,
+      onUpdate: vi.fn().mockReturnValue(() => {}),
+    },
+  }
+}
+
+const { default: ConductorServicesPanel } = await import(
+  '../../../src/renderer/components/ConductorServicesPanel'
+)
+
+async function renderPanel(props: { onClose: () => void }): Promise<{
+  container: HTMLElement
+  unmount: () => void
+}> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  await act(async () => {
+    root.render(React.createElement(ConductorServicesPanel, props))
+  })
+  await act(async () => { await Promise.resolve() })
+  return {
+    container,
+    unmount: () => {
+      act(() => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+function findButton(container: HTMLElement, re: RegExp): HTMLButtonElement {
+  return Array.from(container.querySelectorAll('button')).find((b) =>
+    re.test(b.textContent ?? '')
+  ) as HTMLButtonElement
+}
+
+describe('ConductorServicesPanel', () => {
+  let unmount: () => void
+
+  afterEach(() => {
+    unmount?.()
+    vi.clearAllMocks()
+  })
+
+  it('renders metrics + log and Copy writes DiagnosticsSnapshot JSON', async () => {
+    const snap = mkSnap('listening')
+    snap.services[0].port = 19431
+    snap.services[0].pid = 8421
+    snap.services[0].inFlight = 3
+    snap.services[0].eventsTotal = 42
+    snap.log = [
+      { ts: 1, serviceId: 'hooks', level: 'info', code: 'bound', message: 'bound :19431 pid=8421' },
+    ]
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    ;(navigator as any).clipboard = { writeText }
+    mockApi(snap)
+
+    const r = await renderPanel({ onClose: () => {} })
+    unmount = r.unmount
+
+    expect(r.container.textContent).toContain('19431')
+    expect(r.container.textContent).toContain('8421')
+    expect(r.container.textContent).toContain('bound :19431')
+
+    const copyBtn = findButton(r.container, /Copy/i)
+    expect(copyBtn).toBeTruthy()
+    await act(async () => { copyBtn.click() })
+    expect(writeText).toHaveBeenCalledOnce()
+    const arg = writeText.mock.calls[0][0] as string
+    expect(arg).toContain('"services"')
+    // Round-trips to the exact snapshot.
+    expect(JSON.parse(arg)).toEqual(snap)
+  })
+
+  it('Restart calls serviceHealth.restart("hooks") in utility mode', async () => {
+    mockApi(mkSnap('listening'))
+    const r = await renderPanel({ onClose: () => {} })
+    unmount = r.unmount
+    const restartBtn = findButton(r.container, /Restart/i)
+    expect(restartBtn.hasAttribute('disabled')).toBe(false)
+    await act(async () => { restartBtn.click() })
+    expect(restartMock).toHaveBeenCalledWith('hooks')
+  })
+
+  it('Restart is disabled in fallback', async () => {
+    mockApi(mkSnap('degraded', 'in-process-fallback'))
+    const r = await renderPanel({ onClose: () => {} })
+    unmount = r.unmount
+    const restartBtn = findButton(r.container, /Restart/i)
+    expect(restartBtn.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('renders the disabled "next phase" MCP row', async () => {
+    mockApi(mkSnap('listening'))
+    const r = await renderPanel({ onClose: () => {} })
+    unmount = r.unmount
+    expect(r.container.textContent).toContain('MCP server')
+    expect(r.container.textContent).toMatch(/next phase/i)
+  })
+
+  it('calls onClose on outside mousedown', async () => {
+    const onClose = vi.fn()
+    mockApi(mkSnap('listening'))
+    const r = await renderPanel({ onClose })
+    unmount = r.unmount
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/renderer/titlebar-surface.test.tsx
+++ b/tests/unit/renderer/titlebar-surface.test.tsx
@@ -33,6 +33,11 @@ beforeEach(() => {
       get: vi.fn().mockResolvedValue(null),
       onUpdate: vi.fn().mockReturnValue(() => {}),
     },
+    serviceHealth: {
+      get: vi.fn().mockResolvedValue(null),
+      restart: vi.fn(),
+      onUpdate: vi.fn().mockReturnValue(() => {}),
+    },
   }
   container = document.createElement('div')
   document.body.appendChild(container)

--- a/tests/unit/services/hooks-backbone-smoke.test.ts
+++ b/tests/unit/services/hooks-backbone-smoke.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { ServiceSupervisor } from '../../../src/main/services/service-supervisor'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+
+describe('hooks backbone smoke (headless)', () => {
+  it('a child event flows to a subscriber and the session buffer', () => {
+    const t = new FakeChildTransport()
+    const sup = new ServiceSupervisor({
+      forkChild: () => ({ transport: t, kill: () => {}, onExit: () => {} }),
+      defaultPort: 19430,
+      emit: () => {},
+    })
+    const proxy = sup.start()
+    const sid = 's1'
+    proxy.registerSession(sid)
+    const seen: string[] = []
+    proxy.subscribe((e) => seen.push(e.event))
+    t.emitToParent({ type: 'event', entry: { sessionId: sid, event: 'PostToolUse', toolName: 'Glob', summary: 'Glob', payload: {}, ts: 1 } as never })
+    expect(seen).toEqual(['PostToolUse'])
+    expect(proxy.getBuffer(sid)).toHaveLength(1)
+    expect(sup.getDiagnosticsSnapshot().services[0].id).toBe('hooks')
+  })
+})

--- a/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
@@ -59,6 +59,17 @@ describe('HooksGatewayProxy fail-open + permission bridge', () => {
     expect(secret.length).toBeGreaterThan(0)
   })
 
+  it('a subscriber registered BEFORE failOpen still receives events after failOpen', () => {
+    const t = new FakeChildTransport()
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    const seen: string[] = []
+    p.subscribe((e) => seen.push(e.event))
+    p.failOpen() // copies current subscribers into the in-process gateway
+    // After fail-open the in-process gateway owns fan-out; dispatchForTest delegates there.
+    p.dispatchForTest({ sessionId: 's1', event: 'Stop', summary: 'Stop', payload: {}, ts: 1 } as never)
+    expect(seen).toEqual(['Stop']) // fires exactly once, via the in-process gateway
+  })
+
   it('a child permission-open lets resolvePermission route the decision back to the child', () => {
     const t = new FakeChildTransport(); const sent: unknown[] = []
     t.onChild((m) => sent.push(m))

--- a/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+import { HooksGatewayProxy } from '../../../src/main/services/hooks-gateway-proxy'
+
+describe('HooksGatewayProxy fail-open + permission bridge', () => {
+  let p: HooksGatewayProxy
+  afterEach(async () => { await p?.stop() })
+
+  it('start() posts start to the child (utility-process mode)', async () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    await p.start()
+    expect(sent).toContainEqual({ type: 'start', port: 19430 })
+  })
+
+  it('stop() posts stop to the child (utility-process mode)', async () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    await p.stop()
+    expect(sent).toContainEqual({ type: 'stop' })
+  })
+
+  it('setPermissionGateActive posts setGate (utility-process mode)', () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    p.setPermissionGateActive(true)
+    expect(sent).toContainEqual({ type: 'setGate', active: true })
+  })
+
+  it('failOpen() swaps to an in-process gateway; isInProcessFallback() true; registerSession still sync', () => {
+    const t = new FakeChildTransport()
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    p.failOpen()
+    expect(p.isInProcessFallback()).toBe(true)
+    expect(typeof p.registerSession('s1')).toBe('string')
+  })
+
+  it('after failOpen, registerSession does NOT post to the dead child and status reflects the in-process gateway', async () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    p.failOpen()
+    await new Promise((r) => setTimeout(r, 0)) // let the in-process gateway finish binding
+    p.registerSession('s1')
+    expect(sent.some((m: any) => m.type === 'register')).toBe(false) // went to in-process, not the child
+    expect(p.status().listening).toBe(true)                          // in-process gateway is listening
+  })
+
+  it('failOpen replays known secrets into the in-process gateway', () => {
+    const t = new FakeChildTransport()
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    const secret = p.registerSession('s1') // minted while in utility-process mode
+    p.failOpen()
+    // the in-process gateway must know this session's secret so the live session keeps working
+    expect(p.hasSecretForTest('s1')).toBe(true)
+    expect(secret.length).toBeGreaterThan(0)
+  })
+
+  it('a child permission-open lets resolvePermission route the decision back to the child', () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    t.emitToParent({ type: 'permission-open', requestId: 'r1', sid: 's1' })
+    p.resolvePermission('r1', 'approved')
+    expect(sent).toContainEqual({ type: 'permission-respond', requestId: 'r1', decision: 'approved' })
+  })
+})

--- a/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
@@ -43,7 +43,7 @@ describe('HooksGatewayProxy fail-open + permission bridge', () => {
     t.onChild((m) => sent.push(m))
     p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
     p.failOpen()
-    await new Promise((r) => setTimeout(r, 0)) // let the in-process gateway finish binding
+    await p.start() // deterministically awaits the in-process bind (inProcessReady)
     p.registerSession('s1')
     expect(sent.some((m: any) => m.type === 'register')).toBe(false) // went to in-process, not the child
     expect(p.status().listening).toBe(true)                          // in-process gateway is listening
@@ -68,6 +68,16 @@ describe('HooksGatewayProxy fail-open + permission bridge', () => {
     // After fail-open the in-process gateway owns fan-out; dispatchForTest delegates there.
     p.dispatchForTest({ sessionId: 's1', event: 'Stop', summary: 'Stop', payload: {}, ts: 1 } as never)
     expect(seen).toEqual(['Stop']) // fires exactly once, via the in-process gateway
+  })
+
+  it('a subscriber registered AFTER failOpen fires exactly once (no dormant double-add)', () => {
+    const t = new FakeChildTransport()
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    p.failOpen()
+    const seen: string[] = []
+    p.subscribe((e) => seen.push(e.event)) // registers directly on the in-process gateway
+    p.dispatchForTest({ sessionId: 's1', event: 'Stop', summary: 'Stop', payload: {}, ts: 1 } as never)
+    expect(seen).toEqual(['Stop'])
   })
 
   it('a child permission-open lets resolvePermission route the decision back to the child', () => {

--- a/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
@@ -6,12 +6,32 @@ describe('HooksGatewayProxy fail-open + permission bridge', () => {
   let p: HooksGatewayProxy
   afterEach(async () => { await p?.stop() })
 
-  it('start() posts start to the child (utility-process mode)', async () => {
+  it('start() posts start to the child and resolves listening on bound', async () => {
     const t = new FakeChildTransport(); const sent: unknown[] = []
     t.onChild((m) => sent.push(m))
     p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
-    await p.start()
+    const startP = p.start()
+    t.emitToParent({ type: 'bound', port: 19430, pid: 1 })
+    const status = await startP
     expect(sent).toContainEqual({ type: 'start', port: 19430 })
+    expect(status.listening).toBe(true)
+  })
+
+  it('a bound message sets listening + port AND broadcasts HOOKS_STATUS to the renderer', () => {
+    const t = new FakeChildTransport()
+    const emitted: Array<{ channel: string; payload: unknown }> = []
+    p = new HooksGatewayProxy({
+      transport: t,
+      defaultPort: 19430,
+      emit: (channel, payload) => emitted.push({ channel, payload }),
+    })
+    t.emitToParent({ type: 'bound', port: 19431, pid: 7 })
+    expect(p.status().listening).toBe(true)
+    expect(p.status().port).toBe(19431)
+    const status = emitted.find((e) => e.channel === 'hooks:status')
+    expect(status).toBeDefined()
+    expect((status!.payload as { listening: boolean }).listening).toBe(true)
+    expect((status!.payload as { port: number }).port).toBe(19431)
   })
 
   it('stop() posts stop to the child (utility-process mode)', async () => {

--- a/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy-failopen.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { FakeChildTransport } from '../../../src/main/services/service-transport'
 import { HooksGatewayProxy } from '../../../src/main/services/hooks-gateway-proxy'
 
@@ -32,6 +32,45 @@ describe('HooksGatewayProxy fail-open + permission bridge', () => {
     expect(status).toBeDefined()
     expect((status!.payload as { listening: boolean }).listening).toBe(true)
     expect((status!.payload as { port: number }).port).toBe(19431)
+  })
+
+  it('start() resolves via the 4s timeout fallback (no hang) when bound never arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const t = new FakeChildTransport()
+      p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+      const startP = p.start()                 // utility mode: registers a 4s bound-waiter
+      await vi.advanceTimersByTimeAsync(4000)   // no bound ever arrives -> fallback fires
+      const status = await startP
+      expect(status.listening).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stop() drains a pending start() so an awaited toggle resolves immediately (no 4s wait)', async () => {
+    vi.useFakeTimers()
+    try {
+      const t = new FakeChildTransport()
+      p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+      const startP = p.start()   // pending, awaiting bound
+      await p.stop()             // must drain the waiter synchronously
+      // Without advancing timers: if stop() did NOT drain, this await would hang
+      // (the 4s fallback timer never fires under fake timers) and the test times out.
+      const status = await startP
+      expect(status.listening).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('failOpen() resolves a pending start() with the in-process listening status', async () => {
+    const t = new FakeChildTransport()
+    p = new HooksGatewayProxy({ transport: t, defaultPort: 0 })
+    const startP = p.start()   // utility mode: pending bound-waiter
+    p.failOpen()               // swaps to in-process; drains the waiter once the gateway binds
+    const status = await startP
+    expect(status.listening).toBe(true)   // resolved with the real in-process bind, not a 4s fallback
   })
 
   it('stop() posts stop to the child (utility-process mode)', async () => {

--- a/tests/unit/services/hooks-gateway-proxy.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+import { HooksGatewayProxy } from '../../../src/main/services/hooks-gateway-proxy'
+
+describe('HooksGatewayProxy (core)', () => {
+  it('registerSession returns a secret SYNCHRONOUSLY and posts register to the child', () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    const secret = p.registerSession('s1')
+    expect(typeof secret).toBe('string')
+    expect(secret.length).toBeGreaterThan(0)
+    expect(sent).toContainEqual({ type: 'register', sid: 's1', secret })
+  })
+
+  it('buffers digested events from the child and serves them via getBuffer', () => {
+    const t = new FakeChildTransport()
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    p.registerSession('s1')
+    t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'PostToolUse', toolName: 'Glob', summary: 'Glob', payload: {}, ts: 1 } as never })
+    expect(p.getBuffer('s1')).toHaveLength(1)
+  })
+
+  it('fans a child event out to subscribers', () => {
+    const t = new FakeChildTransport()
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    const seen: unknown[] = []; p.subscribe((e) => seen.push(e))
+    t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'Stop', summary: 'Stop', payload: {}, ts: 2 } as never })
+    expect(seen).toHaveLength(1)
+  })
+
+  it('unregisterSession clears the buffer and posts unregister to the child', () => {
+    const t = new FakeChildTransport(); const sent: unknown[] = []
+    t.onChild((m) => sent.push(m))
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    p.registerSession('s1')
+    t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'Stop', summary: 'Stop', payload: {}, ts: 2 } as never })
+    p.unregisterSession('s1')
+    expect(p.getBuffer('s1')).toHaveLength(0)
+    expect(sent).toContainEqual({ type: 'unregister', sid: 's1' })
+  })
+
+  it('respects RING_BUFFER_CAP (oldest dropped)', () => {
+    const t = new FakeChildTransport()
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
+    for (let i = 0; i < 250; i++) {
+      t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'PostToolUse', summary: String(i), payload: {}, ts: i } as never })
+    }
+    expect(p.getBuffer('s1')).toHaveLength(200)
+    expect(p.getBuffer('s1')[0].summary).toBe('50') // first 50 dropped
+  })
+
+  // The supervisor (Task 9) owns the transport subscription, so the proxy must be
+  // able to NOT self-subscribe and instead receive messages via handleChildMessage.
+  it('with selfSubscribe:false it ignores direct transport emits but processes handleChildMessage', () => {
+    const t = new FakeChildTransport()
+    const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430, selfSubscribe: false })
+    t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'Stop', summary: 'x', payload: {}, ts: 1 } as never })
+    expect(p.getBuffer('s1')).toHaveLength(0) // not self-subscribed
+    p.handleChildMessage({ type: 'event', entry: { sessionId: 's1', event: 'Stop', summary: 'x', payload: {}, ts: 1 } as never })
+    expect(p.getBuffer('s1')).toHaveLength(1)
+  })
+})

--- a/tests/unit/services/hooks-gateway-proxy.test.ts
+++ b/tests/unit/services/hooks-gateway-proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { FakeChildTransport } from '../../../src/main/services/service-transport'
 import { HooksGatewayProxy } from '../../../src/main/services/hooks-gateway-proxy'
+import { RING_BUFFER_CAP } from '../../../src/main/hooks/hooks-types'
 
 describe('HooksGatewayProxy (core)', () => {
   it('registerSession returns a secret SYNCHRONOUSLY and posts register to the child', () => {
@@ -43,11 +44,13 @@ describe('HooksGatewayProxy (core)', () => {
   it('respects RING_BUFFER_CAP (oldest dropped)', () => {
     const t = new FakeChildTransport()
     const p = new HooksGatewayProxy({ transport: t, defaultPort: 19430 })
-    for (let i = 0; i < 250; i++) {
+    const total = RING_BUFFER_CAP + 50
+    for (let i = 0; i < total; i++) {
       t.emitToParent({ type: 'event', entry: { sessionId: 's1', event: 'PostToolUse', summary: String(i), payload: {}, ts: i } as never })
     }
-    expect(p.getBuffer('s1')).toHaveLength(200)
-    expect(p.getBuffer('s1')[0].summary).toBe('50') // first 50 dropped
+    expect(p.getBuffer('s1')).toHaveLength(RING_BUFFER_CAP)
+    // oldest (total - cap) entries dropped, so the first retained summary is that index
+    expect(p.getBuffer('s1')[0].summary).toBe(String(total - RING_BUFFER_CAP))
   })
 
   // The supervisor (Task 9) owns the transport subscription, so the proxy must be

--- a/tests/unit/services/hooks-host-core.test.ts
+++ b/tests/unit/services/hooks-host-core.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { FakeChildTransport } from '../../../src/main/services/service-transport'
 import { createHooksHost } from '../../../src/main/services/hooks-host-core'
 
@@ -32,5 +32,21 @@ describe('createHooksHost', () => {
     host._registerResponderForTest('req-1', (d) => { got = d })
     t.post({ type: 'permission-respond', requestId: 'req-1', decision: 'approved' })
     expect(got).toBe('approved')
+  })
+
+  it('a start control message binds the requested port and announces bound to the parent', async () => {
+    const t = new FakeChildTransport()
+    createHooksHost(t.asHostTransport(), { healthBeat: false })
+    // port 0 -> ephemeral OS-assigned port; the child must announce the ACTUAL bound port
+    t.post({ type: 'start', port: 0 })
+    await vi.waitFor(() => {
+      expect(t.parentMessages.some((m) => m.type === 'bound')).toBe(true)
+    })
+    const bound = t.parentMessages.find((m) => m.type === 'bound') as { type: 'bound'; port: number; pid: number }
+    expect(bound.port).toBeGreaterThan(0)
+    // clean up the real listening socket so the test doesn't leak a handle.
+    // `stop` -> gateway.stop() closes the server asynchronously; give it a tick.
+    t.post({ type: 'stop' })
+    await new Promise((r) => setTimeout(r, 50))
   })
 })

--- a/tests/unit/services/hooks-host-core.test.ts
+++ b/tests/unit/services/hooks-host-core.test.ts
@@ -68,6 +68,15 @@ describe('createHooksHost', () => {
     await new Promise((r) => setTimeout(r, 50))
   })
 
+  it('forwards a log entry to the parent on stop', async () => {
+    const t = new FakeChildTransport()
+    createHooksHost(t.asHostTransport(), { healthBeat: false })
+    t.post({ type: 'stop' })
+    await vi.waitFor(() => {
+      expect(t.parentMessages.some((m) => m.type === 'log' && (m as { entry: { code: string } }).entry.code === 'child-stop')).toBe(true)
+    })
+  })
+
   it('posts bind-failed (not bound) when the gateway cannot bind', async () => {
     const t = new FakeChildTransport()
     const gw = stubGateway(async () => ({

--- a/tests/unit/services/hooks-host-core.test.ts
+++ b/tests/unit/services/hooks-host-core.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, vi } from 'vitest'
 import { FakeChildTransport } from '../../../src/main/services/service-transport'
 import { createHooksHost } from '../../../src/main/services/hooks-host-core'
+import type { HooksGatewayHostFace } from '../../../src/main/services/hooks-host-core'
+
+/** A no-op gateway whose start() resolves to a bind failure. Lets the bind-failed
+ *  path be exercised DETERMINISTICALLY (a real bind failure is not reliable — the
+ *  gateway tries the port plus random offsets). */
+function stubGateway(start: HooksGatewayHostFace['start']): HooksGatewayHostFace {
+  return {
+    registerSessionWithSecret: () => {},
+    unregisterSession: () => {},
+    start,
+    stop: async () => {},
+    setPermissionGateActive: () => {},
+    metrics: () => ({ inFlight: 0, eventsTotal: 0, dropsTotal: 0 }),
+    hasSecret: () => false,
+    _handleRequestForTest: async () => ({ status: 200, body: '' }),
+    permissionRegister: () => {},
+  }
+}
 
 describe('createHooksHost', () => {
   it('a register control message populates the gateway secret map', () => {
@@ -48,5 +66,23 @@ describe('createHooksHost', () => {
     // `stop` -> gateway.stop() closes the server asynchronously; give it a tick.
     t.post({ type: 'stop' })
     await new Promise((r) => setTimeout(r, 50))
+  })
+
+  it('posts bind-failed (not bound) when the gateway cannot bind', async () => {
+    const t = new FakeChildTransport()
+    const gw = stubGateway(async () => ({
+      enabled: false, listening: false, port: null, error: 'bind-failed after 5 attempts',
+    }))
+    createHooksHost(t.asHostTransport(), {
+      healthBeat: false,
+      createGateway: () => gw as unknown as never,
+    } as never)
+    t.post({ type: 'start', port: 19430 })
+    await vi.waitFor(() => {
+      expect(t.parentMessages.some((m) => m.type === 'bind-failed')).toBe(true)
+    })
+    const bf = t.parentMessages.find((m) => m.type === 'bind-failed') as { type: 'bind-failed'; error: string }
+    expect(bf.error).toContain('bind-failed')
+    expect(t.parentMessages.some((m) => m.type === 'bound')).toBe(false)
   })
 })

--- a/tests/unit/services/hooks-host-core.test.ts
+++ b/tests/unit/services/hooks-host-core.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+import { createHooksHost } from '../../../src/main/services/hooks-host-core'
+
+describe('createHooksHost', () => {
+  it('a register control message populates the gateway secret map', () => {
+    const t = new FakeChildTransport()
+    const host = createHooksHost(t.asHostTransport(), { healthBeat: false })
+    t.post({ type: 'register', sid: 's1', secret: 'sekret' })
+    expect(host._gatewayHasSecret('s1')).toBe(true)
+  })
+
+  it('posts a digested event to the parent on a real ingest', async () => {
+    const t = new FakeChildTransport()
+    const host = createHooksHost(t.asHostTransport(), { healthBeat: false })
+    t.post({ type: 'register', sid: 's1', secret: 'sekret' })
+    await host._ingestForTest('s1', 'sekret')
+    expect(t.parentMessages.some((m) => m.type === 'event')).toBe(true)
+  })
+
+  it('routes a held-open permission registration to the parent (B2)', () => {
+    const t = new FakeChildTransport()
+    const host = createHooksHost(t.asHostTransport(), { healthBeat: false })
+    host._registerResponderForTest('req-1', () => {})
+    expect(t.parentMessages).toContainEqual({ type: 'permission-open', requestId: 'req-1', sid: '' })
+  })
+
+  it('a permission-respond control message invokes the local responder (B2 round-trip)', () => {
+    const t = new FakeChildTransport()
+    const host = createHooksHost(t.asHostTransport(), { healthBeat: false })
+    let got: string | undefined
+    host._registerResponderForTest('req-1', (d) => { got = d })
+    t.post({ type: 'permission-respond', requestId: 'req-1', decision: 'approved' })
+    expect(got).toBe('approved')
+  })
+})

--- a/tests/unit/services/service-health-handlers.test.ts
+++ b/tests/unit/services/service-health-handlers.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { buildHealthGet, buildRestart } from '../../../src/main/ipc/service-health-handlers'
+import { createInitialHealth } from '../../../src/shared/service-health'
+
+describe('service-health-handlers', () => {
+  it('GET returns the supervisor snapshot when present', () => {
+    const snap = { capturedAt: 1, services: [createInitialHealth('hooks', 'Hooks gateway')], log: [] }
+    const get = buildHealthGet(() => ({ getDiagnosticsSnapshot: () => snap } as never))
+    expect(get().services[0].id).toBe('hooks')
+  })
+  it('GET returns a synthetic stopped snapshot when no supervisor', () => {
+    const get = buildHealthGet(() => null)
+    const s = get()
+    expect(s.services[0].state).toBe('stopped')
+    expect(s.services[0].id).toBe('hooks')
+  })
+  it('RESTART delegates to manualRestart', () => {
+    const restart = buildRestart(() => ({ manualRestart: (id: string) => ({ ok: true, id }) } as never))
+    expect(restart('hooks')).toEqual({ ok: true, id: 'hooks' })
+  })
+  it('RESTART returns ok:false when no supervisor', () => {
+    const restart = buildRestart(() => null)
+    expect(restart('hooks')).toEqual({ ok: false, reason: 'no-supervisor' })
+  })
+})

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { ServiceSupervisor } from '../../../src/main/services/service-supervisor'
 import { FakeChildTransport } from '../../../src/main/services/service-transport'
 
-function makeSup() {
+function makeSup(emit: (channel: string, payload: unknown) => void = () => {}) {
   const t = new FakeChildTransport()
   const sup = new ServiceSupervisor({
     forkChild: () => ({ transport: t, kill: () => t.kill(), onExit: () => {} }),
     defaultPort: 19430,
-    emit: () => {},
+    emit,
   })
   return { sup, t }
 }
@@ -43,6 +43,16 @@ describe('ServiceSupervisor health', () => {
     t.emitToParent({ type: 'bound', port: 19430, pid: 4242 })
     expect(proxy.status().listening).toBe(true)
     expect(proxy.status().port).toBe(19430)
+  })
+  it('forwarding bound emits HOOKS_STATUS to the renderer (supervisor-driven path)', () => {
+    const emitted: Array<{ channel: string; payload: unknown }> = []
+    const { sup, t } = makeSup((channel, payload) => emitted.push({ channel, payload }))
+    sup.start()
+    t.emitToParent({ type: 'bound', port: 19430, pid: 4242 })
+    const status = emitted.find((e) => e.channel === 'hooks:status')
+    expect(status).toBeDefined()
+    expect((status!.payload as { listening: boolean }).listening).toBe(true)
+    expect((status!.payload as { port: number }).port).toBe(19430)
   })
   it('start() returns a proxy and forwards child events to it (single-owner subscription)', () => {
     const { sup, t } = makeSup()

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { ServiceSupervisor } from '../../../src/main/services/service-supervisor'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+
+function makeSup() {
+  const t = new FakeChildTransport()
+  const sup = new ServiceSupervisor({
+    forkChild: () => ({ transport: t, kill: () => t.kill(), onExit: () => {} }),
+    defaultPort: 19430,
+    emit: () => {},
+  })
+  return { sup, t }
+}
+
+describe('ServiceSupervisor health', () => {
+  it('snapshot starts with one hooks service in starting state', () => {
+    const { sup } = makeSup()
+    const snap = sup.getDiagnosticsSnapshot()
+    expect(snap.services).toHaveLength(1)
+    expect(snap.services[0].id).toBe('hooks')
+    expect(snap.services[0].state).toBe('starting')
+  })
+  it('a child health beat updates counters and lastHeartbeat', () => {
+    const { sup, t } = makeSup()
+    sup.start()
+    t.emitToParent({ type: 'health', inFlight: 2, eventsTotal: 10, dropsTotal: 0, stallsLastMin: 0 })
+    const h = sup.getDiagnosticsSnapshot().services[0]
+    expect(h.inFlight).toBe(2); expect(h.eventsTotal).toBe(10)
+    expect(h.lastHeartbeatAt).toBeGreaterThan(0)
+  })
+  it('a bound message flips state to listening with a port + pid', () => {
+    const { sup, t } = makeSup()
+    sup.start()
+    t.emitToParent({ type: 'bound', port: 19430, pid: 4242 })
+    const h = sup.getDiagnosticsSnapshot().services[0]
+    expect(h.state).toBe('listening'); expect(h.port).toBe(19430); expect(h.pid).toBe(4242)
+    expect(h.host).toBe('utility-process')
+  })
+  it('start() returns a proxy and forwards child events to it (single-owner subscription)', () => {
+    const { sup, t } = makeSup()
+    const proxy = sup.start()
+    const sid = 's1'; proxy.registerSession(sid)
+    const seen: string[] = []; proxy.subscribe((e) => seen.push(e.event))
+    t.emitToParent({ type: 'event', entry: { sessionId: sid, event: 'PostToolUse', summary: 'Glob', payload: {}, ts: 1 } as never })
+    expect(seen).toEqual(['PostToolUse'])
+    expect(proxy.getBuffer(sid)).toHaveLength(1)
+  })
+  it('appends a log entry from the child to the diagnostics log ring', () => {
+    const { sup, t } = makeSup()
+    sup.start()
+    t.emitToParent({ type: 'log', entry: { ts: 1, serviceId: 'hooks', level: 'warn', code: 'x', message: 'hi' } })
+    expect(sup.getDiagnosticsSnapshot().log.some((l) => l.code === 'x')).toBe(true)
+  })
+})

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -88,4 +88,14 @@ describe('ServiceSupervisor health', () => {
     t.emitToParent({ type: 'log', entry: { ts: 1, serviceId: 'hooks', level: 'info', code: 'child-stop', message: 'stop' } })
     expect(emitted.some((e) => e.channel === 'serviceHealth:update')).toBe(true)
   })
+  it('bind-failed marks crashed and schedules a restart', () => {
+    const { sup, t } = makeSup()
+    sup.start()
+    t.emitToParent({ type: 'bind-failed', error: 'bind-failed after N attempts' })
+    const h = sup.getDiagnosticsSnapshot().services[0]
+    expect(h.state).toBe('crashed')
+    expect(h.lastError?.message).toContain('bind-failed')
+    expect(sup.getDiagnosticsSnapshot().log.some((l) => l.code === 'bind-failed')).toBe(true)
+    expect(t.killed).toBe(true)   // escalates by killing the child -> exit-driven restart path
+  })
 })

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -69,4 +69,23 @@ describe('ServiceSupervisor health', () => {
     t.emitToParent({ type: 'log', entry: { ts: 1, serviceId: 'hooks', level: 'warn', code: 'x', message: 'hi' } })
     expect(sup.getDiagnosticsSnapshot().log.some((l) => l.code === 'x')).toBe(true)
   })
+  it('pushes SERVICE_HEALTH_UPDATE with a snapshot on a bound transition', () => {
+    const emitted: Array<{ channel: string; payload: unknown }> = []
+    const { sup, t } = makeSup((c, p) => emitted.push({ channel: c, payload: p }))
+    sup.start()
+    emitted.length = 0   // drop the 'starting' push from spawnChild; assert the bound push
+    t.emitToParent({ type: 'bound', port: 19430, pid: 4242 })
+    const upd = emitted.find((e) => e.channel === 'serviceHealth:update')
+    expect(upd).toBeDefined()
+    const snap = upd!.payload as import('../../../src/shared/service-health').DiagnosticsSnapshot
+    expect(snap.services[0].state).toBe('listening')
+  })
+  it('pushes SERVICE_HEALTH_UPDATE when a forwarded child log lands', () => {
+    const emitted: Array<{ channel: string; payload: unknown }> = []
+    const { sup, t } = makeSup((c, p) => emitted.push({ channel: c, payload: p }))
+    sup.start()
+    emitted.length = 0
+    t.emitToParent({ type: 'log', entry: { ts: 1, serviceId: 'hooks', level: 'info', code: 'child-stop', message: 'stop' } })
+    expect(emitted.some((e) => e.channel === 'serviceHealth:update')).toBe(true)
+  })
 })

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -36,6 +36,14 @@ describe('ServiceSupervisor health', () => {
     expect(h.state).toBe('listening'); expect(h.port).toBe(19430); expect(h.pid).toBe(4242)
     expect(h.host).toBe('utility-process')
   })
+  it('forwards bound to the proxy so its status reflects listening (supervisor-driven path)', () => {
+    const { sup, t } = makeSup()
+    const proxy = sup.start()
+    expect(proxy.status().listening).toBe(false)
+    t.emitToParent({ type: 'bound', port: 19430, pid: 4242 })
+    expect(proxy.status().listening).toBe(true)
+    expect(proxy.status().port).toBe(19430)
+  })
   it('start() returns a proxy and forwards child events to it (single-owner subscription)', () => {
     const { sup, t } = makeSup()
     const proxy = sup.start()

--- a/tests/unit/services/service-supervisor-health.test.ts
+++ b/tests/unit/services/service-supervisor-health.test.ts
@@ -88,7 +88,7 @@ describe('ServiceSupervisor health', () => {
     t.emitToParent({ type: 'log', entry: { ts: 1, serviceId: 'hooks', level: 'info', code: 'child-stop', message: 'stop' } })
     expect(emitted.some((e) => e.channel === 'serviceHealth:update')).toBe(true)
   })
-  it('bind-failed marks crashed and schedules a restart', () => {
+  it('bind-failed marks crashed + kills the child to escalate (restart proven in the lifecycle suite)', () => {
     const { sup, t } = makeSup()
     sup.start()
     t.emitToParent({ type: 'bind-failed', error: 'bind-failed after N attempts' })

--- a/tests/unit/services/service-supervisor-lifecycle.test.ts
+++ b/tests/unit/services/service-supervisor-lifecycle.test.ts
@@ -35,6 +35,24 @@ describe('ServiceSupervisor lifecycle', () => {
     expect(h.state).toBe('degraded')
   })
 
+  it('ignores the self-kill exit after fail-open (single fallback log, no re-entry)', () => {
+    let exitCb: (() => void) | null = null
+    // kill() synchronously fires the stored exit callback — the WORST case for
+    // re-entry (the real utilityProcess fires it async). The fellOpen flag (set
+    // before kill in activateFallback) must suppress it either way.
+    const fork = vi.fn(() => ({
+      transport: new FakeChildTransport(),
+      kill: () => { exitCb?.() },
+      onExit: (cb: () => void) => { exitCb = cb },
+    }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {}, maxRestarts: 1 })
+    sup.start()
+    for (let i = 0; i < 2; i++) { exitCb?.(); vi.advanceTimersByTime(5000) }
+    expect(sup.getProxy()?.isInProcessFallback()).toBe(true)
+    const fallbackLogs = sup.getDiagnosticsSnapshot().log.filter((l) => l.code === 'fallback')
+    expect(fallbackLogs).toHaveLength(1)   // the kill-triggered re-entry was ignored
+  })
+
   it('does NOT restart when shutting down', () => {
     let exitCb: (() => void) | null = null
     const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))

--- a/tests/unit/services/service-supervisor-lifecycle.test.ts
+++ b/tests/unit/services/service-supervisor-lifecycle.test.ts
@@ -71,4 +71,38 @@ describe('ServiceSupervisor lifecycle', () => {
     vi.advanceTimersByTime(5000)
     expect(fork).toHaveBeenCalledTimes(1)   // the pending restart was cancelled
   })
+
+  it('manualRestart (utility mode) kills + respawns and resets counters', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start()
+    exitCb?.(); vi.advanceTimersByTime(300)      // one crash -> restartCount 1
+    expect(sup.getDiagnosticsSnapshot().services[0].restartCount).toBe(1)
+    const r = sup.manualRestart('hooks')
+    expect(r.ok).toBe(true)
+    expect(fork).toHaveBeenCalledTimes(3)        // initial + backoff respawn + manual respawn
+    expect(sup.getDiagnosticsSnapshot().services[0].restartCount).toBe(0)  // counters reset
+  })
+
+  it('manualRestart returns {ok:false, reason:"fallback"} when in in-process fallback', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {}, maxRestarts: 1 })
+    sup.start()
+    for (let i = 0; i < 2; i++) { exitCb?.(); vi.advanceTimersByTime(5000) }   // -> fallback
+    expect(sup.getProxy()?.isInProcessFallback()).toBe(true)
+    const forkCalls = fork.mock.calls.length
+    const r = sup.manualRestart('hooks')
+    expect(r).toEqual({ ok: false, reason: 'fallback' })
+    expect(fork).toHaveBeenCalledTimes(forkCalls)   // no respawn in fallback
+  })
+
+  it('manualRestart returns {ok:false, reason:"shutting-down"} after shutdown', () => {
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: () => {} }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start()
+    sup.shutdown()
+    expect(sup.manualRestart('hooks')).toEqual({ ok: false, reason: 'shutting-down' })
+  })
 })

--- a/tests/unit/services/service-supervisor-lifecycle.test.ts
+++ b/tests/unit/services/service-supervisor-lifecycle.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ServiceSupervisor } from '../../../src/main/services/service-supervisor'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+
+describe('ServiceSupervisor lifecycle', () => {
+  let sup: ServiceSupervisor | undefined
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(async () => {
+    vi.useRealTimers()
+    await sup?.getProxy()?.stop()   // close any in-process socket from fail-open
+    sup = undefined
+  })
+
+  it('restarts the child on unexpected exit (forkChild called again after backoff)', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start()
+    expect(fork).toHaveBeenCalledTimes(1)
+    exitCb?.()                       // simulate crash
+    vi.advanceTimersByTime(300)      // first backoff (250ms)
+    expect(fork).toHaveBeenCalledTimes(2)
+    expect(sup.getDiagnosticsSnapshot().services[0].restartCount).toBe(1)
+  })
+
+  it('fails open to in-process after N failed restarts', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {}, maxRestarts: 2 })
+    sup.start()
+    for (let i = 0; i < 3; i++) { exitCb?.(); vi.advanceTimersByTime(5000) }
+    expect(sup.getProxy()?.isInProcessFallback()).toBe(true)
+    expect(sup.getDiagnosticsSnapshot().services[0].host).toBe('in-process-fallback')
+  })
+
+  it('does NOT restart when shutting down', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start(); sup.shutdown(); exitCb?.(); vi.advanceTimersByTime(5000)
+    expect(fork).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/services/service-supervisor-lifecycle.test.ts
+++ b/tests/unit/services/service-supervisor-lifecycle.test.ts
@@ -30,7 +30,9 @@ describe('ServiceSupervisor lifecycle', () => {
     sup.start()
     for (let i = 0; i < 3; i++) { exitCb?.(); vi.advanceTimersByTime(5000) }
     expect(sup.getProxy()?.isInProcessFallback()).toBe(true)
-    expect(sup.getDiagnosticsSnapshot().services[0].host).toBe('in-process-fallback')
+    const h = sup.getDiagnosticsSnapshot().services[0]
+    expect(h.host).toBe('in-process-fallback')
+    expect(h.state).toBe('degraded')
   })
 
   it('does NOT restart when shutting down', () => {
@@ -39,5 +41,16 @@ describe('ServiceSupervisor lifecycle', () => {
     sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
     sup.start(); sup.shutdown(); exitCb?.(); vi.advanceTimersByTime(5000)
     expect(fork).toHaveBeenCalledTimes(1)
+  })
+
+  it('shutdown() during the backoff window cancels the pending restart (no resurrection)', () => {
+    let exitCb: (() => void) | null = null
+    const fork = vi.fn(() => ({ transport: new FakeChildTransport(), kill: () => {}, onExit: (cb: () => void) => { exitCb = cb } }))
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start()
+    exitCb?.()              // crash -> schedules a backoff restart
+    sup.shutdown()          // races the backoff timer
+    vi.advanceTimersByTime(5000)
+    expect(fork).toHaveBeenCalledTimes(1)   // the pending restart was cancelled
   })
 })

--- a/tests/unit/services/service-supervisor-lifecycle.test.ts
+++ b/tests/unit/services/service-supervisor-lifecycle.test.ts
@@ -35,6 +35,25 @@ describe('ServiceSupervisor lifecycle', () => {
     expect(h.state).toBe('degraded')
   })
 
+  it('bind-failed escalates to a restart (kill -> exit -> backoff -> re-fork)', () => {
+    let exitCb: (() => void) | null = null
+    let curT: FakeChildTransport | null = null
+    // kill() fires the stored exit callback (as a real utilityProcess does), so the
+    // bind-failed handler's child.kill() drives the exit-based restart path end-to-end.
+    const fork = vi.fn(() => {
+      curT = new FakeChildTransport()
+      return { transport: curT, kill: () => exitCb?.(), onExit: (cb: () => void) => { exitCb = cb } }
+    })
+    sup = new ServiceSupervisor({ forkChild: fork, defaultPort: 0, emit: () => {} })
+    sup.start()
+    expect(fork).toHaveBeenCalledTimes(1)
+    curT!.emitToParent({ type: 'bind-failed', error: 'bind-failed after 5 attempts' })
+    expect(sup.getDiagnosticsSnapshot().services[0].state).toBe('crashed')
+    vi.advanceTimersByTime(300)   // first backoff (250ms)
+    expect(fork).toHaveBeenCalledTimes(2)   // escalation re-forked the child
+    expect(sup.getDiagnosticsSnapshot().services[0].restartCount).toBe(1)
+  })
+
   it('ignores the self-kill exit after fail-open (single fallback log, no re-entry)', () => {
     let exitCb: (() => void) | null = null
     // kill() synchronously fires the stored exit callback — the WORST case for

--- a/tests/unit/services/service-transport.test.ts
+++ b/tests/unit/services/service-transport.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { FakeChildTransport } from '../../../src/main/services/service-transport'
+
+describe('FakeChildTransport', () => {
+  it('delivers posted messages to the registered handler', () => {
+    const t = new FakeChildTransport()
+    const got: unknown[] = []
+    t.onChild((m) => got.push(m))
+    t.post({ type: 'register', sid: 's1', secret: 'x' })
+    expect(got).toEqual([{ type: 'register', sid: 's1', secret: 'x' }])
+  })
+  it('captures the opposite direction via emitToParent for assertions', () => {
+    const t = new FakeChildTransport()
+    t.emitToParent({ type: 'bound', port: 19430, pid: 1 })
+    expect(t.parentMessages).toEqual([{ type: 'bound', port: 19430, pid: 1 }])
+  })
+})

--- a/tests/unit/shared/service-health.test.ts
+++ b/tests/unit/shared/service-health.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { createInitialHealth } from '../../../src/shared/service-health'
+import { IPC } from '../../../src/shared/ipc-channels'
+
+describe('service-health', () => {
+  it('createInitialHealth returns a starting, in-process record', () => {
+    const h = createInitialHealth('hooks', 'Hooks gateway')
+    expect(h.id).toBe('hooks')
+    expect(h.state).toBe('starting')
+    expect(h.host).toBe('in-process-fallback')
+    expect(h.inFlight).toBe(0)
+    expect(h.restartCount).toBe(0)
+  })
+  it('defines the service-health IPC channels', () => {
+    expect(IPC.SERVICE_HEALTH_GET).toBe('serviceHealth:get')
+    expect(IPC.SERVICE_HEALTH_UPDATE).toBe('serviceHealth:update')
+    expect(IPC.SERVICE_RESTART).toBe('serviceHealth:restart')
+  })
+})


### PR DESCRIPTION
## Summary
Conductor Control Plane **D1a** — the headless services backbone. Moves the HTTP hooks gateway out of the Electron main process into a supervised `utilityProcess` child, with health/metrics/structured logging and a machine-queryable `getDiagnosticsSnapshot()`. On repeated child crashes it **fails open** to an in-process gateway (worst case = today's exact behavior). Main keeps per-session secrets (PTY spawn stays synchronous); the child does parse/redact; main keeps buffer + fan-out + renderer emit.

This is the foundation for a future V3 "Claude Sentinel" (all telemetry structured + queryable). The diagnostics **UI** (health pill + console) is the next phase (D1b) and is intentionally out of scope here — the `SERVICE_HEALTH_*` channels and `getDiagnosticsSnapshot()` are present-but-unconsumed.

**Stacked on PR #56**: base is `feat/ux-uplift-account-aware`, so this diff is just the 23 backbone commits. It reaches `beta` via #56. No GitHub release intended.

## What changed (23 commits over 957502d..HEAD)
- Electron-free `data-paths.ts` (broke the child's only electron leak) + `hooks-host` utilityProcess entry; child require-closure verified **0 electron** (node builtins + gateway chunk).
- `HooksGatewayProxy implements HooksGatewayLike` — compile-time drop-in for every consumer + IPC handler (B1).
- `ServiceSupervisor`: health + 200-entry log ring, restart/backoff `[250,1000,4000,4000,4000]`, replay-before-listen (S1), fail-open after maxRestarts, shutdown before killAllPty (S5).
- Child announces `bound` end-to-end → proxy resolves `start()` + broadcasts `HOOKS_STATUS`; supervisor forwards `bound` in the production path.
- Held-open permission responders live in the child, bridged to main (B2 — gateway never imports permission-responders).

## Review
Two independent multi-agent review passes (spec + quality, then requirements + adversarial), each with adversarial verification of major findings:
- bound-fix `825fb90`: both reviewers APPROVE_WITH_NITS, end-to-end claim confirmed, **0 blocker/major**. Nit applied (drain boundWaiters) + 4 tests.
- whole-impl `957502d..HEAD`: **GO** — all 8 requirement labels hold (B1/B2/S1/S5, fail-open-independent-of-bound, hooks-disabled-faithful, no-leaks-across-restarts, child-electron-free), **0 blocker/major**. 2 nits applied.

## Deferred to D1b (tracked)
- Child bind-failure (no crash) → no fail-open + no error surfaced; have the child post `bind-failed` so the supervisor escalates.
- Live ring-buffer scrollback dropped on fail-open (5-crash precondition).
- Stale `listening:true` during the restart backoff window (self-heals on next bind).

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full unit suite **1686 pass / 1 skip** (skip = opt-in token-gated real-Claude test)
- [x] `npm run package:win` builds; child closure independently confirmed electron-free
- [ ] **Manual VM (S2 go/no-go):** hooks fire end-to-end with the gateway in a child process; no main-loop freeze under parallel tool use; kill the child -> auto-restart; force fail-open -> hooks still work. Installer `CCC-1.5.29-backbone.exe`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>