### PR TITLE
docs(contributing): always cut an RC branch; keep beta open for features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,25 @@ npx tsc --noEmit       # Type-check only
 
 ## Branching Model
 
-- `beta` - default working branch (all development happens here)
-- `main` - stable releases only (updated by merging the `beta` → `main` GitHub PR with a merge commit)
+- `beta` - default working branch; all feature development happens here, continuously. `beta` is **never frozen** for a release.
+- `release/vX.Y.Z` - a release-candidate branch cut from `beta` for **every** release. All RC stabilization happens here, not on `beta`.
+- `main` - stable releases only (updated by merging the accepted `release/vX.Y.Z` branch with a merge commit).
 
 ### For contributors
 
 1. Fork the repo and create a feature branch from `beta`
 2. Make your changes and ensure tests pass
 3. Submit a PR targeting `beta`
+
+### Release candidates
+
+We cut a dedicated RC branch for every release cycle so that `beta` stays open for feature development at all times — features never wait for a release to finish stabilizing.
+
+- When a release is ready to stabilize, cut a `release/vX.Y.Z` branch from `beta` and tag the `-rc.N` builds **there**.
+- **`beta`:** feature branches and fix branches merge here continuously; it is never frozen.
+- **`release/vX.Y.Z`:** bug fixes and stabilization only — **no features**. The RC branch is the proposed stable release; merging a feature into it invalidates the candidate.
+- Fixes made on the RC branch are back-ported to `beta` so the next cycle keeps them.
+- When the RC is accepted, merge `release/vX.Y.Z` → `main`, then delete the RC branch.
 
 ## Commit Messages
 


### PR DESCRIPTION
Closes #88.

Reworks the **Branching Model** section of `CONTRIBUTING.md` so that a release-candidate branch is cut for **every** release cycle, keeping `beta` open for feature development at all times.

### What changes
- `beta` is documented as a perpetual feature-integration branch that is **never frozen**.
- Adds `release/vX.Y.Z` as a first-class branch: cut from `beta` per cycle, carries the `-rc.N` tags, fixes/stabilization only.
- `main` is now updated by merging the accepted `release/vX.Y.Z` branch (was: `beta → main`).
- New **Release candidates** subsection spelling out the flow: tag RCs on the release branch, back-port fixes to `beta`, ship the accepted RC to `main`, delete the RC branch.

### Scope
Documentation only — `CONTRIBUTING.md`, 1 file.

### Follow-up (not in this PR)
Release automation still assumes RCs are cut from `beta` (`release.yml --ref beta`) and that `main` is promoted via `beta → main` (`scripts/promote.js`). Aligning the tooling — `CLAUDE.md` → Release Process, `scripts/release.js`, `scripts/promote.js` — is tracked in #88 as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
