### PR TITLE
feat(sentinel): copy the compatibility report (header + per-finding)

### DIFF
--- a/src/renderer/components/sentinel/SentinelPanel.tsx
+++ b/src/renderer/components/sentinel/SentinelPanel.tsx
@@ -1,6 +1,48 @@
 import React, { useState } from 'react'
 import { useSentinelStore } from '../../stores/sentinelStore'
 import type { SentinelFinding } from '../../../shared/sentinel-types'
+import { selectSentinelSections, formatFindingText, formatSentinelReportText } from './sentinel-report-text'
+
+// ── Copy-to-clipboard button ──────────────────────────────────────────────────
+// The report modal previously had no way to get its text out. getText is a thunk
+// so the (possibly large) report string is only built on click. Clipboard access
+// can reject when the window isn't focused or OS policy blocks it — swallow so
+// the click never surfaces as an unhandled rejection; the user can still read it.
+
+function CopyButton({
+  getText,
+  label = 'Copy',
+  title,
+  className,
+}: {
+  getText: () => string
+  label?: string
+  title?: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(getText())
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard blocked — swallow */
+    }
+  }
+  return (
+    <button
+      onClick={handleCopy}
+      title={title ?? 'Copy to clipboard'}
+      className={
+        className ??
+        'px-2 py-0.5 text-[11px] rounded bg-surface1/60 text-overlay1 hover:bg-surface2/60 transition-colors shrink-0'
+      }
+    >
+      {copied ? 'Copied' : label}
+    </button>
+  )
+}
 
 // ── Per-row apply error state ─────────────────────────────────────────────────
 
