### PR TITLE
Conductor Proxy T9: migrate built-in tools into proxy (#102)

### DIFF
--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -40,7 +40,8 @@ import { resolveCdpPort, CDP_PORT_PROD } from '../shared/cdp-ports'
 import type { GlobalVisionConfig } from '../shared/types'
 import { registerCodexReviewTool } from './codex-review-mcp-tool'
 import { getProxySupervisor } from './mcp-proxy/supervisor'
-import { registerProxyTools } from './mcp-proxy/proxy-tools'
+import { registerProxyTools, type LocalTool } from './mcp-proxy/proxy-tools'
+import { builtinCatalog, type BuiltinCtx } from './mcp-proxy/builtin-catalog'
 import { onInternal } from './internal-events'
 
 /** P6.9: Parse the `source` query string from the SSE request URL.
@@ -382,7 +383,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
     // off; this filter is belt-and-braces for stale session configs.
     const toolCfg = readConfig<{
       conductorToolsEnabled?: boolean
-      conductorTools?: { vision?: boolean; codexReview?: boolean; hostTransfer?: boolean; proxy?: boolean }
+      conductorTools?: { vision?: boolean; codexReview?: boolean; hostTransfer?: boolean; proxy?: boolean; builtinExposure?: 'passthrough' | 'search' }
       codexEnabled?: boolean
     }>('settings')
     const toolsMaster = toolCfg?.conductorToolsEnabled !== false
@@ -438,13 +439,34 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
     // session's own pinned browser target, so concurrent sessions never collide.
     const withVision = (cmd: VisionCommand) => runVision({ ...cmd, sessionId: boundSessionId ?? undefined })
 
+    // Built-in tool exposure (T9/#102). 'passthrough' (default) keeps the inline
+    // registrations below -- byte-for-byte the pre-proxy behavior. 'search' skips
+    // them (builtinDirect=false) and instead hands the gated built-ins to the
+    // proxy facade as local tools (built below), keeping the ~19 vision tools out
+    // of the advertised set. All original gates still apply either way.
+    const builtinExposure = toolCfg?.conductorTools?.builtinExposure === 'search' ? 'search' : 'passthrough'
+    const builtinDirect = builtinExposure !== 'search'
+    const builtinCtx: BuiltinCtx = {
+      withVision, getVisionManager, imageFileToMcpContent, resultToMcpContent, visionUnavailable, boundSessionId,
+    }
+    const builtinLocalTools: LocalTool[] = builtinExposure === 'search'
+      ? builtinCatalog()
+          .filter((b) => (b.group === 'vision' ? (toolOn('vision') && source !== 'codex') : toolOn('hostTransfer')))
+          .map((b) => ({
+            name: b.name,
+            description: b.description,
+            inputSchema: b.jsonSchema,
+            run: (args: Record<string, unknown>) => b.run(args ?? {}, builtinCtx),
+          }))
+      : []
+
     // ── Host file access (always available, no vision required) ────────────
 
     // -- fetch_host_screenshot --
     // Returns an image from the host's screenshots dir as inline MCP image content.
     // Used by snap, storyboard, and clipboard paste in BOTH local and SSH sessions.
     // SSH sessions reach the MCP server via the existing reverse tunnel.
-    if (toolOn('hostTransfer')) server.tool(
+    if (builtinDirect && toolOn('hostTransfer')) server.tool(
       'fetch_host_screenshot',
       'Fetch an image file from the Conductor host\'s screenshots directory and return it as inline image content. The Conductor app saves clipboard pastes, snap captures, and storyboard frames here so they can be viewed by Claude regardless of session type (local or SSH). Use the filename the user references (e.g. "clipboard-1234.jpg" or "screenshot-2026-04-08-...jpg").',
       {
@@ -459,7 +481,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
     // Registered as one gated group; inner indentation intentionally unchanged.
     // Not advertised to Codex sessions: vision is Claude-only for now (user
     // call 2026-07-02) — the onboarding p6 card carries the same note.
-    if (toolOn('vision') && source !== 'codex') {
+    if (builtinDirect && toolOn('vision') && source !== 'codex') {
     // -- Status --
     server.tool('vision_status', 'Check browser connection status', {}, async () => {
       const vm = getVisionManager()
@@ -597,13 +619,17 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
     // Only registered when at least one upstream is configured, so existing
     // installs with no upstreams see no new tools (zero behavior change until
     // the user adds one in the T5 UI). Absent flag means ON, like the others.
+    // Register the facade when there is anything to expose through it: at least
+    // one configured upstream, OR built-ins in 'search' mode (T9). Installs with
+    // neither see no proxy meta-tools (zero behavior change).
     const proxyOn = toolsMaster && toolCfg?.conductorTools?.proxy !== false
     const supervisor = getProxySupervisor()
-    if (proxyOn && supervisor.getState().length > 0) {
+    if (proxyOn && (supervisor.getState().length > 0 || builtinLocalTools.length > 0)) {
       const cleanup = registerProxyTools(server, z, {
         getTools: () => supervisor.getTools(),
         getState: () => supervisor.getState(),
         callTool: (id, tool, args) => supervisor.callTool(id, tool, args),
+        localTools: builtinLocalTools,
         onChanged: (cb) => onInternal('mcp-proxy:changed', () => cb()),
       })
       ;(server as { __proxyCleanup?: () => void }).__proxyCleanup = cleanup

--- a/src/main/mcp-proxy/builtin-catalog.ts
+++ b/src/main/mcp-proxy/builtin-catalog.ts
@@ -1,0 +1,249 @@
+/**
+ * Conductor Proxy — built-in tool catalog (T9, #102).
+ *
+ * SINGLE SOURCE OF TRUTH for the Conductor built-in tools (browser vision +
+ * host file transfer). Previously these were ~19 inline `server.tool(...)` calls
+ * in conductor-mcp-server.ts, always advertised directly — a parallel set that
+ * bloated the tool context regardless of the proxy.
+ *
+ * Each entry pairs a JSON Schema (converted to Zod for direct registration via
+ * the T4 converter, and used verbatim by describe_tool in search mode) with a
+ * `run` handler. conductor-mcp-server drives the catalog two ways:
+ *   - builtinExposure 'passthrough' (default): register directly — byte-for-byte
+ *     the same tools/behavior as before.
+ *   - builtinExposure 'search': hand the catalog to the proxy facade as local
+ *     tools, so they are discoverable via search_tools and invoked via call_tool
+ *     (namespaced conductor__<name>) instead of bloating the advertised list.
+ *
+ * codex_review is intentionally NOT in this catalog — it is a single tool with
+ * its own per-session ACL and stays registered directly (see conductor-mcp-server).
+ */
+
+import * as path from 'path'
+import type { VisionCommand } from '../vision-manager'
+
+/** Minimal MCP tool result shape the handlers return. */
+export interface McpContentResult {
+  content: Array<Record<string, unknown>>
+  isError?: boolean
+}
+
+/** Operations the built-in handlers need, injected per client connection so
+ *  vision routing stays bound to that connection's session (boundSessionId). */
+export interface BuiltinCtx {
+  withVision: (cmd: VisionCommand) => Promise<McpContentResult>
+  getVisionManager: () => { executeCommand: (cmd: VisionCommand) => Promise<any> } | null
+  imageFileToMcpContent: (filename: string) => McpContentResult
+  resultToMcpContent: (result: any) => McpContentResult
+  visionUnavailable: () => McpContentResult
+  boundSessionId: string | null
+}
+
+export type BuiltinGroup = 'vision' | 'hostTransfer'
+
+export interface BuiltinTool {
+  name: string
+  group: BuiltinGroup
+  description: string
+  /** JSON Schema for the tool input (object schema; empty properties = no args). */
+  jsonSchema: Record<string, unknown>
+  run: (args: Record<string, unknown>, ctx: BuiltinCtx) => Promise<McpContentResult> | McpContentResult
+}
+
+/** Build an object JSON Schema. */
+function obj(
+  properties: Record<string, unknown> = {},
+  required: string[] = [],
+): Record<string, unknown> {
+  return required.length > 0
+    ? { type: 'object', properties, required }
+    : { type: 'object', properties }
+}
+const str = (description: string) => ({ type: 'string', description })
+const num = (description: string) => ({ type: 'number', description })
+
+/** The catalog. Handlers mirror the original inline registrations exactly. */
+export function builtinCatalog(): BuiltinTool[] {
+  return [
+    // ── Host file access ──
+    {
+      name: 'fetch_host_screenshot',
+      group: 'hostTransfer',
+      description:
+        'Fetch an image file from the Conductor host\'s screenshots directory and return it as inline image content. The Conductor app saves clipboard pastes, snap captures, and storyboard frames here so they can be viewed by Claude regardless of session type (local or SSH). Use the filename the user references (e.g. "clipboard-1234.jpg" or "screenshot-2026-04-08-...jpg").',
+      jsonSchema: obj(
+        { filename: str('Bare filename (no path separators) of an image in the Conductor screenshots directory') },
+        ['filename'],
+      ),
+      run: (args, ctx) => ctx.imageFileToMcpContent(String(args.filename ?? '')),
+    },
+
+    // ── Vision ──
+    {
+      name: 'vision_status',
+      group: 'vision',
+      description: 'Check browser connection status',
+      jsonSchema: obj(),
+      run: async (_args, ctx) => {
+        const vm = ctx.getVisionManager()
+        if (!vm) return ctx.resultToMcpContent({ ok: true, data: { connected: false, browser: null } })
+        return ctx.resultToMcpContent(
+          await vm.executeCommand({ command: 'status', args: [], sessionId: ctx.boundSessionId ?? undefined }),
+        )
+      },
+    },
+    {
+      name: 'vision_screenshot',
+      group: 'vision',
+      description:
+        'Capture a screenshot of the current browser page and return it as inline image content. No need to call Read afterwards — the image is included in the response.',
+      jsonSchema: obj(),
+      run: async (_args, ctx) => {
+        const vm = ctx.getVisionManager()
+        if (!vm) return ctx.visionUnavailable()
+        const result = await vm.executeCommand({ command: 'screenshot', args: [], sessionId: ctx.boundSessionId ?? undefined })
+        if (!result.ok || !result.path) return ctx.resultToMcpContent(result)
+        return ctx.imageFileToMcpContent(path.basename(result.path))
+      },
+    },
+    {
+      name: 'vision_navigate',
+      group: 'vision',
+      description: 'Navigate the browser to a URL',
+      jsonSchema: obj({ url: str('URL to navigate to') }, ['url']),
+      run: (args, ctx) => ctx.withVision({ command: 'navigate', args: [String(args.url)] }),
+    },
+    {
+      name: 'vision_click',
+      group: 'vision',
+      description: 'Click an element by CSS selector or x,y coordinates',
+      jsonSchema: obj({ target: str('CSS selector or "x,y" coordinates') }, ['target']),
+      run: (args, ctx) => ctx.withVision({ command: 'click', args: [String(args.target)] }),
+    },
+    {
+      name: 'vision_type',
+      group: 'vision',
+      description: 'Type text into an element',
+      jsonSchema: obj(
+        { selector: str('CSS selector of the input element'), text: str('Text to type') },
+        ['selector', 'text'],
+      ),
+      run: (args, ctx) => ctx.withVision({ command: 'type', args: [String(args.selector), String(args.text)] }),
+    },
+    {
+      name: 'vision_eval',
+      group: 'vision',
+      description: 'Execute JavaScript in the browser and return the result',
+      jsonSchema: obj({ expression: str('JavaScript expression to evaluate') }, ['expression']),
+      run: (args, ctx) => ctx.withVision({ command: 'eval', args: [String(args.expression)] }),
+    },
+    {
+      name: 'vision_wait',
+      group: 'vision',
+      description: 'Wait for a CSS selector to appear on the page',
+      jsonSchema: obj({
+        selector: str('CSS selector to wait for'),
+        timeout: num('Timeout in milliseconds (default 5000)'),
+      }, ['selector']),
+      run: (args, ctx) => {
+        const a = [String(args.selector)]
+        if (args.timeout) a.push(String(args.timeout))
+        return ctx.withVision({ command: 'wait', args: a })
+      },
+    },
+    {
+      name: 'vision_html',
+      group: 'vision',
+      description: 'Get the innerHTML of an element',
+      jsonSchema: obj({ selector: str('CSS selector (default: body)') }),
+      run: (args, ctx) => ctx.withVision({ command: 'html', args: args.selector ? [String(args.selector)] : [] }),
+    },
+    {
+      name: 'vision_text',
+      group: 'vision',
+      description: 'Get the textContent of an element',
+      jsonSchema: obj({ selector: str('CSS selector (default: body)') }),
+      run: (args, ctx) => ctx.withVision({ command: 'text', args: args.selector ? [String(args.selector)] : [] }),
+    },
+    {
+      name: 'vision_title',
+      group: 'vision',
+      description: 'Get the page title',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'title', args: [] }),
+    },
+    {
+      name: 'vision_url',
+      group: 'vision',
+      description: 'Get the current page URL',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'url', args: [] }),
+    },
+    {
+      name: 'vision_tabs',
+      group: 'vision',
+      description: 'List all open browser tabs',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'tabs', args: [] }),
+    },
+    {
+      name: 'vision_tab',
+      group: 'vision',
+      description: 'Switch to a browser tab by index',
+      jsonSchema: obj({ index: num('Tab index (0-based)') }, ['index']),
+      run: (args, ctx) => ctx.withVision({ command: 'tab', args: [String(args.index)] }),
+    },
+    {
+      name: 'vision_back',
+      group: 'vision',
+      description: 'Navigate back in browser history',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'back', args: [] }),
+    },
+    {
+      name: 'vision_forward',
+      group: 'vision',
+      description: 'Navigate forward in browser history',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'forward', args: [] }),
+    },
+    {
+      name: 'vision_reload',
+      group: 'vision',
+      description: 'Reload the current page',
+      jsonSchema: obj(),
+      run: (_args, ctx) => ctx.withVision({ command: 'reload', args: [] }),
+    },
+    {
+      name: 'vision_scroll',
+      group: 'vision',
+      description: 'Scroll the page',
+      jsonSchema: obj({
+        direction: { type: 'string', enum: ['up', 'down', 'left', 'right'], description: 'Scroll direction (default: down)' },
+        pixels: num('Pixels to scroll (default: 400)'),
+      }),
+      run: (args, ctx) => {
+        const a: string[] = []
+        if (args.direction) a.push(String(args.direction))
+        if (args.pixels) a.push(String(args.pixels))
+        return ctx.withVision({ command: 'scroll', args: a })
+      },
+    },
+    {
+      name: 'vision_setViewport',
+      group: 'vision',
+      description:
+        'Set the browser viewport size (and optional deviceScaleFactor) for THIS session. The default headless viewport is ~800x600, which trips responsive layouts and clips wide content -- set e.g. 1440x900 to render at desktop size.',
+      jsonSchema: obj({
+        width: num('Viewport width in CSS pixels'),
+        height: num('Viewport height in CSS pixels'),
+        deviceScaleFactor: num('Device pixel ratio (default 1)'),
+      }, ['width', 'height']),
+      run: (args, ctx) => {
+        const a = [String(args.width), String(args.height)]
+        if (args.deviceScaleFactor !== undefined) a.push(String(args.deviceScaleFactor))
+        return ctx.withVision({ command: 'setViewport', args: a })
+      },
+    },
+  ]
+}

