### PR TITLE
feat(resume): overhaul the resume experience — width, work names, AI titles, XML cleanup, card refresh (#130)

### DIFF
--- a/CONTEXT.d/2026-07-19-resume-prompt-refresh.md
+++ b/CONTEXT.d/2026-07-19-resume-prompt-refresh.md
@@ -1,0 +1,20 @@
+## 2026-07-19 -- Resume Sessions prompt: refresh + width/layout polish (#130)
+
+The startup "Resume previous sessions?" card (`ResumeSessionsPrompt.tsx`) rendered a
+list captured ONCE at boot — `App.tsx` calls `session.load()` a single time into
+`pendingRestore` (App.tsx:393). A session restarted after launch was therefore
+missing from the list until the app was relaunched.
+
+- **Refresh:** added an optional `onRefresh` prop + a refresh icon button in the card
+  header (spins while loading). `App.tsx` wires it to re-call `session.load()` and
+  update `pendingRestore` via a functional update that KEEPS the current list on a
+  transient empty read (never dismisses the prompt out from under a manual refresh).
+  No main/IPC changes — `session.load()` already existed.
+- **Width/layout:** widened `w-80 -> w-96` (capped `max-w-[calc(100vw-2rem)]`), and gave
+  each row a two-line layout — work name primary, label/path as a muted sub-line — both
+  truncating, so long names are no longer chopped. Count moved to a header badge; the
+  body copy trimmed. Kept it a compact bottom-right card (mouse-only, `tabIndex=-1`, no
+  autofocus — unchanged contract).
+- **Tests:** `tests/unit/renderer/resume-sessions-prompt.test.tsx` updated for the
+  two-line rows and given refresh coverage (button present only when `onRefresh` is
+  passed; click fires it). 7/7 pass; typecheck clean.

--- a/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
+++ b/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
@@ -8,7 +8,16 @@ this branch; this fragment covers the CLI picker.
 Three symptoms, three root causes:
 - **Width:** picker hard-clamped to 78 cols (`Math.min(process.stdout.columns||80, 78)`),
   so title/meta/preview lines truncated on any wider terminal. Fix: `computeLayoutWidth`
-  honors real width (floor 60, ceiling 120).
+  renders to the REAL interface width (floor 60; high 400 sanity bound, NOT an artificial
+  narrow cap — an earlier pass mistakenly capped at 120, which a wide window exceeded).
+  Full message text is still read; only the display truncates per line to this width.
+- **XML noise ate the width:** user messages carry structural markup — slash-command
+  invocations (`<command-name>`/`<command-message>`/`<command-args>`), `<local-command-*>`
+  output, `<system-reminder>` blocks. The old filter only skipped messages *starting with*
+  `<command-name>`/`<local-command`, so `<command-message>` and inline tags leaked through
+  and pushed real content off-screen. Fix: `sanitizeMessageText` strips those tag families
+  AND their contents, collapses whitespace, returns null when nothing meaningful remains
+  (pure-command messages are skipped). `extractUserText` routes through it.
 - **Renamed work name never shown:** the picker only reads Claude transcripts
   (`~/.claude/projects/*.jsonl`) and had no access to session-state.json (where
   `customName` lives). It was spawned with only cwd + forwarded flags. Fix: pty-manager

--- a/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
+++ b/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
@@ -26,6 +26,20 @@ Three symptoms, three root causes:
   Conversations that were renamed sessions now lead with the work name (bold peach), with
   the first user message kept as a dim sub-line so context isn't lost.
 - **Hard to pick:** addressed by the above -- recognizable name up front + wider rows.
+- **"(continued session)" everywhere:** parseConversation only looked at type=user/assistant
+  in the 32KB head; resumed/compacted sessions (head full of mode/attachment/
+  file-history-snapshot/command lines) yielded no clean user text -> the "(continued
+  session)" fallback. DISCOVERY: Claude Code already writes `ai-title` ({aiTitle}) and
+  `last-prompt` ({lastPrompt}) entries per transcript -- the AI summary a session
+  processor would have produced already exists. Fix: parseConversation captures aiTitle +
+  lastPrompt (head AND tail, latest-wins since the .jsonl is append-only), firstMessage is
+  now null-when-absent, and the display picks the best label via a chain:
+  workName -> aiTitle -> firstMessage -> lastPrompt -> last user message -> "(continued
+  session)". Real-data check: 5/6 recent transcripts now show their AI title; the 6th shows
+  a real last message. No custom AI processor needed.
+- Also generalized sanitizeMessageText to strip ANY command-*/local-command-* tag family
+  (backreference-matched), so `<local-command-caveat>` (the "Caveat:" preamble) no longer
+  leaks in.
 
 - **Not renderer-only** (contra the issue body): touches `scripts/resume-picker.js` +
   `src/main/pty-manager.ts` (env injection, best-effort/fail-safe). No IPC/schema changes.

