### PR TITLE
Conductor Proxy T6: auto-adopt / import + take-over (#98)

### DIFF
--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -29,6 +29,7 @@ const CONFIG_FILES = {
   visionGlobal: 'vision-global.json',
   conductorSecret: 'conductor-secret.json',
   mcpUpstreams: 'mcp-upstreams.json',
+  mcpAdoptBackup: 'mcp-adopt-backup.json',
   commandSections: 'command-sections.json',
   usageTracking: 'usage-tracking.json',
   commandBarUi: 'command-bar-ui.json',

--- a/src/main/ipc/mcp-proxy-handlers.ts
+++ b/src/main/ipc/mcp-proxy-handlers.ts
@@ -18,6 +18,7 @@ import {
   type McpUpstreamInput,
 } from '../mcp-proxy/upstream-registry'
 import { getProxySupervisor } from '../mcp-proxy/supervisor'
+import { discoverAll, importDiscovered, takeOver, type DiscoveredUpstream, type AdoptSource } from '../mcp-proxy/adopt'
 import { onInternal } from '../internal-events'
 import { logError } from '../debug-logger'
 import type { McpUpstreamView } from '../../shared/types'
@@ -92,6 +93,19 @@ export function registerMcpProxyHandlers(getWindow: () => BrowserWindow | null):
     } catch (err: any) {
       return { ok: false, error: err?.message || 'Failed to restart upstream' }
     }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_DISCOVER, async () => discoverAll())
+
+  ipcMain.handle(IPC.MCP_PROXY_IMPORT, async (_e, items: DiscoveredUpstream[]) => {
+    const added = importDiscovered(items ?? [])
+    getProxySupervisor().sync()
+    return { ok: true, added, upstreams: buildView() }
+  })
+
+  ipcMain.handle(IPC.MCP_PROXY_TAKEOVER, async (_e, source: AdoptSource, names: string[]) => {
+    if (source === 'codex') return { ok: false, removed: 0, error: 'Codex take-over is not supported yet' }
+    return takeOver(source, names ?? [])
   })
 
   // Push supervisor changes (async connect/close/tool-list) to the renderer.

