### PR TITLE
refactor(sessions): remove dead settings (Fast Mode, flickerFree, powershellTool)

### DIFF
--- a/scripts/capture-training-screenshots.ts
+++ b/scripts/capture-training-screenshots.ts
@@ -821,10 +821,10 @@ async function main() {
     })
     await window.waitForTimeout(800)
     // v1.5.13: seed the dialog state so the captured screenshot actually
-    // shows the v1.5.11/12 controls (Opus 4.8 model, Ultracode effort,
-    // Fast Mode). The Edit dialog opened on a "shellOnly:true" config so
-    // the Claude options are hidden by default - we have to uncheck Shell
-    // only FIRST (the effort/fastMode controls are conditionally rendered).
+    // shows the Claude controls (Opus 4.8 model, Ultracode effort). The Edit
+    // dialog opened on a "shellOnly:true" config so the Claude options are
+    // hidden by default - we have to uncheck Shell only FIRST (the Claude
+    // controls are conditionally rendered).
     // All DOM mutation must live in a single inline anonymous arrow
     // because esbuild/tsx names const-assigned arrows which triggers
     // __name in the evaluate context.
@@ -860,19 +860,8 @@ async function main() {
         effortSel.dispatchEvent(new Event('change', { bubbles: true }))
       }
     })
-    await window.waitForTimeout(400)
-    await window.evaluate(() => {
-      const cbs = Array.from(document.querySelectorAll('input[type=checkbox]'))
-      for (const cb of cbs) {
-        const lbl = cb.closest('label')?.textContent || ''
-        if (lbl.includes('Fast mode')) {
-          if (!(cb as HTMLInputElement).checked) (cb as HTMLInputElement).click()
-          break
-        }
-      }
-    })
     await window.waitForTimeout(500)
-    await capture(window, 'step-session-options.jpg', 'Session config dialog (Opus 4.8 + Ultracode + Fast Mode)')
+    await capture(window, 'step-session-options.jpg', 'Session config dialog (Opus 4.8 + Ultracode)')
     // Close dialog — try multiple methods
     await window.keyboard.press('Escape')
     await window.waitForTimeout(300)

--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -213,7 +213,7 @@ export function loadAllConfig(): { data: Record<string, unknown>; needsMigration
 }
 
 // v1.5: provider-shape migration constants