--- a/src/main/mcp-proxy/proxy-tools.ts
+++ b/src/main/mcp-proxy/proxy-tools.ts
@@ -25,6 +25,20 @@ import { ToolIndex } from './tool-index'
 import { ProxyDispatchError } from './supervisor'
 import type { AggregatedTool, UpstreamRuntimeState } from './supervisor'
 
+/** Virtual upstream id/name for the Conductor built-in tools when they are
+ *  exposed through the search facade (T9, builtinExposure='search'). */
+export const BUILTIN_UPSTREAM_ID = 'conductor-builtin'
+export const BUILTIN_UPSTREAM_NAME = 'Conductor'
+
+/** An in-process tool exposed through the facade (Conductor built-in). Unlike
+ *  upstream tools it is invoked via its own `run`, not the supervisor. */
+export interface LocalTool {
+  name: string
+  description: string
+  inputSchema?: unknown
+  run: (args: Record<string, unknown>) => Promise<{ content: unknown[]; isError?: boolean }> | { content: unknown[]; isError?: boolean }
+}
+
 /** Everything registerProxyTools needs from the supervisor — injected for tests. */
 export interface ProxyToolDeps {
   /** All tools across ONLINE upstreams (supervisor.getTools). */
@@ -33,6 +47,8 @@ export interface ProxyToolDeps {
   getState: () => UpstreamRuntimeState[]
   /** Route a resolved call to its upstream (supervisor.callTool). */
   callTool: (upstreamId: string, toolName: string, args: Record<string, unknown> | undefined) => Promise<unknown>
+  /** In-process Conductor built-ins exposed via search (T9). Optional. */
+  localTools?: LocalTool[]
   /** Subscribe to change events; return an unsubscribe fn. Optional (tests skip). */
   onChanged?: (cb: () => void) => () => void
 }
@@ -123,6 +139,18 @@ export function jsonSchemaToZodShape(inputSchema: unknown, z: any): Record<strin
  * conductor-mcp-server's lazy-loaded deps) so this module needs no direct import.
  */
 export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): () => void {
+  const localTools = deps.localTools ?? []
+  const localByName = new Map(localTools.map((t) => [t.name, t]))
+
+  // Local (built-in) tools appear in the index as a virtual `Conductor` upstream
+  // so search_tools/describe_tool/call_tool cover them uniformly with upstreams.
+  const localAsAggregated: AggregatedTool[] = localTools.map((t) => ({
+    upstreamId: BUILTIN_UPSTREAM_ID,
+    upstreamName: BUILTIN_UPSTREAM_NAME,
+    tool: { name: t.name, description: t.description, inputSchema: t.inputSchema },
+  }))
+  const buildIndex = () => new ToolIndex([...deps.getTools(), ...localAsAggregated])
+
   // search_tools ---------------------------------------------------------------
   server.tool(
     'search_tools',
@@ -133,7 +161,7 @@ export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): ()
       limit: z.number().optional().describe('Max results (default 10).'),
     },
     async ({ query, server: serverFilter, limit }: { query: string; server?: string; limit?: number }) => {
-      const index = new ToolIndex(deps.getTools())
+      const index = buildIndex()
       const rows = index.search(query, { server: serverFilter, limit })
       if (rows.length === 0) {
         return textResult(
@@ -155,7 +183,7 @@ export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): ()
       name: z.string().describe('Namespaced tool name, e.g. "filesystem__read_file".'),
     },
     async ({ name }: { name: string }) => {
-      const index = new ToolIndex(deps.getTools())
+      const index = buildIndex()
       const detail = index.describe(name)
       if (!detail) {
         return textResult(`Unknown tool "${name}". Run search_tools to get valid names.`, true)
@@ -180,12 +208,18 @@ export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): ()
       arguments: z.record(z.any()).optional().describe('Arguments object for the tool (see describe_tool).'),
     },
     async ({ name, arguments: args }: { name: string; arguments?: Record<string, unknown> }) => {
-      const index = new ToolIndex(deps.getTools())
+      const index = buildIndex()
       const target = index.resolve(name)
       if (!target) {
         return textResult(`Unknown tool "${name}". Run search_tools to get current names.`, true)
       }
       try {
+        // Built-ins run in-process; everything else routes to its upstream.
+        if (target.upstreamId === BUILTIN_UPSTREAM_ID) {
+          const local = localByName.get(target.toolName)
+          if (!local) return textResult(`Unknown tool "${name}". Run search_tools to get current names.`, true)
+          return await local.run(args ?? {})
+        }
         const raw = await deps.callTool(target.upstreamId, target.toolName, args)
         return passthroughResult(raw)
       } catch (err) {
@@ -207,6 +241,14 @@ export function registerProxyTools(server: any, z: any, deps: ProxyToolDeps): ()
         toolCount: s.toolCount,
         ...(s.lastError ? { lastError: s.lastError } : {}),
       }))
