### PR TITLE
feat(config): per-config Claude permission mode + extra CLI args

### DIFF
--- a/CONTEXT.d/2026-07-28-74-claude-launch-parameters.md
+++ b/CONTEXT.d/2026-07-28-74-claude-launch-parameters.md
@@ -1,0 +1,42 @@
+## 2026-07-28 -- Per-config Claude permission mode + extra CLI args (#74)
+
+Decision recorded in architecture/decisions/2026-07-28-adr-006-claude-launch-parameters.md.
+
+Saved Configs could pin a model, agents and cwd, but a Claude config had no way
+to fix its permission posture — every Claude session launched under the CLI's
+default, so you could not keep one config that always runs `bypassPermissions`
+(trusted scratch workspace) next to one that runs `dontAsk`. Asymmetric with
+Codex, which already had a per-config `permissionsPreset`. `PERMISSION_MODES`
+existed in `src/renderer/lib/claude-cli-options.ts` but nothing consumed it.
+
+- `ClaudeOptions` (src/shared/types.ts) gained `permissionMode?: string` and
+  `extraArgs?: string`, carried through sessionStore -> useLaunchConfig ->
+  App.tsx -> TerminalView -> preload -> pty-handlers, same path as
+  `model`/`effortLevel`.
+- Flag emission at BOTH launch sites: local (pty-manager.ts, the `extraFlags`
+  block) and SSH (the `claudeFlags` array). `default`/`''` emit no flag, so the
+  CLI keeps its own default and clean configs stay clean (`undefined` persisted,
+  matching the loggingEnabled/enableCodexReview pattern).
+- SessionDialog: wired the existing `PERMISSION_MODES` dropdown plus a
+  collapsed `<details>` "Advanced: extra CLI args" free-text field.
+- Both values are shell-interpolated UNQUOTED at spawn, so the IPC Zod schema is
+  the injection boundary (same posture as the existing `resume.uuid` guard):
+  `permissionMode` is a `z.enum` of the CLI's own `--permission-mode` choices;
+  `extraArgs` is charset-guarded and a refine rejects CCC-managed flags. Rejection
+  throws `Invalid parameters: ...` back over IPC, so a bad value fails the spawn
+  loudly rather than reaching a shell.
+- Known limitation, stated in the field hint: because metacharacters are blocked,
+  `extraArgs` cannot carry quoted paths containing spaces. The dropdown covers the
+  safe common case; the text box is best-effort for simple flags.
+- Flag/value set confirmed against the installed CLI's `claude --help`, not
+  guessed. The Zod enum also accepts `manual` (a CLI mode the dropdown does not
+  offer) so the schema is a superset of the UI.
+- Verification on the rebase: `npm run typecheck` clean; `npx vitest run`
+  3091 passed / 4 skipped / 0 failed, incl. tests/unit/pty-spawn-permission-args.test.ts
+  (6 cases: enum acceptance, injection rejection, managed-flag rejection).
+- Landing note: PR #92 was opened 2026-07-15, before the protect-beta ruleset and
+  before CARP adoption (#126). It sat blocked because the test matrix is
+  label-gated on `ci-run` and the PR carried no labels, so the required
+  `Test (windows-2025)` / `Test (macos-latest)` contexts never reported. Rebased
+  onto beta (clean, after #133 and #138 touched the same spawn path) and labelled
+  to land.

--- a/architecture/decisions/2026-07-28-adr-006-claude-launch-parameters.md
+++ b/architecture/decisions/2026-07-28-adr-006-claude-launch-parameters.md
@@ -1,0 +1,89 @@
+# ADR-006: Per-config Claude launch parameters — validated dropdown plus a charset-guarded escape hatch
+
+- **Status:** Accepted (2026-07-28)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-28-74-claude-launch-parameters.md, #74, #92,
+  src/main/ipc/pty-handlers.ts, src/main/pty-manager.ts,
+  src/renderer/components/SessionDialog.tsx
+
+## Context
+
+A saved Claude config could pin a model, effort level, agents and working
+directory, but not its **permission posture**. Every Claude session launched
+under the CLI's own default, so the only way to change permission mode was by
+hand inside the running session — which does not persist with the config and
+makes it easy to run the wrong posture in the wrong directory. Codex configs
+already had a per-config `permissionsPreset`, so the two providers were
+asymmetric.
+
+Beyond permission mode, there was no per-config way to pass **any** launch flag
+to the Claude CLI. Every new upstream flag would otherwise require a bespoke
+control in the config editor, and power users had no escape hatch in the
+meantime.
+
+The constraint that shapes this decision: CCC builds its launch command as a
+**shell command string** (a `cd` followed by `claude <flags>`, for local via the
+platform shell and for SSH via the remote shell), and existing options such as
+`--model` / `--effort` are interpolated into it **unquoted**. Anything new that
+reaches that string is a shell-injection surface.
+
+## Decision
+
+**Ship both a validated structured control and an unstructured escape hatch, and
+make the IPC Zod schema the single injection boundary for both.**
+
+1. `ClaudeOptions.permissionMode` — surfaced as a dropdown over the existing
+   `PERMISSION_MODES` list, emitted as `--permission-mode <mode>`. `undefined` /
+   `'default'` / `''` emit **no flag**, so the CLI keeps its own default and a
+   config that never touched the control persists nothing (the established
+   `loggingEnabled` / `enableCodexReview` pattern).
+2. `ClaudeOptions.extraArgs` — a collapsed "Advanced" free-text field appended
+   verbatim after the structured flags.
+3. Validation lives at the **IPC seam** (`spawnOptionsSchema` in
+   `pty-handlers.ts`), not in the renderer, because the renderer is not a trust
+   boundary and `pty-manager` interpolates unquoted:
+   - `permissionMode` is a `z.enum` of the CLI's own `--permission-mode` choices
+     (`acceptEdits, auto, plan, dontAsk, bypassPermissions, manual`) plus
+     `default`/`''`. An arbitrary string can never reach the shell.
+   - `extraArgs` is length-capped and **charset-guarded** — only
+     `[A-Za-z0-9 _\-=./\\:@,+[\]]` is admitted, which excludes every shell
+     metacharacter (`; | & $ \` ( ) < > ' " * ? ~ ! % ^`) and newlines — and a
+     `refine` rejects **CCC-managed flags** (`--model`, `--effort`,
+     `--permission-mode`, `--settings`, `--mcp-config`, `--agents`, `--resume`).
+   - This mirrors the pre-existing `effortLevel` and `resume.uuid` guards, so the
+     spawn path has one consistent rule: *the schema is the boundary.*
+4. Flags are emitted at **both** launch sites — local (`extraFlags`) and SSH
+   (`claudeFlags`) — so the setting is not silently local-only.
+5. Precedence is resolved structurally rather than by warning: `extraArgs`
+   **cannot** contain `--permission-mode` at all, so the dropdown and the text box
+   can never conflict.
+
+Rejected alternatives: **free-text only** (fastest, but the common case deserves
+validation and it is an unguarded injection footgun); **dropdown only** (safest,
+but every new upstream flag then blocks on a CCC release); **shell-quoting
+`extraArgs`** — quoting correctly across PowerShell, POSIX `sh` and an SSH remote
+shell is three different escaping problems on one string, and getting it wrong is
+exactly the injection we are trying to prevent.
+
+## Consequences
+
+- One saved config can run `bypassPermissions` while another runs `dontAsk`,
+  `acceptEdits` or `plan`; the posture travels with the config instead of being
+  re-set by hand per session. `/permissions` inside a running session still works.
+- **`extraArgs` cannot carry quoted paths containing spaces** — a direct,
+  accepted cost of refusing to solve cross-shell quoting. The field hint says so.
+  Flags that need a path with spaces must wait for a structured control.
+- A rejected value fails **loudly**: `spawnOptionsSchema.parse` throws
+  `Invalid parameters: ...` back over IPC and the session does not spawn. It never
+  degrades to a partially-applied command line.
+- The Zod enum is a **superset** of the dropdown (it accepts `manual`, which the
+  UI does not offer). Adding a mode to the UI list needs no schema change;
+  removing one from the CLI does.
+- `bypassPermissions` is now reachable from a *saved* config, which is by design a
+  sharper tool than the per-session toggle: a config pinned to a directory will
+  keep launching with every prompt skipped until someone changes it. The
+  dropdown label ("Bypass — skip every permission prompt") is the only guardrail;
+  CCC deliberately does not second-guess the operator's choice.
+- If the Claude CLI renames or drops `--permission-mode`, the enum is the single
+  place to update; the flag/value set was confirmed against `claude --help` at
+  implementation time rather than inferred.

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -62,6 +62,18 @@ export const spawnOptionsSchema = z.object({
   // Charset guard = injection defense: value is shell-interpolated UNQUOTED at
   // spawn (pty-manager.ts:1137 local, :563 SSH) — mirrors the resume.uuid guard.
   effortLevel: z.string().min(1).max(32).regex(/^[a-zA-Z0-9_-]+$/).optional(),
+  // Shell-interpolated UNQUOTED at spawn. Constrained to the CLI's own --permission-mode
+  // choices (+ 'default'/'' meaning "emit no flag") so an arbitrary string can never
+  // reach the shell. 'default'/'' are accepted but not emitted.
+  permissionMode: z.enum(['default', 'acceptEdits', 'auto', 'plan', 'dontAsk', 'bypassPermissions', 'manual']).optional().or(z.literal('')),
+  // Advanced escape hatch, shell-interpolated UNQUOTED at spawn. Charset guard blocks
+  // every shell metacharacter (; | & $ ` ( ) < > ' " * ? ~ ! % ^ newline), leaving only
+  // characters that make up ordinary flags/paths. The refine rejects CCC-managed flags
+  // so extraArgs can't clobber --model/--effort/--permission-mode/--settings/etc.
+  extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+[\]]*$/).refine(
+    (v) => !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/.test(v),
+    { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume)' },
+  ).optional(),
   disableAutoMemory: z.boolean().optional(),
   enableCodexReview: z.boolean().optional(),
   // T8b (bug #5): app-relaunch exact-conversation resume target.
@@ -111,6 +123,8 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
     agentsConfig?: Array<{ name: string; description: string; prompt: string; model?: string; tools?: string[] }>
     // Widened to string — the Zod schema's charset guard is the real contract.
     effortLevel?: string
+    permissionMode?: string
+    extraArgs?: string
     disableAutoMemory?: boolean
     enableCodexReview?: boolean
     resume?: { uuid: string; cwd: string }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -290,6 +290,12 @@ export function spawnPty(
     agentsConfig?: Array<{ name: string; description: string; prompt: string; model?: string; tools?: string[] }>
     // Widened to string — the IPC schema's charset guard (/^[a-zA-Z0-9_-]+$/) is the real contract.
     effortLevel?: string
+    // Per-config permission mode -> `--permission-mode`. 'default'/'' => no flag.
+    // IPC schema constrains to the CLI's own mode choices.
+    permissionMode?: string
+    // Advanced escape hatch appended verbatim to the claude command. IPC schema
+    // charset-guards it (no shell metacharacters) and rejects CCC-managed flags.
+    extraArgs?: string
     disableAutoMemory?: boolean
     model?: string
     /** Per-session account isolation: spawn claude under this profile's CLAUDE_CONFIG_DIR. */
@@ -592,6 +598,10 @@ export function spawnPty(
       // the config form means "no override" — the CLI picks whatever
       // the user's plan exposes by default.
       options?.model ? `--model ${options.model}` : '',
+      // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
+      options?.permissionMode && options.permissionMode !== 'default' ? `--permission-mode ${options.permissionMode}` : '',
+      // Advanced escape hatch: extra CLI args verbatim (IPC-charset-guarded).
+      options?.extraArgs && options.extraArgs.trim() ? options.extraArgs.trim() : '',
     ].filter(Boolean).join(' ')
     const claudeCmd = [claudeEnvPrefix, 'claude', claudeFlags].filter(Boolean).join(' ')
     const password = ssh.password
@@ -1203,6 +1213,15 @@ export function spawnPty(
       }
       if (options?.model) {
         extraFlags += ` --model ${options.model}`
+      }
+      // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
+      if (options?.permissionMode && options.permissionMode !== 'default') {
+        extraFlags += ` --permission-mode ${options.permissionMode}`
+      }
+      // Advanced escape hatch: extra CLI args verbatim (IPC-charset-guarded, no
+      // shell metacharacters, CCC-managed flags rejected at the IPC seam).
+      if (options?.extraArgs && options.extraArgs.trim()) {
+        extraFlags += ` ${options.extraArgs.trim()}`
       }
 
       // P7.7.2: seed a per-session settings file for hooks/statusLine

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,6 +71,8 @@ export interface ElectronAPI {
         model?: string; tools?: string[]
       }>
       effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+      permissionMode?: string
+      extraArgs?: string
       disableAutoMemory?: boolean
       enableCodexReview?: boolean
       resume?: { uuid: string; cwd: string }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -825,6 +825,8 @@ export default function App() {
                       legacyVersion={session.legacyVersion}
                       agentIds={session.agentIds}
                       effortLevel={session.effortLevel}
+                      permissionMode={session.permissionMode}
+                      extraArgs={session.extraArgs}
                       disableAutoMemory={session.disableAutoMemory}
                       enableCodexReview={session.enableCodexReview}
                       loggingEnabled={session.loggingEnabled}

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -7,7 +7,7 @@ import { IDENTITY_COLOR_KEYS, resolveIdentityColor, bucketLegacyColorToKey, type
 import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegistryStore } from '../stores/registryStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { modelsFromRegistry } from '../lib/claude-cli-options'
+import { modelsFromRegistry, PERMISSION_MODES } from '../lib/claude-cli-options'
 
 export type SessionType = 'local' | 'ssh'
 
@@ -65,6 +65,10 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   // to whichever Opus version Claude Code currently ships, so this
   // doesn't go stale when Anthropic releases the next one.
   const [model, setModel] = useState(initialClaude?.model ?? initial?.model ?? 'opus')
+  // Per-config Claude permission mode ('default' => no --permission-mode flag) and
+  // an advanced free-text escape hatch for extra CLI args.
+  const [permissionMode, setPermissionMode] = useState(initialClaude?.permissionMode ?? 'default')
+  const [extraArgs, setExtraArgs] = useState(initialClaude?.extraArgs ?? '')
   const [colorKey, setColorKey] = useState<IdentityColorKey>(
     (initial?.identityColorKey as IdentityColorKey) ?? bucketLegacyColorToKey(initial?.color ?? '')
   )
@@ -250,6 +254,9 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
 
     const claudeOptions = provider === 'claude' ? {
       model: model || undefined,
+      // 'default' is the no-op sentinel; persist only a real override.
+      permissionMode: permissionMode && permissionMode !== 'default' ? permissionMode : undefined,
+      extraArgs: extraArgs.trim() || undefined,
       legacyVersion: legacyEnabled && legacyVersion ? { enabled: true, version: legacyVersion } : undefined,
       agentIds: !shellOnly && selectedAgentIds.size > 0 ? Array.from(selectedAgentIds) : undefined,
       disableAutoMemory: !shellOnly && disableAutoMemory ? true : undefined,
@@ -644,6 +651,44 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                 The model sessions start on. Default follows Claude's own setting; /model inside a session still works.
               </p>
             </div>
+
+            {/* Permission mode */}
+            <div>
+              <label className="block text-xs text-subtext0 mb-1">
+                Permission mode
+                <span className="text-overlay0 ml-1">(how Claude asks before actions)</span>
+              </label>
+              <select
+                value={permissionMode}
+                onChange={(e) => setPermissionMode(e.target.value)}
+                className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
+              >
+                {PERMISSION_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+              <p className="text-[10px] text-overlay0 mt-1">
+                Sets --permission-mode at launch, so one config can run Bypass while another runs Don't ask. /permissions inside a session still works.
+              </p>
+            </div>
+
+            {/* Advanced: extra CLI args escape hatch */}
+            <details>
+              <summary className="text-xs text-subtext0 cursor-pointer select-none">Advanced: extra CLI args</summary>
+              <div className="mt-2">
+                <input
+                  type="text"
+                  value={extraArgs}
+                  onChange={(e) => setExtraArgs(e.target.value)}
+                  placeholder="--verbose --add-dir /path/to/dir"
+                  spellCheck={false}
+                  className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text font-mono focus:outline-none focus:border-blue"
+                />
+                <p className="text-[10px] text-overlay0 mt-1">
+                  Appended verbatim to the claude command. Shell metacharacters are blocked, and CCC-managed flags (--model, --effort, --permission-mode, --settings, --mcp-config, --agents, --resume) can't be overridden here.
+                </p>
+              </div>
+            </details>
 
             {/* Disable auto-memory toggle */}
             {!shellOnly && (

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -50,6 +50,10 @@ interface Props {
   }
   agentIds?: string[]
   effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+  /** Per-session permission mode -> claude `--permission-mode`. '' / 'default' = no flag. */
+  permissionMode?: string
+  /** Advanced: extra CLI args appended verbatim to the claude launch command. */
+  extraArgs?: string
   disableAutoMemory?: boolean
   /** P6: when true, the spawned Claude PTY is registered into the
    *  codex_review opt-in set in conductor-mcp-server. Mirrors
@@ -68,7 +72,7 @@ interface Props {
   codexOptions?: CodexOptions
 }
 
-export default function TerminalView({ sessionId, configId, cwd, shellOnly, elevated, ssh, isActive = true, legacyVersion, agentIds, effortLevel, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions }: Props) {
+export default function TerminalView({ sessionId, configId, cwd, shellOnly, elevated, ssh, isActive = true, legacyVersion, agentIds, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions }: Props) {
   const xtermContainerRef = useRef<HTMLDivElement>(null)
   const terminalRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -431,7 +435,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               resumeNudgeGated = true
             }
             window.electronAPI.pty
-              .spawn(sessionId, { cwd, cols, rows, ssh, shellOnly, elevated, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
+              .spawn(sessionId, { cwd, cols, rows, ssh, shellOnly, elevated, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
               .catch((err: unknown) => {
                 // BUG-2: spawn was fire-and-forget, so a main-process throw (e.g.
                 // "Codex CLI not found on PATH") became a silent unhandled

--- a/src/renderer/hooks/useLaunchConfig.ts
+++ b/src/renderer/hooks/useLaunchConfig.ts
@@ -55,6 +55,8 @@ export function useLaunchConfig(): (config: TerminalConfig) => string {
       agentIds: config.claudeOptions?.agentIds,
       machineName: config.machineName,
       effortLevel: config.claudeOptions?.effortLevel,
+      permissionMode: config.claudeOptions?.permissionMode,
+      extraArgs: config.claudeOptions?.extraArgs,
       disableAutoMemory: config.claudeOptions?.disableAutoMemory,
       enableCodexReview: config.claudeOptions?.enableCodexReview,
       provider: config.provider,

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -76,6 +76,11 @@ export interface Session {
     version: string
   }
   agentIds?: string[]                    // Agent template IDs for this session
+  /** Per-session permission mode -> claude `--permission-mode`. '' / 'default' /
+   *  undefined = no flag. Sourced from the config's claudeOptions at launch. */
+  permissionMode?: string
+  /** Advanced: extra CLI args appended verbatim to the claude launch command. */
+  extraArgs?: string
   effortLevel?: EffortLevel
   /** True once a LIVE effort tick (statusline effort.level or the hooks effort
    *  gateway) has arrived for THIS session. The sidebar card gates its EffortPill
@@ -234,7 +239,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 export const STRUCTURAL_SESSION_FIELDS = [
   'id', 'createdAt', 'configId', 'label', 'customName', 'workingDirectory', 'sessionType',
   'shellOnly', 'sshConfig', 'partnerTerminalPath', 'partnerElevated',
-  'legacyVersion', 'agentIds', 'effortLevel', 'disableAutoMemory',
+  'legacyVersion', 'agentIds', 'effortLevel', 'permissionMode', 'extraArgs', 'disableAutoMemory',
   'enableCodexReview', 'loggingEnabled', 'model', 'provider', 'codexOptions',
   'identityColorKey', 'color', 'githubIntegration',
 ] as const

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -151,6 +151,8 @@ export interface ElectronAPI {
         model?: string; tools?: string[]
       }>
       effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+      permissionMode?: string
+      extraArgs?: string
       disableAutoMemory?: boolean
       enableCodexReview?: boolean
       resume?: { uuid: string; cwd: string }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,6 +66,16 @@ export interface AccountIdentity {
 export interface ClaudeOptions {
   model?: string
   effortLevel?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode'
+  /** Per-config permission mode -> claude `--permission-mode <mode>`. Undefined /
+   *  'default' emits no flag (Claude's own default). Valid CLI modes: acceptEdits,
+   *  auto, plan, dontAsk, bypassPermissions, manual. Lets one saved config run
+   *  bypassPermissions while another runs dontAsk. */
+  permissionMode?: string
+  /** Advanced escape hatch: extra CLI args appended verbatim to the claude launch
+   *  command. Charset-guarded at the IPC seam (no shell metacharacters); CCC-managed
+   *  flags (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/
+   *  --resume) are rejected so the escape hatch can't clobber CCC's own wiring. */
+  extraArgs?: string
   legacyVersion?: LegacyVersion
   disableAutoMemory?: boolean
   agentIds?: string[]

--- a/tests/unit/pty-spawn-permission-args.test.ts
+++ b/tests/unit/pty-spawn-permission-args.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { spawnOptionsSchema } from '../../src/main/ipc/pty-handlers'
+
+// permissionMode / extraArgs are shell-interpolated UNQUOTED into the claude
+// launch command (pty-manager local + SSH). The Zod schema is the injection
+// boundary, so these tests pin exactly what may reach the shell.
+
+describe('spawnOptionsSchema — permissionMode', () => {
+  it('accepts every CLI --permission-mode choice', () => {
+    for (const m of ['acceptEdits', 'auto', 'plan', 'dontAsk', 'bypassPermissions', 'manual']) {
+      expect(spawnOptionsSchema.safeParse({ permissionMode: m }).success).toBe(true)
+    }
+  })
+
+  it("accepts the 'default'/'' no-override sentinels", () => {
+    expect(spawnOptionsSchema.safeParse({ permissionMode: 'default' }).success).toBe(true)
+    expect(spawnOptionsSchema.safeParse({ permissionMode: '' }).success).toBe(true)
+  })
+
+  it('rejects anything outside the enum (unquoted-interpolation guard)', () => {
+    expect(spawnOptionsSchema.safeParse({ permissionMode: 'yolo' }).success).toBe(false)
+    expect(spawnOptionsSchema.safeParse({ permissionMode: 'bypassPermissions; rm -rf /' }).success).toBe(false)
+  })
+})
+
+describe('spawnOptionsSchema — extraArgs', () => {
+  it('accepts ordinary flags and paths (incl. Windows backslash paths)', () => {
+    for (const v of ['', '--verbose', '--add-dir /tmp/foo', '--add-dir C:\\Users\\me\\proj', '--foo=bar,baz']) {
+      expect(spawnOptionsSchema.safeParse({ extraArgs: v }).success).toBe(true)
+    }
+  })
+
+  it('rejects shell metacharacters (injection guard)', () => {
+    for (const v of ['; rm -rf /', 'a | b', 'a && b', '$(whoami)', '`id`', 'a > f', "a'b", 'a"b', 'a\nb', 'a & b']) {
+      expect(spawnOptionsSchema.safeParse({ extraArgs: v }).success).toBe(false)
+    }
+  })
+
+  it('rejects CCC-managed flags so the escape hatch cannot clobber wiring', () => {
+    for (const v of ['--model sonnet', '--model=sonnet', '--effort high', '--permission-mode bypassPermissions',
+      '--settings x', '--mcp-config y', '--agents z', '--resume abcd']) {
+      expect(spawnOptionsSchema.safeParse({ extraArgs: v }).success).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Closes #74.

Adds per-config Claude launch parameters so one saved config can run `bypassPermissions` while another runs `dontAsk` — plus an advanced escape hatch for arbitrary flags.

## What's new (config editor, Claude provider)
- **Permission mode dropdown** — wires up the previously-unused `PERMISSION_MODES` list. `default` = no flag (Claude's own default); other values emit `--permission-mode <mode>`.
- **Advanced → extra CLI args** — a collapsible free-text field appended verbatim to the `claude` command.

## Data flow (wired end to end)
`claudeOptions.{permissionMode,extraArgs}` → `Session` → IPC spawn options → `pty-manager` flag emission, for **both** local and SSH launches. Fields added to: `shared/types.ts`, `sessionStore`, `useLaunchConfig`, `App.tsx`, `TerminalView`, `preload`, `electron.d.ts`, `pty-handlers`, `pty-manager`, `SessionDialog`.

## Security (both values are interpolated **unquoted** at spawn)
The IPC Zod schema is the injection boundary, matching the existing `model`/`effortLevel` pattern:
- `permissionMode` — constrained to the CLI's own `--permission-mode` enum (`acceptEdits, auto, plan, dontAsk, bypassPermissions, manual`) + `default`/`''`. Nothing else can reach the shell.
- `extraArgs` — charset-guarded (blocks `; | & $ \` ( ) < > ' " * ? ~ ! % ^` and newlines), and a refine **rejects CCC-managed flags** (`--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume`) so the escape hatch can't clobber CCC's own wiring.

Known limitation (documented in the field hint): because metacharacters are blocked, `extraArgs` can't carry quoted paths with spaces. The dropdown covers the safe common case; the text box is best-effort for simple flags.

## Verification
- `npm run typecheck` — clean
- `npx vitest run` — **2980 passed, 4 skipped, 0 failed**, incl. new `tests/unit/pty-spawn-permission-args.test.ts` (6 cases: enum acceptance, injection rejection, managed-flag rejection)

## Confirmed against the installed CLI
`claude --help` lists `--permission-mode <mode>` with exactly these choices — the flag/values aren't guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
