### PR TITLE
Signal host light/dark to Claude via COLORFGBG (light-mode terminal fix)

### DIFF
--- a/src/main/providers/claude/spawn.ts
+++ b/src/main/providers/claude/spawn.ts
@@ -5,6 +5,21 @@ import { logInfo } from '../../debug-logger'
 import type { LegacyVersion } from '../../../shared/types'
 import type { SpawnOptions } from '../types'
 
+/**
+ * Resolves the host's effective light/dark scheme from the CCC theme setting.
+ * 'light'/'dark' are explicit; 'system' (or absent, but absent defaults to the
+ * app's dark default) follows the OS preference. Pure so it is table-testable;
+ * the caller supplies the OS preference (Electron nativeTheme.shouldUseDarkColors).
+ */
+export function resolveHostColorScheme(
+  themePref: string | undefined,
+  systemPrefersDark: boolean,
+): 'light' | 'dark' {
+  if (themePref === 'light') return 'light'
+  if (themePref === 'system') return systemPrefersDark ? 'dark' : 'light'
+  return 'dark'
+}
+
 export function resolveClaudeBinary(legacyVersion?: LegacyVersion): { cmd: string; args: string[] } {
   if (legacyVersion?.enabled && legacyVersion.version) {
     const legacyBin = resolveVersionBinary(legacyVersion.version)
@@ -43,6 +58,20 @@ export function resolveClaudeBinary(legacyVersion?: LegacyVersion): { cmd: strin
  */
 export function buildClaudeLocalSpawn(opts: SpawnOptions): { cmd: string; args: string[]; env: Record<string, string> } {
   const env: Record<string, string> = { ...process.env, CLAUDE_MULTI_SESSION_ID: opts.sessionId } as Record<string, string>
+
+  // Tell Claude Code (and any TUI) the host terminal's light/dark scheme via
+  // COLORFGBG, which Claude reads FIRST when auto-detecting its theme. Without
+  // this, a session launched while CCC is in light mode keeps Claude's dark
+  // theme, so its user-message blocks render with dark/black backgrounds on the
+  // light terminal. Format is "foreground;background" by ANSI index; Claude reads
+  // the background field (7 / 9-15 = light, 0-6 / 8 = dark). Set for ALL session
+  // kinds (the terminal IS this theme). dark -> "15;0" matches the prior implicit
+  // behavior, so dark mode is unchanged; only theme detection runs at startup, so
+  // this affects newly launched sessions, not ones already running.
+  if (opts.hostColorScheme) {
+    env.COLORFGBG = opts.hostColorScheme === 'light' ? '0;15' : '15;0'
+  }
+
   if (opts.disableAutoMemory) env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1'
 
   const shell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash')

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -23,6 +23,10 @@ export interface SpawnOptions {
    *  copy/paste). When false, CC's mouse mode is preserved. Shell-only sessions
    *  are never affected regardless of this flag. */
   classicTerminalCopyPaste?: boolean
+  /** Host (CCC) effective light/dark scheme, stamped into COLORFGBG so Claude
+   *  Code's startup theme auto-detection matches the terminal. Resolved by the
+   *  caller from AppSettings.theme + the OS preference. Absent = no COLORFGBG. */
+  hostColorScheme?: 'light' | 'dark'
   // Codex-specific (only present when provider === 'codex')
   codexOptions?: CodexOptions
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, nativeTheme } from 'electron'
 import * as pty from 'node-pty'
 import { PasteQueue } from './paste-queue'
 import { runChunkedWrite, WRITE_CHUNK_SIZE, WRITE_CHUNK_DELAY } from './pty-chunked-write'
@@ -14,7 +14,7 @@ import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
-import { resolveClaudeBinary } from './providers/claude/spawn'
+import { resolveClaudeBinary, resolveHostColorScheme } from './providers/claude/spawn'
 import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
 import { isSshCapable } from './providers/types'
@@ -942,9 +942,15 @@ export function spawnPty(
     // bare shell + env comes from the provider.
     const shellOnly = options?.shellOnly
     const provider = getProvider('claude')
-    // Read classicTerminalCopyPaste fresh on every spawn (default true when absent).
-    const claudeSpawnSettings = readConfig<{ classicTerminalCopyPaste?: boolean }>('settings')
+    // Read classicTerminalCopyPaste + theme fresh on every spawn (default true /
+    // dark when absent). The theme drives COLORFGBG so Claude's startup theme
+    // auto-detection matches CCC; 'system' follows the OS via nativeTheme.
+    const claudeSpawnSettings = readConfig<{ classicTerminalCopyPaste?: boolean; theme?: string }>('settings')
     const classicTerminalCopyPaste = claudeSpawnSettings?.classicTerminalCopyPaste !== false
+    const hostColorScheme = resolveHostColorScheme(
+      claudeSpawnSettings?.theme,
+      nativeTheme.shouldUseDarkColors,
+    )
     const { cmd: spawnCmd, args: spawnArgs, env: spawnEnv } = provider.buildSpawnCommand({
       sessionId,
       cwd: options?.cwd,
@@ -959,6 +965,7 @@ export function spawnPty(
       useResumePicker: options?.useResumePicker,
       agentsConfig: options?.agentsConfig,
       classicTerminalCopyPaste,
+      hostColorScheme,
     })
     const wantProfileId = options?.profileId
     if (wantProfileId && fs.existsSync(getProfileConfigDir(wantProfileId))) {

--- a/tests/unit/providers/claude/colorfgbg-env.test.ts
+++ b/tests/unit/providers/claude/colorfgbg-env.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TDD: COLORFGBG env injection (light/dark signal for Claude Code theme detection)
+ *
+ * Claude Code reads COLORFGBG first to auto-detect the terminal background and
+ * pick its light/dark theme. A host (CCC) flipped to light mode but never told
+ * Claude, so Claude kept rendering its user-message blocks with dark backgrounds
+ * (black on a light terminal). We now stamp COLORFGBG from the host's resolved
+ * scheme so a session LAUNCHED in light mode themes light.
+ *
+ * Format is "foreground;background" by ANSI index; Claude reads the background
+ * field (7 or 9-15 = light, 0-6/8 = dark). dark -> "15;0" matches the prior
+ * default behavior, so dark mode is unchanged.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { buildClaudeLocalSpawn, resolveHostColorScheme } from '../../../../src/main/providers/claude/spawn'
+
+const BASE_OPTS = { sessionId: 'ses-1', cwd: '/work', cols: 80, rows: 24 }
+
+beforeEach(() => {
+  delete process.env.COLORFGBG
+})
+afterEach(() => {
+  delete process.env.COLORFGBG
+})
+
+describe('buildClaudeLocalSpawn — COLORFGBG', () => {
+  it('stamps a light background value when the host is light', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, hostColorScheme: 'light' })
+    expect(env.COLORFGBG).toBe('0;15')
+  })
+
+  it('stamps a dark background value when the host is dark', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, hostColorScheme: 'dark' })
+    expect(env.COLORFGBG).toBe('15;0')
+  })
+
+  it('does not set COLORFGBG when the host scheme is unspecified', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS })
+    expect(env.COLORFGBG).toBeUndefined()
+  })
+
+  it('applies to shell-only sessions too (the terminal IS that theme)', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true, hostColorScheme: 'light' })
+    expect(env.COLORFGBG).toBe('0;15')
+  })
+})
+
+describe('resolveHostColorScheme', () => {
+  it('maps explicit light / dark directly (OS preference ignored)', () => {
+    expect(resolveHostColorScheme('light', true)).toBe('light')
+    expect(resolveHostColorScheme('dark', false)).toBe('dark')
+  })
+
+  it('follows the OS preference for the system theme', () => {
+    expect(resolveHostColorScheme('system', true)).toBe('dark')
+    expect(resolveHostColorScheme('system', false)).toBe('light')
+  })
+
+  it('defaults to dark when unset (matches the app default theme)', () => {
+    expect(resolveHostColorScheme(undefined, false)).toBe('dark')
+  })
+})