+      if (localTools.length > 0) {
+        servers.unshift({
+          name: BUILTIN_UPSTREAM_NAME,
+          status: 'online',
+          exposure: 'search',
+          toolCount: localTools.length,
+        })
+      }
       return textResult(JSON.stringify({ servers }))
     },
   )

--- a/tests/unit/main/mcp-proxy/builtin-catalog.test.ts
+++ b/tests/unit/main/mcp-proxy/builtin-catalog.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { builtinCatalog, type BuiltinCtx } from '../../../../src/main/mcp-proxy/builtin-catalog'
+import { jsonSchemaToZodShape } from '../../../../src/main/mcp-proxy/proxy-tools'
+
+function ctx(over: Partial<BuiltinCtx> = {}): BuiltinCtx {
+  return {
+    withVision: vi.fn(async (cmd) => ({ content: [{ type: 'text', text: JSON.stringify(cmd) }] })),
+    getVisionManager: vi.fn(() => ({ executeCommand: vi.fn(async () => ({ ok: true })) })),
+    imageFileToMcpContent: vi.fn((f: string) => ({ content: [{ type: 'image', data: f }] })),
+    resultToMcpContent: vi.fn((r: any) => ({ content: [{ type: 'text', text: JSON.stringify(r) }] })),
+    visionUnavailable: vi.fn(() => ({ content: [{ type: 'text', text: 'unavailable' }], isError: true })),
+    boundSessionId: 'sess-1',
+    ...over,
+  }
+}
+
+describe('catalog completeness', () => {
+  it('carries the 19 built-ins (host transfer + vision), unique names', () => {
+    const cat = builtinCatalog()
+    const names = cat.map((c) => c.name)
+    expect(new Set(names).size).toBe(names.length)
+    expect(names).toContain('fetch_host_screenshot')
+    expect(names).toContain('vision_screenshot')
+    expect(names).toContain('vision_setViewport')
+    expect(cat.filter((c) => c.group === 'vision').length).toBe(18)
+    expect(cat.filter((c) => c.group === 'hostTransfer').length).toBe(1)
+  })
+})
+
+describe('JSON schema -> zod parity (no regression vs the old inline shapes)', () => {
+  const shapeFor = (name: string) => {
+    const b = builtinCatalog().find((c) => c.name === name)!
+    return z.object(jsonSchemaToZodShape(b.jsonSchema, z))
+  }
+
+  it('required args are enforced', () => {
+    expect(shapeFor('vision_navigate').safeParse({}).success).toBe(false)
+    expect(shapeFor('vision_navigate').safeParse({ url: 'http://x' }).success).toBe(true)
+    expect(shapeFor('vision_type').safeParse({ selector: '#a' }).success).toBe(false) // text required
+    expect(shapeFor('vision_setViewport').safeParse({ width: 800 }).success).toBe(false) // height required
+    expect(shapeFor('vision_setViewport').safeParse({ width: 800, height: 600 }).success).toBe(true)
+  })
+
+  it('optional args and enums behave', () => {
+    expect(shapeFor('vision_wait').safeParse({ selector: '#a' }).success).toBe(true) // timeout optional
+    expect(shapeFor('vision_scroll').safeParse({ direction: 'down' }).success).toBe(true)
+    expect(shapeFor('vision_scroll').safeParse({ direction: 'sideways' }).success).toBe(false)
+    expect(shapeFor('vision_scroll').safeParse({}).success).toBe(true)
+  })
+
+  it('no-arg tools accept an empty object', () => {
+    expect(shapeFor('vision_status').safeParse({}).success).toBe(true)
+    expect(shapeFor('vision_screenshot').safeParse({}).success).toBe(true)
+  })
+})
+
+describe('run handlers preserve the original behavior', () => {
+  const get = (name: string) => builtinCatalog().find((c) => c.name === name)!
+
+  it('vision_navigate maps to a navigate VisionCommand', async () => {
+    const c = ctx()
+    await get('vision_navigate').run({ url: 'http://x' }, c)
+    expect(c.withVision).toHaveBeenCalledWith({ command: 'navigate', args: ['http://x'] })
+  })
+
+  it('vision_setViewport appends deviceScaleFactor only when present', async () => {
+    const c = ctx()
+    await get('vision_setViewport').run({ width: 800, height: 600 }, c)
+    expect(c.withVision).toHaveBeenLastCalledWith({ command: 'setViewport', args: ['800', '600'] })
+    await get('vision_setViewport').run({ width: 800, height: 600, deviceScaleFactor: 2 }, c)
+    expect(c.withVision).toHaveBeenLastCalledWith({ command: 'setViewport', args: ['800', '600', '2'] })
+  })
+
+  it('fetch_host_screenshot delegates to imageFileToMcpContent', () => {
+    const c = ctx()
+    get('fetch_host_screenshot').run({ filename: 'a.jpg' }, c)
+    expect(c.imageFileToMcpContent).toHaveBeenCalledWith('a.jpg')
+  })
+
+  it('vision_status returns disconnected when no vision manager', async () => {
+    const c = ctx({ getVisionManager: () => null })
+    await get('vision_status').run({}, c)
+    expect(c.resultToMcpContent).toHaveBeenCalledWith({ ok: true, data: { connected: false, browser: null } })
+  })
+
+  it('vision_screenshot returns unavailable when no vision manager', async () => {
+    const c = ctx({ getVisionManager: () => null })
+    const res = await get('vision_screenshot').run({}, c)
+    expect(c.visionUnavailable).toHaveBeenCalled()
+    expect(res.isError).toBe(true)
+  })
+})

