### PR TITLE
docs(process): codify the in-beta issue lifecycle (label on beta-merge, close on main)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 - Promote to stable: merge `release/vX.Y.Z` → `main`, run the release workflow from `main` with `channel=stable`, then delete the release branch
 - Changelog is generated from `src/renderer/changelog.ts` (single source; also drives the in-app "What's New" modal). Before a release, add the version's entry there, run `npm run changelog` to refresh `CHANGELOG.md`, and commit both. `release.js` already syncs the version line; the release workflow auto-populates the GitHub release notes from the same file (`scripts/gen-changelog.js --notes <version>`) — no hand-pasting. CI (`Changelog in sync`) fails on drift
 - Commits/PR titles follow Conventional Commits, enforced by a Husky `commit-msg` hook and the `PR Title` workflow (`commitlint.config.js`)
+- Issue lifecycle: label an issue `in-beta` (don't close it) when its fix merges to `beta`; close it only when the change promotes to `main`. See CONTRIBUTING.md ("Issue lifecycle")
 - GitHub Actions builds Windows (.exe) + macOS (.dmg) + Linux (.AppImage, experimental) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
 - Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
 - Never commit secrets, .env files, or personal paths

--- a/CONTEXT.d/2026-07-20-in-beta-issue-lifecycle.md
+++ b/CONTEXT.d/2026-07-20-in-beta-issue-lifecycle.md
@@ -1,0 +1,19 @@
+## 2026-07-20 -- Issue lifecycle: `in-beta` label for beta-merged-but-unshipped
+
+Adopted a three-state issue lifecycle to distinguish "merged to beta / in testing"
+from "shipped in main", instead of closing issues the moment a fix hits `beta`.
+
+- Why: GitHub only auto-closes issues on merges to the DEFAULT branch (`main`),
+  never on `beta`. Under the RC-branch model, fixes live on `beta` (in testing)
+  well before a stable `main` release. Closing on beta-merge hides "shipped"
+  behind "merged, still baking".
+- States: open/no-label = todo; open + `in-beta` = fix merged to beta, in testing;
+  closed = promoted to `main` (shipped).
+- Label `in-beta` created (amber). Applied to the currently beta-merged-but-open
+  issues: #117, #119, #120, and #130 (which had been prematurely closed on
+  beta-merge; reopened + labeled).
+- Documented in CONTRIBUTING.md ("Issue lifecycle (beta vs. main)") and AGENTS.md
+  (one-line pointer so agents apply it). Partially addresses the governance
+  codification ask (#116).
+- Close-on-promotion is MANUAL for now; automating it (a GitHub Action that closes
+  `in-beta` issues covered by a main promotion) is tracked in #134.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,27 @@ We cut a dedicated RC branch for every release cycle so that `beta` stays open f
 - Fixes made on the RC branch are back-ported to `beta` so the next cycle keeps them.
 - When the RC is accepted, merge `release/vX.Y.Z` → `main`, then delete the RC branch.
 
+### Issue lifecycle (beta vs. main)
+
+Because fixes merge to `beta` (in testing) long before they ship in a stable
+`main` release, an issue has three states — don't close an issue the moment its
+fix hits `beta`:
+
+- **Open, no status label** — not yet fixed (todo / in progress).
+- **Open, labeled `in-beta`** — the fix is merged to `beta` and in testing, but
+  not yet shipped. Apply `in-beta` when the fixing PR merges to `beta`, and add a
+  comment naming that PR.
+- **Closed (completed)** — the fix has promoted to `main` (shipped in a stable
+  release). Only then close the issue.
+
+Rationale: GitHub only auto-closes issues on merges to the **default** branch
+(`main`), never on `beta` merges — so beta-merged issues won't self-close, and
+closing them early hides "shipped" behind "merged, still baking." The generated
+`CHANGELOG.md`/release notes show the same distinction per version.
+
+At `main` promotion, the `in-beta` issues covered by the release are closed and
+the label removed. This step is manual today; automating it is tracked in #134.
+
 ## Commit Messages
 
 This project follows [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
Codifies the `in-beta` issue-lifecycle convention adopted this cycle (see #134 for the close-on-promotion automation follow-up).

- **CONTRIBUTING.md** — new "Issue lifecycle (beta vs. main)" subsection: open/no-label = todo; open + `in-beta` = merged to beta, in testing; closed = promoted to `main`.
- **AGENTS.md** — one-line pointer so agents apply the label.
- Partially addresses the governance codification ask (#116).

Squash-merge.