### PR TITLE
fix(multi-account): relaunch continues each session under its saved account (#76)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -75,7 +75,7 @@ import AutoDetectBanner from './components/github/AutoDetectBanner'
 import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import RepoBreadcrumb from './components/RepoBreadcrumb'
 import type { SessionState, SavedSession } from './types/electron'
-import { buildSessionState, buildSessionStateWithResumeTargets } from './session-persistence'
+import { buildSessionState, buildSessionStateWithResumeTargets, markRestoredSessionsPredetermined } from './session-persistence'
 import { useSessionAutosave } from './hooks/useSessionAutosave'
 
 // Re-export ViewType from its canonical location for backwards compatibility
@@ -572,6 +572,14 @@ export default function App() {
           markSessionForResumePicker(session.id)
         }
       }
+
+      // Relaunch must CONTINUE each session under the same account it was closed
+      // on (issue #76). The account is already determined (persisted profileId),
+      // so -- like in-session Restart/Recover/Switch -- mark the restored sessions
+      // predetermined BEFORE the store restore mounts their TerminalViews, so each
+      // spawn skips the pre-spawn AccountLaunchGate re-prompt and respawns under
+      // its saved account.
+      markRestoredSessionsPredetermined(restoredSessions.map((s) => s.id))
 
       useSessionStore.getState().restoreSessions(restoredSessions, savedState.activeSessionId)
       await window.electronAPI.session.clear()

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -1,4 +1,5 @@
 import { useSessionStore } from './stores/sessionStore'
+import { useAccountGateStore } from './stores/accountGateStore'
 import type { SessionState, SavedSession } from './types/electron'
 
 // Serialize the current sessionStore into the shape the main process persists.
@@ -108,6 +109,28 @@ export async function buildSessionStateWithResumeTargets(): Promise<SessionState
  * BEFORE the await, so callers that immediately read the store / respawn still
  * see the new id; the disk flush is best-effort and never blocks the spawn.
  */
+/**
+ * Mark every relaunch-restored session as predetermined in the account gate so
+ * its respawn continues under the SAME account it was closed on, skipping the
+ * pre-spawn AccountLaunchGate re-prompt (issue #76).
+ *
+ * The relaunch account is already determined -- it is the persisted
+ * session.profileId -- exactly like an in-session Restart/Recover/Switch, all of
+ * which call markPredetermined for the same reason. Without this, every restored
+ * multi-account (>=2 profiles) session re-pops the picker on each launch and does
+ * not auto-continue under its account; a relaunched session could even come back
+ * on a different account than it left.
+ *
+ * Must be called BEFORE the store restore that mounts the TerminalViews, so the
+ * flag is set before each spawn effect reads consumePredetermined(). The flag is
+ * consumed only on the gate-eligible path, so it is a harmless no-op for
+ * single-account / shell-only / Codex / SSH restores.
+ */
+export function markRestoredSessionsPredetermined(sessionIds: string[]): void {
+  const gate = useAccountGateStore.getState()
+  for (const id of sessionIds) gate.markPredetermined(id)
+}
+
 export async function persistLastUsedAccount(sessionId: string, profileId: string | undefined): Promise<void> {
   useSessionStore.getState().updateSession(sessionId, { profileId })
   try {

--- a/tests/unit/renderer/mark-restored-predetermined.test.ts
+++ b/tests/unit/renderer/mark-restored-predetermined.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+// Regression (issue #76): relaunch-restored sessions must CONTINUE under the
+// account they were closed on, not re-pop the pre-spawn AccountLaunchGate. The
+// restore path marks each restored session predetermined so its respawn skips
+// the gate -- exactly like in-session Restart/Recover/Switch.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { markRestoredSessionsPredetermined } from '../../../src/renderer/session-persistence'
+import { useAccountGateStore } from '../../../src/renderer/stores/accountGateStore'
+
+beforeEach(() => {
+  useAccountGateStore.setState({ queue: [], predetermined: [] })
+})
+
+describe('markRestoredSessionsPredetermined', () => {
+  it('marks every restored session predetermined so its spawn skips the gate', () => {
+    markRestoredSessionsPredetermined(['s1', 's2', 's3'])
+    const gate = useAccountGateStore.getState()
+    // Each id is predetermined: consume returns true once, then clears.
+    expect(gate.consumePredetermined('s1')).toBe(true)
+    expect(gate.consumePredetermined('s2')).toBe(true)
+    expect(gate.consumePredetermined('s3')).toBe(true)
+    // Consumed -> cleared (a later in-session restart re-gates as normal).
+    expect(useAccountGateStore.getState().consumePredetermined('s1')).toBe(false)
+  })
+
+  it('is a no-op for an empty restore set', () => {
+    markRestoredSessionsPredetermined([])
+    expect(useAccountGateStore.getState().predetermined).toHaveLength(0)
+  })
+
+  it('does not disturb an unrelated session (still gates as normal)', () => {
+    markRestoredSessionsPredetermined(['s1'])
+    // A brand-new (non-restored) session was never marked -> still needs the gate.
+    expect(useAccountGateStore.getState().consumePredetermined('brand-new')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

On app relaunch, restored sessions now respawn directly under the account they were closed on, skipping the pre-spawn account picker — consistent with in-session **Restart**/**Recover**/**Switch**.

Closes #76.

## Why

`restoreSavedSessions()` restored `session.profileId` from `session-state.json` but never marked the restored sessions *predetermined* in the account gate. `useRestartSession.restart()`/`recover()` (and Switch, which routes through restart) all call `markPredetermined()` so the respawn skips the `AccountLaunchGate` — the account is already decided. Relaunch is the same case (the account **is** the persisted `profileId`), so every restored multi-account (≥2 profiles) session re-popped the picker on each launch and did not auto-continue under its account. A relaunched session could even come back under a different account than it left, so it couldn't continue its work.

## How

- New `markRestoredSessionsPredetermined(sessionIds)` helper in `session-persistence.ts`.
- `restoreSavedSessions()` calls it **before** the store restore mounts the `TerminalView`s, so the flag is set before each spawn effect reads `consumePredetermined()`.
- The flag is consumed only on the gate-eligible path, so it is a harmless no-op for single-account / shell-only / Codex / SSH restores.

## Test

- `tests/unit/renderer/mark-restored-predetermined.test.ts` — restored ids are predetermined (consume→true then cleared); empty set is a no-op; unrelated sessions still gate.
- Full suite green: `npx vitest run` → 2968 passed / 4 skipped; `npx tsc --noEmit` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
