### PR TITLE
Conductor Proxy T4: search-based meta-tool surface (#96)

### DIFF
--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -39,6 +39,9 @@ import { isPackagedApp } from './update-watcher'
 import { resolveCdpPort, CDP_PORT_PROD } from '../shared/cdp-ports'
 import type { GlobalVisionConfig } from '../shared/types'
 import { registerCodexReviewTool } from './codex-review-mcp-tool'
+import { getProxySupervisor } from './mcp-proxy/supervisor'
+import { registerProxyTools } from './mcp-proxy/proxy-tools'
+import { onInternal } from './internal-events'
 
 /** P6.9: Parse the `source` query string from the SSE request URL.
  *  The Codex TOML writer appends `?source=codex` so the server can skip
@@ -379,7 +382,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
     // off; this filter is belt-and-braces for stale session configs.
     const toolCfg = readConfig<{
       conductorToolsEnabled?: boolean
-      conductorTools?: { vision?: boolean; codexReview?: boolean; hostTransfer?: boolean }
+      conductorTools?: { vision?: boolean; codexReview?: boolean; hostTransfer?: boolean; proxy?: boolean }
       codexEnabled?: boolean
     }>('settings')
     const toolsMaster = toolCfg?.conductorToolsEnabled !== false
@@ -589,6 +592,23 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
       )
     }
 
+    // Conductor Proxy (T4/#96): the search-based meta-tools (search_tools,
+    // describe_tool, call_tool, list_servers) + per-upstream passthrough tools.
+    // Only registered when at least one upstream is configured, so existing
+    // installs with no upstreams see no new tools (zero behavior change until
+    // the user adds one in the T5 UI). Absent flag means ON, like the others.
+    const proxyOn = toolsMaster && toolCfg?.conductorTools?.proxy !== false
+    const supervisor = getProxySupervisor()
+    if (proxyOn && supervisor.getState().length > 0) {
+      const cleanup = registerProxyTools(server, z, {
+        getTools: () => supervisor.getTools(),
+        getState: () => supervisor.getState(),
+        callTool: (id, tool, args) => supervisor.callTool(id, tool, args),
+        onChanged: (cb) => onInternal('mcp-proxy:changed', () => cb()),
+      })
+      ;(server as { __proxyCleanup?: () => void }).__proxyCleanup = cleanup
+    }
+
     return server
   }
 
@@ -640,6 +660,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
 
         res.on('close', () => {
           transports.delete(transport.sessionId)
+          try { (server as { __proxyCleanup?: () => void }).__proxyCleanup?.() } catch { /* ignore */ }
           logInfo(`[vision-mcp] SSE connection closed (${transports.size} remaining)`)
         })
 
@@ -713,6 +734,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
           await server.connect(transport)
           await transport.handleRequest(req, res)
           res.on('close', () => {
+            try { (server as { __proxyCleanup?: () => void }).__proxyCleanup?.() } catch { /* ignore */ }
             try { transport.close() } catch { /* already closed */ }
             try { server.close() } catch { /* already closed */ }
           })