-const CLAUDE_FIELDS = ['model', 'effortLevel', 'legacyVersion', 'disableAutoMemory', 'flickerFree', 'powershellTool', 'agentIds'] as const
+const CLAUDE_FIELDS = ['model', 'effortLevel', 'legacyVersion', 'disableAutoMemory', 'agentIds'] as const
 
 /**
  * Migrate a single TerminalConfig from the legacy flat shape to the

--- a/src/main/session-state.ts
+++ b/src/main/session-state.ts
@@ -14,7 +14,7 @@ export type { SavedSession, SessionState }
 
 // Legacy top-level Claude fields that get migrated into claudeOptions.
 // Mirrors CLAUDE_FIELDS in config-manager.ts for the SavedSession case.
-const LEGACY_CLAUDE_FIELDS = ['model', 'effortLevel', 'legacyVersion', 'disableAutoMemory', 'flickerFree', 'powershellTool', 'agentIds'] as const
+const LEGACY_CLAUDE_FIELDS = ['model', 'effortLevel', 'legacyVersion', 'disableAutoMemory', 'agentIds'] as const
 
 // Lazy getter -- can't call getConfigDir() at module load time
 function getSessionStateFile(): string {

--- a/src/main/tokenomics-manager.ts
+++ b/src/main/tokenomics-manager.ts
@@ -39,10 +39,10 @@ interface ModelPricing {
 
 // Hardcoded fallback pricing (per 1M tokens)
 const FALLBACK_PRICING: Record<string, ModelPricing> = {
-  // v1.5.11: Opus 4.8 (released 2026-05-28) keeps the 4.7 base pricing but
-  // introduces an optional fast mode at 2.5x speed for 2x cost. fast variant
-  // is keyed by `<model>-fast` and selected at calculateCost() time when the
-  // session record carries fastMode: true.
+  // v1.5.11: Opus 4.8 (released 2026-05-28) keeps the 4.7 base pricing. A
+  // `<model>-fast` pricing row exists for the 2.5x-speed/2x-cost variant and
+  // is keyed by model name when reported by the CLI; there is no per-session
+  // toggle that selects it.
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-8-fast': { input: 10, output: 50, cacheRead: 1.0, cacheWrite: 12.5 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -444,8 +444,6 @@ export default function App() {
           sshConfig: saved.sshConfig,
           legacyVersion: claude?.legacyVersion ?? saved.legacyVersion,
           agentIds: claude?.agentIds ?? saved.agentIds,
-          flickerFree: claude?.flickerFree ?? saved.flickerFree,
-          powershellTool: claude?.powershellTool ?? saved.powershellTool,
           effortLevel: claude?.effortLevel ?? saved.effortLevel,
           disableAutoMemory: claude?.disableAutoMemory ?? saved.disableAutoMemory,
           enableCodexReview: claude?.enableCodexReview,

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -102,10 +102,6 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(new Set(initialClaude?.agentIds ?? initial?.agentIds ?? []))
   const [disableAutoMemory, setDisableAutoMemory] = useState(initialClaude?.disableAutoMemory ?? initial?.disableAutoMemory ?? false)
   const [enableCodexReview, setEnableCodexReview] = useState(initialClaude?.enableCodexReview ?? false)
-  // v1.5.11: Opus 4.8 fast mode -- 2.5x speed for 2x cost ($10/$50 per 1M
-  // tokens instead of $5/$25). Persisted on the config so tokenomics can
-  // route the session record to the `<model>-fast` pricing row.
-  const [fastMode, setFastMode] = useState(initialClaude?.fastMode ?? false)
   const [machineName, setMachineName] = useState(initial?.machineName ?? '')
 
   // Fetch available versions when legacy checkbox enabled
@@ -248,7 +244,6 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       agentIds: !shellOnly && selectedAgentIds.size > 0 ? Array.from(selectedAgentIds) : undefined,
       disableAutoMemory: !shellOnly && disableAutoMemory ? true : undefined,
       enableCodexReview: !shellOnly && enableCodexReview ? true : undefined,
-      fastMode: !shellOnly && fastMode ? true : undefined,
     } : undefined
 
     const codexOptions: CodexOptions | undefined = provider === 'codex' ? {
@@ -604,22 +599,6 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                 <option value="haiku">Haiku</option>
               </select>
             </div>
-
-            {/* v1.5.11: Opus 4.8 fast mode toggle */}
-            {!shellOnly && (
-              <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={fastMode}
-                  onChange={(e) => setFastMode(e.target.checked)}
-                  className="mt-0.5 rounded border-surface1"
-                />
-                <span>
-                  Fast mode (Opus 4.8)
-                  <span className="block text-[10px] text-overlay0">2.5x speed at 2x cost ($10/$50 per 1M tokens). Tokenomics tracks Fast spend separately.</span>
-                </span>
-              </label>
-            )}
 
             {/* Disable auto-memory toggle */}
             {!shellOnly && (

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -46,8 +46,6 @@ export function buildSessionState(): SessionState {
       effortLevel: s.effortLevel,
       disableAutoMemory: s.disableAutoMemory,
       enableCodexReview: s.enableCodexReview ? true : undefined,
-      flickerFree: s.flickerFree,
-      powershellTool: s.powershellTool,
     } : undefined,
     codexOptions: s.codexOptions,
   }))

