### PR TITLE
feat: session-card effort indicator + PTY-integrity instrumentation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,7 +37,8 @@ import { registerTokenomicsHandlers } from './ipc/tokenomics-handlers'
 import { registerAccountAttributionHandlers } from './ipc/account-attribution-handlers'
 import { registerGitHubHandlers } from './ipc/github-handlers'
 import { registerHooksHandlers } from './ipc/hooks-handlers'
-import { registerServiceHealthHandlers } from './ipc/service-health-handlers'
+import { registerServiceHealthHandlers, getMergedDiagnostics } from './ipc/service-health-handlers'
+import { PtyIntegrityMonitor, setPtyIntegrityMonitor, getPtyIntegrityMonitor } from './services/pty-integrity-monitor'
 import { registerCodexHandlers } from './ipc/codex-handlers'
 import { registerCodexReviewHandlers } from './ipc/codex-review-handlers'
 import { registerChannelHandlers } from './ipc/channel-handlers'
@@ -704,17 +705,29 @@ if (!gotTheLock) {
         try { win.webContents.send(channel, payload) } catch { /* destroyed */ }
       }
     }
+    // PTY-integrity monitor (D1 diagnostics). Lives in main; surfaces through the
+    // SAME SERVICE_HEALTH_GET/UPDATE as the hooks supervisor via a merge so every
+    // push carries BOTH snapshots (else one source would wipe the other in the UI).
+    const getSup = () => getHooksSupervisor()
+    const getPtyDiag = () => getPtyIntegrityMonitor()?.diagnostics() ?? null
+    const pushDiagnostics = () => emitToWindow(IPC.SERVICE_HEALTH_UPDATE, getMergedDiagnostics(getSup, getPtyDiag))
+    const ptyMonitor = new PtyIntegrityMonitor({ emit: pushDiagnostics })
+    setPtyIntegrityMonitor(ptyMonitor)
+    // Redirect ONLY SERVICE_HEALTH_UPDATE through the merge; every other channel
+    // (HOOKS_STATUS, HOOKS_EVENT, ...) the supervisor/gateway emit passes through.
+    const emitWithMerge = (channel: string, payload: unknown) =>
+      channel === IPC.SERVICE_HEALTH_UPDATE ? pushDiagnostics() : emitToWindow(channel, payload)
     if (hooksEnabled) {
       // Supervised out-of-process gateway: a utilityProcess child runs the HooksGateway,
       // crash-isolated from the main thread, with restart/backoff + fail-open-to-in-process.
-      const hooksSupervisor = new ServiceSupervisor({ forkChild: forkHooksChild, defaultPort: hooksPort, emit: emitToWindow })
+      const hooksSupervisor = new ServiceSupervisor({ forkChild: forkHooksChild, defaultPort: hooksPort, emit: emitWithMerge })
       const hooksProxy = hooksSupervisor.start()   // forks the child + posts start (S1 replay-before-listen inside)
       setGateway(hooksProxy)                        // B1: consumers + handlers all use the proxy
       setHooksSupervisor(hooksSupervisor)           // module-scope ref for before-quit (S5)
     } else {
       // Hooks disabled: today's exact behavior — an in-process gateway exists (so
       // registerSession still mints secrets) but never binds; no child is forked.
-      setGateway(new HooksGateway({ defaultPort: hooksPort, emit: emitToWindow }))
+      setGateway(new HooksGateway({ defaultPort: hooksPort, emit: emitWithMerge }))
     }
     startPermissionTray()
     startEffortTracker()
