### PR TITLE
fix(terminal): honor scrollbar/keyboard scroll-up during live output (#73)

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -15,6 +15,7 @@ import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
 import { isControlReportOnly, decideContextMenuAction } from '../utils/terminalInput'
+import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
 import { ScrollToBottomButton } from './terminal'
@@ -614,12 +615,24 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         bytesReceived += data.length
         strippedBytes += data.length - filtered.length
         bytesWritten += filtered.length
+
+        // Sticky-bottom follow (issue #73): sample the LIVE viewport position
+        // BEFORE this chunk lays out and decide from THAT — not from the
+        // wheel-set latch, which scrollbar-thumb drags and keyboard scrolling
+        // never touched, so live output kept yanking the viewport back down.
+        // onData chunks run atomically, so viewportY is the user's current
+        // position. Keeps the scrolled-up latch (the scroll-to-bottom button)
+        // in sync with where the user actually is, every chunk.
+        const preWriteBuf = term?.buffer.active
+        const follow = decideFollow({
+          viewportY: preWriteBuf?.viewportY ?? 0,
+          baseY: preWriteBuf?.baseY ?? 0,
+        })
+
         term?.write(filtered)
 
-        // Only auto-scroll if user hasn't scrolled up
-        if (!isScrolledUpRef.current) {
-          term?.scrollToBottom()
-        }
+        if (follow.scrollToBottom) term?.scrollToBottom()
+        if (follow.scrolledUp !== isScrolledUpRef.current) updateScrollState(follow.scrolledUp)
 
         // Post-resume settle nudge: every chunk re-arms the timer; it fires only
         // once a burst has gone quiet for 600ms, and only while shots remain.

--- a/src/renderer/utils/terminalScroll.ts
+++ b/src/renderer/utils/terminalScroll.ts
@@ -1,0 +1,46 @@
+// Sticky-bottom scroll-follow decision for the xterm terminal viewport.
+//
+// Issue #73: while a session was producing output, dragging the scrollbar thumb
+// (or scrolling with the keyboard) jumped the viewport straight back to the
+// bottom. The old TerminalView logic gated auto-scroll on a "user scrolled up"
+// latch that was set ONLY by the mouse-wheel handler. Scrollbar-thumb drags and
+// PageUp/Up/Home emit `scroll`/`keydown` events, never `wheel`, so the latch
+// stayed false and the next PTY output chunk's `scrollToBottom()` yanked the
+// viewport down again.
+//
+// The fix is to stop trusting an input-set latch and instead read where the
+// user ACTUALLY is, sampled from the live buffer position BEFORE each output
+// chunk lays out — the same `viewportY >= baseY` check the wheel handler
+// already relies on. That honors a scroll-up performed by ANY means. Sampling
+// before the write is reliable because xterm `onData` chunks run atomically:
+// `viewportY` reflects the user's most recent scroll by the time the next chunk
+// arrives.
+
+/** Live xterm viewport geometry, read from `terminal.buffer.active`. */
+export interface ScrollViewport {
+  /** Top visible buffer line (xterm `buffer.active.viewportY` / ydisp). */
+  viewportY: number
+  /** Top line when scrolled fully to the bottom (`buffer.active.baseY` / ybase). */
+  baseY: number
+}
+
+export interface ScrollFollowDecision {
+  /** Snap the viewport to the bottom after this chunk lays out. */
+  scrollToBottom: boolean
+  /**
+   * The "user scrolled up" latch to apply — drives the scroll-to-bottom
+   * button's visibility. True iff the viewport is currently above the bottom.
+   */
+  scrolledUp: boolean
+}
+
+/**
+ * Decide whether to keep following the tail for an output chunk, from the
+ * viewport position sampled BEFORE the chunk is written. Follow (and hide the
+ * scroll-to-bottom button) exactly when the user is at the bottom; otherwise
+ * preserve their position and surface the button.
+ */
+export function decideFollow(v: ScrollViewport): ScrollFollowDecision {
+  const atBottom = v.viewportY >= v.baseY
+  return { scrollToBottom: atBottom, scrolledUp: !atBottom }
+}

--- a/tests/unit/terminalScroll.test.ts
+++ b/tests/unit/terminalScroll.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { decideFollow } from '../../src/renderer/utils/terminalScroll'
+
+describe('decideFollow (issue #73 sticky-bottom)', () => {
+  it('follows when the viewport is exactly at the bottom', () => {
+    expect(decideFollow({ viewportY: 100, baseY: 100 })).toEqual({
+      scrollToBottom: true,
+      scrolledUp: false,
+    })
+  })
+
+  it('follows a fresh, empty buffer (both zero)', () => {
+    expect(decideFollow({ viewportY: 0, baseY: 0 })).toEqual({
+      scrollToBottom: true,
+      scrolledUp: false,
+    })
+  })
+
+  it('stops following and flags scrolled-up when the user is above the bottom', () => {
+    // The core bug: a scrollbar-thumb drag leaves viewportY < baseY. Previously
+    // the wheel-only latch stayed false here and the next chunk yanked down.
+    expect(decideFollow({ viewportY: 40, baseY: 100 })).toEqual({
+      scrollToBottom: false,
+      scrolledUp: true,
+    })
+  })
+
+  it('treats a viewport past the base (transient over-scroll) as at the bottom', () => {
+    expect(decideFollow({ viewportY: 101, baseY: 100 })).toEqual({
+      scrollToBottom: true,
+      scrolledUp: false,
+    })
+  })
+
+  it('resumes following the moment the user returns to the bottom', () => {
+    // scrolled up ...
+    expect(decideFollow({ viewportY: 40, baseY: 100 }).scrolledUp).toBe(true)
+    // ... then dragged/paged back down to the bottom.
+    expect(decideFollow({ viewportY: 100, baseY: 100 })).toEqual({
+      scrollToBottom: true,
+      scrolledUp: false,
+    })
+  })
+
+  it('keeps honoring a scrolled-up viewport as scrollback grows (baseY climbs)', () => {
+    // Output keeps arriving while the user reads history: viewportY stays put,
+    // baseY climbs. Must remain scrolled-up on every chunk, never snap down.
+    expect(decideFollow({ viewportY: 40, baseY: 200 }).scrolledUp).toBe(true)
+    expect(decideFollow({ viewportY: 40, baseY: 500 }).scrolledUp).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #73.

## Problem
While a session is producing output, dragging the vertical scrollbar thumb (or scrolling with the keyboard) snaps the viewport back to the bottom on the next output chunk. Mouse-wheel scroll-up holds; scrollbar/keyboard do not.

## Root cause
`TerminalView` gated auto-scroll on a single "user scrolled up" latch (`isScrolledUpRef`) that was set **only** by the `wheel` handler. Scrollbar-thumb drags and PageUp/Up/Home emit `scroll`/`keydown` events, never `wheel`, so the latch stayed `false`. The per-chunk PTY output handler then saw `!isScrolledUpRef.current` and called `term.scrollToBottom()`, undoing the scroll. In a running session (continuous output) this reproduces on every chunk.

## Fix
Stop trusting the input-set latch for the follow decision. Sample the **live viewport position** (`viewportY >= baseY` — the same check the wheel handler already trusts) **before** each output chunk lays out, and follow only when the user is at the bottom. `onData` chunks run atomically, so `viewportY` reflects the user's most recent scroll regardless of *how* they scrolled. The scrolled-up latch (which drives the scroll-to-bottom button) is now synced to actual position every chunk.

Decision logic extracted to a pure `decideFollow` helper (`src/renderer/utils/terminalScroll.ts`) with unit tests, matching the existing `terminalInput`/`terminalFormatting` util pattern. The wheel handler (incl. its scroll-corruption `refresh`) and the return-to-bottom `onScroll` handler are unchanged and remain consistent with the per-chunk sync.

## Testing
- `npm run test:unit` — new `tests/unit/terminalScroll.test.ts` (6 cases: at-bottom, empty buffer, scrolled-up, over-scroll, return-to-bottom, scrollback-grows-while-scrolled-up). All pass.
- `npm run typecheck` — clean.
- **Not** covered automatically: the end-to-end GUI drag (Electron + live PTY + manual scrollbar drag). Recommend a manual pass — start a session with continuous output, drag the scrollbar up, confirm it stays put and the scroll-to-bottom button appears, then confirm follow resumes on return to bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)