### PR TITLE
fix(logs): logging manualRestart recovery + review fast-follow minors

### DIFF
--- a/src/main/ipc/service-health-handlers.ts
+++ b/src/main/ipc/service-health-handlers.ts
@@ -44,6 +44,15 @@ export function getMergedDiagnostics(getSup: SupGetter, getPty: PtyGetter): Diag
 
 export function buildRestart(getSup: SupGetter): (serviceId: string) => { ok: boolean; reason?: string } {
   return (serviceId) => {
+    // The logging worker is owned by a SEPARATE supervisor (LogSupervisor) with no
+    // in-process fallback; route its restart there so a permanently-degraded logging
+    // service can actually be revived (the hooks supervisor would only answer
+    // 'unknown-service' for it).
+    if (serviceId === 'logging') {
+      const logSup = getLogSupervisor()
+      if (!logSup) return { ok: false, reason: 'no-supervisor' }
+      return logSup.manualRestart(serviceId)
+    }
     const sup = getSup()
     if (!sup) return { ok: false, reason: 'no-supervisor' }
     return sup.manualRestart(serviceId)

--- a/src/main/logging/log-supervisor.ts
+++ b/src/main/logging/log-supervisor.ts
@@ -416,6 +416,34 @@ export class LogSupervisor {
   }
 
   // -------------------------------------------------------------------------
+  // Manual restart — recovery from permanent degrade
+  // -------------------------------------------------------------------------
+
+  /** User-requested restart of the logging worker. Unlike the hooks supervisor
+   *  there is NO in-process fallback, so once `degradePermanently` fires a manual
+   *  restart is the ONLY way back: clear the terminal `degradedPermanently` flag,
+   *  reset the restart/backoff counters, free any dead worker, and respawn (which
+   *  re-sends `open` so the worker reopens the DB). Mirrors
+   *  ServiceSupervisor.manualRestart. Declines during shutdown. */
+  manualRestart(serviceId: string): { ok: boolean; reason?: string } {
+    if (serviceId !== SERVICE_ID) return { ok: false, reason: 'unknown-service' }
+    if (this.shuttingDown) return { ok: false, reason: 'shutting-down' }
+    this.appendLog('info', 'manual-restart', 'manual restart requested')
+    if (this.restartTimer !== null) { clearTimeout(this.restartTimer); this.restartTimer = null }
+    this.restarts = 0
+    this.backoffIdx = 0
+    this.degradedPermanently = false
+    this.health = { ...this.health, restartCount: 0 }
+    // Free any lingering (dead/degraded) worker before respawning. The old worker's
+    // late exit is ignored by spawnWorker's onExit guard (`this.worker === w`).
+    try { this.worker?.kill() } catch { /* best-effort */ }
+    this.worker = null
+    this.spawnWorker()
+    this.pushHealth()
+    return { ok: true }
+  }
+
+  // -------------------------------------------------------------------------
   // Shutdown
   // -------------------------------------------------------------------------
 

--- a/src/renderer/components/LoggingConsentPrompt.tsx
+++ b/src/renderer/components/LoggingConsentPrompt.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 
 const CLOSE_ANIM_MS = 200
@@ -19,16 +19,22 @@ export default function LoggingConsentPrompt() {
 
   const [entering, setEntering] = useState(false)
   const [closing, setClosing] = useState(false)
+  // The close-animation timer must be cleared on unmount: the parent removes this
+  // prompt as soon as loggingConsentSeen flips, which can happen before the timer
+  // fires — a stale timer would call updateSettings on an unmounted component.
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     const id = requestAnimationFrame(() => setEntering(true))
     return () => cancelAnimationFrame(id)
   }, [])
 
+  useEffect(() => () => { if (closeTimer.current) clearTimeout(closeTimer.current) }, [])
+
   const save = (updates: Parameters<typeof updateSettings>[0]) => {
     if (closing) return
     setClosing(true)
-    setTimeout(() => updateSettings(updates), CLOSE_ANIM_MS)
+    closeTimer.current = setTimeout(() => updateSettings(updates), CLOSE_ANIM_MS)
   }
 
   const handleKeepOn = () => save({ loggingConsentSeen: true })

--- a/src/renderer/stores/migrationStore.ts
+++ b/src/renderer/stores/migrationStore.ts
@@ -55,6 +55,11 @@ export const useMigrationStore = create<MigrationState>((set, get) => ({
   },
 
   run: async () => {
+    // Re-entry guard: both the Settings action and the one-time App prompt can call
+    // run(); a second concurrent call would register a duplicate progress listener
+    // whose unsub leaks (the main handler already rejects the duplicate IPC). Refuse
+    // if a run is already in flight.
+    if (get().phase === 'running') return
     set({ phase: 'running', progressDone: 0, progressTotal: get().sessionFolders, errorMessage: undefined, errorKind: undefined })
     const unsub = window.electronAPI.logMigration.onProgress(({ done, total }) => {
       set({ progressDone: done, progressTotal: total })

--- a/tests/unit/logging/log-supervisor.test.ts
+++ b/tests/unit/logging/log-supervisor.test.ts
@@ -415,4 +415,41 @@ describe('LogSupervisor', () => {
       expect(secondReconciles).toHaveLength(0)
     })
   })
+
+  describe('manualRestart — recovery from permanent degrade', () => {
+    it('revives a permanently-degraded worker: respawns, resets counters, and goes listening on ready', () => {
+      const h = makeHarness({ maxRestarts: 1 })
+      h.sup.start()
+      // Exhaust restarts -> permanent degrade (there is NO in-process fallback).
+      for (let i = 0; i < 2; i++) { h.current().triggerExit(); vi.advanceTimersByTime(5000) }
+      expect(h.sup.getDiagnosticsSnapshot().services[0].state).toBe('degraded')
+      const forksAtDegrade = h.forkSpy.mock.calls.length
+
+      // Manual restart is the ONLY way back. It must respawn + reset counters.
+      const res = h.sup.manualRestart('logging')
+      expect(res).toEqual({ ok: true })
+      expect(h.forkSpy.mock.calls.length).toBe(forksAtDegrade + 1)
+      expect(h.current().posts).toContainEqual({ type: 'open', dbPath: '/tmp/fake-logs.db' })
+      expect(h.sup.getDiagnosticsSnapshot().services[0].restartCount).toBe(0)
+
+      // Crucially the terminal degraded flag was cleared: a fresh `ready` now flips
+      // back to listening (the permanent-degrade stickiness guard would otherwise
+      // swallow it).
+      h.current().emit({ type: 'ready' })
+      expect(h.sup.getDiagnosticsSnapshot().services[0].state).toBe('listening')
+    })
+
+    it('declines an unknown service id', () => {
+      const h = makeHarness()
+      h.sup.start()
+      expect(h.sup.manualRestart('hooks')).toEqual({ ok: false, reason: 'unknown-service' })
+    })
+
+    it('declines once shutting down', () => {
+      const h = makeHarness()
+      h.sup.start()
+      h.sup.shutdown()
+      expect(h.sup.manualRestart('logging')).toEqual({ ok: false, reason: 'shutting-down' })
+    })
+  })
 })

--- a/tests/unit/services/service-health-handlers.test.ts
+++ b/tests/unit/services/service-health-handlers.test.ts
@@ -40,6 +40,18 @@ describe('service-health-handlers', () => {
     const restart = buildRestart(() => null)
     expect(restart('hooks')).toEqual({ ok: false, reason: 'no-supervisor' })
   })
+  it('RESTART routes a logging serviceId to the log supervisor (not the hooks one)', () => {
+    mockGetLogSupervisor.mockReturnValue({ manualRestart: (id: string) => ({ ok: true, who: 'logging', id }) })
+    const hooksGetter = vi.fn(() => ({ manualRestart: () => ({ ok: true, who: 'hooks' }) } as never))
+    const restart = buildRestart(hooksGetter)
+    expect(restart('logging')).toEqual({ ok: true, who: 'logging', id: 'logging' })
+    expect(hooksGetter).not.toHaveBeenCalled()
+  })
+  it('RESTART returns no-supervisor for logging when the log supervisor is absent', () => {
+    mockGetLogSupervisor.mockReturnValue(null)
+    const restart = buildRestart(() => ({ manualRestart: () => ({ ok: true }) } as never))
+    expect(restart('logging')).toEqual({ ok: false, reason: 'no-supervisor' })
+  })
 
   // --- §14: logging service merging ---
 


### PR DESCRIPTION
Post-#61 review fast-follow — the items deferred when #61 merged. Single commit `83d2acb`.

- **LogSupervisor.manualRestart** (deferred "Important"): the logging worker has no in-process fallback, so after a permanent degrade it stayed dead until an app restart. Adds a manual-restart recovery path, routed via SERVICE_RESTART for `serviceId==='logging'`.
- `migrationStore.run()` re-entry guard (duplicate progress-listener leak).
- `LoggingConsentPrompt` close-timer cleared on unmount.

Tests added (3 supervisor + 2 routing). typecheck 0; full suite 1926 pass / 1 skip; native 51 pass. Small, fully unit-tested, non-platform-sensitive fix to the pre-release integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)