### PR TITLE
docs(versioning): document versioning scheme, channels, and rolling re-release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,5 +81,6 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 
 - `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
+- `docs/versioning.md` — versioning scheme, prerelease suffixes, update channels, rolling re-release vs. version bump.
 - `architecture/decisions/` — ADRs (the *why* behind architectural/tooling calls).
 - `docs/dev-alongside-prod.md`, `docs/USER_GUIDE.md`, `docs/code-signing.md` — operational guides.

--- a/CONTEXT.d/2026-07-22-versioning-doc.md
+++ b/CONTEXT.d/2026-07-22-versioning-doc.md
@@ -1,0 +1,27 @@
+## 2026-07-22 -- Added docs/versioning.md
+
+Prompted by a beta Mac rebuild: re-dispatching the release workflow at the SAME
+package.json version (2.1.0-beta.1) is a rolling re-release (assets replaced in
+place), and the in-app updater does NOT notify existing users because it ranks by
+semver, not date — same version = same rank = "not newer". That behavior wasn't
+written down anywhere.
+
+- New `docs/versioning.md` documents: the SemVer scheme + `-beta.N`/`-rc.N`
+  suffixes; package.json as the single source of the version/tag; release channels
+  (stable/beta/dev) vs. updater channels (stable = finals only; beta = finals +
+  beta + rc; `-dev` not served by the updater); semver ordering (final > rc.N >
+  beta.N); rolling re-release vs. version bump; and the end-to-end release flow.
+- Grounded in the actual logic: `github-update.ts` (classifyTag/parseTag),
+  `release.yml` (tag derivation, --clobber rolling re-release, --target), and
+  `release.js` (changelog version sync).
+- Linked from CONTRIBUTING.md (release process) and AGENTS.md (Deeper references).
+- Merge-order note (resolved): this branched off beta (11bb42d) before #135 landed
+  its "Issue lifecycle" section in the same part of CONTRIBUTING.md, which produced
+  a conflict. Rebased onto beta and reconciled by keeping BOTH — the versioning
+  pointer sits with the release-process bullets, followed by the Issue lifecycle
+  section.
+- Follow-up surfaced while releasing 2.1.0-beta.2: the `release/**` ruleset
+  (verified signatures + no merge commits) makes a `release/vX.Y.Z` branch cut from
+  `beta` un-pushable, because beta's history already contains a merge commit
+  (efbc34e, PR #72). The documented RC-branch step therefore cannot be followed
+  as written; the beta.2 bump used a `chore/` branch instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,8 @@ We cut a dedicated RC branch for every release cycle so that `beta` stays open f
 - Fixes made on the RC branch are back-ported to `beta` so the next cycle keeps them.
 - When the RC is accepted, merge `release/vX.Y.Z` → `main`, then delete the RC branch.
 
+For the versioning scheme, prerelease suffixes (`-beta.N`/`-rc.N`), update channels, and when a rebuild ships to users vs. requires a version bump, see [`docs/versioning.md`](docs/versioning.md).
+
 ### Issue lifecycle (beta vs. main)
 
 Because fixes merge to `beta` (in testing) long before they ship in a stable

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,88 @@
+# Versioning & release channels
+
+How Claude Command Center versions builds, what the prerelease suffixes and
+channels mean, and — importantly — when a rebuild ships to users versus when you
+must bump the version. This documents the behavior encoded in
+`.github/workflows/release.yml`, `scripts/release.js`, and the in-app updater
+`src/main/github-update.ts`.
+
+## Scheme
+
+[Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`, with
+dot-numbered prerelease suffixes:
+
+- `-beta.N` — in testing on the `beta` line (e.g. `2.1.0-beta.2`)
+- `-rc.N` — release candidate, stabilizing toward stable (e.g. `2.0.0-rc.2`)
+- no suffix — final stable release (e.g. `2.0.0`)
+
+## Single source of truth
+
+`package.json` `version` is authoritative:
+
+- The release workflow derives the git tag `v<version>` from it.
+- `scripts/release.js` syncs the top `version:` line in
+  `src/renderer/changelog.ts` (the in-app "What's New" + generated `CHANGELOG.md`).
+- Tag rule (`release.yml`): if `package.json` already carries a prerelease suffix,
+  the tag is `v<version>` verbatim; a bare version gets the channel suffix appended.
+
+## Channels
+
+**Release side** — `gh workflow run release.yml -f channel=<...>`:
+
+| channel  | meaning                          | GitHub release |
+| -------- | -------------------------------- | -------------- |
+| `stable` | final release                    | Latest         |
+| `beta`   | pre-release on the beta line     | Pre-release    |
+| `dev`    | experimental pre-release         | Pre-release    |
+
+**Client side** — the in-app updater (`github-update.ts`) serves two channels:
+
+- `stable` — final releases only (`vX.Y.Z`).
+- `beta` — final **plus** `-beta.N` and `-rc.N` prereleases.
+- `-dev` tags are **not** served by the updater — manual download only.
+
+## Ordering: which build is "newer"
+
+The updater ranks by **semver, not by date**:
+
+- final > `rc.N` > `beta.N`; within the same base version a higher `.N` wins.
+- A `beta`-channel user is therefore offered the `rc` and final of a line as they
+  publish; a `stable` user only ever sees finals.
+
+## Rolling re-release vs. a new version (read this)
+
+Re-running the release workflow with the **same** `package.json` version does
+**not** create a new version. `release.yml` detects the existing `v<version>`
+release and **replaces its assets in place** (`gh release upload --clobber`),
+leaving the hand-written notes untouched — a *rolling re-release*.
+
+- **Use it** to refresh a build for **manual download** (e.g. fold in a
+  just-merged fix without a version churn).
+- **The auto-updater will NOT notify existing users** — same version = same
+  semver rank = "not newer".
+- **To push an update users actually receive, bump the version first.**
+
+## When to bump
+
+- Each new beta you want the updater to **deliver**: bump the prerelease number
+  (`2.1.0-beta.1` → `2.1.0-beta.2`).
+- Stabilizing a release: move to `-rc.N` on a `release/vX.Y.Z` branch.
+- Shipping stable: drop the suffix (`2.1.0`) and release from `main` with
+  `channel=stable`.
+
+## End-to-end flow
+
+1. Bump `package.json` `version` and add the matching `src/renderer/changelog.ts`
+   entry.
+2. `npm run changelog` to refresh `CHANGELOG.md`; commit both (CI gate:
+   `Changelog in sync`).
+3. Release — `scripts/release.js` (local bump + dispatch) or
+   `gh workflow run release.yml --ref <branch> -f channel=<...>`.
+4. `release.yml` tags `v<version>` at the exact built commit (`--target`, so the
+   updater orders it correctly), builds Windows + macOS + Linux, and publishes the
+   GitHub release with notes generated from `changelog.ts`.
+5. The updater compares the published tag against the installed version for the
+   user's channel and offers it only if it outranks what's installed.
+
+See also: `CONTRIBUTING.md` (release process, issue lifecycle, changelog) and the
+ADRs under `architecture/decisions/`.


### PR DESCRIPTION
Adds `docs/versioning.md` — the versioning scheme (SemVer + `-beta.N`/`-rc.N`), release vs. updater channels, semver ordering (final > rc.N > beta.N), and the rolling-re-release-vs-version-bump distinction (why a same-version rebuild doesn't reach the auto-updater). Grounded in `github-update.ts`, `release.yml`, `release.js`. Linked from CONTRIBUTING.md + AGENTS.md.

Squash-merge.