--- a/tests/unit/main/mcp-proxy/proxy-tools.test.ts
+++ b/tests/unit/main/mcp-proxy/proxy-tools.test.ts
@@ -152,6 +152,42 @@ describe('passthrough', () => {
   })
 })
 
+describe('local tools (built-ins via search facade, T9)', () => {
+  const local = [
+    { name: 'vision_screenshot', description: 'Capture a screenshot', inputSchema: { type: 'object', properties: {} }, run: vi.fn(async () => ({ content: [{ type: 'text', text: 'shot' }] })) },
+  ]
+
+  it('are discoverable via search_tools under the Conductor server', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ localTools: local }))
+    const { json } = await parse(await s.invoke('search_tools', { query: 'screenshot' }))
+    expect(json.results[0].name).toBe('conductor__vision_screenshot')
+  })
+
+  it('call_tool routes to the local run, not the supervisor', async () => {
+    const callTool = vi.fn()
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ callTool, localTools: local }))
+    const res = await s.invoke('call_tool', { name: 'conductor__vision_screenshot' })
+    expect(local[0].run).toHaveBeenCalled()
+    expect(callTool).not.toHaveBeenCalled()
+    expect(res.content[0].text).toBe('shot')
+  })
+
+  it('list_servers includes the Conductor built-in server', async () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ localTools: local }))
+    const { json } = await parse(await s.invoke('list_servers'))
+    expect(json.servers[0]).toMatchObject({ name: 'Conductor', status: 'online', toolCount: 1 })
+  })
+
+  it('does not register local tools as direct passthrough tools', () => {
+    const s = fakeServer()
+    registerProxyTools(s, z, deps({ localTools: local }))
+    expect(s.tools.has('conductor__vision_screenshot')).toBe(false)
+  })
+})
+
 describe('onChanged hot-reload wiring', () => {
   it('subscribes and calls sendToolListChanged; cleanup unsubscribes', () => {
     let cb: (() => void) | null = null


### PR DESCRIPTION
Part of the Conductor Proxy MCP epic (#101). Resolves #102.

**Stacked PR** — base: `feat/96-proxy-tools`.

Migrate the ~19 built-in tools (vision + host transfer) into the exposure model.
- `builtin-catalog.ts`: one declarative descriptor per built-in (JSON schema + handler)
- `conductorTools.builtinExposure`: `passthrough` (**default**, byte-for-byte current behavior) or `search` (built-ins go behind the facade, out of the advertised set)
- all original gates preserved (master, vision/hostTransfer flags, Codex vision exclusion, boundSessionId routing); codex_review stays direct
- +18 tests incl. JSON-schema→zod parity checks

⚠️ Default stays `passthrough`; flipping to `search` + live app verification is a follow-up decision.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