--- a/src/main/mcp-proxy/proxy-tools.ts
+++ b/src/main/mcp-proxy/proxy-tools.ts
@@ -1,0 +1,250 @@
+/**
+ * Conductor Proxy — client-facing meta-tool surface (T4, #96).
+ *
+ * Registers the proxy's tools onto a per-connection McpServer (the seam in
+ * conductor-mcp-server.ts `createServer`). Two exposure paths:
+ *
+ *  1. SEARCH (default) — a small FIXED set of meta-tools so upstream churn never
+ *     changes the advertised tool list:
+ *       - search_tools(query, [server], [limit])  → BM25 rows (name/server/desc)
+ *       - describe_tool(name)                      → full input schema on demand
+ *       - call_tool(name, [arguments])             → dispatch to the upstream
+ *       - list_servers()                           → upstream online/offline state
+ *
+ *  2. PASSTHROUGH (opt-in per upstream) — each of that upstream's tools is ALSO
+ *     advertised directly as `server__tool`. Upstream tools carry a JSON Schema;
+ *     the SDK wants Zod, so we convert (best-effort — common JSON-Schema shapes;
+ *     anything exotic falls back to z.any() while preserving arg names/optionality).
+ *
+ * This module owns NO state and never touches the SDK client — it drives the
+ * supervisor (T2) + a freshly built tool-index (T3) through the injected deps,
+ * so it is unit-testable with a fake `server` recorder and real zod.
+ */
+
+import { ToolIndex } from './tool-index'
+import { ProxyDispatchError } from './supervisor'
+import type { AggregatedTool, UpstreamRuntimeState } from './supervisor'
+
+/** Everything registerProxyTools needs from the supervisor — injected for tests. */
+export interface ProxyToolDeps {
+  /** All tools across ONLINE upstreams (supervisor.getTools). */
+  getTools: () => AggregatedTool[]
+  /** Per-upstream runtime state incl. exposure mode (supervisor.getState). */
+  getState: () => UpstreamRuntimeState[]
+  /** Route a resolved call to its upstream (supervisor.callTool). */
+  callTool: (upstreamId: string, toolName: string, args: Record<string, unknown> | undefined) => Promise<unknown>
+  /** Subscribe to change events; return an unsubscribe fn. Optional (tests skip). */
+  onChanged?: (cb: () => void) => () => void
+}
+
+function textResult(text: string, isError = false) {
+  return { content: [{ type: 'text' as const, text }], isError }
+}
+
+/** Pass an upstream CallToolResult through unchanged when it already looks like
+ *  MCP content; otherwise wrap it as JSON text so the client always gets a
+ *  well-formed result. */
+function passthroughResult(raw: unknown) {
+  if (raw && typeof raw === 'object' && Array.isArray((raw as any).content)) {
+    return raw as { content: unknown[]; isError?: boolean }
+  }
+  return textResult(JSON.stringify(raw))
+}
+
+/** Map a dispatch failure to a graceful, actionable tool result. TOOL_NOT_FOUND
+ *  is the list→call race — tell the model to re-search rather than erroring hard. */
+function dispatchErrorResult(err: unknown) {
+  if (err instanceof ProxyDispatchError) {
+    if (err.code === 'TOOL_NOT_FOUND') {
+      return textResult(`${err.message}. Run search_tools again to get the current tool list.`, true)
+    }
+    if (err.code === 'UPSTREAM_OFFLINE') {
+      return textResult(`${err.message}. Check list_servers; the server may be starting or stopped.`, true)
+    }
+    return textResult(err.message, true)
+  }
+  return textResult(`Tool call failed: ${err instanceof Error ? err.message : String(err)}`, true)
+}
+
+// ── JSON Schema → Zod (best-effort, for passthrough only) ──
+
+/** Convert one JSON-Schema property definition to a Zod type. Unknown shapes
+ *  degrade to z.any() so a call is never blocked by an untranslatable schema. */
+export function jsonSchemaToZodType(def: unknown, z: any): any {
+  if (!def || typeof def !== 'object') return z.any()
+  const d = def as Record<string, unknown>
+  if (Array.isArray(d.enum) && d.enum.length > 0 && d.enum.every((e) => typeof e === 'string')) {
+    return z.enum(d.enum as [string, ...string[]])
+  }
+  switch (d.type) {
+    case 'string':
+      return z.string()
+    case 'number':
+    case 'integer':
+      return z.number()
+    case 'boolean':
+      return z.boolean()
+    case 'array':
+      return z.array(d.items ? jsonSchemaToZodType(d.items, z) : z.any())
+    case 'object':
+      return z.object({}).passthrough()
+    default:
+      return z.any()
+  }
+}
+
+/** Build a Zod raw shape (Record<string, ZodType>) from a tool's top-level
+ *  JSON-Schema `properties`, honoring `required` and per-arg `description`. */
+export function jsonSchemaToZodShape(inputSchema: unknown, z: any): Record<string, any> {
+  const shape: Record<string, any> = {}
+  if (!inputSchema || typeof inputSchema !== 'object') return shape
+  const props = (inputSchema as Record<string, unknown>).properties
+  if (!props || typeof props !== 'object') return shape
+  const required = new Set(
+    Array.isArray((inputSchema as Record<string, unknown>).required)
+      ? ((inputSchema as Record<string, unknown>).required as unknown[]).filter((r) => typeof r === 'string')
+      : [],
+  )
+  for (const [key, def] of Object.entries(props as Record<string, unknown>)) {
+    let zt = jsonSchemaToZodType(def, z)
+    const desc = def && typeof def === 'object' ? (def as Record<string, unknown>).description : undefined
+    if (typeof desc === 'string') zt = zt.describe(desc)
+    if (!required.has(key)) zt = zt.optional()
+    shape[key] = zt
+  }
+  return shape
+}
+
+/**
+ * Register the proxy tools on `server`. Returns a cleanup function that
+ * unsubscribes the change listener (call it when the connection closes).
+ *
+ * `server` is an McpServer; `z` is the zod module. Both are passed in (matching
+ * conductor-mcp-server's lazy-loaded deps) so this module needs no direct import.
+ */
+export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): () => void {
+  // search_tools ---------------------------------------------------------------
+  server.tool(
+    'search_tools',
+    'Search the tools available across all connected MCP servers by keyword. Returns compact matches (namespaced `server__tool` name, server, one-line description). Use this to discover a tool, then describe_tool for its parameters and call_tool to run it. This is how you reach any proxied MCP tool.',
+    {
+      query: z.string().describe('Keywords describing the tool or capability you need (e.g. "read file", "open issue").'),
+      server: z.string().optional().describe('Restrict to one server by its slug or display name.'),
+      limit: z.number().optional().describe('Max results (default 10).'),
+    },
+    async ({ query, server: serverFilter, limit }: { query: string; server?: string; limit?: number }) => {
+      const index = new ToolIndex(deps.getTools())
+      const rows = index.search(query, { server: serverFilter, limit })
+      if (rows.length === 0) {
+        return textResult(
+          JSON.stringify({
+            results: [],
+            hint: 'No matching tools. Try broader keywords, or call list_servers to see which servers are online.',
+          }),
+        )
+      }
+      return textResult(JSON.stringify({ results: rows }))
+    },
+  )
+
+  // describe_tool --------------------------------------------------------------
+  server.tool(
+    'describe_tool',
+    'Get the full input schema (parameters) for a proxied tool by its namespaced `server__tool` name, as returned by search_tools. Call this before call_tool when you need the argument shape.',
+    {
+      name: z.string().describe('Namespaced tool name, e.g. "filesystem__read_file".'),
+    },
+    async ({ name }: { name: string }) => {
+      const index = new ToolIndex(deps.getTools())
+      const detail = index.describe(name)
+      if (!detail) {
+        return textResult(`Unknown tool "${name}". Run search_tools to get valid names.`, true)
+      }
+      return textResult(
+        JSON.stringify({
+          name: detail.namespacedName,
+          server: detail.server,
+          description: detail.description,
+          inputSchema: detail.inputSchema ?? { type: 'object', properties: {} },
+        }),
+      )
+    },
+  )
+
+  // call_tool ------------------------------------------------------------------
+  server.tool(
+    'call_tool',
+    'Invoke a proxied tool by its namespaced `server__tool` name (from search_tools) with its arguments. Returns the upstream tool result directly.',
+    {
+      name: z.string().describe('Namespaced tool name, e.g. "github__create_issue".'),
+      arguments: z.record(z.any()).optional().describe('Arguments object for the tool (see describe_tool).'),
+    },
+    async ({ name, arguments: args }: { name: string; arguments?: Record<string, unknown> }) => {
+      const index = new ToolIndex(deps.getTools())
+      const target = index.resolve(name)
+      if (!target) {
+        return textResult(`Unknown tool "${name}". Run search_tools to get current names.`, true)
+      }
+      try {
+        const raw = await deps.callTool(target.upstreamId, target.toolName, args)
+        return passthroughResult(raw)
+      } catch (err) {
+        return dispatchErrorResult(err)
+      }
+    },
+  )
+
+  // list_servers ---------------------------------------------------------------
+  server.tool(
+    'list_servers',
+    'List the connected MCP servers behind this proxy with their online/offline status and tool counts.',
+    {},
+    async () => {
+      const servers = deps.getState().map((s) => ({
+        name: s.name,
+        status: s.status,
+        exposure: s.exposure,
+        toolCount: s.toolCount,
+        ...(s.lastError ? { lastError: s.lastError } : {}),
+      }))
+      return textResult(JSON.stringify({ servers }))
+    },
+  )
+
+  // passthrough tools ----------------------------------------------------------
+  // Snapshot of each passthrough upstream's tools at connect time. Live changes
+  // fire sendToolListChanged below; the client (Claude >=2.1.0) re-lists, but
+  // the passthrough *set* only refreshes on reconnect (MVP limitation).
+  const passthroughIds = new Set(
+    deps.getState().filter((s) => s.exposure === 'passthrough' && s.status === 'online').map((s) => s.name),
+  )
+  if (passthroughIds.size > 0) {
+    const index = new ToolIndex(deps.getTools())
+    for (const row of index.all()) {
+      const detail = index.describe(row.name)
+      if (!detail || !passthroughIds.has(detail.server)) continue
+      const target = { upstreamId: detail.upstreamId, toolName: detail.toolName }
+      server.tool(
+        row.name,
+        detail.description || `Proxied tool from ${detail.server}`,
+        jsonSchemaToZodShape(detail.inputSchema, z),
+        async (args: Record<string, unknown>) => {
+          try {
+            return passthroughResult(await deps.callTool(target.upstreamId, target.toolName, args))
+          } catch (err) {
+            return dispatchErrorResult(err)
+          }
+        },
+      )
+    }
+  }
+
+  // Hot-reload: re-advertise the tool list when upstreams change. Harmless in
+  // search mode (the meta-tool set is fixed); prompts a re-list for passthrough.
+  if (deps.onChanged) {
+    return deps.onChanged(() => {
+      try { server.sendToolListChanged?.() } catch { /* connection may be closing */ }
+    })
+  }
+  return () => {}
+}