@@ -723,7 +736,7 @@ if (!gotTheLock) {
     registerHooksHandlers(getGateway()!)   // B1: handlers get whatever gateway backs the singleton
     // D1b: diagnostics IPC. The getter returns null in the hooks-disabled branch
     // (supervisor never set) -> the handler serves an honest synthetic "hooks off" snapshot.
-    registerServiceHealthHandlers(() => getHooksSupervisor())
+    registerServiceHealthHandlers(getSup, getPtyDiag)
     if (hooksEnabled) {
       cleanupStaleHookEntries(new Set())   // supervisor.start() already fired proxy.start()
     }

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -6,6 +6,8 @@ import { logInfo } from '../debug-logger'
 import { isVersionInstalled, installVersion } from '../legacy-version-manager'
 import { loadCredential } from '../credential-store'
 import { IPC } from '../../shared/ipc-channels'
+import { getPtyIntegrityMonitor } from '../services/pty-integrity-monitor'
+import type { PtyIntegrityReport } from '../../shared/service-health'
 
 /** SSH options as received from the renderer (no passwords — only configId) */
 interface RendererSSHOptions {
@@ -141,6 +143,10 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
 
   ipcMain.on('pty:kill', (_event, sessionId: string) => {
     killPty(sessionId)
+  })
+
+  ipcMain.on(IPC.PTY_INTEGRITY_REPORT, (_event, report: PtyIntegrityReport) => {
+    getPtyIntegrityMonitor()?.recordRendererReport(report)
   })
 
   // SSH manual-flow controller — renderer drives stage transitions.

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -46,7 +46,9 @@ export const spawnOptionsSchema = z.object({
     model: z.string().optional(),
     tools: z.array(z.string()).optional(),
   })).optional(),
-  effortLevel: z.enum(['low', 'medium', 'high']).optional(),
+  // All 6 live effort levels (set via /effort, persisted, restored at spawn).
+  // Capping at low/medium/high made a restored xhigh/max/ultracode session throw here.
+  effortLevel: z.enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']).optional(),
   disableAutoMemory: z.boolean().optional(),
   enableCodexReview: z.boolean().optional(),
   model: z.string().optional(),
@@ -81,7 +83,7 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
     useResumePicker?: boolean
     legacyVersion?: { enabled: boolean; version: string }
     agentsConfig?: Array<{ name: string; description: string; prompt: string; model?: string; tools?: string[] }>
-    effortLevel?: 'low' | 'medium' | 'high'
+    effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
     disableAutoMemory?: boolean
     enableCodexReview?: boolean
     model?: string

--- a/src/main/ipc/service-health-handlers.ts
+++ b/src/main/ipc/service-health-handlers.ts
@@ -1,24 +1,29 @@
 import { ipcMain } from 'electron'
 import { IPC } from '../../shared/ipc-channels'
 import { createInitialHealth } from '../../shared/service-health'
-import type { DiagnosticsSnapshot } from '../../shared/service-health'
+import type { DiagnosticsSnapshot, PtyIntegritySnapshot, ServiceLogEntry } from '../../shared/service-health'
 import type { ServiceSupervisor } from '../services/service-supervisor'
 
 type SupGetter = () => Pick<ServiceSupervisor, 'getDiagnosticsSnapshot' | 'manualRestart'> | null
+type PtyGetter = () => { snapshot: PtyIntegritySnapshot; logs: ServiceLogEntry[] } | null
 
-/** Pure: returns the live supervisor snapshot, or an honest synthetic "hooks off"
- *  snapshot (state:'stopped') when no supervisor exists (hooksEnabled=false). */
-export function buildHealthGet(getSup: SupGetter): () => DiagnosticsSnapshot {
-  return () => {
-    const sup = getSup()
-    if (sup) return sup.getDiagnosticsSnapshot()
-    const h = { ...createInitialHealth('hooks', 'Hooks gateway'), state: 'stopped' as const }
-    return { capturedAt: Date.now(), services: [h], log: [] }
-  }
+const LOG_CAP = 200
+
+/** Pure: the live supervisor snapshot (or an honest synthetic "hooks off"
+ *  snapshot when no supervisor exists), with the PTY-integrity block merged in
+ *  and the pty log ring folded into the global log (sorted by ts, capped). */
+export function getMergedDiagnostics(getSup: SupGetter, getPty: PtyGetter): DiagnosticsSnapshot {
+  const sup = getSup()
+  const base: DiagnosticsSnapshot = sup
+    ? sup.getDiagnosticsSnapshot()
+    : { capturedAt: Date.now(), services: [{ ...createInitialHealth('hooks', 'Hooks gateway'), state: 'stopped' }], log: [] }
+  const pd = getPty()
+  if (!pd) return base
+  const log = [...base.log, ...pd.logs].sort((a, b) => a.ts - b.ts)
+  if (log.length > LOG_CAP) log.splice(0, log.length - LOG_CAP)
+  return { ...base, log, pty: pd.snapshot }
 }
 
-/** Pure: delegates to the supervisor's manualRestart, or declines honestly when
- *  there is no supervisor. */
 export function buildRestart(getSup: SupGetter): (serviceId: string) => { ok: boolean; reason?: string } {
   return (serviceId) => {
     const sup = getSup()
@@ -27,9 +32,8 @@ export function buildRestart(getSup: SupGetter): (serviceId: string) => { ok: bo
   }
 }
 
-export function registerServiceHealthHandlers(getSup: SupGetter): void {
-  const get = buildHealthGet(getSup)
+export function registerServiceHealthHandlers(getSup: SupGetter, getPty: PtyGetter = () => null): void {
   const restart = buildRestart(getSup)
-  ipcMain.handle(IPC.SERVICE_HEALTH_GET, async () => get())
+  ipcMain.handle(IPC.SERVICE_HEALTH_GET, async () => getMergedDiagnostics(getSup, getPty))
   ipcMain.handle(IPC.SERVICE_RESTART, async (_e, serviceId: string) => restart(serviceId))
 }

--- a/src/main/ipc/service-health-handlers.ts
+++ b/src/main/ipc/service-health-handlers.ts
@@ -7,6 +7,8 @@ import type { ServiceSupervisor } from '../services/service-supervisor'
 type SupGetter = () => Pick<ServiceSupervisor, 'getDiagnosticsSnapshot' | 'manualRestart'> | null
 type PtyGetter = () => { snapshot: PtyIntegritySnapshot; logs: ServiceLogEntry[] } | null
 
+// Mirrors ServiceSupervisor's own LOG_CAP (service-supervisor.ts) so the merged
+// tail matches the size the diagnostics panel already expects.
 const LOG_CAP = 200
 
 /** Pure: the live supervisor snapshot (or an honest synthetic "hooks off"

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -14,7 +14,7 @@ export interface SpawnOptions {
   useResumePicker?: boolean
   legacyVersion?: LegacyVersion
   agentsConfig?: Array<{ name: string; description: string; prompt: string; model?: string; tools?: string[] }>
-  effortLevel?: 'low' | 'medium' | 'high'
+  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
   disableAutoMemory?: boolean
   model?: string
   // Codex-specific (only present when provider === 'codex')

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -33,6 +33,7 @@ import { captureClaudeAccount, clearClaudeAccount, getAccountIdentity, pushAccou
 import type { AccountIdentity } from '../shared/types'
 import { updateSessionMeta, clearSessionMeta } from './session-registry'
 import { readConfig } from './config-manager'
+import { getPtyIntegrityMonitor } from './services/pty-integrity-monitor'
 
 import * as path from 'path'
 import * as fs from 'fs'
@@ -615,6 +616,7 @@ export function spawnPty(
       // Strip SSH statusline OSC sentinels before forwarding to xterm.
       // Parsed sentinels are dispatched to the statusline pipeline as a side effect.
       const data = extractSshOscSentinels(sessionId, rawData)
+      getPtyIntegrityMonitor()?.recordPtyData(sessionId, data.length)
       win.webContents.send(`pty:data:${sessionId}`, data)
 
       // Arm the idle-data fallback. Re-arms on every chunk so the timer
@@ -813,6 +815,7 @@ export function spawnPty(
       })
       ptyProcess.onData((data) => {
         if (win.isDestroyed()) return
+        getPtyIntegrityMonitor()?.recordPtyData(sessionId, data.length)
         win.webContents.send(`pty:data:${sessionId}`, data)
       })
       // Start rollout watch-and-claim telemetry. Updates are dispatched to the
@@ -1056,6 +1059,7 @@ export function spawnPty(
 
     ptyProcess.onData((data) => {
       if (win.isDestroyed()) return
+      getPtyIntegrityMonitor()?.recordPtyData(sessionId, data.length)
       win.webContents.send(`pty:data:${sessionId}`, data)
     })
   }
@@ -1107,6 +1111,7 @@ export function spawnPty(
     if (weAreCurrent) {
       ptySessions.delete(sessionId)
       clearSessionMeta(sessionId)
+      getPtyIntegrityMonitor()?.endSession(sessionId)
       try {
         const gwExit = getGateway()
         if (gwExit) gwExit.unregisterSession(sessionId)
@@ -1259,6 +1264,7 @@ export function writePty(sessionId: string, data: string): void {
 export function resizePty(sessionId: string, cols: number, rows: number): void {
   try {
     ptySessions.get(sessionId)?.ptyProcess.resize(cols, rows)
+    getPtyIntegrityMonitor()?.recordResizeApplied(sessionId, cols, rows)
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException)?.code
     if (code === 'EPIPE' || code === 'EIO') {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -236,7 +236,7 @@ export function spawnPty(
     useResumePicker?: boolean
     legacyVersion?: { enabled: boolean; version: string }
     agentsConfig?: Array<{ name: string; description: string; prompt: string; model?: string; tools?: string[] }>
-    effortLevel?: 'low' | 'medium' | 'high'
+    effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
     disableAutoMemory?: boolean
     model?: string
     /** Per-session account isolation: spawn claude under this profile's CLAUDE_CONFIG_DIR. */

--- a/src/main/services/pty-integrity-monitor.ts
+++ b/src/main/services/pty-integrity-monitor.ts
@@ -17,6 +17,7 @@ interface SessionRec {
   rendererResizeCount: number
   widthDesyncCount: number
   byteGapFlagged: boolean
+  desyncFlagged: boolean
 }
 
 export interface PtyIntegrityMonitorOptions {
@@ -59,7 +60,7 @@ export class PtyIntegrityMonitor {
         lastAppliedCols: null, lastAppliedRows: null,
         bytesReceived: 0, bytesWritten: 0, strippedBytes: 0,
         lastRendererCols: null, lastRendererRows: null, rendererResizeCount: 0,
-        widthDesyncCount: 0, byteGapFlagged: false,
+        widthDesyncCount: 0, byteGapFlagged: false, desyncFlagged: false,
       }
       this.sessions.set(sessionId, r)
     }
@@ -123,10 +124,19 @@ export class PtyIntegrityMonitor {
   }
 
   private checkDesync(r: SessionRec): void {
-    if (r.lastAppliedCols != null && r.lastRendererCols != null && r.lastAppliedCols !== r.lastRendererCols) {
+    // Hysteresis (mirrors checkByteGap): count + log ONE event per desync EPISODE
+    // (a synced->desynced transition), not once per report tick. Persistent
+    // mismatches would otherwise inflate widthDesyncCount and flood the rings,
+    // evicting the genuinely-useful timeline.
+    const isDesynced =
+      r.lastAppliedCols != null && r.lastRendererCols != null && r.lastAppliedCols !== r.lastRendererCols
+    if (isDesynced && !r.desyncFlagged) {
+      r.desyncFlagged = true
       r.widthDesyncCount += 1
       this.pushEvent('desync', r.sessionId, `cols main=${r.lastAppliedCols} renderer=${r.lastRendererCols}`)
       this.pushLog('warn', 'pty-width-desync', `${r.sessionId}: cols main=${r.lastAppliedCols} renderer=${r.lastRendererCols}`)
+    } else if (!isDesynced && r.desyncFlagged) {
+      r.desyncFlagged = false
     }
   }
 

--- a/src/main/services/pty-integrity-monitor.ts
+++ b/src/main/services/pty-integrity-monitor.ts
@@ -163,6 +163,9 @@ export class PtyIntegrityMonitor {
         resizes: sessions.reduce((a, s) => a + s.resizeCount, 0),
         desyncs: sessions.reduce((a, s) => a + s.widthDesyncCount, 0),
       },
+      // Shallow array copies are safe: event/log entries are write-once (pushed,
+      // never mutated), and the only consumer is IPC structured-clone. Matches the
+      // ServiceSupervisor's own shallow `[...this.log]` pattern.
       recentEvents: [...this.events],
     }
   }

--- a/src/main/services/pty-integrity-monitor.ts
+++ b/src/main/services/pty-integrity-monitor.ts
@@ -1,0 +1,180 @@
+import type {
+  PtyIntegritySnapshot, PtySessionIntegrity, PtyIntegrityEvent, PtyIntegrityReport, ServiceLogEntry,
+} from '../../shared/service-health'
+
+interface SessionRec {
+  sessionId: string
+  bytesFromPty: number
+  chunksFromPty: number
+  resizeCount: number
+  lastAppliedCols: number | null
+  lastAppliedRows: number | null
+  bytesReceived: number
+  bytesWritten: number
+  strippedBytes: number
+  lastRendererCols: number | null
+  lastRendererRows: number | null
+  rendererResizeCount: number
+  widthDesyncCount: number
+  byteGapFlagged: boolean
+}
+
+export interface PtyIntegrityMonitorOptions {
+  emit: () => void              // push a merged diagnostics snapshot to the renderer
+  now?: () => number
+  eventCap?: number             // recent-events ring (default 100)
+  logCap?: number               // notable-log ring (default 50)
+  emitDebounceMs?: number       // default 250
+  byteGapThreshold?: number     // default 4096
+}
+
+const LOG_SERVICE = 'pty'
+
+export class PtyIntegrityMonitor {
+  private sessions = new Map<string, SessionRec>()
+  private events: PtyIntegrityEvent[] = []
+  private logs: ServiceLogEntry[] = []
+  private now: () => number
+  private emitFn: () => void
+  private eventCap: number
+  private logCap: number
+  private debounceMs: number
+  private gapThreshold: number
+  private emitTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(opts: PtyIntegrityMonitorOptions) {
+    this.emitFn = opts.emit
+    this.now = opts.now ?? (() => Date.now())
+    this.eventCap = opts.eventCap ?? 100
+    this.logCap = opts.logCap ?? 50
+    this.debounceMs = opts.emitDebounceMs ?? 250
+    this.gapThreshold = opts.byteGapThreshold ?? 4096
+  }
+
+  private rec(sessionId: string): SessionRec {
+    let r = this.sessions.get(sessionId)
+    if (!r) {
+      r = {
+        sessionId, bytesFromPty: 0, chunksFromPty: 0, resizeCount: 0,
+        lastAppliedCols: null, lastAppliedRows: null,
+        bytesReceived: 0, bytesWritten: 0, strippedBytes: 0,
+        lastRendererCols: null, lastRendererRows: null, rendererResizeCount: 0,
+        widthDesyncCount: 0, byteGapFlagged: false,
+      }
+      this.sessions.set(sessionId, r)
+    }
+    return r
+  }
+
+  private pushEvent(kind: PtyIntegrityEvent['kind'], sessionId: string, detail: string): void {
+    this.events.push({ ts: this.now(), kind, sessionId, detail })
+    if (this.events.length > this.eventCap) this.events.splice(0, this.events.length - this.eventCap)
+  }
+
+  private pushLog(level: ServiceLogEntry['level'], code: string, message: string): void {
+    this.logs.push({ ts: this.now(), serviceId: LOG_SERVICE, level, code, message })
+    if (this.logs.length > this.logCap) this.logs.splice(0, this.logs.length - this.logCap)
+  }
+
+  private scheduleEmit(): void {
+    if (this.debounceMs <= 0) { try { this.emitFn() } catch { /* window gone */ } ; return }
+    if (this.emitTimer) return
+    this.emitTimer = setTimeout(() => {
+      this.emitTimer = null
+      try { this.emitFn() } catch { /* window gone */ }
+    }, this.debounceMs)
+  }
+
+  recordPtyData(sessionId: string, byteLength: number): void {
+    const r = this.rec(sessionId)
+    r.bytesFromPty += byteLength
+    r.chunksFromPty += 1
+    this.scheduleEmit()
+  }
+
+  recordResizeApplied(sessionId: string, cols: number, rows: number): void {
+    const r = this.rec(sessionId)
+    r.resizeCount += 1
+    r.lastAppliedCols = cols
+    r.lastAppliedRows = rows
+    this.pushEvent('resize', sessionId, `applied ${cols}x${rows}`)
+    this.checkDesync(r)
+    this.scheduleEmit()
+  }
+
+  recordRendererReport(report: PtyIntegrityReport): void {
+    const r = this.rec(report.sessionId)
+    r.bytesReceived = report.bytesReceived
+    r.bytesWritten = report.bytesWritten
+    r.strippedBytes = report.strippedBytes
+    r.lastRendererCols = report.cols
+    r.lastRendererRows = report.rows
+    r.rendererResizeCount = report.resizeCount
+    this.checkDesync(r)
+    this.checkByteGap(r)
+    this.scheduleEmit()
+  }
+
+  endSession(sessionId: string): void {
+    if (!this.sessions.has(sessionId)) return
+    this.sessions.delete(sessionId)
+    this.pushEvent('end', sessionId, 'session ended')
+    this.scheduleEmit()
+  }
+
+  private checkDesync(r: SessionRec): void {
+    if (r.lastAppliedCols != null && r.lastRendererCols != null && r.lastAppliedCols !== r.lastRendererCols) {
+      r.widthDesyncCount += 1
+      this.pushEvent('desync', r.sessionId, `cols main=${r.lastAppliedCols} renderer=${r.lastRendererCols}`)
+      this.pushLog('warn', 'pty-width-desync', `${r.sessionId}: cols main=${r.lastAppliedCols} renderer=${r.lastRendererCols}`)
+    }
+  }
+
+  private checkByteGap(r: SessionRec): void {
+    const gap = r.bytesFromPty - r.bytesReceived
+    if (gap > this.gapThreshold && !r.byteGapFlagged) {
+      r.byteGapFlagged = true
+      this.pushEvent('byte-gap', r.sessionId, `gap ${gap} bytes (sent ${r.bytesFromPty}, received ${r.bytesReceived})`)
+      this.pushLog('warn', 'pty-byte-gap', `${r.sessionId}: ${gap} bytes unaccounted (sent ${r.bytesFromPty}, received ${r.bytesReceived})`)
+    } else if (gap <= 0 && r.byteGapFlagged) {
+      r.byteGapFlagged = false
+    }
+  }
+
+  snapshot(): PtyIntegritySnapshot {
+    const sessions: PtySessionIntegrity[] = [...this.sessions.values()].map((r) => ({
+      sessionId: r.sessionId,
+      bytesFromPty: r.bytesFromPty,
+      bytesReceived: r.bytesReceived,
+      bytesWritten: r.bytesWritten,
+      strippedBytes: r.strippedBytes,
+      byteGap: r.bytesReceived > 0 ? r.bytesFromPty - r.bytesReceived : 0,
+      chunksFromPty: r.chunksFromPty,
+      appliedCols: r.lastAppliedCols,
+      rendererCols: r.lastRendererCols,
+      resizeCount: r.resizeCount,
+      widthDesyncCount: r.widthDesyncCount,
+    }))
+    return {
+      sessions,
+      totals: {
+        activeSessions: sessions.length,
+        bytesFromPty: sessions.reduce((a, s) => a + s.bytesFromPty, 0),
+        resizes: sessions.reduce((a, s) => a + s.resizeCount, 0),
+        desyncs: sessions.reduce((a, s) => a + s.widthDesyncCount, 0),
+      },
+      recentEvents: [...this.events],
+    }
+  }
+
+  /** Snapshot + the notable-log ring (serviceId 'pty'), for the diagnostics merge. */
+  diagnostics(): { snapshot: PtyIntegritySnapshot; logs: ServiceLogEntry[] } {
+    return { snapshot: this.snapshot(), logs: [...this.logs] }
+  }
+}
+
+// Module singleton so pty-manager (a separate module) can record without an
+// import cycle through index.ts.
+let _monitor: PtyIntegrityMonitor | null = null
+export function setPtyIntegrityMonitor(m: PtyIntegrityMonitor | null): void { _monitor = m }
+export function getPtyIntegrityMonitor(): PtyIntegrityMonitor | null { return _monitor }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,7 +60,7 @@ export interface ElectronAPI {
         name: string; description: string; prompt: string
         model?: string; tools?: string[]
       }>
-      effortLevel?: 'low' | 'medium' | 'high'
+      effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
       disableAutoMemory?: boolean
       enableCodexReview?: boolean
       model?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -379,6 +379,10 @@ const electronAPI: ElectronAPI = {
       return () => ipcRenderer.removeListener(channel, handler)
     }
   },
+  ptyIntegrity: {
+    report: (report: import('../shared/service-health').PtyIntegrityReport) =>
+      ipcRenderer.send(IPC.PTY_INTEGRITY_REPORT, report),
+  },
   ssh: {
     runPostCommand: (sessionId: string) =>
       ipcRenderer.invoke(IPC.SSH_FLOW_RUN_POSTCOMMAND, sessionId),

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '1.5.29',
+    date: '2026-06-03',
+    highlights: 'See each session effort at a glance, plus a new terminal-health view in the Conductor diagnostics.',
+    changes: [
+      { type: 'feature', description: 'Session cards now show a colour-coded effort pill (Low through Ultracode) in the top-right, tinted from green to red as effort rises, so you can read each session effort level at a glance without opening it.' },
+      { type: 'improvement', description: 'Tidied the session cards by removing the small leading dot. It only showed grey when idle and duplicated the status pill already shown on the right.' },
+      { type: 'feature', description: 'The Conductor diagnostics console gained a PTY integrity section with live terminal metrics per session (bytes received, resize events and width desyncs) to help track down terminal display glitches.' },
+    ],
+  },
+  {
     version: '1.5.28',
     date: '2026-06-02',
     highlights: 'Per-account statusline stats, settable account colours, and the account follows a mid-session sign-in.',

--- a/src/renderer/components/ConductorHealthPill.tsx
+++ b/src/renderer/components/ConductorHealthPill.tsx
@@ -72,7 +72,7 @@ export default function ConductorHealthPill({ open, onOpen }: Props) {
       }`}
       title={w.tip}
       aria-expanded={open}
-      aria-label="Services health"
+      aria-label="Services health and PTY integrity diagnostics"
     >
       <span className={`w-1.5 h-1.5 rounded-full ${DOT[w.tone]}`} />
       <span className={`text-[10px] font-medium leading-none ${TXT[w.tone]}`}>

--- a/src/renderer/components/ConductorServicesPanel.tsx
+++ b/src/renderer/components/ConductorServicesPanel.tsx
@@ -97,7 +97,10 @@ function LogTail({ log }: { log: ServiceLogEntry[] }) {
 function PtySection({ pty }: { pty: PtyIntegritySnapshot }) {
   return (
     <div className="rounded border border-surface0 bg-crust/50 p-2.5">
-      <div className="flex items-center gap-1.5 mb-2">
+      <div
+        className="flex items-center gap-1.5 mb-2"
+        title="Per-session terminal health. Bytes in = bytes read from the shell; Resizes = terminal size changes; Desyncs = times the app and the shell disagreed on the terminal width (a display-corruption signal)."
+      >
         <span className="w-2 h-2 rounded-full bg-overlay0" />
         <span className="text-[12px] font-semibold text-text">PTY integrity</span>
         <span className="text-[10px] text-subtext0">{pty.totals.activeSessions} active</span>

--- a/src/renderer/components/ConductorServicesPanel.tsx
+++ b/src/renderer/components/ConductorServicesPanel.tsx
@@ -3,6 +3,7 @@ import type {
   DiagnosticsSnapshot,
   ServiceHealth,
   ServiceLogEntry,
+  PtyIntegritySnapshot,
 } from '../../shared/service-health'
 
 // No \u{...} escapes in JSX (esbuild). U+21BB CLOCKWISE OPEN CIRCLE ARROW,
@@ -93,6 +94,34 @@ function LogTail({ log }: { log: ServiceLogEntry[] }) {
   )
 }
 
+function PtySection({ pty }: { pty: PtyIntegritySnapshot }) {
+  return (
+    <div className="rounded border border-surface0 bg-crust/50 p-2.5">
+      <div className="flex items-center gap-1.5 mb-2">
+        <span className="w-2 h-2 rounded-full bg-overlay0" />
+        <span className="text-[12px] font-semibold text-text">PTY integrity</span>
+        <span className="text-[10px] text-subtext0">{pty.totals.activeSessions} active</span>
+      </div>
+      <div className="grid grid-cols-4 gap-x-2 gap-y-1.5 mb-2">
+        <Metric label="Sessions" value={pty.totals.activeSessions} />
+        <Metric label="Bytes in" value={pty.totals.bytesFromPty} />
+        <Metric label="Resizes" value={pty.totals.resizes} />
+        <Metric label="Desyncs" value={pty.totals.desyncs} />
+      </div>
+      {pty.sessions.length > 0 && (
+        <div className="font-mono text-[10px] leading-snug text-subtext0 max-h-24 overflow-y-auto">
+          {pty.sessions.map((s) => (
+            <div key={s.sessionId} className="whitespace-pre-wrap break-words">
+              <span className="text-overlay1">{s.sessionId.slice(0, 8)} </span>
+              in:{s.bytesFromPty} gap:{s.byteGap} cols:{s.appliedCols ?? '-'}/{s.rendererCols ?? '-'} dsy:{s.widthDesyncCount}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function ConductorServicesPanel({ open = true, onClose }: { open?: boolean; onClose: () => void }) {
   const [snap, setSnap] = useState<DiagnosticsSnapshot | null>(null)
   const [entered, setEntered] = useState(false)
@@ -156,6 +185,7 @@ export default function ConductorServicesPanel({ open = true, onClose }: { open?
         <ServiceCard key={s.id} s={s} />
       ))}
       <LogTail log={snap?.log ?? []} />
+      {snap?.pty && <PtySection pty={snap.pty} />}
       <div
         className="rounded border border-surface0/60 bg-crust/30 px-2.5 py-1.5 text-[11px] text-overlay1 flex items-center gap-1.5"
         title="MCP relocation is a future phase"

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -178,6 +178,25 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let refreshTimer: ReturnType<typeof setTimeout> | null = null
     let handleWheel: ((e: WheelEvent) => void) | null = null
 
+    // PTY-integrity instrumentation (scoped to this session's mount; resets on
+    // sessionId change because the effect re-runs).
+    let bytesReceived = 0, bytesWritten = 0, strippedBytes = 0, ptyResizeCount = 0
+    let lastSentCols: number | null = null, lastSentRows: number | null = null
+    let reportTimer: ReturnType<typeof setTimeout> | null = null
+    let resizeDebounce: ReturnType<typeof setTimeout> | null = null
+    const reportIntegrity = () => {
+      if (reportTimer) return
+      reportTimer = setTimeout(() => {
+        reportTimer = null
+        window.electronAPI.ptyIntegrity?.report({
+          sessionId,
+          bytesReceived, bytesWritten, strippedBytes,
+          cols: lastSentCols ?? 0, rows: lastSentRows ?? 0,
+          resizeCount: ptyResizeCount,
+        })
+      }, 1000)
+    }
+
     const initTerminal = () => {
       if (disposed) return
 
@@ -510,6 +529,9 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // backgrounds, or spinner glyphs.
       unsubData = window.electronAPI.pty.onData(sessionId, (data) => {
         const filtered = shellOnly ? data : stripCursorSequences(data)
+        bytesReceived += data.length
+        strippedBytes += data.length - filtered.length
+        bytesWritten += filtered.length
         term?.write(filtered)
 
         // Only auto-scroll if user hasn't scrolled up
@@ -517,6 +539,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           term?.scrollToBottom()
         }
 
+        reportIntegrity()
         pendingParseData += data
         scheduleParse()
       })
@@ -527,14 +550,28 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
 
       // Handle resize
       resizeObserver = new ResizeObserver(() => {
-        if (disposed || !fitAddon || !term) return
-        try {
-          fitAddon.fit()
-          window.electronAPI.pty.resize(sessionId, term.cols, term.rows)
-          // xterm recreates / resizes the cursor canvas after fit;
-          // re-stamp the inline hide so the caret stays gone.
-          hideClaudeCursorLayer()
-        } catch { /* ignore */ }
+        // Trailing debounce: coalesce resize storms (a ConPTY-reflow aggravator)
+        // into a single fit + resize.
+        if (resizeDebounce) clearTimeout(resizeDebounce)
+        resizeDebounce = setTimeout(() => {
+          resizeDebounce = null
+          if (disposed || !fitAddon || !term) return
+          try {
+            fitAddon.fit()
+            const cols = term.cols, rows = term.rows
+            // Guard: only resize on a valid, CHANGED geometry (skip failed/no-op fits).
+            if (cols > 0 && rows > 0 && (cols !== lastSentCols || rows !== lastSentRows)) {
+              lastSentCols = cols
+              lastSentRows = rows
+              ptyResizeCount += 1
+              window.electronAPI.pty.resize(sessionId, cols, rows)
+              reportIntegrity()
+            }
+            // xterm recreates / resizes the cursor canvas after fit;
+            // re-stamp the inline hide so the caret stays gone.
+            hideClaudeCursorLayer()
+          } catch { /* ignore */ }
+        }, 80)
       })
       resizeObserver.observe(container)
 
@@ -586,6 +623,8 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       if (attentionTimerRef.current) clearTimeout(attentionTimerRef.current)
       if (parseTimer) clearTimeout(parseTimer)
       if (refreshTimer) clearTimeout(refreshTimer)
+      if (reportTimer) clearTimeout(reportTimer)
+      if (resizeDebounce) clearTimeout(resizeDebounce)
       if (handleKeyDownCopy) document.removeEventListener('keydown', handleKeyDownCopy)
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -316,6 +316,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       const fitAndSpawn = () => {
         if (disposed || !fitAddon || !term) return
         try { fitAddon.fit() } catch { /* ignore */ }
+        // Seed the integrity geometry from the initial (font-aware) fit so the
+        // first throttled report carries the real cols/rows instead of 0 — and
+        // so the ResizeObserver's "changed" guard has a correct baseline.
+        if (term.cols > 0 && term.rows > 0) { lastSentCols = term.cols; lastSentRows = term.rows }
 
         if (!hasSpawned(sessionId)) {
           const gate = useAccountGateStore.getState()

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Session } from '../../stores/sessionStore'
 import { CodexBadge, ShellBadge, SshBadge } from './Badges'
-import { StatusDot, type SessionState } from '../ui/StatusDot'
+import { type SessionState } from '../ui/StatusDot'
+import { EffortPill } from '../ui/EffortPill'
 import { StatusPill } from '../ui/StatusPill'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
 import { useResolvedTheme } from '../../hooks/useThemeController'
@@ -125,9 +126,6 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
         <div className="absolute inset-0 rounded-md attention-pulse-bg" style={{ backgroundColor: identity }} />
       )}
 
-      {/* Line 1, col 1: health dot */}
-      <span className="relative z-10 row-start-1"><StatusDot state={st} /></span>
-
       {/* Line 1, col 2: name + (non-default) provider/ssh badges + optional
           v1.5.9 account alias. The project name keeps the higher visual weight;
           the alias sits to the right in non-bold text-secondary. Truncation
@@ -149,13 +147,14 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
           were redundant with that dot and the card's left identity rail. */}
       <span className="relative z-10 row-start-1 flex items-center gap-1.5 justify-self-end">
         <StatusPill state={st} />
+        {session.effortLevel && <EffortPill level={session.effortLevel} />}
       </span>
 
       {/* Line 2: model meta + context meter + right-aligned %. One grid child
           spanning the name+meta columns (2 / 4) so the meta does NOT auto-place
           into the 9px dot column (col 1) and get clipped. The dot column stays
           empty on line 2, so line 2 aligns under the name. */}
-      <div className="relative z-10 row-start-2 flex items-center gap-2" style={{ gridColumn: '2 / 4' }} data-testid="card-line2">
+      <div className="relative z-10 row-start-2 flex items-center gap-2" style={{ gridColumn: '1 / 3' }} data-testid="card-line2">
         <span className="meta truncate">{metaLine}</span>
         <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
           <div className={`meter-fill ${meterClass(pct)}`} style={{ width: `${pct}%` }} />
@@ -169,7 +168,7 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
           under the name/meta and never clips the way the cramped line-2 chip did).
           Rendered only when accountEmail is set so accountless sessions stay 2 lines. */}
       {accountName && (
-        <div className="relative z-10 row-start-3 flex items-center gap-1.5 min-w-0" style={{ gridColumn: '2 / 4' }} data-testid="card-line3">
+        <div className="relative z-10 row-start-3 flex items-center gap-1.5 min-w-0" style={{ gridColumn: '1 / 3' }} data-testid="card-line3">
           {accountDot && (
             <span data-testid="account-dot" className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: accountDot }} role="img" aria-label={accountName ? `Account: ${accountName}` : 'Account'} title={session.accountEmail} />
           )}

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -151,9 +151,8 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
       </span>
 
       {/* Line 2: model meta + context meter + right-aligned %. One grid child
-          spanning the name+meta columns (2 / 4) so the meta does NOT auto-place
-          into the 9px dot column (col 1) and get clipped. The dot column stays
-          empty on line 2, so line 2 aligns under the name. */}
+          spanning the full 2-column grid (1 / 3) so it aligns under the name in
+          column 1. */}
       <div className="relative z-10 row-start-2 flex items-center gap-2" style={{ gridColumn: '1 / 3' }} data-testid="card-line2">
         <span className="meta truncate">{metaLine}</span>
         <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
@@ -164,7 +163,7 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
         </span>
       </div>
 
-      {/* Line 3: account on its own row, under the model (col 2/4 so it aligns
+      {/* Line 3: account on its own row, under the model (spans 1 / 3 so it aligns
           under the name/meta and never clips the way the cramped line-2 chip did).
           Rendered only when accountEmail is set so accountless sessions stay 2 lines. */}
       {accountName && (

--- a/src/renderer/components/ui/EffortPill.tsx
+++ b/src/renderer/components/ui/EffortPill.tsx
@@ -5,6 +5,8 @@ import type { EffortLevel } from '../../stores/sessionStore'
 // grammar) coloured by the per-level --effort-<level> ramp token (theme-aware,
 // defined in styles.css). Text + tooltip carry the meaning, so it is not
 // colour-only. Returns null for an unknown level (defensive).
+// Background tint is 18% (vs StatusPill's 15%): the effort pill often sits
+// immediately right of the status pill, so a hair more fill reads as its own chip.
 const LEVELS = new Set<EffortLevel>(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
 
 export function EffortPill({ level }: { level: EffortLevel }) {

--- a/src/renderer/components/ui/EffortPill.tsx
+++ b/src/renderer/components/ui/EffortPill.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import type { EffortLevel } from '../../stores/sessionStore'
+
+// Effort indicator for session cards. Tinted text pill (mirrors StatusPill's
+// grammar) coloured by the per-level --effort-<level> ramp token (theme-aware,
+// defined in styles.css). Text + tooltip carry the meaning, so it is not
+// colour-only. Returns null for an unknown level (defensive).
+const LEVELS = new Set<EffortLevel>(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
+
+export function EffortPill({ level }: { level: EffortLevel }) {
+  if (!LEVELS.has(level)) return null
+  const token = `var(--effort-${level})`
+  return (
+    <span
+      data-testid="effort-pill"
+      title={`Effort: ${level}`}
+      className="text-[9px] font-medium uppercase tracking-wide px-1.5 py-px rounded-full shrink-0 leading-none transition-colors duration-150"
+      style={{ color: token, background: `color-mix(in srgb, ${token} 18%, transparent)` }}
+    >
+      {level}
+    </span>
+  )
+}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -4,6 +4,7 @@ import type { IdentityColorKey } from '../../shared/identity-colors'
 
 export type SessionStatus = 'idle' | 'working' | 'complete' | 'error' | 'disconnected'
 export type SessionType = 'local' | 'ssh'
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
 
 export interface SSHConfig {
   host: string
@@ -70,7 +71,7 @@ export interface Session {
   agentIds?: string[]                    // Agent template IDs for this session
   flickerFree?: boolean                  // Enable flicker-free alternate screen rendering
   powershellTool?: boolean               // Enable native PowerShell tool
-  effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+  effortLevel?: EffortLevel
   disableAutoMemory?: boolean
   /** P6: Claude opts in to the codex_review MCP tool for this session.
    *  Mirrors disableAutoMemory in shape (sparse boolean) and lifecycle. */

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -79,6 +79,15 @@
   --status-danger: #f08a8a;
   --status-info: #5b9df0;
 
+  /* Effort ramp (R2 smooth heat green->yellow->red). Used by EffortPill on
+     session cards via var(--effort-<level>). Not status colours -> distinct tokens. */
+  --effort-low: #a6e3a1;
+  --effort-medium: #cfe2a8;
+  --effort-high: #f9e2af;
+  --effort-xhigh: #f7c5ad;
+  --effort-max: #f5a8aa;
+  --effort-ultracode: #f38ba8;
+
   --chart-opus: #b8714a;
   --chart-sonnet: #3fbecb;
   --chart-codex: #5b9df0;
@@ -155,6 +164,14 @@
   --status-warning: #946a12;
   --status-danger: #bd3a2c;
   --status-info: #2360c2;
+
+  /* Effort ramp — darkened for contrast as text on the light background. */
+  --effort-low: #40a02b;
+  --effort-medium: #8f9724;
+  --effort-high: #df8e1d;
+  --effort-xhigh: #e46426;
+  --effort-max: #d6392f;
+  --effort-ultracode: #d20f39;
 
   --chart-opus: #a85a2c;
   --chart-sonnet: #15808d;
@@ -233,7 +250,7 @@ body {
      - keyboard focus        -> quiet teal DASHED ring, distinct from selection */
 .session-card {
   display: grid;
-  grid-template-columns: 9px 1fr auto;
+  grid-template-columns: 1fr auto;
   align-items: center;
   column-gap: 9px;
   row-gap: 2px;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -152,6 +152,9 @@ export interface ElectronAPI {
     onData: (sessionId: string, callback: (data: string) => void) => () => void
     onExit: (sessionId: string, callback: (exitCode: number) => void) => () => void
   }
+  ptyIntegrity: {
+    report: (report: import('../../shared/service-health').PtyIntegrityReport) => void
+  }
   ssh: {
     runPostCommand: (sessionId: string) => Promise<void>
     launchClaude: (sessionId: string) => Promise<void>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -39,6 +39,7 @@ export const IPC = {
   PTY_KILL: 'pty:kill',
   PTY_DATA: 'pty:data',   // Suffixed with :sessionId at runtime
   PTY_EXIT: 'pty:exit',   // Suffixed with :sessionId at runtime
+  PTY_INTEGRITY_REPORT: 'pty:integrityReport',   // renderer -> main per-session byte/resize report
 
   // SSH connection-flow controller (manual mode user-gated stages).
   // Main->renderer notification is suffixed with :<sessionId> at runtime.

--- a/src/shared/service-health.ts
+++ b/src/shared/service-health.ts
@@ -33,6 +33,45 @@ export interface DiagnosticsSnapshot {
   capturedAt: number
   services: ServiceHealth[]
   log: ServiceLogEntry[]
+  pty?: PtyIntegritySnapshot
+}
+
+export interface PtyIntegrityEvent {
+  ts: number
+  kind: 'resize' | 'desync' | 'byte-gap' | 'end'
+  sessionId: string
+  detail: string
+}
+
+export interface PtySessionIntegrity {
+  sessionId: string
+  bytesFromPty: number       // bytes main read from node-pty and sent
+  bytesReceived: number      // bytes the renderer received over IPC
+  bytesWritten: number       // bytes the renderer wrote to xterm
+  strippedBytes: number      // bytes stripCursorSequences removed
+  byteGap: number            // bytesFromPty - bytesReceived (loss signal; 0 until renderer reports)
+  chunksFromPty: number
+  appliedCols: number | null // last cols main applied to the PTY
+  rendererCols: number | null// last cols the renderer reported
+  resizeCount: number
+  widthDesyncCount: number
+}
+
+export interface PtyIntegritySnapshot {
+  sessions: PtySessionIntegrity[]
+  totals: { activeSessions: number; bytesFromPty: number; resizes: number; desyncs: number }
+  recentEvents: PtyIntegrityEvent[]
+}
+
+/** Renderer -> main per-session integrity report (throttled). */
+export interface PtyIntegrityReport {
+  sessionId: string
+  bytesReceived: number
+  bytesWritten: number
+  strippedBytes: number
+  cols: number
+  rows: number
+  resizeCount: number
 }
 
 export function createInitialHealth(id: string, label: string): ServiceHealth {

--- a/tests/unit/main/pty-handlers-effort.test.ts
+++ b/tests/unit/main/pty-handlers-effort.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression: the IPC `pty:spawn` zod schema must accept ALL SIX effort levels
+ * (low/medium/high/xhigh/max/ultracode), not just the original three. The live
+ * effort can be xhigh/max/ultracode (set via /effort, shown on the session card)
+ * and is persisted (session-persistence.ts); restoring such a session passes its
+ * effortLevel to pty.spawn. If the schema only allowed low/medium/high, parse()
+ * would throw "Invalid parameters" and the session would fail to respawn.
+ */
+import { describe, it, expect } from 'vitest'
+import { spawnOptionsSchema } from '../../../src/main/ipc/pty-handlers'
+
+describe('pty-handlers spawnOptionsSchema -- effortLevel (all 6 levels)', () => {
+  const LEVELS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'] as const
+
+  it('accepts and preserves every effort level through parse', () => {
+    for (const level of LEVELS) {
+      const parsed = spawnOptionsSchema.parse({ cwd: 'C:/work', effortLevel: level })
+      expect(parsed?.effortLevel).toBe(level)
+    }
+  })
+
+  it('parses cleanly when effortLevel is omitted', () => {
+    const parsed = spawnOptionsSchema.parse({ cwd: 'C:/work' })
+    expect(parsed?.effortLevel).toBeUndefined()
+  })
+
+  it('rejects an unknown effort level', () => {
+    expect(() =>
+      spawnOptionsSchema.parse({ cwd: 'C:/work', effortLevel: 'turbo' as never }),
+    ).toThrow()
+  })
+})

--- a/tests/unit/renderer/ConductorServicesPanel.pty.test.tsx
+++ b/tests/unit/renderer/ConductorServicesPanel.pty.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import ConductorServicesPanel from '../../../src/renderer/components/ConductorServicesPanel'
+import type { DiagnosticsSnapshot } from '../../../src/shared/service-health'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const snap: DiagnosticsSnapshot = {
+  capturedAt: 0, services: [], log: [],
+  pty: {
+    sessions: [{ sessionId: 'sess-abcdef', bytesFromPty: 2048, bytesReceived: 2048, bytesWritten: 2000,
+      strippedBytes: 48, byteGap: 0, chunksFromPty: 12, appliedCols: 120, rendererCols: 120,
+      resizeCount: 3, widthDesyncCount: 0 }],
+    totals: { activeSessions: 1, bytesFromPty: 2048, resizes: 3, desyncs: 0 },
+    recentEvents: [{ ts: 1, kind: 'resize', sessionId: 'sess-abcdef', detail: 'applied 120x30' }],
+  },
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as any).window.electronAPI = {
+    serviceHealth: {
+      get: () => Promise.resolve(snap),
+      onUpdate: (_cb: unknown) => () => {},
+      restart: () => Promise.resolve({ ok: true }),
+    },
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+describe('ConductorServicesPanel PTY section', () => {
+  it('renders the PTY integrity totals when snap.pty is present', async () => {
+    await act(async () => {
+      root.render(createElement(ConductorServicesPanel, { open: true, onClose: () => {} }))
+    })
+    // Let the async serviceHealth.get().then(setSnap) settle.
+    await act(async () => { await Promise.resolve() })
+
+    const text = container.textContent ?? ''
+    expect(text).toMatch(/PTY integrity/i)
+    expect(text).toMatch(/sess-abc/i)
+  })
+})

--- a/tests/unit/renderer/EffortPill.test.tsx
+++ b/tests/unit/renderer/EffortPill.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { EffortPill } from '../../../src/renderer/components/ui/EffortPill'
+import type { EffortLevel } from '../../../src/renderer/stores/sessionStore'
+
+describe('EffortPill', () => {
+  const LEVELS: EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']
+
+  it('renders the level word and the matching effort token for every level', () => {
+    for (const level of LEVELS) {
+      const html = renderToStaticMarkup(<EffortPill level={level} />)
+      // text + tooltip carry the meaning
+      expect(html).toContain(`>${level}</span>`)
+      expect(html).toContain(`Effort: ${level}`)
+      // colour is driven by the per-level CSS var
+      expect(html).toContain(`var(--effort-${level})`)
+    }
+  })
+
+  it('renders nothing for an unknown level', () => {
+    // @ts-expect-error deliberately invalid to exercise the guard
+    const html = renderToStaticMarkup(<EffortPill level={'bogus'} />)
+    expect(html).toBe('')
+  })
+})

--- a/tests/unit/renderer/SessionRow.effort.test.tsx
+++ b/tests/unit/renderer/SessionRow.effort.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// SessionRow reads useResolvedTheme + useAccountProfilesStore + useSettingsStore.
+// Mock them (the codebase pattern; @testing-library/react is not a dependency).
+const settingsState: any = { settings: { accountAliases: {}, accountColourOverrides: {} } }
+const profilesState: any = { profiles: [] }
+
+vi.mock('../../../src/renderer/hooks/useThemeController', () => ({ useResolvedTheme: () => 'dark' }))
+vi.mock('../../../src/renderer/stores/accountProfilesStore', () => ({
+  useAccountProfilesStore: (sel: any) => sel(profilesState),
+}))
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const useSettingsStore: any = (sel: any) => sel(settingsState)
+  useSettingsStore.getState = () => settingsState
+  return { useSettingsStore }
+})
+
+const { default: SessionRow } = await import('../../../src/renderer/components/sidebar/SessionRow')
+import type { Session } from '../../../src/renderer/stores/sessionStore'
+
+function makeSession(over: Partial<Session> = {}): Session {
+  return {
+    id: 's1', label: 'API Refactor', workingDirectory: '/x', model: 'opus',
+    color: '#89b4fa', status: 'idle', createdAt: 0, sessionType: 'local', ...over,
+  } as Session
+}
+
+const baseProps = {
+  isActive: false, needsAttention: false, isRenaming: false, renameValue: '',
+  renameRef: { current: null }, onRenameChange: () => {}, onRenameFinish: () => {},
+  onRenameCancel: () => {}, onClick: () => {}, onContextMenu: () => {},
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+describe('SessionRow effort indicator', () => {
+  it('shows the EffortPill when the session has an effort level', () => {
+    act(() => { root.render(createElement(SessionRow, { session: makeSession({ effortLevel: 'xhigh' }), ...baseProps })) })
+    const pill = container.querySelector('[data-testid="effort-pill"]') as HTMLElement
+    expect(pill).not.toBeNull()
+    expect(pill.textContent).toBe('xhigh')
+  })
+
+  it('omits the EffortPill when there is no effort level', () => {
+    act(() => { root.render(createElement(SessionRow, { session: makeSession(), ...baseProps })) })
+    expect(container.querySelector('[data-testid="effort-pill"]')).toBeNull()
+  })
+
+  it('no longer renders the 7px status dot', () => {
+    act(() => { root.render(createElement(SessionRow, { session: makeSession({ status: 'working' }), ...baseProps })) })
+    // StatusDot rendered an inline 7x7 span; it must be gone.
+    expect(container.querySelector('span[style*="width: 7px"]')).toBeNull()
+  })
+})

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -109,7 +109,7 @@ describe('SessionRow card', () => {
     // Account name now lives on its own line-3 row, not crammed into line-2.
     const line3 = container.querySelector('[data-testid="card-line3"]') as HTMLElement
     expect(line3).toBeTruthy()
-    expect(line3.style.gridColumn).toBe('2 / 4')
+    expect(line3.style.gridColumn).toBe('1 / 3')
     expect(line3.contains(name)).toBe(true)
   })
 
@@ -142,14 +142,15 @@ describe('SessionRow card', () => {
     expect(container.querySelector('[data-testid="card-line3"]')).toBeNull()
   })
 
-  it('line 2 spans out of the 9px dot column so the model meta is not clipped', () => {
+  it('line 2 spans the full 2-column grid so the model meta is not clipped', () => {
     // jsdom cannot compute CSS grid, so lock the structural intent: the line-2
-    // content lives in ONE child that spans grid columns 2 / 4 (never auto-placed
-    // into the dot column), and the model meta text lives inside that wrapper.
+    // content lives in ONE child that spans the full grid (columns 1 / 3, after
+    // the leading status-dot column was removed), and the model meta text lives
+    // inside that wrapper.
     render(root, { model: 'sonnet', provider: 'claude' })
     const line2 = container.querySelector('[data-testid="card-line2"]') as HTMLElement
     expect(line2).toBeTruthy()
-    expect(line2.style.gridColumn).toBe('2 / 4')
+    expect(line2.style.gridColumn).toBe('1 / 3')
     expect(line2.textContent).toContain('sonnet')
     expect(line2.textContent).toContain('claude')
   })

--- a/tests/unit/services/diagnostics-merge.test.ts
+++ b/tests/unit/services/diagnostics-merge.test.ts
@@ -31,4 +31,16 @@ describe('getMergedDiagnostics', () => {
     expect(out.pty).toBeUndefined()
     expect(out.log).toHaveLength(1)
   })
+
+  it('caps the merged log at 200, keeping the newest by ts', () => {
+    // 150 hooks logs (ts 0..149) + 150 pty logs (ts 1000..1149) = 300 -> capped to 200.
+    const hooksLog: ServiceLogEntry[] = Array.from({ length: 150 }, (_, i) => ({ ts: i, serviceId: 'hooks', level: 'info', code: 'h', message: `h${i}` }))
+    const ptyLog: ServiceLogEntry[] = Array.from({ length: 150 }, (_, i) => ({ ts: 1000 + i, serviceId: 'pty', level: 'info', code: 'p', message: `p${i}` }))
+    const bigSup: DiagnosticsSnapshot = { ...supSnap, log: hooksLog }
+    const out = getMergedDiagnostics(() => ({ getDiagnosticsSnapshot: () => bigSup, manualRestart: () => ({ ok: true }) }) as any, () => ({ snapshot: ptySnap, logs: ptyLog }))
+    expect(out.log).toHaveLength(200)
+    // Newest 200 kept (oldest 100 hooks entries dropped): first survivor is hooks ts=100, last is pty ts=1149.
+    expect(out.log[0].ts).toBe(100)
+    expect(out.log[out.log.length - 1].ts).toBe(1149)
+  })
 })

--- a/tests/unit/services/diagnostics-merge.test.ts
+++ b/tests/unit/services/diagnostics-merge.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { getMergedDiagnostics } from '../../../src/main/ipc/service-health-handlers'
+import type { DiagnosticsSnapshot, PtyIntegritySnapshot, ServiceLogEntry } from '../../../src/shared/service-health'
+
+const supSnap: DiagnosticsSnapshot = {
+  capturedAt: 10,
+  services: [{ id: 'hooks', label: 'Hooks gateway', host: 'utility-process', state: 'listening',
+    port: 1, pid: 2, startedAt: 0, inFlight: 0, eventsTotal: 0, dropsTotal: 0, throughputPerSec: 0,
+    restartCount: 0, lastError: null, mainLoopStallsLastMin: 0, childLoopStallsLastMin: 0, lastHeartbeatAt: 0 }],
+  log: [{ ts: 5, serviceId: 'hooks', level: 'info', code: 'bound', message: 'bound' }],
+}
+const ptySnap: PtyIntegritySnapshot = { sessions: [], totals: { activeSessions: 0, bytesFromPty: 0, resizes: 0, desyncs: 0 }, recentEvents: [] }
+const ptyLogs: ServiceLogEntry[] = [{ ts: 7, serviceId: 'pty', level: 'warn', code: 'pty-width-desync', message: 'x' }]
+
+describe('getMergedDiagnostics', () => {
+  it('attaches the pty block and merges logs sorted by ts', () => {
+    const out = getMergedDiagnostics(() => ({ getDiagnosticsSnapshot: () => supSnap, manualRestart: () => ({ ok: true }) }) as any, () => ({ snapshot: ptySnap, logs: ptyLogs }))
+    expect(out.pty).toBe(ptySnap)
+    expect(out.log.map(l => l.serviceId)).toEqual(['hooks', 'pty']) // ts 5 then 7
+    expect(out.services[0].id).toBe('hooks')
+  })
+
+  it('serves a synthetic hooks-off base but still attaches pty', () => {
+    const out = getMergedDiagnostics(() => null, () => ({ snapshot: ptySnap, logs: [] }))
+    expect(out.services[0].state).toBe('stopped')
+    expect(out.pty).toBe(ptySnap)
+  })
+
+  it('returns the plain base when there is no pty provider data', () => {
+    const out = getMergedDiagnostics(() => ({ getDiagnosticsSnapshot: () => supSnap, manualRestart: () => ({ ok: true }) }) as any, () => null)
+    expect(out.pty).toBeUndefined()
+    expect(out.log).toHaveLength(1)
+  })
+})

--- a/tests/unit/services/pty-integrity-monitor.test.ts
+++ b/tests/unit/services/pty-integrity-monitor.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PtyIntegrityMonitor } from '../../../src/main/services/pty-integrity-monitor'
+
+function makeMonitor(over = {}) {
+  let t = 1000
+  const emit = vi.fn()
+  const m = new PtyIntegrityMonitor({ emit, now: () => t, emitDebounceMs: 0, eventCap: 3, ...over })
+  return { m, emit, tick: (n: number) => { t += n } }
+}
+
+describe('PtyIntegrityMonitor', () => {
+  it('accumulates pty bytes/chunks per session and reports totals', () => {
+    const { m } = makeMonitor()
+    m.recordPtyData('s1', 100)
+    m.recordPtyData('s1', 50)
+    m.recordPtyData('s2', 10)
+    const snap = m.snapshot()
+    expect(snap.totals.activeSessions).toBe(2)
+    expect(snap.totals.bytesFromPty).toBe(160)
+    expect(snap.sessions.find(s => s.sessionId === 's1')!.chunksFromPty).toBe(2)
+  })
+
+  it('flags a width desync when applied cols differ from the renderer cols', () => {
+    const { m } = makeMonitor()
+    m.recordResizeApplied('s1', 120, 30)
+    m.recordRendererReport({ sessionId: 's1', bytesReceived: 0, bytesWritten: 0, strippedBytes: 0, cols: 100, rows: 30, resizeCount: 1 })
+    const s = m.snapshot().sessions.find(x => x.sessionId === 's1')!
+    expect(s.widthDesyncCount).toBe(1)
+    expect(m.snapshot().recentEvents.some(e => e.kind === 'desync')).toBe(true)
+  })
+
+  it('computes byteGap and emits a byte-gap event once past the threshold', () => {
+    const { m } = makeMonitor({ byteGapThreshold: 4096 })
+    m.recordPtyData('s1', 10000)
+    m.recordRendererReport({ sessionId: 's1', bytesReceived: 5000, bytesWritten: 4800, strippedBytes: 200, cols: 120, rows: 30, resizeCount: 0 })
+    const s = m.snapshot().sessions.find(x => x.sessionId === 's1')!
+    expect(s.byteGap).toBe(5000)
+    expect(m.diagnostics().logs.some(l => l.code === 'pty-byte-gap')).toBe(true)
+  })
+
+  it('caps the recent-events ring', () => {
+    const { m } = makeMonitor() // eventCap: 3
+    for (let i = 0; i < 5; i++) m.recordResizeApplied('s1', 100 + i, 30)
+    expect(m.snapshot().recentEvents.length).toBe(3)
+  })
+
+  it('removes a session on endSession', () => {
+    const { m } = makeMonitor()
+    m.recordPtyData('s1', 5)
+    m.endSession('s1')
+    expect(m.snapshot().totals.activeSessions).toBe(0)
+  })
+
+  it('debounces emit (one emit per quiet window)', () => {
+    vi.useFakeTimers()
+    const emit = vi.fn()
+    const m = new PtyIntegrityMonitor({ emit, now: () => 0, emitDebounceMs: 250 })
+    m.recordPtyData('s1', 1)
+    m.recordPtyData('s1', 1)
+    expect(emit).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250)
+    expect(emit).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+})

--- a/tests/unit/services/pty-integrity-monitor.test.ts
+++ b/tests/unit/services/pty-integrity-monitor.test.ts
@@ -29,6 +29,21 @@ describe('PtyIntegrityMonitor', () => {
     expect(m.snapshot().recentEvents.some(e => e.kind === 'desync')).toBe(true)
   })
 
+  it('counts a desync once per episode (hysteresis), not once per persistent report', () => {
+    const { m } = makeMonitor({ eventCap: 100 })
+    m.recordResizeApplied('s1', 120, 30)
+    // Three reports with the SAME mismatch -> ONE desync episode.
+    for (let i = 0; i < 3; i++) {
+      m.recordRendererReport({ sessionId: 's1', bytesReceived: 0, bytesWritten: 0, strippedBytes: 0, cols: 100, rows: 30, resizeCount: 1 })
+    }
+    expect(m.snapshot().sessions.find(x => x.sessionId === 's1')!.widthDesyncCount).toBe(1)
+    expect(m.snapshot().recentEvents.filter(e => e.kind === 'desync').length).toBe(1)
+    // Re-sync (renderer matches main) clears the flag; a fresh mismatch is a NEW episode.
+    m.recordRendererReport({ sessionId: 's1', bytesReceived: 0, bytesWritten: 0, strippedBytes: 0, cols: 120, rows: 30, resizeCount: 2 })
+    m.recordRendererReport({ sessionId: 's1', bytesReceived: 0, bytesWritten: 0, strippedBytes: 0, cols: 90, rows: 30, resizeCount: 3 })
+    expect(m.snapshot().sessions.find(x => x.sessionId === 's1')!.widthDesyncCount).toBe(2)
+  })
+
   it('computes byteGap and emits a byte-gap event once past the threshold', () => {
     const { m } = makeMonitor({ byteGapThreshold: 4096 })
     m.recordPtyData('s1', 10000)

--- a/tests/unit/services/service-health-handlers.test.ts
+++ b/tests/unit/services/service-health-handlers.test.ts
@@ -1,16 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { buildHealthGet, buildRestart } from '../../../src/main/ipc/service-health-handlers'
+import { getMergedDiagnostics, buildRestart } from '../../../src/main/ipc/service-health-handlers'
 import { createInitialHealth } from '../../../src/shared/service-health'
 
 describe('service-health-handlers', () => {
   it('GET returns the supervisor snapshot when present', () => {
     const snap = { capturedAt: 1, services: [createInitialHealth('hooks', 'Hooks gateway')], log: [] }
-    const get = buildHealthGet(() => ({ getDiagnosticsSnapshot: () => snap } as never))
-    expect(get().services[0].id).toBe('hooks')
+    const s = getMergedDiagnostics(() => ({ getDiagnosticsSnapshot: () => snap } as never), () => null)
+    expect(s.services[0].id).toBe('hooks')
   })
   it('GET returns a synthetic stopped snapshot when no supervisor', () => {
-    const get = buildHealthGet(() => null)
-    const s = get()
+    const s = getMergedDiagnostics(() => null, () => null)
     expect(s.services[0].state).toBe('stopped')
     expect(s.services[0].id).toBe('hooks')
   })


### PR DESCRIPTION
## Summary

Two related session-card / observability items on one branch (per directive), stacked on the Conductor D1 backbone.

### Item 2 — per-session effort indicator on the sidebar cards
- New **`EffortPill`** (tinted text pill) in each session card's top-right cluster, showing the live `session.effortLevel` (low → ultracode) with a **green→yellow→red Catppuccin ramp** (theme-aware `--effort-*` tokens, dark + light).
- **Removed the leading status dot** — it was reactive but fully redundant with the existing `StatusPill` (idle was its only unique state); collapsed the card grid `9px 1fr auto → 1fr auto`.
- **No fast-mode "⚡"**: verified it is *not* detectable per-session (Claude's statusline exposes no fast field; the config `fastMode` is dead code). We don't fake signals.

### Item 3 — PTY-integrity instrumentation (via the D1 diagnostics console)
- New main-process **`PtyIntegrityMonitor`**: per-session byte counters, main↔renderer byte reconciliation (loss signal), width-desync detection (hysteresis — one count per episode), and timestamped recent-events + notable-log rings.
- Surfaced through the **existing** `SERVICE_HEALTH_GET/UPDATE` via an additive merge — **the reviewed `ServiceSupervisor` is untouched**. New **"PTY integrity"** section in `ConductorServicesPanel`; **Copy diagnostics** now captures PTY state automatically.
- **Safe hardening** (cannot regress normal use): ResizeObserver **debounce (~80ms)**, **fit-validity guard** (only resize on valid+changed geometry), resize **echo** (applied size recorded), and data-path byte/strip counters.
- The actual corruption **root-cause fix is deferred** to an instrumented repro (systematic-debugging — no guessing).

## Verification
- `tsc --noEmit` clean; full unit suite **1728 pass / 1 skip** (skip = opt-in token-gated real-Claude test). The lone full-run timeout is the known load-flaky `providers/claude/resume.test.ts` (passes in isolation; unrelated).
- New tests: `EffortPill`, `SessionRow` (pill + dot removal), `PtyIntegrityMonitor` (counters, desync hysteresis, byte-gap, ring caps, debounce), diagnostics-merge (incl. log cap), `ConductorServicesPanel` PTY section.

## Review
Each item got an independent **two-stage review** (spec-conformance + adversarial/quality) plus a plan-level review; all blocker/major findings fixed (3 plan blockers, plus a desync-flood blocker and an initial-geometry major caught in integration review). Nits applied.

## Notes
- Spec/plan: `docs/superpowers/{specs,plans}/2026-06-03-session-cards-and-pty-integrity*` (gitignored, local).
- **Deep stack:** `beta ← #56 (ux-uplift) ← #57 (backbone) ← this`. Targeted at `feat/conductor-services-backbone` for the smallest diff — happy to re-target to `feat/ux-uplift-account-aware` or hold until #56/#57 merge to flatten.
- V2 screenshot ship-gate (Win+Mac `capture-training`) **deferred to the V2 release PR** (small in-card change; dev installer, not a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
