### PR TITLE
docs: adopt CARP running log + ADRs + dev/user guides + agent conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ test-results/
 process-snapshot-*.txt
 .tip-screenshots/
 .tmp-e2e/
+
+# CARP running log: CONTEXT.md is a GENERATED aggregate of CONTEXT.d/ fragments
+# (rendered on demand); never commit it. The fragments under CONTEXT.d/ are the
+# sole tracked source. (aai-core AAI-407 / ADR-043 convention, mirrored here.)
+/CONTEXT.md

--- a/CONTEXT.d/2026-07-17-boot-vision-cursor-keychain-fixes.md
+++ b/CONTEXT.d/2026-07-17-boot-vision-cursor-keychain-fixes.md
@@ -1,0 +1,34 @@
+## 2026-07-17 -- Boot/vision/cursor/keychain fixes (PRs #118, #121, #122)
+
+Four field bugs fixed, each on its own branch off `beta`; all open PRs, green CI
+(Win + macOS), pending owner review.
+
+- #120 / #115 boot freeze (PR #121, branch fix/120-boot-backfill-perf): first
+  paint stalled ~26s in dev. Two independent SYNCHRONOUS main-thread sweeps in
+  the whenReady tail were the cause. Fix: make both async + deferred.
+  - companion-dir backfill: stat-stormed the projects store -> backfill
+    CompanionDirsAsync (yields every ~150 stat ops), deferred ~5s after boot.
+  - update-watcher hash sweep: computeHashes() readFileSync+md5'd the whole dev
+    src/ tree, twice -> computeHashesAsync (fs.promises + yields every ~50
+    files); checkForUpdates now async; initial check deferred ~3s off boot.
+  - Also carries the #115 vision boot-resilience commit (stacked base).
+
+- #119 terminal cursor (PR #122, branch fix/119-terminal-cursor-visibility): no
+  caret even while a shell terminal was focused/typing, on Win + macOS. Root
+  cause is an xterm.js WebGL bug (issues #1194/#891): cursor options passed to
+  the Terminal CONSTRUCTOR do not initialize the WebGL cursor layer. Fix:
+  RE-APPLY term.options.cursorBlink/cursorStyle/cursorWidth/cursorInactiveStyle
+  at runtime after the WebGL addon loads (shell sessions only). Plus cursorWidth
+  1->2 (HiDPI hairline) and cursorInactiveStyle none->outline for shells; default
+  cursorBlink false->true. Verified: reporter already had cursorBlink:true, so
+  the default was never the cause -- it was the constructor no-op.
+
+- #117 macOS keychain (PR #118, branch fix/117-macos-keychain-home-redirect):
+  the login keychain resolves via $HOME; redirecting HOME to the fake profile
+  home (no ~/Library/Keychains) broke it. Fix: redirect HOME only on Linux, not
+  macOS/Windows (macOS multi-account is disabled anyway; Linux keychains are not
+  HOME-path-based).
+
+CI note: the `Test` matrix is gated on a `ci-run` PR label (ci.yml). All three
+PRs carry it and are green. Merge is blocked purely by the protect-beta ruleset
+requiring a @nubbymong code-owner review (self-approval not allowed).

--- a/CONTEXT.d/2026-07-17-ccc-launcher-and-docs-protocol.md
+++ b/CONTEXT.d/2026-07-17-ccc-launcher-and-docs-protocol.md
@@ -1,0 +1,30 @@
+## 2026-07-17 -- ccc dev launcher (repo-distributed) + docs protocol adoption
+
+ccc launcher:
+- Moved the `ccc` dev launcher INTO the repo (scripts/ccc.cmd) so its
+  isolation/seed/cleanup logic is versioned; the PATH entry
+  (%APPDATA%\npm\ccc.cmd) is now a thin shim that forwards to it.
+- Behavior: sets CCC_DEV_DATA_DIR; auto-closes the window on exit; on exit KILLS
+  the whole dev process set so nothing leaks -- headless vision Chrome (matched
+  by its --user-data-dir=...chrome-debug-9322 marker), dev port holders (5173,
+  9847, 19433, 9322, 19434), and dev electron (matched by the hyphenated repo
+  path so a prod install never matches).
+- Flags: --seed (copy PROD CONFIG into the dev data dir first; reads
+  ResourcesDirectory from HKCU\Software\Claude Command Center, falls back to the
+  default), --clean (wipe the dev data dir first), -nv/--no-vision. `--seed`
+  still launches the app afterward (it is a pre-launch step, not seed-only).
+
+Docs protocol (this branch, docs/handbook-and-carp):
+- The repo had README + CONTRIBUTING but NO running decision log and NO ADRs.
+  Adopted the CARP convention: CONTEXT.d/ fragments are the sole tracked source;
+  CONTEXT.md is a generated aggregate and is gitignored (/CONTEXT.md).
+- Added architecture/decisions/ ADRs for the two architectural calls
+  (multi-instance dev/prod isolation; session work-name model), a
+  docs/agent-conventions.md, a docs/dev-alongside-prod.md guide, and a
+  docs/USER_GUIDE.md end-user manual. NOTE: root AGENTS.md is gitignored here
+  (".gitignore # Personal/local config"), so agent conventions live in
+  docs/agent-conventions.md instead of a tracked root AGENTS.md.
+
+Branch/landing state at time of writing: nothing merged to beta yet -- 3 fix PRs
+(#118/#121/#122) + feat/session-rename + feat/multi-instance-dev + this docs
+branch are all pending, blocked on owner review of the fixes.

--- a/CONTEXT.d/2026-07-17-multi-instance-dev.md
+++ b/CONTEXT.d/2026-07-17-multi-instance-dev.md
@@ -1,0 +1,32 @@
+## 2026-07-17 -- Multi-instance: DEV alongside PROD (branch feat/multi-instance-dev)
+
+Goal: run the installed PROD build continuously while opening a DEV build (npm
+run dev / ccc) beside it, with the dev window clearly labeled. See
+architecture/decisions ADR for multi-instance for the full rationale.
+
+Already in place before this work (split by app.isPackaged):
+- Single-instance lock: dev skips it, prod takes it -> they already coexist.
+- MCP port dev 19433 / prod 19333; vision CDP dev 9322 / prod 9222; update-server
+  9847 + vite 5173 are dev-only.
+
+Gaps closed:
+- DATA ISOLATION (the master switch): everything (resources/CONFIG,
+  session-state.json, transcripts.db, app.log, profiles, credentials) derives
+  from getDataDirectory(). Added a CCC_DEV_DATA_DIR override in data-paths.ts
+  (mirrors CCC_E2E_DATA_DIR), checked before the registry, treated as configured
+  (skips the wizard). index.ts sets it early when !app.isPackaged (before any
+  data-dir read / worker fork) to <LOCALAPPDATA>\Claude Command Center\dev. Prod
+  is completely unaffected.
+- HOOKS PORT split: resolveHooksPort(isPackaged) -> dev 19434 / prod 19334 (the
+  last unsplit port).
+- DEV labeling: OS title "Claude Command Center -- DEV" (guards
+  page-title-updated); app:isDev IPC + preload appIsDev + useIsDev() hook;
+  TitleBar amber DEV pill + amber underline accent.
+
+Non-goals: two prod instances (blocked by design); two dev instances (the ccc
+launcher refuses a 2nd via a port-5173 guard rather than an app-side lock, to
+avoid Electron's single-lock/userData entanglement with prod).
+
+Caveat: CCC's own state is isolated, but the underlying Claude CLI global home
+(~/.claude) is still shared -- don't run the SAME account's Claude session in
+both instances simultaneously.

--- a/CONTEXT.d/2026-07-17-session-rename.md
+++ b/CONTEXT.d/2026-07-17-session-rename.md
@@ -1,0 +1,32 @@
+## 2026-07-17 -- Session work-name (rename) decoupled from config (branch feat/session-rename)
+
+New feature: rename an open session to track the work in each window. Persists
+by session id across restarts; cleared when the session is closed in CCC.
+
+Decisions:
+- New `customName` field on Session/SavedSession, DISTINCT from the config-derived
+  `label`. Display = `customName || label` everywhere (tab, sidebar row, header).
+  Blank clears it (reverts to label). Display-only -- never renames the Claude
+  transcript or the OS window.
+- DECOUPLE from the Saved Config. The pre-existing sidebar rename did
+  updateSession(label) + updateConfig(label), so renaming a session silently
+  renamed its config -- the reported "confusing" behavior. Now the rename writes
+  customName ONLY; config rename stays separate in Saved Configs.
+- Edit surfaces: sidebar right-click Rename, tab double-click / right-click, a
+  click-to-edit name field in SessionHeader, and F2. F2 was deliberately routed
+  to the ACTIVE SESSIONS list in the sidebar (only when the sidebar is visible),
+  preferred over the tab, per the owner's call.
+- Header consolidation: folded the standalone RepoBreadcrumb strip (cwd + GitHub
+  repo/connection) into SessionHeader, so there is ONE bar below the tabs instead
+  of two. Deleted RepoBreadcrumb + its tests; SessionHeader test reproduces the
+  path/repo coverage.
+- Logs durability: renaming persists the name into transcripts.db (new run-rename
+  worker message -> TranscriptsDb.renameRun UPDATE on the latest open run; new
+  LOGS2_RENAME_SESSION IPC). store.renameSession is the single choke point (writes
+  customName + fires the IPC). Spawn-time configLabel uses customName || label so
+  a restored/pre-named session's log carries the name from its first run. Chosen
+  over a renderer-only join because the owner wanted the name to survive in the
+  history even after the session is closed.
+
+Branch also merges the #120/#115 boot fix so a dev build boots fast; that merge
+de-dupes once #121 lands on beta.

--- a/CONTEXT.d/README.md
+++ b/CONTEXT.d/README.md
@@ -1,0 +1,28 @@
+# CONTEXT.d -- running decision log (CARP)
+
+This directory is the **running decision log**: a dated record of decisions,
+changes, blockers, and assumptions as work happens. It follows the CARP
+convention (one entry per file) so parallel branches never collide on a shared
+log file.
+
+## How it works
+
+- **One fragment per entry:** `CONTEXT.d/YYYY-MM-DD-<key>.md` (optional
+  `-<slug>`), containing a single `## YYYY-MM-DD -- <title>` block. Plain
+  Markdown, ASCII, no frontmatter.
+- **Add a NEW fragment** for your ticket/session. Never edit another entry's
+  fragment. Roll very old entries into `CONTEXT.d/0000-00-00-archive.md` (sorts
+  last).
+- **`CONTEXT.md` is generated, not tracked.** It is the aggregate of all
+  fragments (header + fragments, newest first) and is gitignored (`/CONTEXT.md`).
+  Regenerate on demand; never hand-edit or commit it. Because it is never
+  tracked, it can never be a merge conflict.
+- **Architecture/decisions** with lasting rationale go in
+  `architecture/decisions/` as ADRs (`YYYY-MM-DD-adr-NNN-title.md`), not here.
+  This log records *what happened and why, when*; ADRs record *the decision*.
+
+## What belongs here
+
+Decisions and their rationale, notable changes, blockers, assumptions,
+follow-ups. Not: durable structural docs (README/AGENTS), secrets, or
+third-party restricted content.

--- a/architecture/decisions/2026-07-17-adr-001-multi-instance-dev-prod-isolation.md
+++ b/architecture/decisions/2026-07-17-adr-001-multi-instance-dev-prod-isolation.md
@@ -1,0 +1,64 @@
+# ADR-001: Multi-instance dev-alongside-prod isolation
+
+- **Status:** Accepted (2026-07-17)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-17-multi-instance-dev.md, docs/dev-alongside-prod.md
+
+## Context
+
+Developers need to run the installed **production** build continuously (as their
+daily driver) while opening a **development** build (`npm run dev` / `ccc`)
+beside it to test changes. Before this decision the two builds could technically
+both launch (dev already skipped the single-instance lock), but they shared
+mutable state and one port, so running them together was unsafe:
+
+- **Shared data dir.** `getDataDirectory()` resolved to the same location for
+  both. Everything hangs off it — `resources/CONFIG` (configs + `session-
+  state.json`), `transcripts.db`, `debug/app.log`, account profiles, credentials.
+  Concurrent read/write would corrupt config and session state.
+- **One shared port.** The hooks gateway defaulted to `19334` for both. MCP
+  (19433/19333) and vision CDP (9322/9222) were already split by `app.isPackaged`;
+  hooks was not, so a second instance hit `EADDRINUSE`.
+- **No visual distinction.** Two identical windows are easy to confuse — a
+  destructive action in the wrong one is a real risk.
+
+## Decision
+
+Activate a **dev profile** whenever `app.isPackaged === false`. Production
+behavior is unchanged (every branch below is a no-op when packaged).
+
+1. **Data isolation via a single switch.** Add a `CCC_DEV_DATA_DIR` override in
+   `data-paths.ts`, checked *before* the registry and treated as "configured"
+   (skips the setup wizard) — mirroring the existing `CCC_E2E_DATA_DIR`. Because
+   `resources/CONFIG`, `transcripts.db`, `app.log`, profiles, and credentials all
+   derive from `getDataDirectory()`, this one override isolates all of them. The
+   main process sets it early (before any data-dir read or worker fork; workers
+   inherit the env) to `<LOCALAPPDATA>\Claude Command Center\dev`. The `ccc`
+   launcher also sets it, so a bare `npm run dev` is isolated too.
+2. **Split the last shared port.** `resolveHooksPort(isPackaged)` → dev `19434` /
+   prod `19334`, matching the MCP/CDP pattern. A per-config `settings.hooksPort`
+   still overrides.
+3. **Label the dev window.** OS title `Claude Command Center — DEV` (guarding
+   `page-title-updated` so the renderer can't overwrite it); an `app:isDev` IPC
+   surfaced to the renderer (`useIsDev()`), driving an amber `DEV` pill + accent
+   in the title bar.
+4. **Keep the single-instance model.** Prod keeps its lock; dev keeps skipping
+   it (so it coexists with prod). A *second dev* is refused by the `ccc` launcher
+   (a port-5173 check), NOT by an app-side lock.
+
+## Consequences
+
+- One prod + one dev run safely in parallel, on fully separate data and ports.
+- First isolated dev launch starts empty; `ccc --seed` copies prod's `CONFIG`,
+  `ccc --clean` wipes the dev dir. (See docs/dev-alongside-prod.md.)
+- **Rejected: an app-side dev single-instance lock.** Electron's lock is keyed on
+  the app identity/`userData`; making dev request it would entangle it with
+  prod's lock (or require moving `userData`, which relocates Electron's cache/
+  cookies). The launcher-side port guard is simpler and prod-safe.
+- **Known limitation:** CCC's own state is isolated, but the underlying Claude
+  CLI global home (`~/.claude`) is shared. Running the *same account's* Claude
+  session in both instances at once can contend on OAuth token rotation. Documented,
+  not fixed here.
+- Cost: a small amount of dev-only branching (`!app.isPackaged`) across
+  `data-paths`, `index`, `hooks-types`, and the title bar. All unit-tested
+  (`resolveHooksPort`, the `CCC_DEV_DATA_DIR` override + E2E precedence).

--- a/architecture/decisions/2026-07-17-adr-002-session-work-name-model.md
+++ b/architecture/decisions/2026-07-17-adr-002-session-work-name-model.md
@@ -1,0 +1,59 @@
+# ADR-002: Session work-name (rename) model
+
+- **Status:** Accepted (2026-07-17)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-17-session-rename.md
+
+## Context
+
+Users run many sessions at once and need to name each one for the work it's
+doing ("IM-8315 keychain fix"), tracked through restarts until the session is
+closed. Two problems with the state before this decision:
+
+1. **No editable session name existed** beyond the config-derived `label` shown
+   on the tab.
+2. The sidebar's existing "Rename" wrote **both** the session `label` **and** the
+   underlying Saved Config's `label` (`updateSession` + `updateConfig`). So
+   renaming a session silently renamed the *config template* it launched from —
+   the confusing behavior users hit.
+
+## Decision
+
+Introduce a per-session **`customName`**, distinct from `label`, as the work name.
+
+- **Decoupled from the config.** Rename writes `customName` ONLY; it never
+  touches the Saved Config. Config rename stays a separate action in Saved
+  Configs. `label` remains the config-derived origin (shown as secondary /
+  tooltip).
+- **Display = `customName || label`** everywhere a session is named (tab, sidebar
+  row, session header). Blank clears `customName` (reverts to `label`).
+- **Display-only.** It is CCC metadata; it does not rename the Claude transcript,
+  the `~/.claude` project, or the OS window.
+- **Lifecycle = the session's `id`.** Persisted in `session-state.json` by id, so
+  it survives app restart and returns when a saved session reopens; it is gone
+  once the session is closed in CCC (which is the whole point — it tracks *open*
+  work).
+- **Edit surfaces:** sidebar right-click Rename, tab double-click / right-click,
+  a click-to-edit field in the session header, and **F2**. F2 targets the
+  **Active Sessions** row in the sidebar (only while the sidebar is visible),
+  preferred over the tab.
+- **Logs durability (deliberate extra).** Renaming persists the name into
+  `transcripts.db` (`run-rename` worker message → `renameRun` UPDATE on the
+  latest run; `LOGS2_RENAME_SESSION` IPC), and spawn-time `configLabel` uses
+  `customName || label`. So the logs/history tab keeps the name **even after the
+  session is closed**. Chosen over a renderer-only join (which would only cover
+  live sessions) because the owner wanted the name to survive in history.
+
+## Consequences
+
+- Renaming a session no longer mutates its config — the reported confusion is
+  gone, and configs stay stable templates.
+- One choke point: `store.renameSession` writes `customName` and fires the logs
+  IPC; every edit surface routes through it.
+- The standalone `RepoBreadcrumb` strip (cwd + repo/connection) was folded into
+  the session header at the same time, collapsing two bars into one below the
+  tabs (see CONTEXT.d fragment).
+- Cost: a DB write path across the transcripts worker/IPC/preload, plus a new
+  persisted field on `Session`/`SavedSession`. Unit-tested (store rename set/
+  clear, persistence round-trip, `renameRun` targets the latest run, logs IPC
+  fires with the effective name).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,107 @@
+# Claude Command Center — User Guide
+
+A task-oriented manual: *how do I…* for everyday use. For the feature tour and
+install instructions see [`README.md`](../README.md); for running a dev build
+next to your install see [`dev-alongside-prod.md`](./dev-alongside-prod.md).
+
+---
+
+## Getting started
+
+1. Install (see README → Install) and launch. On first run, CCC picks a data
+   directory and checks that the `claude` CLI is on your PATH.
+2. Create a **saved config** — a reusable launch template (working directory,
+   account, model, provider, options). Configs live in the sidebar.
+3. Click a config to start a **session**. Each session is a live terminal running
+   Claude Code (or a plain shell / SSH / Codex, depending on the config).
+
+**Mental model:** a *config* is a reusable template; a *session* is one running
+instance of it. You can run many sessions from the same config.
+
+## Working with sessions
+
+- **Switch** sessions from the tab bar, the sidebar's Active Sessions list, or
+  `Ctrl+Tab` / `Ctrl+1`–`Ctrl+9`.
+- **Close** a session from its tab's ✕, the sidebar right-click menu, or
+  `Ctrl+W`.
+- **The header bar** (below the tabs) shows the active session's name, working
+  directory, and — if the repo is wired to GitHub — the repo + connection state.
+
+### Naming the work in each window (rename)
+
+Give a session a **work name** so you can tell your windows apart at a glance —
+e.g. `IM-8315 keychain fix`. The name:
+
+- persists across app restarts, and comes back when a saved session reopens;
+- is cleared when you **close** the session in CCC;
+- is **independent of the config** — renaming a session never renames its saved
+  config;
+- shows up in the **logs/history** tab too, so past sessions stay identifiable.
+
+**How to rename** (any of these):
+
+- **`F2`** with the session active → edits it in the **Active Sessions** list.
+- **Double-click** the tab, or **right-click** the tab → *Rename…*.
+- Click the **name in the header bar**.
+
+Clear the name (blank + Enter) to revert to the config's label.
+
+## Multiple accounts
+
+CCC isolates accounts per session so you can run different Claude logins side by
+side. Switch a session's account from its sidebar right-click menu → *Switch
+Account*. (macOS runs a single account — see the keychain note in the README.)
+
+## Logs & transcript viewer
+
+Every session's conversation is indexed locally (never leaves your machine). The
+**Logs** tab is a chat-style transcript viewer with search and a timeline. Slots
+are labeled by the session's work name (or config label), so a renamed session is
+easy to find later.
+
+## Tokenomics, Memory, and the rest
+
+The README covers these in depth: **Tokenomics** (cost/usage analytics),
+**Memory** dashboard, **Sentinel**, **Conductor MCP** (incl. vision capture),
+**Agent Hub**, **Codex** provider, **GitHub** PR context, **Combined Mode /
+Draw**, **Snap / Vision**, and **Dynamic workflows**. See README → *Highlights*
+and *The rest of the surface*.
+
+## Best practices
+
+- **Name every long-lived session** (`F2`). It pays off in the tab strip, the
+  window picker, and the logs tab weeks later.
+- **One config per project/role**, then spin up sessions as needed — don't create
+  a new config for every run.
+- **Keep configs as stable templates.** Rename the *session* for per-window work;
+  rename the *config* only when the template itself changes.
+- **Use per-session accounts** rather than switching your global login, so
+  parallel work doesn't contend on one token.
+- **Mind the context meter** in the sidebar row; start a fresh session when a
+  conversation gets long rather than fighting a bloated context.
+- **Testing changes to CCC itself?** Run the dev build with `ccc` so it can't
+  touch your real config/sessions — see the dev-alongside-prod guide.
+
+## Keyboard shortcuts (defaults, rebindable in Settings)
+
+| Action | Shortcut |
+|---|---|
+| New config | `Ctrl+T` |
+| Close session | `Ctrl+W` |
+| Next / previous session | `Ctrl+Tab` / `Ctrl+Shift+Tab` |
+| Jump to session 1–9 | `Ctrl+1`…`Ctrl+9` |
+| Rename active session | `F2` |
+| Toggle sidebar | `Ctrl+B` |
+| Paste clipboard image | `Alt+V` |
+
+## Troubleshooting
+
+- **CLI not found:** ensure `claude` is on your PATH (Onboarding → *Find Claude*).
+- **No terminal cursor:** the caret is a thin bar; it shows a hollow outline when
+  the terminal isn't focused. (Claude/TUI sessions deliberately hide it — they
+  draw their own.)
+- **Slow first paint in dev:** use a current build — the boot-time backfill and
+  dev source-watcher now run deferred/async.
+- **Where's my data?** Prod uses the data dir chosen at setup (default
+  `%LOCALAPPDATA%\Claude Command Center`); a dev build uses `…\Claude Command
+  Center\dev`.

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -1,0 +1,69 @@
+# Agent & contributor conventions
+
+Working conventions for AI agents and contributors in this repo. Read this
+before making changes. It complements `README.md` (what the product is),
+`CONTRIBUTING.md` (contributor mechanics), and `CLAUDE.md` (harness-specific
+instructions).
+
+## Build, run, test
+
+```bash
+npm run dev          # dev with HMR (prefer the `ccc` launcher — see below)
+npm run build        # production build (electron-vite)
+npm run typecheck    # tsc --noEmit (node + web projects)
+npm run test:unit    # vitest (fast; run `npx vitest run` for one-shot)
+npm run test:e2e     # Playwright
+```
+
+- **Run dev via `ccc`** when you can — it isolates dev data from prod and cleans
+  up all dev processes on exit. See `docs/dev-alongside-prod.md`.
+- Some logging/db tests are **native** (better-sqlite3 built for Electron's ABI):
+  `npm run test:unit:native` / `*.native.test.ts`.
+
+## Architecture (where things live)
+
+- **Main** (`src/main/`): Electron main — PTY (node-pty), IPC handlers
+  (`src/main/ipc/`, one file per domain), config/session persistence, statusline,
+  vision MCP, cloud agents, tokenomics, the forked logging/tokenomics workers.
+- **Renderer** (`src/renderer/`): React 18 SPA, Zustand stores
+  (`src/renderer/stores/`), xterm.js terminals (WebGL addon), Tailwind v4.
+- **Preload** (`src/preload/`): the typed IPC bridge — ALL renderer↔main traffic.
+- **Shared** (`src/shared/`): types + IPC channel constants used by both sides.
+
+## Hard constraints (don't violate)
+
+- **Renderer never imports Node** (`path`, `fs`, …) — go through IPC/preload.
+- **`src/main/data-paths.ts` stays electron-free** (it runs inside the hooks
+  utilityProcess). No `electron` imports; there's a unit test guarding this.
+- **IPC channels** are declared once in `src/shared/ipc-channels.ts` and typed in
+  both the preload `ElectronAPI` interface and `src/renderer/types/electron.d.ts`.
+  Add a channel in all three places.
+- **No default exports** except a React component that is the sole export of its
+  file.
+- **Terminal perf:** xterm scrollback ≤ 10000; only chunk PTY writes > 256B; never
+  queue all writes.
+- **dev/prod isolation:** new dev-only behavior gates on `!app.isPackaged` and
+  must be a no-op when packaged. New long-lived ports must be split dev/prod (see
+  `resolveHooksPort` / `resolveConductorMcpPort` / `resolveCdpPort`). See ADR-001.
+
+## Branching & review
+
+- Branch off `beta`; PR back into `beta`. `beta` is never frozen; releases
+  stabilize on their own `release/vX.Y.Z` branch (see `CONTRIBUTING.md`).
+- Protected branches (`beta`/`main`) require a **code-owner (@nubbymong)** review
+  — you cannot self-approve. CI (`Test` matrix, Win + macOS) is gated on a
+  `ci-run` PR label.
+- Commit messages: imperative subject, explain the *why*; end with the
+  `Co-Authored-By:` trailer when authored with an assistant.
+
+## Documentation protocol (CARP)
+
+- **Running log:** add a dated fragment under `CONTEXT.d/` for your work (see
+  `CONTEXT.d/README.md`). `CONTEXT.md` is generated + gitignored — never commit
+  it.
+- **Architecture decisions:** add an ADR under `architecture/decisions/`
+  (`YYYY-MM-DD-adr-NNN-title.md`).
+- **README / AGENTS.md:** update only on a *structural* change (new subsystem,
+  changed conventions), not per feature.
+- Don't add status/summary docs; summarize in the PR. Keep docs at the right
+  scope (root = project-wide; subdir = component-specific).

--- a/docs/dev-alongside-prod.md
+++ b/docs/dev-alongside-prod.md
@@ -1,0 +1,83 @@
+# Running DEV alongside PROD
+
+You can run the installed **production** build and a **development** build at the
+same time. Dev is fully isolated from prod — separate data directory and separate
+ports — and its window is labeled so you never confuse the two.
+
+> Rationale and the full decision record: `architecture/decisions/2026-07-17-adr-001-multi-instance-dev-prod-isolation.md`.
+
+## TL;DR
+
+```bat
+ccc            :: launch dev (reuse existing dev data), vision on
+ccc --seed     :: copy PROD's config into the dev data dir, then launch
+ccc --clean    :: wipe the dev data dir first (fresh; setup wizard skipped)
+ccc -nv        :: launch with the vision browser auto-launch off
+```
+
+Flags combine, e.g. `ccc --clean --seed -nv`. Keep prod running; `ccc` opens a
+separate, amber-labeled **DEV** window beside it.
+
+## The `ccc` launcher
+
+`ccc` is on your PATH as a thin shim (`%APPDATA%\npm\ccc.cmd`) that forwards to
+the versioned launcher in the repo, **`scripts/ccc.cmd`** — so the isolation /
+seed / cleanup logic updates with the code.
+
+What it does:
+
+- Sets `CCC_DEV_DATA_DIR` so the dev build uses its own data root.
+- Refuses to start a **second** dev instance (checks port 5173).
+- Tees all output to a timestamped log under
+  `<dev-data-dir>\dev-logs\ccc-dev-<timestamp>.log` (latest path in
+  `ccc-dev-latest.txt`).
+- On exit, **auto-closes the window and kills the whole dev process set** so
+  nothing leaks between runs: dev electron, vite (5173), the update-server
+  (9847), the MCP server (19433), the hooks gateway (19434), and the headless
+  vision Chrome (matched by its `chrome-debug-9322` profile — your normal Chrome
+  is never touched).
+
+> Close the app (or Ctrl+C the window) so cleanup runs. Closing the window with
+> the **X** button hard-kills the shell before cleanup can run.
+
+## Seeding dev config
+
+The dev data dir starts empty. To work with your real configs:
+
+- `ccc --seed` copies prod's `CONFIG` (configs + settings) into the dev data dir.
+  Sessions and transcripts stay fresh. Safe to re-run; it overwrites the dev
+  `CONFIG` from prod.
+- `ccc --clean` deletes the dev data dir first (a true reset), then launches into
+  a wizard-skipped empty state. Combine with `--seed` for "reset, then reseed".
+
+`--seed` reads prod's resources dir from `HKCU\Software\Claude Command Center`
+(`ResourcesDirectory`), falling back to
+`%LOCALAPPDATA%\Claude Command Center\resources`.
+
+## What's isolated (dev vs prod)
+
+| Resource | Prod | Dev |
+|---|---|---|
+| Data root | `…\Claude Command Center\` (or registry) | `…\Claude Command Center\dev\` |
+| CONFIG / sessions / transcripts / logs / profiles | under the data root | under the dev data root |
+| MCP server port | 19333 | 19433 |
+| Vision CDP port | 9222 | 9322 |
+| Hooks gateway port | 19334 | 19434 |
+| Update-server / Vite | (prod doesn't run them) | 9847 / 5173 |
+| Single-instance lock | held (2nd prod focuses the 1st) | skipped (coexists with prod); 2nd dev refused by the launcher |
+
+The dev switch activates whenever the build is **unpackaged** (`app.isPackaged
+=== false`). A packaged prod build never takes the dev path.
+
+## DEV labeling
+
+- OS window / taskbar title: **"Claude Command Center — DEV"**.
+- Title bar: an amber **DEV** pill and an amber underline accent.
+
+## Caveats
+
+- CCC's own state is isolated, but the underlying **Claude CLI global home
+  (`~/.claude`) is shared** between dev and prod. Avoid running the *same
+  account's* Claude session in both instances at the same time (OAuth token
+  rotation can contend).
+- First isolated dev launch is empty unless you `--seed`.


### PR DESCRIPTION
The repo had README + CONTRIBUTING but no running decision log and no ADRs. Establishes the documentation protocol and captures this session's work.

- **CARP running log:** \`CONTEXT.d/\` fragments (sole tracked source); \`CONTEXT.md\` generated + gitignored. Seeded with dated fragments (boot/vision/cursor/keychain fixes, session-rename, multi-instance-dev, ccc launcher). \`CONTEXT.d/README.md\` documents the convention.
- **ADRs** (architecture/decisions/): ADR-001 multi-instance dev/prod isolation, ADR-002 session work-name model.
- **Guides** (docs/): \`dev-alongside-prod.md\`, \`USER_GUIDE.md\` (end-user manual + best practices), \`agent-conventions.md\` (root \`AGENTS.md\` is gitignored here as personal/local, so the tracked copy lives under docs/).

Docs-only; no code. Describes features in-flight on \`feat/session-rename\` and \`feat/multi-instance-dev\` (not yet on beta) — content settles as those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)