### PR TITLE
fix(resume): surface + resume direct-work conversations with no companion dir

### DIFF
--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -50,6 +50,56 @@ function encodeProjectPath(p) {
   return String(p).replace(/[^A-Za-z0-9]/g, '-')
 }
 
+// ── Project-dir resolution ──────────────────────────────────────────
+// Mangle a cwd and case-insensitively match it against the on-disk
+// ~/.claude/projects folders (belt-and-braces on top of the now-correct
+// mangle). Returns the matched absolute folder path or null. FAIL-SAFE.
+function resolveProjectDir(claudeProjectsDir, cwd) {
+  try {
+    const encoded = encodeProjectPath(cwd)
+    let dirs
+    try { dirs = fs.readdirSync(claudeProjectsDir) } catch { return null }
+    for (const d of dirs) {
+      if (d.toLowerCase() === encoded.toLowerCase()) return path.join(claudeProjectsDir, d)
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// ── Companion-dir ensure ────────────────────────────────────────────
+// Mirror of src/main/logging/companion-dir.ts (this CJS script cannot import
+// the TS module). The Claude CLI only creates a `<uuid>/` companion dir beside a
+// transcript LAZILY (first subagent/workflow/large-tool-result). A direct-work
+// conversation has the `.jsonl` but no companion dir, and `claude --resume`
+// needs one — so before resuming the chosen conversation we ensure it exists.
+//
+// Creates `<projectDir>/<uuid>/subagents/` + `/workflows/` (a recursive mkdir of
+// each subdir creates the `<uuid>/` parent too). ORPHAN-SAFE: only acts when the
+// `<uuid>.jsonl` transcript exists. IDEMPOTENT: a no-op when the dir is already
+// present; never deletes. FAIL-SAFE: any fs error returns false, never throws.
+function ensureCompanionDir(projectDir, uuid) {
+  try {
+    if (!projectDir || !uuid) return false
+    const transcript = path.join(projectDir, `${uuid}.jsonl`)
+    if (!fs.existsSync(transcript)) return false // never create an orphan dir
+    const companion = path.join(projectDir, uuid)
+    if (fs.existsSync(companion)) {
+      // A stray same-named FILE must never be mkdir'd over — refuse it.
+      let isDir
+      try { isDir = fs.statSync(companion).isDirectory() } catch { return false }
+      if (!isDir) return false
+      // Otherwise fall through: recursive mkdir HEALS a partially-created dir.
+    }
+    fs.mkdirSync(path.join(companion, 'subagents'), { recursive: true })
+    fs.mkdirSync(path.join(companion, 'workflows'), { recursive: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
 // ── Worktree enumeration ────────────────────────────────────────────
 // Parse `git worktree list --porcelain` output into worktree records.
 //
@@ -229,42 +279,28 @@ function parseConversation(filePath) {
 
 // ── Scan one worktree's project dir ─────────────────────────────────
 // Mangle the worktree path → case-insensitive match in ~/.claude/projects →
-// filter .jsonl that have a companion dir (current Claude CLI format) →
-// parseConversation. Each returned conversation is tagged with `sourceCwd` (the
-// worktree path) and `worktreeLabel` (null for the main worktree). FAIL-SAFE:
-// any error → [].
+// list EVERY .jsonl → parseConversation. Each returned conversation is tagged
+// with `sourceCwd` (the worktree path) and `worktreeLabel` (null for the main
+// worktree). FAIL-SAFE: any error → [].
+//
+// We deliberately do NOT gate on a companion directory. The CLI only creates a
+// `<uuid>/` companion dir LAZILY (first subagent/workflow/large-tool-result), so
+// a conversation worked on directly never gets one — and the old gate hid those
+// from the picker entirely, which is exactly how the user lost real work. We
+// list them all here; launchClaude() ensures the companion dir for the chosen
+// conversation just before `claude --resume`.
 //
 // `claudeProjectsDir` and the worktree record are injectable for testing.
 function scanWorktreeConversations(worktree, claudeProjectsDir) {
   try {
-    const encoded = encodeProjectPath(worktree.path)
-
-    // Find matching project directory (case-insensitive; belt-and-braces on top
-    // of the now-correct mangle).
-    let projectDir = null
-    let dirs
-    try {
-      dirs = fs.readdirSync(claudeProjectsDir)
-    } catch {
-      return []
-    }
-    for (const d of dirs) {
-      if (d.toLowerCase() === encoded.toLowerCase()) {
-        projectDir = path.join(claudeProjectsDir, d)
-        break
-      }
-    }
+    const projectDir = resolveProjectDir(claudeProjectsDir, worktree.path)
     if (!projectDir || !fs.existsSync(projectDir)) return []
 
-    // .jsonl files that have a companion directory (current Claude CLI format).
+    // List EVERY .jsonl (no companion-dir gate — see header above).
     let files
     try {
-      const entries = fs.readdirSync(projectDir)
-      const dirSet = new Set(entries.filter(e => {
-        try { return fs.statSync(path.join(projectDir, e)).isDirectory() } catch { return false }
-      }))
-      files = entries
-        .filter(f => f.endsWith('.jsonl') && dirSet.has(f.replace('.jsonl', '')))
+      files = fs.readdirSync(projectDir)
+        .filter(f => f.endsWith('.jsonl'))
         .map(f => path.join(projectDir, f))
     } catch {
       return []
@@ -490,6 +526,19 @@ function launchClaude(resumeId, sourceCwd) {
   const args = resumeId ? ['--resume', resumeId, ...forwarded] : [...forwarded]
   const cmd = resolveClaudeCmd()
 
+  // Ensure the chosen conversation's companion dir exists so a direct-work
+  // conversation (no subagent/workflow → no companion dir from the CLI) can be
+  // resumed. Best-effort: any failure must NOT block the launch.
+  if (resumeId) {
+    try {
+      const projectDir = resolveProjectDir(
+        path.join(os.homedir(), '.claude', 'projects'),
+        sourceCwd || process.cwd(),
+      )
+      if (projectDir) ensureCompanionDir(projectDir, resumeId)
+    } catch { /* best-effort */ }
+  }
+
   // Only override cwd for an actual resume into a different directory. Be
   // FAIL-SAFE: an unresolvable/missing sourceCwd silently falls back to inherit.
   const spawnOpts = {
@@ -529,6 +578,8 @@ function launchClaude(resumeId, sourceCwd) {
 // a sanity `node -e "require('./scripts/resume-picker.js')"`) does NOT run main.
 module.exports = {
   encodeProjectPath,
+  resolveProjectDir,
+  ensureCompanionDir,
   parseWorktrees,
   listWorktrees,
   worktreeLabelFor,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell } from 'electron'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { registerPtyHandlers } from './ipc/pty-handlers'
@@ -57,6 +57,7 @@ import { forkHooksChild } from './services/fork-hooks-child'
 import { start as startLoopStallMonitor, stop as stopLoopStallMonitor } from './services/loop-stall-monitor'
 import { initLogging, shutdownLogging, getTranscriptBinder } from './logging/logging-service'
 import { detectOldLogArtifacts, executeWipe } from './logging/logs-wipe'
+import { backfillCompanionDirs, nodeFsCompanionDeps } from './logging/companion-dir'
 import { cleanupStaleHookEntries } from './hooks/boot-cleanup'
 import { DEFAULT_HOOKS_PORT } from './hooks/hooks-types'
 import { fetchModelPricing } from './tokenomics/tk-pricing'
@@ -616,6 +617,26 @@ if (!gotTheLock) {
       .then(() => getProvider('claude').deployResumePickerScript?.(getResourcesDirectory()))
       .then(() => getProvider('codex').deployResumePickerScript?.(getResourcesDirectory()))
       .catch((err) => console.warn('[main] Failed to deploy provider scripts:', err))
+      // Resume-picker bug fix: backfill companion dirs so DIRECT-WORK
+      // conversations (no subagent/workflow → no companion dir from the CLI) are
+      // visible in the picker AND resumable via `claude --resume`. Idempotent,
+      // additive, NEVER deletes. One sweep of the canonical projects store covers
+      // every account (per-account .claude/projects are junctions to it). Runs
+      // after the .catch so a deploy failure never skips it; off the synchronous
+      // boot path (microtask) so it never delays window creation. Each session's
+      // own resume path also ensures its companion dir, so this is a bulk
+      // visibility pass, not a per-resume requirement.
+      .then(() => {
+        try {
+          const projectsRoot = join(homedir(), '.claude', 'projects')
+          const res = backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+          if (res.created > 0) {
+            console.log(`[main] companion-dir backfill: created ${res.created} companion dir(s) (scanned ${res.scanned} transcripts across ${res.projectFolders} project folders)`)
+          }
+        } catch (err) {
+          console.warn('[main] companion-dir backfill failed:', err)
+        }
+      })
 
     // Content Security Policy
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {

--- a/src/main/logging/companion-dir.ts
+++ b/src/main/logging/companion-dir.ts
@@ -1,0 +1,144 @@
+/**
+ * companion-dir.ts — make direct-work conversations resumable.
+ *
+ * The Claude CLI stores each conversation as `<projectDir>/<uuid>.jsonl`. It
+ * ALSO creates a same-named `<projectDir>/<uuid>/` companion directory — but
+ * only LAZILY, the first time that conversation writes a subagent transcript, a
+ * workflow transcript, or a large tool-result. A conversation worked on DIRECTLY
+ * (no delegation) therefore has the `.jsonl` but NO companion dir.
+ *
+ * Both CCC's resume picker (scripts/resume-picker.js) and the CLI's own
+ * `claude --resume <uuid>` only surface conversations that have a companion dir,
+ * so direct-work conversations become invisible and unresumable — the user lost
+ * real, critical work to this repeatedly.
+ *
+ * These helpers fix that by ENSURING the companion dir exists. They are
+ * idempotent, additive, and NEVER delete anything (see [[feedback-no-wipe-configs]]).
+ * The created shape (`<uuid>/subagents/` + `<uuid>/workflows/`) mirrors the
+ * structure the CLI creates itself and matches the manual recovery that was
+ * verified to make a previously-dir-less conversation resumable.
+ *
+ * Pure + dependency-injected: all fs access goes through CompanionDirDeps so the
+ * logic is unit-tested against a temp dir (or fakes) without monkey-patching fs.
+ * No default export (project convention).
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+/** The minimal fs surface these helpers need. Injected for testability. */
+export interface CompanionDirDeps {
+  existsSync: (p: string) => boolean
+  mkdirSync: (p: string, opts: { recursive: boolean }) => void
+  readdirSync: (p: string) => string[]
+  statSync: (p: string) => { isDirectory: () => boolean }
+}
+
+/** Production deps: thin wrappers over node fs. */
+export const nodeFsCompanionDeps: CompanionDirDeps = {
+  existsSync: (p) => fs.existsSync(p),
+  mkdirSync: (p, opts) => { fs.mkdirSync(p, opts) },
+  readdirSync: (p) => fs.readdirSync(p),
+  statSync: (p) => fs.statSync(p),
+}
+
+/**
+ * Ensure the companion directory for ONE transcript exists.
+ *
+ * Creates `<projectDir>/<uuid>/` plus empty `subagents/` and `workflows/`
+ * subdirs (a recursive mkdir of each subdir creates the `<uuid>/` parent too).
+ *
+ * Guarantees:
+ *   - ORPHAN-SAFE: only acts when `<projectDir>/<uuid>.jsonl` exists. Never
+ *     fabricates a companion dir for a uuid that has no transcript.
+ *   - IDEMPOTENT: a no-op when the companion dir already exists; existing
+ *     contents are never touched or deleted.
+ *   - FAIL-SAFE: any fs error returns false and never throws.
+ *
+ * Returns true when the companion dir exists as a directory afterwards (created
+ * or already present); false when skipped (no transcript / name collides with a
+ * file) or on error.
+ */
+export function ensureCompanionDir(projectDir: string, uuid: string, deps: CompanionDirDeps): boolean {
+  try {
+    if (!projectDir || !uuid) return false
+    const transcript = path.join(projectDir, `${uuid}.jsonl`)
+    if (!deps.existsSync(transcript)) return false // never create an orphan dir
+
+    const companion = path.join(projectDir, uuid)
+    if (deps.existsSync(companion)) {
+      // A stray same-named FILE must never be mkdir'd over (would not pass the
+      // picker's directory gate either) — refuse it.
+      if (!deps.statSync(companion).isDirectory()) return false
+      // Otherwise fall through: recursive mkdir HEALS a partially-created
+      // companion dir (a no-op for a subdir already present) so a true return
+      // always means both subdirs exist.
+    }
+
+    // Create the dir + the two lazily-created subdirs the CLI uses (a recursive
+    // mkdir of each subdir creates the `<uuid>/` parent too; never deletes).
+    deps.mkdirSync(path.join(companion, 'subagents'), { recursive: true })
+    deps.mkdirSync(path.join(companion, 'workflows'), { recursive: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Counts returned by {@link backfillCompanionDirs} for logging. */
+export interface BackfillResult {
+  /** Project folders (immediate subdirs of projectsRoot) examined. */
+  projectFolders: number
+  /** Total `.jsonl` transcripts examined. */
+  scanned: number
+  /** Companion dirs created this sweep. */
+  created: number
+}
+
+/**
+ * Idempotent backfill across the whole Claude projects store.
+ *
+ * For every transcript under `projectsRoot/<mangled-cwd>/<uuid>.jsonl` that
+ * lacks a companion dir, create one. Walks each immediate subfolder (one per
+ * mangled cwd). Fail-safe at every level — an unreadable folder or file is
+ * skipped, never aborting the sweep — and NEVER deletes anything.
+ *
+ * `projectsRoot` is the canonical `~/.claude/projects` (per-account profile
+ * `.claude/projects` dirs are junctions to it, so one sweep covers all accounts).
+ */
+export function backfillCompanionDirs(projectsRoot: string, deps: CompanionDirDeps): BackfillResult {
+  const result: BackfillResult = { projectFolders: 0, scanned: 0, created: 0 }
+
+  let folders: string[]
+  try {
+    folders = deps.readdirSync(projectsRoot)
+  } catch {
+    return result // projects store not present yet — nothing to do
+  }
+
+  for (const folder of folders) {
+    const projectDir = path.join(projectsRoot, folder)
+    let isDir = false
+    try { isDir = deps.statSync(projectDir).isDirectory() } catch { isDir = false }
+    if (!isDir) continue
+    result.projectFolders++
+
+    let entries: string[]
+    try { entries = deps.readdirSync(projectDir) } catch { continue }
+
+    // Names of entries that are already directories (existing companion dirs).
+    const dirNames = new Set<string>()
+    for (const e of entries) {
+      try { if (deps.statSync(path.join(projectDir, e)).isDirectory()) dirNames.add(e) } catch { /* skip */ }
+    }
+
+    for (const e of entries) {
+      if (!e.endsWith('.jsonl')) continue
+      result.scanned++
+      const stem = e.slice(0, -'.jsonl'.length)
+      if (dirNames.has(stem)) continue // already has a companion dir
+      if (ensureCompanionDir(projectDir, stem, deps)) result.created++
+    }
+  }
+
+  return result
+}

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -9,6 +9,7 @@ import { shouldRegisterRun } from './logging/should-register-run'
 import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service'
 import { resolveResumeTargetFromTranscript, mangleCwdToProjectDir } from './logging/transcript-discovery'
 import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath } from './spawn-claude-command'
+import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
@@ -1082,6 +1083,9 @@ export function spawnPty(
           homedir: os.homedir,
           mangleCwdToProjectDir,
           projectsRoot: path.join(os.homedir(), '.claude', 'projects'),
+          // Best-effort: ensure a direct-work conversation (no subagent/workflow,
+          // hence no companion dir from the CLI) is resumable. Never throws.
+          ensureCompanionDir: (projectDir, uuid) => { ensureCompanionDir(projectDir, uuid, nodeFsCompanionDeps) },
         })
         if (launch) {
           resumeUuid = launch.resumeUuid

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1038,23 +1038,28 @@ export function spawnPty(
       //
       // `claude --resume <uuid>` is cwd-SCOPED: it only resolves a conversation
       // from the LAUNCH cwd's mangled ~/.claude/projects/<mangled> folder, and
-      // needs both <uuid>.jsonl and a same-name companion dir there. The default
-      // resume-picker / newest-in-folder behaviour can therefore pick a STALE
-      // conversation when the live one ran under a DIFFERENT cwd (e.g. a git
-      // worktree). So we must do BOTH: pass --resume <uuid> AND override the
-      // launch cwd to the directory the conversation actually ran in (read out
-      // of the JSONL — the mangled folder name is lossy and not reversible).
+      // needs both <uuid>.jsonl AND a same-name companion dir there. The CLI only
+      // creates that companion dir LAZILY (first subagent/workflow), so a
+      // direct-work conversation lacks one — CCC therefore ENSURES it on demand
+      // (see below) rather than requiring it. The default resume-picker /
+      // newest-in-folder behaviour can also pick a STALE conversation when the
+      // live one ran under a DIFFERENT cwd (e.g. a git worktree). So we must do
+      // BOTH: pass --resume <uuid> AND override the launch cwd to the directory
+      // the conversation actually ran in (read out of the JSONL — the mangled
+      // folder name is lossy and not reversible).
       //
       // Effective target precedence (all fail-open):
       //   options.resume          (app-relaunch: persisted on the restored session)
       //   lastResumeTarget        (in-session Restart / Switch-account: self-captured)
       //
       // The whole override is gated by the pure resolveResumeLaunch() helper:
-      // transcript file present, companion dir present, and the RAW target cwd
-      // is a real directory (stat'd directly — NOT via the homedir-fallback
-      // resolveCwd). ANY miss → drop resume entirely and fall back to existing
-      // behaviour. We never launch --resume from os.homedir() (a deleted
-      // worktree therefore falls back, it does not silently retarget home).
+      // transcript file present AND the RAW target cwd is a real directory
+      // (stat'd directly — NOT via the homedir-fallback resolveCwd). A missing
+      // companion dir is NO LONGER a gate — the helper creates it best-effort so
+      // a direct-work conversation stays resumable. ANY OTHER miss → drop resume
+      // entirely and fall back to existing behaviour. We never launch --resume
+      // from os.homedir() (a deleted worktree therefore falls back, it does not
+      // silently retarget home).
       let resumeUuid: string | undefined = undefined
       let claudeCwd = resolvedCwd
       // Precedence: app-relaunch persisted target wins over the self-captured

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -77,6 +77,15 @@ export interface ResolveResumeLaunchDeps {
   mangleCwdToProjectDir: (cwd: string) => string
   /** Canonical `~/.claude/projects` root (homedir-based; per-account homes are junctions to it). */
   projectsRoot: string
+  /**
+   * Best-effort: ensure the `<projectDir>/<uuid>/` companion dir exists so the
+   * CLI can resume a DIRECT-WORK conversation that never spawned a
+   * subagent/workflow (and therefore has no companion dir of its own). Called
+   * AFTER the transcript gate passes; its failure must NOT drop the resume (the
+   * transcript is real — we still launch `--resume`). Side-effecting; injected so
+   * the decision logic stays unit-testable. Production wraps companion-dir.ts.
+   */
+  ensureCompanionDir: (projectDir: string, uuid: string) => void
 }
 
 /**
@@ -96,9 +105,13 @@ export interface ResolveResumeLaunchDeps {
  * Returns `{ resumeUuid, claudeCwd }` only when ALL hold:
  *   - target present + has a uuid + a cwd;
  *   - the raw cwd (with `~` expanded) exists AND is a directory;
- *   - the transcript file `projectsRoot/<mangle(cwd)>/<uuid>.jsonl` exists;
- *   - the companion dir `projectsRoot/<mangle(cwd)>/<uuid>` exists.
+ *   - the transcript file `projectsRoot/<mangle(cwd)>/<uuid>.jsonl` exists.
  * Returns null on ANY miss or error (fail-open).
+ *
+ * The companion dir `projectsRoot/<mangle(cwd)>/<uuid>` is NO LONGER a
+ * precondition: a direct-work conversation never got one from the CLI but is
+ * still resumable, so we ENSURE it (best-effort, via deps.ensureCompanionDir)
+ * after the transcript gate rather than gating on it.
  *
  * `claudeCwd` is the resolved (absolute, `~`-expanded) launch directory.
  */
@@ -136,9 +149,15 @@ export function resolveResumeLaunch(
 
     const projDir = nodePath.join(deps.projectsRoot, deps.mangleCwdToProjectDir(target.cwd))
     const transcriptPath = nodePath.join(projDir, `${target.uuid}.jsonl`)
-    const companionDir = nodePath.join(projDir, target.uuid)
+    // The transcript MUST exist — without it there is no conversation to resume.
     if (!deps.existsSync(transcriptPath)) return null
-    if (!deps.existsSync(companionDir)) return null
+
+    // The companion dir is NO LONGER a precondition. A conversation worked on
+    // directly (no subagent/workflow) never got one from the CLI, yet it is a
+    // real, resumable conversation. Ensure it exists (best-effort) so
+    // `claude --resume` can find it. A failure here must NOT drop the resume —
+    // the transcript is real; we still launch and let the CLI/fresh-fallback cope.
+    try { deps.ensureCompanionDir(projDir, target.uuid) } catch { /* best-effort */ }
 
     return { resumeUuid: target.uuid, claudeCwd: expanded }
   } catch {

--- a/tests/unit/main/companion-dir.test.ts
+++ b/tests/unit/main/companion-dir.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the companion-dir helper (resume-picker bug — CRITICAL).
+ *
+ * ROOT CAUSE: the Claude CLI only creates a `<uuid>/` companion directory beside
+ * a `<uuid>.jsonl` transcript when that conversation spawns a subagent / workflow
+ * / large tool-result. A conversation worked on DIRECTLY (no delegation) has the
+ * transcript but NO companion dir — and both the resume picker AND `claude
+ * --resume <uuid>` only surface conversations that have one. So direct-work
+ * conversations become invisible and unresumable (the user lost real work).
+ *
+ * These helpers make a transcript resumable by ENSURING its companion dir exists,
+ * individually (ensureCompanionDir) and across the whole projects store on app
+ * launch (backfillCompanionDirs). Both are idempotent, additive, and NEVER delete
+ * — see [[feedback-no-wipe-configs]]. Tests run against a real fs temp dir
+ * (mkdtemp isolation) using the production node-fs deps.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, rmSync,
+} from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  ensureCompanionDir,
+  backfillCompanionDirs,
+  nodeFsCompanionDeps,
+  type CompanionDirDeps,
+} from '../../../src/main/logging/companion-dir'
+
+const UUID_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const UUID_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+const UUID_C = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+
+function seedTranscript(dir: string, uuid: string): string {
+  mkdirSync(dir, { recursive: true })
+  const file = join(dir, `${uuid}.jsonl`)
+  writeFileSync(file, JSON.stringify({ type: 'user', message: { content: 'hi' } }) + '\n')
+  return file
+}
+
+// ── ensureCompanionDir ─────────────────────────────────────────────
+describe('ensureCompanionDir', () => {
+  let projectDir: string
+  beforeEach(() => { projectDir = mkdtempSync(join(tmpdir(), 'ccc-companion-')) })
+  afterEach(() => { try { rmSync(projectDir, { recursive: true, force: true }) } catch {} })
+
+  it('creates <uuid>/ with subagents/ and workflows/ when the transcript exists and the dir is missing', () => {
+    seedTranscript(projectDir, UUID_A)
+    const ok = ensureCompanionDir(projectDir, UUID_A, nodeFsCompanionDeps)
+    expect(ok).toBe(true)
+    expect(statSync(join(projectDir, UUID_A)).isDirectory()).toBe(true)
+    expect(statSync(join(projectDir, UUID_A, 'subagents')).isDirectory()).toBe(true)
+    expect(statSync(join(projectDir, UUID_A, 'workflows')).isDirectory()).toBe(true)
+  })
+
+  it('is idempotent and NEVER deletes existing companion contents', () => {
+    seedTranscript(projectDir, UUID_A)
+    mkdirSync(join(projectDir, UUID_A, 'subagents'), { recursive: true })
+    const marker = join(projectDir, UUID_A, 'subagents', 'agent-keep.jsonl')
+    writeFileSync(marker, 'real subagent transcript')
+    const ok = ensureCompanionDir(projectDir, UUID_A, nodeFsCompanionDeps)
+    expect(ok).toBe(true)
+    // existing content untouched
+    expect(readFileSync(marker, 'utf-8')).toBe('real subagent transcript')
+  })
+
+  it('refuses to create an ORPHAN companion dir when no transcript exists', () => {
+    const ok = ensureCompanionDir(projectDir, UUID_A, nodeFsCompanionDeps)
+    expect(ok).toBe(false)
+    expect(existsSync(join(projectDir, UUID_A))).toBe(false)
+  })
+
+  it('heals a partially-created companion dir (adds a missing subdir when the dir already exists)', () => {
+    // If an earlier ensure half-completed (e.g. a transient fs error between the
+    // two mkdirs), the <uuid>/ dir exists with only one subdir. A later ensure
+    // must heal it — recursive mkdir is a no-op for the present subdir. Contract:
+    // a true return means BOTH subdirs exist.
+    seedTranscript(projectDir, UUID_A)
+    mkdirSync(join(projectDir, UUID_A, 'subagents'), { recursive: true }) // workflows missing
+    const ok = ensureCompanionDir(projectDir, UUID_A, nodeFsCompanionDeps)
+    expect(ok).toBe(true)
+    expect(statSync(join(projectDir, UUID_A, 'workflows')).isDirectory()).toBe(true)
+  })
+
+  it('returns false when <uuid> exists but is a FILE, not a directory', () => {
+    seedTranscript(projectDir, UUID_A)
+    writeFileSync(join(projectDir, UUID_A), 'not a dir') // collides with the would-be companion dir name
+    const ok = ensureCompanionDir(projectDir, UUID_A, nodeFsCompanionDeps)
+    expect(ok).toBe(false)
+  })
+
+  it('fails safe (returns false, never throws) when a dep throws', () => {
+    seedTranscript(projectDir, UUID_A)
+    const throwingDeps: CompanionDirDeps = {
+      ...nodeFsCompanionDeps,
+      mkdirSync: () => { throw new Error('EACCES') },
+    }
+    expect(() => ensureCompanionDir(projectDir, UUID_A, throwingDeps)).not.toThrow()
+    expect(ensureCompanionDir(projectDir, UUID_A, throwingDeps)).toBe(false)
+  })
+})
+
+// ── backfillCompanionDirs ──────────────────────────────────────────
+describe('backfillCompanionDirs', () => {
+  let projectsRoot: string
+  beforeEach(() => { projectsRoot = mkdtempSync(join(tmpdir(), 'ccc-backfill-')) })
+  afterEach(() => { try { rmSync(projectsRoot, { recursive: true, force: true }) } catch {} })
+
+  it('creates a companion dir for every dir-less transcript across all project folders', () => {
+    const projA = join(projectsRoot, 'F--proj-a')
+    const projB = join(projectsRoot, 'F--proj-b')
+    seedTranscript(projA, UUID_A) // dir-less
+    seedTranscript(projA, UUID_B) // will already have a dir
+    mkdirSync(join(projA, UUID_B), { recursive: true })
+    seedTranscript(projB, UUID_C) // dir-less
+
+    const res = backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+
+    expect(statSync(join(projA, UUID_A)).isDirectory()).toBe(true)
+    expect(statSync(join(projB, UUID_C)).isDirectory()).toBe(true)
+    expect(res.projectFolders).toBe(2)
+    expect(res.scanned).toBe(3)
+    expect(res.created).toBe(2) // UUID_B already had a dir
+  })
+
+  it('is idempotent: a second run creates nothing and preserves existing contents', () => {
+    const projA = join(projectsRoot, 'F--proj-a')
+    seedTranscript(projA, UUID_A)
+    backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+    // drop a marker inside the freshly-created companion dir
+    const marker = join(projA, UUID_A, 'subagents', 'marker.txt')
+    writeFileSync(marker, 'keep me')
+
+    const res2 = backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+    expect(res2.created).toBe(0)
+    expect(readFileSync(marker, 'utf-8')).toBe('keep me')
+  })
+
+  it('ignores non-.jsonl files and non-directory entries at the root', () => {
+    writeFileSync(join(projectsRoot, 'loose-file.txt'), 'x') // not a project folder
+    const projA = join(projectsRoot, 'F--proj-a')
+    seedTranscript(projA, UUID_A)
+    writeFileSync(join(projA, 'notes.md'), 'notes') // not a transcript
+
+    const res = backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+    expect(res.projectFolders).toBe(1)
+    expect(res.scanned).toBe(1)
+    expect(res.created).toBe(1)
+    expect(existsSync(join(projA, 'notes'))).toBe(false) // never made a dir for the .md
+  })
+
+  it('never clobbers a stray same-named FILE during the sweep (never-wipe invariant)', () => {
+    // A file named exactly <uuid> (no extension) sitting beside <uuid>.jsonl must
+    // survive the sweep untouched: the dirNames pre-filter only suppresses
+    // directory entries, so ensureCompanionDir IS invoked and must refuse via its
+    // file-vs-dir guard rather than mkdir over the file. Protects [[feedback-no-wipe-configs]].
+    const projA = join(projectsRoot, 'F--proj-a')
+    seedTranscript(projA, UUID_A)
+    writeFileSync(join(projA, UUID_A), 'a real file, not a companion dir')
+    const res = backfillCompanionDirs(projectsRoot, nodeFsCompanionDeps)
+    expect(res.scanned).toBe(1)
+    expect(res.created).toBe(0)
+    expect(statSync(join(projA, UUID_A)).isFile()).toBe(true)
+    expect(readFileSync(join(projA, UUID_A), 'utf-8')).toBe('a real file, not a companion dir')
+  })
+
+  it('returns zero counts (no throw) when the projects root does not exist', () => {
+    const res = backfillCompanionDirs(join(projectsRoot, 'does-not-exist'), nodeFsCompanionDeps)
+    expect(res).toEqual({ projectFolders: 0, scanned: 0, created: 0 })
+  })
+
+  it('skips an unreadable project folder without aborting the whole sweep', () => {
+    const projGood = join(projectsRoot, 'F--good')
+    const projBad = join(projectsRoot, 'F--bad')
+    seedTranscript(projGood, UUID_A)
+    seedTranscript(projBad, UUID_B)
+    const badDir = projBad
+    const deps: CompanionDirDeps = {
+      ...nodeFsCompanionDeps,
+      readdirSync: (p: string) => {
+        if (p === badDir) throw new Error('EACCES')
+        return nodeFsCompanionDeps.readdirSync(p)
+      },
+    }
+    const res = backfillCompanionDirs(projectsRoot, deps)
+    // the good folder was still processed
+    expect(statSync(join(projGood, UUID_A)).isDirectory()).toBe(true)
+    expect(res.created).toBe(1)
+  })
+})

--- a/tests/unit/main/spawn-resume-command.test.ts
+++ b/tests/unit/main/spawn-resume-command.test.ts
@@ -13,7 +13,7 @@
  *      `--resume <uuid>` is emitted FIRST (before --settings/--mcp-config/etc.),
  *      mirroring scripts/resume-picker.js:299 ordering, with the cwd overridden.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import * as os from 'os'
 import * as path from 'path'
 import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath } from '../../../src/main/spawn-claude-command'
@@ -188,6 +188,7 @@ describe('resolveResumeLaunch — gate', () => {
     dirPaths?: Set<string>
     homedir?: string
     projectsRoot?: string
+    ensureCompanionDir?: (projectDir: string, uuid: string) => void
   } = {}) {
     const exists = opts.existsPaths
     const dirs = opts.dirPaths
@@ -197,8 +198,11 @@ describe('resolveResumeLaunch — gate', () => {
       homedir: () => opts.homedir ?? HOME,
       mangleCwdToProjectDir: mangle,
       projectsRoot: opts.projectsRoot ?? PROJECTS_ROOT,
+      ensureCompanionDir: opts.ensureCompanionDir ?? vi.fn(),
     }
   }
+
+  const projDirOf = (cwd: string) => path.join(PROJECTS_ROOT, mangle(cwd))
 
   it('happy path: all paths present → returns { resumeUuid, claudeCwd }', () => {
     const out = resolveResumeLaunch({ uuid: T_UUID, cwd: REAL_CWD }, makeDeps())
@@ -242,13 +246,49 @@ describe('resolveResumeLaunch — gate', () => {
     expect(out).toBeNull()
   })
 
-  it('missing companion dir → null', () => {
+  it('missing companion dir → ENSURES it and still returns the launch (no longer a precondition)', () => {
+    // THE FIX: a direct-work conversation (transcript present, companion dir
+    // never created by the CLI) must still be resumable. The gate no longer
+    // drops it — it ensures the companion dir and proceeds.
     const existsPaths = new Set<string>([
       transcriptOf(REAL_CWD, T_UUID),
       path.resolve(REAL_CWD),
+      // companion dir intentionally absent
     ])
-    const out = resolveResumeLaunch({ uuid: T_UUID, cwd: REAL_CWD }, makeDeps({ existsPaths, dirPaths: existsPaths }))
+    const ensureCompanionDir = vi.fn()
+    const out = resolveResumeLaunch(
+      { uuid: T_UUID, cwd: REAL_CWD },
+      makeDeps({ existsPaths, dirPaths: existsPaths, ensureCompanionDir }),
+    )
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(REAL_CWD) })
+    expect(ensureCompanionDir).toHaveBeenCalledWith(projDirOf(REAL_CWD), T_UUID)
+  })
+
+  it('happy path ensures the companion dir with the project dir + uuid', () => {
+    const ensureCompanionDir = vi.fn()
+    const out = resolveResumeLaunch({ uuid: T_UUID, cwd: REAL_CWD }, makeDeps({ ensureCompanionDir }))
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(REAL_CWD) })
+    expect(ensureCompanionDir).toHaveBeenCalledTimes(1)
+    expect(ensureCompanionDir).toHaveBeenCalledWith(projDirOf(REAL_CWD), T_UUID)
+  })
+
+  it('a throwing ensureCompanionDir still returns the launch (best-effort ensure, never drops resume)', () => {
+    const ensureCompanionDir = vi.fn(() => { throw new Error('EACCES') })
+    const out = resolveResumeLaunch({ uuid: T_UUID, cwd: REAL_CWD }, makeDeps({ ensureCompanionDir }))
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(REAL_CWD) })
+  })
+
+  it('a MISSING transcript still drops resume (we never resume a conversation with no transcript)', () => {
+    // Guard against over-correction: ungating the companion dir must NOT also
+    // ungate the transcript. No transcript => no conversation => fall back.
+    const existsPaths = new Set<string>([path.resolve(REAL_CWD)])
+    const ensureCompanionDir = vi.fn()
+    const out = resolveResumeLaunch(
+      { uuid: T_UUID, cwd: REAL_CWD },
+      makeDeps({ existsPaths, dirPaths: existsPaths, ensureCompanionDir }),
+    )
     expect(out).toBeNull()
+    expect(ensureCompanionDir).not.toHaveBeenCalled()
   })
 
   it('undefined target → null', () => {
@@ -275,6 +315,7 @@ describe('resolveResumeLaunch — gate', () => {
       homedir: () => home,
       mangleCwdToProjectDir: mangle,
       projectsRoot: path.join(home, '.claude', 'projects'),
+      ensureCompanionDir: () => {},
     }
     const out = resolveResumeLaunch({ uuid: T_UUID, cwd: tildeCwd }, deps)
     expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: expanded })
@@ -288,6 +329,7 @@ describe('resolveResumeLaunch — gate', () => {
       homedir: () => home,
       mangleCwdToProjectDir: mangle,
       projectsRoot: path.join(home, '.claude', 'projects'),
+      ensureCompanionDir: () => {},
     })
     expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: home })
   })
@@ -299,6 +341,7 @@ describe('resolveResumeLaunch — gate', () => {
       homedir: () => HOME,
       mangleCwdToProjectDir: mangle,
       projectsRoot: PROJECTS_ROOT,
+      ensureCompanionDir: () => {},
     })
     expect(out).toBeNull()
   })

--- a/tests/unit/scripts/resume-picker.test.ts
+++ b/tests/unit/scripts/resume-picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -20,6 +20,7 @@ const picker = require('../../../scripts/resume-picker.js') as {
     conversationsBySource: Array<Array<{ mtime: number; filePath: string }>>,
     cap?: number,
   ) => Array<{ mtime: number; filePath: string }>
+  ensureCompanionDir: (projectDir: string, uuid: string) => boolean
 }
 
 // ── encodeProjectPath ──────────────────────────────────────────────
@@ -154,12 +155,19 @@ describe('resume-picker scanWorktreeConversations', () => {
 
   // Build one valid (>20480 byte) transcript with a companion dir under the
   // mangled folder for the given worktree path.
-  function seedConversation(worktreePath: string, uuid: string, firstMsg: string, mtimeMs?: number) {
+  function seedConversation(
+    worktreePath: string,
+    uuid: string,
+    firstMsg: string,
+    mtimeMs?: number,
+    withCompanionDir = true,
+  ) {
     const mangled = picker.encodeProjectPath(worktreePath)
     const dir = join(projectsDir, mangled)
     mkdirSync(dir, { recursive: true })
-    // companion dir (current Claude CLI format requirement)
-    mkdirSync(join(dir, uuid), { recursive: true })
+    // companion dir — present for conversations that spawned a subagent/workflow,
+    // ABSENT for direct-work conversations (the bug: those used to be hidden).
+    if (withCompanionDir) mkdirSync(join(dir, uuid), { recursive: true })
     const head = JSON.stringify({ type: 'user', message: { content: firstMsg } })
     // Pad past the 20480-byte ghost filter.
     const padLine = JSON.stringify({ type: 'system', message: 'x'.repeat(200) })
@@ -211,6 +219,78 @@ describe('resume-picker scanWorktreeConversations', () => {
       projectsDir,
     )
     expect(out).toEqual([])
+  })
+
+  it('THE FIX: lists a direct-work transcript that has NO companion dir', () => {
+    // The root-cause bug: a conversation that never spawned a subagent/workflow
+    // has no companion dir, so the old companion-dir gate hid it from the picker
+    // (and the user lost it). It must now appear in the list.
+    const wtPath = join(projectsDir, '..', 'direct-repo')
+    seedConversation(wtPath, 'dddddddd-dddd-dddd-dddd-dddddddddddd', 'direct work, no subagents', undefined, false)
+    const out = picker.scanWorktreeConversations({ path: wtPath, branch: 'main', isMain: true }, projectsDir)
+    expect(out).toHaveLength(1)
+    expect(out[0].sessionId).toBe('dddddddd-dddd-dddd-dddd-dddddddddddd')
+    expect(out[0].firstMessage).toBe('direct work, no subagents')
+  })
+
+  it('lists BOTH dir-less and dir-having transcripts together', () => {
+    const wtPath = join(projectsDir, '..', 'mixed-repo')
+    seedConversation(wtPath, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'has companion', undefined, true)
+    seedConversation(wtPath, 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'no companion', undefined, false)
+    const out = picker.scanWorktreeConversations({ path: wtPath, branch: 'main', isMain: true }, projectsDir)
+    expect(out.map((c) => c.sessionId).sort()).toEqual([
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    ])
+  })
+})
+
+// ── ensureCompanionDir (inline, mirrors src/main/logging/companion-dir.ts) ──
+describe('resume-picker ensureCompanionDir', () => {
+  let projectDir: string
+  const UUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+  beforeEach(() => { projectDir = mkdtempSync(join(tmpdir(), 'ccc-rp-companion-')) })
+  afterEach(() => { try { rmSync(projectDir, { recursive: true, force: true }) } catch {} })
+
+  function seedTranscript(uuid: string) {
+    writeFileSync(join(projectDir, `${uuid}.jsonl`), '{}\n')
+  }
+
+  it('creates <uuid>/ with subagents/ and workflows/ when the transcript exists', () => {
+    seedTranscript(UUID)
+    expect(picker.ensureCompanionDir(projectDir, UUID)).toBe(true)
+    expect(statSync(join(projectDir, UUID)).isDirectory()).toBe(true)
+    expect(statSync(join(projectDir, UUID, 'subagents')).isDirectory()).toBe(true)
+    expect(statSync(join(projectDir, UUID, 'workflows')).isDirectory()).toBe(true)
+  })
+
+  it('is idempotent and never deletes existing contents', () => {
+    seedTranscript(UUID)
+    mkdirSync(join(projectDir, UUID, 'subagents'), { recursive: true })
+    writeFileSync(join(projectDir, UUID, 'subagents', 'keep.jsonl'), 'real')
+    expect(picker.ensureCompanionDir(projectDir, UUID)).toBe(true)
+    expect(readFileSync(join(projectDir, UUID, 'subagents', 'keep.jsonl'), 'utf-8')).toBe('real')
+  })
+
+  it('refuses to create an orphan dir when no transcript exists', () => {
+    expect(picker.ensureCompanionDir(projectDir, UUID)).toBe(false)
+    expect(existsSync(join(projectDir, UUID))).toBe(false)
+  })
+
+  it('heals a partially-created companion dir (adds a missing subdir)', () => {
+    seedTranscript(UUID)
+    mkdirSync(join(projectDir, UUID, 'subagents'), { recursive: true }) // workflows missing
+    expect(picker.ensureCompanionDir(projectDir, UUID)).toBe(true)
+    expect(statSync(join(projectDir, UUID, 'workflows')).isDirectory()).toBe(true)
+  })
+
+  it('returns false and never clobbers a stray same-named FILE', () => {
+    seedTranscript(UUID)
+    writeFileSync(join(projectDir, UUID), 'real file')
+    expect(picker.ensureCompanionDir(projectDir, UUID)).toBe(false)
+    expect(statSync(join(projectDir, UUID)).isFile()).toBe(true)
+    expect(readFileSync(join(projectDir, UUID), 'utf-8')).toBe('real file')
   })
 })
 


### PR DESCRIPTION
## The bug (root-caused + confirmed at scale on real data)

The Claude CLI creates a `<uuid>/` **companion directory** beside each `<uuid>.jsonl` transcript — but only **lazily**, the first time that conversation spawns a subagent / workflow / large tool-result. A conversation worked on **directly** (no delegation) has the transcript but **no companion dir**.

Both CCC's resume picker (`scripts/resume-picker.js`) **and** the CLI's own `claude --resume <uuid>` only surfaced conversations that had a companion dir. So direct-work conversations were **invisible and unresumable** — the user repeatedly lost critical work (e.g. the 5MB `d8de9718` conversation).

Measured on the real store at the time of the fix: **54 transcripts across 13 project folders** were hidden.

## The fix

| Part | Change |
|---|---|
| **`src/main/logging/companion-dir.ts`** (new) | `ensureCompanionDir` (orphan-safe, idempotent, self-healing, **never-deletes**, fail-safe) + `backfillCompanionDirs` (whole-store sweep) |
| **`resolveResumeLaunch`** | Dropped the companion-dir **precondition**; ensures it (best-effort) *after* the transcript gate so a direct-work resume is never silently dropped to a fresh session. Deleted-worktree + transcript guards preserved. |
| **`resume-picker.js`** | `scanWorktreeConversations` lists **every** `.jsonl` (no companion-dir gate); `launchClaude` ensures the dir before `claude --resume` |
| **`index.ts`** | Idempotent companion-dir backfill on boot (additive, never deletes, one sweep covers all accounts via the junctioned projects store) |

Created shape is `<uuid>/subagents/` + `<uuid>/workflows/` — the structure the CLI creates itself, and the exact recipe a prior manual recovery proved makes a previously-dir-less conversation resumable.

## Verification

- **End-to-end on the real store:** 54 dir-less → **0**; all previously-hidden conversations now listed by the picker and resumable. (This run also recovered the 54 hidden conversations — additive, nothing deleted.)
- **Tests:** suite **2614 pass** / 4 skip, native **93**, typecheck clean. Every change was TDD'd (failing test first).
- **Adversarial review:** 6 dimensions, each finding independently verified by a skeptic. Boot backfill empirically benchmarked on the real store (40 folders / 287 transcripts / 4.7 GB → ~35-40 ms; does not stall boot). Two minor findings confirmed and closed (self-healing partial dirs; never-clobber tests locking the never-wipe invariant).

## Safety

Purely additive — `mkdir` only, never `unlink`/`rm`. Idempotent. Fail-open everywhere (a resume is never dropped on an ensure failure; the picker never crashes a session spawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)