### PR TITLE
fix(accounts): recover orphaned per-profile projects for cross-account resume (#131)

### DIFF
--- a/CONTEXT.d/2026-07-19-cross-account-resume-orphan-repair.md
+++ b/CONTEXT.d/2026-07-19-cross-account-resume-orphan-repair.md
@@ -1,0 +1,30 @@
+## 2026-07-19 -- Cross-account resume: recover orphaned per-profile projects dirs (#131)
+
+Session transcripts are meant to be SHARED across accounts: each profile's
+`.claude/projects` is a junction into the shared `~/.claude/projects`, so discovery
+(which scans `os.homedir()/.claude/projects`) already sees every account's sessions
+and resume works cross-account. The bug: the junction can silently fail to establish.
+
+`ensureLink` (account-profiles.ts) only replaced an EMPTY dir or an existing link. If
+a REAL, non-empty `projects` dir already existed at the link path — Claude wrote
+transcripts there before the junction was set up — `rmdirSync` threw ENOTEMPTY
+(swallowed) and `symlinkSync` threw EEXIST, so the junction never formed and that
+account's sessions were orphaned in an isolated real folder, invisible to every other
+account. Observed on the dev machine: one of four profiles had a real `projects` dir
+with 170 `.jsonl` transcripts that existed nowhere else.
+
+Fix (merge + repair, scoped to `projects` — uuid filenames are union-safe):
+- `ensureLink(target, link, mergeOrphans=true)` for the `projects` junction now
+  union-moves an orphaned real dir into the shared store before junctioning
+  (`mergeTreeInto`), keeping the LARGER file on a name collision (a transcript only
+  grows, so larger = more complete → history never lost). If the dir can't be fully
+  drained (e.g. a cross-volume copy failed), it skips junctioning that pass rather
+  than lose data (`removeTreeIfDrained` returns false → bail).
+- `repairSharedProjectJunctions()` runs at startup (index.ts, beside
+  `migrateProfilesToHomeLayout`) across ALL profiles, so existing orphans are
+  recovered at launch, not only when that account is next spawned. Idempotent + best
+  effort; per-profile failures don't abort the sweep.
+- Deliberately NOT applied to `memory` (curated MEMORY.md index is not union-safe) or
+  the synced config dirs (agents/skills/commands/plugins) — only `projects`.
+- Tests: `tests/unit/account-profiles-orphan-repair.test.ts` (merge, keep-larger both
+  directions, cross-profile sweep, idempotency). Full account-profiles suite green.

--- a/src/main/account-profiles.ts
+++ b/src/main/account-profiles.ts
@@ -180,14 +180,94 @@ function realHomeDir(): string {
 // everything else mirrors the real home so tools behave identically.
 const HOME_PRIVATE = new Set(['.claude', '.claude.json'])
 
-function ensureLink(target: string, link: string): void {
+/**
+ * Union-move the contents of an orphaned REAL dir (inside a fake home) into the
+ * app-shared target so nothing is orphaned; the caller then replaces the drained
+ * dir with a junction. Reads only from `src` (a fake home) and writes only into
+ * `dest` (the shared ~/.claude store) -- NEVER the real home. On a filename
+ * collision keeps the LARGER file: a session transcript only grows, so the larger
+ * copy is the more complete one and conversation history is never lost.
+ */
+function mergeTreeInto(src: string, dest: string): void {
+  let entries: fs.Dirent[]
+  try { entries = fs.readdirSync(src, { withFileTypes: true }) } catch { return }
+  fs.mkdirSync(dest, { recursive: true })
+  for (const e of entries) {
+    const s = path.join(src, e.name)
+    const d = path.join(dest, e.name)
+    let st: fs.Stats
+    try { st = fs.lstatSync(s) } catch { continue }
+    if (st.isSymbolicLink()) continue          // never chase a link out of the fake home
+    if (st.isDirectory()) { mergeTreeInto(s, d); continue }
+    try {
+      let dstat: fs.Stats | null = null
+      try { dstat = fs.statSync(d) } catch { /* absent */ }
+      if (!dstat) {
+        try { fs.renameSync(s, d) }             // fast move (same volume)
+        catch { fs.copyFileSync(s, d); fs.rmSync(s, { force: true }) } // cross-volume
+      } else if (st.size > dstat.size) {
+        fs.rmSync(d, { force: true })
+        try { fs.renameSync(s, d) } catch { fs.copyFileSync(s, d); fs.rmSync(s, { force: true }) }
+      } else {
+        fs.rmSync(s, { force: true })           // dest is >= complete; drop the dominated dup
+      }
+    } catch { /* leave un-drained; removeTreeIfDrained preserves it and skips junctioning */ }
+  }
+}
+
+/**
+ * Remove `dir` (a drained fake-home dir) bottom-up. Returns true only if the whole
+ * tree was empty/removed; if any file survived the merge (e.g. a cross-volume copy
+ * failed), it is LEFT in place and false is returned so the caller does NOT junction
+ * over it -- preserving data beats establishing the junction (retried next spawn).
+ */
+function removeTreeIfDrained(dir: string): boolean {
+  let entries: fs.Dirent[]
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return true }
+  let drained = true
+  for (const e of entries) {
+    const full = path.join(dir, e.name)
+    let st: fs.Stats
+    try { st = fs.lstatSync(full) } catch { drained = false; continue }
+    if (st.isDirectory() && !st.isSymbolicLink()) {
+      if (!removeTreeIfDrained(full)) drained = false
+    } else {
+      drained = false                           // a leftover file/link -> preserve, not drained
+    }
+  }
+  if (drained) { try { fs.rmdirSync(dir) } catch { drained = false } }
+  return drained
+}
+
+/**
+ * Point `link` at `target` as a junction/symlink. `link` is ALWAYS inside a fake
+ * home; we only replace our own link there, never the target.
+ *
+ * `mergeOrphans` (used for the shared `projects` store): if `link` is a pre-existing
+ * REAL directory -- e.g. Claude wrote transcripts there before the junction was ever
+ * established, orphaning them from every other account (#131) -- union-merge its
+ * contents into the shared `target` first, then junction. A non-empty real dir would
+ * otherwise block symlinkSync (EEXIST) forever, and those sessions would never be
+ * discoverable cross-account. If the dir can't be fully drained, we skip junctioning
+ * this pass rather than lose data.
+ */
+function ensureLink(target: string, link: string, mergeOrphans = false): void {
   // Replace any existing entry at `link` (safely: never recurse a junction).
   try {
     const st = fs.lstatSync(link)
     if (st.isSymbolicLink()) { try { fs.rmdirSync(link) } catch { fs.unlinkSync(link) } }
-    else if (st.isDirectory()) fs.rmdirSync(link) // only if empty; a real dir we created
+    else if (st.isDirectory()) {
+      if (mergeOrphans) {
+        mergeTreeInto(link, target)
+        if (!removeTreeIfDrained(link)) return  // couldn't drain -> preserve data, don't junction
+      } else {
+        fs.rmdirSync(link) // only if empty; a real dir we created
+      }
+    }
     else fs.unlinkSync(link)
-  // NOTE: a pre-existing REAL non-empty dir at `link` throws ENOTEMPTY here (swallowed) then EEXIST at symlinkSync. That is safe (rmdirSync never deletes non-empty dirs) but surfaces a confusing error; in this feature's flows `link` is always our own junction or absent.
+  // NOTE (non-merge path): a pre-existing REAL non-empty dir at `link` throws ENOTEMPTY
+  // here (swallowed) then EEXIST at symlinkSync. That is safe (rmdirSync never deletes
+  // non-empty dirs). The `projects` junction passes mergeOrphans=true to recover instead.
   } catch { /* not present */ }
   fs.mkdirSync(path.dirname(link), { recursive: true })
   fs.symlinkSync(target, link, isWin ? 'junction' : 'dir')
@@ -264,7 +344,11 @@ function buildHomeLinks(home: string): void {
   for (const name of SHARED_DIR_NAMES) {
     const target = path.join(shared, name)
     if (!fs.existsSync(target)) fs.mkdirSync(target, { recursive: true })
-    ensureLink(target, path.join(claudeDir, name))
+    // `projects` (session transcripts, uuid filenames -> union-safe) recovers an
+    // orphaned real dir into the shared store before junctioning (#131). Other
+    // shared dirs keep the plain replace-if-empty behavior: `memory` has a curated
+    // MEMORY.md index that is NOT union-safe, and the rest are synced config.
+    ensureLink(target, path.join(claudeDir, name), name === 'projects')
   }
   const srcSettings = path.join(shared, 'settings.json')
   if (fs.existsSync(srcSettings)) fs.copyFileSync(srcSettings, path.join(claudeDir, 'settings.json'))
@@ -283,6 +367,30 @@ export function setupProfileLinks(id: string): void {
   const home = getProfileConfigDir(id)
   fs.mkdirSync(home, { recursive: true })
   buildHomeLinks(home)
+}
+
+/**
+ * Startup repair (#131): recover sessions orphaned in a profile's REAL
+ * `.claude/projects` dir (a junction that never established) by merging them into
+ * the shared store and junctioning, for EVERY profile -- so orphans are visible
+ * cross-account at launch, not only when that account is next spawned. Idempotent
+ * and best-effort: an already-junctioned profile is skipped; a per-profile failure
+ * never aborts the sweep. Only ever touches a profile's own `.claude/projects` and
+ * the shared store.
+ */
+export function repairSharedProjectJunctions(): void {
+  const shared = path.join(sharedRoot(), 'projects')
+  for (const p of listProfiles()) {
+    if (!isValidProfileId(p.id)) continue
+    const link = path.join(getProfileConfigDir(p.id), '.claude', 'projects')
+    let st: fs.Stats
+    try { st = fs.lstatSync(link) } catch { continue }   // absent -> nothing to repair
+    if (st.isSymbolicLink() || !st.isDirectory()) continue // already a junction (or a file)
+    try {
+      fs.mkdirSync(shared, { recursive: true })
+      ensureLink(shared, link, true)                     // merge orphaned transcripts -> junction
+    } catch { /* best-effort; retried next launch/spawn */ }
+  }
 }
 
 /** Re-copy settings.json from shared -> profile's `.claude/` (after shared edits). */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ import { registerNotesHandlers } from './ipc/notes-handlers'
 import { registerVisionHandlers } from './ipc/vision-handlers'
 import { registerConfigHandlers } from './ipc/config-handlers'
 import { registerAccountProfilesHandlers } from './ipc/account-profiles-handlers'
-import { migrateProfilesToHomeLayout, cleanupSessionHomes, syncPrimaryCredentialsWithGlobal } from './account-profiles'
+import { migrateProfilesToHomeLayout, cleanupSessionHomes, syncPrimaryCredentialsWithGlobal, repairSharedProjectJunctions } from './account-profiles'
 import { runFirstRunCapture } from './first-run-accounts'
 import { backupRealClaudeOnce } from './claude-backup'
 import { registerCloudAgentHandlers } from './ipc/cloud-agent-handlers'
@@ -785,6 +785,10 @@ if (!gotTheLock) {
     // profiles isolated only CLAUDE_CONFIG_DIR, which never isolated the account
     // identity). Idempotent + best-effort; never touches the real home.
     try { migrateProfilesToHomeLayout() } catch (e) { logInfo(`[profiles] home-layout migration skipped: ${e}`) }
+    // Recover sessions orphaned in a profile's REAL projects dir (a junction that
+    // never established) into the shared store so they're resumable cross-account
+    // (#131). Idempotent + best-effort; only touches per-profile projects + shared.
+    try { repairSharedProjectJunctions() } catch (e) { logInfo(`[profiles] project-junction repair skipped: ${e}`) }
     // Capture the current global login into a protected "primary" profile so no
     // session runs on the bare global ~/.claude (idempotent; best-effort).
     try { runFirstRunCapture() } catch (e) { logInfo(`[profiles] first-run capture skipped: ${e}`) }

--- a/tests/unit/account-profiles-orphan-repair.test.ts
+++ b/tests/unit/account-profiles-orphan-repair.test.ts
@@ -1,0 +1,102 @@
+// tests/unit/account-profiles-orphan-repair.test.ts
+// #131: a profile whose `.claude/projects` became a REAL dir (the junction never
+// established, e.g. Claude wrote transcripts there first) orphans those sessions
+// from every other account. setupProfileLinks / repairSharedProjectJunctions must
+// merge them into the shared store and replace the dir with a junction, without
+// losing conversation history.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  _setRootsForTest, getProfileConfigDir, setupProfileLinks, upsertProfile,
+  repairSharedProjectJunctions,
+} from '../../src/main/account-profiles'
+
+let tmp: string
+let shared: string
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ap-orphan-'))
+  shared = path.join(tmp, 'shared')
+  _setRootsForTest({ resourcesDir: path.join(tmp, 'resources'), sharedRoot: shared })
+  fs.mkdirSync(path.join(tmp, 'resources'), { recursive: true })
+  fs.mkdirSync(path.join(shared, 'projects'), { recursive: true })
+})
+afterEach(() => { _setRootsForTest(null); try { fs.rmSync(tmp, { recursive: true, force: true }) } catch { /* ignore */ } })
+
+/** Seed a profile whose `.claude/projects` is a REAL dir holding a transcript. */
+function seedOrphan(id: string, project: string, file: string, body: string): string {
+  const proj = path.join(getProfileConfigDir(id), '.claude', 'projects', project)
+  fs.mkdirSync(proj, { recursive: true })
+  fs.writeFileSync(path.join(proj, file), body)
+  return path.join(getProfileConfigDir(id), '.claude', 'projects')
+}
+
+describe('orphaned projects recovery (#131)', () => {
+  it('setupProfileLinks merges an orphaned REAL projects dir into shared and junctions it', () => {
+    const link = seedOrphan('p1', 'C--proj', 'uuid1.jsonl', 'line1\n')
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(false) // REAL dir before
+
+    setupProfileLinks('p1')
+
+    // Transcript recovered into the shared store...
+    const sharedFile = path.join(shared, 'projects', 'C--proj', 'uuid1.jsonl')
+    expect(fs.existsSync(sharedFile)).toBe(true)
+    expect(fs.readFileSync(sharedFile, 'utf8')).toBe('line1\n')
+    // ...and the profile's projects is now a junction reaching the same file.
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(fs.existsSync(path.join(link, 'C--proj', 'uuid1.jsonl'))).toBe(true)
+  })
+
+  it('keeps the LARGER transcript on a filename collision (history never lost)', () => {
+    // shared has a short copy; the orphan has a longer (more complete) one.
+    const sharedProj = path.join(shared, 'projects', 'C--proj')
+    fs.mkdirSync(sharedProj, { recursive: true })
+    fs.writeFileSync(path.join(sharedProj, 'u.jsonl'), 'short')
+    seedOrphan('p1', 'C--proj', 'u.jsonl', 'a much longer, more complete transcript')
+
+    setupProfileLinks('p1')
+
+    expect(fs.readFileSync(path.join(shared, 'projects', 'C--proj', 'u.jsonl'), 'utf8'))
+      .toBe('a much longer, more complete transcript')
+  })
+
+  it('keeps the SHARED transcript when it is the larger one', () => {
+    const sharedProj = path.join(shared, 'projects', 'C--proj')
+    fs.mkdirSync(sharedProj, { recursive: true })
+    fs.writeFileSync(path.join(sharedProj, 'u.jsonl'), 'the shared copy is longer and complete')
+    seedOrphan('p1', 'C--proj', 'u.jsonl', 'stub')
+
+    setupProfileLinks('p1')
+
+    expect(fs.readFileSync(path.join(shared, 'projects', 'C--proj', 'u.jsonl'), 'utf8'))
+      .toBe('the shared copy is longer and complete')
+  })
+
+  it('repairSharedProjectJunctions recovers orphans across all registered profiles', () => {
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    upsertProfile({ id: 'p2', name: 'B', accountEmail: 'b@x.com', createdAt: 2 })
+    const link1 = seedOrphan('p1', 'C--a', 'u1.jsonl', 'from-p1')
+    setupProfileLinks('p2') // p2 is already correctly junctioned (no orphan)
+    const link2 = path.join(getProfileConfigDir('p2'), '.claude', 'projects')
+
+    repairSharedProjectJunctions()
+
+    expect(fs.lstatSync(link1).isSymbolicLink()).toBe(true)            // repaired
+    expect(fs.lstatSync(link2).isSymbolicLink()).toBe(true)           // left junctioned
+    expect(fs.existsSync(path.join(shared, 'projects', 'C--a', 'u1.jsonl'))).toBe(true)
+    expect(fs.readFileSync(path.join(shared, 'projects', 'C--a', 'u1.jsonl'), 'utf8')).toBe('from-p1')
+  })
+
+  it('is idempotent — a second pass over an already-junctioned profile is a no-op', () => {
+    seedOrphan('p1', 'C--proj', 'u.jsonl', 'body')
+    setupProfileLinks('p1')
+    const before = fs.readFileSync(path.join(shared, 'projects', 'C--proj', 'u.jsonl'), 'utf8')
+    // Re-run both entry points; must not throw or corrupt the recovered data.
+    setupProfileLinks('p1')
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    repairSharedProjectJunctions()
+    expect(fs.lstatSync(path.join(getProfileConfigDir('p1'), '.claude', 'projects')).isSymbolicLink()).toBe(true)
+    expect(fs.readFileSync(path.join(shared, 'projects', 'C--proj', 'u.jsonl'), 'utf8')).toBe(before)
+  })
+})


### PR DESCRIPTION
Closes #131

## Problem
Session transcripts are meant to be shared across accounts: each profile's `<profileHome>/.claude/projects` is a junction into the shared `~/.claude/projects`, so discovery sees every account's sessions and resume works cross-account.

But the junction can silently fail. `ensureLink` only replaces an *empty* dir or an existing link; if a real, non-empty `projects` dir already exists (Claude wrote transcripts there before the junction was set up), `rmdirSync` throws `ENOTEMPTY` (swallowed) and `symlinkSync` throws `EEXIST`. That account's sessions are then orphaned in an isolated real folder, invisible to every other account. Observed on-machine: one profile with 170 orphaned `.jsonl` transcripts.

## Fix (merge + repair)
- Teach `ensureLink` (projects junction only) to union-merge an orphaned real dir into the shared target before junctioning: move each transcript into the shared store; on name collision keep the larger file (transcripts only grow → never lose history). Then remove the drained dir and create the junction. If a file can't be drained, bail without junctioning (preserve data; retried next spawn).
- Add a startup repair sweep across all profiles so existing orphans are recovered at launch.
- Scope: `projects` only (uuid filenames → union-safe). Does NOT touch `memory` or synced config dirs.

## Verification
Confirmed working on desktop by the maintainer prior to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)