### PR TITLE
fix(hooks): merge inherited user/project hooks into per-session settings (#137)

### DIFF
--- a/CONTEXT.d/2026-07-22-merge-inherited-hooks.md
+++ b/CONTEXT.d/2026-07-22-merge-inherited-hooks.md
@@ -1,0 +1,26 @@
+## 2026-07-22 -- CCC merges inherited hooks into per-session --settings (#137)
+
+Decision recorded in architecture/decisions/2026-07-22-adr-005-merge-inherited-hooks.md.
+
+Bug: CCC-launched sessions didn't run hooks a plain `claude` would in the same
+folder. `injectHooks` set `settings.hooks = buildHooksBlock(...)` (CCC HTTP hooks
+ONLY), and Claude treats a `--settings` `hooks` key as an OVERRIDE (not a
+concatenating array — confirmed via docs + the user's empirical carp-hook case).
+So project `.claude/settings.json` hooks (e.g. carp-hook.ps1) were shadowed.
+
+- `session-hooks-writer.ts`: added `resolveInheritedHooks(cwd, homeDir)` — reads
+  + concatenates hooks from user (~/.claude/settings.json), project
+  (<root>/.claude/settings.json), and project-local (settings.local.json). Project
+  root found by walking up from cwd to the nearest `.claude`, bounded by the home
+  dir (so ~/.claude is only the user source, and the walk never escapes home).
+  `injectHooks` now writes `concat(inherited, cccHooks)` with byte-identical
+  dedupe. `injectHooks` gained a `cwd` arg (pty-manager passes `claudeCwd`).
+- `homeDir` param is a test seam (default os.homedir()); os.homedir() isn't
+  env-overridable on macOS, and — noted during testing — in the sandboxed agent
+  env os.homedir() is a profile dir while os.tmpdir() is not under it, which is
+  why the walk must be bounded by the passed homeDir, not the real home.
+- Scope: LOCAL sessions only. SSH (ssh-shim.ts) resolves against a remote FS —
+  separate follow-up. Enterprise "managed" settings outrank --settings anyway.
+- Tests: tests/unit/hooks/session-hooks-writer.test.ts — merge of project+CCC,
+  user+project+local ordering, nested-cwd walk-up, dedupe, fail-safe empty. 13/13;
+  broader hooks + per-session suites 90/90; node typecheck clean.

--- a/architecture/decisions/2026-07-22-adr-005-merge-inherited-hooks.md
+++ b/architecture/decisions/2026-07-22-adr-005-merge-inherited-hooks.md
@@ -1,0 +1,56 @@
+# ADR-005: Per-session settings merge inherited hooks instead of replacing them
+
+- **Status:** Accepted (2026-07-22)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-22-merge-inherited-hooks.md, #137, src/main/hooks/session-hooks-writer.ts, src/main/hooks/per-session-settings.ts
+
+## Context
+
+CCC launches Claude with a per-session `--settings <file>` whose `hooks` key it
+sets to **only** CCC's HTTP gateway hooks (`injectHooks` did
+`settings.hooks = buildHooksBlock(...)`). Claude Code treats a `--settings`
+`hooks` key as an **override**, not a concatenating array (verified against the
+docs: `hooks` is absent from the documented merge-able-array list; empirically a
+project hook stops firing under `--settings`). Result: user- and project-level
+hooks are shadowed — a project `.claude/settings.json` command hook (e.g.
+`carp-hook.ps1`) fires in a direct `claude` session but **never** in a
+CCC-launched one. `per-session-settings.ts` compounded it by cloning only the
+*user* `~/.claude/settings.json`, never the project settings.
+
+Goal: a CCC session should do everything a plain `claude` would in the same
+folder, **plus** CCC's gateway hooks.
+
+## Decision
+
+**CCC resolves the hooks Claude would inherit for the session's launch cwd and
+merges them with its own hooks before writing the `--settings` file** (Option A —
+pre-merge; the alternative of relying on Claude to merge is impossible given the
+override semantics).
+
+- `resolveInheritedHooks(cwd, homeDir)` reads and concatenates hooks, low→high
+  precedence: user `~/.claude/settings.json`, project `<root>/.claude/settings.json`,
+  project-local `<root>/.claude/settings.local.json`. The project root is found by
+  walking up from cwd to the nearest `.claude`, **bounded by the home dir** (so
+  `~/.claude` is only ever the user source, never a "project", and the walk never
+  escapes home into other users/system).
+- `injectHooks` sets `settings.hooks = concat(inherited, cccGatewayHooks)` —
+  inherited entries keep their order; CCC's http entries (unique per-session URL)
+  are appended. Byte-identical entries are de-duplicated as a guard against
+  double-firing.
+- `homeDir` is an injectable seam (defaults to `os.homedir()`) purely so unit
+  tests are hermetic; `os.homedir()` is not overridable via env on macOS.
+
+## Consequences
+
+- CCC sessions now run inherited user/project/local hooks **and** the CCC gateway
+  hooks. The reported `carp-hook.ps1` case works.
+- FAIL-SAFE throughout: missing/unparseable settings contribute nothing and never
+  block session spawn (matches the rest of the hooks pipeline).
+- **Enterprise "managed" settings** outrank `--settings` regardless, so folding
+  them in wouldn't change Claude's resolution — left to Claude (out of scope).
+- **SSH remote sessions are NOT covered.** `ssh-shim.ts` builds the hooks literal
+  against a *remote* filesystem the main process can't read at settings-write
+  time; merging remote-inherited hooks there is a separate follow-up.
+- If Claude ever changes `hooks` to a concatenating array, our pre-merge would
+  risk double-adding project hooks — the byte-identical dedupe guards the common
+  case, and this ADR records the assumption to revisit.

--- a/src/main/hooks/session-hooks-writer.ts
+++ b/src/main/hooks/session-hooks-writer.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import os from 'node:os'
 import type { HookEventKind } from '../../shared/hook-types'
 
 // Injected hook events. SubagentStart/SubagentStop bracket subagent and
@@ -22,6 +23,13 @@ export interface InjectArgs {
   settingsPath: string
   port: number
   secret: string
+  /** The directory Claude launches in. Used to resolve the user/project hooks
+   *  Claude would otherwise apply, so they can be MERGED with CCC's hooks
+   *  instead of shadowed by the --settings override (#137). */
+  cwd: string
+  /** Test-only override for the user-settings home dir. Defaults to
+   *  os.homedir(); production callers omit it. */
+  homeDir?: string
 }
 
 export interface RemoveArgs {
@@ -62,12 +70,121 @@ export function buildHooksBlock(
   return hooks
 }
 
-// NOTE: this writer is NOT diff-aware. It rewrites the entire `hooks` key
-// on every inject. Per-session settings files are ours to manage — if a
-// user hand-edits hooks in one of them their edits are lost on next spawn.
+/**
+ * Read the `hooks` object out of a settings JSON file, keeping only
+ * array-valued events. FAIL-SAFE: missing/unparseable/odd-shaped → {}.
+ */
+function readHooksFrom(file: string): Record<string, unknown[]> {
+  try {
+    const raw = fs.readFileSync(file, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    const hooks = parsed && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>).hooks
+      : undefined
+    if (hooks && typeof hooks === 'object' && !Array.isArray(hooks)) {
+      const out: Record<string, unknown[]> = {}
+      for (const [event, arr] of Object.entries(hooks as Record<string, unknown>)) {
+        if (Array.isArray(arr)) out[event] = arr.slice()
+      }
+      return out
+    }
+  } catch { /* missing / unparseable — contributes nothing */ }
+  return {}
+}
+
+/**
+ * Walk up from `cwd` to the nearest ancestor holding a `.claude/settings.json`
+ * or `.claude/settings.local.json` — Claude's project-settings root. Returns
+ * that `.claude` dir, or null. FAIL-SAFE.
+ *
+ * The walk STOPS at the home directory: `~/.claude` is the USER source (read
+ * separately), never a "project", and we must not escape home into other users
+ * or system dirs. `homeCeiling` defaults to os.homedir() (overridable for tests).
+ */
+function findProjectClaudeDir(cwd: string, homeCeiling: string = os.homedir()): string | null {
+  try {
+    const ceiling = path.resolve(homeCeiling)
+    let dir = path.resolve(cwd)
+    for (;;) {
+      if (dir === ceiling) return null // reached home — user source covers it
+      const claudeDir = path.join(dir, '.claude')
+      if (fs.existsSync(path.join(claudeDir, 'settings.json')) ||
+          fs.existsSync(path.join(claudeDir, 'settings.local.json'))) {
+        return claudeDir
+      }
+      const parent = path.dirname(dir)
+      if (parent === dir) return null // reached filesystem root
+      dir = parent
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Concatenate per-event hook arrays across maps (source order preserved),
+ *  then drop byte-identical duplicate entries within each event — a guard so
+ *  a hook can never double-fire if Claude's own resolution ever also merges. */
+function concatHookMaps(...maps: Record<string, unknown[]>[]): Record<string, unknown[]> {
+  const merged: Record<string, unknown[]> = {}
+  for (const m of maps) {
+    for (const [event, arr] of Object.entries(m)) {
+      if (Array.isArray(arr)) merged[event] = (merged[event] || []).concat(arr)
+    }
+  }
+  const out: Record<string, unknown[]> = {}
+  for (const [event, arr] of Object.entries(merged)) {
+    const seen = new Set<string>()
+    const kept: unknown[] = []
+    for (const entry of arr) {
+      let key: string
+      try { key = JSON.stringify(entry) } catch { key = String(entry) }
+      if (seen.has(key)) continue
+      seen.add(key)
+      kept.push(entry)
+    }
+    out[event] = kept
+  }
+  return out
+}
+
+/**
+ * Reproduce the hooks Claude Code would apply for a session launched in `cwd`,
+ * so CCC can MERGE them with its own gateway hooks rather than shadow them.
+ * Claude treats a --settings `hooks` key as an override (it is NOT a
+ * concatenating array), so without this a project/user hook — e.g. a project
+ * `carp-hook.ps1` — never fires in a CCC-launched session (#137).
+ *
+ * Sources, low→high precedence (all concatenated; all run):
+ *   user     ~/.claude/settings.json
+ *   project  <root>/.claude/settings.json
+ *   local    <root>/.claude/settings.local.json
+ * Enterprise "managed" settings outrank --settings regardless, so folding them
+ * in would not change Claude's resolution — left to Claude. FAIL-SAFE.
+ */
+export function resolveInheritedHooks(cwd: string, homeDir: string = os.homedir()): Record<string, unknown[]> {
+  const userClaude = path.join(homeDir, '.claude')
+  const maps: Record<string, unknown[]>[] = [readHooksFrom(path.join(userClaude, 'settings.json'))]
+  const projectClaude = findProjectClaudeDir(cwd, homeDir)
+  // Guard: when cwd's project root IS the home dir, don't re-read user settings.
+  if (projectClaude && path.resolve(projectClaude) !== path.resolve(userClaude)) {
+    maps.push(readHooksFrom(path.join(projectClaude, 'settings.json')))
+    maps.push(readHooksFrom(path.join(projectClaude, 'settings.local.json')))
+  }
+  return concatHookMaps(...maps)
+}
+
+// Rewrites the entire `hooks` key on every inject with the MERGE of the hooks
+// Claude would inherit for this cwd (user + project + project-local) and CCC's
+// own gateway hooks — so CCC sessions behave like a plain `claude` in the same
+// folder, plus the CCC hooks (#137). Per-session settings files are ours to
+// manage; a user hand-editing hooks in one is overwritten on next spawn.
 export function injectHooks(a: InjectArgs): void {
   const settings = readJsonSafe(a.settingsPath)
-  settings.hooks = buildHooksBlock(a.sessionId, a.port, a.secret)
+  const inherited = resolveInheritedHooks(a.cwd, a.homeDir)
+  const ccc = buildHooksBlock(a.sessionId, a.port, a.secret)
+  // CCC hooks last so inherited hooks keep their natural order; CCC's http
+  // entries are unique (per-session URL) so dedupe never drops them.
+  settings.hooks = concatHookMaps(inherited, ccc)
   writeJson(a.settingsPath, settings)
 }
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1236,7 +1236,7 @@ export function spawnPty(
         if (gw && gwStatus?.listening && gwStatus.port) {
           try {
             const secret = gw.registerSession(sessionId)
-            injectHooks({ sessionId, settingsPath: sesPath, port: gwStatus.port, secret })
+            injectHooks({ sessionId, settingsPath: sesPath, port: gwStatus.port, secret, cwd: claudeCwd })
           } catch (err) {
             logError(`[pty] Failed to inject hooks for ${sessionId}: ${(err as Error)?.message ?? err}`)
           }

--- a/tests/unit/hooks/session-hooks-writer.test.ts
+++ b/tests/unit/hooks/session-hooks-writer.test.ts
@@ -6,6 +6,7 @@ import {
   injectHooks,
   removeHooks,
   buildHooksBlock,
+  resolveInheritedHooks,
   MVP_EVENTS,
 } from '../../../src/main/hooks/session-hooks-writer'
 
@@ -13,19 +14,43 @@ function tmp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-writer-test-'))
 }
 
+// A project/user command-hook entry, in Claude's matcher-wrapped schema.
+function cmdHook(command: string, matcher = '') {
+  return { matcher, hooks: [{ type: 'command', command }] }
+}
+
+function writeSettings(claudeDir: string, hooks: unknown, file = 'settings.json') {
+  fs.mkdirSync(claudeDir, { recursive: true })
+  fs.writeFileSync(path.join(claudeDir, file), JSON.stringify({ hooks }))
+}
+
 describe('session-hooks-writer', () => {
   let dir = ''
   let file = ''
+  let home = '' // hermetic user-settings home (no real ~/.claude)
+  let proj = '' // hermetic project cwd (no .claude unless a test adds one)
   beforeEach(() => {
     dir = tmp()
     file = path.join(dir, 'settings-sid-a.json')
+    home = path.join(dir, 'home')
+    // Project cwd nested UNDER the fake home so the project-root walk is bounded
+    // by the homeDir ceiling (keeps the test off the real ~/.claude).
+    proj = path.join(home, 'work')
+    fs.mkdirSync(home, { recursive: true })
+    fs.mkdirSync(proj, { recursive: true })
   })
   afterEach(() => {
     fs.rmSync(dir, { recursive: true, force: true })
   })
 
+  // Base args with hermetic cwd/home so no real user/project hooks leak in.
+  const base = (over: Record<string, unknown> = {}) => ({
+    sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'abc123',
+    cwd: proj, homeDir: home, ...over,
+  })
+
   it('injects hooks for all MVP events', () => {
-    injectHooks({ sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'abc123' })
+    injectHooks(base())
     const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
     for (const kind of MVP_EVENTS) {
       expect(Array.isArray(settings.hooks[kind])).toBe(true)
@@ -43,7 +68,7 @@ describe('session-hooks-writer', () => {
       file,
       JSON.stringify({ statusLine: { type: 'command', command: 'x' }, model: 'opus' }),
     )
-    injectHooks({ sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'abc' })
+    injectHooks(base({ secret: 'abc' }))
     const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
     expect(settings.statusLine.command).toBe('x')
     expect(settings.model).toBe('opus')
@@ -51,8 +76,8 @@ describe('session-hooks-writer', () => {
   })
 
   it('inject is idempotent - repeated calls do not duplicate entries', () => {
-    injectHooks({ sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'abc' })
-    injectHooks({ sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'def' })
+    injectHooks(base({ secret: 'abc' }))
+    injectHooks(base({ secret: 'def' }))
     const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
     expect(settings.hooks.PreToolUse.length).toBe(1)
     expect(settings.hooks.PreToolUse[0].hooks[0].headers['X-CCC-Hook-Token']).toBe('def')
@@ -60,7 +85,7 @@ describe('session-hooks-writer', () => {
 
   it('remove strips only the hooks key', () => {
     fs.writeFileSync(file, JSON.stringify({ statusLine: 'keep' }))
-    injectHooks({ sessionId: 'sid-a', settingsPath: file, port: 19334, secret: 'abc' })
+    injectHooks(base({ secret: 'abc' }))
     removeHooks({ settingsPath: file })
     const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
     expect(settings.statusLine).toBe('keep')
@@ -82,12 +107,58 @@ describe('session-hooks-writer', () => {
 
   it('inject creates the parent dir if missing', () => {
     const deep = path.join(dir, 'nested', 'dir', 'settings-sid-b.json')
-    injectHooks({ sessionId: 'sid-b', settingsPath: deep, port: 19335, secret: 'xyz' })
+    injectHooks(base({ sessionId: 'sid-b', settingsPath: deep, port: 19335, secret: 'xyz' }))
     expect(fs.existsSync(deep)).toBe(true)
   })
 
   it('injects a UserPromptSubmit hook (clear signal for the flasher)', () => {
     const block = buildHooksBlock('sess', 1234, 'secret')
     expect(block.UserPromptSubmit).toBeDefined()
+  })
+
+  // ── #137: merge inherited hooks instead of shadowing them ──
+  it('MERGES a project command hook with the CCC http hook (#137)', () => {
+    writeSettings(path.join(proj, '.claude'), { PreToolUse: [cmdHook('carp-hook.ps1', 'Bash')] })
+    injectHooks(base())
+    const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    const pre = settings.hooks.PreToolUse
+    expect(pre.length).toBe(2)
+    // inherited project hook preserved (order: inherited first)...
+    expect(pre[0].hooks[0].command).toBe('carp-hook.ps1')
+    expect(pre[0].matcher).toBe('Bash')
+    // ...and CCC's http hook still present.
+    expect(pre[1].hooks[0].type).toBe('http')
+  })
+
+  it('merges user + project + project-local hooks', () => {
+    writeSettings(path.join(home, '.claude'), { UserPromptSubmit: [cmdHook('user.sh')] })
+    writeSettings(path.join(proj, '.claude'), { UserPromptSubmit: [cmdHook('project.sh')] })
+    writeSettings(path.join(proj, '.claude'), { UserPromptSubmit: [cmdHook('local.sh')] }, 'settings.local.json')
+    const inherited = resolveInheritedHooks(proj, home)
+    const cmds = inherited.UserPromptSubmit.map((e: { hooks: { command: string }[] }) => e.hooks[0].command)
+    expect(cmds).toEqual(['user.sh', 'project.sh', 'local.sh'])
+  })
+
+  it('resolves project hooks from a nested cwd (walks up to the .claude root)', () => {
+    writeSettings(path.join(proj, '.claude'), { Stop: [cmdHook('root.sh')] })
+    const nested = path.join(proj, 'packages', 'app')
+    fs.mkdirSync(nested, { recursive: true })
+    const inherited = resolveInheritedHooks(nested, home)
+    expect(inherited.Stop[0].hooks[0].command).toBe('root.sh')
+  })
+
+  it('dedupes a byte-identical hook present in both project and local (no double-fire)', () => {
+    writeSettings(path.join(proj, '.claude'), { Stop: [cmdHook('same.sh')] })
+    writeSettings(path.join(proj, '.claude'), { Stop: [cmdHook('same.sh')] }, 'settings.local.json')
+    const inherited = resolveInheritedHooks(proj, home)
+    expect(inherited.Stop.length).toBe(1)
+  })
+
+  it('is fail-safe when there are no inherited settings (empty → CCC hooks only)', () => {
+    const inherited = resolveInheritedHooks(proj, home)
+    expect(inherited).toEqual({})
+    injectHooks(base())
+    const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    expect(settings.hooks.PreToolUse.length).toBe(1)
   })
 })


### PR DESCRIPTION
Fixes #137 — CCC-launched sessions now run the hooks a plain `claude` would in the same folder, **plus** CCC's gateway hooks.

## Root cause
`injectHooks` set the per-session `--settings` `hooks` key to only CCC's HTTP hooks. Claude treats a `--settings` `hooks` key as an **override** (not a concatenating array — confirmed against the docs and the reported `carp-hook.ps1` behavior), so user/project hooks were shadowed.

## Fix (`session-hooks-writer.ts` + `pty-manager.ts`)
- `resolveInheritedHooks(cwd, homeDir)` concatenates hooks from **user** (`~/.claude/settings.json`), **project** (`<root>/.claude/settings.json`), and **project-local** (`settings.local.json`). Project root = nearest `.claude` walking up from cwd, **bounded by the home dir** (so `~/.claude` is only ever the user source and the walk never escapes home).
- `injectHooks` writes `concat(inherited, cccHooks)` with byte-identical dedupe (guards against double-fire). It gained a `cwd` arg; `pty-manager` passes `claudeCwd`.
- FAIL-SAFE: missing/unparseable settings contribute nothing and never block spawn.

## Scope / follow-ups
- **Local sessions only.** SSH (`ssh-shim.ts`) resolves against a remote FS the main process can't read at write time — separate follow-up.
- Enterprise "managed" settings outrank `--settings` regardless, so they're left to Claude.

## Tests
- `tests/unit/hooks/session-hooks-writer.test.ts`: merge (project+CCC), user→project→local ordering, nested-cwd walk-up, dedupe, fail-safe empty. 13/13; broader hooks + per-session suites 90/90; node typecheck clean.

See ADR-005.
