### PR TITLE
fix(auth): external claude -p no longer breaks (keep real global login in lockstep with primary account)

### DIFF
--- a/src/main/account-profiles.ts
+++ b/src/main/account-profiles.ts
@@ -505,6 +505,79 @@ export function backupProfileHomeToCanonical(id: string): void {
   writeCanonicalIdentity(id, { claudeJson, credentials })
 }
 
+export type PrimaryCredentialSyncResult = 'none' | 'profile->global' | 'global->profile'
+
+/** Atomic file write (tmp + rename), creating parent dirs. */
+function atomicWriteFile(file: string, data: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  const tmp = file + '.tmp'
+  fs.writeFileSync(tmp, data)
+  fs.renameSync(tmp, file)
+}
+
+function readFileMaybe(file: string): string | undefined {
+  try { return fs.readFileSync(file, 'utf8') } catch { return undefined }
+}
+
+/**
+ * Keep the user's REAL global Claude login (`~/.claude/.credentials.json`) in
+ * lockstep with the PRIMARY account's profile home, so an OAuth token rotation
+ * inside a CCC session never leaves an external `claude -p` on a stale, dead
+ * refresh token -- and a `/login` OUTSIDE CCC is picked up by the next session.
+ * (Root cause: capture COPIES the global creds into the primary profile home;
+ * sessions then rotate the token there, silently invalidating the global copy.)
+ *
+ * Deliberately minimal + safe:
+ *  - Syncs ONLY the small `.credentials.json` token file. NEVER writes the large
+ *    `~/.claude.json` identity/state file (it only READS the email from it).
+ *  - FRESHEST-WINS on the OAuth expiry: whichever side holds the newer token
+ *    wins; we never downgrade a live token to an older one.
+ *  - EMAIL-GUARDED on BOTH sides: the primary profile home AND the real global
+ *    must CURRENTLY be the primary account. A `/login` to a DIFFERENT account on
+ *    either side aborts the sync, so a wrong account's token can never be written
+ *    across. Primary-only; no-op without a captured primary profile + email.
+ *  - Atomic write; best-effort; never throws. The one-time backupRealClaudeOnce
+ *    snapshot of the real `~/.claude` is the recovery net.
+ *
+ * Returns what it did (for logging/tests).
+ */
+export function syncPrimaryCredentialsWithGlobal(): PrimaryCredentialSyncResult {
+  try {
+    const primaryId = getPrimaryProfileId()
+    if (!primaryId || !isValidProfileId(primaryId)) return 'none'
+    const prof = listProfiles().find((p) => p.id === primaryId)
+    if (!prof?.accountEmail) return 'none' // no known account -> cannot guard
+    const want = canonicaliseEmail(prof.accountEmail)
+
+    const home = getProfileConfigDir(primaryId)
+    // Guard A: the primary profile home must STILL be the primary account. A
+    // mid-session /login may have switched it -> let detection handle that, not us.
+    if (canonicaliseEmail(readEmailFromFile(path.join(home, '.claude.json')) ?? '') !== want) return 'none'
+    // Guard B: the real global must ALSO be the primary account. The user may have
+    // logged a DIFFERENT account globally -> never cross-contaminate either store.
+    if (canonicaliseEmail(readEmailFromFile(path.join(realHomeDir(), '.claude.json')) ?? '') !== want) return 'none'
+
+    const profCredPath = path.join(home, '.claude', '.credentials.json')
+    const globalCredPath = path.join(sharedRoot(), '.credentials.json')
+    const profCred = readFileMaybe(profCredPath)
+    const globalCred = readFileMaybe(globalCredPath)
+    const profExp = credentialExpiry(profCred)
+    const globalExp = credentialExpiry(globalCred)
+
+    if (profCred != null && profExp > globalExp) {
+      atomicWriteFile(globalCredPath, profCred)
+      return 'profile->global'
+    }
+    if (globalCred != null && globalExp > profExp) {
+      atomicWriteFile(profCredPath, globalCred)
+      // Keep canonical in lockstep with the externally-refreshed token.
+      try { writeCanonicalIdentity(primaryId, { credentials: globalCred }) } catch { /* best-effort */ }
+      return 'global->profile'
+    }
+    return 'none'
+  } catch { return 'none' }
+}
+
 /** A /login switched a session to a new account, written into the account's SHARED
  *  profile home. Capture it as a NEW named profile from that home. The caller is
  *  responsible for restoring the source profile home from canonical afterwards so

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,7 @@ import { registerNotesHandlers } from './ipc/notes-handlers'
 import { registerVisionHandlers } from './ipc/vision-handlers'
 import { registerConfigHandlers } from './ipc/config-handlers'
 import { registerAccountProfilesHandlers } from './ipc/account-profiles-handlers'
-import { migrateProfilesToHomeLayout, cleanupSessionHomes } from './account-profiles'
+import { migrateProfilesToHomeLayout, cleanupSessionHomes, syncPrimaryCredentialsWithGlobal } from './account-profiles'
 import { runFirstRunCapture } from './first-run-accounts'
 import { backupRealClaudeOnce } from './claude-backup'
 import { registerCloudAgentHandlers } from './ipc/cloud-agent-handlers'
@@ -661,6 +661,10 @@ if (!gotTheLock) {
     // token out of any retired account-homes/<sessionId>/ into the profile home +
     // canonical (so no re-auth after upgrade), then remove them. Idempotent.
     try { cleanupSessionHomes() } catch (e) { logInfo(`[profiles] session-home cleanup skipped: ${e}`) }
+    // Auth-outside-CCC fix: heal a stale real global ~/.claude/.credentials.json on
+    // launch (a prior session rotated the primary account's OAuth token, leaving
+    // external `claude -p` on a dead refresh token). Freshest-wins + email-guarded.
+    try { const r = syncPrimaryCredentialsWithGlobal(); if (r !== 'none') logInfo(`[profiles] primary<->global credential sync at launch: ${r}`) } catch (e) { logInfo(`[profiles] credential sync skipped: ${e}`) }
     registerScreenshotHandlers(getWindow)
     registerWebviewHandlers(getWindow)
     registerInsightsHandlers(getWindow)

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -28,7 +28,7 @@ import {
 import { registerCodexReviewSession, unregisterCodexReviewSession } from './conductor-mcp-server'
 import { disposeSession as disposeCodexReviewUsage } from './codex-review-usage'
 import { readCodexAccountEmail } from './account-identity'
-import { getProfileConfigDir, setupProfileLinks, getPrimaryProfileId, backupProfileHomeToCanonical } from './account-profiles'
+import { getProfileConfigDir, setupProfileLinks, getPrimaryProfileId, backupProfileHomeToCanonical, syncPrimaryCredentialsWithGlobal } from './account-profiles'
 import { captureClaudeAccount, clearClaudeAccount, getAccountIdentity, pushAccountIdentity, startWatchingAccountIdentity, stopWatchingAccountIdentity, getWatchedProfileId } from './claude-account-identity'
 import type { AccountIdentity } from '../shared/types'
 import { updateSessionMeta, clearSessionMeta } from './session-registry'
@@ -879,6 +879,11 @@ export function spawnPty(
     // way a normal single-account install does. The old per-session-home model gave
     // each session a private COPY of the credential; the first refresh rotated the
     // token and invalidated every other copy, forcing a re-auth on resume.
+    // Auth-outside-CCC fix: before a session reads the primary account's profile
+    // home, pull a fresher global token (e.g. a /login the user ran OUTSIDE CCC)
+    // into it so this session starts on the live token. Primary-only + email-guarded;
+    // no-op otherwise.
+    try { syncPrimaryCredentialsWithGlobal() } catch { /* best-effort */ }
     let home: string | null = null
     if (resolvedProfileId) {
       try { setupProfileLinks(resolvedProfileId) } catch (e) { logWarn(`[profiles] session ${sessionId}: home refresh failed: ${e}`) }
@@ -1133,6 +1138,11 @@ export function spawnPty(
       // switched the home to a different account can never corrupt canonical.
       // No-op for default (no-profile) sessions.
       if (exitProfileId) { try { backupProfileHomeToCanonical(exitProfileId) } catch { /* best-effort */ } }
+      // Auth-outside-CCC fix: this session may have rotated the primary account's
+      // OAuth token; push the freshest token back to the real global ~/.claude so an
+      // external `claude -p` keeps working. Freshest-wins + email-guarded; no-op when
+      // the exiting session wasn't the primary account.
+      try { syncPrimaryCredentialsWithGlobal() } catch { /* best-effort */ }
       // Bug 4: release this session's pinned vision browser target/context.
       try { teardownVisionSession(sessionId) } catch { /* best-effort */ }
     } else {

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -17,8 +17,9 @@ export const changelog: ChangelogEntry[] = [
   {
     version: '1.5.29',
     date: '2026-06-03',
-    highlights: 'See each session effort at a glance, plus a new terminal-health view in the Conductor diagnostics.',
+    highlights: 'Keeps your Claude login working in scripts outside the app, shows each session effort at a glance, plus a new terminal-health view.',
     changes: [
+      { type: 'fix', description: 'Running the Claude CLI outside the app (e.g. claude -p in your own scripts) no longer breaks authentication. The app now keeps your real Claude login in lockstep with your main account, so a token refresh inside a session never leaves your outside scripts on a dead login. Only your main account\'s token is mirrored, and only when both sides are still that account.' },
       { type: 'feature', description: 'Session cards now show a colour-coded effort pill (Low through Ultracode) in the top-right, tinted from green to red as effort rises, so you can read each session effort level at a glance without opening it.' },
       { type: 'improvement', description: 'Tidied the session cards by removing the small leading dot. It only showed grey when idle and duplicated the status pill already shown on the right.' },
       { type: 'feature', description: 'The Conductor diagnostics console gained a PTY integrity section with live terminal metrics per session (bytes received, resize events and width desyncs) to help track down terminal display glitches.' },

--- a/tests/unit/account-profiles-global-credential-sync.test.ts
+++ b/tests/unit/account-profiles-global-credential-sync.test.ts
@@ -1,0 +1,127 @@
+/**
+ * syncPrimaryCredentialsWithGlobal keeps the user's REAL global Claude login
+ * (~/.claude/.credentials.json) in lockstep with the PRIMARY account's profile
+ * home, so a CCC session's OAuth token rotation never leaves an external
+ * `claude -p` on a dead refresh token (and an external /login is picked up by
+ * the next session). Token-file only, freshest-wins, email-guarded, primary-only.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'; import os from 'node:os'; import path from 'node:path'
+import {
+  _setRootsForTest, createProfile, setPrimaryProfile, upsertProfile, listProfiles,
+  getProfileConfigDir, syncPrimaryCredentialsWithGlobal, getAccountIdentityDir,
+} from '../../src/main/account-profiles'
+
+let base: string; let resourcesDir: string; let sharedRoot: string; let realHome: string
+
+function idJson(email: string): string {
+  return JSON.stringify({ oauthAccount: { emailAddress: email } })
+}
+function credJson(expiresAt: number, token = `tok-${expiresAt}`): string {
+  return JSON.stringify({ claudeAiOauth: { expiresAt, refreshToken: token } })
+}
+function writeProfileHome(id: string, email: string, expiresAt: number | null): void {
+  const home = getProfileConfigDir(id)
+  fs.mkdirSync(path.join(home, '.claude'), { recursive: true })
+  fs.writeFileSync(path.join(home, '.claude.json'), idJson(email))
+  if (expiresAt != null) fs.writeFileSync(path.join(home, '.claude', '.credentials.json'), credJson(expiresAt))
+}
+function writeGlobal(email: string | null, expiresAt: number | null): void {
+  if (email != null) fs.writeFileSync(path.join(realHome, '.claude.json'), idJson(email))
+  if (expiresAt != null) fs.writeFileSync(path.join(sharedRoot, '.credentials.json'), credJson(expiresAt))
+}
+function readGlobalCredExp(): number {
+  const c = JSON.parse(fs.readFileSync(path.join(sharedRoot, '.credentials.json'), 'utf8'))
+  return c.claudeAiOauth.expiresAt
+}
+function readProfileCredExp(id: string): number {
+  const c = JSON.parse(fs.readFileSync(path.join(getProfileConfigDir(id), '.claude', '.credentials.json'), 'utf8'))
+  return c.claudeAiOauth.expiresAt
+}
+function makePrimary(email: string): string {
+  const p = createProfile('Primary')
+  upsertProfile({ ...p, accountEmail: email })
+  setPrimaryProfile(p.id)
+  return p.id
+}
+
+beforeEach(() => {
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-gsync-'))
+  resourcesDir = path.join(base, 'res')
+  realHome = path.join(base, 'home')
+  sharedRoot = path.join(realHome, '.claude')
+  fs.mkdirSync(resourcesDir, { recursive: true }); fs.mkdirSync(sharedRoot, { recursive: true })
+  _setRootsForTest({ resourcesDir, sharedRoot })
+})
+afterEach(() => { _setRootsForTest(null); fs.rmSync(base, { recursive: true, force: true }) })
+
+describe('syncPrimaryCredentialsWithGlobal', () => {
+  const EMAIL = 'me@live.co.uk'
+
+  it('pushes the fresher PROFILE token to the stale global (the reported bug)', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, EMAIL, 5000) // session rotated to a newer token
+    writeGlobal(EMAIL, 1000)          // global frozen at the old token
+
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('profile->global')
+    expect(readGlobalCredExp()).toBe(5000) // external claude -p now has the live token
+  })
+
+  it('pulls a fresher GLOBAL token (external /login) into the profile + canonical', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, EMAIL, 1000)
+    writeGlobal(EMAIL, 9000) // user re-logged outside CCC
+
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('global->profile')
+    expect(readProfileCredExp(id)).toBe(9000)
+    // canonical kept in lockstep
+    const canon = JSON.parse(fs.readFileSync(path.join(getAccountIdentityDir(id), '.credentials.json'), 'utf8'))
+    expect(canon.claudeAiOauth.expiresAt).toBe(9000)
+  })
+
+  it('is a no-op when both tokens are equally fresh', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, EMAIL, 3000)
+    writeGlobal(EMAIL, 3000)
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('none')
+    expect(readGlobalCredExp()).toBe(3000)
+  })
+
+  it('GUARD A: refuses to sync when the profile home was switched to a different account', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, 'other@example.com', 9000) // mid-session /login switched it
+    writeGlobal(EMAIL, 1000)
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('none')
+    expect(readGlobalCredExp()).toBe(1000) // global untouched -> no cross-contamination
+  })
+
+  it('GUARD B: refuses to sync when the global is a different account', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, EMAIL, 9000)
+    writeGlobal('other@example.com', 1000) // a different account is logged in globally
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('none')
+    expect(readGlobalCredExp()).toBe(1000) // never overwrite a different global account
+  })
+
+  it('creates the global token when missing (profile fresher, identity matches)', () => {
+    const id = makePrimary(EMAIL)
+    writeProfileHome(id, EMAIL, 7000)
+    writeGlobal(EMAIL, null) // global identity present, but creds gone
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('profile->global')
+    expect(readGlobalCredExp()).toBe(7000)
+  })
+
+  it('no-op when there is no primary profile', () => {
+    writeGlobal(EMAIL, 1000)
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('none')
+  })
+
+  it('no-op when the primary profile has no known account email', () => {
+    const p = createProfile('Primary')
+    setPrimaryProfile(p.id) // accountEmail stays ''
+    writeProfileHome(p.id, EMAIL, 9000)
+    writeGlobal(EMAIL, 1000)
+    expect(syncPrimaryCredentialsWithGlobal()).toBe('none')
+    expect(listProfiles().find((x) => x.id === p.id)?.accountEmail).toBe('')
+  })
+})


### PR DESCRIPTION
## The bug

Running the Claude CLI **outside** the app (e.g. `claude -p` in your own scripts) was failing authentication. Root cause traced in code (3-angle investigation):

- CCC's account isolation **copies** your global Claude OAuth token (`~/.claude/.credentials.json`) into a private per-account "primary" profile home at capture time.
- Every CCC session runs under that profile home (`USERPROFILE` override), **never the real global home**.
- When a session refreshes its access token, the server **rotates the refresh token and invalidates the old one**. The fresh token lands in the profile home; **the real global copy is never updated**, so it goes stale.
- Your external `claude -p` reads the now-dead global token → auth fails. `/login` fixes it until the next CCC rotation.

The codebase even documents this rotation hazard (the "Bug 2" comment) — but the prior fix only kept CCC's *own* sessions consistent; it never extended to the real global home that external tools use.

## The fix

A new `syncPrimaryCredentialsWithGlobal()` (in `account-profiles.ts`) keeps the real global `~/.claude/.credentials.json` in lockstep with the **primary** account's profile home, wired at **app startup, session spawn, and session exit**:

- **Token file only.** Syncs `.credentials.json`; **never writes** the large `~/.claude.json` identity/state file (only reads the email from it).
- **Freshest-wins** on the OAuth `expiresAt` — pushes a session's newer token out to the global, and pulls an external `/login`'s newer token back in. Never downgrades.
- **Email-guarded on BOTH sides** — the primary profile home AND the real global must currently be the primary account, so a `/login` to a different account on either side aborts the sync. A wrong account's token can never be written across.
- **Primary-only**, atomic write (tmp+rename), best-effort (never throws). The existing one-time `backupRealClaudeOnce` snapshot remains the recovery net.

Net effect: external `claude -p` stays on a live token, and an external `/login` is picked up by the next session.

## Verification
- New `account-profiles-global-credential-sync.test.ts` — 8 tests covering both sync directions, both email-guard aborts (profile-switched, different-global), missing-creds creation, equal-expiry no-op, no-primary, no-email. All account-profiles tests (32) green.
- `tsc --noEmit` clean; full unit suite green apart from the known load-flaky `providers/claude/resume.test.ts` (a >10s timeout under parallel load; passes in isolation with headroom; unrelated to this change).
- **Independent adversarial safety review** focused on "can this ever corrupt/clobber/downgrade/cross-contaminate the global login": **APPROVE** — no harmful path found.

## Scope / stacking
- Independent of the dead-settings cleanup (PR #59); touches `account-profiles.ts`, `index.ts`, `pty-manager.ts` only. Based on PR #58 (`feat/session-cards-and-pty-integrity`) for a clean diff. **This is the urgent one** — happy to retarget straight to `beta` if you want it out ahead of the stack.
- User controls merge + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
