### PR TITLE
fix(ci): Windows release-branch steps never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,9 @@ jobs:
       # uses, so the macOS DMG is unsigned and Gatekeeper will warn on
       # first launch (right-click → Open). The Windows installer is also
       # unsigned, same SmartScreen warning as the release pipeline.
-      # Gate on runner.os, NOT a matrix image name: `matrix.os` is pinned
-      # (windows-2025) and drifts whenever an image is re-pinned, which silently
-      # turns these steps off. They were dead from the windows-latest -> -2025 pin
-      # until 2026-07-15 for exactly that reason.
+      # Gate on runner.os, NOT a matrix image name: `matrix.os` carries whatever
+      # image is pinned above, so a re-pin silently turns these steps off while
+      # the job stays green.
       - name: Package Windows installer (release/* branches only)
         if: runner.os == 'Windows' && startsWith(github.head_ref, 'release/')
         run: npx electron-builder --win

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,20 +97,24 @@ jobs:
       # uses, so the macOS DMG is unsigned and Gatekeeper will warn on
       # first launch (right-click → Open). The Windows installer is also
       # unsigned, same SmartScreen warning as the release pipeline.
+      # Gate on runner.os, NOT a matrix image name: `matrix.os` is pinned
+      # (windows-2025) and drifts whenever an image is re-pinned, which silently
+      # turns these steps off. They were dead from the windows-latest -> -2025 pin
+      # until 2026-07-15 for exactly that reason.
       - name: Package Windows installer (release/* branches only)
-        if: matrix.os == 'windows-latest' && startsWith(github.head_ref, 'release/')
+        if: runner.os == 'Windows' && startsWith(github.head_ref, 'release/')
         run: npx electron-builder --win
 
       - name: Verify native modules unpacked (release/* branches only)
-        if: matrix.os == 'windows-latest' && startsWith(github.head_ref, 'release/')
+        if: runner.os == 'Windows' && startsWith(github.head_ref, 'release/')
         run: npm run verify:package
 
       - name: Package macOS DMG (release/* branches only)
-        if: matrix.os == 'macos-latest' && startsWith(github.head_ref, 'release/')
+        if: runner.os == 'macOS' && startsWith(github.head_ref, 'release/')
         run: npx electron-builder --mac
 
       - name: Upload Windows installer
-        if: matrix.os == 'windows-latest' && startsWith(github.head_ref, 'release/')
+        if: runner.os == 'Windows' && startsWith(github.head_ref, 'release/')
         uses: actions/upload-artifact@v4
         with:
           name: windows-installer-${{ github.sha }}
@@ -119,7 +123,7 @@ jobs:
           retention-days: 14
 
       - name: Upload macOS DMG
-        if: matrix.os == 'macos-latest' && startsWith(github.head_ref, 'release/')
+        if: runner.os == 'macOS' && startsWith(github.head_ref, 'release/')
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg-${{ github.sha }}


### PR DESCRIPTION
## What

Three CI steps have been dead since the runner image was pinned:

| Step | Gate | Matrix value | Ran? |
|---|---|---|---|
| Package Windows installer | `matrix.os == 'windows-latest'` | `windows-2025` | **never** |
| Verify native modules unpacked | `matrix.os == 'windows-latest'` | `windows-2025` | **never** |
| Upload Windows installer | `matrix.os == 'windows-latest'` | `windows-2025` | **never** |
| Package macOS DMG | `matrix.os == 'macos-latest'` | `macos-latest` | yes |
| Upload macOS DMG | `matrix.os == 'macos-latest'` | `macos-latest` | yes |

When `windows-latest` was pinned to `windows-2025` (the vs2026 image broke
`@electron/node-gyp`), the matrix changed but these `if:` conditions didn't.
`windows-latest` no longer matches any leg, so the steps skip. The macOS twins
kept working, so the job stayed green and nothing surfaced the gap.

## Why it matters

These steps only fire on PRs **from** `release/*` — i.e. exactly the
`release/2.0.0 → main` stable promote. Local packaging isn't possible on the
maintainer's machine (VS2026 ships no Spectre libs, so node-pty can't
source-build), so CI is the *only* Windows installer + native-unpack check
that runs before a promote. Right now it isn't running.

## Fix

Gate on `runner.os` rather than an image name. This is already the idiom used
by the VS2022 Build Tools step, and it survives future re-pins.

The macOS conditions are converted too — they pass today only because
`macos-latest` is still literally the matrix value, and would break in exactly
the same silent way the next time that gets pinned.

## Verification

- `ci.yml` parses; matrix resolves to `["windows-2025","macos-latest"]`
- No `matrix.os ==` conditions remain
- Both packaging steps now reachable on their respective legs

Note the steps still can't be exercised by *this* PR — its head isn't
`release/*`. First real exercise is the promote PR.