### PR TITLE
Conductor Proxy T1: upstream registry + config schema (#93)

### DIFF
--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -28,6 +28,7 @@ const CONFIG_FILES = {
   accounts: 'accounts.json',
   visionGlobal: 'vision-global.json',
   conductorSecret: 'conductor-secret.json',
+  mcpUpstreams: 'mcp-upstreams.json',
   commandSections: 'command-sections.json',
   usageTracking: 'usage-tracking.json',
   commandBarUi: 'command-bar-ui.json',

--- a/src/main/mcp-proxy/upstream-registry.ts
+++ b/src/main/mcp-proxy/upstream-registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Conductor Proxy — upstream MCP server registry (T1, #93).
+ *
+ * The persisted list of upstream MCP servers the proxy supervises. This module
+ * is ONLY the data model + persistence: it does not connect to, spawn, or
+ * otherwise touch a real MCP server (that is the supervisor, T2/#94). Keeping
+ * validation pure and side-effect-free here means the whole schema contract is
+ * unit-testable without Electron or a live process.
+ *
+ * Persistence: a single `mcp-upstreams.json` under CONFIG/, via config-manager's
+ * `readConfig`/`saveConfig` ('mcpUpstreams' key). The stored shape is a bare
+ * array of McpUpstream; a corrupt/partial entry is dropped on read rather than
+ * throwing, so one bad hand-edit can never take the whole registry offline.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { readConfig, saveConfig } from '../config-manager'
+import { logWarn } from '../debug-logger'
+import type {
+  McpUpstream,
+  McpUpstreamExposure,
+  McpUpstreamTransport,
+} from '../../shared/types'
+
+const CONFIG_KEY = 'mcpUpstreams' as const
+
+const VALID_EXPOSURES: readonly McpUpstreamExposure[] = ['search', 'passthrough']
+
+/** Fields a caller supplies when creating an upstream. `id` is minted for them;
+ *  the booleans/exposure fall back to safe defaults when omitted. */
+export interface McpUpstreamInput {
+  name: string
+  transport: McpUpstreamTransport
+  enabled?: boolean
+  exposure?: McpUpstreamExposure
+  autostart?: boolean
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+/** Optional `Record<string,string>` — accept only a plain object of string
+ *  values; anything else normalizes to undefined rather than corrupting the
+ *  spawn env / request headers with non-strings. */
+function normalizeStringMap(v: unknown): Record<string, string> | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined
+  const out: Record<string, string> = {}
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof val === 'string') out[k] = val
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/** Validate + normalize a raw transport. Returns null if the transport is not
+ *  a usable stdio/http/sse descriptor (the whole upstream is then dropped). */
+export function normalizeTransport(raw: unknown): McpUpstreamTransport | null {
+  if (!raw || typeof raw !== 'object') return null
+  const t = raw as Record<string, unknown>
+
+  if (t.kind === 'stdio') {
+    if (!isNonEmptyString(t.command)) return null
+    const args = Array.isArray(t.args)
+      ? t.args.filter((a): a is string => typeof a === 'string')
+      : undefined
+    const env = normalizeStringMap(t.env)
+    const out: McpUpstreamTransport = { kind: 'stdio', command: t.command }
+    if (args && args.length > 0) out.args = args
+    if (env) out.env = env
+    return out
+  }
+
+  if (t.kind === 'http' || t.kind === 'sse') {
+    if (!isNonEmptyString(t.url)) return null
+    const headers = normalizeStringMap(t.headers)
+    const out: McpUpstreamTransport = { kind: t.kind, url: t.url }
+    if (headers) out.headers = headers
+    return out
+  }
+
+  return null
+}
+
+/** Validate + normalize one raw registry entry into a full McpUpstream.
+ *  Returns null (caller drops it) when required fields are missing/invalid.
+ *  Pure — safe to call on untrusted JSON. */
+export function normalizeUpstream(raw: unknown): McpUpstream | null {
+  if (!raw || typeof raw !== 'object') return null
+  const u = raw as Record<string, unknown>
+
+  if (!isNonEmptyString(u.id)) return null
+  if (!isNonEmptyString(u.name)) return null
+
+  const transport = normalizeTransport(u.transport)
+  if (!transport) return null
+
+  const exposure: McpUpstreamExposure =
+    VALID_EXPOSURES.includes(u.exposure as McpUpstreamExposure)
+      ? (u.exposure as McpUpstreamExposure)
+      : 'search'
+
+  return {
+    id: u.id,
+    name: u.name,
+    transport,
+    // Absent booleans default ON for enabled (an entry in the list is meant to
+    // be used) and OFF for autostart (connect lazily unless asked).
+    enabled: u.enabled !== false,
+    exposure,
+    autostart: u.autostart === true,
+  }
+}
+
+/** Validate a raw persisted array into a clean McpUpstream[]. Non-array input
+ *  yields []; individual bad entries are dropped (and logged), never thrown. */
+export function normalizeUpstreams(raw: unknown): McpUpstream[] {
+  if (!Array.isArray(raw)) return []
+  const out: McpUpstream[] = []
+  const seen = new Set<string>()
+  for (const entry of raw) {
+    const u = normalizeUpstream(entry)
+    if (!u) {
+      logWarn('[mcp-proxy] Dropping invalid upstream entry from registry')
+      continue
+    }
+    if (seen.has(u.id)) {
+      logWarn(`[mcp-proxy] Dropping duplicate upstream id: ${u.id}`)
+      continue
+    }
+    seen.add(u.id)
+    out.push(u)
+  }
+  return out
+}
+
+/** Build a full McpUpstream from caller input, minting an id and filling
+ *  defaults. Throws if the transport is invalid (a create-time programmer error
+ *  the UI should have prevented — unlike read-time entries, which are dropped). */
+export function buildUpstream(input: McpUpstreamInput): McpUpstream {
+  const transport = normalizeTransport(input.transport)
+  if (!transport) {
+    throw new Error('Cannot create upstream: invalid transport')
+  }
+  if (!isNonEmptyString(input.name)) {
+    throw new Error('Cannot create upstream: name is required')
+  }
+  return {
+    id: randomUUID(),
+    name: input.name,
+    transport,
+    enabled: input.enabled !== false,
+    exposure: VALID_EXPOSURES.includes(input.exposure as McpUpstreamExposure)
+      ? (input.exposure as McpUpstreamExposure)
+      : 'search',
+    autostart: input.autostart === true,
+  }
+}
+
+// ── Persistence CRUD ──
+
+/** All upstreams, cleaned. Empty array when nothing is stored. */
+export function listUpstreams(): McpUpstream[] {
+  return normalizeUpstreams(readConfig(CONFIG_KEY))
+}
+
+export function getUpstream(id: string): McpUpstream | null {
+  return listUpstreams().find((u) => u.id === id) ?? null
+}
+
+function persist(upstreams: McpUpstream[]): boolean {
+  return saveConfig(CONFIG_KEY, upstreams)
+}
+
+/** Create a new upstream from input and persist it. Returns the created entry,
+ *  or null if the write failed. */
+export function addUpstream(input: McpUpstreamInput): McpUpstream | null {
+  const created = buildUpstream(input)
+  const next = [...listUpstreams(), created]
+  return persist(next) ? created : null
+}
+
+/** Merge a partial patch into an existing upstream by id and persist. The id
+ *  and transport-kind are preserved unless the patch supplies a valid new
+ *  transport. Returns the updated entry, or null if not found / write failed. */
+export function updateUpstream(
+  id: string,
+  patch: Partial<McpUpstreamInput>,
+): McpUpstream | null {
+  const current = listUpstreams()
+  const idx = current.findIndex((u) => u.id === id)
+  if (idx < 0) return null
+
+  const existing = current[idx]
+  const merged: McpUpstream = {
+    ...existing,
+    ...(patch.name !== undefined && isNonEmptyString(patch.name)
+      ? { name: patch.name }
+      : {}),
+    ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
+    ...(patch.autostart !== undefined ? { autostart: patch.autostart } : {}),
+    ...(patch.exposure !== undefined &&
+    VALID_EXPOSURES.includes(patch.exposure)
+      ? { exposure: patch.exposure }
+      : {}),
+  }
+  if (patch.transport !== undefined) {
+    const t = normalizeTransport(patch.transport)
+    if (t) merged.transport = t
+  }
+
+  const next = [...current]
+  next[idx] = merged
+  return persist(next) ? merged : null
+}
+
+/** Remove an upstream by id. Returns true if an entry was removed and the
+ *  write succeeded; false if the id was absent or the write failed. */
+export function removeUpstream(id: string): boolean {
+  const current = listUpstreams()
+  const next = current.filter((u) => u.id !== id)
+  if (next.length === current.length) return false
+  return persist(next)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,49 @@ export interface GlobalVisionConfig {
   headless?: boolean    // default true
 }
 
+// ── MCP Proxy (upstreams) ──
+
+/** How the Conductor proxy exposes an upstream's tools to the LLM.
+ *  'search'      — tools are discoverable ONLY through the fixed search
+ *                  meta-tools (search_tools / describe_tool / call_tool).
+ *                  Default: upstream churn never changes the advertised list.
+ *  'passthrough' — the upstream's tools are ALSO advertised directly as
+ *                  `server__tool`, skipping the search round-trip. Reserve
+ *                  for a few high-frequency servers; keep the total advertised
+ *                  tool count under the ~30-50 selection-accuracy ceiling. */
+export type McpUpstreamExposure = 'search' | 'passthrough'
+
+/** Stdio transport: CCC spawns `command args...` and speaks MCP over the
+ *  child's stdin/stdout. `env` is merged over the inherited environment. */
+export interface McpStdioTransport {
+  kind: 'stdio'
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+}
+
+/** Remote transport: CCC connects to an already-running MCP server.
+ *  'http' = Streamable HTTP (current MCP standard); 'sse' = legacy SSE. */
+export interface McpHttpTransport {
+  kind: 'http' | 'sse'
+  url: string
+  headers?: Record<string, string>
+}
+
+export type McpUpstreamTransport = McpStdioTransport | McpHttpTransport
+
+/** A single upstream MCP server the Conductor proxy supervises. One shared
+ *  connection per upstream is fanned out to every CCC session (local + SSH). */
+export interface McpUpstream {
+  id: string
+  name: string
+  transport: McpUpstreamTransport
+  enabled: boolean
+  exposure: McpUpstreamExposure
+  /** Connect at proxy startup rather than lazily on first use. */
+  autostart: boolean
+}
+
 // ── SSH ──
 
 export interface SshConfig {

--- a/tests/unit/main/mcp-proxy/upstream-registry.test.ts
+++ b/tests/unit/main/mcp-proxy/upstream-registry.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// In-memory config store backing the mocked config-manager.
+let store: unknown = null
+const mockReadConfig = vi.fn((_key: string) => store)
+const mockSaveConfig = vi.fn((_key: string, value: unknown) => {
+  store = value
+  return true
+})
+
+vi.mock('../../../../src/main/config-manager', () => ({
+  readConfig: (...args: any[]) => mockReadConfig(...(args as [string])),
+  saveConfig: (...args: any[]) => mockSaveConfig(...(args as [string, unknown])),
+}))
+
+vi.mock('../../../../src/main/debug-logger', () => ({
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+}))
+
+const {
+  normalizeTransport,
+  normalizeUpstream,
+  normalizeUpstreams,
+  buildUpstream,
+  addUpstream,
+  getUpstream,
+  listUpstreams,
+  updateUpstream,
+  removeUpstream,
+} = await import('../../../../src/main/mcp-proxy/upstream-registry')
+
+beforeEach(() => {
+  store = null
+  mockReadConfig.mockClear()
+  mockSaveConfig.mockClear()
+})
+
+describe('normalizeTransport', () => {
+  it('accepts a stdio transport and drops empty args/env', () => {
+    expect(normalizeTransport({ kind: 'stdio', command: 'npx', args: [], env: {} })).toEqual({
+      kind: 'stdio',
+      command: 'npx',
+    })
+  })
+
+  it('keeps non-empty args and string-only env', () => {
+    expect(
+      normalizeTransport({
+        kind: 'stdio',
+        command: 'node',
+        args: ['server.js', 42, 'x'],
+        env: { A: '1', B: 2 },
+      }),
+    ).toEqual({ kind: 'stdio', command: 'node', args: ['server.js', 'x'], env: { A: '1' } })
+  })
+
+  it('rejects stdio without a command', () => {
+    expect(normalizeTransport({ kind: 'stdio', command: '   ' })).toBeNull()
+    expect(normalizeTransport({ kind: 'stdio' })).toBeNull()
+  })
+
+  it('accepts http and sse transports with a url', () => {
+    expect(normalizeTransport({ kind: 'http', url: 'http://x/mcp' })).toEqual({
+      kind: 'http',
+      url: 'http://x/mcp',
+    })
+    expect(
+      normalizeTransport({ kind: 'sse', url: 'http://x/sse', headers: { Authorization: 'Bearer t' } }),
+    ).toEqual({ kind: 'sse', url: 'http://x/sse', headers: { Authorization: 'Bearer t' } })
+  })
+
+  it('rejects http/sse without a url and unknown kinds', () => {
+    expect(normalizeTransport({ kind: 'http' })).toBeNull()
+    expect(normalizeTransport({ kind: 'websocket', url: 'ws://x' })).toBeNull()
+    expect(normalizeTransport(null)).toBeNull()
+  })
+})
+
+describe('normalizeUpstream', () => {
+  const base = { id: 'u1', name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } }
+
+  it('fills defaults: enabled=true, exposure=search, autostart=false', () => {
+    expect(normalizeUpstream(base)).toEqual({
+      id: 'u1',
+      name: 'FS',
+      transport: { kind: 'stdio', command: 'fs-mcp' },
+      enabled: true,
+      exposure: 'search',
+      autostart: false,
+    })
+  })
+
+  it('honors explicit flags and a valid exposure', () => {
+    const u = normalizeUpstream({ ...base, enabled: false, exposure: 'passthrough', autostart: true })
+    expect(u).toMatchObject({ enabled: false, exposure: 'passthrough', autostart: true })
+  })
+
+  it('coerces an invalid exposure back to search', () => {
+    expect(normalizeUpstream({ ...base, exposure: 'bogus' })?.exposure).toBe('search')
+  })
+
+  it('drops entries missing id, name, or a valid transport', () => {
+    expect(normalizeUpstream({ ...base, id: '' })).toBeNull()
+    expect(normalizeUpstream({ ...base, name: '' })).toBeNull()
+    expect(normalizeUpstream({ ...base, transport: { kind: 'stdio' } })).toBeNull()
+    expect(normalizeUpstream('nope')).toBeNull()
+  })
+})
+
+describe('normalizeUpstreams', () => {
+  it('returns [] for non-array input', () => {
+    expect(normalizeUpstreams(null)).toEqual([])
+    expect(normalizeUpstreams({})).toEqual([])
+  })
+
+  it('drops invalid and duplicate-id entries, keeps the first of a dup', () => {
+    const raw = [
+      { id: 'a', name: 'A', transport: { kind: 'stdio', command: 'a' } },
+      { id: 'bad' }, // invalid
+      { id: 'a', name: 'A2', transport: { kind: 'stdio', command: 'a2' } }, // dup id
+      { id: 'b', name: 'B', transport: { kind: 'http', url: 'http://b' } },
+    ]
+    const out = normalizeUpstreams(raw)
+    expect(out.map((u) => u.id)).toEqual(['a', 'b'])
+    expect(out[0].name).toBe('A')
+  })
+})
+
+describe('buildUpstream', () => {
+  it('mints a uuid id and applies defaults', () => {
+    const u = buildUpstream({ name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } })
+    expect(u.id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(u).toMatchObject({ name: 'FS', enabled: true, exposure: 'search', autostart: false })
+  })
+
+  it('throws on an invalid transport or empty name', () => {
+    expect(() => buildUpstream({ name: 'x', transport: { kind: 'stdio' } as any })).toThrow()
+    expect(() =>
+      buildUpstream({ name: '  ', transport: { kind: 'stdio', command: 'x' } }),
+    ).toThrow()
+  })
+})
+
+describe('CRUD round-trip', () => {
+  it('add → list → get persists a clean entry', () => {
+    const created = addUpstream({ name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } })
+    expect(created).not.toBeNull()
+    expect(mockSaveConfig).toHaveBeenCalledWith('mcpUpstreams', expect.any(Array))
+    expect(listUpstreams()).toHaveLength(1)
+    expect(getUpstream(created!.id)).toEqual(created)
+  })
+
+  it('update merges a patch and preserves id + untouched fields', () => {
+    const created = addUpstream({ name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } })!
+    const updated = updateUpstream(created.id, { exposure: 'passthrough', enabled: false })
+    expect(updated).toMatchObject({ id: created.id, name: 'FS', exposure: 'passthrough', enabled: false })
+    expect(getUpstream(created.id)?.exposure).toBe('passthrough')
+  })
+
+  it('update swaps the transport when a valid one is supplied, ignores an invalid one', () => {
+    const created = addUpstream({ name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } })!
+    updateUpstream(created.id, { transport: { kind: 'http', url: 'http://x/mcp' } })
+    expect(getUpstream(created.id)?.transport).toEqual({ kind: 'http', url: 'http://x/mcp' })
+    updateUpstream(created.id, { transport: { kind: 'stdio' } as any })
+    expect(getUpstream(created.id)?.transport).toEqual({ kind: 'http', url: 'http://x/mcp' })
+  })
+
+  it('update returns null for an unknown id', () => {
+    expect(updateUpstream('missing', { name: 'x' })).toBeNull()
+  })
+
+  it('remove deletes by id and reports absence', () => {
+    const created = addUpstream({ name: 'FS', transport: { kind: 'stdio', command: 'fs-mcp' } })!
+    expect(removeUpstream(created.id)).toBe(true)
+    expect(listUpstreams()).toHaveLength(0)
+    expect(removeUpstream(created.id)).toBe(false)
+  })
+})


### PR DESCRIPTION
Part of the Conductor Proxy MCP epic (#101). Resolves #93.

**Stacked PR** — base: `beta`. First in the stack; merge this before the others.

Data model + persistence for upstream MCP servers (no runtime yet).
- `McpUpstream` / transport / exposure types in `src/shared/types.ts`
- new `mcpUpstreams` config key
- `src/main/mcp-proxy/upstream-registry.ts`: pure normalize/validate + CRUD; corrupt/duplicate entries dropped on read, never thrown
- 18 unit tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)
