### PR TITLE
fix(release): teach release.js + promote.js the RC-branch model (#88)

### DIFF
--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -1,31 +1,48 @@
 #!/usr/bin/env node
 /**
- * Promote the current beta to a stable release.
+ * Promote an accepted release candidate to stable.
  *
- * Branching model:
- *   - `beta` is the working branch where all features land.
- *   - `main` is stable-only — it receives changes by merging the beta → main PR.
+ * Branching model (RC-branch model — see CONTRIBUTING.md → Branching Model):
+ *   - `beta`          : perpetual feature integration, never frozen.
+ *   - `release/X.Y.Z` : stabilization for one release, carrying `X.Y.Z-rc.N`.
+ *   - `main`          : stable only. Receives `release/X.Y.Z` at promote time.
  *
  * What this script does:
- *   1. Verifies you're on `beta`, tree is clean, `main` is a strict ancestor.
- *   2. Fetches the latest state of both branches from origin.
- *   3. Merges the beta → main PR via `gh pr merge`, promoting beta to main.
- *   4. Syncs local main to match the merged remote main.
- *   5. Optionally runs `node scripts/release.js --stable --no-bump` from main
- *      to ship a stable release at the same version as the current beta.
+ *   1. Verifies you're on `release/X.Y.Z`, tree is clean, in sync with origin.
+ *   2. Verifies package.json is an `-rc.N` of exactly the branch's base version.
+ *   3. Warns about release-branch work that was never back-ported to `beta`.
+ *   4. Finds or creates the `release/X.Y.Z → main` PR and merges it.
+ *   5. Syncs local main, then ships stable from main at the stripped version
+ *      (`2.0.0-rc.2` → `2.0.0`).
  *
  * Usage:
  *   npm run promote           (interactive — asks before running release)
  *   npm run promote -- --yes  (no prompts, immediately releases stable)
  *   npm run promote -- --ff-only  (just promote main, don't run release)
  *
- * After this script runs, you'll be left on `beta` ready for the next
- * round of feature work.
+ * Requires repo-admin rights. Two ruleset rules are bypassed on the way through,
+ * both by design and both only the owner can satisfy:
+ *   - The PR needs a code-owner approval, and the promote PR's author IS the
+ *     code owner (CODEOWNERS is `* @nubbymong`). Nobody can self-approve, so
+ *     the merge lands via the owner's admin bypass.
+ *   - `protect-release-lines` allows squash only. Stable promotes have always
+ *     been merge commits (`Promote beta v1.4.x → main` on main's first-parent
+ *     walk), which is what keeps main's history connected to the release lines;
+ *     a squash would flatten the release into one commit and cut main's shared
+ *     ancestry with beta. The squash-only rule predates this path and was
+ *     written for feature PRs.
+ *
+ * After this script runs you are left on main. Delete the release branch once
+ * the stable release is verified — the script does not do it for you.
  */
 
 const { execSync } = require('child_process')
 const path = require('path')
 const readline = require('readline')
+
+// Version rules live in release.js, which guards main() behind
+// `require.main === module` — requiring it here imports only pure helpers.
+const { parseVersion, releaseBranchBase } = require('./release.js')
 
 const PROJECT_ROOT = path.resolve(__dirname, '..')
 
@@ -56,13 +73,63 @@ function ask(question) {
   })
 }
 