--- a/src/main/mcp-proxy/adopt.ts
+++ b/src/main/mcp-proxy/adopt.ts
@@ -1,0 +1,290 @@
+/**
+ * Conductor Proxy — auto-adopt / import + take-over (T6, #98).
+ *
+ * Discovers MCP servers already configured in the user's clients (Claude CLI
+ * `~/.claude.json`, Claude Desktop `claude_desktop_config.json`, Codex
+ * `~/.codex/config.toml`), imports them into the proxy registry (T1), and can
+ * optionally "take over" — remove the entry from the client config, leaving the
+ * proxy the single instance. Take-over backs up the removed raw entries so it is
+ * reversible.
+ *
+ * The parsers/transforms are PURE and fail closed: a config that can't be parsed
+ * yields no discoveries and is NEVER rewritten (so a malformed client file is
+ * never clobbered). File IO is injected (see FileIo) so the orchestration is
+ * unit-testable without touching the real home directory.
+ */
+
+import * as os from 'os'
+import * as path from 'path'
+import * as fs from 'fs'
+import { logInfo, logWarn, logError } from '../debug-logger'
+import { readConfig, saveConfig } from '../config-manager'
+import { listUpstreams, addUpstream } from './upstream-registry'
+import type { McpUpstreamTransport } from '../../shared/types'
+import type { McpUpstreamInput } from './upstream-registry'
+
+export type AdoptSource = 'claude' | 'claude-desktop' | 'codex'
+
+/** A server found in a client config, ready to import. */
+export interface DiscoveredUpstream {
+  source: AdoptSource
+  input: McpUpstreamInput
+  /** True if an equivalent upstream (same name + transport) is already in the registry. */
+  existing: boolean
+}
+
+// ── pure: map a Claude/Desktop mcpServers entry to a transport ──
+
+function mcpServerEntryToTransport(entry: unknown): McpUpstreamTransport | null {
+  if (!entry || typeof entry !== 'object') return null
+  const e = entry as Record<string, unknown>
+  if (typeof e.command === 'string' && e.command.trim()) {
+    const t: McpUpstreamTransport = { kind: 'stdio', command: e.command }
+    if (Array.isArray(e.args)) t.args = e.args.filter((a): a is string => typeof a === 'string')
+    if (e.env && typeof e.env === 'object' && !Array.isArray(e.env)) {
+      const env: Record<string, string> = {}
+      for (const [k, v] of Object.entries(e.env as Record<string, unknown>)) if (typeof v === 'string') env[k] = v
+      if (Object.keys(env).length) t.env = env
+    }
+    return t
+  }
+  if (typeof e.url === 'string' && e.url.trim()) {
+    // 'streamable-http' / 'http' -> http; 'sse' -> sse; default http.
+    const kind = e.type === 'sse' ? 'sse' : 'http'
+    const t: McpUpstreamTransport = { kind, url: e.url }
+    if (e.headers && typeof e.headers === 'object' && !Array.isArray(e.headers)) {
+      const headers: Record<string, string> = {}
+      for (const [k, v] of Object.entries(e.headers as Record<string, unknown>)) if (typeof v === 'string') headers[k] = v
+      if (Object.keys(headers).length) t.headers = headers
+    }
+    return t
+  }
+  return null
+}
+
+/** Parse a `{ mcpServers: {...} }` object (Claude CLI / Claude Desktop share it). */
+export function parseMcpServersObject(parsed: unknown): Array<{ name: string; transport: McpUpstreamTransport }> {
+  if (!parsed || typeof parsed !== 'object') return []
+  const servers = (parsed as Record<string, unknown>).mcpServers
+  if (!servers || typeof servers !== 'object') return []
+  const out: Array<{ name: string; transport: McpUpstreamTransport }> = []
+  for (const [name, entry] of Object.entries(servers as Record<string, unknown>)) {
+    const transport = mcpServerEntryToTransport(entry)
+    if (transport) out.push({ name, transport })
+  }
+  return out
+}
+
+// ── pure: minimal Codex TOML reader for [mcp_servers.NAME] tables ──
+
+function parseTomlString(raw: string): string | null {
+  const m = /^"(.*)"$/.exec(raw.trim()) || /^'(.*)'$/.exec(raw.trim())
+  return m ? m[1] : null
+}
+
+function parseTomlStringArray(raw: string): string[] {
+  const inner = raw.trim().replace(/^\[/, '').replace(/\]$/, '')
+  const out: string[] = []
+  for (const part of inner.split(',')) {
+    const s = parseTomlString(part)
+    if (s !== null) out.push(s)
+  }
+  return out
+}
+
+/** Parse Codex `[mcp_servers.NAME]` tables. Only command/args/url are read
+ *  (the shapes the proxy supports); anything else is ignored. Tolerant of
+ *  surrounding user config. */
+export function parseCodexMcpServers(content: string): Array<{ name: string; transport: McpUpstreamTransport }> {
+  const lines = content.split('\n')
+  const sections = new Map<string, Record<string, string>>()
+  let current: string | null = null
+  for (const line of lines) {
+    const trimmed = line.trim()
+    const header = /^\[mcp_servers\.([^\]]+)\]$/.exec(trimmed)
+    if (header) {
+      current = header[1].replace(/^"|"$/g, '')
+      sections.set(current, {})
+      continue
+    }
+    if (trimmed.startsWith('[')) { current = null; continue } // left the table
+    if (!current) continue
+    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+)$/.exec(trimmed)
+    if (kv) sections.get(current)![kv[1]] = kv[2].trim()
+  }
+
+  const out: Array<{ name: string; transport: McpUpstreamTransport }> = []
+  for (const [name, kv] of sections) {
+    if (kv.command !== undefined) {
+      const command = parseTomlString(kv.command)
+      if (!command) continue
+      const t: McpUpstreamTransport = { kind: 'stdio', command }
+      if (kv.args) t.args = parseTomlStringArray(kv.args)
+      out.push({ name, transport: t })
+    } else if (kv.url !== undefined) {
+      const url = parseTomlString(kv.url)
+      if (url) out.push({ name, transport: { kind: 'http', url } })
+    }
+  }
+  return out
+}
+
+// ── pure: removal transforms for take-over ──
+
+/** Remove named servers from a parsed Claude/Desktop object. Returns the new
+ *  object and the removed raw entries (for backup/restore). */
+export function removeServersFromObject(
+  parsed: Record<string, unknown>,
+  names: string[],
+): { next: Record<string, unknown>; removed: Record<string, unknown> } {
+  const removed: Record<string, unknown> = {}
+  const servers = parsed.mcpServers
+  if (!servers || typeof servers !== 'object') return { next: parsed, removed }
+  const nextServers = { ...(servers as Record<string, unknown>) }
+  for (const name of names) {
+    if (name in nextServers) {
+      removed[name] = nextServers[name]
+      delete nextServers[name]
+    }
+  }
+  const next = { ...parsed, mcpServers: nextServers }
+  return { next, removed }
+}
+
+// ── IO layer (injectable) ──
+
+export interface FileIo {
+  read: (p: string) => string | null
+  write: (p: string, content: string) => boolean
+  exists: (p: string) => boolean
+}
+
+const realIo: FileIo = {
+  read: (p) => {
+    try { return fs.readFileSync(p, 'utf-8') } catch { return null }
+  },
+  write: (p, content) => {
+    // Strict atomic: tmp + rename; abort (leave original intact) on failure.
+    const tmp = `${p}.tmp.${process.pid}`
+    try {
+      fs.writeFileSync(tmp, content, 'utf-8')
+      fs.renameSync(tmp, p)
+      return true
+    } catch (err) {
+      try { fs.unlinkSync(tmp) } catch { /* ignore */ }
+      logError(`[mcp-adopt] atomic write failed for ${p}: ${String(err)}`)
+      return false
+    }
+  },
+  exists: (p) => fs.existsSync(p),
+}
+
+export function claudeJsonPath(): string {
+  return path.join(os.homedir(), '.claude.json')
+}
+export function codexTomlPath(): string {
+  return path.join(process.env.CODEX_HOME ?? path.join(os.homedir(), '.codex'), 'config.toml')
+}
+export function claudeDesktopPath(): string {
+  const home = os.homedir()
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json')
+  }
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+  }
+  return path.join(home, '.config', 'Claude', 'claude_desktop_config.json')
+}
+
+function signature(t: McpUpstreamTransport): string {
+  return t.kind === 'stdio' ? `stdio:${t.command}:${(t.args ?? []).join(' ')}` : `${t.kind}:${t.url}`
+}
+
+// ── orchestration ──
+
+/** Discover servers across all known client configs. Never throws; a source
+ *  that is missing or unparseable simply contributes nothing. */
+export function discoverAll(io: FileIo = realIo): DiscoveredUpstream[] {
+  const existing = new Set(listUpstreams().map((u) => `${u.name}|${signature(u.transport)}`))
+  const results: DiscoveredUpstream[] = []
+
+  const addAll = (source: AdoptSource, found: Array<{ name: string; transport: McpUpstreamTransport }>) => {
+    for (const { name, transport } of found) {
+      results.push({
+        source,
+        input: { name, transport, enabled: true, exposure: 'search', autostart: false },
+        existing: existing.has(`${name}|${signature(transport)}`),
+      })
+    }
+  }
+
+  const claudeRaw = io.read(claudeJsonPath())
+  if (claudeRaw) {
+    try { addAll('claude', parseMcpServersObject(JSON.parse(claudeRaw))) }
+    catch { logWarn('[mcp-adopt] ~/.claude.json parse failed; skipping') }
+  }
+  const desktopRaw = io.read(claudeDesktopPath())
+  if (desktopRaw) {
+    try { addAll('claude-desktop', parseMcpServersObject(JSON.parse(desktopRaw))) }
+    catch { logWarn('[mcp-adopt] claude_desktop_config.json parse failed; skipping') }
+  }
+  const codexRaw = io.read(codexTomlPath())
+  if (codexRaw) {
+    try { addAll('codex', parseCodexMcpServers(codexRaw)) }
+    catch { logWarn('[mcp-adopt] ~/.codex/config.toml parse failed; skipping') }
+  }
+  return results
+}
+
+/** Import the given discovered servers into the registry, skipping ones that
+ *  already exist. Returns the number added. */
+export function importDiscovered(items: DiscoveredUpstream[]): number {
+  let added = 0
+  for (const item of items) {
+    if (item.existing) continue
+    if (addUpstream(item.input)) added++
+  }
+  if (added > 0) logInfo(`[mcp-adopt] imported ${added} upstream(s)`)
+  return added
+}
+
+/**
+ * Take over the named servers in a client config: remove them from the client
+ * file so the proxy is the single instance. Backs up removed entries to
+ * CONFIG/mcp-adopt-backup.json for reversibility. Fails closed — a source whose
+ * file can't be parsed is left untouched. Only JSON sources (claude,
+ * claude-desktop) are supported here; codex take-over is deferred.
+ */
+export function takeOver(
+  source: Extract<AdoptSource, 'claude' | 'claude-desktop'>,
+  names: string[],
+  io: FileIo = realIo,
+): { ok: boolean; removed: number; error?: string } {
+  const filePath = source === 'claude' ? claudeJsonPath() : claudeDesktopPath()
+  const raw = io.read(filePath)
+  if (raw === null) return { ok: false, removed: 0, error: 'Config file not found' }
+  let parsed: Record<string, unknown>
+  try {
+    const p = JSON.parse(raw)
+    if (!p || typeof p !== 'object') throw new Error('not an object')
+    parsed = p as Record<string, unknown>
+  } catch {
+    // Fail closed: never rewrite a file we couldn't parse.
+    return { ok: false, removed: 0, error: 'Config file is not valid JSON; left untouched' }
+  }
+  const { next, removed } = removeServersFromObject(parsed, names)
+  const removedNames = Object.keys(removed)
+  if (removedNames.length === 0) return { ok: true, removed: 0 }
+
+  if (!io.write(filePath, JSON.stringify(next, null, 2))) {
+    return { ok: false, removed: 0, error: 'Failed to write config file' }
+  }
+
+  // Back up removed entries so take-over is reversible.
+  const backup = readConfig<Record<string, Record<string, unknown>>>('mcpAdoptBackup') ?? {}
+  backup[source] = { ...(backup[source] ?? {}), ...removed }
+  saveConfig('mcpAdoptBackup', backup)
+
+  logInfo(`[mcp-adopt] took over ${removedNames.length} server(s) from ${source}: ${removedNames.join(', ')}`)
+  return { ok: true, removed: removedNames.length }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -309,6 +309,9 @@ export interface ElectronAPI {
     start: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
     stop: (id: string) => Promise<{ ok: boolean; upstreams?: import('../shared/types').McpUpstreamView[] }>
     restart: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    discover: () => Promise<import('../shared/types').McpDiscoveredUpstream[]>
+    importServers: (items: import('../shared/types').McpDiscoveredUpstream[]) => Promise<{ ok: boolean; added: number; upstreams?: import('../shared/types').McpUpstreamView[] }>
+    takeOver: (source: 'claude' | 'claude-desktop', names: string[]) => Promise<{ ok: boolean; removed: number; error?: string }>
     onChanged: (callback: (upstreams: import('../shared/types').McpUpstreamView[]) => void) => () => void
   }
   legacyVersion: {
@@ -780,6 +783,9 @@ const electronAPI: ElectronAPI = {
     start: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_START, id),
     stop: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_STOP, id),
     restart: (id: string) => ipcRenderer.invoke(IPC.MCP_PROXY_RESTART, id),
+    discover: () => ipcRenderer.invoke(IPC.MCP_PROXY_DISCOVER),
+    importServers: (items: any) => ipcRenderer.invoke(IPC.MCP_PROXY_IMPORT, items),
+    takeOver: (source: string, names: string[]) => ipcRenderer.invoke(IPC.MCP_PROXY_TAKEOVER, source, names),
     onChanged: (callback: (upstreams: any) => void) => {
       const handler = (_: unknown, upstreams: any) => callback(upstreams)
       ipcRenderer.on(IPC.MCP_PROXY_CHANGED, handler)

--- a/src/renderer/components/conductor-mcp/ProxySubTool.tsx
+++ b/src/renderer/components/conductor-mcp/ProxySubTool.tsx
@@ -43,11 +43,18 @@ const EMPTY_DRAFT: McpUpstreamDraft = {
 export default function ProxySubTool() {
   const upstreams = useMcpProxyStore((s) => s.upstreams)
   const error = useMcpProxyStore((s) => s.error)
-  const { load, add, update, remove, start, stop, restart } = useMcpProxyStore.getState()
+  const { load, add, update, remove, start, stop, restart, importFromClients } = useMcpProxyStore.getState()
 
   const [showAdd, setShowAdd] = useState(false)
   const [draft, setDraft] = useState<McpUpstreamDraft>(EMPTY_DRAFT)
   const [argsText, setArgsText] = useState('')
+  const [importMsg, setImportMsg] = useState<string | null>(null)
+
+  async function runImport() {
+    setImportMsg('Scanning Claude / Codex configs…')
+    const { added, found } = await importFromClients()
+    setImportMsg(found === 0 ? 'No servers found in client configs.' : `Imported ${added} of ${found} discovered server(s).`)
+  }
 
   useEffect(() => {
     load()
@@ -80,15 +87,25 @@ export default function ProxySubTool() {
       statusColor={onlineCount > 0 ? 'green' : 'overlay1'}
       description="Aggregate external MCP servers behind Conductor. One shared instance per server is fanned out to every session; tools are discovered on demand via search_tools (or advertised directly in passthrough mode)."
       actions={
-        <button
-          className="text-xs px-2 py-1 rounded-md bg-surface1 hover:bg-surface2 text-text transition-colors"
-          onClick={() => setShowAdd((v) => !v)}
-        >
-          {showAdd ? 'Cancel' : '+ Add server'}
-        </button>
+        <div className="flex gap-2">
+          <button
+            className="text-xs px-2 py-1 rounded-md bg-surface1 hover:bg-surface2 text-text transition-colors"
+            onClick={runImport}
+            title="Discover and import MCP servers already configured in Claude / Codex"
+          >
+            Import existing
+          </button>
+          <button
+            className="text-xs px-2 py-1 rounded-md bg-surface1 hover:bg-surface2 text-text transition-colors"
+            onClick={() => setShowAdd((v) => !v)}
+          >
+            {showAdd ? 'Cancel' : '+ Add server'}
+          </button>
+        </div>
       }
     >
       {error && <div className="text-xs text-red">{error}</div>}
+      {importMsg && <div className="text-xs text-subtext0">{importMsg}</div>}
 
       {showAdd && (
         <div className="rounded-lg p-3 space-y-2" style={{ background: 'var(--surface-sunken, rgba(0,0,0,0.15))', border: '1px solid var(--border-subtle)' }}>

--- a/src/renderer/stores/mcpProxyStore.ts
+++ b/src/renderer/stores/mcpProxyStore.ts
@@ -16,6 +16,7 @@ interface McpProxyState {
   start: (id: string) => Promise<void>
   stop: (id: string) => Promise<void>
   restart: (id: string) => Promise<void>
+  importFromClients: () => Promise<{ added: number; found: number }>
   handleChanged: (upstreams: McpUpstreamView[]) => void
 }
 
@@ -70,6 +71,14 @@ export const useMcpProxyStore = create<McpProxyState>((set, get) => ({
     const res = await window.electronAPI.mcpProxy.restart(id)
     if (res.upstreams) set({ upstreams: res.upstreams })
     if (!res.ok && res.error) set({ error: res.error })
+  },
+
+  importFromClients: async () => {
+    const found = await window.electronAPI.mcpProxy.discover()
+    const toImport = found.filter((f) => !f.existing)
+    const res = await window.electronAPI.mcpProxy.importServers(toImport)
+    if (res.ok && res.upstreams) set({ upstreams: res.upstreams, error: null })
+    return { added: res.added ?? 0, found: found.length }
   },
 
   // Push updates from the main process (async connect/close/tool-list changes).

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -371,6 +371,9 @@ export interface ElectronAPI {
     start: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
     stop: (id: string) => Promise<{ ok: boolean; upstreams?: import('../../shared/types').McpUpstreamView[] }>
     restart: (id: string) => Promise<{ ok: boolean; error?: string; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    discover: () => Promise<import('../../shared/types').McpDiscoveredUpstream[]>
+    importServers: (items: import('../../shared/types').McpDiscoveredUpstream[]) => Promise<{ ok: boolean; added: number; upstreams?: import('../../shared/types').McpUpstreamView[] }>
+    takeOver: (source: 'claude' | 'claude-desktop', names: string[]) => Promise<{ ok: boolean; removed: number; error?: string }>
     onChanged: (callback: (upstreams: import('../../shared/types').McpUpstreamView[]) => void) => () => void
   }
   legacyVersion: {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -192,6 +192,9 @@ export const IPC = {
   MCP_PROXY_STOP: 'mcpProxy:stop',
   MCP_PROXY_RESTART: 'mcpProxy:restart',
   MCP_PROXY_CHANGED: 'mcpProxy:changed',
+  MCP_PROXY_DISCOVER: 'mcpProxy:discover',
+  MCP_PROXY_IMPORT: 'mcpProxy:import',
+  MCP_PROXY_TAKEOVER: 'mcpProxy:takeover',
 
   // Cloud agents
   CLOUD_AGENT_DISPATCH: 'cloudAgent:dispatch',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,20 @@ export interface McpUpstream {
   autostart: boolean
 }
 
+/** A server discovered in a client config (Claude CLI / Desktop / Codex),
+ *  offered for import into the proxy registry (T6). */
+export interface McpDiscoveredUpstream {
+  source: 'claude' | 'claude-desktop' | 'codex'
+  input: {
+    name: string
+    transport: McpUpstreamTransport
+    enabled?: boolean
+    exposure?: McpUpstreamExposure
+    autostart?: boolean
+  }
+  existing: boolean
+}
+
 /** Registry config + live runtime state for one upstream, as shown in the UI. */
 export interface McpUpstreamView extends McpUpstream {
   status: 'offline' | 'connecting' | 'online' | 'error'

--- a/tests/fixtures/mcp-echo-server.mjs
+++ b/tests/fixtures/mcp-echo-server.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Minimal real MCP server over stdio, used by the live proxy integration test
+ * (tests/integration/mcp-proxy-live.test.ts). Exposes two tools so the test can
+ * exercise real tools/list + tools/call through the actual stdio transport.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+const server = new McpServer({ name: 'echo-fixture', version: '1.0.0' }, { capabilities: {} })
+
+server.tool(
+  'echo',
+  'Echo back the provided text',
+  { text: z.string().describe('text to echo back') },
+  async ({ text }) => ({ content: [{ type: 'text', text }] }),
+)
+
+server.tool(
+  'add',
+  'Add two numbers and return the sum',
+  { a: z.number().describe('first addend'), b: z.number().describe('second addend') },
+  async ({ a, b }) => ({ content: [{ type: 'text', text: String(a + b) }] }),
+)
+
+const transport = new StdioServerTransport()
+await server.connect(transport)

--- a/tests/integration/mcp-proxy-live.test.ts
+++ b/tests/integration/mcp-proxy-live.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+/**
+ * LIVE end-to-end verification of the Conductor proxy (plan verification steps).
+ *
+ * Unlike the unit tests (which inject fakes), this exercises the REAL stack:
+ *   - a real child-process MCP server over the real stdio transport
+ *     (tests/fixtures/mcp-echo-server.mjs)
+ *   - the real McpProxySupervisor default connection factory (spawns the child,
+ *     speaks MCP, caches tools, routes calls)
+ *   - the real ToolIndex (BM25) + registerProxyTools facade on a real McpServer
+ *   - a real MCP Client over a real (in-memory) transport pair — i.e. exactly
+ *     the path Claude Code takes: tools/list -> search_tools -> call_tool.
+ *
+ * Only the config/persistence + logging boundary is stubbed (no Electron here);
+ * everything protocol-related is real.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { fileURLToPath } from 'node:url'
+
+// Stub only the Electron-bound leaves. Registry is bypassed via injected deps.
+vi.mock('../../src/main/config-manager', () => ({
+  readConfig: () => null,
+  saveConfig: () => true,
+}))
+vi.mock('../../src/main/debug-logger', () => ({
+  logInfo: () => {}, logWarn: () => {}, logError: () => {}, logDebug: () => {},
+}))
+
+const { McpProxySupervisor } = await import('../../src/main/mcp-proxy/supervisor')
+const { registerProxyTools } = await import('../../src/main/mcp-proxy/proxy-tools')
+const { Client } = await import('@modelcontextprotocol/sdk/client/index.js')
+const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js')
+const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js')
+const zod = await import('zod')
+const z = (zod as any).z ?? zod
+
+const fixture = fileURLToPath(new URL('../fixtures/mcp-echo-server.mjs', import.meta.url))
+const upstream = {
+  id: 'echo1',
+  name: 'Echo',
+  transport: { kind: 'stdio' as const, command: process.execPath, args: [fixture] },
+  enabled: true,
+  exposure: 'search' as const,
+  autostart: true,
+}
+
+let sup: InstanceType<typeof McpProxySupervisor>
+
+beforeAll(async () => {
+  sup = new McpProxySupervisor({ loadUpstreams: () => [upstream], emitChanged: () => {} })
+  await sup.start()
+}, 30000)
+
+afterAll(async () => {
+  await sup?.stopAll()
+})
+
+describe('LIVE: supervisor <-> real stdio MCP upstream', () => {
+  it('connects the child process and comes online', () => {
+    const state = sup.getState()
+    expect(state).toHaveLength(1)
+    expect(state[0]).toMatchObject({ name: 'Echo', status: 'online' })
+  })
+
+  it('caches the upstream tool list via a real tools/list', () => {
+    const names = sup.getTools().map((t) => t.tool.name).sort()
+    expect(names).toEqual(['add', 'echo'])
+  })
+
+  it('routes a real tools/call to the child and returns its result', async () => {
+    const res: any = await sup.callTool('echo1', 'add', { a: 2, b: 3 })
+    expect(res.content[0].text).toBe('5')
+  })
+})
+
+describe('LIVE: MCP client <-> proxy facade (the path Claude takes)', () => {
+  let client: InstanceType<typeof Client>
+
+  beforeAll(async () => {
+    const server = new McpServer({ name: 'conductor-test', version: '1.0.0' }, { capabilities: {} })
+    registerProxyTools(server, z, {
+      getTools: () => sup.getTools(),
+      getState: () => sup.getState(),
+      callTool: (id, tool, args) => sup.callTool(id, tool, args),
+    })
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair()
+    client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+    await Promise.all([server.connect(serverT), client.connect(clientT)])
+  }, 30000)
+
+  it('advertises exactly the fixed meta-tools (upstream tools are NOT in the list)', async () => {
+    const { tools } = await client.listTools()
+    const names = tools.map((t: any) => t.name).sort()
+    expect(names).toEqual(['call_tool', 'describe_tool', 'list_servers', 'search_tools'])
+  })
+
+  it('search_tools finds a namespaced upstream tool', async () => {
+    const res: any = await client.callTool({ name: 'search_tools', arguments: { query: 'echo text' } })
+    const payload = JSON.parse(res.content[0].text)
+    expect(payload.results.map((r: any) => r.name)).toContain('echo__echo')
+  })
+
+  it('describe_tool returns the upstream input schema on demand', async () => {
+    const res: any = await client.callTool({ name: 'describe_tool', arguments: { name: 'echo__add' } })
+    const payload = JSON.parse(res.content[0].text)
+    expect(payload.inputSchema.properties.a).toBeTruthy()
+    expect(payload.inputSchema.properties.b).toBeTruthy()
+  })
+
+  it('call_tool routes through the proxy to the real upstream', async () => {
+    const res: any = await client.callTool({ name: 'call_tool', arguments: { name: 'echo__echo', arguments: { text: 'hello proxy' } } })
+    expect(res.content[0].text).toBe('hello proxy')
+  })
+
+  it('list_servers reports the upstream online', async () => {
+    const res: any = await client.callTool({ name: 'list_servers', arguments: {} })
+    const payload = JSON.parse(res.content[0].text)
+    expect(payload.servers.find((s: any) => s.name === 'Echo')).toMatchObject({ status: 'online' })
+  })
+
+  it('after the upstream stops, call_tool fails gracefully (race guard)', async () => {
+    await sup.stopUpstream('echo1')
+    const res: any = await client.callTool({ name: 'call_tool', arguments: { name: 'echo__echo', arguments: { text: 'x' } } })
+    // Tool no longer resolvable -> unknown-tool guidance, not a crash.
+    expect(res.isError).toBe(true)
+    expect(res.content[0].text.toLowerCase()).toContain('search_tools')
+  })
+})

--- a/tests/unit/main/mcp-proxy/adopt.test.ts
+++ b/tests/unit/main/mcp-proxy/adopt.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../../../src/main/debug-logger', () => ({
+  logInfo: vi.fn(), logWarn: vi.fn(), logError: vi.fn(), logDebug: vi.fn(),
+}))
+
+const listUpstreams = vi.fn(() => [] as any[])
+const addUpstream = vi.fn((input: any) => ({ id: 'new', ...input }))
+vi.mock('../../../../src/main/mcp-proxy/upstream-registry', () => ({
+  listUpstreams: () => listUpstreams(),
+  addUpstream: (input: any) => addUpstream(input),
+}))
+
+let backupStore: any = null
+const readConfig = vi.fn(() => backupStore)
+const saveConfig = vi.fn((_k: string, v: any) => { backupStore = v; return true })
+vi.mock('../../../../src/main/config-manager', () => ({
+  readConfig: (...a: any[]) => readConfig(...(a as [])),
+  saveConfig: (...a: any[]) => saveConfig(...(a as [string, any])),
+}))
+
+const {
+  parseMcpServersObject,
+  parseCodexMcpServers,
+  removeServersFromObject,
+  discoverAll,
+  importDiscovered,
+  takeOver,
+  claudeJsonPath,
+} = await import('../../../../src/main/mcp-proxy/adopt')
+
+beforeEach(() => {
+  listUpstreams.mockReturnValue([])
+  addUpstream.mockClear()
+  readConfig.mockClear()
+  saveConfig.mockClear()
+  backupStore = null
+})
+
+describe('parseMcpServersObject', () => {
+  it('maps stdio and http/sse entries; skips invalid', () => {
+    const out = parseMcpServersObject({
+      mcpServers: {
+        fs: { command: 'npx', args: ['-y', 'server-fs', '/tmp'], env: { TOKEN: 'x', N: 5 } },
+        remote: { type: 'sse', url: 'http://h/sse', headers: { Authorization: 'Bearer t' } },
+        streamable: { type: 'streamable-http', url: 'http://h/mcp' },
+        broken: { nonsense: true },
+      },
+    })
+    expect(out).toEqual([
+      { name: 'fs', transport: { kind: 'stdio', command: 'npx', args: ['-y', 'server-fs', '/tmp'], env: { TOKEN: 'x' } } },
+      { name: 'remote', transport: { kind: 'sse', url: 'http://h/sse', headers: { Authorization: 'Bearer t' } } },
+      { name: 'streamable', transport: { kind: 'http', url: 'http://h/mcp' } },
+    ])
+  })
+
+  it('returns [] for objects without mcpServers', () => {
+    expect(parseMcpServersObject({})).toEqual([])
+    expect(parseMcpServersObject(null)).toEqual([])
+  })
+})
+
+describe('parseCodexMcpServers', () => {
+  it('reads [mcp_servers.NAME] command/args and url tables', () => {
+    const toml = [
+      '[mcp_servers.fs]',
+      'command = "npx"',
+      'args = ["-y", "server-fs"]',
+      '',
+      '[mcp_servers.web]',
+      'url = "http://h/mcp"',
+      '',
+      '[other.section]',
+      'command = "ignored"',
+    ].join('\n')
+    const out = parseCodexMcpServers(toml)
+    expect(out).toEqual([
+      { name: 'fs', transport: { kind: 'stdio', command: 'npx', args: ['-y', 'server-fs'] } },
+      { name: 'web', transport: { kind: 'http', url: 'http://h/mcp' } },
+    ])
+  })
+})
+
+describe('removeServersFromObject', () => {
+  it('removes named servers and reports the removed entries without mutating input', () => {
+    const orig = { mcpServers: { a: { command: 'x' }, b: { command: 'y' } }, other: 1 }
+    const { next, removed } = removeServersFromObject(orig, ['a'])
+    expect(Object.keys((next.mcpServers as any))).toEqual(['b'])
+    expect(removed).toEqual({ a: { command: 'x' } })
+    expect(Object.keys((orig.mcpServers as any))).toEqual(['a', 'b']) // untouched
+  })
+})
+
+describe('discoverAll (injected IO)', () => {
+  it('collects across sources and flags existing entries', () => {
+    listUpstreams.mockReturnValue([
+      { id: 'e1', name: 'fs', transport: { kind: 'stdio', command: 'npx', args: ['-y', 'server-fs'] }, enabled: true, exposure: 'search', autostart: false },
+    ])
+    const io = {
+      read: (p: string) => {
+        if (p === claudeJsonPath()) return JSON.stringify({ mcpServers: { fs: { command: 'npx', args: ['-y', 'server-fs'] }, gh: { command: 'gh-mcp' } } })
+        return null
+      },
+      write: () => true,
+      exists: () => true,
+    }
+    const found = discoverAll(io)
+    const fs = found.find((f) => f.input.name === 'fs')!
+    const gh = found.find((f) => f.input.name === 'gh')!
+    expect(fs.existing).toBe(true)
+    expect(gh.existing).toBe(false)
+    expect(fs.source).toBe('claude')
+  })
+
+  it('skips a source whose JSON is malformed (never throws)', () => {
+    const io = { read: (p: string) => (p === claudeJsonPath() ? '{ not json' : null), write: () => true, exists: () => true }
+    expect(discoverAll(io)).toEqual([])
+  })
+})
+
+describe('importDiscovered', () => {
+  it('adds only non-existing entries', () => {
+    const items = [
+      { source: 'claude' as const, existing: true, input: { name: 'fs', transport: { kind: 'stdio' as const, command: 'x' } } },
+      { source: 'claude' as const, existing: false, input: { name: 'gh', transport: { kind: 'stdio' as const, command: 'gh' } } },
+    ]
+    const added = importDiscovered(items)
+    expect(added).toBe(1)
+    expect(addUpstream).toHaveBeenCalledTimes(1)
+    expect(addUpstream).toHaveBeenCalledWith(items[1].input)
+  })
+})
+
+describe('takeOver', () => {
+  it('strips servers from the client file and backs up removed entries', () => {
+    let written: string | null = null
+    const io = {
+      read: () => JSON.stringify({ mcpServers: { fs: { command: 'x' }, gh: { command: 'y' } } }),
+      write: (_p: string, c: string) => { written = c; return true },
+      exists: () => true,
+    }
+    const res = takeOver('claude', ['fs'], io)
+    expect(res).toEqual({ ok: true, removed: 1 })
+    expect(JSON.parse(written!).mcpServers).toEqual({ gh: { command: 'y' } })
+    expect(saveConfig).toHaveBeenCalledWith('mcpAdoptBackup', { claude: { fs: { command: 'x' } } })
+  })
+
+  it('fails closed on malformed JSON — never writes', () => {
+    let wrote = false
+    const io = { read: () => '{ broken', write: () => { wrote = true; return true }, exists: () => true }
+    const res = takeOver('claude', ['fs'], io)
+    expect(res.ok).toBe(false)
+    expect(wrote).toBe(false)
+  })
+
+  it('reports zero removed when the name is absent', () => {
+    const io = { read: () => JSON.stringify({ mcpServers: { gh: { command: 'y' } } }), write: () => true, exists: () => true }
+    expect(takeOver('claude', ['fs'], io)).toEqual({ ok: true, removed: 0 })
+  })
+})

--- a/tests/unit/renderer/conductor-mcp-page.test.ts
+++ b/tests/unit/renderer/conductor-mcp-page.test.ts
@@ -12,6 +12,26 @@ import { act } from 'react'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
+// The page now renders ProxySubTool, which uses the real mcpProxyStore and hits
+// window.electronAPI.mcpProxy on mount (list + onChanged). Stub it so the page
+// renders; the proxy card is exercised in its own store test.
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(globalThis as any).window.electronAPI = {
+  mcpProxy: {
+    list: vi.fn().mockResolvedValue([]),
+    add: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    discover: vi.fn().mockResolvedValue([]),
+    importServers: vi.fn(),
+    takeOver: vi.fn(),
+    onChanged: vi.fn(() => () => {}),
+  },
+}
+
 const mockState = {
   serverRunning: true,
   mcpPort: 19333,
@@ -61,9 +81,10 @@ describe('ConductorMcpPage umbrella (P7.4)', () => {
     expect(text).toContain('19333')
   })
 
-  it('renders all three sub-tool cards', () => {
+  it('renders the sub-tool cards (proxy + vision + codex review + host transfer)', () => {
     act(() => { root.render(React.createElement(ConductorMcpPage)) })
     const text = container.textContent ?? ''
+    expect(text).toContain('MCP Proxy')
     expect(text).toContain('Vision (browser automation)')
     expect(text).toContain('Codex review (Claude-driven)')
     expect(text).toContain('Host transfer')


### PR DESCRIPTION
Part of the Conductor Proxy MCP epic (#101). Resolves #98.

**Stacked PR** — base: `feat/97-proxy-ui`. Top of the stack.

Import existing MCP servers and optionally make the proxy the single instance.
- `adopt.ts`: discover from `~/.claude.json`, Claude Desktop, `~/.codex/config.toml`; import (dedupe); reversible take-over (atomic write + backup)
- pure parsers fail closed — a config that won't parse is never rewritten
- IO injected for testability; IPC + preload + "Import existing" button
- 10 unit tests

Also carries two verification commits: a test fix for the ConductorMcpPage (it now renders the proxy card) and the **live end-to-end integration harness** (real stdio MCP child + real client through the facade, 9 assertions).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
