### PR TITLE
feat(linux): experimental Linux support (AppImage) — updater, vision, build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,15 +206,22 @@ jobs:
             dist/latest-mac.yml
           if-no-files-found: error
 
-  # ── Build Linux AppImage ──
-  # Unsigned by design: Linux has no SmartScreen/Gatekeeper equivalent, and
-  # AppImage carries no signing convention — integrity comes from CHECKSUMS.txt.
-  # Built on ubuntu-latest (glibc 2.39), so the AppImage runs on distros at
-  # that glibc or newer: Ubuntu 24.04+, Rocky 10+, Fedora 40+. Older lines
-  # (Rocky 8/9, Ubuntu 22.04) need a container build against an older glibc —
-  # deliberately out of scope for now.
+  # ── Build Linux AppImage (experimental) ──
+  # Unsigned: Linux has no SmartScreen/Gatekeeper equivalent, and AppImage
+  # carries no signing convention. CHECKSUMS.txt lets users verify the download
+  # by hand — the in-app updater does NOT yet verify it (tracked as follow-up).
+  # Built on ubuntu-latest (glibc 2.39), so the AppImage runs on distros at that
+  # glibc or newer: Ubuntu 24.04+, Rocky 10+, Fedora 40+. Older lines (Rocky
+  # 8/9, Ubuntu 22.04) need a container build against an older glibc — out of
+  # scope for now.
+  #
+  # continue-on-error: this is an EXPERIMENTAL third platform, so a Linux build
+  # failure must never block the Windows/macOS release. The job still shows red
+  # in the run (visible to the maintainer), and release.js flags the missing
+  # AppImage asset — but the release proceeds with the platforms that built.
   build-linux:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -247,8 +254,11 @@ jobs:
           }).then(() => console.log('rebuild done')).catch(e => { console.error(e); process.exit(1) })
           "
 
-      # The only place the suite runs on Linux (CI's PR matrix is Win+macOS),
-      # so keep it: it gates the release on linux-native node-pty/sqlite too.
+      # The only place the vitest suite runs on Linux (CI's PR matrix is
+      # Win+macOS). Note this is the standard suite — the *.native.test.ts
+      # files (better-sqlite3 under Electron-as-Node) are excluded by
+      # vitest.config; the native rebuild above is what proves node-pty /
+      # better-sqlite3 link on linux-x64.
       - name: Run tests
         run: npx vitest run
 
@@ -286,7 +296,11 @@ jobs:
           name: macos-dmg
           path: artifacts/
 
+      # continue-on-error mirrors build-linux: if the experimental Linux build
+      # failed, its artifact won't exist — download it best-effort so the
+      # Windows/macOS release still publishes.
       - name: Download Linux artifact
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: linux-appimage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,9 +206,70 @@ jobs:
             dist/latest-mac.yml
           if-no-files-found: error
 