-;(async () => {
+// ============================================================
+// PURE LOGIC (exported for unit tests — tests/unit/scripts/promote.test.ts)
+// ============================================================
+
+/**
+ * The stable version a release branch promotes to, with the guards that make
+ * the promote safe. Throws with an actionable message rather than returning a
+ * sentinel, because every one of these is a stop-the-line condition.
+ */
+function stableVersionFor(branch, currentVersion) {
+  const base = releaseBranchBase(branch)
+  if (!base) {
+    throw new Error(
+      `Must be on a release branch to promote — '${branch}' is not release/X.Y.Z.\n      ` +
+      `Under the RC-branch model, stable is promoted from the release branch, not from beta.`
+    )
+  }
+  const cur = parseVersion(currentVersion)
+  if (!cur) {
+    throw new Error(`Cannot parse package.json version "${currentVersion}"`)
+  }
+  const curBase = `${cur.major}.${cur.minor}.${cur.patch}`
+  if (curBase !== base) {
+    throw new Error(
+      `Version mismatch: ${branch} stabilizes ${base} but package.json says ${currentVersion}. ` +
+      `Promoting would ship ${curBase} under a ${base} branch.`
+    )
+  }
+  if (cur.preId !== 'rc') {
+    throw new Error(
+      `package.json is ${currentVersion}, which is not a release candidate. ` +
+      `Cut an rc first: npm run release -- --beta`
+    )
+  }
+  return base
+}
+
+/**
+ * Commits on the release branch that never made it back to beta. The `-rc.N`
+ * version bumps are expected to be release-branch-only (beta carries its own
+ * version line), so they are not back-port debt. Anything else is: it would be
+ * silently dropped when the release branch is deleted.
+ */
+function unBackportedCommits(logLines) {
+  return (logLines || [])
+    .map((l) => String(l).trim())
+    .filter(Boolean)
+    .filter((l) => !/^[0-9a-f]{7,40}\s+build\(release\):/i.test(l))
+}
+
+async function main() {
 
 const TOTAL = FF_ONLY ? 5 : 6
 
 console.log('')
 console.log('  ===========================================')
-console.log('    Promote beta → main (stable release)')
+console.log('    Promote release/X.Y.Z → main (stable)')
 console.log('  ===========================================')
 
 // --- Step 1: Validate starting state ---
@@ -75,21 +142,21 @@ try {
   fail('Not a git repository')
 }
 
-if (currentBranch !== 'beta') {
-  fail(`Must be on the 'beta' branch to promote — currently on '${currentBranch}'. Run: git checkout beta`)
+const pkgVersion = require(path.join(PROJECT_ROOT, 'package.json')).version
+let stableVersion
+try {
+  stableVersion = stableVersionFor(currentBranch, pkgVersion)
+} catch (err) {
+  fail(err.message)
 }
-ok(`On beta branch`)
+ok(`On ${currentBranch}, promoting ${pkgVersion} → ${stableVersion}`)
 
 // Clean tree — promoting with uncommitted changes would be ambiguous.
-// If the status check itself fails (git unavailable, corrupt repo, etc.),
-// treat it as a hard failure: we can't safely promote without confirming
-// the working tree is clean, since later steps (checkout main, push) could
-// either fail mid-flow or accidentally promote uncommitted work.
 try {
   const status = run('git status --porcelain')
   if (status.length > 0) {
     fail(
-      `Working tree has uncommitted changes. Either commit them on beta (then re-run promote) ` +
+      `Working tree has uncommitted changes. Either commit them (then re-run promote) ` +
       `or stash them:\n${status.split('\n').map((l) => '         ' + l).join('\n')}`
     )
   }
@@ -99,7 +166,6 @@ try {
   fail(`Could not check git status: ${err.message}`)
 }
 
-// gh auth
 try {
   run('gh auth status 2>&1')
   ok('GitHub CLI authenticated')
@@ -107,108 +173,89 @@ try {
   fail('GitHub CLI not authenticated. Run: gh auth login')
 }
 
-// --- Step 2: Fetch latest from origin ---
+// --- Step 2: Fetch and confirm the branch is pushed ---
 step(2, TOTAL, 'Fetching latest from origin...')
 try {
-  run('git fetch origin beta main --tags')
-  ok('Fetched origin/beta, origin/main, and tags')
+  run(`git fetch origin ${currentBranch} main beta --tags`)
+  ok(`Fetched origin/${currentBranch}, origin/main, origin/beta`)
 } catch (err) {
   fail(`git fetch failed: ${err.message}`)
 }
 
-// Verify local beta is in sync with origin/beta
 try {
-  const localBeta = run('git rev-parse beta')
-  const originBeta = run('git rev-parse origin/beta')
-  if (localBeta !== originBeta) {
+  const local = run('git rev-parse HEAD')
+  const remote = run(`git rev-parse origin/${currentBranch}`)
+  if (local !== remote) {
     fail(
-      `Local beta (${localBeta.slice(0, 7)}) does not match origin/beta (${originBeta.slice(0, 7)}). ` +
-      `Push or reset beta first.`
+      `Local ${currentBranch} (${local.slice(0, 7)}) does not match ` +
+      `origin/${currentBranch} (${remote.slice(0, 7)}). Push first.`
     )
   }
-  ok('Local beta matches origin/beta')
+  ok(`Local ${currentBranch} matches origin`)
 } catch (err) {
-  if (err.message.includes('Local beta')) throw err
-  fail(`Could not compare beta refs: ${err.message}`)
+  if (err.message.includes('does not match')) throw err
+  fail(`Could not compare refs: ${err.message}`)
 }
 
-// Ensure local main exists and is in sync with origin/main before we touch it.
-// A stale or diverged local main can break the ancestry check or result in a
-// surprising push (promoting an unexpected history). We hard-reset local main
-// to origin/main — this is safe because the promote flow only ever
-// fast-forwards main to beta; there should never be local-only commits on main
-// that we want to preserve. If a user has made local commits to main they
-// didn't push, that's a workflow violation the reset cleanly recovers from.
+// --- Step 3: Merge safety + back-port debt ---
+step(3, TOTAL, 'Checking merge safety and back-port debt...')
+
+// NOTE: deliberately NOT a strict-ancestor check. The old script required main
+// to be an ancestor of the promoted branch, which fails permanently here: main
+// carries commits the release branch does not (CODEOWNERS landed directly on
+// main). A merge commit handles divergence fine, so the real question is only
+// whether it conflicts.
 try {
-  run('git rev-parse --verify main')
+  run(`git merge-tree --write-tree origin/main origin/${currentBranch}`, { stdio: 'pipe' })
+  ok('release → main merges cleanly (no conflicts)')
 } catch {
-  // Create a local main tracking origin/main if it doesn't exist yet
-  run('git branch --track main origin/main')
-  ok('Created local main branch tracking origin/main')
+  fail(
+    `Merging ${currentBranch} into main produces conflicts. Resolve by merging ` +
+    `main into ${currentBranch} first:\n      ` +
+    `git merge origin/main && git push origin ${currentBranch}`
+  )
 }
 
 try {
-  const localMain = run('git rev-parse main')
-  const originMain = run('git rev-parse origin/main')
-  if (localMain !== originMain) {
-    run('git branch -f main origin/main')
-    ok(`Reset local main from ${localMain.slice(0, 7)} to origin/main (${originMain.slice(0, 7)})`)
-  } else {
-    ok('Local main matches origin/main')
+  const behind = run(`git rev-list --count origin/${currentBranch}..origin/main`)
+  if (Number(behind) > 0) {
+    ok(`main has ${behind} commit(s) not on the release branch — the merge preserves them`)
   }
-} catch (err) {
-  fail(`Could not synchronize main with origin/main: ${err.message}`)
-}
+} catch { /* informational only */ }
 
-// --- Step 3: Verify main is strictly behind beta ---
-step(3, TOTAL, 'Checking that main is a strict ancestor of beta...')
+// Work that only exists on the release branch dies with the branch unless it is
+// back-ported. The version bumps are expected to be release-branch-only.
 try {
-  const mainSha = run('git rev-parse main')
-  const betaSha = run('git rev-parse beta')
-
-  if (mainSha === betaSha) {
-    warn('main is already at beta — nothing to promote')
-    if (FF_ONLY) process.exit(0)
-    // Fall through to release step — maybe they want to re-ship stable
+  const raw = run(`git log --oneline origin/beta..origin/${currentBranch}`)
+  const debt = unBackportedCommits(raw ? raw.split('\n') : [])
+  if (debt.length > 0) {
+    warn(`${debt.length} release-branch commit(s) are NOT on beta and will be lost when it is deleted:`)
+    for (const line of debt) console.log(`         ${line}`)
+    warn(`Back-port them first: git checkout beta && git cherry-pick <sha>`)
   } else {
-    // Check: is main an ancestor of beta? (i.e. can we merge cleanly?)
-    try {
-      run(`git merge-base --is-ancestor main beta`)
-      const ahead = run('git rev-list --count main..beta')
-      ok(`Beta is ${ahead} commit(s) ahead of main — ready to merge`)
-    } catch {
-      fail(
-        `Cannot merge: beta has diverged from main. This means main has commits ` +
-        `not on beta (e.g. a hotfix landed directly on main). Resolve by merging main ` +
-        `into beta first: git checkout beta && git merge main && git push`
-      )
-    }
+    ok('All release-branch fixes are already back-ported to beta')
   }
 } catch (err) {
-  if (err.message.includes('Cannot merge')) throw err
-  fail(`Ancestry check failed: ${err.message}`)
+  warn(`Could not compute back-port debt: ${err.message}`)
 }
 
-// --- Step 4: Find and merge the beta→main PR ---
-step(4, TOTAL, 'Merging beta → main PR...')
+// --- Step 4: Find/create and merge the release → main PR ---
+step(4, TOTAL, `Merging ${currentBranch} → main PR...`)
 
 let prNumber = null
 try {
-  const prJson = run('gh pr list --base main --head beta --state open --json number,title --limit 1')
+  const prJson = run(`gh pr list --base main --head ${currentBranch} --state open --json number,title --limit 1`)
   const prs = JSON.parse(prJson)
   if (prs.length > 0) {
     prNumber = prs[0].number
     ok(`Found open PR #${prNumber}: ${prs[0].title}`)
   } else {
-    // No PR exists — create one on the fly so the merge is recorded as a PR event
-    warn('No open beta→main PR found — creating one now')
-    const version = run("node -e \"console.log(require('./package.json').version)\"")
+    warn(`No open ${currentBranch}→main PR found — creating one now`)
     const createResult = run(
-      `gh pr create --base main --head beta ` +
-      `--title "Beta v${version} → stable promotion" ` +
-      `--body "Automated promotion from beta to main for stable release v${version}."`
+      `gh pr create --base main --head ${currentBranch} ` +
+      `--title "Promote ${currentBranch} → main (stable v${stableVersion})" ` +
+      `--body "Promotes the accepted release candidate ${pkgVersion} to stable v${stableVersion}."`
     )
-    // Extract PR number from the URL returned by gh pr create
     const match = createResult.match(/\/pull\/(\d+)/)
     if (match) {
       prNumber = parseInt(match[1], 10)
@@ -221,19 +268,26 @@ try {
   fail(`PR lookup/creation failed: ${err.message}`)
 }
 
-// Merge the PR with a merge commit (Style A — visible "promoted" marker in history)
+// Merge commit, matching every prior promote on main's first-parent walk.
 try {
-  run(`gh pr merge ${prNumber} --merge --subject "Promote beta → main (stable)" --delete-branch=false`)
+  run(`gh pr merge ${prNumber} --merge --subject "Promote ${currentBranch} → main (stable v${stableVersion})" --delete-branch=false`)
   ok(`Merged PR #${prNumber} into main`)
 } catch (err) {
-  fail(`PR merge failed: ${err.message}`)
+  fail(
+    `PR merge failed: ${err.message}\n      ` +
+    `This step needs repo-admin bypass: the promote PR requires a code-owner\n      ` +
+    `approval its own author cannot give, and the ruleset allows squash only.\n      ` +
+    `If gh refuses on a stale BLOCKED state, the REST call takes the same path:\n      ` +
+    `gh api -X PUT repos/nubbymong/claude-command-center/pulls/${prNumber}/merge -f merge_method=merge`
+  )
 }
 
 // --- Step 5: Sync local main after the remote merge ---
 step(5, TOTAL, 'Syncing local main after merge...')
 try {
   run('git fetch origin main')
-  run('git branch -f main origin/main')
+  run('git checkout main')
+  run('git reset --hard origin/main')
   ok('Local main updated to match origin/main')
 } catch (err) {
   fail(`Could not sync local main: ${err.message}`)
@@ -242,10 +296,9 @@ try {
 if (FF_ONLY) {
   console.log('')
   console.log('  ===========================================')
-  console.log('    Main is promoted. Run the release manually:')
-  console.log('      git checkout main')
-  console.log('      npm run release -- --stable --no-bump')
-  console.log('    Then: git checkout beta')
+  console.log('    Main is promoted. Ship the release with:')
+  console.log('      npm run release -- --stable')
+  console.log(`    Then delete the branch: git push origin --delete ${currentBranch}`)
   console.log('  ===========================================')
   process.exit(0)
 }
@@ -255,15 +308,14 @@ step(6, TOTAL, 'Shipping stable release from main...')
 
 let confirm = 'y'
 if (!AUTO_YES) {
-  confirm = await ask('      Run `npm run release -- --stable --no-bump` now? (y/N): ')
+  confirm = await ask(`      Run \`npm run release -- --stable\` now (ships v${stableVersion})? (y/N): `)
 }
 
 if (confirm === 'y' || confirm === 'yes') {
   try {
-    // Checkout main for the release script's branch enforcement check
-    run('git checkout main')
-    ok('Switched to main branch')
-    runInherit('node scripts/release.js --stable --no-bump')
+    // No --no-bump: release.js derives the stable version by stripping the rc
+    // suffix. Reusing the version verbatim would tag stable as v2.0.0-rc.2.
+    runInherit('node scripts/release.js --stable')
     ok('Stable release dispatched')
   } catch {
     fail('Release failed — check the output above')
@@ -271,25 +323,33 @@ if (confirm === 'y' || confirm === 'yes') {
 } else {
   console.log('')
   console.log('  Skipped release. To ship stable manually:')
-  console.log('    npm run release -- --stable --no-bump')
+  console.log('    npm run release -- --stable')
 }
 
-// Switch back to beta and merge main into it so the merge commit exists on both branches.
-// This keeps the ancestry check clean for the next promote cycle.
-try {
-  run('git checkout beta')
-  run('git merge main --no-edit')
-  run('git push origin beta')
-  ok('Switched to beta and synced with main (merge commit now on both branches)')
-} catch {
-  warn('Could not sync beta with main — run `git checkout beta && git merge main` manually')
-}
-
+// The old script merged main back into beta here. Under the RC-branch model
+// that is wrong: beta is already ahead on its own version line (e.g. 2.1.0-beta.N
+// while main lands 2.0.0), so the merge conflicts on package.json and leaves a
+// half-merged beta behind. Release-branch fixes reach beta by back-port instead,
+// which step 3 verifies.
 console.log('')
 console.log('  ===========================================')
 console.log('    Promote complete!')
-console.log('    You are on the beta branch, ready for')
-console.log('    continued feature work.')
+console.log(`    main is now stable v${stableVersion}.`)
+console.log('')
+console.log('    Once the release is verified, clean up:')
+console.log(`      git push origin --delete ${currentBranch}`)
+console.log('    Feature work continues on beta (never frozen).')
 console.log('  ===========================================')
 
-})()
+}
+
+// Pure-logic exports for unit testing. Guarded so `require()` from a test does
+// NOT run a promote.
+module.exports = {
+  stableVersionFor,
+  unBackportedCommits,
+}
+
+if (require.main === module) {
+  main()
+}

--- a/scripts/promote.js
+++ b/scripts/promote.js
@@ -123,6 +123,36 @@ function unBackportedCommits(logLines) {
     .filter((l) => !/^[0-9a-f]{7,40}\s+build\(release\):/i.test(l))
 }
 
+/**
+ * The closing summary. Pure so that "did we actually ship?" is testable.
+ *
+ * Skipping the release leaves main merged but still carrying the -rc.N version
+ * and no stable tag. Announcing "main is now stable" there is a lie told at
+ * precisely the moment someone would act on it by deleting the release branch —
+ * which is the one thing that makes the state unrecoverable.
+ */
+function promoteSummaryLines({ released, branch, rcVersion, stableVersion }) {
+  if (released) {
+    return [
+      'Promote complete!',
+      `main is now stable v${stableVersion}.`,
+      '',
+      'Once the release is verified, clean up:',
+      `  git push origin --delete ${branch}`,
+      'Feature work continues on beta (never frozen).',
+    ]
+  }
+  return [
+    'Promote INCOMPLETE — no release was shipped.',
+    `main carries ${branch}'s code, but package.json still says`,
+    `${rcVersion} and no v${stableVersion} tag exists.`,
+    '',
+    'Finish with:',
+    '  npm run release -- --stable',
+    `Do NOT delete ${branch} until that succeeds.`,
+  ]
+}
+
 async function main() {
 
 const TOTAL = FF_ONLY ? 5 : 6
@@ -311,19 +341,20 @@ if (!AUTO_YES) {
   confirm = await ask(`      Run \`npm run release -- --stable\` now (ships v${stableVersion})? (y/N): `)
 }
 
+let released = false
 if (confirm === 'y' || confirm === 'yes') {
   try {
     // No --no-bump: release.js derives the stable version by stripping the rc
     // suffix. Reusing the version verbatim would tag stable as v2.0.0-rc.2.
     runInherit('node scripts/release.js --stable')
+    released = true
     ok('Stable release dispatched')
   } catch {
     fail('Release failed — check the output above')
   }
 } else {
   console.log('')
-  console.log('  Skipped release. To ship stable manually:')
-  console.log('    npm run release -- --stable')
+  console.log('  Skipped release.')
 }
 
 // The old script merged main back into beta here. Under the RC-branch model
@@ -333,12 +364,14 @@ if (confirm === 'y' || confirm === 'yes') {
 // which step 3 verifies.
 console.log('')
 console.log('  ===========================================')
-console.log('    Promote complete!')
-console.log(`    main is now stable v${stableVersion}.`)
-console.log('')
-console.log('    Once the release is verified, clean up:')
-console.log(`      git push origin --delete ${currentBranch}`)
-console.log('    Feature work continues on beta (never frozen).')
+for (const line of promoteSummaryLines({
+  released,
+  branch: currentBranch,
+  rcVersion: pkgVersion,
+  stableVersion,
+})) {
+  console.log(line ? `    ${line}` : '')
+}
 console.log('  ===========================================')
 
 }
@@ -348,6 +381,7 @@ console.log('  ===========================================')
 module.exports = {
   stableVersionFor,
   unBackportedCommits,
+  promoteSummaryLines,
 }
 
 if (require.main === module) {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -20,21 +20,32 @@
  *   8. Watch the workflow run to completion
  *   9. Verify the final release has both .exe and .dmg attached
  *
- * Branching model:
- *   - Work on the `beta` branch. Beta/dev releases cut from there.
- *   - When a beta is stable, use `npm run promote` to merge the beta→main PR
- *     with a merge commit, then cut a stable release at the SAME version
- *     (no bump — the code is identical).
- *   - Hotfixes can land directly on main and release as stable from there.
+ * Branching model (RC-branch model — see CONTRIBUTING.md → Branching Model):
+ *   - `beta`          : perpetual feature integration, NEVER frozen.
+ *                       Carries `X.Y.Z-beta.N`. Beta/dev releases cut here.
+ *   - `release/X.Y.Z` : stabilization for one release; fixes only, no features.
+ *                       Carries `X.Y.Z-rc.N`. RC releases cut here, on the beta
+ *                       channel (`-beta.N` and `-rc.N` both ride beta updates).
+ *   - `main`          : stable only. Carries the bare `X.Y.Z`. Reached by
+ *                       merging `release/X.Y.Z` → main via `npm run promote`.
+ *
+ * Version rules:
+ *   - The prerelease identifier comes from the BRANCH, not the channel:
+ *     beta → `-beta.N`, release/X.Y.Z → `-rc.N`, main → none.
+ *   - Default bump increments the prerelease counter ONLY; the base version is
+ *     never touched implicitly. Use --major/--minor/--patch to move the base
+ *     (beta only — a release branch's base is pinned by its name).
+ *   - Stable strips the prerelease: `2.0.0-rc.2` ships as `2.0.0`.
  *
  * Usage:
- *   npm run release                 (interactive channel prompt, patch bump)
- *   npm run release -- --beta       (force beta channel — must be on beta branch)
+ *   npm run release                 (interactive channel prompt; bumps -rc.N/-beta.N)
+ *   npm run release -- --beta       (force beta channel — on `beta` or `release/X.Y.Z`)
  *   npm run release -- --stable     (force stable channel — must be on main branch)
  *   npm run release -- --dev        (force dev channel — must be on beta branch)
- *   npm run release -- --minor      (minor version bump)
- *   npm run release -- --major      (major version bump)
- *   npm run release -- --no-bump    (reuse current version — used by promote flow)
+ *   npm run release -- --minor      (minor base bump, resets prerelease to .1)
+ *   npm run release -- --major      (major base bump, resets prerelease to .1)
+ *   npm run release -- --patch      (patch base bump, resets prerelease to .1)
+ *   npm run release -- --no-bump    (reuse current version verbatim — escape hatch)
  *   npm run release -- --skip-tests (skip local typecheck + vitest)
  *   npm run release -- --skip-build (skip local build smoke test)
  *   npm run release -- --skip-watch (don't wait for workflow to finish)
@@ -47,12 +58,14 @@
  *   - Changelog generation is hand-authored. Edit src/renderer/changelog.ts to
  *     add a new entry BEFORE running this script. The script will update the
  *     version field of the first entry to match the bumped version.
- *   - The workflow is dispatched on the current branch (typically main).
+ *   - This script does NOT create or push a git tag. release.yml creates the tag
+ *     via `gh release create --target $GITHUB_SHA`, pinning it to the commit it
+ *     actually built. A pre-pushed tag would defeat that and can strand the
+ *     release on a stale commit (see src/main/github-update.ts).
  */
 
 const { execSync } = require('child_process')
 const fs = require('fs')
-const os = require('os')
 const path = require('path')
 const readline = require('readline')
 
@@ -65,27 +78,117 @@ const SKIP_WATCH = args.includes('--skip-watch')
 const SKIP_PUSH = args.includes('--skip-push')
 const SKIP_BRANCH_CHECK = args.includes('--skip-branch-check')
 const NO_BUMP = args.includes('--no-bump')
-const BUMP_MINOR = args.includes('--minor')
-const BUMP_MAJOR = args.includes('--major')
+const BUMP = args.includes('--major') ? 'major'
+  : args.includes('--minor') ? 'minor'
+  : args.includes('--patch') ? 'patch'
+  : null
 const FORCE_BETA = args.includes('--beta')
 const FORCE_STABLE = args.includes('--stable')
 const FORCE_DEV = args.includes('--dev')
 
+// ============================================================
+// PURE LOGIC (exported for unit tests — see tests/unit/scripts/release.test.ts)
+// ============================================================
+
 /**
- * Branching model:
- *   - `main`  : stable-only branch. Only stable releases are cut here.
- *   - `beta`  : default working branch. All features land here first.
- *               Beta and dev releases are cut from beta.
- *
- * Channel → required branch:
- *   stable → main  (release must be reviewed + promoted from beta)
- *   beta   → beta  (daily releases)
- *   dev    → beta  (experimental, released from the same branch as beta)
+ * Parse `X.Y.Z` or `X.Y.Z-<id>.<n>`. Returns null for anything else, including
+ * a bare `-beta` with no counter (the retired v1 TAG shape, never a version).
  */
-const CHANNEL_BRANCH = {
-  stable: 'main',
-  beta: 'beta',
-  dev: 'beta',
+function parseVersion(version) {
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)\.(\d+))?$/.exec(String(version || '').trim())
+  if (!m) return null
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    preId: m[4] || null,
+    preNum: m[5] === undefined ? null : Number(m[5]),
+  }
+}
+
+/** `release/2.0.0` or `release/v2.0.0` → `2.0.0`. Anything else → null. */
+function releaseBranchBase(branch) {
+  const m = /^release\/v?(\d+\.\d+\.\d+)$/.exec(String(branch || '').trim())
+  return m ? m[1] : null
+}
+
+/**
+ * The prerelease identifier is a property of the BRANCH, never the channel.
+ * That keeps `--dev` from minting a `-dev.N` version on beta and colliding with
+ * the `-beta.N` line: dev is a presentation choice made by release.yml, not a
+ * separate version series.
+ */
+function preIdForBranch(branch) {
+  if (branch === 'beta') return 'beta'
+  if (releaseBranchBase(branch)) return 'rc'
+  return null // main → stable, no prerelease
+}
+
+/**
+ * Channel → allowed branch. `beta` accepts BOTH `beta` and any `release/X.Y.Z`
+ * because -beta.N and -rc.N both ride the beta update channel.
+ */
+function branchAllowsChannel(branch, channel) {
+  if (channel === 'stable') return branch === 'main'
+  if (channel === 'dev') return branch === 'beta'
+  if (channel === 'beta') return branch === 'beta' || releaseBranchBase(branch) !== null
+  return false
+}
+
+/** Human-readable answer to "where should I be to cut this?" */
+function branchHintFor(channel) {
+  if (channel === 'stable') return 'main'
+  if (channel === 'dev') return 'beta'
+  return 'beta or release/X.Y.Z'
+}
+
+/**
+ * Next version for (current, branch, channel, bump).
+ *
+ * Default = increment the prerelease counter. The base version NEVER moves
+ * implicitly: the old script defaulted to a patch bump, which on `2.1.0-beta.0`
+ * produced `2.1.1-...` for a 2.1.0 that had not shipped yet.
+ */
+function nextVersion(currentVersion, { branch, channel, bump = null } = {}) {
+  const cur = parseVersion(currentVersion)
+  if (!cur) {
+    throw new Error(`Cannot parse version "${currentVersion}" (expected 2.0.0 or 2.0.0-rc.2)`)
+  }
+
+  // Stable ships the accepted candidate's base version unchanged — the code is
+  // identical to the RC, only the tag differs.
+  if (channel === 'stable') {
+    if (bump) throw new Error(`--${bump} is not valid for a stable release: stable ships the RC's base version unchanged`)
+    return `${cur.major}.${cur.minor}.${cur.patch}`
+  }
+
+  const base = releaseBranchBase(branch)
+  if (base) {
+    if (bump) {
+      throw new Error(`--${bump} is not valid on ${branch}: a release branch stabilizes exactly ${base}. Cut a new release branch instead.`)
+    }
+    // The branch NAME is the source of truth for the base version, not
+    // package.json — this is what stops a stray `2.1.0-rc.1` from being cut on
+    // release/2.0.0. A first rc cut from beta (2.0.0-beta.6) starts at rc.1.
+    const b = parseVersion(base)
+    const sameBase = cur.major === b.major && cur.minor === b.minor && cur.patch === b.patch
+    const n = sameBase && cur.preId === 'rc' ? cur.preNum + 1 : 1
+    return `${base}-rc.${n}`
+  }
+
+  const preId = preIdForBranch(branch)
+  if (!preId) {
+    throw new Error(`Branch "${branch}" is not a release line (expected beta or release/X.Y.Z)`)
+  }
+
+  let { major, minor, patch } = cur
+  if (bump === 'major') { major += 1; minor = 0; patch = 0 }
+  else if (bump === 'minor') { minor += 1; patch = 0 }
+  else if (bump === 'patch') { patch += 1 }
+
+  // Moving the base, or switching identifier, restarts the counter at .1.
+  const n = !bump && cur.preId === preId ? cur.preNum + 1 : 1
+  return `${major}.${minor}.${patch}-${preId}.${n}`
 }
 
 // ============================================================
@@ -150,7 +253,19 @@ function pickChannel() {
   })
 }
 
+/**
+ * MUST stay identical to release.yml → "Determine version". The workflow owns
+ * tag creation; this is only used to pre-clean a stale release and to verify
+ * assets afterwards. If the two disagree, the script cleans/verifies a tag that
+ * does not exist while the workflow publishes one nobody checked.
+ *
+ * A version carrying a prerelease suffix IS the tag (v2.0.0-rc.2) — appending a
+ * second channel suffix would give the v2.0.0-rc.2-beta nonsense the old code
+ * produced. The channel-suffixed form is the retired v1 scheme (v1.5.45-beta),
+ * kept only so a bare version still tags correctly.
+ */
 function tagFor(version, channel) {
+  if (String(version).includes('-')) return `v${version}`
   switch (channel) {
     case 'beta': return `v${version}-beta`
     case 'dev':  return `v${version}-dev`
@@ -162,9 +277,9 @@ function tagFor(version, channel) {
 // MAIN
 // ============================================================
 
-;(async () => {
+async function main() {
 
-const TOTAL_STEPS = 10
+const TOTAL_STEPS = 9
 let exitCode = 0
 
 const channel = await pickChannel()
@@ -235,17 +350,19 @@ ok(`Current branch: ${currentBranch}`)
 // Enforce branch ↔ channel correspondence to prevent shipping beta code as
 // stable (or vice versa). `--skip-branch-check` exists for emergencies but
 // should not be used in normal operation.
-const requiredBranch = CHANNEL_BRANCH[channel]
-if (!SKIP_BRANCH_CHECK && currentBranch !== requiredBranch) {
+const branchOk = branchAllowsChannel(currentBranch, channel)
+if (!SKIP_BRANCH_CHECK && !branchOk) {
   fail(
-    `Channel '${channel}' must be released from the '${requiredBranch}' branch, ` +
+    `Channel '${channel}' must be released from ${branchHintFor(channel)}, ` +
     `but current branch is '${currentBranch}'.\n      ` +
-    `Run: git checkout ${requiredBranch}\n      ` +
     `(or pass --skip-branch-check to bypass — not recommended)`
   )
 }
-if (SKIP_BRANCH_CHECK && currentBranch !== requiredBranch) {
-  warn(`Branch check skipped: releasing ${channel} from '${currentBranch}' instead of '${requiredBranch}'`)
+if (SKIP_BRANCH_CHECK && !branchOk) {
+  warn(`Branch check skipped: releasing ${channel} from '${currentBranch}' (expected ${branchHintFor(channel)})`)
+}
+if (releaseBranchBase(currentBranch)) {
+  ok(`Release branch stabilizing ${releaseBranchBase(currentBranch)} — cutting an rc`)
 }
 
 // Git status (uncommitted changes will be included in the release commit)
@@ -270,19 +387,15 @@ const oldVersion = pkg.version
 
 let version
 if (NO_BUMP) {
-  // Used by the promote flow: stable release reuses the beta's version so
-  // v1.2.166-beta → v1.2.166 (same code, different tag, no version drift).
+  // Escape hatch: reuse package.json verbatim. The promote flow no longer needs
+  // this — a stable release derives its version by stripping the RC suffix.
   version = oldVersion
 } else {
-  const parts = oldVersion.split('.').map(Number)
-  if (BUMP_MAJOR) {
-    parts[0] += 1; parts[1] = 0; parts[2] = 0
-  } else if (BUMP_MINOR) {
-    parts[1] += 1; parts[2] = 0
-  } else {
-    parts[2] = (parts[2] || 0) + 1
+  try {
+    version = nextVersion(oldVersion, { branch: currentBranch, channel, bump: BUMP })
+  } catch (err) {
+    fail(err.message)
   }
-  version = parts.join('.')
   pkg.version = version
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
 
@@ -313,8 +426,12 @@ step(3, TOTAL_STEPS, 'Aligning changelog version with bumped version...')
 const changelogPath = path.join(PROJECT_ROOT, 'src', 'renderer', 'changelog.ts')
 try {
   let changelogContent = fs.readFileSync(changelogPath, 'utf-8')
-  // Match the FIRST `version: '...'` entry — that's the topmost (newest) entry
-  const versionRegex = /version:\s*'(\d+\.\d+\.\d+)'/
+  // Match the FIRST `version: '...'` entry — that's the topmost (newest) entry.
+  // The prerelease suffix is NOT optional decoration: without it this regex
+  // skipped straight past `2.0.0-rc.2` at the top of the file and rewrote the
+  // first BARE version it found (the historical `2.0.0` entry), corrupting an
+  // old entry while reporting success and leaving the real one stale.
+  const versionRegex = /version:\s*'(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+\.\d+)?)'/
   const match = changelogContent.match(versionRegex)
   if (!match) {
     warn('Could not locate first version entry in changelog.ts')
@@ -373,84 +490,32 @@ try {
   run('git add -A')
   const staged = run('git diff --cached --stat 2>&1 || echo ""')
   if (staged.length > 0) {
-    run(`git commit -m "Release v${version}"`)
-    ok(`Committed: Release v${version}`)
+    run(`git commit -m "build(release): ${version}"`)
+    ok(`Committed: build(release): ${version}`)
   } else {
     ok('Nothing to commit')
   }
 
-  // Tag — clean up any pre-existing tag with the same name (rare edge case)
-  try {
-    run(`git tag ${tag}`)
-    ok(`Tagged: ${tag}`)
-  } catch {
-    warn(`Tag ${tag} may already exist locally — continuing`)
-  }
-
+  // No `git tag` here on purpose. release.yml creates the tag with
+  // `gh release create --target $GITHUB_SHA`, pinning it to the commit CI
+  // actually built. Pre-pushing a tag hands `gh release create` an existing ref
+  // and defeats --target, which is how betas ended up stranded on a stale
+  // created_at and invisible to the in-app updater.
   console.log('      Pushing to origin...')
-  run(`git push origin ${currentBranch} --tags 2>&1`, { timeout: 60000 })
-  ok(`Pushed ${currentBranch} + tags to origin`)
+  run(`git push origin ${currentBranch} 2>&1`, { timeout: 60000 })
+  ok(`Pushed ${currentBranch} to origin (tag ${tag} will be created by the workflow)`)
 } catch (err) {
   fail(`Git push failed: ${err.message}`)
 }
 
-// --- Step 6: Create or update beta→main PR (beta/dev releases only) ---
-if (channel === 'beta' || channel === 'dev') {
-  step(6, TOTAL_STEPS, 'Creating/updating beta → main PR...')
-  try {
-    // Check if there's already an open PR from beta → main
-    const existingPrJson = run(
-      'gh pr list --base main --head beta --state open --json number,title --limit 1'
-    )
-    const existingPrs = JSON.parse(existingPrJson)
+// The old Step 6 created/updated a rolling `beta → main` PR on every beta
+// release. Under the RC-branch model beta never promotes to main directly —
+// stabilization goes to release/X.Y.Z first — so that PR tracked a merge that
+// must not happen (it is what left #30 open and stale). The promotion PR is
+// now `release/X.Y.Z → main`, created by `npm run promote` at promote time.
 
-    const prTitle = `Beta v${version} → stable promotion candidate`
-    const prBody = [
-      '## What this is',
-      '',
-      'This PR tracks everything on the `beta` branch that is a candidate for the next stable release.',
-      '',
-      `**Current beta release**: [${tag}](https://github.com/nubbymong/claude-command-center/releases/tag/${tag})`,
-      '',
-      'Merging this PR promotes all these changes to the stable channel.',
-      '',
-      '## How to promote',
-      '',
-      'Run `npm run promote` from the `beta` branch. It will merge this PR and cut a stable release.',
-    ].join('\n')
-
-    // Write PR body to a unique temp file to avoid shell escaping issues
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-pr-body-'))
-    const tmpBody = path.join(tmpDir, 'body.md')
-
-    try {
-      fs.writeFileSync(tmpBody, prBody)
-
-      if (existingPrs.length > 0) {
-        // Update the existing PR title to reflect the new version
-        const prNumber = existingPrs[0].number
-        run(`gh pr edit ${prNumber} --title "${prTitle}" --body-file "${tmpBody}"`)
-        ok(`Updated PR #${prNumber}: ${prTitle}`)
-      } else {
-        // Create a new PR for this promotion cycle
-        const createResult = run(
-          `gh pr create --base main --head beta --title "${prTitle}" --body-file "${tmpBody}"`
-        )
-        ok(`Created PR: ${createResult}`)
-      }
-    } finally {
-      try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch (_) {}
-    }
-  } catch (err) {
-    // PR creation is non-fatal — the release still ships without it
-    warn(`PR create/update failed: ${err.message}`)
-  }
-} else {
-  step(6, TOTAL_STEPS, 'Skipping PR (stable releases do not create beta→main PRs)')
-}
-
-// --- Step 7: Pre-clean any existing GitHub release for this tag ---
-step(7, TOTAL_STEPS, 'Checking for stale GitHub release...')
+// --- Step 6: Pre-clean any existing GitHub release for this tag ---
+step(6, TOTAL_STEPS, 'Checking for stale GitHub release...')
 try {
   const existing = run(`gh release view ${tag} --json tagName -q .tagName 2>&1 || echo ""`)
   if (existing.trim() === tag) {
@@ -464,8 +529,8 @@ try {
   warn(`Could not check/delete existing release: ${err.message}`)
 }
 
-// --- Step 8: Dispatch GitHub Actions workflow ---
-step(8, TOTAL_STEPS, 'Dispatching GitHub Actions release workflow...')
+// --- Step 7: Dispatch GitHub Actions workflow ---
+step(7, TOTAL_STEPS, 'Dispatching GitHub Actions release workflow...')
 
 try {
   run(`gh workflow run release.yml --ref ${currentBranch} -f channel=${channel} -f skip_vt=false`)
@@ -508,8 +573,8 @@ if (!runId) {
   ok(`Run URL: https://github.com/nubbymong/claude-command-center/actions/runs/${runId}`)
 }
 
-// --- Step 9: Watch the workflow to completion ---
-step(9, TOTAL_STEPS, 'Watching workflow run...')
+// --- Step 8: Watch the workflow to completion ---
+step(8, TOTAL_STEPS, 'Watching workflow run...')
 
 if (SKIP_WATCH || !runId) {
   warn(SKIP_WATCH ? 'Skipped (--skip-watch)' : 'No run ID — cannot watch')
@@ -525,8 +590,8 @@ if (SKIP_WATCH || !runId) {
   }
 }
 
-// --- Step 10: Verify final release has both platforms ---
-step(10, TOTAL_STEPS, 'Verifying release artifacts...')
+// --- Step 9: Verify final release has both platforms ---
+step(9, TOTAL_STEPS, 'Verifying release artifacts...')
 
 if (exitCode !== 0) {
   warn('Skipping verification because workflow did not complete cleanly')
@@ -564,4 +629,20 @@ header(
 
 process.exit(exitCode)
 
-})()
+}
+
+// Pure-logic exports for unit testing. Guarded so `require()` from a test does
+// NOT dispatch a release.
+module.exports = {
+  parseVersion,
+  releaseBranchBase,
+  preIdForBranch,
+  branchAllowsChannel,
+  branchHintFor,
+  nextVersion,
+  tagFor,
+}
+
+if (require.main === module) {
+  main()
+}

--- a/tests/unit/scripts/promote.test.ts
+++ b/tests/unit/scripts/promote.test.ts
@@ -6,9 +6,15 @@ import { describe, it, expect } from 'vitest'
 const promote = require('../../../scripts/promote.js') as {
   stableVersionFor: (branch: string, currentVersion: string) => string
   unBackportedCommits: (logLines: string[]) => string[]
+  promoteSummaryLines: (opts: {
+    released: boolean
+    branch: string
+    rcVersion: string
+    stableVersion: string
+  }) => string[]
 }
 
-const { stableVersionFor, unBackportedCommits } = promote
+const { stableVersionFor, unBackportedCommits, promoteSummaryLines } = promote
 
 // ── stableVersionFor ───────────────────────────────────────────────
 describe('promote stableVersionFor', () => {
@@ -79,5 +85,41 @@ describe('promote unBackportedCommits', () => {
     // As of the v2.0.0 promote, the only commit on release/2.0.0 that is not on
     // beta is the rc.2 bump, so the promote should report a clean back-port.
     expect(unBackportedCommits(['78471f1 build(release): 2.0.0-rc.2'])).toEqual([])
+  })
+})
+
+// ── promoteSummaryLines ────────────────────────────────────────────
+describe('promote promoteSummaryLines', () => {
+  const opts = { branch: 'release/2.0.0', rcVersion: '2.0.0-rc.2', stableVersion: '2.0.0' }
+
+  it('claims stable only when the release actually shipped', () => {
+    const lines = promoteSummaryLines({ ...opts, released: true }).join('\n')
+    expect(lines).toContain('Promote complete!')
+    expect(lines).toContain('main is now stable v2.0.0.')
+    expect(lines).toContain('git push origin --delete release/2.0.0')
+  })
+
+  it('does NOT claim stable when the release was skipped', () => {
+    // Reported by Copilot on #91. Skipping the release leaves main merged but
+    // still on 2.0.0-rc.2 with no v2.0.0 tag, so the old unconditional
+    // "main is now stable v2.0.0" was false exactly where it would be believed.
+    const lines = promoteSummaryLines({ ...opts, released: false }).join('\n')
+    expect(lines).not.toContain('Promote complete!')
+    expect(lines).not.toContain('main is now stable')
+    expect(lines).toContain('INCOMPLETE')
+  })
+
+  it('names the version main is actually left on when skipped', () => {
+    const lines = promoteSummaryLines({ ...opts, released: false }).join('\n')
+    expect(lines).toContain('2.0.0-rc.2')
+    expect(lines).toContain('no v2.0.0 tag exists')
+    expect(lines).toContain('npm run release -- --stable')
+  })
+
+  it('warns against deleting the release branch when skipped', () => {
+    // The unrecoverable move: delete the branch believing stable shipped.
+    const lines = promoteSummaryLines({ ...opts, released: false }).join('\n')
+    expect(lines).toContain('Do NOT delete release/2.0.0')
+    expect(lines).not.toContain('git push origin --delete release/2.0.0\n')
   })
 })

--- a/tests/unit/scripts/promote.test.ts
+++ b/tests/unit/scripts/promote.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+
+// promote.js guards main() behind `require.main === module`, so require()-ing
+// it here imports only the pure helpers without running a promote.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const promote = require('../../../scripts/promote.js') as {
+  stableVersionFor: (branch: string, currentVersion: string) => string
+  unBackportedCommits: (logLines: string[]) => string[]
+}
+
+const { stableVersionFor, unBackportedCommits } = promote
+
+// ── stableVersionFor ───────────────────────────────────────────────
+describe('promote stableVersionFor', () => {
+  it('strips the rc suffix to the branch base', () => {
+    expect(stableVersionFor('release/2.0.0', '2.0.0-rc.2')).toBe('2.0.0')
+    expect(stableVersionFor('release/2.0.0', '2.0.0-rc.1')).toBe('2.0.0')
+    expect(stableVersionFor('release/v2.1.3', '2.1.3-rc.7')).toBe('2.1.3')
+  })
+
+  it('refuses to promote from beta', () => {
+    // The old script REQUIRED being on beta. Under the RC-branch model beta is
+    // never frozen, so promoting from it would ship whatever features happened
+    // to be mid-flight.
+    expect(() => stableVersionFor('beta', '2.1.0-beta.0')).toThrow(/not release\/X\.Y\.Z/)
+  })
+
+  it('refuses to promote from main or a feature branch', () => {
+    expect(() => stableVersionFor('main', '2.0.0')).toThrow(/not release\/X\.Y\.Z/)
+    expect(() => stableVersionFor('fix/whatever', '2.0.0-rc.1')).toThrow(/not release\/X\.Y\.Z/)
+  })
+
+  it('catches a version that disagrees with the branch name', () => {
+    // Would otherwise ship 2.1.0 out of a branch called release/2.0.0.
+    expect(() => stableVersionFor('release/2.0.0', '2.1.0-rc.1')).toThrow(/Version mismatch/)
+  })
+
+  it('refuses a version that is not a release candidate', () => {
+    expect(() => stableVersionFor('release/2.0.0', '2.0.0-beta.6')).toThrow(/not a release candidate/)
+    expect(() => stableVersionFor('release/2.0.0', '2.0.0')).toThrow(/not a release candidate/)
+  })
+
+  it('throws on an unparseable version', () => {
+    expect(() => stableVersionFor('release/2.0.0', 'garbage')).toThrow(/Cannot parse/)
+  })
+})
+
+// ── unBackportedCommits ────────────────────────────────────────────
+describe('promote unBackportedCommits', () => {
+  it('ignores the rc version bumps, which are release-branch-only by design', () => {
+    // beta carries its own version line, so `build(release):` commits are never
+    // back-ported and must not be reported as debt.
+    expect(unBackportedCommits(['78471f1 build(release): 2.0.0-rc.2'])).toEqual([])
+    expect(unBackportedCommits([
+      '78471f1 build(release): 2.0.0-rc.2',
+      'aaaaaaa build(release): 2.0.0-rc.1',
+    ])).toEqual([])
+  })
+
+  it('reports a real fix that never reached beta', () => {
+    const debt = unBackportedCommits([
+      '78471f1 build(release): 2.0.0-rc.2',
+      'bbbbbbb fix(terminal): stop the flicker',
+    ])
+    expect(debt).toEqual(['bbbbbbb fix(terminal): stop the flicker'])
+  })
+
+  it('handles empty and blank input', () => {
+    expect(unBackportedCommits([])).toEqual([])
+    expect(unBackportedCommits(['', '   '])).toEqual([])
+  })
+
+  it('does not mistake a commit that merely mentions build(release) for a bump', () => {
+    const debt = unBackportedCommits(['ccccccc fix(ci): repair build(release): parsing'])
+    expect(debt).toEqual(['ccccccc fix(ci): repair build(release): parsing'])
+  })
+
+  it('matches the real release/2.0.0 state — no debt', () => {
+    // As of the v2.0.0 promote, the only commit on release/2.0.0 that is not on
+    // beta is the rc.2 bump, so the promote should report a clean back-port.
+    expect(unBackportedCommits(['78471f1 build(release): 2.0.0-rc.2'])).toEqual([])
+  })
+})

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest'
+
+// release.js is plain Node.js (CommonJS) and guards main() behind
+// `require.main === module`, so require()-ing it here imports only the pure
+// helpers without dispatching a release.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const release = require('../../../scripts/release.js') as {
+  parseVersion: (v: string) => { major: number; minor: number; patch: number; preId: string | null; preNum: number | null } | null
+  releaseBranchBase: (branch: string) => string | null
+  preIdForBranch: (branch: string) => string | null
+  branchAllowsChannel: (branch: string, channel: string) => boolean
+  branchHintFor: (channel: string) => string
+  nextVersion: (current: string, opts: { branch: string; channel: string; bump?: string | null }) => string
+  tagFor: (version: string, channel: string) => string
+}
+
+const { parseVersion, releaseBranchBase, preIdForBranch, branchAllowsChannel, nextVersion, tagFor } = release
+
+// ── parseVersion ───────────────────────────────────────────────────
+describe('release parseVersion', () => {
+  it('parses a bare stable version', () => {
+    expect(parseVersion('2.0.0')).toEqual({ major: 2, minor: 0, patch: 0, preId: null, preNum: null })
+  })
+
+  it('parses the rc and beta prerelease shapes actually in use', () => {
+    expect(parseVersion('2.0.0-rc.2')).toEqual({ major: 2, minor: 0, patch: 0, preId: 'rc', preNum: 2 })
+    expect(parseVersion('2.1.0-beta.0')).toEqual({ major: 2, minor: 1, patch: 0, preId: 'beta', preNum: 0 })
+  })
+
+  it('rejects the retired v1 TAG shape and other junk', () => {
+    // `v1.5.45-beta` was a tag, never a package.json version. A counter-less
+    // prerelease has no successor, so refusing it beats guessing.
+    expect(parseVersion('1.5.45-beta')).toBeNull()
+    expect(parseVersion('v2.0.0')).toBeNull()
+    expect(parseVersion('2.0')).toBeNull()
+    expect(parseVersion('')).toBeNull()
+  })
+})
+
+// ── releaseBranchBase ──────────────────────────────────────────────
+describe('release releaseBranchBase', () => {
+  it('accepts both the real branch name and the form CLAUDE.md documents', () => {
+    // Reality is `release/2.0.0`; the docs say `release/vX.Y.Z`. Both match the
+    // `release/**` ruleset, so both must work.
+    expect(releaseBranchBase('release/2.0.0')).toBe('2.0.0')
+    expect(releaseBranchBase('release/v2.0.0')).toBe('2.0.0')
+  })
+
+  it('is null for non-release branches', () => {
+    expect(releaseBranchBase('beta')).toBeNull()
+    expect(releaseBranchBase('main')).toBeNull()
+    expect(releaseBranchBase('release/notaversion')).toBeNull()
+    expect(releaseBranchBase('fix/release/2.0.0')).toBeNull()
+  })
+})
+
+// ── branch → prerelease identifier ─────────────────────────────────
+describe('release preIdForBranch', () => {
+  it('derives the identifier from the branch, not the channel', () => {
+    expect(preIdForBranch('beta')).toBe('beta')
+    expect(preIdForBranch('release/2.0.0')).toBe('rc')
+    expect(preIdForBranch('main')).toBeNull()
+  })
+})
+
+// ── branch ↔ channel ───────────────────────────────────────────────
+describe('release branchAllowsChannel', () => {
+  it('lets the beta channel run from a release branch', () => {
+    // The regression that made `npm run release` unusable for rc.1/rc.2: the old
+    // map was a strict beta→beta equality, so every release branch was rejected.
+    expect(branchAllowsChannel('release/2.0.0', 'beta')).toBe(true)
+    expect(branchAllowsChannel('beta', 'beta')).toBe(true)
+  })
+
+  it('pins stable to main', () => {
+    expect(branchAllowsChannel('main', 'stable')).toBe(true)
+    expect(branchAllowsChannel('beta', 'stable')).toBe(false)
+    expect(branchAllowsChannel('release/2.0.0', 'stable')).toBe(false)
+  })
+
+  it('keeps dev on beta only', () => {
+    expect(branchAllowsChannel('beta', 'dev')).toBe(true)
+    expect(branchAllowsChannel('release/2.0.0', 'dev')).toBe(false)
+  })
+
+  it('rejects a feature branch on every channel', () => {
+    for (const channel of ['stable', 'beta', 'dev']) {
+      expect(branchAllowsChannel('fix/whatever', channel)).toBe(false)
+    }
+  })
+})
+
+// ── nextVersion ────────────────────────────────────────────────────
+describe('release nextVersion on a release branch', () => {
+  it('increments the rc counter', () => {
+    // The headline bug: `2.0.0-rc.2`.split('.').map(Number) => [2,0,NaN,2],
+    // which produced the four-component "2.0.1.2".
+    expect(nextVersion('2.0.0-rc.2', { branch: 'release/2.0.0', channel: 'beta' })).toBe('2.0.0-rc.3')
+    expect(nextVersion('2.0.0-rc.1', { branch: 'release/2.0.0', channel: 'beta' })).toBe('2.0.0-rc.2')
+  })
+
+  it('starts at rc.1 when a release branch is first cut from a beta', () => {
+    expect(nextVersion('2.0.0-beta.6', { branch: 'release/2.0.0', channel: 'beta' })).toBe('2.0.0-rc.1')
+  })
+
+  it('takes the base version from the branch NAME, not package.json', () => {
+    // Guards against a stray 2.1.0-rc.1 being cut on release/2.0.0 if the branch
+    // was cut before beta's version line moved on.
+    expect(nextVersion('2.1.0-beta.4', { branch: 'release/2.0.0', channel: 'beta' })).toBe('2.0.0-rc.1')
+  })
+
+  it('refuses a base bump — that would be a different release', () => {
+    expect(() => nextVersion('2.0.0-rc.2', { branch: 'release/2.0.0', channel: 'beta', bump: 'minor' }))
+      .toThrow(/release branch stabilizes exactly 2\.0\.0/)
+  })
+})
+
+describe('release nextVersion on beta', () => {
+  it('increments the beta counter without touching the base', () => {
+    // 2.1.0 has not shipped, so a default patch bump (the old behaviour) would
+    // have wrongly moved this to 2.1.1.
+    expect(nextVersion('2.1.0-beta.0', { branch: 'beta', channel: 'beta' })).toBe('2.1.0-beta.1')
+    expect(nextVersion('2.0.0-beta.5', { branch: 'beta', channel: 'beta' })).toBe('2.0.0-beta.6')
+  })
+
+  it('resets the counter to .1 when the base moves', () => {
+    expect(nextVersion('2.1.0-beta.3', { branch: 'beta', channel: 'beta', bump: 'minor' })).toBe('2.2.0-beta.1')
+    expect(nextVersion('2.1.0-beta.3', { branch: 'beta', channel: 'beta', bump: 'major' })).toBe('3.0.0-beta.1')
+    expect(nextVersion('2.1.0-beta.3', { branch: 'beta', channel: 'beta', bump: 'patch' })).toBe('2.1.1-beta.1')
+  })
+
+  it('keeps the -beta.N line for a dev release rather than forking a -dev.N series', () => {
+    expect(nextVersion('2.1.0-beta.2', { branch: 'beta', channel: 'dev' })).toBe('2.1.0-beta.3')
+  })
+})
+
+describe('release nextVersion for stable', () => {
+  it('strips the prerelease suffix', () => {
+    // `--no-bump` used to be the promote path, which would have shipped stable
+    // under the tag v2.0.0-rc.2.
+    expect(nextVersion('2.0.0-rc.2', { branch: 'main', channel: 'stable' })).toBe('2.0.0')
+    expect(nextVersion('2.1.0-beta.4', { branch: 'main', channel: 'stable' })).toBe('2.1.0')
+  })
+
+  it('is idempotent on an already-stable version', () => {
+    expect(nextVersion('2.0.0', { branch: 'main', channel: 'stable' })).toBe('2.0.0')
+  })
+
+  it('refuses a bump — stable ships the RC base unchanged', () => {
+    expect(() => nextVersion('2.0.0-rc.2', { branch: 'main', channel: 'stable', bump: 'minor' }))
+      .toThrow(/not valid for a stable release/)
+  })
+})
+
+describe('release nextVersion error handling', () => {
+  it('throws on an unparseable version instead of emitting NaN', () => {
+    expect(() => nextVersion('garbage', { branch: 'beta', channel: 'beta' })).toThrow(/Cannot parse version/)
+  })
+
+  it('throws on a branch that is not a release line', () => {
+    expect(() => nextVersion('2.1.0-beta.0', { branch: 'fix/whatever', channel: 'beta' }))
+      .toThrow(/not a release line/)
+  })
+})
+
+// ── tagFor ─────────────────────────────────────────────────────────
+describe('release tagFor', () => {
+  it('does not double-suffix a version that already carries a prerelease', () => {
+    // The old code produced `v2.0.0-rc.2-beta`, so the script pre-cleaned and
+    // verified a tag the workflow never creates.
+    expect(tagFor('2.0.0-rc.2', 'beta')).toBe('v2.0.0-rc.2')
+    expect(tagFor('2.1.0-beta.1', 'beta')).toBe('v2.1.0-beta.1')
+    expect(tagFor('2.1.0-beta.1', 'dev')).toBe('v2.1.0-beta.1')
+  })
+
+  it('tags a stable version bare', () => {
+    expect(tagFor('2.0.0', 'stable')).toBe('v2.0.0')
+  })
+
+  it('keeps the retired v1 channel-suffix scheme for bare non-stable versions', () => {
+    expect(tagFor('1.5.45', 'beta')).toBe('v1.5.45-beta')
+    expect(tagFor('1.5.45', 'dev')).toBe('v1.5.45-dev')
+  })
+
+  // This is the contract with .github/workflows/release.yml → "Determine
+  // version". If that shell logic changes, this test must change with it.
+  it('agrees with the workflow for every version/channel pair we ship', () => {
+    const workflowTag = (version: string, channel: string) => {
+      if (version.includes('-')) return `v${version}`
+      if (channel === 'beta') return `v${version}-beta`
+      if (channel === 'dev') return `v${version}-dev`
+      return `v${version}`
+    }
+    for (const version of ['2.0.0-rc.2', '2.1.0-beta.1', '2.0.0', '1.5.45']) {
+      for (const channel of ['stable', 'beta', 'dev']) {
+        expect(tagFor(version, channel)).toBe(workflowTag(version, channel))
+      }
+    }
+  })
+})
+
+// ── end-to-end: the real cycles ────────────────────────────────────
+describe('release version flow across a full cycle', () => {
+  it('walks the 2.0.0 stabilization exactly as it happened', () => {
+    let v = '2.0.0-beta.6'
+    v = nextVersion(v, { branch: 'release/2.0.0', channel: 'beta' })
+    expect(v).toBe('2.0.0-rc.1')
+    expect(tagFor(v, 'beta')).toBe('v2.0.0-rc.1')
+
+    v = nextVersion(v, { branch: 'release/2.0.0', channel: 'beta' })
+    expect(v).toBe('2.0.0-rc.2')
+    expect(tagFor(v, 'beta')).toBe('v2.0.0-rc.2')
+
+    v = nextVersion(v, { branch: 'main', channel: 'stable' })
+    expect(v).toBe('2.0.0')
+    expect(tagFor(v, 'stable')).toBe('v2.0.0')
+  })
+
+  it('keeps beta moving independently while a release branch stabilizes', () => {
+    // The whole point of the RC-branch model: beta is never frozen.
+    let beta = '2.1.0-beta.0'
+    beta = nextVersion(beta, { branch: 'beta', channel: 'beta' })
+    expect(beta).toBe('2.1.0-beta.1')
+    const rc = nextVersion('2.0.0-rc.2', { branch: 'release/2.0.0', channel: 'beta' })
+    expect(rc).toBe('2.0.0-rc.3')
+    // The two lines never collide.
+    expect(tagFor(beta, 'beta')).not.toBe(tagFor(rc, 'beta'))
+  })
+})


### PR DESCRIPTION
Closes #88.

#88's "Follow-up (NOT in the CONTRIBUTING PR)" section named three files.
`CLAUDE.md` was done in `728dcdc`; this is the other two. The workflow itself
(`release.yml`) is correct and unchanged — only the helper scripts lagged.

## Why this was invisible

Both scripts were written for the two-branch model and silently rotted when v2
moved the prerelease suffix into `package.json`. rc.1 and rc.2 were both cut by
hand, so nothing exercised them and nothing went red.

`npm run release` is currently broken on **every** v2 branch:

| Branch | package.json | `npm run release` produces | Tag it would push |
|---|---|---|---|
| `release/2.0.0` | `2.0.0-rc.2` | `2.0.1.2` — not semver | `v2.0.1.2-beta` |
| `beta` | `2.1.0-beta.0` | `2.1.1.0` | `v2.1.1.0-beta` |

`'2.0.0-rc.2'.split('.').map(Number)` → `[2, 0, NaN, 2]`, and `NaN || 0` quietly
becomes `0`.

## release.js — six defects

1. **Version bump** was string surgery (above).
2. **`tagFor()`** appended a channel suffix unconditionally → `v2.0.0-rc.2-beta`,
   a tag `release.yml` never creates. The script pre-cleaned and verified that
   phantom tag while the real release went unchecked.
3. **Branch↔channel map** was strict equality (`beta → 'beta'`), so every
   `release/*` branch was rejected outright.
4. **Changelog sync** couldn't match `version: '2.0.0-rc.2'`. Rather than fail it
   scanned past the newest entry and rewrote the first *bare* version below —
   the historical `2.0.0` entry at line 61 — then reported success. Silent
   corruption of an old entry, real entry left stale.
5. **Rolling `beta → main` PR** created on every beta release. That merge must
   never happen now; it is what left #30 open and stale.
6. **Pushed a local tag**, handing `gh release create` an existing ref and
   defeating the `--target $GITHUB_SHA` pin — the exact fault that hid betas
   from the in-app updater. The workflow owns tag creation now.

## promote.js — could not run at all

1. Hard-required branch `beta`.
2. **Strict-ancestor check fails permanently**: CODEOWNERS (`da41377`) landed
   directly on `main`, so main carries a commit `release/2.0.0` doesn't. No
   re-run clears it. Replaced with a conflict test (`git merge-tree`), since a
   merge commit handles divergence fine.
3. Opened/merged a `beta → main` PR.
4. `release.js --stable --no-bump` would have tagged stable **`v2.0.0-rc.2`**.
5. Finished by merging `main` back into `beta` — conflicts on `package.json` the
   moment the lines differ (`2.1.0-beta.0` vs `2.0.0`), leaving beta half-merged.
   Replaced with a back-port *verification*.

## The model, now explicit

- The prerelease id comes from the **branch**, never the channel: `beta` →
  `-beta.N`, `release/X.Y.Z` → `-rc.N`, `main` → none. `--dev` can no longer
  fork a colliding `-dev.N` series.
- Default bump moves **only the prerelease counter**. The base never moves
  implicitly — the old default patch bump would have pushed the unshipped
  `2.1.0-beta.0` to `2.1.1`.
- A release branch takes its base from its **name**, so a stray `2.1.0-rc.1`
  can't be cut on `release/2.0.0`.
- Stable strips the suffix: `2.0.0-rc.2` ships as `2.0.0`.

## On the merge method

The promote stays a **merge commit**. Every prior promote on main's first-parent
walk is one (`Promote beta v1.4.3 → main`), and it keeps main's ancestry
connected to the release lines. The ruleset's squash-only rule was created
2026-04-15 — *after* the last promote — and was written for feature PRs. The
owner's admin bypass covers it, and is required regardless: the promote PR needs
a code-owner approval its own author cannot give.

## Verification

- Full suite: **3013 passed**, 0 failures (2974 baseline + 39 new). Typecheck clean.
- Pure logic extracted behind `require.main === module`, matching
  `scripts/resume-picker.js`; `require()`-ing either script runs nothing.
- One test **re-implements release.yml's shell tag logic and asserts the two
  agree** for every version/channel pair we ship — defect 2 was exactly a silent
  divergence between those files.
- Checked against live repo state: `release/2.0.0 → main` merges cleanly, and the
  only commit on `release/2.0.0` absent from `beta` is the rc.2 bump, which the
  new back-port check classifies as expected rather than debt.

Landing on `beta` because this is tooling, not RC stabilization.