@@ -42,6 +84,7 @@ function ProposalRow({ finding }: { finding: SentinelFinding }) {
       <div className="flex items-start justify-between gap-2">
         <span className="text-xs font-medium text-text">{finding.title}</span>
         <div className="flex gap-1.5 shrink-0">
+          <CopyButton getText={() => formatFindingText(finding)} title="Copy this finding" />
           <button
             onClick={handleApply}
             disabled={applying}
@@ -82,12 +125,15 @@ function CompatRow({ finding }: { finding: SentinelFinding }) {
           <SeverityChip severity={finding.severity} />
           <span className="text-xs font-medium text-text truncate">{finding.title}</span>
         </div>
-        <button
-          onClick={handleMute}
-          className="px-2 py-0.5 text-[11px] rounded bg-surface1/60 text-overlay1 hover:bg-surface2/60 transition-colors shrink-0"
-        >
-          Mute
-        </button>
+        <div className="flex gap-1.5 shrink-0">
+          <CopyButton getText={() => formatFindingText(finding)} title="Copy this finding" />
+          <button
+            onClick={handleMute}
+            className="px-2 py-0.5 text-[11px] rounded bg-surface1/60 text-overlay1 hover:bg-surface2/60 transition-colors"
+          >
+            Mute
+          </button>
+        </div>
       </div>
       {finding.affectedFeature && (
         <span className="inline-block mt-0.5 text-[10px] px-1.5 py-px rounded bg-surface1/60 text-overlay1">
@@ -128,13 +174,7 @@ export default function SentinelPanel() {
 
   if (!panelOpen) return null
 
-  const proposals = snap
-    ? snap.findings.filter((f) => f.kind === 'registry-proposal' && f.status === 'open')
-    : []
-  const compatFindings = snap
-    ? snap.findings.filter((f) => (f.kind === 'compat' || f.kind === 'info') && f.status === 'open')
-    : []
-  const applied = snap ? snap.findings.filter((f) => f.status === 'applied') : []
+  const { proposals, compatFindings, applied } = selectSentinelSections(snap)
   const hasAny = proposals.length > 0 || compatFindings.length > 0 || applied.length > 0
 
   const subtitleDate = snap?.lastAnalysisAt
@@ -161,6 +201,14 @@ export default function SentinelPanel() {
             <p className="text-[11px] text-overlay0 mt-0.5">{subtitle}</p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            {hasAny && (
+              <CopyButton
+                getText={() => formatSentinelReportText(snap)}
+                label="Copy"
+                title="Copy the full report to the clipboard"
+                className="px-2.5 py-1 text-[11px] rounded border border-surface1 bg-surface0 text-overlay1 hover:bg-surface1 transition-colors"
+              />
+            )}
             <button
               onClick={() => void window.electronAPI.sentinel.rerun()}
               disabled={!!snap?.analyzing}

--- a/src/renderer/components/sentinel/sentinel-report-text.ts
+++ b/src/renderer/components/sentinel/sentinel-report-text.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure helpers for the CCC Sentinel panel: section selection + plain-text
+ * rendering of findings so the panel can offer "Copy" (the modal had no way to
+ * get the report text out). Kept pure + framework-free so it is unit-tested
+ * without rendering, and so the panel and the copy buttons share ONE definition
+ * of "what is shown" — copy output can never drift from the rendered report.
+ * No default export (project convention).
+ */
+import type { SentinelFinding, SentinelStateSnapshot } from '../../../shared/sentinel-types'
+
+export interface SentinelSections {
+  proposals: SentinelFinding[]
+  compatFindings: SentinelFinding[]
+  applied: SentinelFinding[]
+}
+
+/**
+ * Partition a snapshot's findings the same way SentinelPanel renders them:
+ *   - proposals     = open registry-proposal findings
+ *   - compatFindings = open compat/info findings
+ *   - applied       = findings with status 'applied'
+ * dismissed/muted are excluded. A null snapshot yields empty sections.
+ */
+export function selectSentinelSections(snap: SentinelStateSnapshot | null): SentinelSections {
+  const findings = snap?.findings ?? []
+  return {
+    proposals: findings.filter((f) => f.kind === 'registry-proposal' && f.status === 'open'),
+    compatFindings: findings.filter((f) => (f.kind === 'compat' || f.kind === 'info') && f.status === 'open'),
+    applied: findings.filter((f) => f.status === 'applied'),
+  }
+}
+
+/** One finding as copyable plain text: a severity/title head line, the evidence,
+ *  and (for proposals) the proposed patch JSON. */
+export function formatFindingText(finding: SentinelFinding): string {
+  const head = `[${finding.severity.toUpperCase()}] ${finding.title}${finding.affectedFeature ? ` (${finding.affectedFeature})` : ''}`
+  const lines = [head]
+  if (finding.evidence) lines.push(finding.evidence)
+  if (finding.proposedPatch) lines.push(JSON.stringify(finding.proposedPatch, null, 2))
+  return lines.join('\n')
+}
+
+/** The whole report as copyable plain text — header + only the non-empty
+ *  sections, mirroring what the panel shows. */
+export function formatSentinelReportText(snap: SentinelStateSnapshot | null): string {
+  const { proposals, compatFindings, applied } = selectSentinelSections(snap)
+  const version = snap?.lastSeenCcVersion ?? 'unknown'
+  const when = snap?.lastAnalysisAt ? new Date(snap.lastAnalysisAt).toISOString() : 'no analysis yet'
+
+  const out: string[] = ['CCC Sentinel — Compatibility Report', `CC ${version} · ${when}`, '']
+
+  if (proposals.length > 0) {
+    out.push('## Proposed fixes')
+    for (const f of proposals) out.push(formatFindingText(f), '')
+  }
+  if (compatFindings.length > 0) {
+    out.push('## Compatibility report')
+    for (const f of compatFindings) out.push(formatFindingText(f), '')
+  }
+  if (applied.length > 0) {
+    out.push('## Applied')
+    for (const f of applied) out.push(`- ${f.title}`)
+    out.push('')
+  }
+  if (proposals.length === 0 && compatFindings.length === 0 && applied.length === 0) {
+    out.push('No findings — Claude Code and CCC look compatible.')
+  }
+
+  return out.join('\n').trim() + '\n'
+}

--- a/tests/unit/renderer/sentinel-panel-copy.test.tsx
+++ b/tests/unit/renderer/sentinel-panel-copy.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+// Wiring test for the Sentinel report Copy buttons (the modal previously had no
+// way to get its text out). Verifies the header "Copy" writes the full report and
+// a per-row "Copy" writes that finding, through the real component + store.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import SentinelPanel from '../../../src/renderer/components/sentinel/SentinelPanel'
+import { useSentinelStore } from '../../../src/renderer/stores/sentinelStore'
+import {
+  formatSentinelReportText,
+  formatFindingText,
+} from '../../../src/renderer/components/sentinel/sentinel-report-text'
+import type { SentinelFinding, SentinelStateSnapshot } from '../../../src/shared/sentinel-types'
+
+;(globalThis as never as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  act(() => root.render(ui))
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+const compat: SentinelFinding = {
+  id: 'c1',
+  kind: 'compat',
+  severity: 'warn',
+  title: 'enforceAvailableModels constrains --model flag resolution',
+  evidence: 'Added `enforceAvailableModels` managed setting',
+  affectedFeature: 'sessions',
+  status: 'open',
+  createdAt: 1,
+}
+const snap: SentinelStateSnapshot = {
+  lastSeenCcVersion: '2.1.177',
+  analyzing: false,
+  lastAnalysisAt: 1700000000000,
+  lastAnalysisError: null,
+  findings: [compat],
+}
+
+let writeText: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+})
+afterEach(() => {
+  act(() => useSentinelStore.setState({ snap: null, panelOpen: false } as never))
+})
+
+function click(el: Element | null) {
+  expect(el).toBeTruthy()
+  act(() => { el!.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+}
+
+describe('SentinelPanel copy buttons', () => {
+  it('header Copy writes the full report to the clipboard', () => {
+    act(() => useSentinelStore.setState({ snap, panelOpen: true } as never))
+    const { container, unmount } = render(<SentinelPanel />)
+    click(container.querySelector('button[title="Copy the full report to the clipboard"]'))
+    expect(writeText).toHaveBeenCalledWith(formatSentinelReportText(snap))
+    unmount()
+  })
+
+  it('per-row Copy writes just that finding', () => {
+    act(() => useSentinelStore.setState({ snap, panelOpen: true } as never))
+    const { container, unmount } = render(<SentinelPanel />)
+    click(container.querySelector('button[title="Copy this finding"]'))
+    expect(writeText).toHaveBeenCalledWith(formatFindingText(compat))
+    unmount()
+  })
+
+  it('hides the header Copy button when there are no findings', () => {
+    const empty: SentinelStateSnapshot = { ...snap, findings: [] }
+    act(() => useSentinelStore.setState({ snap: empty, panelOpen: true } as never))
+    const { container, unmount } = render(<SentinelPanel />)
+    expect(container.querySelector('button[title="Copy the full report to the clipboard"]')).toBeNull()
+    unmount()
+  })
+})

--- a/tests/unit/renderer/sentinel-report-text.test.ts
+++ b/tests/unit/renderer/sentinel-report-text.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectSentinelSections,
+  formatFindingText,
+  formatSentinelReportText,
+} from '../../../src/renderer/components/sentinel/sentinel-report-text'
+import type { SentinelFinding, SentinelStateSnapshot } from '../../../src/shared/sentinel-types'
+
+function finding(over: Partial<SentinelFinding> = {}): SentinelFinding {
+  return {
+    id: over.id ?? 'cc:2.1.177:1',
+    kind: over.kind ?? 'compat',
+    severity: over.severity ?? 'warn',
+    title: over.title ?? 'enforceAvailableModels constrains --model flag resolution',
+    evidence: over.evidence ?? 'Added `enforceAvailableModels` managed setting',
+    affectedFeature: over.affectedFeature,
+    proposedPatch: over.proposedPatch,
+    status: over.status ?? 'open',
+    createdAt: over.createdAt ?? 1,
+  }
+}
+
+const snap = (over: Partial<SentinelStateSnapshot> = {}): SentinelStateSnapshot => ({
+  lastSeenCcVersion: over.lastSeenCcVersion ?? '2.1.177',
+  analyzing: over.analyzing ?? false,
+  lastAnalysisAt: over.lastAnalysisAt ?? 1700000000000,
+  lastAnalysisError: over.lastAnalysisError ?? null,
+  findings: over.findings ?? [],
+})
+
+describe('selectSentinelSections', () => {
+  it('splits open findings into proposals / compat / applied, excluding dismissed + muted', () => {
+    const findings: SentinelFinding[] = [
+      finding({ id: 'p1', kind: 'registry-proposal', status: 'open' }),
+      finding({ id: 'c1', kind: 'compat', status: 'open' }),
+      finding({ id: 'i1', kind: 'info', status: 'open' }),
+      finding({ id: 'a1', kind: 'compat', status: 'applied' }),
+      finding({ id: 'm1', kind: 'compat', status: 'muted' }),
+      finding({ id: 'd1', kind: 'info', status: 'dismissed' }),
+    ]
+    const out = selectSentinelSections(snap({ findings }))
+    expect(out.proposals.map((f) => f.id)).toEqual(['p1'])
+    expect(out.compatFindings.map((f) => f.id)).toEqual(['c1', 'i1'])
+    expect(out.applied.map((f) => f.id)).toEqual(['a1'])
+  })
+
+  it('returns empty arrays for a null snapshot', () => {
+    expect(selectSentinelSections(null)).toEqual({ proposals: [], compatFindings: [], applied: [] })
+  })
+})
+
+describe('formatFindingText', () => {
+  it('renders severity, title, affected feature and evidence', () => {
+    const text = formatFindingText(finding({ affectedFeature: 'sessions' }))
+    expect(text).toBe(
+      '[WARN] enforceAvailableModels constrains --model flag resolution (sessions)\n' +
+        'Added `enforceAvailableModels` managed setting',
+    )
+  })
+
+  it('omits the feature parenthetical when there is no affected feature', () => {
+    const text = formatFindingText(finding({ affectedFeature: undefined }))
+    expect(text.startsWith('[WARN] enforceAvailableModels constrains --model flag resolution\n')).toBe(true)
+    expect(text).not.toContain('()')
+  })
+
+  it('appends the proposed patch JSON for a proposal finding', () => {
+    const text = formatFindingText(
+      finding({ kind: 'registry-proposal', proposedPatch: { id: 'claude-x', displayName: 'Claude X' } as never }),
+    )
+    expect(text).toContain('"id": "claude-x"')
+  })
+})
+
+describe('formatSentinelReportText', () => {
+  it('includes the CC version header and only the non-empty sections', () => {
+    const findings: SentinelFinding[] = [
+      finding({ id: 'c1', kind: 'compat', title: 'Compat one', evidence: 'ev one' }),
+      finding({ id: 'i1', kind: 'info', severity: 'info', title: 'Info two', evidence: 'ev two' }),
+    ]
+    const text = formatSentinelReportText(snap({ findings }))
+    expect(text).toContain('CCC Sentinel')
+    expect(text).toContain('CC 2.1.177')
+    expect(text).toContain(new Date(1700000000000).toISOString())
+    expect(text).toContain('Compatibility report')
+    expect(text).toContain('[WARN] Compat one')
+    expect(text).toContain('[INFO] Info two')
+    // no empty sections
+    expect(text).not.toContain('Proposed fixes')
+    expect(text).not.toContain('Applied')
+  })
+
+  it('renders a clean "no findings" line when there is nothing open', () => {
+    const text = formatSentinelReportText(snap({ findings: [] }))
+    expect(text).toContain('No findings')
+  })
+
+  it('handles a null snapshot without throwing', () => {
+    expect(() => formatSentinelReportText(null)).not.toThrow()
+    expect(formatSentinelReportText(null)).toContain('CCC Sentinel')
+  })
+})


### PR DESCRIPTION
The CCC Sentinel compatibility-report modal had no way to get its text out.

- **Header "Copy"** copies the whole report as plain text (CC version + date, each non-empty section, every finding with severity/title/feature/evidence). Shown only when there are findings.
- **Per-finding "Copy"** on each row copies just that finding.
- A shared `selectSentinelSections()` drives both the rendered panel and the copy output, so copied text can't drift from what's shown.

### Tests
- Formatter/selector: 8 unit tests (TDD).
- Component wiring: 3 tests that render `SentinelPanel`, click the header + per-row Copy, and assert `clipboard.writeText`.
- Full suite 2625 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)