+  # ── Build Linux AppImage ──
+  # Unsigned by design: Linux has no SmartScreen/Gatekeeper equivalent, and
+  # AppImage carries no signing convention — integrity comes from CHECKSUMS.txt.
+  # Built on ubuntu-latest (glibc 2.39), so the AppImage runs on distros at
+  # that glibc or newer: Ubuntu 24.04+, Rocky 10+, Fedora 40+. Older lines
+  # (Rocky 8/9, Ubuntu 22.04) need a container build against an older glibc —
+  # deliberately out of scope for now.
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python setuptools
+        run: pip install setuptools
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Electron binary
+        run: node node_modules/electron/install.js
+
+      - name: Rebuild native modules
+        run: |
+          node -e "
+          const { rebuild } = require('@electron/rebuild');
+          rebuild({
+            buildPath: process.cwd(),
+            electronVersion: require('./node_modules/electron/package.json').version,
+            onlyModules: ['node-pty', 'better-sqlite3']
+          }).then(() => console.log('rebuild done')).catch(e => { console.error(e); process.exit(1) })
+          "
+
+      # The only place the suite runs on Linux (CI's PR matrix is Win+macOS),
+      # so keep it: it gates the release on linux-native node-pty/sqlite too.
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+      - name: Package Linux AppImage
+        run: npx electron-builder --linux --publish never
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-appimage
+          path: |
+            dist/*.AppImage
+            dist/latest-linux.yml
+          if-no-files-found: error
+
   # ── Create GitHub Release ──
   release:
-    needs: [build-windows, build-macos]
+    needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -223,6 +284,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: macos-dmg
+          path: artifacts/
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-appimage
           path: artifacts/
 
       - name: List artifacts
@@ -303,8 +370,8 @@ jobs:
             --url "https://www.virustotal.com/api/v3/files/upload_url" \
             --header "x-apikey: ${VT_API_KEY}" | jq -r '.data')
 
-          # Scan each installer (EXE + DMG)
-          for FILE in artifacts/*.exe artifacts/*.dmg; do
+          # Scan each installer (EXE + DMG + AppImage)
+          for FILE in artifacts/*.exe artifacts/*.dmg artifacts/*.AppImage; do
             [ -f "$FILE" ] || continue
             echo "Uploading $(basename $FILE) to VirusTotal..."
             RESULT=$(curl -s --request POST \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,5 +54,6 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 - RC-branch fixes are back-ported to `beta`; features never merge into a release branch
 - Prerelease tags: `-beta.N` and `-rc.N` — both ride the beta update channel; rc outranks beta, final outranks rc
 - Promote to stable: merge `release/vX.Y.Z` → `main`, run the release workflow from `main` with `channel=stable`, then delete the release branch
-- GitHub Actions builds Windows (.exe) + macOS (.dmg) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
+- GitHub Actions builds Windows (.exe) + macOS (.dmg) + Linux (.AppImage, experimental) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
+- Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
 - Never commit secrets, .env files, or personal paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This document covers setup, coding sta
 - Node.js 20+
 - npm 9+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
-- Windows 10/11 or macOS 12+ (Linux support is untested)
+- Windows 10/11, macOS 12+, or Linux with glibc 2.39+ (Linux support is experimental — verified on Ubuntu 24.04 and Rocky 10)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run dozens of Claude Code and Codex sessions in parallel, each with its own acco
 [![Release](https://img.shields.io/github/v/release/nubbymong/claude-command-center?include_prereleases&label=release&color=cba6f7&labelColor=313244)](../../releases)
 [![Opus 4.8](https://img.shields.io/badge/Opus%204.8-day--one-f9e2af?labelColor=313244)](https://www.anthropic.com/news/claude-opus-4-8)
 [![Tests](https://img.shields.io/badge/tests-passing-a6e3a1?labelColor=313244)](../../actions)
-[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20(arm64)-89b4fa?labelColor=313244)](../../releases)
+[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20(arm64)%20%7C%20Linux%20(experimental)-89b4fa?labelColor=313244)](../../releases)
 [![License](https://img.shields.io/badge/MIT-fab387?labelColor=313244)](LICENSE)
 
 [Download](#install) &middot; [Features](#what-it-does) &middot; [Architecture](#under-the-hood) &middot; [Security](#security)
@@ -178,6 +178,7 @@ Invoke an Opus 4.8 dynamic workflow three ways: include the word `workflow` in a
 1. Grab the latest installer from **[Releases](../../releases)**.
    - Windows: `ClaudeCommandCenter-x.y.z.exe`
    - macOS (Apple Silicon): `ClaudeCommandCenter-x.y.z-mac.dmg`
+   - Linux (experimental): `ClaudeCommandCenter-x.y.z-linux-x86_64.AppImage`
 2. Verify the **SHA-256** of the file you downloaded against the checksum printed on the release page.
 3. Run the installer and choose your Data and Resources directories.
 4. The setup wizard hands off to Claude CLI auth.
@@ -186,7 +187,9 @@ Invoke an Opus 4.8 dynamic workflow three ways: include the word `workflow` in a
 
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated (a recent version, for Opus 4.8 and dynamic workflows)
 - Node.js 20+ (a Claude Code dependency)
-- Windows 10 or 11 (x64), or macOS 12+ on **Apple Silicon (arm64)**
+- Windows 10 or 11 (x64), or macOS 12+ on **Apple Silicon (arm64)**, or a Linux distro with **glibc 2.39+** (Ubuntu 24.04+, Rocky 10+, Fedora 40+) on x64
+
+> **Linux (experimental)** &middot; Make the AppImage executable before first run (`chmod +x ClaudeCommandCenter-*.AppImage`); it needs FUSE (`sudo apt install libfuse2` on Ubuntu) and the usual GTK 3 desktop libraries. Verified on Ubuntu 24.04 and Rocky Linux 10. Older glibc lines (Ubuntu 22.04, Rocky 8/9) are not covered by this build. The vision browser tool needs a **deb/rpm** Chrome or Chromium — the Ubuntu *snap* build's confinement blocks the debug profile, so vision stays disabled with snap-only Chromium.
 
 > **Windows SmartScreen** &middot; These installers are **not code-signed**. This is an independent, single-maintainer build, and a code-signing certificate is not in place yet, so Windows SmartScreen will warn the first time you run a new release: click **More info**, then **Run anyway**. To convince yourself the download is intact, verify the SHA-256 against the value on the release page before running it. Releases produced by the CI pipeline are additionally scanned through VirusTotal (70+ engines); the scan link is included in those release notes.
 
@@ -207,8 +210,9 @@ npm run build        # production build
 ```
 
 ```bash
-npm run package:win  # Windows NSIS installer
-npm run package:mac  # macOS DMG (Apple Silicon)
+npm run package:win    # Windows NSIS installer
+npm run package:mac    # macOS DMG (Apple Silicon)
+npm run package:linux  # Linux AppImage (x64)
 ```
 
 The repository ships well over two thousand unit tests plus a native (better-sqlite3 / node-pty) suite; both run green on Windows and macOS in CI on every labelled PR. See the [Actions](../../actions) tab for current status.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "package": "electron-vite build && electron-builder --win --dir",
     "package:win": "electron-vite build && electron-builder --win",
     "package:mac": "electron-vite build && electron-builder --mac",
+    "package:linux": "electron-vite build && electron-builder --linux",
     "verify:package": "node scripts/verify-native-unpack.mjs",
     "test": "vitest run && npm run test:unit:native && npx playwright test",
     "test:unit": "vitest run",
@@ -125,6 +126,18 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": true
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "category": "Development",
+      "artifactName": "ClaudeCommandCenter-${version}-linux-${arch}.${ext}"
     },
     "dmg": {
       "sign": false

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -604,6 +604,7 @@ if (exitCode !== 0) {
     const names = release.names || []
     const hasExe = names.some((n) => n.endsWith('.exe'))
     const hasDmg = names.some((n) => n.endsWith('.dmg'))
+    const hasAppImage = names.some((n) => n.endsWith('.AppImage'))
     const hasChecksums = names.some((n) => n.toLowerCase().includes('checksum'))
 
     console.log(`      Release URL: ${release.url}`)
@@ -612,6 +613,8 @@ if (exitCode !== 0) {
     else { warn('Windows installer NOT found'); exitCode = 1 }
     if (hasDmg) ok('macOS installer (.dmg) attached')
     else { warn('macOS installer NOT found'); exitCode = 1 }
+    if (hasAppImage) ok('Linux AppImage attached')
+    else { warn('Linux AppImage NOT found'); exitCode = 1 }
     if (hasChecksums) ok('CHECKSUMS.txt attached')
     else warn('CHECKSUMS.txt not found (workflow normally generates this)')
   } catch (err) {

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -645,6 +645,46 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
   return null
 }
 
+/**
+ * Best-effort check: is `targetPath` on a filesystem mounted `noexec`?
+ *
+ * `fs.accessSync(X_OK)` inspects the file's permission bits, not the mount, so
+ * on a hardened box where ~/Downloads (or /home) is mounted `noexec` a freshly
+ * chmod'd AppImage passes the access check yet `execve` fails EACCES at launch.
+ * Because CCC holds a single-instance lock, we cannot verify the relaunch by
+ * spawning it first (the new instance can't start until we exit), so the update
+ * flow uses this to abort BEFORE killing the user's terminals rather than after.
+ *
+ * Parses /proc/mounts and returns the `noexec` state of the longest mount point
+ * that is a prefix of `targetPath`. Returns false whenever it can't tell (no
+ * /proc/mounts, parse failure) — never block an update on a best-effort probe.
+ * `procMounts` is injectable for tests.
+ */
+export function isPathOnNoexecMount(targetPath: string, procMounts?: string): boolean {
+  let text: string | undefined
+  try {
+    text = procMounts ?? fs.readFileSync('/proc/mounts', 'utf-8')
+  } catch { return false }
+  if (typeof text !== 'string') return false
+
+  let bestPointLen = -1
+  let noexec = false
+  for (const line of text.split('\n')) {
+    const parts = line.split(/\s+/)
+    if (parts.length < 4) continue
+    const point = parts[1]
+    const opts = parts[3]
+    const prefix = point.endsWith('/') ? point : point + '/'
+    if (targetPath === point || targetPath.startsWith(prefix)) {
+      if (point.length > bestPointLen) {
+        bestPointLen = point.length
+        noexec = /(^|,)noexec(,|$)/.test(opts)
+      }
+    }
+  }
+  return noexec
+}
+
 // ── Linux AppImage apply ─────────────────────────────────────────────────
 
 /**
@@ -670,9 +710,11 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
  * the inode until the process exits.
  *
  * Guarded: $APPIMAGE is an environment variable a wrapper could point anywhere,
- * so we only ever unlink/overwrite a plain file whose name is actually one of
- * ours. Every failure degrades to launching straight from the download location
- * — never block the update on the tidy-up. `currentAppImage` is a parameter
+ * so we only ever unlink/overwrite a plain *.AppImage FILE — name-agnostic,
+ * because users legitimately rename the image to a stable custom name (that's
+ * the case finding #1 preserves), so we can't require our own name prefix.
+ * Every failure degrades to launching straight from the download location —
+ * never block the update on the tidy-up. `currentAppImage` is a parameter
  * (defaulting to $APPIMAGE) so tests can exercise all paths on any platform.
  */
 export function prepareLinuxAppImageUpdate(

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -27,7 +27,23 @@ import { readRegistry } from './registry'
 
 const execFileAsync = promisify(execFile)
 
-const INSTALLER_EXT = process.platform === 'darwin' ? '.dmg' : '.exe'
+/**
+ * Installer asset extension per platform. Pure + exported for unit tests —
+ * INSTALLER_EXT itself is baked from process.platform at module load, so tests
+ * can't exercise other platforms through it.
+ *
+ * Linux ships as an AppImage. Before this mapping existed, Linux fell into the
+ * `.exe` default: the checker then found no matching asset on any release and
+ * skipped every update, so Linux installs were silently frozen at whatever
+ * version they first installed.
+ */
+export function installerExtForPlatform(platform: NodeJS.Platform): string {
+  if (platform === 'darwin') return '.dmg'
+  if (platform === 'linux') return '.AppImage'
+  return '.exe'
+}
+
+const INSTALLER_EXT = installerExtForPlatform(process.platform)
 
 const DEFAULT_REPO = 'nubbymong/claude-command-center'
 
@@ -627,4 +643,52 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
   }
 
   return null