### PR DESCRIPTION
## Summary

Found during v1.5.43-beta light-mode testing: Claude Code's own user-message blocks (`>` lines) render with dark/black backgrounds in light mode. Root cause — CCC's light flip recolors the xterm background + palette, but **Claude themes its own UI at startup** based on the terminal background, and CCC never signaled it. Claude defaulted to dark and painted true-color dark blocks CCC's palette can't remap.

## Fix

Stamp `COLORFGBG` into the Claude spawn env from CCC's resolved scheme — Claude reads it first for theme auto-detection.

- New pure `resolveHostColorScheme(themePref, systemPrefersDark)` maps `AppSettings.theme` (`light`/`dark`/`system` → OS via `nativeTheme`).
- `buildClaudeLocalSpawn` sets `COLORFGBG` (`light → "0;15"`, `dark → "15;0"`) for all session kinds.
- `pty-manager` reads the theme fresh per spawn.

**Additive + dark-mode-neutral:** `"15;0"` matches the prior implicit behavior, so dark mode is byte-identical. Theme detection is startup-only, so this applies to **newly launched** sessions (restart / new), not ones already running; a **pinned** Claude theme still wins (`/config → Light`).

## Verification

- TDD: COLORFGBG env injection + `resolveHostColorScheme` (7 tests). typecheck **0**, unit **2687**, native **93**.
- Note: a live light-mode render couldn't be verified here (can't double-boot CCC); grounded in Claude Code's documented COLORFGBG-first detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)