--- a/tests/unit/main/mcp-proxy/proxy-tools.test.ts
+++ b/tests/unit/main/mcp-proxy/proxy-tools.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import {
+  registerProxyTools,
+  jsonSchemaToZodShape,
+  jsonSchemaToZodType,
+  type ProxyToolDeps,
+} from '../../../../src/main/mcp-proxy/proxy-tools'
+import { ProxyDispatchError, type AggregatedTool, type UpstreamRuntimeState } from '../../../../src/main/mcp-proxy/supervisor'
+
+function fakeServer() {
+  const tools = new Map<string, { description: string; shape: any; handler: (a?: any) => any }>()
+  return {
+    tools,
+    tool(name: string, description: string, shape: any, handler: (a?: any) => any) {
+      tools.set(name, { description, shape, handler })
+    },
+    sendToolListChanged: vi.fn(),
+    invoke(name: string, args?: any) {
+      return tools.get(name)!.handler(args)
+    },
+  }
+}
+
+async function parse(result: any) {
+  return { json: JSON.parse(result.content[0].text), isError: !!result.isError }
+}
+
+const TOOLS: AggregatedTool[] = [
+  { upstreamId: 'u1', upstreamName: 'Filesystem', tool: { name: 'read_file', description: 'Read a file from disk', inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'path' } }, required: ['path'] } } },
+  { upstreamId: 'u2', upstreamName: 'GitHub', tool: { name: 'create_issue', description: 'Open an issue' } },
+]
+const STATE: UpstreamRuntimeState[] = [
+  { id: 'u1', name: 'Filesystem', status: 'online', exposure: 'search', toolCount: 1 },
+  { id: 'u2', name: 'GitHub', status: 'online', exposure: 'search', toolCount: 1 },
+]
+
+function deps(over: Partial<ProxyToolDeps> = {}): ProxyToolDeps {
+  return {
+    getTools: () => TOOLS,
+    getState: () => STATE,
+    callTool: vi.fn(async () => ({ content: [{ type: 'text', text: 'upstream-ok' }] })),
+    ...over,
+  }
+}
+
+describe('meta-tool registration', () => {
+  it('registers exactly the four search meta-tools when no upstream is passthrough', () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    expect([...s.tools.keys()].sort()).toEqual(['call_tool', 'describe_tool', 'list_servers', 'search_tools'])
+  })
+})
+
+describe('search_tools', () => {
+  it('returns ranked rows', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    const { json } = await parse(await s.invoke('search_tools', { query: 'read file' }))
+    expect(json.results[0].name).toBe('filesystem__read_file')
+  })
+
+  it('returns a hint when nothing matches', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    const { json } = await parse(await s.invoke('search_tools', { query: 'kubernetes' }))
+    expect(json.results).toEqual([])
+    expect(json.hint).toBeTruthy()
+  })
+})
+
+describe('describe_tool', () => {
+  it('returns the full input schema', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    const { json } = await parse(await s.invoke('describe_tool', { name: 'filesystem__read_file' }))
+    expect(json.inputSchema.properties.path).toBeTruthy()
+  })
+
+  it('errors for an unknown name', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    const res = await s.invoke('describe_tool', { name: 'nope__x' })
+    expect(res.isError).toBe(true)
+  })
+})
+
+describe('call_tool', () => {
+  it('resolves the namespaced name and routes to the upstream', async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: 'text', text: 'done' }] }))
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool }))
+    const res = await s.invoke('call_tool', { name: 'filesystem__read_file', arguments: { path: '/x' } })
+    expect(callTool).toHaveBeenCalledWith('u1', 'read_file', { path: '/x' })
+    expect(res.content[0].text).toBe('done')
+  })
+
+  it('errors on an unknown tool name (before dispatch)', async () => {
+    const callTool = vi.fn()
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool }))
+    const res = await s.invoke('call_tool', { name: 'ghost__tool' })
+    expect(res.isError).toBe(true)
+    expect(callTool).not.toHaveBeenCalled()
+  })
+
+  it('maps a TOOL_NOT_FOUND race to a re-search hint, not a hard error', async () => {
+    const callTool = vi.fn(async () => {
+      throw new ProxyDispatchError('TOOL_NOT_FOUND', 'Tool read_file is no longer offered by Filesystem')
+    })
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool }))
+    const res = await s.invoke('call_tool', { name: 'filesystem__read_file' })
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text).toContain('search_tools')
+  })
+
+  it('wraps a non-content upstream result as JSON text', async () => {
+    const callTool = vi.fn(async () => ({ raw: 42 }))
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool }))
+    const res = await s.invoke('call_tool', { name: 'github__create_issue' })
+    expect(JSON.parse(res.content[0].text)).toEqual({ raw: 42 })
+  })
+})
+
+describe('list_servers', () => {
+  it('reports status + exposure per server', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps())
+    const { json } = await parse(await s.invoke('list_servers'))
+    expect(json.servers).toHaveLength(2)
+    expect(json.servers[0]).toMatchObject({ name: 'Filesystem', status: 'online', exposure: 'search' })
+  })
+})
+
+describe('passthrough', () => {
+  it('registers server__tool directly for passthrough upstreams and routes calls', async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: 'text', text: 'pt' }] }))
+    const state: UpstreamRuntimeState[] = [
+      { id: 'u1', name: 'Filesystem', status: 'online', exposure: 'passthrough', toolCount: 1 },
+      { id: 'u2', name: 'GitHub', status: 'online', exposure: 'search', toolCount: 1 },
+    ]
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool, getState: () => state }))
+    // Filesystem is passthrough -> its tool is advertised directly; GitHub is not.
+    expect(s.tools.has('filesystem__read_file')).toBe(true)
+    expect(s.tools.has('github__create_issue')).toBe(false)
+    const res = await s.invoke('filesystem__read_file', { path: '/y' })
+    expect(callTool).toHaveBeenCalledWith('u1', 'read_file', { path: '/y' })
+    expect(res.content[0].text).toBe('pt')
+  })
+})
+
+describe('onChanged hot-reload wiring', () => {
+  it('subscribes and calls sendToolListChanged; cleanup unsubscribes', () => {
+    let cb: (() => void) | null = null
+    const unsub = vi.fn()
+    const onChanged = vi.fn((fn: () => void) => {
+      cb = fn
+      return unsub
+    })
+    const s = fakeServer()
+    const cleanup = registerProxyTools(s, z, deps({ onChanged }))
+    expect(onChanged).toHaveBeenCalled()
+    cb!()
+    expect(s.sendToolListChanged).toHaveBeenCalled()
+    cleanup()
+    expect(unsub).toHaveBeenCalled()
+  })
+})
+
+describe('jsonSchemaToZod (passthrough conversion)', () => {
+  it('builds a shape honoring required/optional and descriptions', () => {
+    const shape = jsonSchemaToZodShape(
+      {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'the path' },
+          limit: { type: 'number' },
+        },
+        required: ['path'],
+      },
+      z,
+    )
+    const obj = z.object(shape)
+    expect(obj.safeParse({ path: '/a' }).success).toBe(true) // limit optional
+    expect(obj.safeParse({ limit: 3 }).success).toBe(false) // path required
+  })
+
+  it('maps primitive/array/enum types and falls back to any', () => {
+    expect(jsonSchemaToZodType({ type: 'boolean' }, z).safeParse(true).success).toBe(true)
+    expect(jsonSchemaToZodType({ type: 'array', items: { type: 'string' } }, z).safeParse(['a']).success).toBe(true)
+    expect(jsonSchemaToZodType({ enum: ['a', 'b'] }, z).safeParse('a').success).toBe(true)
+    expect(jsonSchemaToZodType({ enum: ['a', 'b'] }, z).safeParse('c').success).toBe(false)
+    expect(jsonSchemaToZodType({ type: 'weird' }, z).safeParse({ anything: 1 }).success).toBe(true) // z.any()
+  })
+
+  it('returns an empty shape for a schema without properties', () => {
+    expect(jsonSchemaToZodShape(undefined, z)).toEqual({})
+    expect(jsonSchemaToZodShape({ type: 'object' }, z)).toEqual({})
+  })
+})


### PR DESCRIPTION
Part of the Conductor Proxy MCP epic (#101). Resolves #96.

**Stacked PR** — base: `feat/95-tool-index`.

Search-based meta-tool surface on the existing conductor endpoint.
- `search_tools` / `describe_tool` / `call_tool` / `list_servers`; `call_tool` maps error codes to graceful results (TOOL_NOT_FOUND → re-run search_tools)
- per-upstream `passthrough` opt-in with a best-effort JSON-Schema→Zod converter
- wired into `createServer` behind `conductorTools.proxy`; only registers when ≥1 upstream is configured (zero change for installs with none)
- 15 new tests; existing conductor suite (51) still green


🤖 Generated with [Claude Code](https://claude.com/claude-code)