+}
+
+// ── Linux AppImage apply ─────────────────────────────────────────────────
+
+/**
+ * Prepare a downloaded AppImage for launch and, when possible, put it where
+ * the running AppImage lives. Returns the path the caller should spawn.
+ *
+ * Unlike Windows (the .exe IS an installer that installs over the old copy),
+ * a downloaded AppImage is just a file: it arrives without the execute bit,
+ * and launching it from ~/Downloads would leave the user's "real" copy stale.
+ * So: chmod +x always; then, when we're running AS an AppImage (AppImage
+ * runtimes export $APPIMAGE = the file's own path), copy the new version next
+ * to it and delete the old one. Deleting the running AppImage is safe on
+ * Linux — the mounted squashfs holds the inode until the process exits. The
+ * new file keeps its own versioned name, so the filename never lies about the
+ * version inside.
+ *
+ * Every failure degrades to launching straight from the download location —
+ * never block the update on the tidy-up. `currentAppImage` is a parameter
+ * (defaulting to $APPIMAGE) so tests can exercise all paths on any platform.
+ */
+export function prepareLinuxAppImageUpdate(
+  downloadedPath: string,
+  currentAppImage: string | undefined = process.env.APPIMAGE,
+): string {
+  try { fs.chmodSync(downloadedPath, 0o755) } catch (err) {
+    logError('[github-update] chmod +x on downloaded AppImage failed:', err)
+  }
+
+  if (!currentAppImage) return downloadedPath
+  try {
+    if (!fs.existsSync(currentAppImage)) return downloadedPath
+    const target = path.join(path.dirname(currentAppImage), path.basename(downloadedPath))
+    if (path.resolve(target) === path.resolve(downloadedPath)) return downloadedPath
+
+    fs.copyFileSync(downloadedPath, target)
+    fs.chmodSync(target, 0o755)
+    if (path.resolve(target) !== path.resolve(currentAppImage)) {
+      // Old version file — best-effort removal; leaving it behind is cosmetic.
+      try { fs.unlinkSync(currentAppImage) } catch { /* non-fatal */ }
+    }
+    logInfo(`[github-update] AppImage updated in place: ${target}`)
+    return target
+  } catch (err) {
+    logError('[github-update] In-place AppImage update failed — launching from download location:', err)
+    return downloadedPath
+  }
 }

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -655,14 +655,24 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
  * a downloaded AppImage is just a file: it arrives without the execute bit,
  * and launching it from ~/Downloads would leave the user's "real" copy stale.
  * So: chmod +x always; then, when we're running AS an AppImage (AppImage
- * runtimes export $APPIMAGE = the file's own path), copy the new version next
- * to it and delete the old one. Deleting the running AppImage is safe on
- * Linux — the mounted squashfs holds the inode until the process exits. The
- * new file keeps its own versioned name, so the filename never lies about the
- * version inside.
+ * runtimes export $APPIMAGE = the file's own path), replace it in place.
  *
