### PR TITLE
fix(terminal): restore visible/blinking caret in shell terminals under WebGL (#119)

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -266,10 +266,14 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         fontWeight: (ts.fontWeight || 450) as import('@xterm/xterm').FontWeight,
         fontWeightBold: 700,
         lineHeight: ts.lineHeight || 1.2,
-        cursorBlink: ts.cursorBlink ?? false,
+        cursorBlink: ts.cursorBlink ?? true,
         cursorStyle: ts.cursorStyle || 'bar',
-        cursorWidth: 1,
-        cursorInactiveStyle: 'none',
+        // 1px is a HiDPI hairline that reads as "no caret"; 2px is a visible bar.
+        cursorWidth: 2,
+        // Shell terminals show a hollow caret when unfocused so the input point
+        // stays visible after focus shifts to the sidebar/config/input bar.
+        // Claude/TUI sessions keep the caret fully hidden (they draw their own).
+        cursorInactiveStyle: shellOnly ? 'outline' : 'none',
         scrollback: 10000,
         allowTransparency: true,
         // Light mode only: enforce a minimum contrast ratio so Claude's dim,
@@ -303,6 +307,20 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         raf: requestAnimationFrame,
         isDisposed: () => disposed,
       })
+
+      // #119: cursor options passed to the Terminal constructor do NOT reliably
+      // initialize the WebGL renderer's cursor layer — the caret stays absent
+      // even while focused/typing (xterm.js #1194 "initial cursorBlink has no
+      // effect", #891 "cursor not visible initially"; the WebGL cursor is a
+      // separate 2D canvas that this gap leaves empty). Re-assigning the options
+      // at runtime after the addon loads forces the layer to build and draw.
+      // Shell sessions only — Claude/TUI sessions intentionally hide the caret.
+      if (shellOnly) {
+        term.options.cursorBlink = ts.cursorBlink ?? true
+        term.options.cursorStyle = ts.cursorStyle || 'bar'
+        term.options.cursorWidth = 2
+        term.options.cursorInactiveStyle = 'outline'
+      }
 
       // Belt-and-braces hide for xterm's caret in Claude sessions.
       // The .claude-session class + global CSS rule should already

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -104,7 +104,7 @@ export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   fontWeight: 450,
   lineHeight: 1.2,
   cursorStyle: 'bar',
-  cursorBlink: false,
+  cursorBlink: true,
 }
 
 export interface AppSettings {


### PR DESCRIPTION
## Problem

The terminal caret was **absent even in a focused, actively-typed shell session** on both Windows and macOS — no blinking bar, nothing.

## Root cause

An xterm.js WebGL bug: cursor options passed to the `Terminal` **constructor** don't reliably initialize the WebGL renderer's cursor layer (a separate 2D canvas), so the caret never draws — [xterm.js #1194 "initial cursorBlink has no effect"](https://github.com/xtermjs/xterm.js/issues/1194), [#891 "cursor not visible initially"](https://github.com/xtermjs/xterm.js/issues/891). Confirmed the reporter already had `cursorBlink: true` persisted, so the default was never the cause — it was the constructor no-op, plus two visibility papercuts.

## Fix (`TerminalView.tsx`, shell sessions only)

- **Re-apply the cursor options at runtime** after `installWebglWithRecovery()` (`term.options.cursorBlink/cursorStyle/cursorWidth/cursorInactiveStyle`). Re-assigning post-load forces xterm to build + draw the cursor layer. *This is the actual fix.*
- `cursorWidth 1 → 2` — a 1px bar is a HiDPI hairline at the default 3200×1800 window.
- `cursorInactiveStyle 'none' → 'outline'` for shell sessions — the caret survives focus shifts to the sidebar/config/input as a hollow outline instead of vanishing. Claude/TUI keep `'none'`.
- `settingsStore` default `cursorBlink false → true` (fresh installs; existing persisted values respected).

Claude/TUI sessions are untouched — the runtime re-apply is gated to `shellOnly`, and they still hide the caret via theme + CSS nuke.

## Verification

On-machine (reporter): blinking 2px bar while focused, hollow outline when unfocused, **Claude sessions still caret-less** (non-regression confirmed). Typecheck clean; full unit suite green (3026).

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)