--- a/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
+++ b/CONTEXT.d/2026-07-20-resume-picker-cli-width-worknames.md
@@ -1,0 +1,29 @@
+## 2026-07-20 -- CLI resume-picker: real terminal width + surface CCC work names (#130)
+
+The bug driving #130 is the CLI resume/new-conversation picker (`scripts/resume-picker.js`)
+that runs INSIDE the terminal before Claude opens -- not the React startup card
+(`ResumeSessionsPrompt.tsx`) the issue body originally described. Both are addressed on
+this branch; this fragment covers the CLI picker.
+
+Three symptoms, three root causes:
+- **Width:** picker hard-clamped to 78 cols (`Math.min(process.stdout.columns||80, 78)`),
+  so title/meta/preview lines truncated on any wider terminal. Fix: `computeLayoutWidth`
+  honors real width (floor 60, ceiling 120).
+- **Renamed work name never shown:** the picker only reads Claude transcripts
+  (`~/.claude/projects/*.jsonl`) and had no access to session-state.json (where
+  `customName` lives). It was spawned with only cwd + forwarded flags. Fix: pty-manager
+  sets `CCC_CONFIG_DIR` on the PTY env; `loadWorkNames(configDir)` reads session-state.json
+  and maps `resumeUuid -> customName` (the transcript basename UUID equals resumeUuid).
+  Conversations that were renamed sessions now lead with the work name (bold peach), with
+  the first user message kept as a dim sub-line so context isn't lost.
+- **Hard to pick:** addressed by the above -- recognizable name up front + wider rows.
+
+- **Not renderer-only** (contra the issue body): touches `scripts/resume-picker.js` +
+  `src/main/pty-manager.ts` (env injection, best-effort/fail-safe). No IPC/schema changes.
+- **Tests:** `tests/unit/scripts/resume-picker.test.ts` gains `computeLayoutWidth` (wide/narrow/
+  fallback) and `loadWorkNames` (map, skip-missing, fail-safe) coverage. 62/62 pass;
+  node + web typecheck clean.
+- Env var chosen over passing the name as a flag: it lets the picker label the WHOLE list
+  from one read, and keeps the visible command line clean. The current-session-name-in-header
+  variant was dropped -- customName isn't in the spawn options, and cwd->name is ambiguous
+  when sessions share a cwd; `resumeUuid` gives a precise per-row match instead.