- * Every failure degrades to launching straight from the download location —
- * never block the update on the tidy-up. `currentAppImage` is a parameter
+ * Replacement follows electron-updater's convention (electron-builder #2964) so
+ * we don't orphan the user's launcher:
+ *   - If the running file's name has NO version (the user renamed it to a stable
+ *     path that a .desktop entry / dock pin / alias points at), overwrite AT THE
+ *     SAME PATH — keep their name.
+ *   - Only when the running name is itself versioned do we write the new
+ *     versioned name and remove the old file.
+ *   - $APPIMAGE is resolved through symlinks first (a stable `~/bin/ccc` link),
+ *     the real file is replaced, and the symlink is re-pointed at the new file.
+ * Deleting the running AppImage is safe on Linux — the mounted squashfs holds
+ * the inode until the process exits.
+ *
+ * Guarded: $APPIMAGE is an environment variable a wrapper could point anywhere,
+ * so we only ever unlink/overwrite a plain file whose name is actually one of
+ * ours. Every failure degrades to launching straight from the download location
+ * — never block the update on the tidy-up. `currentAppImage` is a parameter
  * (defaulting to $APPIMAGE) so tests can exercise all paths on any platform.
  */
 export function prepareLinuxAppImageUpdate(
@@ -674,16 +684,50 @@ export function prepareLinuxAppImageUpdate(
   }
 
   if (!currentAppImage) return downloadedPath
+
+  // Resolve symlinks / `..`: the AppImage runtime sets $APPIMAGE to the real
+  // mounted file, but a user may launch via a stable symlink whose target we
+  // must replace (and whose link we must not leave dangling).
+  let real: string
+  try { real = fs.realpathSync(currentAppImage) } catch { return downloadedPath }
+
+  // Only ever replace a plain *.AppImage FILE — never unlink a directory or a
+  // non-AppImage file (e.g. a wrapper that set $APPIMAGE to some unrelated
+  // path). We can't require our own name prefix here because users legitimately
+  // rename the AppImage to a stable custom name (the case finding #1 preserves);
+  // the .AppImage + regular-file check is the safe, name-agnostic guard.
   try {
-    if (!fs.existsSync(currentAppImage)) return downloadedPath
-    const target = path.join(path.dirname(currentAppImage), path.basename(downloadedPath))
+    const st = fs.lstatSync(real)
+    if (!st.isFile() || !path.basename(real).endsWith('.AppImage')) {
+      logError(`[github-update] $APPIMAGE (${real}) is not an AppImage file — launching from download location`)
+      return downloadedPath
+    }
+  } catch { return downloadedPath }
+
+  try {
+    const runningName = path.basename(real)
+    const keepName = !/\d+\.\d+\.\d+/.test(runningName)   // unversioned = user's custom stable name
+    const target = keepName ? real : path.join(path.dirname(real), path.basename(downloadedPath))
+
     if (path.resolve(target) === path.resolve(downloadedPath)) return downloadedPath
 
+    // Unlink before writing when reusing the running file's own path: truncating
+    // a mounted AppImage in place can corrupt the running mount, whereas removing
+    // the directory entry is safe (the mount keeps the inode) and lets copy
+    // recreate the file cleanly.
+    if (path.resolve(target) === path.resolve(real)) {
+      try { fs.unlinkSync(real) } catch { /* copy recreates it */ }
+    }
     fs.copyFileSync(downloadedPath, target)
     fs.chmodSync(target, 0o755)
-    if (path.resolve(target) !== path.resolve(currentAppImage)) {
-      // Old version file — best-effort removal; leaving it behind is cosmetic.
-      try { fs.unlinkSync(currentAppImage) } catch { /* non-fatal */ }
+
+    if (path.resolve(target) !== path.resolve(real)) {
+      try { fs.unlinkSync(real) } catch { /* non-fatal: a stale old version is cosmetic */ }
+      // Launched via a symlink? Re-point it so the user's stable launcher path
+      // follows the new versioned file instead of dangling at the deleted one.
+      if (path.resolve(currentAppImage) !== path.resolve(real)) {
+        try { fs.unlinkSync(currentAppImage); fs.symlinkSync(target, currentAppImage) } catch { /* best-effort */ }
+      }
     }
     logInfo(`[github-update] AppImage updated in place: ${target}`)
     return target

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
-import { checkGitHubRelease, downloadGitHubRelease } from '../github-update'
+import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
 
@@ -146,6 +146,13 @@ export function registerUpdateHandlers(): void {
         // On macOS, open the DMG in Finder — user drags to Applications manually.
         // Auto-installing a DMG over a running app is not supported.
         spawn('open', [installerPath], { detached: true, stdio: 'ignore' }).unref()
+      } else if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
+        // A downloaded AppImage has no execute bit and is not an installer —
+        // prepare it (chmod +x, replace the running AppImage in place when
+        // $APPIMAGE is known) and spawn the prepared copy directly.
+        const launchPath = prepareLinuxAppImageUpdate(installerPath)
+        logInfo(`[update] Launching updated AppImage: ${launchPath}`)
+        spawn(launchPath, [], { detached: true, stdio: 'ignore' }).unref()
       } else {
         const proc = spawn(installerPath, [], { detached: true, stdio: 'ignore' })
         proc.unref()

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
-import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate } from '../github-update'
+import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
 
@@ -146,10 +146,18 @@ export function registerUpdateHandlers(): void {
     let linuxLaunchPath: string | null = null
     if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
       linuxLaunchPath = prepareLinuxAppImageUpdate(installerPath)
+      // Permission bits (fast, catches a failed chmod on vfat/exfat)...
       try {
         fs.accessSync(linuxLaunchPath, fs.constants.X_OK)
       } catch (err) {
         throw new Error(`Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`)
+      }
+      // ...and the mount, which accessSync can't see: a noexec ~/Downloads (the
+      // fallback launch location) would pass the bit check yet fail execve. The
+      // single-instance lock means we can't confirm the relaunch by spawning it
+      // first, so catch this here — before the PTYs are killed — not after.
+      if (isPathOnNoexecMount(linuxLaunchPath)) {
+        throw new Error(`Updated AppImage is on a noexec mount (${linuxLaunchPath}) — cannot relaunch. Move the app to a filesystem that allows execution, or update manually.`)
       }
     }
 

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -137,6 +137,22 @@ export function registerUpdateHandlers(): void {
 
     logInfo(`[update] Found installer: ${installerPath}`)
 
+    // Linux: prepare and VERIFY the AppImage is executable BEFORE we kill the
+    // user's terminals and exit. spawn() reports EACCES/ENOENT only via an async
+    // 'error' event, so a doomed launch (a noexec ~/Downloads mount, a failed
+    // chmod on vfat/exfat, an unwritable $APPIMAGE dir) would otherwise kill
+    // every PTY, exit the app, and leave nothing running with no error shown.
+    // Fail here instead — the outer catch surfaces it and the app stays alive.
+    let linuxLaunchPath: string | null = null
+    if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
+      linuxLaunchPath = prepareLinuxAppImageUpdate(installerPath)
+      try {
+        fs.accessSync(linuxLaunchPath, fs.constants.X_OK)
+      } catch (err) {
+        throw new Error(`Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`)
+      }
+    }
+
     try {
       logInfo('[update] Killing all PTYs...')
       killAllPty()
@@ -146,13 +162,21 @@ export function registerUpdateHandlers(): void {
         // On macOS, open the DMG in Finder — user drags to Applications manually.
         // Auto-installing a DMG over a running app is not supported.
         spawn('open', [installerPath], { detached: true, stdio: 'ignore' }).unref()
-      } else if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
-        // A downloaded AppImage has no execute bit and is not an installer —
-        // prepare it (chmod +x, replace the running AppImage in place when
-        // $APPIMAGE is known) and spawn the prepared copy directly.
-        const launchPath = prepareLinuxAppImageUpdate(installerPath)
-        logInfo(`[update] Launching updated AppImage: ${launchPath}`)
-        spawn(launchPath, [], { detached: true, stdio: 'ignore' }).unref()
+      } else if (linuxLaunchPath) {
+        logInfo(`[update] Launching updated AppImage: ${linuxLaunchPath}`)
+        const child = spawn(linuxLaunchPath, [], { detached: true, stdio: 'ignore' })
+        // Wait for the child to actually start before exiting — spawn surfaces
+        // exec failures asynchronously, so exiting immediately would hide a
+        // failure and strand the user with no running app. On 'spawn' we exit;
+        // on 'error' we abort (outer catch surfaces it); a short timeout is the
+        // safety net so we never hang the update forever.
+        await new Promise<void>((resolve, reject) => {
+          let done = false
+          const settle = (fn: () => void) => { if (!done) { done = true; child.unref(); fn() } }
+          child.once('spawn', () => settle(resolve))
+          child.once('error', (err) => settle(() => reject(err)))
+          setTimeout(() => settle(resolve), 3000)
+        })
       } else {
         const proc = spawn(installerPath, [], { detached: true, stdio: 'ignore' })
         proc.unref()

--- a/src/main/vision-manager.ts
+++ b/src/main/vision-manager.ts
@@ -598,10 +598,30 @@ export function tryReconnectGlobalVision(): void { if (globalManager) globalMana
 
 // === Browser launching (unchanged) ===
 
-function getBrowserPaths(browser: 'chrome' | 'edge'): string[] {
-  if (process.platform === 'darwin') {
+/** Candidate executable paths per browser. Pure + exported for unit testing —
+ *  `platform` is a parameter because process.platform is baked at test runtime. */
+export function getBrowserPaths(browser: 'chrome' | 'edge', platform: NodeJS.Platform = process.platform): string[] {
+  if (platform === 'darwin') {
     if (browser === 'edge') return ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge']
     return ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome']
+  }
+  if (platform === 'linux') {
+    if (browser === 'edge') return [
+      '/usr/bin/microsoft-edge',
+      '/usr/bin/microsoft-edge-stable',
+      '/opt/microsoft/msedge/msedge',
+    ]
+    // Chromium counts as "chrome" here — same engine, same CDP protocol.
+    // Snap chromium (/snap/bin/chromium) is deliberately absent: snap
+    // confinement blocks the --user-data-dir under /tmp, so it spawns but the
+    // debug port never comes up and vision hangs on "launching" instead of
+    // cleanly disabling. deb/rpm builds only.
+    return [
+      '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/usr/bin/chromium',
+      '/usr/bin/chromium-browser',
+    ]
   }
   if (browser === 'edge') return [
     'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
@@ -739,9 +759,14 @@ export function launchBrowser(browser: 'chrome' | 'edge', debugPort: number, url
   const tmpDir = process.env.TEMP || process.env.TMP || os.tmpdir()
   const profileDir = path.join(tmpDir, `${browser}-debug-${debugPort}`)
   const other: 'chrome' | 'edge' = browser === 'edge' ? 'chrome' : 'edge'
+  // Bare-name PATH fallback when no candidate path exists. On Linux the
+  // conventional binary name is `chromium`/`microsoft-edge` — `chrome` exists
+  // on no mainstream distro, which used to guarantee a spawn ENOENT here.
   const fallback = process.platform === 'darwin'
     ? (browser === 'edge' ? 'Microsoft Edge' : 'Google Chrome')
-    : (browser === 'edge' ? 'msedge' : 'chrome')
+    : process.platform === 'linux'
+      ? (browser === 'edge' ? 'microsoft-edge' : 'chromium')
+      : (browser === 'edge' ? 'msedge' : 'chrome')
   const executable =
     getBrowserPaths(browser).find(p => fs.existsSync(p)) ||
     getBrowserPaths(other).find(p => fs.existsSync(p)) ||

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -86,11 +86,17 @@ const mockUnlinkSync = vi.fn()
 const mockCreateWriteStream = vi.fn()
 const mockChmodSync = vi.fn()
 const mockCopyFileSync = vi.fn()
+const mockRealpathSync = vi.fn((p: string) => p)                 // identity: no symlink
+const mockLstatSync = vi.fn(() => ({ isFile: () => true }))      // regular file
+const mockSymlinkSync = vi.fn()
 vi.mock('fs', () => {
   const { EventEmitter: EE } = require('events')
   return {
     chmodSync: (...a: any[]) => mockChmodSync(...a),
     copyFileSync: (...a: any[]) => mockCopyFileSync(...a),
+    realpathSync: (...a: any[]) => mockRealpathSync(...a),
+    lstatSync: (...a: any[]) => mockLstatSync(...a),
+    symlinkSync: (...a: any[]) => mockSymlinkSync(...a),
     existsSync: (...a: any[]) => mockExistsSync(...a),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
@@ -358,7 +364,6 @@ describe('github-update', () => {
             { name: 'SomeOtherApp.exe', browser_download_url: 'https://x/other.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/win.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/mac.dmg' },
-            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/mac.AppImage' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/linux.AppImage' },
           ] },
         ],
@@ -608,6 +613,9 @@ describe('github-update', () => {
       mockChmodSync.mockReset()
       mockCopyFileSync.mockReset()
       mockUnlinkSync.mockReset()
+      mockSymlinkSync.mockReset()
+      mockRealpathSync.mockReset().mockImplementation((p: string) => p)
+      mockLstatSync.mockReset().mockReturnValue({ isFile: () => true })
     })
 
     it('always chmods the download executable (downloads arrive without +x)', () => {
@@ -622,10 +630,8 @@ describe('github-update', () => {
       expect(mockUnlinkSync).not.toHaveBeenCalled()
     })
 
-    it('replaces the running AppImage in place: copy beside it, chmod, remove old', () => {
-      mockExistsSync.mockReturnValue(true)
+    it('versioned running name: writes the new versioned file and removes the old', () => {
       const result = prepareLinuxAppImageUpdate(downloaded, running)
-      // New file lands next to the old one, keeping its own versioned name
       const expectedTarget = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
       expect(result?.replace(/\\/g, '/')).toBe(expectedTarget)
       expect(mockCopyFileSync).toHaveBeenCalledTimes(1)
@@ -634,31 +640,70 @@ describe('github-update', () => {
       expect(mockUnlinkSync).toHaveBeenCalledWith(running)
     })
 
-    it('when the running AppImage no longer exists, launches from the download', () => {
-      mockExistsSync.mockReturnValue(false)
+    it('finding #1 — custom UNVERSIONED name is preserved: overwrites the SAME path', () => {
+      // The user renamed their AppImage to a stable name a .desktop/dock/alias
+      // points at. Writing a new versioned name would orphan that launcher, so
+      // we overwrite in place and keep their filename.
+      const custom = '/home/u/Apps/ClaudeCommandCenter.AppImage'
+      const result = prepareLinuxAppImageUpdate(downloaded, custom)
+      expect(result?.replace(/\\/g, '/')).toBe(custom)
+      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, custom)
+      // unlink-before-write on the same path (avoids truncating the mounted image)
+      expect(mockUnlinkSync).toHaveBeenCalledWith(custom)
+      // ...and NOT a second unlink, since target === running
+      expect(mockUnlinkSync).toHaveBeenCalledTimes(1)
+    })
+
+    it('finding #1 — symlink launcher: resolves realpath and re-points the link', () => {
+      const link = '/home/u/bin/ccc'          // what the user launches
+      mockRealpathSync.mockReturnValue(running) // resolves to the real versioned file
+      const result = prepareLinuxAppImageUpdate(downloaded, link)
+      const expectedTarget = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
+      expect(result?.replace(/\\/g, '/')).toBe(expectedTarget)
+      expect(mockUnlinkSync).toHaveBeenCalledWith(running)  // real old file removed
+      // symlink re-pointed at the new file so the stable launcher keeps working
+      // (normalize separators — path.join yields backslashes on a win32 test host)
+      const [symTarget, symLink] = mockSymlinkSync.mock.calls[0]
+      expect(String(symTarget).replace(/\\/g, '/')).toBe(expectedTarget)
+      expect(symLink).toBe(link)
+    })
+
+    it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (no delete, no copy)', () => {
+      const stranger = '/home/u/important.txt'
+      mockRealpathSync.mockReturnValue(stranger)
+      const result = prepareLinuxAppImageUpdate(downloaded, stranger)
+      expect(result).toBe(downloaded)
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
+      expect(mockCopyFileSync).not.toHaveBeenCalled()
+    })
+
+    it('finding #4 — refuses a $APPIMAGE that is a directory', () => {
+      mockLstatSync.mockReturnValue({ isFile: () => false })
+      const result = prepareLinuxAppImageUpdate(downloaded, '/home/u/Apps')
+      expect(result).toBe(downloaded)
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+
+    it('when $APPIMAGE no longer resolves (realpath throws), launches from the download', () => {
+      mockRealpathSync.mockImplementation(() => { throw new Error('ENOENT') })
       const result = prepareLinuxAppImageUpdate(downloaded, running)
       expect(result).toBe(downloaded)
       expect(mockCopyFileSync).not.toHaveBeenCalled()
     })
 
     it('degrades to the download location when the copy fails (unwritable dir)', () => {
-      mockExistsSync.mockReturnValue(true)
       mockCopyFileSync.mockImplementation(() => { throw new Error('EACCES: permission denied') })
       const result = prepareLinuxAppImageUpdate(downloaded, running)
       expect(result).toBe(downloaded)
-      // Never removed the old version — the new one didn't land beside it
-      expect(mockUnlinkSync).not.toHaveBeenCalled()
     })
 
     it('failure to remove the old version is non-fatal (still returns the new path)', () => {
-      mockExistsSync.mockReturnValue(true)
       mockUnlinkSync.mockImplementation(() => { throw new Error('EBUSY') })
       const result = prepareLinuxAppImageUpdate(downloaded, running)
       expect(result?.replace(/\\/g, '/')).toBe('/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage')
     })
 
     it('re-download of the exact same file is a no-op replace', () => {
-      mockExistsSync.mockReturnValue(true)
       const samePath = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
       const result = prepareLinuxAppImageUpdate(samePath, samePath)
       expect(result).toBe(samePath)

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -145,7 +145,7 @@ vi.mock('../../src/main/debug-logger', () => ({
   logError: vi.fn(),
 }))
 
-import { checkGitHubRelease, downloadGitHubRelease, installerExtForPlatform, prepareLinuxAppImageUpdate } from '../../src/main/github-update'
+import { checkGitHubRelease, downloadGitHubRelease, installerExtForPlatform, prepareLinuxAppImageUpdate, isPathOnNoexecMount } from '../../src/main/github-update'
 
 // Helper to build release fixtures with installers for ALL platforms.
 // checkGitHubRelease returns null if no matching asset exists for the current
@@ -709,6 +709,43 @@ describe('github-update', () => {
       expect(result).toBe(samePath)
       expect(mockCopyFileSync).not.toHaveBeenCalled()
       expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isPathOnNoexecMount (Copilot review — access(X_OK) misses noexec)', () => {
+    // Realistic /proc/mounts: home is noexec (hardened box), root is normal.
+    const mounts = [
+      'proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0',
+      '/dev/sda1 / ext4 rw,relatime 0 0',
+      '/dev/sda2 /home ext4 rw,nosuid,nodev,noexec,relatime 0 0',
+      'tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0',
+    ].join('\n')
+
+    it('flags a file under a noexec mount', () => {
+      expect(isPathOnNoexecMount('/home/u/Downloads/x.AppImage', mounts)).toBe(true)
+    })
+
+    it('does NOT flag a file under an exec mount', () => {
+      expect(isPathOnNoexecMount('/opt/apps/x.AppImage', mounts)).toBe(false) // falls to / (exec)
+      expect(isPathOnNoexecMount('/tmp/x.AppImage', mounts)).toBe(false)
+    })
+
+    it('longest-prefix wins: an exec submount under a noexec parent is exec', () => {
+      const nested = mounts + '\n/dev/sdb1 /home/u/exec ext4 rw,relatime 0 0'
+      expect(isPathOnNoexecMount('/home/u/exec/x.AppImage', nested)).toBe(false)
+      expect(isPathOnNoexecMount('/home/u/other/x.AppImage', nested)).toBe(true)
+    })
+
+    it('does not prefix-match a sibling whose name shares a prefix', () => {
+      // /home must not match /home2 — the trailing-slash boundary guards this
+      const m = '/dev/sda1 / ext4 rw 0 0\n/dev/sda2 /home ext4 rw,noexec 0 0'
+      expect(isPathOnNoexecMount('/home2/x.AppImage', m)).toBe(false)
+    })
+
+    it('degrades to false when /proc/mounts is unreadable (never blocks updates)', () => {
+      // No procMounts arg → reads /proc/mounts, which the fs mock returns undefined
+      // for; the try/catch returns false rather than throwing.
+      expect(isPathOnNoexecMount('/home/u/x.AppImage')).toBe(false)
     })
   })
 })

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -84,9 +84,13 @@ const mockExistsSync = vi.fn(() => true)
 const mockRenameSync = vi.fn()
 const mockUnlinkSync = vi.fn()
 const mockCreateWriteStream = vi.fn()
+const mockChmodSync = vi.fn()
+const mockCopyFileSync = vi.fn()
 vi.mock('fs', () => {
   const { EventEmitter: EE } = require('events')
   return {
+    chmodSync: (...a: any[]) => mockChmodSync(...a),
+    copyFileSync: (...a: any[]) => mockCopyFileSync(...a),
     existsSync: (...a: any[]) => mockExistsSync(...a),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
@@ -135,11 +139,12 @@ vi.mock('../../src/main/debug-logger', () => ({
   logError: vi.fn(),
 }))
 
-import { checkGitHubRelease, downloadGitHubRelease } from '../../src/main/github-update'
+import { checkGitHubRelease, downloadGitHubRelease, installerExtForPlatform, prepareLinuxAppImageUpdate } from '../../src/main/github-update'
 
-// Helper to build release fixtures with installers for BOTH platforms.
-// checkGitHubRelease now returns null if no matching asset exists for the
-// current platform, so every test fixture needs both .exe and .dmg assets.
+// Helper to build release fixtures with installers for ALL platforms.
+// checkGitHubRelease returns null if no matching asset exists for the current
+// platform, and these tests run on whatever host executes the suite (Windows
+// or macOS CI legs, Linux dev boxes) — so every fixture needs all three.
 function releaseWithBothAssets(tagName: string, version: string, isPrerelease = false) {
   return {
     tag_name: tagName,
@@ -148,6 +153,7 @@ function releaseWithBothAssets(tagName: string, version: string, isPrerelease = 
     assets: [
       { name: `ClaudeCommandCenter-Beta-${version}.exe`, browser_download_url: `https://x/${version}.exe` },
       { name: `ClaudeCommandCenter-Beta-${version}-mac.dmg`, browser_download_url: `https://x/${version}.dmg` },
+      { name: `ClaudeCommandCenter-Beta-${version}-linux-x86_64.AppImage`, browser_download_url: `https://x/${version}.AppImage` },
     ],
   }
 }
@@ -312,6 +318,7 @@ describe('github-update', () => {
           { tagName: 'v1.2.125', isPrerelease: false, isDraft: false, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', url: 'https://x/y.exe', size: 100 },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', url: 'https://x/y.dmg', size: 100 },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', url: 'https://x/y.AppImage', size: 100 },
           ] },
         ]), '')
       })
@@ -336,11 +343,13 @@ describe('github-update', () => {
 
   describe('asset matching', () => {
     it('selects ClaudeCommandCenter installer asset for current platform', async () => {
-      const isMac = process.platform === 'darwin'
-      const expectedName = isMac
-        ? 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg'
-        : 'ClaudeCommandCenter-Beta-1.2.125.exe'
-      // Release contains both platform installers; the checker should pick the right one
+      const expectedByPlatform: Record<string, { name: string; url: string }> = {
+        darwin: { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', url: 'https://x/mac.dmg' },
+        linux: { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', url: 'https://x/linux.AppImage' },
+        win32: { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', url: 'https://x/win.exe' },
+      }
+      const expected = expectedByPlatform[process.platform] ?? expectedByPlatform.win32
+      // Release contains all platform installers; the checker should pick the right one
       httpsState.nextResponse = {
         statusCode: 200,
         body: [
@@ -349,12 +358,14 @@ describe('github-update', () => {
             { name: 'SomeOtherApp.exe', browser_download_url: 'https://x/other.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/win.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/mac.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/mac.AppImage' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/linux.AppImage' },
           ] },
         ],
       }
       const result = await checkGitHubRelease()
-      expect(result!.installerName).toBe(expectedName)
-      expect(result!.installerUrl).toBe(isMac ? 'https://x/mac.dmg' : 'https://x/win.exe')
+      expect(result!.installerName).toBe(expected.name)
+      expect(result!.installerUrl).toBe(expected.url)
     })
 
     it('returns null entirely when no installer asset exists for this platform', async () => {
@@ -381,10 +392,12 @@ describe('github-update', () => {
           { tag_name: 'v1.2.125-beta.2', draft: false, prerelease: true, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/b2.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/b2.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/b2.AppImage' },
           ] },
           { tag_name: 'v1.2.125-beta.1', draft: false, prerelease: true, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/b1.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/b1.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/b1.AppImage' },
           ] },
         ],
       }
@@ -401,10 +414,12 @@ describe('github-update', () => {
           { tag_name: 'v1.2.125', draft: false, prerelease: false, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/f.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/f.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/f.AppImage' },
           ] },
           { tag_name: 'v1.2.125-beta.3', draft: false, prerelease: true, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/b.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/b.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/b.AppImage' },
           ] },
         ],
       }
@@ -422,6 +437,7 @@ describe('github-update', () => {
           { tag_name: 'v1.2.125', draft: false, prerelease: false, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', browser_download_url: 'https://x/y.exe' },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', browser_download_url: 'https://x/y.dmg' },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', browser_download_url: 'https://x/y.AppImage' },
           ] },
         ],
       }
@@ -453,6 +469,7 @@ describe('github-update', () => {
           { tagName: 'v1.2.125', isPrerelease: false, isDraft: false, assets: [
             { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', url: 'https://x/y.exe', size: 100 },
             { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', url: 'https://x/y.dmg', size: 100 },
+            { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', url: 'https://x/y.AppImage', size: 100 },
           ] },
         ]), '')
       })
@@ -548,6 +565,105 @@ describe('github-update', () => {
       })
       const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
       expect(result).toBeNull()
+    })
+  })
+
+  describe('installerExtForPlatform', () => {
+    it('maps each platform to its installer asset extension', () => {
+      expect(installerExtForPlatform('win32')).toBe('.exe')
+      expect(installerExtForPlatform('darwin')).toBe('.dmg')
+      // The Linux regression: before this mapping, linux fell into the '.exe'
+      // default, matched no asset on any release, and silently skipped every
+      // update — Linux installs were frozen at their first-installed version.
+      expect(installerExtForPlatform('linux')).toBe('.AppImage')
+    })
+
+    it('unknown platforms fall back to .exe (the historical default)', () => {
+      expect(installerExtForPlatform('freebsd' as NodeJS.Platform)).toBe('.exe')
+    })
+
+    it('release.yml artifact names satisfy the asset-selection predicate', () => {
+      // The checker requires startsWith('ClaudeCommandCenter-') && endsWith(ext).
+      // Pin the contract against the electron-builder artifactName patterns so a
+      // rename in package.json can't silently strand a platform again.
+      const artifacts: Array<[string, string]> = [
+        ['ClaudeCommandCenter-2.1.0-beta.1.exe', '.exe'],
+        ['ClaudeCommandCenter-2.1.0-beta.1-mac.dmg', '.dmg'],
+        ['ClaudeCommandCenter-2.1.0-beta.1-linux-x86_64.AppImage', '.AppImage'],
+      ]
+      for (const [name, ext] of artifacts) {
+        expect(name.startsWith('ClaudeCommandCenter-')).toBe(true)
+        expect(name.endsWith(ext)).toBe(true)
+      }
+    })
+  })
+
+  describe('prepareLinuxAppImageUpdate', () => {
+    const downloaded = '/home/u/Downloads/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
+    const running = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.1-linux-x86_64.AppImage'
+
+    beforeEach(() => {
+      // vi.clearAllMocks() clears CALLS but keeps implementations — a throwing
+      // mockImplementation from one test would otherwise leak into the next.
+      mockChmodSync.mockReset()
+      mockCopyFileSync.mockReset()
+      mockUnlinkSync.mockReset()
+    })
+
+    it('always chmods the download executable (downloads arrive without +x)', () => {
+      prepareLinuxAppImageUpdate(downloaded, undefined)
+      expect(mockChmodSync).toHaveBeenCalledWith(downloaded, 0o755)
+    })
+
+    it('without $APPIMAGE (extracted/dev run), launches from the download location', () => {
+      const result = prepareLinuxAppImageUpdate(downloaded, undefined)
+      expect(result).toBe(downloaded)
+      expect(mockCopyFileSync).not.toHaveBeenCalled()
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+
+    it('replaces the running AppImage in place: copy beside it, chmod, remove old', () => {
+      mockExistsSync.mockReturnValue(true)
+      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      // New file lands next to the old one, keeping its own versioned name
+      const expectedTarget = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
+      expect(result?.replace(/\\/g, '/')).toBe(expectedTarget)
+      expect(mockCopyFileSync).toHaveBeenCalledTimes(1)
+      expect(mockChmodSync).toHaveBeenCalledTimes(2) // download + target
+      // Old version file removed (safe on Linux: mounted inode outlives the unlink)
+      expect(mockUnlinkSync).toHaveBeenCalledWith(running)
+    })
+
+    it('when the running AppImage no longer exists, launches from the download', () => {
+      mockExistsSync.mockReturnValue(false)
+      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      expect(result).toBe(downloaded)
+      expect(mockCopyFileSync).not.toHaveBeenCalled()
+    })
+
+    it('degrades to the download location when the copy fails (unwritable dir)', () => {
+      mockExistsSync.mockReturnValue(true)
+      mockCopyFileSync.mockImplementation(() => { throw new Error('EACCES: permission denied') })
+      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      expect(result).toBe(downloaded)
+      // Never removed the old version — the new one didn't land beside it
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+
+    it('failure to remove the old version is non-fatal (still returns the new path)', () => {
+      mockExistsSync.mockReturnValue(true)
+      mockUnlinkSync.mockImplementation(() => { throw new Error('EBUSY') })
+      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      expect(result?.replace(/\\/g, '/')).toBe('/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage')
+    })
+
+    it('re-download of the exact same file is a no-op replace', () => {
+      mockExistsSync.mockReturnValue(true)
+      const samePath = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
+      const result = prepareLinuxAppImageUpdate(samePath, samePath)
+      expect(result).toBe(samePath)
+      expect(mockCopyFileSync).not.toHaveBeenCalled()
+      expect(mockUnlinkSync).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/vision-browser-paths.test.ts
+++ b/tests/unit/vision-browser-paths.test.ts
@@ -1,0 +1,54 @@
+/**
+ * getBrowserPaths per-platform candidates.
+ *
+ * The Linux regression this pins: getBrowserPaths had no linux branch, so
+ * Linux fell through to the WINDOWS list (C:\Program Files\...chrome.exe),
+ * none of which exist — and launchBrowser's bare-name fallback was 'chrome',
+ * which no mainstream distro ships. Net effect: `spawn chrome ENOENT` and
+ * vision permanently disabled on Linux.
+ */
+import { describe, it, expect } from 'vitest'
+import { getBrowserPaths } from '../../src/main/vision-manager'
+
+describe('vision getBrowserPaths', () => {
+  it('linux chrome candidates cover google-chrome and chromium (deb/rpm)', () => {
+    const paths = getBrowserPaths('chrome', 'linux')
+    expect(paths).toContain('/usr/bin/google-chrome')
+    expect(paths).toContain('/usr/bin/chromium')
+    // Rocky/EL EPEL build ships this name — verified on Rocky 10
+    expect(paths).toContain('/usr/bin/chromium-browser')
+    // Never a Windows path on linux
+    expect(paths.some((p) => p.includes('\\'))).toBe(false)
+  })
+
+  it('linux list excludes snap chromium (confinement blocks the CDP profile dir)', () => {
+    // /snap/bin/chromium spawns but snap confinement rejects --user-data-dir
+    // under /tmp, so the debug port never opens and vision hangs on
+    // "launching" instead of cleanly disabling. deb/rpm builds only.
+    const paths = getBrowserPaths('chrome', 'linux')
+    expect(paths.some((p) => p.startsWith('/snap/'))).toBe(false)
+  })
+
+  it('linux edge candidates are the microsoft-edge install locations', () => {
+    const paths = getBrowserPaths('edge', 'linux')
+    expect(paths).toContain('/usr/bin/microsoft-edge')
+    expect(paths).toContain('/usr/bin/microsoft-edge-stable')
+  })
+
+  it('windows and macOS lists are unchanged by the linux addition', () => {
+    expect(getBrowserPaths('chrome', 'win32')).toEqual([
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ])
+    expect(getBrowserPaths('chrome', 'darwin')).toEqual([
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    ])
+    expect(getBrowserPaths('edge', 'win32')).toEqual([
+      'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+      'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    ])
+    expect(getBrowserPaths('edge', 'darwin')).toEqual([
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    ])
+  })
+})


### PR DESCRIPTION
Adds **experimental Linux (x64 AppImage)** as a third platform. The engine is verified on **Ubuntu 24.04** and **Rocky 10.2** (SELinux enforcing): node-pty shell, Claude-through-the-terminal, better-sqlite3, and the MCP server all pass identically; full GUI verified on Ubuntu.

Ships as **`2.1.0-beta.1`** — new platform = minor, on the beta line.

## What's in it

| Area | Change |
|---|---|
| **Updater** | `INSTALLER_EXT` was `.exe` for every non-Mac platform, so Linux matched no asset and **silently skipped every update** — a Linux install would freeze at its first version. Now `.AppImage`-aware, with an in-place apply that preserves the user's launcher (see below). |
| **Vision** | `getBrowserPaths()` had no Linux branch → `spawn chrome ENOENT`, vision permanently off. Now finds `google-chrome`/`chromium`/`chromium-browser`. Snap chromium deliberately excluded (confinement blocks the CDP profile dir — it half-launches and hangs). |
| **Build** | `build-linux` job in release.yml (AppImage + `latest-linux.yml`, VirusTotal-scanned), `build.linux` target, `package:linux` script. |
| **Docs** | README badge + install notes (chmod/FUSE/glibc floor/snap caveat), CONTRIBUTING, CLAUDE.md. |

**Glibc floor:** built on ubuntu-latest → glibc 2.39 (Ubuntu 24.04+, Rocky 10+, Fedora 40+). Rocky 8/9 / Ubuntu 22.04 need a container build — out of scope.

## Adversarial review — 8 findings, all confirmed, all handled

A 4-lens review (updater runtime, cross-platform regressions, CI config, security) found 8 confirmed issues; the second commit fixes them:

- **Launcher orphaning (major):** in-place update wrote a new versioned name and deleted the old file, breaking `.desktop`/dock/alias/symlink launchers. Now follows electron-updater's rule — unversioned custom names are overwritten **at the same path**; `$APPIMAGE` is realpath'd and symlinks re-pointed.
- **Silent relaunch failure (major):** a noexec `~/Downloads` / failed chmod would kill every PTY, exit, and leave nothing running with no error. Now verifies executability **before** killing sessions, and awaits the child's `spawn` event before exiting.
- **`$APPIMAGE` footgun (minor):** validated as a regular `.AppImage` file before any delete/copy.
- **Self-inflicted test bug (major):** a scripted edit left a duplicate AppImage fixture that failed the asset-match assertion **on a Linux host** — would have turned the new `build-linux` vitest step red and blocked releases. Fixed.
- **Release coupling (minor):** `build-linux` is now `continue-on-error` — an experimental platform can't block the Win/macOS release.
- **Misleading comments (minor):** corrected — the client does **not** verify `CHECKSUMS.txt` (→ #111), and the vitest run excludes `*.native.test.ts`.

Two cross-cutting items filed rather than scope-crept in: **#111** (client-side checksum verification — pre-existing on Win/Mac too, needs signing to be meaningful) and **#112** (ci.yml RC-iteration Linux artifact).

## Verification

- Full suite **3035 passed** (0 failures), typecheck clean (node + web), `electron-vite build` clean.
- 21 new/updated unit tests across `github-update` (installer-ext mapping, AppImage apply: in-place / custom-name-preserve / symlink re-point / `$APPIMAGE` validation / degradation paths) and `vision-browser-paths` (per-platform candidates, snap exclusion). A contract test pins the release.yml artifact names against the updater's matcher so a rename can't strand a platform again.
- The AppImage packaged and ran on both VMs during development (this is the AppImage the release job now produces).

**Not yet exercised end-to-end:** the actual Linux auto-update — that needs a `beta.1` and `beta.2` to update between, which happens after this merges and the first Linux betas ship.