### PR TITLE
Conductor Proxy T5: management UI sub-tool card (#97)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,7 @@ import { closeAllWebviews } from './webview-manager'
 import { registerInsightsHandlers } from './ipc/insights-handlers'
 import { registerNotesHandlers } from './ipc/notes-handlers'
 import { registerVisionHandlers } from './ipc/vision-handlers'
+import { registerMcpProxyHandlers } from './ipc/mcp-proxy-handlers'
 import { registerConfigHandlers } from './ipc/config-handlers'
 import { registerAccountProfilesHandlers } from './ipc/account-profiles-handlers'
 import { migrateProfilesToHomeLayout, cleanupSessionHomes, syncPrimaryCredentialsWithGlobal } from './account-profiles'
@@ -770,6 +771,7 @@ if (!gotTheLock) {
     registerInsightsHandlers(getWindow)
     registerNotesHandlers()
     registerVisionHandlers(getWindow)
+    registerMcpProxyHandlers(getWindow)
     registerCodexHandlers()
     registerCodexReviewHandlers()
     registerChannelHandlers()

--- a/src/main/ipc/mcp-proxy-handlers.ts
+++ b/src/main/ipc/mcp-proxy-handlers.ts
@@ -1,0 +1,105 @@
+/**
+ * IPC handlers for the Conductor MCP proxy UI (T5, #97).
+ *
+ * Bridges the renderer's Proxy sub-tool to the registry (T1) + supervisor (T2).
+ * Every mutation reconciles the supervisor (`sync`) so runtime state tracks the
+ * registry, and returns the merged view so the renderer refreshes in one round
+ * trip. A push channel (MCP_PROXY_CHANGED) fires on any supervisor change so the
+ * UI reflects async connect/close without polling.
+ */
+
+import { ipcMain, BrowserWindow } from 'electron'
+import { IPC } from '../../shared/ipc-channels'
+import {
+  listUpstreams,
+  addUpstream,
+  updateUpstream,
+  removeUpstream,
+  type McpUpstreamInput,
+} from '../mcp-proxy/upstream-registry'
+import { getProxySupervisor } from '../mcp-proxy/supervisor'
+import { onInternal } from '../internal-events'
+import { logError } from '../debug-logger'
+import type { McpUpstreamView } from '../../shared/types'
+
+/** Merge the persisted registry with live supervisor state into the UI view. */
+function buildView(): McpUpstreamView[] {
+  const supervisor = getProxySupervisor()
+  supervisor.sync()
+  const runtime = new Map(supervisor.getState().map((s) => [s.id, s]))
+  return listUpstreams().map((u) => {
+    const rt = runtime.get(u.id)
+    return {
+      ...u,
+      status: rt?.status ?? 'offline',
+      toolCount: rt?.toolCount ?? 0,
+      lastError: rt?.lastError,
+    }
+  })
+}
+
+export function registerMcpProxyHandlers(getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle(IPC.MCP_PROXY_LIST, async () => buildView())
+
+  ipcMain.handle(IPC.MCP_PROXY_ADD, async (_e, input: McpUpstreamInput) => {
+    try {
+      const created = addUpstream(input)
+      if (!created) return { ok: false, error: 'Failed to save upstream' }
+      const supervisor = getProxySupervisor()
+      supervisor.sync()
+      if (created.enabled && created.autostart) {
+        void supervisor.startUpstream(created.id)
+      }
+      return { ok: true, upstreams: buildView() }
+    } catch (err: any) {
+      return { ok: false, error: err?.message || 'Failed to add upstream' }
+    }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_UPDATE, async (_e, id: string, patch: Partial<McpUpstreamInput>) => {
+    const updated = updateUpstream(id, patch)
+    if (!updated) return { ok: false, error: 'Upstream not found' }
+    getProxySupervisor().sync()
+    return { ok: true, upstreams: buildView() }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_REMOVE, async (_e, id: string) => {
+    const supervisor = getProxySupervisor()
+    await supervisor.stopUpstream(id)
+    const removed = removeUpstream(id)
+    supervisor.sync()
+    return { ok: removed, upstreams: buildView() }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_START, async (_e, id: string) => {
+    try {
+      await getProxySupervisor().startUpstream(id)
+      return { ok: true, upstreams: buildView() }
+    } catch (err: any) {
+      return { ok: false, error: err?.message || 'Failed to start upstream' }
+    }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_STOP, async (_e, id: string) => {
+    await getProxySupervisor().stopUpstream(id)
+    return { ok: true, upstreams: buildView() }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_RESTART, async (_e, id: string) => {
+    try {
+      await getProxySupervisor().restartUpstream(id)
+      return { ok: true, upstreams: buildView() }
+    } catch (err: any) {
+      return { ok: false, error: err?.message || 'Failed to restart upstream' }
+    }
+  })
+
+  // Push supervisor changes (async connect/close/tool-list) to the renderer.
+  onInternal('mcp-proxy:changed', () => {
+    try {
+      getWindow()?.webContents.send(IPC.MCP_PROXY_CHANGED, buildView())
+    } catch (err) {
+      logError(`[mcp-proxy-handlers] change broadcast failed: ${String(err)}`)
+    }
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -301,6 +301,16 @@ export interface ElectronAPI {
     getConfig: () => Promise<{ enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null>
     onStatusChanged: (callback: (data: { connected: boolean; browser: string; mcpPort: number }) => void) => () => void
   }
+  mcpProxy: {
+    list: () => Promise<import('../shared/types').McpUpstreamView[]>
+    add: (input: Omit<import('../shared/types').McpUpstream, 'id'>) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    update: (id: string, patch: Partial<Omit<import('../shared/types').McpUpstream, 'id'>>) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    remove: (id: string) => Promise<{ ok: boolean; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    start: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    stop: (id: string) => Promise<{ ok: boolean; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    restart: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    onChanged: (callback: (upstreams: import('../shared/types').McpUpstreamView[]) => void) => () => void
+  }
   legacyVersion: {
     fetchVersions: () => Promise<string[]>
     isInstalled: (version: string) => Promise<boolean>
@@ -761,6 +771,20 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.on(IPC.VISION_STATUS_CHANGED, handler)
       return () => ipcRenderer.removeListener(IPC.VISION_STATUS_CHANGED, handler)
     }
+  },
+  mcpProxy: {
+    list: () => ipcRenderer.invoke(IPC.MCP_PROXY_LIST),
+    add: (input: any) => ipcRenderer.invoke(IPC.MCP_PROXY_ADD, input),
+    update: (id: string, patch: any) => ipcRenderer.invoke(IPC.MCP_PROXY_UPDATE, id, patch),
+    remove: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_REMOVE, id),
+    start: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_START, id),
+    stop: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_STOP, id),
+    restart: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_RESTART, id),
+    onChanged: (callback: (upstreams: any) => void) => {
+      const handler = (_: unknown, upstreams: any) => callback(upstreams)
+      ipcRenderer.on(IPC.MCP_PROXY_CHANGED, handler)
+      return () => ipcRenderer.removeListener(IPC.MCP_PROXY_CHANGED, handler)
+    },
   },
   cloudAgent: {
     dispatch: (params: { name: string; description: string; projectPath: string; configId?: string; profileId?: string; legacyVersion?: { enabled: boolean; version: string }; skipPermissions?: boolean }) =>

--- a/src/renderer/components/ConductorMcpPage.tsx
+++ b/src/renderer/components/ConductorMcpPage.tsx
@@ -5,6 +5,7 @@ import CompatBadge from './sentinel/CompatBadge'
 import VisionSubTool from './conductor-mcp/VisionSubTool'
 import CodexReviewSubTool from './conductor-mcp/CodexReviewSubTool'
 import HostTransferSubTool from './conductor-mcp/HostTransferSubTool'
+import ProxySubTool from './conductor-mcp/ProxySubTool'
 
 const headerIcon = (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
@@ -74,6 +75,7 @@ export default function ConductorMcpPage() {
               Sub-tools below own their own state; the server stays running independent of any of them.
             </div>
 
+            <ProxySubTool />
             <VisionSubTool />
             <CodexReviewSubTool />
             <HostTransferSubTool />

--- a/src/renderer/components/conductor-mcp/ProxySubTool.tsx
+++ b/src/renderer/components/conductor-mcp/ProxySubTool.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from 'react'
+import { useMcpProxyStore, type McpUpstreamDraft } from '../../stores/mcpProxyStore'
+import { setupMcpProxyListener } from '../../stores/mcpProxyStore'
+import SubToolCard from './SubToolCard'
+import type { McpUpstreamView, McpUpstreamExposure } from '../../../shared/types'
+
+const icon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="3" />
+    <circle cx="5" cy="5" r="2" />
+    <circle cx="19" cy="5" r="2" />
+    <circle cx="5" cy="19" r="2" />
+    <circle cx="19" cy="19" r="2" />
+    <line x1="7" y1="6.5" x2="10" y2="10" />
+    <line x1="17" y1="6.5" x2="14" y2="10" />
+    <line x1="7" y1="17.5" x2="10" y2="14" />
+    <line x1="17" y1="17.5" x2="14" y2="14" />
+  </svg>
+)
+
+const STATUS_COLOR: Record<McpUpstreamView['status'], 'green' | 'yellow' | 'red' | 'overlay1'> = {
+  online: 'green',
+  connecting: 'yellow',
+  error: 'red',
+  offline: 'overlay1',
+}
+
+function transportSummary(u: McpUpstreamView): string {
+  if (u.transport.kind === 'stdio') {
+    return [u.transport.command, ...(u.transport.args ?? [])].join(' ')
+  }
+  return `${u.transport.kind.toUpperCase()} ${u.transport.url}`
+}
+
+const EMPTY_DRAFT: McpUpstreamDraft = {
+  name: '',
+  transport: { kind: 'stdio', command: '', args: [] },
+  enabled: true,
+  exposure: 'search',
+  autostart: true,
+}
+
+export default function ProxySubTool() {
+  const upstreams = useMcpProxyStore((s) => s.upstreams)
+  const error = useMcpProxyStore((s) => s.error)
+  const { load, add, update, remove, start, stop, restart } = useMcpProxyStore.getState()
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [draft, setDraft] = useState<McpUpstreamDraft>(EMPTY_DRAFT)
+  const [argsText, setArgsText] = useState('')
+
+  useEffect(() => {
+    load()
+    return setupMcpProxyListener()
+  }, [])
+
+  const onlineCount = upstreams.filter((u) => u.status === 'online').length
+  const statusLabel = upstreams.length === 0 ? 'No servers' : `${onlineCount}/${upstreams.length} online`
+
+  const kind = draft.transport.kind
+
+  async function submitDraft() {
+    const transport =
+      kind === 'stdio'
+        ? { kind: 'stdio' as const, command: (draft.transport as any).command?.trim(), args: argsText.split(/\s+/).filter(Boolean) }
+        : { kind, url: (draft.transport as any).url?.trim() }
+    const ok = await add({ ...draft, transport })
+    if (ok) {
+      setDraft(EMPTY_DRAFT)
+      setArgsText('')
+      setShowAdd(false)
+    }
+  }
+
+  return (
+    <SubToolCard
+      title="MCP Proxy"
+      icon={icon}
+      statusLabel={statusLabel}
+      statusColor={onlineCount > 0 ? 'green' : 'overlay1'}
+      description="Aggregate external MCP servers behind Conductor. One shared instance per server is fanned out to every session; tools are discovered on demand via search_tools (or advertised directly in passthrough mode)."
+      actions={
+        <button
+          className="text-xs px-2 py-1 rounded-md bg-surface1 hover:bg-surface2 text-text transition-colors"
+          onClick={() => setShowAdd((v) => !v)}
+        >
+          {showAdd ? 'Cancel' : '+ Add server'}
+        </button>
+      }
+    >
+      {error && <div className="text-xs text-red">{error}</div>}
+
+      {showAdd && (
+        <div className="rounded-lg p-3 space-y-2" style={{ background: 'var(--surface-sunken, rgba(0,0,0,0.15))', border: '1px solid var(--border-subtle)' }}>
+          <input
+            className="w-full text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1"
+            placeholder="Display name (e.g. Filesystem)"
+            value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+          />
+          <div className="flex gap-2">
+            <select
+              className="text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1"
+              value={kind}
+              onChange={(e) => {
+                const k = e.target.value as 'stdio' | 'http' | 'sse'
+                setDraft({ ...draft, transport: k === 'stdio' ? { kind: 'stdio', command: '', args: [] } : { kind: k, url: '' } })
+              }}
+            >
+              <option value="stdio">stdio</option>
+              <option value="http">http</option>
+              <option value="sse">sse</option>
+            </select>
+            <select
+              className="text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1"
+              value={draft.exposure}
+              onChange={(e) => setDraft({ ...draft, exposure: e.target.value as McpUpstreamExposure })}
+            >
+              <option value="search">search (via search_tools)</option>
+              <option value="passthrough">passthrough (direct)</option>
+            </select>
+          </div>
+          {kind === 'stdio' ? (
+            <>
+              <input
+                className="w-full text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1 font-mono"
+                placeholder="command (e.g. npx)"
+                value={(draft.transport as any).command}
+                onChange={(e) => setDraft({ ...draft, transport: { kind: 'stdio', command: e.target.value } })}
+              />
+              <input
+                className="w-full text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1 font-mono"
+                placeholder="args (space-separated, e.g. -y @modelcontextprotocol/server-filesystem /path)"
+                value={argsText}
+                onChange={(e) => setArgsText(e.target.value)}
+              />
+            </>
+          ) : (
+            <input
+              className="w-full text-sm px-2 py-1 rounded bg-mantle text-text border border-surface1 font-mono"
+              placeholder="url (e.g. http://localhost:3000/mcp)"
+              value={(draft.transport as any).url}
+              onChange={(e) => setDraft({ ...draft, transport: { kind, url: e.target.value } })}
+            />
+          )}
+          <label className="flex items-center gap-2 text-xs text-subtext0">
+            <input type="checkbox" checked={draft.autostart} onChange={(e) => setDraft({ ...draft, autostart: e.target.checked })} />
+            Connect on startup
+          </label>
+          <button
+            className="text-xs px-3 py-1 rounded-md bg-blue/20 hover:bg-blue/30 text-blue transition-colors disabled:opacity-40"
+            disabled={!draft.name.trim() || (kind === 'stdio' ? !(draft.transport as any).command?.trim() : !(draft.transport as any).url?.trim())}
+            onClick={submitDraft}
+          >
+            Add server
+          </button>
+        </div>
+      )}
+
+      {upstreams.length === 0 && !showAdd && (
+        <div className="text-xs text-overlay1">No upstream MCP servers configured yet. Add one to share it across all your sessions.</div>
+      )}
+
+      <div className="space-y-2">
+        {upstreams.map((u) => (
+          <div key={u.id} className="rounded-lg p-3 flex items-center gap-3" style={{ background: 'var(--surface-sunken, rgba(0,0,0,0.12))', border: '1px solid var(--border-subtle)' }}>
+            <span className={`text-xs px-2 py-0.5 rounded-full ${STATUS_COLOR[u.status] === 'green' ? 'bg-green/15 text-green' : STATUS_COLOR[u.status] === 'yellow' ? 'bg-yellow/15 text-yellow' : STATUS_COLOR[u.status] === 'red' ? 'bg-red/15 text-red' : 'bg-overlay1/15 text-overlay1'}`}>
+              {u.status}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm text-text font-medium truncate">
+                {u.name}
+                {u.status === 'online' && <span className="text-overlay1 font-normal"> · {u.toolCount} tools</span>}
+              </div>
+              <div className="text-xs text-overlay1 font-mono truncate">{transportSummary(u)}</div>
+              {u.lastError && <div className="text-xs text-red truncate">{u.lastError}</div>}
+            </div>
+            <select
+              className="text-xs px-1.5 py-0.5 rounded bg-mantle text-subtext0 border border-surface1"
+              value={u.exposure}
+              onChange={(e) => update(u.id, { exposure: e.target.value as McpUpstreamExposure })}
+              title="How this server's tools are exposed to the model"
+            >
+              <option value="search">search</option>
+              <option value="passthrough">passthrough</option>
+            </select>
+            {u.status === 'online' || u.status === 'connecting' ? (
+              <button className="text-xs px-2 py-1 rounded bg-surface1 hover:bg-surface2 text-text" onClick={() => stop(u.id)}>Stop</button>
+            ) : (
+              <button className="text-xs px-2 py-1 rounded bg-surface1 hover:bg-surface2 text-text" onClick={() => start(u.id)} disabled={!u.enabled}>Start</button>
+            )}
+            <button className="text-xs px-2 py-1 rounded bg-surface1 hover:bg-surface2 text-text" onClick={() => restart(u.id)} title="Restart">↻</button>
+            <button className="text-xs px-2 py-1 rounded bg-red/15 hover:bg-red/25 text-red" onClick={() => remove(u.id)} title="Remove">✕</button>
+          </div>
+        ))}
+      </div>
+    </SubToolCard>
+  )
+}

--- a/src/renderer/stores/mcpProxyStore.ts
+++ b/src/renderer/stores/mcpProxyStore.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand'
+import type { McpUpstream, McpUpstreamView } from '../../shared/types'
+
+/** Fields the UI supplies to create an upstream (id is minted main-side). */
+export type McpUpstreamDraft = Omit<McpUpstream, 'id'>
+
+interface McpProxyState {
+  upstreams: McpUpstreamView[]
+  loading: boolean
+  error: string | null
+
+  load: () => Promise<void>
+  add: (draft: McpUpstreamDraft) => Promise<boolean>
+  update: (id: string, patch: Partial<McpUpstreamDraft>) => Promise<void>
+  remove: (id: string) => Promise<void>
+  start: (id: string) => Promise<void>
+  stop: (id: string) => Promise<void>
+  restart: (id: string) => Promise<void>
+  handleChanged: (upstreams: McpUpstreamView[]) => void
+}
+
+export const useMcpProxyStore = create<McpProxyState>((set, get) => ({
+  upstreams: [],
+  loading: false,
+  error: null,
+
+  load: async () => {
+    set({ loading: true })
+    try {
+      const upstreams = await window.electronAPI.mcpProxy.list()
+      set({ upstreams, loading: false, error: null })
+    } catch (err: any) {
+      set({ loading: false, error: err?.message || 'Failed to load upstreams' })
+    }
+  },
+
+  add: async (draft) => {
+    const res = await window.electronAPI.mcpProxy.add(draft)
+    if (res.ok && res.upstreams) {
+      set({ upstreams: res.upstreams, error: null })
+      return true
+    }
+    set({ error: res.error || 'Failed to add upstream' })
+    return false
+  },
+
+  update: async (id, patch) => {
+    const res = await window.electronAPI.mcpProxy.update(id, patch)
+    if (res.ok && res.upstreams) set({ upstreams: res.upstreams, error: null })
+    else set({ error: res.error || 'Failed to update upstream' })
+  },
+
+  remove: async (id) => {
+    const res = await window.electronAPI.mcpProxy.remove(id)
+    if (res.upstreams) set({ upstreams: res.upstreams })
+  },
+
+  start: async (id) => {
+    const res = await window.electronAPI.mcpProxy.start(id)
+    if (res.upstreams) set({ upstreams: res.upstreams })
+    if (!res.ok && res.error) set({ error: res.error })
+  },
+
+  stop: async (id) => {
+    const res = await window.electronAPI.mcpProxy.stop(id)
+    if (res.upstreams) set({ upstreams: res.upstreams })
+  },
+
+  restart: async (id) => {
+    const res = await window.electronAPI.mcpProxy.restart(id)
+    if (res.upstreams) set({ upstreams: res.upstreams })
+    if (!res.ok && res.error) set({ error: res.error })
+  },
+
+  // Push updates from the main process (async connect/close/tool-list changes).
+  handleChanged: (upstreams) => set({ upstreams }),
+}))
+
+// Idempotent global listener (mirrors conductorMcpStore).
+let proxyListenerUnsub: (() => void) | null = null
+
+export function setupMcpProxyListener(): () => void {
+  if (proxyListenerUnsub) return proxyListenerUnsub
+  proxyListenerUnsub = window.electronAPI.mcpProxy.onChanged((upstreams) => {
+    useMcpProxyStore.getState().handleChanged(upstreams)
+  })
+  return proxyListenerUnsub
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -363,6 +363,16 @@ export interface ElectronAPI {
     getConfig: () => Promise<{ enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null>
     onStatusChanged: (callback: (data: { connected: boolean; browser: string; mcpPort: number }) => void) => () => void
   }
+  mcpProxy: {
+    list: () => Promise<import('../../shared/types').McpUpstreamView[]>
+    add: (input: Omit<import('../../shared/types').McpUpstream, 'id'>) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    update: (id: string, patch: Partial<Omit<import('../../shared/types').McpUpstream, 'id'>>) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    remove: (id: string) => Promise<{ ok: boolean; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    start: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    stop: (id: string) => Promise<{ ok: boolean; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    restart: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    onChanged: (callback: (upstreams: import('../../shared/types').McpUpstreamView[]) => void) => () => void
+  }
   legacyVersion: {
     fetchVersions: () => Promise<string[]>
     isInstalled: (version: string) => Promise<boolean>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -183,6 +183,16 @@ export const IPC = {
   VISION_GET_CONFIG: 'vision:getConfig',
   VISION_STATUS_CHANGED: 'vision:statusChanged',
 
+  // MCP proxy (Conductor upstream aggregation)
+  MCP_PROXY_LIST: 'mcpProxy:list',
+  MCP_PROXY_ADD: 'mcpProxy:add',
+  MCP_PROXY_UPDATE: 'mcpProxy:update',
+  MCP_PROXY_REMOVE: 'mcpProxy:remove',
+  MCP_PROXY_START: 'mcpProxy:start',
+  MCP_PROXY_STOP: 'mcpProxy:stop',
+  MCP_PROXY_RESTART: 'mcpProxy:restart',
+  MCP_PROXY_CHANGED: 'mcpProxy:changed',
+
   // Cloud agents
   CLOUD_AGENT_DISPATCH: 'cloudAgent:dispatch',
   CLOUD_AGENT_CANCEL: 'cloudAgent:cancel',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,13 @@ export interface McpUpstream {
   autostart: boolean
 }
 
+/** Registry config + live runtime state for one upstream, as shown in the UI. */
+export interface McpUpstreamView extends McpUpstream {
+  status: 'offline' | 'connecting' | 'online' | 'error'
+  toolCount: number
+  lastError?: string
+}
+
 // ── SSH ──
 
 export interface SshConfig {

--- a/tests/unit/renderer/mcp-proxy-store.test.ts
+++ b/tests/unit/renderer/mcp-proxy-store.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * T5 (#97): useMcpProxyStore drives the Proxy sub-tool. Verifies it reads the
+ * merged view from IPC, applies mutation responses, and accepts pushed updates.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { McpUpstreamView } from '../../../src/shared/types'
+
+const api = {
+  list: vi.fn(),
+  add: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  restart: vi.fn(),
+  onChanged: vi.fn(() => () => {}),
+}
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(globalThis as any).window.electronAPI = { mcpProxy: api }
+
+const { useMcpProxyStore } = await import('../../../src/renderer/stores/mcpProxyStore')
+
+function view(over: Partial<McpUpstreamView> = {}): McpUpstreamView {
+  return {
+    id: 'u1',
+    name: 'FS',
+    transport: { kind: 'stdio', command: 'fs-mcp' },
+    enabled: true,
+    exposure: 'search',
+    autostart: true,
+    status: 'offline',
+    toolCount: 0,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  Object.values(api).forEach((f) => (f as any).mockReset?.())
+  api.onChanged.mockReturnValue(() => {})
+  useMcpProxyStore.setState({ upstreams: [], loading: false, error: null })
+})
+
+describe('load', () => {
+  it('populates upstreams from IPC', async () => {
+    api.list.mockResolvedValue([view()])
+    await useMcpProxyStore.getState().load()
+    expect(useMcpProxyStore.getState().upstreams).toHaveLength(1)
+    expect(useMcpProxyStore.getState().loading).toBe(false)
+  })
+
+  it('records an error when the IPC throws', async () => {
+    api.list.mockRejectedValue(new Error('boom'))
+    await useMcpProxyStore.getState().load()
+    expect(useMcpProxyStore.getState().error).toBe('boom')
+  })
+})
+
+describe('add', () => {
+  it('applies the returned view and reports success', async () => {
+    api.add.mockResolvedValue({ ok: true, upstreams: [view({ status: 'online', toolCount: 3 })] })
+    const ok = await useMcpProxyStore.getState().add({
+      name: 'FS',
+      transport: { kind: 'stdio', command: 'fs-mcp' },
+      enabled: true,
+      exposure: 'search',
+      autostart: true,
+    })
+    expect(ok).toBe(true)
+    expect(useMcpProxyStore.getState().upstreams[0].toolCount).toBe(3)
+  })
+
+  it('surfaces an error and returns false on failure', async () => {
+    api.add.mockResolvedValue({ ok: false, error: 'bad transport' })
+    const ok = await useMcpProxyStore.getState().add({
+      name: '',
+      transport: { kind: 'stdio', command: '' },
+      enabled: true,
+      exposure: 'search',
+      autostart: false,
+    })
+    expect(ok).toBe(false)
+    expect(useMcpProxyStore.getState().error).toBe('bad transport')
+  })
+})
+
+describe('start/stop/remove apply returned views', () => {
+  it('start applies the view', async () => {
+    api.start.mockResolvedValue({ ok: true, upstreams: [view({ status: 'online' })] })
+    await useMcpProxyStore.getState().start('u1')
+    expect(useMcpProxyStore.getState().upstreams[0].status).toBe('online')
+  })
+
+  it('remove applies the (empty) view', async () => {
+    useMcpProxyStore.setState({ upstreams: [view()] })
+    api.remove.mockResolvedValue({ ok: true, upstreams: [] })
+    await useMcpProxyStore.getState().remove('u1')
+    expect(useMcpProxyStore.getState().upstreams).toHaveLength(0)
+  })
+})
+
+describe('handleChanged (push)', () => {
+  it('replaces upstreams from a main-process broadcast', () => {
+    useMcpProxyStore.getState().handleChanged([view({ status: 'online', toolCount: 5 })])
+    expect(useMcpProxyStore.getState().upstreams[0].toolCount).toBe(5)
+  })
+})


### PR DESCRIPTION
Part of the Conductor Proxy MCP epic (#101). Resolves #97.

**Stacked PR** — base: `feat/102-migrate-builtins`.

Manage upstream servers from the Conductor MCP page.
- `mcp-proxy-handlers` IPC (list/add/update/remove/start/stop/restart) merging registry + live supervisor state; `MCP_PROXY_CHANGED` push
- IPC channels + preload + renderer typings
- `mcpProxyStore` + `ProxySubTool` card: status pills, add form (stdio/http/sse), exposure toggle, lifecycle buttons
- 7 store tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)
