### PR TITLE
fix(macos): stop redirecting $HOME so login keychain resolves (#117)

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -83,7 +83,15 @@ export function withProfileHome(env: Record<string, string>, home: string | null
     GIT_CONFIG_GLOBAL: path.join(realHome, '.gitconfig'),
     npm_config_userconfig: path.join(realHome, '.npmrc'),
   }
-  if (process.platform !== 'win32') next.HOME = home
+  // macOS locates the login keychain via $HOME (~/Library/Keychains/login.keychain-db).
+  // Pointing HOME at the fake profile home — which mirrors only dot-entries, never
+  // ~/Library (see mirrorRealHome) — leaves the spawned `claude` with no keychain to
+  // resolve, surfacing the macOS "A keychain cannot be found to store ..." dialog (#117).
+  // Multi-account is disabled on macOS anyway (see AccountsPanel), so HOME-based identity
+  // isolation buys nothing there; leaving HOME at the real home restores keychain access
+  // and resolves the single global account correctly. Linux keychains (Secret Service /
+  // D-Bus) are not HOME-path-based, so keep the redirect there for multi-account isolation.
+  if (process.platform === 'linux') next.HOME = home
   // Claude's native install lives at `$HOME/.local/bin`. With the home redirected,
   // CC computes that as `<home>/.local/bin` (a junction to the real ~/.local) but
   // PATH still carries the *real* home's `.local/bin`, so `/doctor` falsely warns

--- a/tests/unit/pty-spawn-env.test.ts
+++ b/tests/unit/pty-spawn-env.test.ts
@@ -41,4 +41,17 @@ describe('withProfileHome', () => {
     const base = { PATH: '/x' }
     expect(withProfileHome(base, null)).toBe(base)
   })
+
+  // #117: macOS resolves the login keychain via $HOME. Redirecting HOME to the fake
+  // profile home (no ~/Library/Keychains) breaks keychain access ("A keychain cannot
+  // be found to store ..."). HOME must be redirected ONLY on Linux (Secret Service /
+  // D-Bus keychains are not HOME-path-based); never on macOS or Windows.
+  it('redirects HOME only on Linux, not macOS/Windows (#117)', () => {
+    const env = withProfileHome({ PATH: '/x' }, HOME)
+    if (process.platform === 'linux') {
+      expect(env.HOME).toBe(HOME)
+    } else {
+      expect(env.HOME).toBeUndefined()
+    }
+  })
 })


### PR DESCRIPTION
Fixes #117.

## Problem

On macOS, launching CCC surfaces the system dialog **"A keychain cannot be found to store …"** (buttons *Close* / *Reset to Defaults*) at launch and from headless runners. Claude Code auth in the spawned session can't read/write its token.

## Root cause

macOS locates the login keychain via `$HOME` → `~/Library/Keychains/login.keychain-db`. `withProfileHome` redirects `$HOME` to a per-account fake home (`src/main/pty-manager.ts`), and `mirrorRealHome` mirrors only dot-entries into that home (`src/main/account-profiles.ts:227`), so `~/Library/Keychains` is never present. The spawned `claude` runs with `HOME=<fake home>` and macOS finds no keychain there.

It triggers even though the macOS multi-account UI is disabled, because the clobber-proofing fallback (`src/main/pty-manager.ts:1006-1011`) still resolves the captured primary profile home for every interactive session, and headless paths (insights/sentinel/cloud-agent) do the same.

## Fix

Redirect `$HOME` **only on Linux** (Secret Service/D-Bus keychains are not HOME-path-based). On macOS/Windows leave `$HOME` at the real home, so macOS resolves `~/Library/Keychains` again. Multi-account is already disabled on macOS, so HOME-based identity isolation buys nothing there — the spawned `claude` correctly uses the real global account. All spawn paths funnel through `withProfileHome`, so this covers interactive, headless, and cloud-agent spawns.

## Testing

- `npm run typecheck` — clean
- `vitest` on the three suites exercising `withProfileHome` (pty-spawn-env, insights-lock, claude-headless-timeout-kill) — all pass
- Added a `#117` regression test asserting HOME is redirected only on Linux

> ⚠️ Not yet verified on a real Mac (author is on Windows; owner waived the desktop-test gate for the push). The macOS keychain behavior should be confirmed on a Mac build before merge.

## Risk

Low. Single-line platform gate; no change to Windows or Linux behavior. macOS reverts to using the real home for the (single) account, which is the intended macOS behavior.