--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -196,11 +196,11 @@ function worktreeLabelFor(worktree) {
 function sanitizeMessageText(raw) {
   if (typeof raw !== 'string') return null
   const text = raw
-    .replace(/<command-name>[\s\S]*?<\/command-name>/gi, ' ')
-    .replace(/<command-message>[\s\S]*?<\/command-message>/gi, ' ')
-    .replace(/<command-args>[\s\S]*?<\/command-args>/gi, ' ')
-    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/gi, ' ')
-    .replace(/<local-command-stderr>[\s\S]*?<\/local-command-stderr>/gi, ' ')
+    // <command-*>…</command-*> (name/message/args) and <local-command-*>…
+    // </local-command-*> (stdout/stderr/caveat/…) — strip tags AND contents.
+    // The backreference keeps each open tag matched to its own close tag.
+    .replace(/<(command-[a-z]+)>[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<(local-command-[a-z]+)>[\s\S]*?<\/\1>/gi, ' ')
     .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, ' ')
     // Leftover unpaired/partial wrapper tags (defensive).
     .replace(/<\/?(?:command-[a-z]+|local-command-[a-z]+|system-reminder)>/gi, ' ')
@@ -247,17 +247,27 @@ function parseConversation(filePath) {
 
     let firstMessage = null
     let model = null
+    // Claude Code writes these metadata entries into the transcript: `ai-title`
+    // is its own concise AI-generated title for the conversation; `last-prompt`
+    // holds the most recent prompt text. They're the best labels when the head
+    // has no clean user message (resumed/compacted sessions), so a conversation
+    // no longer degrades to "(continued session)" (#130). No early break — these
+    // entries sit after the first user/assistant lines, and the head is small.
+    let aiTitle = null
+    let lastPrompt = null
 
     for (const line of headLines) {
       try {
         const obj = JSON.parse(line)
         if (obj.type === 'user' && !firstMessage) {
           firstMessage = extractUserText(obj)
-        }
-        if (obj.type === 'assistant' && obj.message?.model && !model) {
+        } else if (obj.type === 'assistant' && obj.message?.model && !model) {
           model = obj.message.model
+        } else if (obj.type === 'ai-title' && typeof obj.aiTitle === 'string') {
+          aiTitle = obj.aiTitle.trim() || aiTitle
+        } else if (obj.type === 'last-prompt' && typeof obj.lastPrompt === 'string') {
+          lastPrompt = sanitizeMessageText(obj.lastPrompt) || lastPrompt
         }
-        if (firstMessage && model) break
       } catch { /* skip */ }
     }
 
@@ -280,6 +290,11 @@ function parseConversation(filePath) {
         if (obj.type === 'user') {
           const text = extractUserText(obj)
           if (text) recentMessages.push(text)
+        } else if (obj.type === 'ai-title' && typeof obj.aiTitle === 'string' && obj.aiTitle.trim()) {
+          aiTitle = obj.aiTitle.trim() // append-only log: the latest title wins
+        } else if (obj.type === 'last-prompt' && typeof obj.lastPrompt === 'string') {
+          const p = sanitizeMessageText(obj.lastPrompt)
+          if (p) lastPrompt = p // latest wins
         }
       } catch { /* skip */ }
     }
@@ -287,9 +302,13 @@ function parseConversation(filePath) {
     // Last 5 user messages
     const lastMessages = recentMessages.slice(-5)
 
+    // firstMessage stays null when the head had no clean user text — the display
+    // builds the label from the aiTitle/lastPrompt/lastMessages fallback chain.
     return {
       sessionId,
-      firstMessage: (firstMessage || '(continued session)').trim(),
+      aiTitle,
+      firstMessage,
+      lastPrompt,
       lastMessages,
       model,
       mtime: stat.mtimeMs,
@@ -486,10 +505,12 @@ async function main() {
     const conv = conversations[i]
     const num = String(i + 1).padStart(2)
     const workName = workNames.get(conv.sessionId)
-    const firstMsg = conv.firstMessage.replace(/[\r\n]+/g, ' ')
-    // Lead with the recognizable CCC work name when this conversation was a
-    // renamed session; otherwise fall back to the first user message (#130).
-    const primary = workName || firstMsg
+    // Best available label, most→least useful: the user's own work name, then
+    // Claude's AI title, then the first real user message, then the last prompt,
+    // then the most recent user message. "(continued session)" only when the
+    // conversation truly yielded no readable text (#130).
+    const recent = conv.lastMessages.length ? conv.lastMessages[conv.lastMessages.length - 1] : null
+    const primary = workName || conv.aiTitle || conv.firstMessage || conv.lastPrompt || recent || '(continued session)'
     const primaryColored = workName
       ? `${C.bold}${C.peach}${truncate(primary, innerWidth - 6)}${C.reset}`
       : `${C.text}${truncate(primary, innerWidth - 6)}${C.reset}`
@@ -509,9 +530,11 @@ async function main() {
     console.log(titleLine)
     // Meta line
     console.log(`  ${C.surface}│${C.reset}      ${C.overlay}${meta}${C.reset}`)
-    // When we led with the work name, still show what the conversation was about.
-    if (workName) {
-      console.log(`  ${C.surface}│${C.reset}      ${C.dim}${C.subtext}${truncate(firstMsg, innerWidth - 10)}${C.reset}`)
+    // When we led with the work name, show the AI title / first message beneath
+    // so the row still says what the conversation was about.
+    const sub = workName ? (conv.aiTitle || conv.firstMessage || conv.lastPrompt) : null
+    if (sub) {
+      console.log(`  ${C.surface}│${C.reset}      ${C.dim}${C.subtext}${truncate(sub, innerWidth - 10)}${C.reset}`)
     }
 
     // Last 5 user messages (dim, indented)

--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -185,6 +185,30 @@ function worktreeLabelFor(worktree) {
   return null
 }
 
+// ── Sanitize message text ───────────────────────────────────────────
+// The Claude CLI records structural XML inside user messages — slash-command
+// invocations (<command-name>/foo</command-name><command-message>…</command-message>
+// <command-args>…</command-args>), local-command output, and injected
+// <system-reminder> blocks. Left in, this markup fills the row and pushes the
+// real content off-screen (#130). Strip these tag families AND their contents
+// (they're structure, not conversation), collapse whitespace, and return null
+// when nothing meaningful remains (so a pure-command message is skipped).
+function sanitizeMessageText(raw) {
+  if (typeof raw !== 'string') return null
+  const text = raw
+    .replace(/<command-name>[\s\S]*?<\/command-name>/gi, ' ')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/gi, ' ')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/gi, ' ')
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/gi, ' ')
+    .replace(/<local-command-stderr>[\s\S]*?<\/local-command-stderr>/gi, ' ')
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, ' ')
+    // Leftover unpaired/partial wrapper tags (defensive).
+    .replace(/<\/?(?:command-[a-z]+|local-command-[a-z]+|system-reminder)>/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text || null
+}
+
 // ── Extract user text from a message object ─────────────────────────
 function extractUserText(obj) {
   if (obj.isMeta) return null
@@ -200,10 +224,10 @@ function extractUserText(obj) {
     }
   }
   if (!text) return null
-  // Skip commands, caveats, and tool interrupts
-  if (text.startsWith('<command-name>') || text.startsWith('<local-command')
-      || text.startsWith('[Request interrupted')) return null
-  return text.replace(/[\r\n]+/g, ' ').trim()
+  // Tool-interrupt marker — not a tag, so sanitize won't catch it.
+  if (text.startsWith('[Request interrupted')) return null
+  // Strip command / system markup so the picker shows real content, not XML.
+  return sanitizeMessageText(text)
 }
 
 // ── Parse conversation: first message from head, last 5 from tail ───
@@ -380,13 +404,15 @@ function truncate(str, maxLen) {
 }
 
 // ── Layout width ────────────────────────────────────────────────────
-// Honor the real terminal width instead of the old hard 78-col clamp, which
-// truncated the title/meta/preview lines on any wider terminal (#130). Floor 60
-// keeps a narrow terminal usable; ceiling 120 keeps lines readable on very wide
-// ones. Injectable for testing.
+// Render to the REAL interface width — the old hard clamp (78, then 120)
+// truncated content on wide terminals even though the window could show more
+// (#130). We only ever *display* what fits the window; the full message text is
+// read regardless and truncated to this width per line. Floor 60 keeps a narrow
+// terminal usable; a high sanity bound (400) guards a pathological columns value
+// without imposing an artificial narrow cap. Injectable for testing.
 function computeLayoutWidth(columns) {
   const cols = Number(columns) || 80
-  return Math.max(60, Math.min(cols - 4, 120))
+  return Math.max(60, Math.min(cols - 4, 400))
 }
 
 // ── CCC work names ──────────────────────────────────────────────────
@@ -636,6 +662,7 @@ module.exports = {
   parseConversation,
   computeLayoutWidth,
   loadWorkNames,
+  sanitizeMessageText,
 }
 
 if (require.main === module) {

--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -379,6 +379,40 @@ function truncate(str, maxLen) {
   return str.slice(0, maxLen - 1) + '…'
 }
 
+// ── Layout width ────────────────────────────────────────────────────
+// Honor the real terminal width instead of the old hard 78-col clamp, which
+// truncated the title/meta/preview lines on any wider terminal (#130). Floor 60
+// keeps a narrow terminal usable; ceiling 120 keeps lines readable on very wide
+// ones. Injectable for testing.
+function computeLayoutWidth(columns) {
+  const cols = Number(columns) || 80
+  return Math.max(60, Math.min(cols - 4, 120))
+}
+
+// ── CCC work names ──────────────────────────────────────────────────
+// Read the CCC session-state.json (its dir is passed via CCC_CONFIG_DIR by
+// pty-manager) and map each session's resume conversation UUID -> its
+// user-assigned work name (customName, from the rename feature). Lets the picker
+// show the recognizable work name next to the matching conversation instead of
+// only the first user message (#130). The transcript's basename UUID equals the
+// session's resumeUuid (both are what `claude --resume <uuid>` takes).
+// FAIL-SAFE: missing env / file / field / parse error -> empty map. Never throws.
+function loadWorkNames(configDir) {
+  const map = new Map()
+  try {
+    if (!configDir) return map
+    const raw = fs.readFileSync(path.join(configDir, 'session-state.json'), 'utf-8')
+    const data = JSON.parse(raw)
+    const sessions = Array.isArray(data && data.sessions) ? data.sessions : []
+    for (const s of sessions) {
+      const name = s && typeof s.customName === 'string' ? s.customName.trim() : ''
+      const uuid = s && typeof s.resumeUuid === 'string' ? s.resumeUuid : ''
+      if (name && uuid) map.set(uuid, name)
+    }
+  } catch { /* fail-safe */ }
+  return map
+}
+
 // ── Main ────────────────────────────────────────────────────────────
 async function main() {
   const cwd = process.cwd()
@@ -407,9 +441,12 @@ async function main() {
   }
 
   // ── Display ─────────────────────────────────────────────────────
-  const maxWidth = Math.min(process.stdout.columns || 80, 78)
+  const maxWidth = computeLayoutWidth(process.stdout.columns)
   const innerWidth = maxWidth - 6
   const dirDisplay = truncate(cwd, innerWidth)
+
+  // Map resume UUID -> CCC work name so a renamed session is recognizable here.
+  const workNames = loadWorkNames(process.env.CCC_CONFIG_DIR)
 
   console.log('')
   console.log(`  ${C.surface}╭─${C.blue} Resume Conversation ${C.surface}─ ${C.subtext}${dirDisplay} ${C.surface}${'─'.repeat(Math.max(0, maxWidth - 26 - dirDisplay.length))}╮${C.reset}`)
@@ -422,7 +459,14 @@ async function main() {
   for (let i = 0; i < conversations.length; i++) {
     const conv = conversations[i]
     const num = String(i + 1).padStart(2)
-    const title = truncate(conv.firstMessage.replace(/[\r\n]+/g, ' '), innerWidth - 6)
+    const workName = workNames.get(conv.sessionId)
+    const firstMsg = conv.firstMessage.replace(/[\r\n]+/g, ' ')
+    // Lead with the recognizable CCC work name when this conversation was a
+    // renamed session; otherwise fall back to the first user message (#130).
+    const primary = workName || firstMsg
+    const primaryColored = workName
+      ? `${C.bold}${C.peach}${truncate(primary, innerWidth - 6)}${C.reset}`
+      : `${C.text}${truncate(primary, innerWidth - 6)}${C.reset}`
     const meta = [
       timeAgo(conv.mtime),
       formatSize(conv.size),
@@ -432,13 +476,17 @@ async function main() {
 
     // Title line. A non-main worktree conversation gets a distinct themed tag
     // (⑂ = branch/fork glyph) appended so the worktree is CALLED OUT.
-    let titleLine = `  ${C.surface}│${C.reset}  ${C.green}${num}${C.reset}  ${C.text}${title}${C.reset}`
+    let titleLine = `  ${C.surface}│${C.reset}  ${C.green}${num}${C.reset}  ${primaryColored}`
     if (conv.worktreeLabel) {
       titleLine += `  ${C.mauve}⑂ ${truncate(conv.worktreeLabel, 24)}${C.reset}`
     }
     console.log(titleLine)
     // Meta line
     console.log(`  ${C.surface}│${C.reset}      ${C.overlay}${meta}${C.reset}`)
+    // When we led with the work name, still show what the conversation was about.
+    if (workName) {
+      console.log(`  ${C.surface}│${C.reset}      ${C.dim}${C.subtext}${truncate(firstMsg, innerWidth - 10)}${C.reset}`)
+    }
 
     // Last 5 user messages (dim, indented)
     if (conv.lastMessages.length > 0) {
@@ -586,6 +634,8 @@ module.exports = {
   scanWorktreeConversations,
   mergeAndLabel,
   parseConversation,
+  computeLayoutWidth,
+  loadWorkNames,
 }
 
 if (require.main === module) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -39,7 +39,7 @@ import { getProfileConfigDir, setupProfileLinks, getPrimaryProfileId, backupProf
 import { captureClaudeAccount, clearClaudeAccount, getAccountIdentity, pushAccountIdentity, startWatchingAccountIdentity, stopWatchingAccountIdentity, getWatchedProfileId } from './claude-account-identity'
 import type { AccountIdentity } from '../shared/types'
 import { updateSessionMeta, clearSessionMeta } from './session-registry'
-import { readConfig } from './config-manager'
+import { readConfig, getConfigDir } from './config-manager'
 import { getPtyIntegrityMonitor } from './services/pty-integrity-monitor'
 
 import * as path from 'path'
@@ -1035,6 +1035,10 @@ export function spawnPty(
       home = getProfileConfigDir(resolvedProfileId)
     }
     const finalSpawnEnv = withProfileHome(spawnEnv, home)
+    // Give the resume-picker (run inside this PTY) the CONFIG dir so it can read
+    // session-state.json and label conversations with their CCC work name
+    // (customName). Read-only, best-effort — never block the spawn (#130).
+    try { finalSpawnEnv.CCC_CONFIG_DIR = getConfigDir() } catch { /* best-effort */ }
     logInfo(`[profiles] session ${sessionId} account spawn: requestedProfileId=${wantProfileId ?? '(none)'} resolvedProfileId=${resolvedProfileId ?? '(none/bare-global)'} shellOnly=${shellOnly} USERPROFILE=${home ?? '(real home)'}`)
     // Reliable, drift-immune account identity: capture once at spawn from the
     // session's profile (or the default ~/.claude.json), never re-read.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1059,6 +1059,17 @@ export default function App() {
               // conversations themselves stay resumable from inside Claude.
               void window.electronAPI.session.clear()
             }}
+            onRefresh={async () => {
+              // The list is a boot-time snapshot; re-read the saved set so a
+              // session restarted since launch shows up (#130). Keep the current
+              // list on a transient empty read rather than dismissing the prompt.
+              try {
+                const saved = await window.electronAPI.session.load() as SessionState | null
+                setPendingRestore((prev) => (saved && saved.sessions.length > 0 ? saved : prev))
+              } catch (err) {
+                console.error('[App] Resume refresh failed:', err)
+              }
+            }}
           />
         )}
 

--- a/src/renderer/components/ResumeSessionsPrompt.tsx
+++ b/src/renderer/components/ResumeSessionsPrompt.tsx
@@ -9,19 +9,27 @@ import React, { useEffect, useState } from 'react'
  * underlying Claude conversations remain resumable from inside Claude itself).
  * Mouse-driven; it does not autofocus or trap keys (so it never interrupts
  * typing in a terminal).
+ *
+ * The list is a snapshot of the saved set loaded at boot, so a session restarted
+ * after launch would otherwise be missing — `onRefresh` re-reads the saved set in
+ * place so the newest sessions appear without relaunching (#130).
  */
 export default function ResumeSessionsPrompt({
   sessions,
   onResume,
   onDontOpen,
+  onRefresh,
 }: {
   /** The saved sessions that would reopen. Rendered by work name so the user
    *  can see which named windows are coming back before choosing. */
   sessions: Array<{ id: string; label: string; customName?: string }>
   onResume: () => void
   onDontOpen: () => void
+  /** Re-pull the saved set (App re-calls session.load and updates the list). */
+  onRefresh?: () => Promise<void> | void
 }) {
   const [entering, setEntering] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
   const count = sessions.length
 
   useEffect(() => {
@@ -29,8 +37,18 @@ export default function ResumeSessionsPrompt({
     return () => cancelAnimationFrame(id)
   }, [])
 
+  const handleRefresh = async () => {
+    if (!onRefresh || refreshing) return
+    setRefreshing(true)
+    try {
+      await onRefresh()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   const cardClass = [
-    'fixed bottom-4 right-4 z-40 w-80 rounded-xl shadow-2xl p-4',
+    'fixed bottom-4 right-4 z-40 w-96 max-w-[calc(100vw-2rem)] rounded-xl shadow-2xl p-4',
     'transition-all duration-200 ease-out',
     entering ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2',
   ].join(' ')
@@ -43,38 +61,86 @@ export default function ResumeSessionsPrompt({
       aria-labelledby="resume-sessions-heading"
       tabIndex={-1}
     >
-      <h2 id="resume-sessions-heading" className="text-sm font-semibold text-text mb-1">
-        Resume previous sessions?
-      </h2>
-      <p className="text-xs leading-relaxed mb-2" style={{ color: 'var(--text-secondary)' }}>
-        {count.toLocaleString()} saved session{count === 1 ? '' : 's'} from your last run
-        {count === 1 ? ' is' : ' are'} ready to reopen. Choosing &quot;Don&apos;t open&quot; discards
-        the saved cards; your Claude conversations stay resumable from inside Claude.
-      </p>
-      {/* Named list so the user recognizes which windows will reopen. */}
-      <ul className="mb-3 max-h-40 overflow-y-auto rounded-lg" style={{ background: 'var(--surface-overlay, var(--color-surface1))' }}>
-        {sessions.map((s) => (
-          <li
-            key={s.id}
-            className="truncate px-2.5 py-1 text-xs"
-            style={{ color: 'var(--text-primary)' }}
-            title={s.customName?.trim() ? `${s.customName.trim()} (${s.label})` : s.label}
+      <div className="mb-1.5 flex items-center gap-2">
+        <h2 id="resume-sessions-heading" className="min-w-0 flex-1 truncate text-sm font-semibold text-text">
+          Resume previous sessions?
+        </h2>
+        <span
+          className="shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+          style={{ background: 'var(--surface-overlay, var(--color-surface1))', color: 'var(--text-secondary)' }}
+        >
+          {count.toLocaleString()}
+        </span>
+        {onRefresh && (
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            title="Refresh — pick up sessions restarted since launch"
+            aria-label="Refresh sessions"
+            className="shrink-0 rounded-md p-1 transition-colors hover:text-text disabled:opacity-60"
+            style={{ color: 'var(--text-secondary)' }}
           >
-            {s.customName?.trim() || s.label}
-          </li>
-        ))}
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={refreshing ? 'animate-spin' : ''}
+            >
+              <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+              <path d="M21 3v6h-6" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <p className="mb-2 text-xs leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+        Saved from your last run. &quot;Don&apos;t open&quot; discards these cards; your Claude
+        conversations stay resumable from inside Claude.
+      </p>
+
+      {/* Named list so the user recognizes which windows will reopen. */}
+      <ul
+        className="mb-3 max-h-44 overflow-y-auto rounded-lg"
+        style={{ background: 'var(--surface-overlay, var(--color-surface1))' }}
+      >
+        {sessions.map((s) => {
+          const name = s.customName?.trim() || s.label
+          const sub = s.customName?.trim() ? s.label : ''
+          return (
+            <li
+              key={s.id}
+              className="px-2.5 py-1.5 transition-colors hover:bg-[var(--surface-raised)]"
+              title={sub ? `${name} (${sub})` : name}
+            >
+              <div className="truncate text-xs" style={{ color: 'var(--text-primary)' }}>
+                {name}
+              </div>
+              {sub && (
+                <div className="truncate text-[11px] leading-tight" style={{ color: 'var(--text-secondary)' }}>
+                  {sub}
+                </div>
+              )}
+            </li>
+          )
+        })}
       </ul>
+
       <div className="flex items-center justify-end gap-2">
         <button
           onClick={onDontOpen}
-          className="px-3 py-1.5 rounded-lg text-sm text-subtext0 transition-colors hover:text-text"
+          className="rounded-lg px-3 py-1.5 text-sm text-subtext0 transition-colors hover:text-text"
           style={{ background: 'var(--surface-overlay, var(--color-surface1))' }}
         >
           Don&apos;t open
         </button>
         <button
           onClick={onResume}
-          className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+          className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors"
           style={{ background: 'var(--color-blue)', color: 'var(--color-crust)' }}
         >
           Resume

--- a/tests/unit/renderer/resume-sessions-prompt.test.tsx
+++ b/tests/unit/renderer/resume-sessions-prompt.test.tsx
@@ -47,7 +47,7 @@ describe('ResumeSessionsPrompt', () => {
     unmount()
   })
 
-  it('lists each session by its work name (customName over label)', () => {
+  it('lists each session by its work name (customName primary, label as sub-line)', () => {
     const { container, unmount } = renderComponent(
       <ResumeSessionsPrompt
         sessions={[
@@ -58,9 +58,40 @@ describe('ResumeSessionsPrompt', () => {
         onDontOpen={() => {}}
       />,
     )
-    const items = Array.from(container.querySelectorAll('li')).map((li) => li.textContent)
-    expect(items).toContain('IM-8315 keychain fix') // customName wins
-    expect(items).toContain('opus · ~/other')       // falls back to label
+    const items = Array.from(container.querySelectorAll('li'))
+    // Named session: customName is the primary line, label shown as a sub-line.
+    const named = items.find((li) => li.textContent?.includes('IM-8315 keychain fix'))!
+    expect(named).toBeTruthy()
+    expect(named.querySelector('div')?.textContent).toBe('IM-8315 keychain fix')
+    expect(named.textContent).toContain('sonnet · ~/proj')
+    // Unnamed session: label is the primary (and only) line.
+    const unnamed = items.find((li) => li.textContent === 'opus · ~/other')!
+    expect(unnamed).toBeTruthy()
+    unmount()
+  })
+
+  it('shows a refresh control only when onRefresh is given, and it fires onRefresh', async () => {
+    const onRefresh = vi.fn()
+    const { container, unmount } = renderComponent(
+      <ResumeSessionsPrompt
+        sessions={mkSessions(1)}
+        onResume={() => {}}
+        onDontOpen={() => {}}
+        onRefresh={onRefresh}
+      />,
+    )
+    const refresh = container.querySelector<HTMLButtonElement>('button[aria-label="Refresh sessions"]')
+    expect(refresh).toBeTruthy()
+    await act(async () => { refresh!.click() })
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('omits the refresh control when onRefresh is not provided', () => {
+    const { container, unmount } = renderComponent(
+      <ResumeSessionsPrompt sessions={mkSessions(1)} onResume={() => {}} onDontOpen={() => {}} />,
+    )
+    expect(container.querySelector('button[aria-label="Refresh sessions"]')).toBeNull()
     unmount()
   })
 

--- a/tests/unit/scripts/resume-picker.test.ts
+++ b/tests/unit/scripts/resume-picker.test.ts
@@ -21,6 +21,8 @@ const picker = require('../../../scripts/resume-picker.js') as {
     cap?: number,
   ) => Array<{ mtime: number; filePath: string }>
   ensureCompanionDir: (projectDir: string, uuid: string) => boolean
+  computeLayoutWidth: (columns: number | undefined) => number
+  loadWorkNames: (configDir: string | undefined) => Map<string, string>
 }
 
 // ── encodeProjectPath ──────────────────────────────────────────────
@@ -330,5 +332,67 @@ describe('resume-picker mergeAndLabel', () => {
   it('tolerates non-array sources (fail-safe)', () => {
     const out = picker.mergeAndLabel([null, undefined, [{ sessionId: 'y', mtime: 1, filePath: '/p/y.jsonl', worktreeLabel: null }]] as never)
     expect(out).toHaveLength(1)
+  })
+})
+
+// ── computeLayoutWidth (#130 width fix) ─────────────────────────────
+describe('resume-picker computeLayoutWidth', () => {
+  it('honors a wide terminal instead of the old 78-col clamp (capped at 120)', () => {
+    expect(picker.computeLayoutWidth(200)).toBe(120)
+    expect(picker.computeLayoutWidth(100)).toBe(96) // cols - 4
+  })
+
+  it('floors at 60 for a narrow terminal', () => {
+    expect(picker.computeLayoutWidth(40)).toBe(60)
+    expect(picker.computeLayoutWidth(10)).toBe(60)
+  })
+
+  it('falls back to 80 columns when width is unknown (→ 76)', () => {
+    expect(picker.computeLayoutWidth(undefined)).toBe(76)
+    expect(picker.computeLayoutWidth(0)).toBe(76)
+  })
+})
+
+// ── loadWorkNames (#130: surface the renamed session's work name) ────
+describe('resume-picker loadWorkNames', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccc-worknames-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  const write = (state: unknown) =>
+    writeFileSync(join(dir, 'session-state.json'), JSON.stringify(state), 'utf-8')
+
+  it('maps resumeUuid -> customName for renamed sessions', () => {
+    write({
+      sessions: [
+        { id: 'a', resumeUuid: 'uuid-1', customName: 'Billing refactor' },
+        { id: 'b', resumeUuid: 'uuid-2', customName: '  Docs sweep  ' }, // trimmed
+      ],
+    })
+    const map = picker.loadWorkNames(dir)
+    expect(map.get('uuid-1')).toBe('Billing refactor')
+    expect(map.get('uuid-2')).toBe('Docs sweep')
+    expect(map.size).toBe(2)
+  })
+
+  it('skips sessions without a customName or without a resumeUuid', () => {
+    write({
+      sessions: [
+        { id: 'a', resumeUuid: 'uuid-1' },                    // no name
+        { id: 'b', customName: 'Named but no uuid' },         // no uuid
+        { id: 'c', resumeUuid: 'uuid-3', customName: '   ' }, // blank name
+        { id: 'd', resumeUuid: 'uuid-4', customName: 'Keep' },
+      ],
+    })
+    const map = picker.loadWorkNames(dir)
+    expect(map.size).toBe(1)
+    expect(map.get('uuid-4')).toBe('Keep')
+  })
+
+  it('is fail-safe: missing dir, missing file, or bad JSON → empty map', () => {
+    expect(picker.loadWorkNames(undefined).size).toBe(0)
+    expect(picker.loadWorkNames(dir).size).toBe(0) // no file written yet
+    writeFileSync(join(dir, 'session-state.json'), '{ not json', 'utf-8')
+    expect(picker.loadWorkNames(dir).size).toBe(0)
   })
 })

--- a/tests/unit/scripts/resume-picker.test.ts
+++ b/tests/unit/scripts/resume-picker.test.ts
@@ -15,7 +15,7 @@ const picker = require('../../../scripts/resume-picker.js') as {
   scanWorktreeConversations: (
     wt: { path: string; branch: string | null; isMain: boolean },
     claudeProjectsDir: string,
-  ) => Array<{ sessionId: string; mtime: number; size: number; filePath: string; sourceCwd: string; worktreeLabel: string | null; firstMessage: string; lastMessages: string[] }>
+  ) => Array<{ sessionId: string; mtime: number; size: number; filePath: string; sourceCwd: string; worktreeLabel: string | null; firstMessage: string | null; aiTitle: string | null; lastPrompt: string | null; lastMessages: string[] }>
   mergeAndLabel: (
     conversationsBySource: Array<Array<{ mtime: number; filePath: string }>>,
     cap?: number,
@@ -224,6 +224,47 @@ describe('resume-picker scanWorktreeConversations', () => {
     expect(out).toEqual([])
   })
 
+  it('surfaces ai-title + last-prompt; a command-only first message is skipped (#130)', () => {
+    const wtPath = join(projectsDir, '..', 'titled-repo')
+    const dir = join(projectsDir, picker.encodeProjectPath(wtPath))
+    mkdirSync(dir, { recursive: true })
+    const uuid = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+    const lines = [
+      JSON.stringify({ type: 'last-prompt', lastPrompt: 'wire up the release notes' }),
+      JSON.stringify({ type: 'ai-title', aiTitle: 'Add changelog infrastructure' }),
+      // First user message is a pure slash command → sanitized to null, skipped.
+      JSON.stringify({ type: 'user', message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } }),
+      JSON.stringify({ type: 'user', message: { content: 'now do the AGENTS.md migration' } }),
+    ]
+    const pad = JSON.stringify({ type: 'file-history-snapshot', data: 'x'.repeat(200) })
+    for (let i = 0; i < 200; i++) lines.push(pad)
+    writeFileSync(join(dir, `${uuid}.jsonl`), lines.join('\n') + '\n')
+    const out = picker.scanWorktreeConversations({ path: wtPath, branch: 'main', isMain: true }, projectsDir)
+    expect(out).toHaveLength(1)
+    expect(out[0].aiTitle).toBe('Add changelog infrastructure')
+    expect(out[0].lastPrompt).toBe('wire up the release notes')
+    // The first *clean* user message wins for firstMessage (command-only skipped).
+    expect(out[0].firstMessage).toBe('now do the AGENTS.md migration')
+  })
+
+  it('firstMessage is null when the head has no clean user text (→ display falls back)', () => {
+    const wtPath = join(projectsDir, '..', 'nofirst-repo')
+    const dir = join(projectsDir, picker.encodeProjectPath(wtPath))
+    mkdirSync(dir, { recursive: true })
+    const uuid = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    const lines = [
+      JSON.stringify({ type: 'ai-title', aiTitle: 'Only a title here' }),
+      JSON.stringify({ type: 'user', message: { content: '<command-name>/clear</command-name>' } }),
+    ]
+    const pad = JSON.stringify({ type: 'system', message: 'x'.repeat(200) })
+    for (let i = 0; i < 200; i++) lines.push(pad)
+    writeFileSync(join(dir, `${uuid}.jsonl`), lines.join('\n') + '\n')
+    const out = picker.scanWorktreeConversations({ path: wtPath, branch: 'main', isMain: true }, projectsDir)
+    expect(out).toHaveLength(1)
+    expect(out[0].firstMessage).toBeNull()
+    expect(out[0].aiTitle).toBe('Only a title here')
+  })
+
   it('THE FIX: lists a direct-work transcript that has NO companion dir', () => {
     // The root-cause bug: a conversation that never spawned a subagent/workflow
     // has no companion dir, so the old companion-dir gate hid it from the picker
@@ -374,6 +415,10 @@ describe('resume-picker sanitizeMessageText', () => {
     expect(picker.sanitizeMessageText('<command-args>--flag x</command-args>real')).toBe('real')
     expect(picker.sanitizeMessageText('keep<local-command-stdout>noise</local-command-stdout>')).toBe('keep')
     expect(picker.sanitizeMessageText('<system-reminder>be nice</system-reminder>fix the bug')).toBe('fix the bug')
+  })
+
+  it('strips a local-command-caveat block (real-world head noise)', () => {
+    expect(picker.sanitizeMessageText('<local-command-caveat>Caveat: messages below were generated…</local-command-caveat>the real ask')).toBe('the real ask')
   })
 
   it('removes leftover unpaired wrapper tags and collapses whitespace', () => {

--- a/tests/unit/scripts/resume-picker.test.ts
+++ b/tests/unit/scripts/resume-picker.test.ts
@@ -23,6 +23,7 @@ const picker = require('../../../scripts/resume-picker.js') as {
   ensureCompanionDir: (projectDir: string, uuid: string) => boolean
   computeLayoutWidth: (columns: number | undefined) => number
   loadWorkNames: (configDir: string | undefined) => Map<string, string>
+  sanitizeMessageText: (raw: unknown) => string | null
 }
 
 // ── encodeProjectPath ──────────────────────────────────────────────
@@ -337,9 +338,9 @@ describe('resume-picker mergeAndLabel', () => {
 
 // ── computeLayoutWidth (#130 width fix) ─────────────────────────────
 describe('resume-picker computeLayoutWidth', () => {
-  it('honors a wide terminal instead of the old 78-col clamp (capped at 120)', () => {
-    expect(picker.computeLayoutWidth(200)).toBe(120)
-    expect(picker.computeLayoutWidth(100)).toBe(96) // cols - 4
+  it('renders to the real interface width (no artificial 120 clamp)', () => {
+    expect(picker.computeLayoutWidth(200)).toBe(196) // cols - 4, wide window
+    expect(picker.computeLayoutWidth(100)).toBe(96)
   })
 
   it('floors at 60 for a narrow terminal', () => {
@@ -347,9 +348,46 @@ describe('resume-picker computeLayoutWidth', () => {
     expect(picker.computeLayoutWidth(10)).toBe(60)
   })
 
+  it('caps at a 400-col sanity bound for pathological widths', () => {
+    expect(picker.computeLayoutWidth(10000)).toBe(400)
+  })
+
   it('falls back to 80 columns when width is unknown (→ 76)', () => {
     expect(picker.computeLayoutWidth(undefined)).toBe(76)
     expect(picker.computeLayoutWidth(0)).toBe(76)
+  })
+})
+
+// ── sanitizeMessageText (#130: strip command/system XML) ────────────
+describe('resume-picker sanitizeMessageText', () => {
+  it('drops a pure slash-command invocation entirely (→ null)', () => {
+    const raw = '<command-name>/compact</command-name><command-message>compact</command-message>'
+    expect(picker.sanitizeMessageText(raw)).toBeNull()
+  })
+
+  it('strips command markup but keeps surrounding prose', () => {
+    const raw = 'before <command-message>running foo</command-message> after'
+    expect(picker.sanitizeMessageText(raw)).toBe('before after')
+  })
+
+  it('strips command-args, local-command output, and system-reminder blocks', () => {
+    expect(picker.sanitizeMessageText('<command-args>--flag x</command-args>real')).toBe('real')
+    expect(picker.sanitizeMessageText('keep<local-command-stdout>noise</local-command-stdout>')).toBe('keep')
+    expect(picker.sanitizeMessageText('<system-reminder>be nice</system-reminder>fix the bug')).toBe('fix the bug')
+  })
+
+  it('removes leftover unpaired wrapper tags and collapses whitespace', () => {
+    expect(picker.sanitizeMessageText('a  <command-message>\n\n b')).toBe('a b')
+  })
+
+  it('is fail-safe for non-strings and empties', () => {
+    expect(picker.sanitizeMessageText(undefined)).toBeNull()
+    expect(picker.sanitizeMessageText(123)).toBeNull()
+    expect(picker.sanitizeMessageText('   ')).toBeNull()
+  })
+
+  it('leaves normal prose untouched (whitespace-collapsed)', () => {
+    expect(picker.sanitizeMessageText('Fix the login redirect loop')).toBe('Fix the login redirect loop')
   })
 })
 


### PR DESCRIPTION
Fixes the resume experience end to end (#130). **Squash-merge** — this PR title becomes the commit.

### CLI resume-picker (`scripts/resume-picker.js` + `pty-manager.ts`)
- **Width** — dropped the hard 78/120-col clamp; renders to the real terminal width (floor 60, 400 sanity bound). Full message text is read; only per-line display truncates.
- **Work names** — `pty-manager` passes `CCC_CONFIG_DIR`; the picker maps `resumeUuid → customName` and leads renamed sessions with their work name.
- **AI titles instead of "(continued session)"** — reads Claude Code's own `ai-title` + `last-prompt` entries (head & tail, latest wins). Label chain: work name → AI title → first user message → last prompt → last message → "(continued session)". *(No custom summarizer — the AI title already exists.)*
- **XML cleanup** — `sanitizeMessageText` strips any `command-*` / `local-command-*` (incl. `<local-command-caveat>`) and `<system-reminder>` blocks that were eating the row.

### Startup card (`ResumeSessionsPrompt.tsx`)
- Refresh control, wider card, two-line rows, count badge.

### Tests
- `tests/unit/scripts/resume-picker.test.ts` (+ card test): width, work-name map, `ai-title`/`last-prompt` extraction, XML/caveat stripping, null-firstMessage. 72/72 pass; typecheck clean.
