### PR TITLE
chore(dev): changelog generation, commit enforcement, and canonical AGENTS.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Keep these LF on every platform, independent of core.autocrlf.
+#
+# CHANGELOG.md is generated with LF by scripts/gen-changelog.js; pinning it means
+# the working tree matches the rendered output byte-for-byte, so the drift check
+# (npm run changelog:check) is stable on Windows and in Linux CI alike.
+CHANGELOG.md text eol=lf
+
+# Husky hooks are POSIX shell run via sh — CRLF would inject stray \r and break
+# execution.
+.husky/commit-msg text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,20 @@ permissions:
   contents: read
 
 jobs:
+  # Fast, always-on guard (not gated on the `ci-run` label): CHANGELOG.md is
+  # generated from src/renderer/changelog.ts, so it must never drift. The
+  # generator is zero-dependency, so no npm install is needed.
+  changelog:
+    name: Changelog in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify CHANGELOG.md matches changelog.ts
+        run: node scripts/gen-changelog.js --check
+
   test:
     # Gate the test matrix on a `ci-run` label for PRs.
     # Rationale: this repo accumulates many WIP commits per PR (multi-phase v1.x

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+# Squash-merge makes the PR title the commit subject, so the title is what lands
+# in history and drives changelog/release-note tooling. Validate it against the
+# Conventional Commits rules in commitlint.config.js.
+#
+# Local commits are checked by the .husky/commit-msg hook; this is the CI
+# backstop for anyone who bypassed hooks (or contributed via the web UI).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install commitlint
+        run: npm ci --ignore-scripts
+
+      - name: Lint PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx --no-install commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Derive the release body from src/renderer/changelog.ts (the single
+      # source of truth). Empty output = no changelog entry for this version;
+      # the create step then falls back to the checksums-only note.
+      - name: Generate release notes
+        id: notes
+        run: |
+          VERSION="${{ needs.build-windows.outputs.version }}"
+          node scripts/gen-changelog.js --notes "$VERSION" > RELEASE_NOTES.md || true
+          if [ -s RELEASE_NOTES.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Release notes for v${VERSION}:"
+            cat RELEASE_NOTES.md
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No changelog.ts entry for v${VERSION} - using checksums-only note."
+          fi
+
       - name: Download Windows artifact
         uses: actions/download-artifact@v4
         with:
@@ -342,7 +363,21 @@ jobs:
               LABEL="**${CHANNEL} Release**"
               ;;
           esac
-          BODY="## ${RELEASE_NAME} v${VERSION}\n\n${LABEL}\n\nSHA-256 checksums are in CHECKSUMS.txt attached to this release."
+          # Assemble the release body: title + channel label + generated notes
+          # (or a checksums-only fallback), then the checksums pointer. Written
+          # to a file so multi-line markdown survives intact (--notes-file).
+          {
+            echo "## ${RELEASE_NAME} v${VERSION}"
+            echo ""
+            echo "${LABEL}"
+            echo ""
+            if [ "${{ steps.notes.outputs.found }}" = "true" ]; then
+              cat RELEASE_NOTES.md
+              echo ""
+            fi
+            echo "---"
+            echo "SHA-256 checksums are in CHECKSUMS.txt attached to this release."
+          } > RELEASE_BODY.md
 
           # Tag stable as latest release; beta and dev are pre-releases
           PRERELEASE_FLAG=""
@@ -366,7 +401,7 @@ jobs:
             gh release create "${TAG}" $PRERELEASE_FLAG \
               --target "$GITHUB_SHA" \
               --title "${TITLE}" \
-              --notes "$(echo -e "${BODY}")" \
+              --notes-file RELEASE_BODY.md \
               artifacts/*
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ dist/
 # Personal/local config
 .claude/
 .agents/
-AGENTS.md
+# AGENTS.md is now TRACKED — it is the canonical, cross-tool agent brief
+# (ADR-004 / 2026-07-18). CLAUDE.md imports it via `@AGENTS.md`.
 .copilot-review-notes.md
 .superpowers/
 docs/superpowers/

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Claude Command Center — agent & contributor brief
+
+Canonical instructions for any AI agent or contributor working in this repo. This
+is the cross-tool standard file (read by Claude Code via `@AGENTS.md` in
+`CLAUDE.md`, and directly by Codex, Cursor, Copilot, and others). Read it before
+making changes.
+
+Multi-session Claude Code terminal orchestrator built with Electron 42 + React 19
++ TypeScript.
+
+## Build & Run
+
+```bash
+npm run dev          # Development with HMR (prefer the `ccc` launcher — see below)
+npm run build        # Production build (electron-vite)
+npm run typecheck    # tsc --noEmit
+npm run test:unit    # vitest
+npm run test:e2e     # playwright
+npm run test         # both
+```
+
+- Prefer the `ccc` launcher for dev — it isolates dev data from prod and cleans
+  up all dev processes on exit. See `docs/dev-alongside-prod.md`.
+
+## Architecture
+
+- **Main process** (`src/main/`): Electron main, PTY management (node-pty), IPC handlers, config persistence, statusline, vision MCP server, cloud agents, tokenomics
+- **Renderer** (`src/renderer/`): React 19 SPA with Zustand stores, xterm.js terminals, Tailwind CSS v4
+- **Preload** (`src/preload/`): IPC bridge - all renderer↔main communication goes through typed channels
+- **Shared** (`src/shared/`): Types and IPC channel constants used by both processes
+
+### Key patterns
+
+- IPC handlers are in `src/main/ipc/` - one file per domain (pty, config, logs, etc.)
+- Config persistence via `src/main/config-manager.ts` - JSON files in a user-selected resources directory
+- Stores in `src/renderer/stores/` - Zustand, hydrated from config on startup
+- Terminal rendering via xterm.js with WebGL addon
+- SSH sessions use node-pty to spawn ssh.exe, with automated setup scripts for statusline/vision
+
+## Coding Conventions
+
+- No default exports (except React components that are the sole export of their file)
+- Tailwind v4 with `@theme` in `src/renderer/styles.css` - no tailwind.config file
+- Catppuccin Mocha color palette (base, mantle, crust, surface0-2, overlay0-2, subtext0-1, text, etc.)
+- Never import Node.js modules (path, fs, etc.) in renderer - use IPC
+- Never use `\u{...}` Unicode escapes in JSX - esbuild doesn't support them. Use `String.fromCodePoint()` or SVG
+- PTY writes: only chunk large pastes (>256B). Never queue all writes - causes severe input lag
+- xterm.js scrollback: keep at 10000 max. Higher values cause ~1GB RAM per terminal
+
+## Testing
+
+- Unit tests: `vitest` in `tests/unit/`
+- E2E tests: Playwright in `tests/e2e/`
+- Run `npx vitest run` for fast unit test feedback
+- Tests mock Electron APIs - no real PTY/window in unit tests
+
+## Release Process
+
+RC-branch model (adopted with #89): `beta` is never frozen — features merge there continuously; each release stabilizes on its own branch.
+
+- Feature/fix work: branch off `beta`, PR back into `beta` (owner review + green CI required)
+- To stabilize a release: cut `release/vX.Y.Z` from `beta`; on that branch bump `package.json` (e.g. `2.0.0-rc.2`), commit `build(release): <version>`, push, then `gh workflow run release.yml --ref release/vX.Y.Z -f channel=beta -f skip_vt=false` and watch it to green
+- RC-branch fixes are back-ported to `beta`; features never merge into a release branch
+- Prerelease tags: `-beta.N` and `-rc.N` — both ride the beta update channel; rc outranks beta, final outranks rc
+- Promote to stable: merge `release/vX.Y.Z` → `main`, run the release workflow from `main` with `channel=stable`, then delete the release branch
+- Changelog is generated from `src/renderer/changelog.ts` (single source; also drives the in-app "What's New" modal). Before a release, add the version's entry there, run `npm run changelog` to refresh `CHANGELOG.md`, and commit both. `release.js` already syncs the version line; the release workflow auto-populates the GitHub release notes from the same file (`scripts/gen-changelog.js --notes <version>`) — no hand-pasting. CI (`Changelog in sync`) fails on drift
+- Commits/PR titles follow Conventional Commits, enforced by a Husky `commit-msg` hook and the `PR Title` workflow (`commitlint.config.js`)
+- GitHub Actions builds Windows (.exe) + macOS (.dmg) + Linux (.AppImage, experimental) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
+- Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
+- Never commit secrets, .env files, or personal paths
+
+## Documentation protocol (CARP)
+
+- **Running log:** add a dated fragment under `CONTEXT.d/` for your work (see `CONTEXT.d/README.md`). `CONTEXT.md` is generated + gitignored — never commit it.
+- **Architecture decisions:** add an ADR under `architecture/decisions/` (`YYYY-MM-DD-adr-NNN-title.md`).
+- **README / AGENTS.md:** update only on a *structural* change (new subsystem, changed conventions), not per feature.
+- Don't add status/summary docs; summarize in the PR. Keep docs at the right scope.
+
+## Deeper references
+
+- `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
+- `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
+- `architecture/decisions/` — ADRs (the *why* behind architectural/tooling calls).
+- `docs/dev-alongside-prod.md`, `docs/USER_GUIDE.md`, `docs/code-signing.md` — operational guides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,968 @@
+# Changelog
+
+All notable changes to Claude Command Center are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Generated file — do not edit by hand.** The source of truth is
+> `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
+> (CI enforces that this file is in sync via `npm run changelog:check`).
+
+## [2.1.0-beta.1] - 2026-07-17
+
+> Experimental Linux support — Claude Command Center now runs on Linux as an AppImage, alongside Windows and macOS.
+
+### Added
+- Linux (experimental): download the AppImage, make it executable (chmod +x), and run it. Verified on Ubuntu 24.04 and Rocky Linux 10; needs a modern glibc (2.39+, i.e. Ubuntu 24.04+, Rocky 10+, Fedora 40+). Older distributions are not covered by this build yet.
+
+### Changed
+- The in-app updater and the vision browser tool now understand Linux. On Linux the vision tool needs a deb/rpm build of Chrome or Chromium — the Ubuntu snap build is sandboxed away from the debug port, so vision stays off there.
+
+## [2.0.0-rc.2] - 2026-07-15
+
+> Release Candidate 2: terminal scrolling holds your place during live output, and relaunch reopens every session under its saved account — the first community-contributed fixes.
+
+### Fixed
+- Scrolling up with the scrollbar or keyboard now holds your place while a session streams output. Previously only mouse-wheel scrolling was recognised, so any other way of scrolling up got yanked back to the bottom by the next burst of output.
+- Relaunching CCC reopens each session under the account it was closed with, instead of re-asking which account to use for every restored session.
+
+## [2.0.0-rc.1] - 2026-07-10
+
+> v2.0 Release Candidate 1: in-app updates work again, every signed-in account shows live usage, the stray blank browser window is gone, and a full dependency security refresh.
+
+### Changed
+- Security refresh: the one remaining vulnerable dependency (the WebSocket client used for browser automation) is patched, and the dependency audit is clean — 0 known vulnerabilities across the shipped tree.
+
+### Fixed
+- In-app update checks now find newer releases. Releases were being tagged against a stale commit, which mis-dated them so the updater never saw them; they are now tagged at the exact commit that was built, the updater scans the full release list, and it understands release-candidate versions.
+- The all-accounts usage panel now shows live usage for every signed-in account — even ones you have not opened a session with recently. It quietly refreshes each account's short-lived key in the background, only for accounts with no running session or sign-in in progress. Your primary account is deliberately left untouched (its credentials are shared with Claude outside CCC) — it shows last-known usage until you open a session.
+- Codex sessions no longer double-count cached input and reasoning tokens in the statusline and Tokenomics — token counts and dollar costs for cache-heavy Codex sessions were inflated (input could read nearly double).
+- Fixed a blank browser window that could appear on startup (and linger after closing the app) when the browser/vision tool was enabled. The automation browser is now kept off-screen and is reliably shut down together with the app.
+- The automation browser no longer runs Chrome's first-run setup on every launch, which was touching the desktop shortcuts and making the Chrome icon flicker on OneDrive-synced desktops.
+- Codex sessions: the context meter now shows how full the context window actually is (the last request against the window), instead of the session's lifetime token total — which pinned the bar red at ~100% on long sessions whose window was mostly free.
+- Resumed sessions: after the resume replay finishes, the terminal geometry is re-confirmed and the view repainted — targeting the garbled overlay text (stray line fragments over the input box) that could appear and persist after resuming a session.
+
+## [2.0.0-beta.6] - 2026-07-08
+
+> The all-accounts usage panel is far more reliable — no more spurious "Sign in" or "HTTP 429" on accounts that are actually fine.
+
+### Changed
+- When a live refresh can't complete (rate-limit, a network blip, or a lapsed token), the panel keeps showing each account's last-known figures with their age, instead of blanking the card.
+
+### Fixed
+- The account usage panel no longer loads every account at once, which was triggering rate-limit (HTTP 429) errors on perfectly valid accounts. Accounts now load staggered, with automatic retry, so a transient rate-limit recovers on its own instead of showing an error.
+- Accounts that are still signed in no longer show a false "Sign in" prompt. Between sessions only the short-lived access token lapses — the account stays logged in — so the panel now shows the last-known usage (or a quiet "open a session to refresh") instead of a misleading Sign in button. A real Sign in appears only when an account genuinely has no credentials.
+
+## [2.0.0-beta.5] - 2026-07-07
+
+> Two SSH fixes: Conductor tools and the session status line both work again inside SSH sessions.
+
+### Fixed
+- Conductor tools (host screenshot and browser vision) work in SSH sessions again. The reverse tunnel that carries them was connecting to the wrong loopback address on the host — the server listens on IPv4 while the tunnel was landing on IPv6 — so remote sessions saw the connection close immediately. It now targets the right address.
+- The session status line shows again in SSH sessions on Linux hosts (model, context, cost, and rate limits). Over SSH, Claude runs the status-line command without a terminal of its own, so the update was being dropped; it is now routed back through the session's terminal.
+
+## [2.0.0] - 2026-07-02
+
+> Claude Command Center 2.0: a guided first-run setup, an in-app Ask Command Center guide, a modernized engine, and a privacy pass that keeps every Claude config write per-session.
+
+### Added
+- New guided setup on first launch (and once after this upgrade): pick your theme, point CCC at your Claude install, see how accounts and GitHub connect, and switch on exactly the features you want. Every step shows real state from your machine, and nothing runs or gets enabled without you seeing it.
+- A live guided tour follows setup: coach marks anchored to the real app walk you to your first session. The old static tour and the stack of first-launch popups are retired.
+- Ask Command Center: the ? button in the sidebar opens a searchable guide to every feature, or hands your question to a Claude session primed with the app's docs so you can ask in plain language.
+- Built-in tools are now under your control: a master switch plus per-tool toggles (vision, code review, host transfer) in setup and Settings, enforced everywhere a session spawns: local, SSH, and Codex.
+- The status line has a real master switch: turn it off and CCC stops injecting it into sessions entirely, local and SSH alike.
+- Codex support is now clearly marked Beta with its own master switch, and you can sign in during setup with the browser flow or an API key. Off means off: Codex configs are marked disabled (with the reason) and will not launch while the master is off.
+
+### Changed
+- Engine modernization: Electron 42, React 19, xterm.js 6, Vite 7, and TypeScript 6. A faster renderer on a current Chromium security baseline.
+- Privacy pass: the status line and the Conductor MCP server are now delivered per session instead of being written into your global Claude config, legacy global entries are cleaned up on boot, per-session SSH files are swept on close, and your ~/.claude/CLAUDE.md is never touched.
+- Claude Code 2.1.195+ renders its questions with clickable answer options; inside CCC a stray terminal click could select one, so they are switched off by default and answers stay keyboard-driven. Opt back in under Settings, General, Terminal.
+- CCC Sentinel and cloud-agent permissions now default to off. Both are opt-in, with the ask made plainly during setup, so nothing spends tokens or grants permissions without your say-so.
+- Agent Hub is reorganized into Tasks, Pipelines, and Library, with clearer first-run guidance.
+- Insights reliability round: runs compare against the previous run of the same account, concurrent runs are locked per account, failed runs and KPI-extraction failures are surfaced instead of silently vanishing, and KPI extraction no longer bypasses permissions.
+- Security hardening: external links open only over verified https, config files are validated as they load, the vision browser's debug port binds to loopback only, memory files are contained against symlink escape, and all known dependency vulnerabilities are resolved (undici, ws).
+
+### Fixed
+- Alt+V now pastes copied image files (not just screenshots), with inline feedback when the clipboard has no usable image.
+- Each rate-limit window in the status line shows its own reset time (5-hour and weekly), instead of one shared timestamp.
+
+## [1.5.45] - 2026-06-14
+
+> CCC Sentinel's status dot now only turns amber when a finding actually affects your setup.
+
+### Changed
+- The Sentinel status dot is graded by reachability: amber means a compatibility finding reaches the accounts and features you actually use, and a calm grey state shows once you have reviewed the report.
+
+## [1.5.44] - 2026-06-14
+
+> Light theme: Claude sessions now start with a matching light terminal theme.
+
+### Fixed
+- When CCC is in light mode, new Claude sessions are told about it (via the standard COLORFGBG signal) so Claude picks its light terminal theme instead of rendering dark-on-light. Applies to newly started sessions.
+
+## [1.5.43] - 2026-06-14
+
+> The Copilot AI-credits meter now tracks your current billing cycle, with a progress bar.
+
+### Changed
+- The Copilot chip counts credits used in the current billing cycle instead of a lifetime total, and gains an inline progress bar matching the Claude rate-limit meters.
+- Copilot meter configuration (including your plan's included-credits cap) now lives in Settings, Status Line, next to the other status-line elements.
+
+## [1.5.42] - 2026-06-13
+
+> GitHub settings, round two: re-auth now targets the right account and asks only for what it needs, and a Copilot usage meter lands in the session status strip.
+
+### Added
+- A Copilot AI-credits meter in the session status strip, with a toggle to show or hide it.
+
+### Changed
+- Re-auth requests are additive and minimal: the scopes asked for are derived from the features you actually have enabled, so you never grant more than the app uses.
+- GitHub settings are recomposed account-first, with one consistent panel per account and an app-wide group for the settings that span accounts.
+
+### Fixed
+- Re-authenticating a GitHub account now works per account and per auth kind (OAuth, PAT, or gh CLI), fixing the long-standing bug where re-auth could target the wrong profile or silently do nothing.
+
+## [1.5.41] - 2026-06-13
+
+> Copy the CCC Sentinel compatibility report to your clipboard.
+
+### Added
+- The Sentinel report gains copy buttons: copy the whole report or a single finding, ready to paste into an issue or a Claude session.
+
+## [1.5.40] - 2026-06-13
+
+> Fix: conversations recorded outside a CCC session now show up in the resume picker.
+
+### Fixed
+- The resume picker now surfaces and resumes conversations that were recorded without a companion log folder (for example, work done directly in a repo before or outside CCC sessions). Existing conversations are backfilled on the next scan.
+
+## [1.5.39] - 2026-06-13
+
+> GitHub settings are rebuilt around your accounts, plus a batch of fixes: first-launch prompts no longer stack, the Sentinel watcher no longer hangs, and the Tokenomics cost donut is cleaner.
+
+### Added
+- GitHub settings are rebuilt around accounts. Each connected account gets its own panel with a Status and permissions tab and a Features tab, so you can see and control each account on its own terms instead of one flat list.
+- A new "Features for all accounts" master section sits above the per-account panels: each feature shows a tri-state (on, off, or mixed across your accounts) with an "apply to all accounts" action to set it everywhere at once.
+- Per-account feature toggles. Turn features like active PR, CI, reviews, linked issues, notifications, and AI credits on or off for each account independently, with the state held per account.
+
+### Changed
+- Honest re-auth surfacing. When a feature is switched on for an account whose token cannot power it yet, the account now shows a clear "switched on but needs re-auth" state instead of silently doing nothing, and a collapsible "what each feature needs" reference shows which scopes the features you enabled require.
+
+### Fixed
+- First-launch prompts (logging consent, What's New, setup steps) now appear one at a time in priority order instead of stacking on top of each other.
+- CCC Sentinel's background compatibility analysis no longer hangs on a shared login or leaves stray claude processes behind: it now runs against one of your signed-in accounts and tears the whole process tree down on timeout.
+- The Tokenomics cost donut no longer shows a "<synthetic>" slice; those system rows are labelled and excluded from the cost breakdown.
+
+## [1.5.38] - 2026-06-12
+
+> Memory is now a full dashboard -- KPIs, charts, ranked projects, drilldown, and a reading drawer -- and the Sentinel status dot is now a labelled chip.
+
+### Added
+- The Memory page is rebuilt as a dashboard: a KPI strip (memories, projects, total size, stale over 30 days, and an index-health KPI that replaces the old warning banner), an activity area-chart, and a type donut for the whole store.
+- Ranked project list with staleness dots, index warnings, and live-session chips. Click a project to drill in: a sortable memory table plus a sessions rail where live sessions jump straight to the terminal and recent sessions deep-link into the Logs viewer.
+- New reading drawer for distraction-free memory reading, and the search view restyled to match.
+
+### Changed
+- The Sentinel status dot is now a persistent labelled "Sentinel" chip, so the compatibility watcher is easier to find.
+
+### Fixed
+- The memory scanner no longer warns about custom frontmatter fields or types, silencing hundreds of spurious warnings on stores with custom metadata while keeping real signals.
+
+## [1.5.37] - 2026-06-11
+
+> New: CCC Sentinel -- an opt-in watcher that flags when a Claude Code update might affect the app, plus Memory and Hooks fixes.
+
+### Added
+- CCC Sentinel (opt-in, fail-open) detects Claude Code version changes on startup, checks the CC changelog against CCC's compatibility assumptions, and surfaces findings in a status dot plus a panel. It proposes model and effort registry fixes you apply yourself (never automatically) and reports compatibility for everything else. Toggle it in Settings, CCC Sentinel.
+
+### Changed
+- A new hot-reloadable model and effort registry replaces around ten hardcoded model-identity sites, so an unknown or brand-new model now gets a colour, a label, and flagged pricing instead of vanishing.
+- Memory scanning now runs off the main thread, so opening Memory on a large store no longer stalls the UI. Spurious "unknown frontmatter field" warnings for the standard metadata block are gone, and the close button is back on sessions.
+
+### Fixed
+- Raised the hooks request body cap from 256 KiB to 4 MiB so large file-edit events are no longer dropped from the activity feed; the first oversized payload per session is now logged.
+
+## [1.5.36] - 2026-06-11
+
+> Three big workstreams land: Logs v2 (a chat-transcript viewer), a ground-up Tokenomics rebuild, and the removal of the permission tray.
+
+### Added
+- Logs v2: a clean-slate transcript system. CCC indexes Claude's own conversation transcripts and renders them back as a readable chat with a timeline rail and full-text search. Restart and relaunch now resume the conversation you were actually in, worktree-aware. The old logging stack is removed.
+
+### Changed
+- Tokenomics is rebuilt on its own background indexer that reads ALL transcripts including subagent and sidechain files (the old scan missed around half the events), dedups globally, computes cost at query time from live pricing, attributes by config, and opens instantly with an indexing state and a green nav badge.
+- Heads up: life-to-date spend will read LOWER than the old page. The old ledger priced Opus at a stale 3x tier and double-counted statusline costs. The new number is the deduped API-equivalent at current pricing.
+- Security: dependency updates (vitest, ws, hono, tmp). The Electron 38 to 39 upgrade is deferred to a dedicated task.
+
+### Fixed
+- The permission tray has been removed. Claude's permission notifications are generic and fire for auto-approved subagent tools, producing phantom cards no heuristic could filter. The session attention pulse is kept.
+
+## [1.5.34] - 2026-06-09
+
+> Fix: closing all your sessions now reliably means no resume prompt on the next launch -- even when you update via the installer.
+
+### Fixed
+- The "Resume previous sessions?" prompt no longer offers sessions you already closed. Your open sessions are now saved continuously as you open and close them, so the next launch always reflects what was actually open -- even if the app was force-closed by an external installer or a crash (which previously left a stale list and re-offered phantom sessions). Close everything, and there is nothing to resume.
+
+## [1.5.33] - 2026-06-09
+
+> Fable 5 support -- Anthropic's new flagship model (the tier above Opus) is now a first-class choice across the app.
+
+### Added
+- Fable 5 is now selectable in the session model dropdown and the agent/config model pickers. It is Anthropic's most capable model (the tier above Opus) and runs roughly 2x faster than Opus.
+- Tokenomics now prices Fable 5 correctly out of the box ($10/$50 per 1M tokens) and gives it its own colour in the model breakdown, so Fable spend is tracked and shown distinctly. LiteLLM live pricing still wins when reachable.
+
+## [1.5.32] - 2026-06-06
+
+> Critical fix: importing your existing logs no longer freezes the app. Tested against a real 16 GB log set, with live progress, a completion notice, and safe interruption.
+
+### Added
+- A notice now appears when the log import finishes, wherever you are in the app, with a View report shortcut to the reconciliation report. If anything failed it says so clearly, and nothing is deleted.
+- Closing the app while a log import runs now asks first. Quitting is safe: the import stops cleanly and continues from where it left off the next time you run it.
+- New startup choice for saved sessions: Resume or Don't open. You are no longer forced to resume your saved sessions on every launch.
+
+### Fixed
+- Importing existing logs no longer freezes the app. The import now runs entirely in the background logging worker, streams the data in small pieces, keeps the app fully usable throughout, and shows live progress. Verified end to end against a real 16 GB, 990-session log set.
+- An interrupted log import is now safe by design: anything already imported stays, the interrupted session is automatically redone on the next run, re-runs skip completed sessions instantly, and the permanent space reclaim stays locked until an import completes 100% cleanly.
+- The per-session Logs pane no longer goes blank after running /clear in a session. The replay now keeps the full history scrollable and marks where the screen was cleared with a divider. Your captured logs were never lost; this was purely a display issue.
+
+## [1.5.31] - 2026-06-05
+
+> More accurate per-account cost tracking under the hood, plus a clearer warning in the account attribution tool.
+
+### Changed
+- Per-account cost tracking is now anchored to a stable account id captured when each session starts, so your usage stays attributed to the right account even if you later rename that account or change its sign-in email.
+- Daily cost totals now keep a per-account breakdown, so your per-account spending history stays correct over time even as older session details age out.
+
+### Fixed
+- The account attribution tool now explains that its email suggestions come from a history that records one sign-in at a time, so they can be wrong for a setup that ran several accounts at once. Double-check each before applying, or mark a group as mixed.
+
+## [1.5.30] - 2026-06-04
+
+> Critical multi-account stability: upgrades no longer disrupt a running session memory, and your last-used account survives a crash.
+
+### Fixed
+- Upgrades no longer disrupt session memory. A session left running across an app update could end up pointing at an old per-session home that the update had cleaned away, so on resume it looked like it had lost its memory. The update now keeps those old homes and re-points them at your shared memory store, so resuming or switching accounts across an update always reaches the same memory. No data was affected, your memory is shared as designed.
+- Your last-used account now survives a crash. The account you pick for a session is saved to disk immediately instead of only on a clean close, so after an unexpected shutdown a session still defaults to the account you last used for it.
+
+## [1.5.29] - 2026-06-04
+
+> Keeps your Claude login working in scripts outside the app, read each session effort and fast mode at a glance, with a tidier, more consistent dark and light theme, plus a new terminal-health view in the Conductor diagnostics.
+
+### Added
+- Session cards now show a colour-coded effort pill (Low through Ultracode) in the top-right, tinted from green to red as effort rises, so you can read each session effort level at a glance without opening it.
+- Session cards now show a lightning bolt when a session is running in Fast Mode, so you can spot fast-mode sessions at a glance. It appears only while Fast Mode is actually on and clears the moment you turn it off.
+- The Conductor diagnostics console gained a PTY integrity section with live terminal metrics per session (bytes received, resize events and width desyncs) to help track down terminal display glitches.
+
+### Changed
+- The effort pill now waits for live data before it appears, so a card no longer briefly shows a stale or default effort (for example XHIGH) before the real level loads. A restarted session stays calm until its new effort is known.
+- Tidied the session cards by removing the small leading dot. It only showed grey when idle and duplicated the status pill already shown on the right.
+
+### Fixed
+- Running the Claude CLI outside the app (e.g. claude -p in your own scripts) no longer breaks authentication. The app now keeps your real Claude login in lockstep with your main account, so a token refresh inside a session never leaves your outside scripts on a dead login. Only your main account's token is mirrored, and only when both sides are still that account.
+- Themed the Settings pages and the top and tab bars to match the rest of the app, removing the leftover near-black backgrounds and making dark and light mode consistent throughout. The window background now follows the theme instead of staying dark in light mode.
+
+## [1.5.28] - 2026-06-02
+
+> Per-account statusline stats, settable account colours, and the account follows a mid-session sign-in.
+
+### Added
+- Set a colour for each account in Settings that sticks, so you can tell your accounts apart at a glance.
+
+### Fixed
+- Each account now shows its own usage and rate limits in the statusline. Previously the usage numbers could briefly show another account figures.
+- When you sign in to a different account inside a session, the account name and colour now follow the new account.
+- Your captured main account now shows its email instead of a generic placeholder name.
+
+## [1.5.27] - 2026-06-02
+
+> Per-session account isolation, plus a safety backup of your Claude config taken before anything runs.
+
+### Added
+- Safety backup: on first launch the app snapshots your existing Claude login and settings to a backup folder before the multi-account feature does anything, so your original login is always recoverable.
+
+### Fixed
+- Two sessions running the same account are now fully isolated. Previously they shared one login on disk, so signing into a different account in one session changed the other and could overwrite the saved account. Each session now gets its own private home.
+
+## [1.5.26] - 2026-06-02
+
+> Multi-account is always on and clobber-proof: your accounts are protected and signing in never overwrites your main login.
+
+### Added
+- No on/off switch any more. On first run your current Claude login is captured into a protected account, and every session runs under a saved account, so you are multi-account ready from the start.
+- New account detection: run /login as a different account inside a session and CCC offers to add it as a separate named account, keeping your original account intact.
+
+### Changed
+- The Accounts list shows every account the same way, with the captured original marked as primary (and never deletable).
+
+### Fixed
+- Your main login can no longer be overwritten. A session never runs on the bare global login, so running /login in a session can no longer replace the account you are signed in with globally.
+
+## [1.5.25] - 2026-06-01
+
+> Sessions now genuinely run under the account you choose, with no impact on your other tools.
+
+### Changed
+- Zero degradation to your other tools: each account home mirrors your real home, so git, ssh, npm and the rest behave exactly as before. Only the Claude account is private; your memory and history stay shared.
+- Cleaner session cards: removed the redundant right-side dots. The account colour dot stays next to the account name.
+
+### Fixed
+- Added accounts are now truly isolated. Previously only the credentials were separated, not the account identity, so a session could still run as the wrong account. Each added account now runs under its own private home, so the account you pick is the account Claude uses.
+- One-time after this update: re-run /login once per added account so it re-establishes its isolated login.
+
+## [1.5.23] - 2026-06-01
+
+> Pick the account a session runs under when it starts, and a clearer Accounts list.
+
+### Changed
+- Account is now chosen when a session starts, not saved on the config. The first time a session launches you pick which account it runs under, so the account stays a live choice rather than a buried setting.
+- The Accounts list in Settings now shows each account by its email, with a clearly labelled Name field below it to give the account a friendly label. Add and remove accounts as before.
+- The start-session account picker now shows the friendly name you gave each account, including your default account.
+- Added the independent-project disclaimer to the startup splash screen.
+
+### Fixed
+- If you run /login inside a session and change account, the status strip, session card and statusline now update to the new account (previously they stayed on the account the session started with).
+- You can now switch a session between your Default account and a single added account from the status strip (previously this needed two added accounts).
+- Removed the leftover Setup Statusline command from existing setups.
+
+## [1.5.19] - 2026-06-01
+
+> Run multiple Claude accounts in CCC: add accounts, switch per session, keep them isolated.
+
+### Added
+- Multiple accounts: add a second or third Claude account and run different sessions under different accounts. A first-run prompt walks you through it, and you can manage accounts anytime in Settings then Accounts.
+- Switch a session to another account from the status strip pill or the right-click menu (it respawns and resumes under the chosen account). Signing in or out of an added account never touches your other accounts.
+
+### Changed
+- The status strip shows which account a session is using, and the account chip now resolves correctly for single-account users.
+- Effort level now reflects live /effort changes in the status line, and you can toggle the Effort and Account elements in Statusline settings.
+- Removed the Mode pill from the status strip (use Shift+Tab to change permission mode) and the redundant Setup Statusline command.
+
+## [1.5.18] - 2026-05-31
+
+### Changed
+- Permission tray no longer shows a card for the session you are currently viewing (Claude prompts you right there). The card appears if you switch to another session while the prompt is still waiting.
+- Added a footer note clarifying this is an independent project, not affiliated with or endorsed by Anthropic.
+
+### Fixed
+- Permission cards now reliably show which tool and command Claude is asking about, even when several tools run at once.
+- Permission cards are now mouse-only: they never steal keyboard focus or interrupt your typing, and a stray Enter or Escape can no longer action a card.
+
+## [1.5.17] - 2026-05-31
+
+### Added
+- Each card has Go to session and Ignore; a Settings toggle disables the tray.
+
+### Changed
+- Permission tray now surfaces only genuine prompts Claude is blocked on, honoring your Claude settings (no more cards for auto-approved commands).
+
+## [1.5.16] - 2026-05-30
+
+### Added
+- Permission tray: approve or deny any tool request from one place, across all sessions
+
+### Changed
+- Attention indicator no longer re-fires when you revisit a session
+
+### Fixed
+- Effort level now shows permanently in the status line
+- Settings toggles no longer overlap their labels
+
+## [1.5.15] - 2026-05-29
+
+> Removes the per-session account alias feature. Showing which Claude account a session is on is not reliable without isolating each session's config (which would fragment your shared memory and settings), so the alias label on session rows, the right-click Account tagging, and the Settings account-alias list are gone. Per-account spend tracking on the Tokenomics page is unaffected.
+
+### Changed
+- Removed the session account-alias feature: the alias label on session rows, the right-click 'Account' tagging menu, and the Settings account-aliases list. Claude exposes no reliable per-session account signal (it is global / last-login only), so the labels were frequently wrong whenever more than one account was in use
+- Tokenomics per-account spend (the Account filter and group-by-account view) is unchanged -- it uses a separate ledger-side mechanism, not the live session label
+
+## [1.5.14] - 2026-05-29
+
+> Polish pass: the session duration in the status strip now reads as hours and days past an hour (no more '1731m 38s'), the Permission Attention Tray stops false-flagging safe commands, and sessions whose saved folder no longer exists open in your home directory instead of dying on launch.
+
+### Fixed
+- Status strip: session duration rolls up to hours past 60 minutes and days past 24 hours, showing two units max (e.g. '1d 4h'). Long-running or resumed sessions no longer show an unreadable raw-minutes count
+- Permission tray: `git push --force-with-lease` (the safe push form) is no longer flagged as a high-risk force-push, and `sudo` detection only fires when sudo is the command being run -- not when it appears inside a quoted string or a path like /etc/sudoers
+- Sessions with a working directory that no longer exists (a deleted worktree, an un-cloned repo, a demo path) now fall back to your home directory instead of exiting immediately with '[Process exited with code 1]'
+
+## [1.5.13] - 2026-05-29
+
+> Day-two Opus 4.8 polish: Ultracode effort level (xhigh + automatic dynamic workflows), a global Disable Claude Code dynamic workflows toggle in Settings > Security, and new tour + tips entries for the Permission Attention Tray and Dynamic Workflows so they actually show up in /help.
+
+### Added
+- Effort dropdown: **Ultracode** option added. Sets `--effort ultracode` so Claude Code (2.1.154+) automatically plans dynamic workflows for every substantive task. Resets when you start a new session
+- Settings > Security: **Disable Claude Code dynamic workflows** toggle writes `disableWorkflows: true` into the per-session Claude settings so workflows are off for newly spawned sessions. Applies on next spawn; existing sessions keep their setting
+- Tour: dedicated **Permission Attention Tray** step covering the high-risk Bash patterns, the 50-entry cap, and how the gateway intercepts before Claude runs the command
+- Tour: dedicated **Dynamic Workflows** step covering the three ways to invoke (workflow keyword, Ultracode, /deep-research), the /workflows progress view, the 1000-subagent cap, and the global disable
+
+### Changed
+- Tips: new entries for the Permission Tray and Dynamic Workflows so the contextual tip system surfaces them after first use
+
+## [1.5.11] - 2026-05-29
+
+> Opus 4.8 lands as the new default, with Extra high effort and a Fast mode toggle (2.5x speed at 2x cost). The Permission Attention Tray from v1.5.10 is now actually wired -- v1.5.10 shipped the toast stack but the hook injection was disabled, so no toast ever fired; v1.5.11 fixes the wiring and ties it to Claude Code's real PreToolUse hook.
+
+### Added
+- Opus 4.8 default: new Claude sessions land on Opus 4.8 (Anthropic's newest model, released 2026-05-28). The model dropdown uses the `opus` alias so the default stays current as Anthropic releases new versions
+- Effort levels: Extra high (xhigh) and Max added to the Session dropdown; Opus 4.8 supports xhigh as its hardest-task setting
+- Fast mode toggle for Opus 4.8: 2.5x speed at 2x cost ($10/$50 per 1M tokens vs standard $5/$25). Tokenomics tracks Fast spend through a separate `<model>-fast` pricing row
+
+### Changed
+- Tokenomics: hardcoded fallback pricing for Opus 4.8 + 4.7 ($5/$25 standard, $10/$50 fast). LiteLLM live pricing still wins when reachable
+
+### Fixed
+- Permission Attention Tray wiring: v1.5.10 had injectHooks disabled and the gateway only matched a 'PermissionRequest' event Claude Code never fires. v1.5.11 re-enables hook injection per Claude session, ties the gateway to the real PreToolUse hook for Bash, and updates the disposition rule so the tray only fires for the high-risk patterns (rm -rf, sudo, force-push, dd, mkfs, chmod 777, fork bombs)
+
+## [1.5.10] - 2026-05-28
+
+> V2 UX uplift across Tokenomics, Insights, Logs, Settings, and Agent Hub -- plus a new Permission Attention Tray for high-risk Bash prompts. Insights drops its iframe and renders natively, Logs paginates large buffers, and Tokenomics gains a Project / Account / Model group-by lens.
+
+### Added
+- Permission Attention Tray: high-risk Bash commands (rm -rf, dd, mkfs, force-push, etc.) now stack as toasts in the top-right corner. Keyboard shortcuts let you approve or reject without scrolling back to the prompt; auto-allow handles read-only commands transparently
+- Tokenomics: new Group by lens (Project / Account / Model) pivots the breakdown panel + sessions table without re-running anything
+
+### Changed
+- Insights: native renderer replaces the iframe + injected dark theme CSS, so the report loads faster, follows your theme cleanly, and inherits the V2 surface tokens
+- Logs: chunked virtualization (500 entries per page with a Load older button) plus incremental filter diff -- big session logs no longer freeze the UI
+- Settings and Agent Hub: V2 primitive pass (StatusDot, MetricChip, SectionLabel, Kbd) and accent-token rails for tab + filter selection
+- TitleBar and Session Status Strip lifted onto the V2 raised-surface tier so they read as a single instrument cluster against the chrome below
+
+### Fixed
+- Cloud agent status colours now go through semantic tokens; status dot uses the StatusDot primitive (no more broken hex+alpha concat on the box-shadow)
+
+## [1.5.9] - 2026-05-27
+
+> Account labels are now user-managed -- you set them once in Settings and tag any session by right-click. The v1.5.7 auto-detected email chip was structurally unreliable (the field it read is global, not per-session) and has been removed.
+
+### Added
+- Settings > General > Account Aliases lets you keep a short list of email + alias rows; right-click any session in the sidebar to tag it with one. The alias shows after the project name in non-bold text
+
+### Fixed
+- Removed the per-session account-email chip from the session header and status strip -- it was reading a global file and could display the wrong account when you switched logins in another session
+- Use this repo: clicking on a freshly-spawned session now persists correctly instead of silently doing nothing (regression introduced in v1.5.8 where the session state had not yet been flushed to disk before the IPC write)
+
+## [1.5.8] - 2026-05-27
+
+> Three bug fixes: 'Use this repo' in the auto-detect banner now persists across restarts and skips the Settings detour when you are already authed; the Codex MCP server's 'Session not found' 404 now logs diagnostics and returns an actionable recovery message.
+
+### Changed
+- Conductor MCP /messages 404 now logs the requested transport id, active-transport count, sample ids and user-agent, and returns a multi-line recovery message instead of a bare 'Session not found' (helps when Claude reports the Codex review tool as unavailable mid-session)
+
+### Fixed
+- Clicking 'Use this repo' in the auto-detect banner now writes the repo to the parent saved config (not just the live session), so the selection survives an app restart
+- When at least one GitHub auth profile already exists, 'Use this repo' enables the integration in place and auto-picks a matching profile by repo or username -- no more bounce to the Settings tab
+
+## [1.5.7] - 2026-05-27
+
+> Your account email is back in the status line and session header -- coloured per account -- and you can now pin a fixed colour to any account in Settings. The Update pill also appears on its own now, without needing a restart.
+
+### Added
+- Assign a fixed colour to any account email in Settings > General > Account Colours. Detected accounts are listed automatically, or add one manually; the chosen colour tints that account's email everywhere it shows
+
+### Changed
+- The app now re-checks for updates periodically and when the window regains focus, so the Update pill appears on its own instead of only after a manual restart
+
+### Fixed
+- The active account email is shown again in the per-session status line and the session header, coloured per account -- it was dropped during the V2 shell refactor
+
+## [1.5.6] - 2026-05-26
+
+> Identity colours now span the full hue wheel so sessions are instantly distinguishable, the GitHub panel slides in when shown, and a few first-launch papercuts are fixed.
+
+### Changed
+- Identity colours are re-tuned across the whole colour wheel (blues, teals, greens, ambers, oranges, roses, purples) so saved configs and active sessions are instantly distinguishable in the left rail, tabs, and inactive dots -- not all variations of purple
+- The GitHub panel now slides in and fades when shown, and the collapsed floating logo button fades in (both respect reduced-motion)
+
+### Fixed
+- The Claude service-status pills (Code / Claude.ai) now appear immediately on launch instead of staying blank until the first background poll minutes later
+- Pasting an image with Alt+V now works on the first try -- previously the first attempt after copying could report 'no image detected' until you typed something (a Windows clipboard timing quirk)
+
+## [1.5.5] - 2026-05-26
+
+> Bottom-region rework from UAT: the per-session status line now sits directly above the command rows, CLI/version is a slim status bar at the bottom-left, and the GitHub panel ends above the command rows with a floating logo button when collapsed.
+
+### Changed
+- The per-session status line (model, tokens, context, rate limits) and the Mode / Model / Compact / Restart controls now sit directly above the command rows, where the old context bar lived
+- CLI, version and channel are now a slim global status bar pinned to the bottom-left of the window, spanning the full width -- separate from the per-session status line
+- When the GitHub panel is collapsed it is now a floating GitHub-logo button in the top-right corner instead of a thin vertical bar (with a coloured hover)
+- The update notification is no longer duplicated. The large 'Update Available' card is gone; the status-bar Update pill gently pulses when an update is ready
+- Command chips and the Mode / Model / Compact / Restart controls restyled into one consistent set; the model name shows properly and Restart is set apart
+
+### Fixed
+- The GitHub panel no longer stretches down past the status line and command rows. It ends above them, beside the terminal
+- The 'New: GitHub sidebar' onboarding popup no longer reappears on every launch once you have a GitHub account configured
+
+## [1.5.4] - 2026-05-26
+
+> V2 shell polish from first-look feedback: the bottom instrument bar now sits under the terminal only, inactive sessions keep their identity colour, and the global/custom command rows follow the theme.
+
+### Fixed
+- The bottom instrument bar is now scoped to the content area instead of spanning the full window width underneath the sidebar
+- Inactive sessions keep a muted identity-colour rail, so you can still tell sessions apart at a glance; the selected session shows the full rail, tint, and border
+- Global and custom command rows now use the theme's surface tokens instead of a fixed dark background, so they follow light and dark correctly
+
+## [1.5.3] - 2026-05-26
+
+> V2 command-center shell -- a ground-up visual redesign: dense session cards, a single bottom instrument bar, a cleaner header and terminal framing, light/dark theming, and per-session identity colours.
+
+### Added
+- New 'Command Workbench' shell. The session list is rebuilt as dense two-line cards with an unmistakable selected state (identity rail, tint, elevation, bold name, chip); health reads only as a status dot and pill; keyboard focus is a quiet dashed ring distinct from selection
+- Single bottom instrument bar replaces the old status bar, the per-terminal context bar, and the dead toolbar: runtime (CLI, version, channel, update) on the left, live session telemetry inline in the middle, and Mode / Model / Compact / Restart controls on the right
+- Per-session identity colours, resolved per theme, shown consistently on cards, tabs, and the header accent -- a curated non-status palette that never collides with running/warning/error status or the teal focus ring. Legacy session colours are migrated once, with a dismissible notice
+- Light and dark themes with a one-click Light/Dark flip in the title bar; the full Dark / Light / System choice lives in Settings
+- A passive breadcrumb strip in the header (working directory + detected repo), a quieter info-style repo auto-detect suggestion, and a collapsible command bar with neutral command chips
+
+### Changed
+- Context-aware empty state: with saved configs you get launch cards plus 'Show all configs'; with none, a clear 'Create a terminal config' action. Saved configs are reachable by keyboard, not hover-only
+- Terminal container framing -- comfortable padding and a real left gutter so text no longer crowds the edge
+
+### Fixed
+- Theme toggle no longer shows duplicate icons or dead clicks -- every click reliably and visibly changes the theme
+- Session attention pulse no longer re-fires when you simply switch away from a session; it only re-arms on genuine new keyboard input, not focus or mouse reports
+- New branded startup splash
+
+## [1.5.2] - 2026-05-24
+
+> Per-session account attribution -- see which Claude/Codex account each session and dollar belongs to. Plus the Electron 38 engine upgrade.
+
+### Added
+- Per-session account attribution. The active account email now shows in the context bar, coloured deterministically per account, so you can tell at a glance which login a session is running under. Works for both Claude (read live from ~/.claude.json) and Codex (decoded from the session JWT)
+- Tokenomics page gains an Account filter. Slice spend by account email, or by (Mixed) and (Unknown) for sessions that span logins or predate attribution
+- Account attribution back-fill wizard. Historic sessions recorded before this release are bucketed by config and suggested an account from your ~/.claude backup timeline -- confirm, override, or mark mixed. Runs once on first launch and is re-openable from the tokenomics page
+
+### Changed
+- Removed the global account picker from the title bar. Attribution is now per-session and automatic -- no manual switching, and historic spend is never silently re-stamped to whoever is logged in now
+- Electron 33 to 38 engine upgrade (Chromium 132 to 140). Newer rendering engine and security baseline under the hood
+
+### Fixed
+- Codex sessions no longer open to a blank terminal on Windows. ConPTY does not do PATH lookup, so the bare 'node' spawn failed silently -- now resolved to a full node.exe path
+- Codex MCP handshake now speaks streamable HTTP alongside SSE, so the conductor tools (vision, codex review) connect correctly under Codex CLI 0.128+
+- Codex resume picker reads the newer 0.133 rollout format, so resuming a Codex session lists the right sessions with readable labels instead of '(continued session)'
+- GitHub sidebar can be collapsed when open, and its per-session enablement now persists across app restarts
+
+## [1.5.1] - 2026-05-08
+
+> Codex provider, mega release
+
+### Fixed
+- Removed the peak/off-peak indicator -- Anthropic no longer differentiates peak hours in their rate-limit policy, so the badge was reporting outdated information
+
+## [1.4.3] - 2026-04-29
+
+> New branded splash now actually shows on launch, plus a refreshed README with v1.4 feature highlights
+
+### Changed
+- README overhaul. Branded splash at the top, six new feature highlight cards (Excalidraw, Combined Mode, Insights, Logs, GitHub sidebar, Vision), accurate v1.4 feature audit, dedicated 'What's New' section, corrected installer naming, and a 'Defence in Depth' security subsection covering daily CONFIG backups
+
+### Fixed
+- Splash window now displays the new branded artwork. The 1.5 MB PNG was being inlined into a data: URL that exceeded Electron's loadURL size limit, so the window was created but never reached ready-to-show. Switched to writing the wrapper HTML to a temp file and loading via loadFile -- works for any image size
+
+## [1.4.2] - 2026-04-28
+
+> Safety-net daily backups of your CONFIG directory -- never lose a session list to a corrupted write again
+
+### Added
+- Daily auto-backup of CONFIG/*.json under CONFIG/_backups/YYYY-MM-DD/ on every app launch. Last 7 days kept, prunes older. Recovery is a manual copy back into CONFIG/ -- but the data is always there if anything goes sideways
+
+### Fixed
+- Capture-training script no longer destroys real config data on cleanup. PID lock prevents concurrent captures; cleanup only restores files it explicitly backed up; never blind-deletes by filename match
+- Memory frontmatter writer now produces valid YAML for values containing backslashes, newlines, and other control chars. Previously only escaped quotes -- anything else round-tripped as malformed YAML. Switched to JSON-stringify which is a strict subset of YAML 1.2's double-quoted scalar grammar
+
+## [1.4.0] - 2026-04-24
+
+> GitHub sidebar -- PR, CI, reviews, linked issues, and session context next to the terminal
+
+### Added
+- New GitHub sidebar. Collapsible right panel that shows the PR for your current branch, CI runs, reviews, linked issues, local git state, and a session-context summary of what this terminal is working on
+- Sign in with GitHub via OAuth device flow, fine-grained PAT, or gh CLI adoption. Nothing runs until you opt in per session
+- Per-session enable with repo auto-detection banner. Ctrl+/ (Cmd+/ on Mac) toggles the panel
+- PR-body reference scanning. Closes/fixes/resolves #N and owner/repo#N refs in a PR body all surface in the session context
+- Notifications mini-section with mark-read, plus rate-limit and expiry banners on your auth profiles
+- First-launch onboarding modal for the GitHub sidebar, with a Set up now button that deep-links into the GitHub settings tab
+
+### Changed
+- HTTP Hooks Gateway plumbing. Opt-in loopback 127.0.0.1 listener that receives tool-call, permission, and lifecycle events from your Claude Code sessions via per-session UUID secrets. No UI in this release - it's the foundation for desktop notifications and external automations in upcoming versions. Toggle under Settings > GitHub
+- What's New modal fade-out now uses a shared 200 ms constant matched to the Tailwind transition, so the animation never truncates
+
+### Fixed
+- Right-click paste in terminals now respects bracketed-paste mode. Pasting multi-line text into Claude Code (or any other app that enables the mode) lands as a single atomic paste instead of submitting on the first newline
+- Session labels no longer leak into Claude as user prompts. Dropped the --name CLI flag whose value was being split by Windows shell quoting, sending part of the label as the first message
+
+## [1.3.1] - 2026-04-15
+
+> First public release -- open-sourced on GitHub
+
+### Added
+- Command bar sections: drag commands into named sections, right-click to rename/delete, custom text colors, independent Claude/Partner row sections
+- SSH statusline now shows full second line (rate limits, extra spend, peak/off-peak) -- fetches from Anthropic API on the remote
+- Insights report links now open in your system browser instead of showing blank pages
+
+### Changed
+- Tips updated for new section features with trackUsage calls
+- Pre-release checklist prompt added to release script
+
+### Fixed
+- SSH sessions now auto-start Claude (was broken for sessions without a post-connect command)
+- SSH setup script no longer echoes binary text -- suppressed with stty
+- Logs tab no longer freezes the UI -- async file reads with loading spinner
+- Memory manager: 'originSessionId' recognized as valid field, warnings now expandable
+- Insights KPI extraction: prompt piped via stdin instead of fragile shell arguments
+
+## [1.2.166] - 2026-04-08
+
+> Branching model: beta + main with promote flow
+
+### Added
+- New `npm run promote` command merges the beta→main PR and ships a stable release at the same version as the current beta
+- New --no-bump flag on the release script reuses the current package.json version instead of incrementing -- used by the promote flow to keep beta and stable version numbers aligned
+- New --ff-only and --yes flags on the promote script for partial/automated runs
+
+### Changed
+- New branching model: all feature work happens on the `beta` branch; the `main` branch is stable-only and receives fast-forwards from beta
+- Release script now enforces branch ↔ channel correspondence -- --stable must run on main, --beta/--dev must run on beta (bypass with --skip-branch-check in emergencies)
+
+## [1.2.165] - 2026-04-08
+
+> Release script hotfix: cross-platform sleep + proper workflow watching
+
+### Changed
+- Run-ID detection picks the newest workflow_dispatch run regardless of branch, so the filter doesn't miss the just-dispatched run due to API pagination lag
+
+### Fixed
+- Local release script now uses Node-native sleep instead of shelling out to `timeout`/`sleep`, which was silently failing inside execSync and preventing the script from finding the dispatched workflow run ID
+- Release script now surfaces real errors from the run-ID polling loop instead of swallowing them -- gives a useful hint if GitHub API is unreachable
+
+## [1.2.164] - 2026-04-08
+
+> Unified release pipeline + channel label on update button
+
+### Added
+- Check for Updates button now shows the active channel -- 'Check for Beta Updates' / 'Check for Stable Updates' / 'Check for Dev Updates' -- so you always know what you're checking against without opening the dropdown
+
+### Changed
+- Release script now dispatches the GitHub Actions workflow for canonical dual-platform builds (Windows EXE + macOS DMG, both signed/notarized, both VirusTotal-scanned, single release with checksums) instead of doing a Windows-only local build
+- Local release script does fast smoke checks (typecheck + unit tests + build) for fast feedback before pushing to CI, then watches the workflow run to completion and verifies both .exe and .dmg are attached
+- Release script now supports stable / beta / dev channels via --stable / --beta / --dev (default: interactive prompt with beta as fallback)
+
+## [1.2.163] - 2026-04-08
+
+> SSH statusline + unified MCP image transport + dual service status indicator
+
+### Added
+- Image paste, snap, and storyboard now work in BOTH local and SSH sessions via the conductor-vision MCP fetch_host_screenshot tool -- one unified code path, no path-vs-base64 hacks
+- vision_screenshot returns inline image content directly -- no second Read tool call needed to view the captured browser screenshot
+- Conductor MCP server now starts at app launch independent of browser/vision config so fetch_host_screenshot is always available
+- Title bar service status redesigned: separate Claude Code + Claude.ai pills with colored dots, plus API status surfacing only when degraded
+
+### Changed
+- All screenshot capture sites cap longest edge to 1920px and use JPEG q85 (q78 for storyboard frames) to reduce token cost
+- Clipboard paste regression fixed -- was sending raw base64 to the PTY, now uses saveImage path through the MCP fetch tool
+
+### Fixed
+- SSH statusline now updates: a tiny shim deployed to the remote ~/.claude emits an OSC sentinel via /dev/tty that the host parses out of the PTY stream (no SMB mount needed)
+- 'Got it' tip button now actually clears the tip pill from the session header (markTipActed clears currentTipId)
+- Snap, storyboard, and clipboard image resize now preserve aspect ratio -- was previously distorting non-square images by passing both width and height to nativeImage.resize()
+
+## [1.2.162] - 2026-04-07
+
+> Update system refactor: GitHub-only with stable/beta/dev channels + PTY dedupe
+
+### Added
+- Update checker now polls GitHub releases directly instead of a local WebSocket server
+- New update channel selector next to Check for Updates button -- stable / beta / dev with full keyboard accessibility
+- Dev channel for experimental builds (alongside existing stable and beta)
+
+### Changed
+- Update checker works without gh CLI once the repo is public (tries public GitHub API first, falls back to gh CLI only when needed)
+- Safer update downloads: HTTPS-only redirects, Windows retry safety (unlinks stale files before rename), no shell injection risk
+- Proper prerelease ordering (beta.2 > beta.1, final > beta)
+- CI workflow on every PR -- typecheck, tests, build on both Windows and macOS
+
+### Fixed
+- Duplicate Claude prompts: PTY now suppresses identical submitted payloads within 300ms (prevents double-sends that triggered rate limits)
+
+## [1.2.161] - 2026-04-07
+
+> Intelligent tips system with 26 seed tips and transparency disclosures
+
+### Added
+- Animated tip pill in the session header shows contextual, one-per-session feature discovery hints
+- Clicking a tip opens a platform-aware modal with full details, optional navigation, and dismiss/silence controls
+- New Transparency category: explicit tips about statusline injection, Vision MCP, session logging, credential storage, resources folder, and all network activity
+- Usage tracking persists to CONFIG/usage-tracking.json -- tips intelligently skip features you've already used or show 'did you know' variants
+- Toggle 'Show intelligent tips' in Settings > General to disable the system
+
+### Changed
+- Platform-aware tip copy: Partner Terminal, Credential Storage, Resources Folder, and Session Logs tips show correct Windows vs macOS paths
+
+## [1.2.160] - 2026-04-07
+
+> Guided first-run config + terminal column fix
+
+### Added
+- New users see a 'Get Started' card with a guided split-view to create their first config with inline help
+
+### Fixed
+- Terminal column mismatch: wait for custom fonts to load before computing cols (no more text fragments on the right edge)
+
+## [1.2.159] - 2026-04-07
+
+> First CI/CD release: parallel Windows + macOS builds with signing
+
+### Added
+- GitHub Actions workflow builds Windows EXE and macOS DMG in parallel
+- macOS DMG is code-signed and notarized via Apple Developer ID
+
+### Changed
+- Tour walkthrough consolidated to 7 focused steps with matching screenshots
+
+### Fixed
+- Splash screen now shows before main window renders
+- CLI setup dialog now works on macOS via login shell PATH
+- Setup dialog no longer crashes with null ResizeObserver target
+
+## [1.2.158] - 2026-02-11
+
+> Maintenance release with internal improvements
+
+### Changed
+- Internal code maintenance and stability improvements
+
+## [1.2.68] - 2026-02-11
+
+> Automated release pipeline with Claude CLI, VirusTotal, and GitHub Releases
+
+### Added
+- Release pipeline now auto-generates changelog and release notes via Claude CLI
+- VirusTotal scan of installer with results linked in GitHub Release
+- SHA-256 checksums generated and attached to each release
+- GitHub Releases created automatically with installer download
+
+### Changed
+- Old installer versions auto-cleaned from project root on each release
+- npm audit pre-check blocks release if critical vulnerabilities found
+
+## [1.2.67] - 2026-02-08
+
+> Platform v9 theme, rate limits, enriched statusline, config improvements
+
+### Added
+- Rate limit tracking -- 5-hour and weekly usage with colored dot bars, reset times, and extra usage cost shown in context bar
+- Enriched context bar -- now shows model name, token count (135k/200k), context %, cost, lines changed, and session duration
+- Config right-click menu now includes Edit and Delete options alongside group management
+
+### Changed
+- New platform v9 dark theme -- deeper blue-black backgrounds replace the old purple-tinted Catppuccin palette
+- Config items show Claude/Shell badges and colored left borders. Active tabs have colored bottom border
+
+### Fixed
+- Command button context menu no longer truncates at window edge -- opens upward when near bottom
+
+## [1.2.36] - 2026-02-07
+
+> Insights fix, command button fix, update reliability
+
+### Fixed
+- Insights now works -- /insights runs via PTY with proper TTY instead of headless spawn that hung forever
+- Custom command buttons no longer re-fire when pressing Enter -- buttons no longer steal keyboard focus
+- Update process simplified -- copies installer to Downloads, kills PTYs, launches installer, exits immediately
+
+## [1.2.24] - 2026-02-07
+
+> Debug logging overhaul, input protection, crash recovery
+
+### Changed
+- Debug toggle now controls verbose app logging instead of screenshot capture -- logs persist across updates
+- Log rotation increased to 10MB with 3 backup files for better diagnostic history
+- Insights timeout increased from 5 to 10 minutes
+- Error boundary catches renderer crashes and shows error with recovery button instead of blank screen
+- Verbose PTY lifecycle logging (spawn, exit, kill) for debugging session issues
+
+### Fixed
+- Restored image paste handler -- clipboard images saved as JPEG (max 1920px, 85%) with file path sent to Claude
+- Right-click in terminal pastes clipboard text when no text is selected
+- Input bar blocks multi-char text when Claude is asking a question -- prevents losing typed content
+- Image paste debounced (3s) to prevent duplicate sends via Alt+V or Ctrl+V
+
+## [1.2.20] - 2026-02-06
+
+> Config and session groups with collapsible tree view
+
+### Added
+- Group saved configs into named groups -- collapsible tree view in sidebar
+- Launch all configs in a group at once with the group play button
+- Active sessions auto-group based on their config's group
+- Right-click configs to move between groups or create new ones
+- Group field in config dialog for assigning during create/edit
+
+### Fixed
+- Context remaining indicator now works for SSH sessions (accumulation buffer for chunked data)
+
+## [1.2.5] - 2026-02-06
+
+> Image optimization, yellow cursor fix, and update button fix
+
+### Fixed
+- Clipboard images (Alt+V) now resized to max 1920px and saved as JPEG -- drastically reduces context usage
+- Screenshot capture also switched from PNG to JPEG for smaller files
+- Yellow cursor block eliminated by stripping yellow background color sequences
+- Screenshot dropdown labels render properly (SVG icons instead of broken Unicode)
+- Update button now runs pre-built installer instead of rebuilding from source
+
+## [1.2.3] - 2026-02-06
+
+> Smart insights with AI-powered analysis and actionable summaries
+
+### Added
+- KPI extraction now uses smart Claude skill that compares to previous run and produces actionable bullet points
+- Insights sidebar shows improvements (green), regressions (red), and suggestions (purple) at the top
+
+### Changed
+- KPI format is now fully dynamic -- the skill decides categories, metrics, and lists without hardcoded schemas
+- What's New modal now triggers on version change, not every build
+
+## [1.2.2] - 2026-02-06
+
+> Screenshot button redesign, input persistence, and release automation
+
+### Added
+- npm run release -- single command for full build, package, and update notification
+
+### Changed
+- Screenshot button restyled to match app design (no more garish cyan)
+
+### Fixed
+- Input text no longer lost when switching between sessions and other views
+
+## [1.2.1] - 2026-02-06
+
+> Better insights rendering, screenshot button fix, and clipboard paste fix
+
+### Added
+- CLI availability indicator (green/red dot) in status bar
+
+### Changed
+- Insights report now renders with full Catppuccin dark theme matching the app
+
+### Fixed
+- Screenshot button replaced with clean SVG icon instead of emoji
+- Ctrl+V paste no longer intercepts clipboard images -- screenshot workflow uses right-click only
+- Stuck insight runs automatically marked as failed on app restart
+- Restart button now works for SSH/remote sessions (kills old PTY before re-spawning)
+
+## [1.2.0] - 2026-02-06
+
+> Insights analytics with KPI tracking and trend comparison
+
+### Added
+- Insights integration: run claude /insights from the sidebar and view reports in-app
+- KPI extraction via Claude headless with automatic trend comparison between runs
+- Insights archive with history browsing and versioned reports
+- KPI sidebar showing metrics grouped by category with trend arrows
+- Auto-seeds existing report on first launch so your data is immediately available
+
+### Fixed
+- Update process now properly rebuilds, runs the installer, and relaunches the app
+
+## [1.1.0] - 2026-02-05
+
+> Session restore, Docker screenshot support, and graceful shutdown
+
+### Added
+- Sessions are now saved on close and restored on launch with /resume
+- Graceful shutdown sends /exit to Claude before closing
+- Screenshots now work in Docker containers via docker cp
+- Shell-only terminals (without Claude) option added
+- Push-based update notifications via WebSocket
+
+### Changed
+- Build timestamp shown in status bar for version tracking
+- Expanded color palette with 24 vibrant colors
+
+### Fixed
+- Log viewer now properly displays terminal logs
+- Yellow cursor issue resolved by hiding cursor layer
+
+## [1.0.0] - 2026-02-01
+
+> Initial release
+
+### Added
+- Multi-session Claude Code terminal management
+- SSH session support with password authentication
+- Custom commands per session/config
+- Session logging with history viewer
+- Tab attention indicators for waiting prompts
+- Context usage tracking via statusline API
+
+[2.1.0-beta.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.1
+[2.0.0-rc.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-rc.2
+[2.0.0-rc.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-rc.1
+[2.0.0-beta.6]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-beta.6
+[2.0.0-beta.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-beta.5
+[2.0.0]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0
+[1.5.45]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.45
+[1.5.44]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.44
+[1.5.43]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.43
+[1.5.42]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.42
+[1.5.41]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.41
+[1.5.40]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.40
+[1.5.39]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.39
+[1.5.38]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.38
+[1.5.37]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.37
+[1.5.36]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.36
+[1.5.34]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.34
+[1.5.33]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.33
+[1.5.32]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.32
+[1.5.31]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.31
+[1.5.30]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.30
+[1.5.29]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.29
+[1.5.28]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.28
+[1.5.27]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.27
+[1.5.26]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.26
+[1.5.25]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.25
+[1.5.23]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.23
+[1.5.19]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.19
+[1.5.18]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.18
+[1.5.17]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.17
+[1.5.16]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.16
+[1.5.15]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.15
+[1.5.14]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.14
+[1.5.13]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.13
+[1.5.11]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.11
+[1.5.10]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.10
+[1.5.9]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.9
+[1.5.8]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.8
+[1.5.7]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.7
+[1.5.6]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.6
+[1.5.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.5
+[1.5.4]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.4
+[1.5.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.3
+[1.5.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.2
+[1.5.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.5.1
+[1.4.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.4.3
+[1.4.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.4.2
+[1.4.0]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.4.0
+[1.3.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.3.1
+[1.2.166]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.166
+[1.2.165]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.165
+[1.2.164]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.164
+[1.2.163]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.163
+[1.2.162]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.162
+[1.2.161]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.161
+[1.2.160]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.160
+[1.2.159]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.159
+[1.2.158]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.158
+[1.2.68]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.68
+[1.2.67]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.67
+[1.2.36]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.36
+[1.2.24]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.24
+[1.2.20]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.20
+[1.2.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.5
+[1.2.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.3
+[1.2.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.2
+[1.2.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.1
+[1.2.0]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.2.0
+[1.1.0]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.1.0
+[1.0.0]: https://github.com/nubbymong/claude-command-center/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,7 @@
-# Claude Command Center
+# Claude Command Center — Claude Code entry point
 
-Multi-session Claude Code terminal orchestrator built with Electron 39 + React 18 + TypeScript.
+The canonical agent instructions live in `AGENTS.md` (the cross-tool standard,
+read by every agent that runs in this repo). This file imports it so Claude Code
+picks up exactly the same brief — keep instructions in `AGENTS.md`, not here.
 
-## Build & Run
-
-```bash
-npm run dev          # Development with HMR
-npm run build        # Production build (electron-vite)
-npm run typecheck    # tsc --noEmit
-npm run test:unit    # vitest
-npm run test:e2e     # playwright
-npm run test         # both
-```
-
-## Architecture
-
-- **Main process** (`src/main/`): Electron main, PTY management (node-pty), IPC handlers, config persistence, statusline, vision MCP server, cloud agents, tokenomics
-- **Renderer** (`src/renderer/`): React 18 SPA with Zustand stores, xterm.js terminals, Tailwind CSS v4
-- **Preload** (`src/preload/`): IPC bridge - all renderer↔main communication goes through typed channels
-- **Shared** (`src/shared/`): Types and IPC channel constants used by both processes
-
-### Key patterns
-
-- IPC handlers are in `src/main/ipc/` - one file per domain (pty, config, logs, etc.)
-- Config persistence via `src/main/config-manager.ts` - JSON files in a user-selected resources directory
-- Stores in `src/renderer/stores/` - Zustand, hydrated from config on startup
-- Terminal rendering via xterm.js with WebGL addon
-- SSH sessions use node-pty to spawn ssh.exe, with automated setup scripts for statusline/vision
-
-## Coding Conventions
-
-- No default exports (except React components that are the sole export of their file)
-- Tailwind v4 with `@theme` in `src/renderer/styles.css` - no tailwind.config file
-- Catppuccin Mocha color palette (base, mantle, crust, surface0-2, overlay0-2, subtext0-1, text, etc.)
-- Never import Node.js modules (path, fs, etc.) in renderer - use IPC
-- Never use `\u{...}` Unicode escapes in JSX - esbuild doesn't support them. Use `String.fromCodePoint()` or SVG
-- PTY writes: only chunk large pastes (>256B). Never queue all writes - causes severe input lag
-- xterm.js scrollback: keep at 10000 max. Higher values cause ~1GB RAM per terminal
-
-## Testing
-
-- Unit tests: `vitest` in `tests/unit/`
-- E2E tests: Playwright in `tests/e2e/`
-- Run `npx vitest run` for fast unit test feedback
-- Tests mock Electron APIs - no real PTY/window in unit tests
-
-## Release Process
-
-RC-branch model (adopted with #89): `beta` is never frozen — features merge there continuously; each release stabilizes on its own branch.
-
-- Feature/fix work: branch off `beta`, PR back into `beta` (owner review + green CI required)
-- To stabilize a release: cut `release/vX.Y.Z` from `beta`; on that branch bump `package.json` (e.g. `2.0.0-rc.2`), commit `build(release): <version>`, push, then `gh workflow run release.yml --ref release/vX.Y.Z -f channel=beta -f skip_vt=false` and watch it to green
-- RC-branch fixes are back-ported to `beta`; features never merge into a release branch
-- Prerelease tags: `-beta.N` and `-rc.N` — both ride the beta update channel; rc outranks beta, final outranks rc
-- Promote to stable: merge `release/vX.Y.Z` → `main`, run the release workflow from `main` with `channel=stable`, then delete the release branch
-- GitHub Actions builds Windows (.exe) + macOS (.dmg) + Linux (.AppImage, experimental) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
-- Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
-- Never commit secrets, .env files, or personal paths
+@AGENTS.md

--- a/CONTEXT.d/2026-07-18-agents-md-canonical.md
+++ b/CONTEXT.d/2026-07-18-agents-md-canonical.md
@@ -1,0 +1,22 @@
+## 2026-07-18 -- AGENTS.md made canonical; CLAUDE.md imports it
+
+Decision recorded in architecture/decisions/2026-07-18-adr-004-agents-md-canonical-agent-brief.md.
+
+Ensured every agent that runs in the repo gets the same brief, from the file its
+tool actually reads.
+
+- Reversed the 2026-07-17 call that gitignored root AGENTS.md as "personal/local".
+  Removed `AGENTS.md` from .gitignore (breadcrumb comment left; git check-ignore
+  now returns not-ignored).
+- AGENTS.md (root, tracked) is now the canonical cross-tool agent brief: migrated
+  the old CLAUDE.md project content, corrected stack versions to Electron 42 /
+  React 19, added a "Deeper references" section linking docs/agent-conventions.md,
+  CONTRIBUTING.md, ADRs, and the operational guides.
+- CLAUDE.md reduced to a short header + `@AGENTS.md` import (Claude-Code-specific;
+  other tools read AGENTS.md directly as literal text, so AGENTS.md holds the real
+  content).
+- docs/agent-conventions.md intro updated to name AGENTS.md as the canonical brief
+  it expands on.
+
+Note: the outer non-git workspace (C:\Users\severson\Projects\Claude Command
+Center) has its own AGENTS.md/PROJECT.md; unrelated to this repo.

--- a/CONTEXT.d/2026-07-18-changelog-and-commit-standards.md
+++ b/CONTEXT.d/2026-07-18-changelog-and-commit-standards.md
@@ -1,0 +1,46 @@
+## 2026-07-18 -- Changelog generation + Conventional Commit enforcement
+
+Decision recorded in architecture/decisions/2026-07-18-adr-003-changelog-and-commit-standards.md.
+
+Added standard changelog/release-note tooling. Gap before: 48 tags but no root
+CHANGELOG.md, GitHub release bodies were a hardcoded placeholder + checksums line
+(release.yml), and the commit convention was habit-only (CONTRIBUTING said just
+"imperative, <72 chars"). The rich user-facing notes already lived in
+src/renderer/changelog.ts (in-app "What's New" modal); nothing surfaced them
+elsewhere.
+
+Decision: single source of truth = src/renderer/changelog.ts. Derive everything
+from it rather than maintain notes twice. Full commit enforcement. No backfill of
+historical GitHub release bodies (going forward only).
+
+- scripts/gen-changelog.js (zero-dep, CJS): parses the changelog array out of the
+  TS source by bracket-matching the literal and eval-ing it (no TS toolchain).
+  Modes: default writes CHANGELOG.md (Keep a Changelog format, feature->Added,
+  improvement->Changed, fix->Fixed); `--check` fails on drift; `--notes <ver>`
+  prints one version's release-note markdown (empty if no entry).
+  - Parser gotcha fixed: must start the array scan AFTER the `=`, else
+    indexOf('[') matches the `[` in the `ChangelogEntry[]` type annotation and
+    yields an empty array.
+- CHANGELOG.md generated (70 versions) and committed. It is TRACKED (unlike the
+  CARP CONTEXT.md aggregate) because it is the GitHub-facing artifact; drift is
+  guarded by CI instead of being untracked.
+- package.json: scripts `changelog`, `changelog:check`, `prepare: husky`; devDeps
+  @commitlint/cli, @commitlint/config-conventional, husky. Installed with
+  --ignore-scripts to avoid the electron-rebuild postinstall.
+- commitlint.config.js: config-conventional + `deps` type (Dependabot prefix),
+  header-max-length 120, body/footer line-length rules disabled to fit the repo's
+  detailed commit style.
+- Enforcement: .husky/commit-msg (commitlint --edit) blocks local bad commits;
+  .github/workflows/pr-title.yml lints the PR title (squash-merge -> title is the
+  subject). Historical compound types (docs+chore:, docs+ci:) are now invalid.
+- release.yml: `Generate release notes` step runs gen-changelog.js --notes for the
+  built version; the create step builds RELEASE_BODY.md (title + channel label +
+  notes or checksums-only fallback) and passes --notes-file. Rolling re-release
+  branch still leaves existing notes untouched.
+- ci.yml: new always-on `changelog` job (not gated on the `ci-run` label) runs
+  gen-changelog.js --check.
+- CONTRIBUTING.md + CLAUDE.md updated to document the commit convention and the
+  generate-then-commit changelog workflow.
+
+Workflow now: edit changelog.ts -> `npm run changelog` -> commit both files. Release
+notes populate automatically from the same source.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,44 @@ We cut a dedicated RC branch for every release cycle so that `beta` stays open f
 
 ## Commit Messages
 
-- Keep the first line under 72 characters
-- Use imperative mood ("Add feature" not "Added feature")
-- Reference issues where applicable (`Fixes #123`)
+This project follows [Conventional Commits](https://www.conventionalcommits.org/).
+The format is enforced two ways, so a non-conforming message is caught before it lands:
+
+- **Locally:** a Husky `commit-msg` hook runs commitlint on every `git commit`
+  (installed automatically the first time you run `npm install`).
+- **In CI:** because PRs are squash-merged, the **PR title** becomes the commit
+  subject — the `PR Title` workflow lints it against the same rules.
+
+Format:
+
+```
+<type>(<optional scope>): <imperative subject>
+```
+
+- **Allowed types:** `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`,
+  `ci`, `chore`, `style`, `revert`, `deps` (`deps` is reserved for Dependabot).
+- Use imperative mood ("add feature", not "added feature").
+- Aim for a subject under 72 characters (hard cap 120).
+- One type per subject — compound types like `docs+chore:` are **not** valid.
+- Reference issues/PRs where applicable (`Fixes #123`).
+
+Examples: `feat(sessions): add per-session rename`, `fix(terminal): restore caret under WebGL`.
+
+Rules live in `commitlint.config.js`.
+
+## Changelog & Release Notes
+
+The changelog is **generated**, not hand-edited. The single source of truth is
+`src/renderer/changelog.ts` (it also drives the in-app "What's New" modal).
+
+- When your change is user-facing, add an entry to the top of the array in
+  `src/renderer/changelog.ts` (type: `feature` | `fix` | `improvement`).
+- Run `npm run changelog` to regenerate the root `CHANGELOG.md`, and commit both files.
+- CI (`Changelog in sync`) fails if `CHANGELOG.md` is stale — run
+  `npm run changelog:check` locally to verify.
+- The release workflow reads the same source to populate the **GitHub release
+  notes** automatically (`scripts/gen-changelog.js --notes <version>`), so there
+  is nothing to paste by hand at release time.
 
 ## What We're Looking For
 

--- a/architecture/decisions/2026-07-18-adr-003-changelog-and-commit-standards.md
+++ b/architecture/decisions/2026-07-18-adr-003-changelog-and-commit-standards.md
@@ -1,0 +1,88 @@
+# ADR-003: Generated changelog + Conventional Commit enforcement
+
+- **Status:** Accepted (2026-07-18)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-18-changelog-and-commit-standards.md, CONTRIBUTING.md ("Commit Messages", "Changelog & Release Notes"), scripts/gen-changelog.js, commitlint.config.js
+
+## Context
+
+The repo shipped 48 tagged releases with no discoverable change history and no
+enforced commit convention:
+
+- **No root `CHANGELOG.md`.** The only real change history lived in
+  `src/renderer/changelog.ts` — a hand-authored, typed array (`feature` | `fix` |
+  `improvement`) that drives the in-app "What's New" modal. Excellent content,
+  invisible on GitHub.
+- **Empty GitHub release notes.** `release.yml` wrote a hardcoded body (release
+  title + channel label + "checksums are in CHECKSUMS.txt") for every release.
+  Nothing surfaced the actual changes.
+- **Commit convention by habit only.** History already looked like Conventional
+  Commits (`feat`/`fix`/`perf`/…), but `CONTRIBUTING.md` asked only for
+  "imperative mood, <72 chars." Nothing enforced it, so automated note
+  generation could not rely on the format.
+
+The constraint that shaped the decision: the curated, user-facing wording in
+`changelog.ts` is the valuable asset. Any solution that regenerated notes from
+raw commit subjects (semantic-release style) would regress that quality.
+
+## Decision
+
+**Single source of truth = `src/renderer/changelog.ts`. Derive `CHANGELOG.md` and
+GitHub release notes from it. Enforce Conventional Commits. Do not backfill
+historical release bodies.**
+
+1. **Generator (`scripts/gen-changelog.js`, zero-dependency CJS).** Parses the
+   `changelog` array out of the TS source by bracket-matching the literal and
+   evaluating it (no TS toolchain in the path). Modes:
+   - default → writes `CHANGELOG.md` in Keep a Changelog format
+     (`feature`→Added, `improvement`→Changed, `fix`→Fixed);
+   - `--check` → non-zero exit on drift;
+   - `--notes <version>` → prints one version's release-note markdown (empty if
+     the version has no entry).
+   Exposed as `npm run changelog` / `npm run changelog:check`.
+2. **`CHANGELOG.md` is generated but TRACKED.** Unlike the CARP `CONTEXT.md`
+   aggregate (untracked to avoid merge-queue conflicts, per the running-log
+   protocol), `CHANGELOG.md` is the GitHub-facing artifact and must be committed.
+   Drift is prevented by a CI gate rather than by leaving it untracked.
+3. **Release notes auto-populate.** `release.yml` runs `gen-changelog.js --notes`
+   for the built version and passes the result to `gh release create` via
+   `--notes-file` (title + channel label + notes, or a checksums-only fallback
+   when no entry exists). The existing rolling-re-release path still leaves an
+   existing release's notes untouched.
+4. **Conventional Commits, enforced two ways.** `commitlint.config.js`
+   (`@commitlint/config-conventional` + a `deps` type for Dependabot;
+   `header-max-length` 120; body/footer line-length rules disabled to fit the
+   repo's detailed commit style). Enforced by a Husky `commit-msg` hook locally
+   and by the `PR Title` workflow in CI (squash-merge makes the PR title the
+   commit subject).
+5. **CI drift gate.** `ci.yml` gains an always-on `changelog` job (NOT gated on
+   the `ci-run` label) that runs `gen-changelog.js --check`.
+
+Contributor workflow: edit `changelog.ts` → `npm run changelog` → commit both
+files.
+
+## Consequences
+
+- One edit site (`changelog.ts`) feeds the in-app modal, `CHANGELOG.md`, and
+  GitHub release notes. No double-maintenance, no paste-at-release-time step.
+- **Rejected: full commit automation (semantic-release / conventional-changelog).**
+  Lowest manual effort, but it would replace the curated user-facing wording with
+  raw commit subjects — a quality regression given the existing `changelog.ts`
+  investment.
+- **Rejected: `CHANGELOG.md` as the source of truth.** More conventional, but it
+  would re-tool the working in-app-modal pipeline and duplicate the typed
+  structure already in `changelog.ts`.
+- **No backfill of historical release bodies.** The 48 existing releases keep
+  their bare bodies; only new releases get generated notes. A future
+  `gh release edit` loop over tags with a matching `changelog.ts` entry could
+  backfill if wanted.
+- **Behavioral change for contributors:** compound commit types (`docs+chore:`,
+  `docs+ci:`) used occasionally in history are now rejected — one type per
+  subject. Relaxable via `type-enum` if the team wants compounds back.
+- **Local hooks require `npm install`.** The `commit-msg` hook only activates
+  after Husky's `prepare` runs (i.e. once a contributor installs deps); the
+  `PR Title` CI check is the backstop for anyone who bypasses hooks or edits via
+  the web UI.
+- Cost: one new script, one config, one workflow, one CI job, and three
+  devDependencies (`@commitlint/cli`, `@commitlint/config-conventional`,
+  `husky`).

--- a/architecture/decisions/2026-07-18-adr-004-agents-md-canonical-agent-brief.md
+++ b/architecture/decisions/2026-07-18-adr-004-agents-md-canonical-agent-brief.md
@@ -1,0 +1,67 @@
+# ADR-004: AGENTS.md is the canonical, tracked, cross-tool agent brief
+
+- **Status:** Accepted (2026-07-18)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-18-agents-md-canonical.md, CONTEXT.d/2026-07-17-ccc-launcher-and-docs-protocol.md (the decision this reverses), CLAUDE.md, AGENTS.md, docs/agent-conventions.md
+
+## Context
+
+Instructions for agents were fragmented and, worse, not reliably delivered to
+every agent that runs in the repo:
+
+- `CLAUDE.md` (read only by Claude Code) held a full project brief.
+- `docs/agent-conventions.md` (tracked) held the detailed conventions.
+- Root `AGENTS.md` — the emerging **cross-tool** standard read by Codex, Cursor,
+  Copilot and others — was **gitignored** (2026-07-17 docs-protocol adoption
+  treated it as "Personal/local config"). So the one file most non-Claude agents
+  look for was never committed: a fresh clone or CI checkout had no `AGENTS.md`.
+
+Goal: any agent executing in the repo picks up the same instructions, from the
+file its tool actually reads.
+
+Two constraints shaped the design:
+
+1. **`@import` is Claude-Code-specific.** Other agents read `AGENTS.md` as literal
+   text and do not expand `@path` imports — so `AGENTS.md` must contain real
+   content, not merely reference other files.
+2. **Avoid a third divergent copy.** `docs/agent-conventions.md` already exists as
+   the deep-dive; `AGENTS.md` should be the canonical entry point that points to
+   it, not duplicate every detail.
+
+## Decision
+
+**Make `AGENTS.md` the canonical, tracked, cross-tool agent brief; reduce
+`CLAUDE.md` to a one-line import of it.**
+
+1. **Un-ignore `AGENTS.md`.** Remove it from `.gitignore` (breadcrumb comment left
+   in place). This reverses the 2026-07-17 "AGENTS.md is personal/local" call —
+   that rationale is obsolete now that the file is the shared source.
+2. **`AGENTS.md` (root, tracked) = canonical brief.** Migrated from the old
+   `CLAUDE.md` content (build/run, architecture, coding conventions, testing,
+   release/changelog/commit standards, CARP protocol), corrected to the actual
+   stack versions (Electron 42 / React 19), plus a "Deeper references" section
+   linking `docs/agent-conventions.md`, `CONTRIBUTING.md`, the ADRs, and the
+   operational guides.
+3. **`CLAUDE.md` = `@AGENTS.md`.** A short header plus the import, so Claude Code
+   gets the identical brief with no second copy to maintain.
+4. **`docs/agent-conventions.md` stays the deep-dive.** Its intro now names
+   `AGENTS.md` as the canonical brief it expands on.
+
+## Consequences
+
+- Every agent tool reads the same instructions from the file it natively loads:
+  Claude Code via `CLAUDE.md → @AGENTS.md`, others via `AGENTS.md` directly. CI
+  and fresh clones now ship the brief.
+- Single edit site: change `AGENTS.md`; `CLAUDE.md` follows automatically.
+- **Reverses ADR-adjacent prior decision.** The 2026-07-17 fragment's "root
+  AGENTS.md is gitignored" note is now superseded; see the breadcrumb in
+  `.gitignore` and the new CONTEXT.d fragment.
+- **Some overlap remains** between `AGENTS.md` and `docs/agent-conventions.md`
+  (architecture, hard constraints). Deliberate: `AGENTS.md` must be self-contained
+  for non-Claude agents; `agent-conventions.md` carries the exhaustive detail.
+  Keep them in sync on *structural* changes only (per the CARP doc rule).
+- **Anyone who kept a personal, uncommitted `AGENTS.md`** at the repo root would
+  find it now tracked — it must be moved out (e.g. to `.agents/`, still ignored)
+  before committing.
+- Watch for stale stack-version strings elsewhere (e.g. `docs/agent-conventions.md`
+  still says "React 18"); correct opportunistically.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,42 @@
+// Conventional Commits enforcement (commitlint).
+//
+// Applied two ways:
+//   - locally via the .husky/commit-msg hook (blocks a bad `git commit`)
+//   - in CI via .github/workflows/pr-title.yml (checks the PR *title*, which
+//     becomes the squash-merge commit subject)
+//
+// Kept deliberately close to the project's existing habits so enforcement
+// documents reality rather than fighting it.
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Allowed types. Standard Conventional set plus `deps` — Dependabot is
+    // configured (.github/dependabot.yml) to prefix its PRs with `deps`.
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'deps',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
+    // This repo's subjects run long and descriptive (often with trailing PR
+    // refs). 120 keeps them honest without rejecting the established style;
+    // aim for ~72 per CONTRIBUTING.md.
+    'header-max-length': [2, 'always', 120],
+    // Commit bodies here carry detailed rationale with long lines and URLs.
+    // Don't hard-wrap-police them.
+    'body-max-line-length': [0, 'always', Infinity],
+    'footer-max-line-length': [0, 'always', Infinity],
+  },
+}

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -1,9 +1,9 @@
 # Agent & contributor conventions
 
 Working conventions for AI agents and contributors in this repo. Read this
-before making changes. It complements `README.md` (what the product is),
-`CONTRIBUTING.md` (contributor mechanics), and `CLAUDE.md` (harness-specific
-instructions).
+before making changes. It expands on `AGENTS.md` (the canonical, cross-tool agent
+brief; `CLAUDE.md` just imports it via `@AGENTS.md`) and complements `README.md`
+(what the product is) and `CONTRIBUTING.md` (contributor mechanics).
 
 ## Build, run, test
 
@@ -25,7 +25,7 @@ npm run test:e2e     # Playwright
 - **Main** (`src/main/`): Electron main — PTY (node-pty), IPC handlers
   (`src/main/ipc/`, one file per domain), config/session persistence, statusline,
   vision MCP, cloud agents, tokenomics, the forked logging/tokenomics workers.
-- **Renderer** (`src/renderer/`): React 18 SPA, Zustand stores
+- **Renderer** (`src/renderer/`): React 19 SPA, Zustand stores
   (`src/renderer/stores/`), xterm.js terminals (WebGL addon), Tailwind v4.
 - **Preload** (`src/preload/`): the typed IPC bridge — ALL renderer↔main traffic.
 - **Shared** (`src/shared/`): types + IPC channel constants used by both sides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@commitlint/cli": "^21.2.1",
+        "@commitlint/config-conventional": "^21.2.0",
         "@electron/rebuild": "^4.0.4",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.3.1",
@@ -38,6 +40,7 @@
         "electron": "42.4.0",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
+        "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
@@ -441,6 +444,448 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
+      "integrity": "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-conventional": "^21.2.0",
+        "@commitlint/format": "^21.2.0",
+        "@commitlint/lint": "^21.2.0",
+        "@commitlint/load": "^21.2.0",
+        "@commitlint/read": "^21.2.1",
+        "@commitlint/types": "^21.2.0",
+        "tinyexec": "^1.0.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+      "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-conventionalcommits": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+      "integrity": "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+      "integrity": "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "es-toolkit": "^1.46.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
+      "integrity": "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
+      "integrity": "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
+      "integrity": "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^21.2.0",
+        "@commitlint/parse": "^21.2.0",
+        "@commitlint/rules": "^21.2.0",
+        "@commitlint/types": "^21.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
+      "integrity": "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.2.0",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
+        "is-plain-obj": "^4.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+      "integrity": "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
+      "integrity": "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-angular": "^9.0.0",
+        "conventional-commits-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.1.tgz",
+      "integrity": "sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
+        "@conventional-changelog/git-client": "^3.0.0",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
+      "integrity": "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
+        "es-toolkit": "^1.46.0",
+        "global-directory": "^5.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
+      "integrity": "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^21.2.0",
+        "@commitlint/message": "^21.2.0",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+      "integrity": "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+      "integrity": "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^7.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
+      "integrity": "sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^2.0.0",
+        "@simple-libs/stream-utils": "^2.0.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-parser": "^7.0.1"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@conventional-changelog/git-client/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -3055,6 +3500,35 @@
         "win32"
       ]
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+      "integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+      "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -4349,6 +4823,19 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -4843,6 +5330,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001800",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
@@ -5114,6 +5611,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/conventional-changelog-angular": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+      "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5170,6 +5710,61 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/cross-dirname": {
@@ -6460,6 +7055,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6974,6 +7579,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -7107,6 +7725,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/globalthis": {
@@ -7371,6 +8015,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -7410,6 +8070,33 @@
       "license": "MIT",
       "dependencies": {
         "pica": "^7.1.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/inflight": {
@@ -7463,6 +8150,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7513,6 +8207,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -7720,6 +8427,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8095,6 +8809,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.18.1",
@@ -8924,6 +9645,38 @@
       "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -9667,6 +10420,16 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test:e2e": "npx playwright test",
     "release": "node scripts/release.js",
     "promote": "node scripts/promote.js",
+    "changelog": "node scripts/gen-changelog.js",
+    "changelog:check": "node scripts/gen-changelog.js --check",
+    "prepare": "husky",
     "update-server": "node scripts/update-server.js",
     "postinstall": "electron-rebuild --only=node-pty,better-sqlite3",
     "rebuild": "electron-rebuild",
@@ -46,6 +49,8 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.2.1",
+    "@commitlint/config-conventional": "^21.2.0",
     "@electron/rebuild": "^4.0.4",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.1",
@@ -56,6 +61,7 @@
     "electron": "42.4.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",

--- a/scripts/gen-changelog.js
+++ b/scripts/gen-changelog.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Changelog generator — single source of truth is src/renderer/changelog.ts.
+ *
+ * That TS file is the hand-authored, user-facing changelog (it also drives the
+ * in-app "What's New" modal). This script derives everything else from it so we
+ * never maintain the same notes twice:
+ *
+ *   node scripts/gen-changelog.js            Write CHANGELOG.md (Keep a Changelog)
+ *   node scripts/gen-changelog.js --check    Exit 1 if CHANGELOG.md is stale
+ *   node scripts/gen-changelog.js --notes V  Print release-note markdown for
+ *                                            version V to stdout (empty if the
+ *                                            version has no entry). Used by
+ *                                            .github/workflows/release.yml to
+ *                                            populate the GitHub release body.
+ *
+ * changelog.ts entries carry typed changes: 'feature' | 'fix' | 'improvement'.
+ * We map those to Keep-a-Changelog section headings (Added / Fixed / Changed).
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const PROJECT_ROOT = path.resolve(__dirname, '..')
+const SOURCE = path.join(PROJECT_ROOT, 'src', 'renderer', 'changelog.ts')
+const OUTPUT = path.join(PROJECT_ROOT, 'CHANGELOG.md')
+const REPO_URL = 'https://github.com/nubbymong/claude-command-center'
+
+// changelog.ts change-type -> Keep a Changelog section. Order here is the order
+// sections render within a version block.
+const SECTIONS = [
+  { type: 'feature', heading: 'Added' },
+  { type: 'improvement', heading: 'Changed' },
+  { type: 'fix', heading: 'Fixed' },
+]
+
+/**
+ * Pull the `changelog` array out of the TS source without a TS toolchain.
+ * The array is a pure data literal (strings/arrays/objects, no runtime calls),
+ * so we slice out the literal by bracket-matching and evaluate it in isolation.
+ */
+function loadChangelog() {
+  const src = fs.readFileSync(SOURCE, 'utf-8')
+  const anchor = src.indexOf('changelog: ChangelogEntry[] =')
+  if (anchor === -1) {
+    throw new Error(`Could not find "changelog: ChangelogEntry[] =" in ${SOURCE}`)
+  }
+  // Start AFTER the `=` — searching from `anchor` would match the `[` in the
+  // `ChangelogEntry[]` type annotation instead of the array literal.
+  const eq = src.indexOf('=', anchor)
+  const start = src.indexOf('[', eq)
+  if (start === -1) throw new Error('Could not find start of changelog array')
+
+  // Bracket-match, ignoring brackets that appear inside string literals.
+  let depth = 0
+  let end = -1
+  let inString = false
+  let quote = ''
+  for (let i = start; i < src.length; i++) {
+    const ch = src[i]
+    if (inString) {
+      if (ch === '\\') { i++; continue } // skip escaped char
+      if (ch === quote) inString = false
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inString = true; quote = ch; continue }
+    if (ch === '[') depth++
+    else if (ch === ']') {
+      depth--
+      if (depth === 0) { end = i; break }
+    }
+  }
+  if (end === -1) throw new Error('Could not find end of changelog array')
+
+  const literal = src.slice(start, end + 1)
+  // eslint-disable-next-line no-new-func — trusted, in-repo data literal only.
+  const entries = new Function(`return (${literal})`)()
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('Parsed changelog is empty or not an array')
+  }
+  return entries
+}
+
+/** Render the grouped change sections for one entry (shared by file + notes). */
+function renderSections(entry) {
+  const lines = []
+  for (const { type, heading } of SECTIONS) {
+    const items = (entry.changes || []).filter((c) => c.type === type)
+    if (items.length === 0) continue
+    lines.push(`### ${heading}`)
+    for (const c of items) lines.push(`- ${c.description}`)
+    lines.push('')
+  }
+  return lines
+}
+
+/** Full CHANGELOG.md text. */
+function renderChangelog(entries) {
+  const out = []
+  out.push('# Changelog')
+  out.push('')
+  out.push('All notable changes to Claude Command Center are documented here.')
+  out.push('')
+  out.push('The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),')
+  out.push('and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).')
+  out.push('')
+  out.push('> **Generated file — do not edit by hand.** The source of truth is')
+  out.push('> `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`')
+  out.push('> (CI enforces that this file is in sync via `npm run changelog:check`).')
+  out.push('')
+
+  for (const entry of entries) {
+    out.push(`## [${entry.version}] - ${entry.date}`)
+    out.push('')
+    if (entry.highlights) {
+      out.push(`> ${entry.highlights}`)
+      out.push('')
+    }
+    out.push(...renderSections(entry))
+  }
+
+  // Reference-style links: each version -> its release tag.
+  for (const entry of entries) {
+    out.push(`[${entry.version}]: ${REPO_URL}/releases/tag/v${entry.version}`)
+  }
+  out.push('')
+
+  return out.join('\n')
+}
+
+/** Release-note body for a single version (GitHub release). Empty if unknown. */
+function renderNotes(entries, version) {
+  const entry = entries.find((e) => e.version === version)
+  if (!entry) return ''
+  const out = []
+  if (entry.highlights) {
+    out.push(entry.highlights)
+    out.push('')
+  }
+  out.push(...renderSections(entry))
+  out.push(`**Full changelog:** ${REPO_URL}/blob/v${version}/CHANGELOG.md`)
+  return out.join('\n').trimEnd() + '\n'
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const entries = loadChangelog()
+
+  const notesIdx = args.indexOf('--notes')
+  if (notesIdx !== -1) {
+    const version = args[notesIdx + 1]
+    if (!version) {
+      console.error('--notes requires a version argument')
+      process.exit(2)
+    }
+    process.stdout.write(renderNotes(entries, version))
+    return
+  }
+
+  const content = renderChangelog(entries)
+
+  if (args.includes('--check')) {
+    const existing = fs.existsSync(OUTPUT) ? fs.readFileSync(OUTPUT, 'utf-8') : ''
+    // Compare EOL-insensitively: the file is written with LF, but a Windows
+    // checkout under core.autocrlf=true can present it as CRLF on disk. Without
+    // this, the check would spuriously fail for Windows devs while passing in
+    // Linux CI. (.gitattributes also pins CHANGELOG.md to LF as defense in depth.)
+    const norm = (s) => s.replace(/\r\n/g, '\n')
+    if (norm(existing) !== norm(content)) {
+      console.error('CHANGELOG.md is out of sync with src/renderer/changelog.ts.')
+      console.error('Run `npm run changelog` and commit the result.')
+      process.exit(1)
+    }
+    console.log('CHANGELOG.md is in sync.')
+    return
+  }
+
+  fs.writeFileSync(OUTPUT, content, 'utf-8')
+  console.log(`Wrote ${path.relative(PROJECT_ROOT, OUTPUT)} (${entries.length} versions).`)
+}
+
+main()


### PR DESCRIPTION
Implements changelog/release-note tooling and makes AGENTS.md the canonical agent brief. Two commits (kept separate — please **rebase-merge**, not squash):

**1. `chore(changelog)` — ADR-003**
- `scripts/gen-changelog.js` generates `CHANGELOG.md` (Keep a Changelog) and per-version GitHub release notes from the single source `src/renderer/changelog.ts`
- `CHANGELOG.md` added (70 versions); `.gitattributes` pins it + the husky hook to LF (autocrlf-proof)
- Conventional Commits enforced: `commitlint.config.js` + husky `commit-msg` hook + `PR Title` workflow
- `ci.yml` gains an always-on `Changelog in sync` drift gate; `release.yml` injects the generated notes via `--notes-file`
- `CONTRIBUTING.md` documents the commit convention + changelog workflow

**2. `docs(agents)` — ADR-004**
- Un-ignores `AGENTS.md` and makes it the canonical cross-tool brief; `CLAUDE.md` reduced to `@AGENTS.md`
- `docs/agent-conventions.md` updated; stack versions corrected (Electron 42 / React 19)

See `architecture/decisions/2026-07-18-adr-003-*` and `-adr-004-*`.