--- a/src/renderer/stores/configStore.ts
+++ b/src/renderer/stores/configStore.ts
@@ -61,10 +61,6 @@ export interface TerminalConfig {
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   agentIds?: string[]  // Selected agent template IDs
   /** @deprecated read from claudeOptions; removed in P1.2+ */
-  flickerFree?: boolean // Enable CLAUDE_CODE_NO_FLICKER=1 (alternate screen buffer rendering)
-  /** @deprecated read from claudeOptions; removed in P1.2+ */
-  powershellTool?: boolean // Enable CLAUDE_CODE_USE_POWERSHELL_TOOL=1 (native PowerShell tool)
-  /** @deprecated read from claudeOptions; removed in P1.2+ */
   effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode' // Claude Code --effort flag
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   disableAutoMemory?: boolean // Disable CLAUDE.md auto-memory writes

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -69,8 +69,6 @@ export interface Session {
     version: string
   }
   agentIds?: string[]                    // Agent template IDs for this session
-  flickerFree?: boolean                  // Enable flicker-free alternate screen rendering
-  powershellTool?: boolean               // Enable native PowerShell tool
   effortLevel?: EffortLevel
   disableAutoMemory?: boolean
   /** P6: Claude opts in to the codex_review MCP tool for this session.

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -132,8 +132,6 @@ export interface ElectronAPI {
         name: string; description: string; prompt: string
         model?: string; tools?: string[]
       }>
-      flickerFree?: boolean
-      powershellTool?: boolean
       effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
       disableAutoMemory?: boolean
       enableCodexReview?: boolean

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,16 +68,11 @@ export interface ClaudeOptions {
   effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
   legacyVersion?: LegacyVersion
   disableAutoMemory?: boolean
-  flickerFree?: boolean
-  powershellTool?: boolean
   agentIds?: string[]
   /** v1.5 P6: when true, the Claude PTY is registered into the codex_review opt-in set
    *  and the SessionDialog toggle is persisted. Tool description still appears to all
    *  Claude sessions (soft ACL); this flag controls authorisation server-side. */
   enableCodexReview?: boolean
-  /** v1.5.11: Opus 4.8 fast mode (2.5x speed, $10/$50 per 1M tokens vs standard $5/$25).
-   *  Per-session toggle; tokenomics uses this to pick the correct pricing row. */
-  fastMode?: boolean
 }
 
 export interface CodexOptions {
@@ -119,10 +114,6 @@ export interface SavedSession {
   legacyVersion?: LegacyVersion
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   agentIds?: string[]
-  /** @deprecated read from claudeOptions; removed in P1.2+ */
-  flickerFree?: boolean
-  /** @deprecated read from claudeOptions; removed in P1.2+ */
-  powershellTool?: boolean
   /** @deprecated read from claudeOptions; removed in P1.2+ */
   effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
   /** @deprecated read from claudeOptions; removed in P1.2+ */

--- a/tests/unit/stores/configStore.test.ts
+++ b/tests/unit/stores/configStore.test.ts
@@ -104,16 +104,6 @@ describe('configStore', () => {
   })
 
   describe('TerminalConfig new fields', () => {
-    it('supports flickerFree field', () => {
-      useConfigStore.getState().addConfig(makeConfig({ id: 'c1', flickerFree: true }))
-      expect(useConfigStore.getState().configs[0].flickerFree).toBe(true)
-    })
-
-    it('supports powershellTool field', () => {
-      useConfigStore.getState().addConfig(makeConfig({ id: 'c1', powershellTool: true }))
-      expect(useConfigStore.getState().configs[0].powershellTool).toBe(true)
-    })
-
     it('supports effortLevel field', () => {
       useConfigStore.getState().addConfig(makeConfig({ id: 'c1', effortLevel: 'low' }))
       expect(useConfigStore.getState().configs[0].effortLevel).toBe('low')
@@ -135,8 +125,6 @@ describe('configStore', () => {
     it('new fields default to undefined when not set', () => {
       useConfigStore.getState().addConfig(makeConfig({ id: 'c1' }))
       const config = useConfigStore.getState().configs[0]
-      expect(config.flickerFree).toBeUndefined()
-      expect(config.powershellTool).toBeUndefined()
       expect(config.effortLevel).toBeUndefined()
       expect(config.disableAutoMemory).toBeUndefined()
       expect(config.machineName).toBeUndefined()


### PR DESCRIPTION
## Summary

D2 settings cleanup surfaced by a full per-session settings audit: removes three **verified-dead** session settings. No behaviour change for users beyond one dead toggle disappearing.

### Removed
- **Fast Mode** — a *visible* "Fast mode (Opus 4.8)" checkbox in the session dialog that was collected and persisted but **never reached spawn / the CLI / tokenomics** (a control that did nothing). The `<model>-fast` tokenomics pricing rows (keyed by CLI model name) are **kept** — only the dead per-session toggle is gone.
- **flickerFree** — dead persisted field, no UI, no consumer (`CLAUDE_CODE_NO_FLICKER` was only ever mentioned in comments, never set).
- **powershellTool** — dead persisted field, no UI, no consumer (`CLAUDE_CODE_USE_POWERSHELL_TOOL` likewise comment-only).

Removed end-to-end across types, the session dialog, hydration, persistence, the `CLAUDE_FIELDS`/`LEGACY_CLAUDE_FIELDS` allowlists, the stores, and the preload/renderer types. Also cleaned an orphaned Fast-Mode click in the training-capture script and two stale tests.

### Safety / backward-compat
- The fields were **optional and unconsumed**, so old saved-session JSON that still contains these keys loads fine (keys are simply ignored — no migration needed). A legacy-session load test (`session-state-github.test.ts`) deliberately keeps a `flickerFree` key to prove this.

## Verification
- `git grep` for the three identifiers: clean across `src/` + `scripts/` (only the intentional legacy-load test references one).
- `tsc --noEmit` clean; full unit suite **1730 pass / 1 skip**.
- Independent adversarial review: confirmed no live code removed, dialog layout intact, pricing rows correctly kept; it caught the orphaned capture-script reference (now fixed).

## Notes
- Audit findings (full live/dead/partial table) are in the session record; the related **effort-enum spawn fix** (restored xhigh/max/ultracode sessions) shipped separately on PR #58.
- **Stacked** on `feat/session-cards-and-pty-integrity` (PR #58) for the smallest diff. Re-targetable. User controls merge + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
