### PR TITLE
build(release): 2.1.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.2] - 2026-07-29
+
+> Resuming your work is far easier to read, your own Claude hooks now run in CCC sessions, and each config can set its own permission mode and CLI arguments.
+
+### Added
+- Each config can now set its own Claude permission mode and extra command-line arguments, instead of every session sharing one global setting.
+- Sessions can be given a work name (renamed) independently of their config, so restored windows are recognisable at a glance. The startup "Resume previous sessions?" card is wider, lists each session on two lines so long names are not chopped, shows a count, and has a refresh button that picks up a session you restarted after launch.
+- A development instance can now run alongside your installed copy with fully separate data, ports, and an amber DEV badge, so testing a change can no longer disturb your day-to-day sessions.
+
+### Changed
+- The Resume Conversation picker shown in the terminal is much easier to scan: it now fills the width of your window instead of being capped at a narrow column, leads each entry with a recognisable title (your session's work name when you renamed it, otherwise Claude's own summary of the conversation), and strips the slash-command markup that used to crowd out the actual content. Conversations that only showed "(continued session)" now show what they were about.
+
+### Fixed
+- Hooks you configure yourself now run in CCC sessions. CCC was replacing the whole hooks block with its own, so hooks from your user settings or a project's .claude/settings.json never fired in a CCC session even though they worked in a plain Claude session in the same folder. They are now merged, so a CCC session behaves like a normal Claude session in that folder, plus CCC's own hooks.
+- The text cursor is visible and blinking again in shell terminals on Windows and macOS.
+- Startup no longer freezes for roughly half a minute: two long synchronous sweeps during boot now run in the background.
+- macOS: fixed the "A keychain cannot be found to store" error at launch, which was caused by CCC redirecting your home directory away from your login keychain.
+- Multi-account: sessions belonging to a signed-in account whose per-account project folder had been orphaned are recovered, so cross-account resume finds your conversations again.
+
 ## [2.1.0-beta.1] - 2026-07-17
 
 > Experimental Linux support — Claude Command Center now runs on Linux as an AppImage, alongside Windows and macOS.
@@ -896,6 +915,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.2
 [2.1.0-beta.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.1
 [2.0.0-rc.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-rc.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -15,6 +15,22 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.2',
+    date: '2026-07-29',
+    highlights: 'Resuming your work is far easier to read, your own Claude hooks now run in CCC sessions, and each config can set its own permission mode and CLI arguments.',
+    changes: [
+      { type: 'improvement', description: 'The Resume Conversation picker shown in the terminal is much easier to scan: it now fills the width of your window instead of being capped at a narrow column, leads each entry with a recognisable title (your session\'s work name when you renamed it, otherwise Claude\'s own summary of the conversation), and strips the slash-command markup that used to crowd out the actual content. Conversations that only showed "(continued session)" now show what they were about.' },
+      { type: 'fix', description: 'Hooks you configure yourself now run in CCC sessions. CCC was replacing the whole hooks block with its own, so hooks from your user settings or a project\'s .claude/settings.json never fired in a CCC session even though they worked in a plain Claude session in the same folder. They are now merged, so a CCC session behaves like a normal Claude session in that folder, plus CCC\'s own hooks.' },
+      { type: 'feature', description: 'Each config can now set its own Claude permission mode and extra command-line arguments, instead of every session sharing one global setting.' },
+      { type: 'feature', description: 'Sessions can be given a work name (renamed) independently of their config, so restored windows are recognisable at a glance. The startup "Resume previous sessions?" card is wider, lists each session on two lines so long names are not chopped, shows a count, and has a refresh button that picks up a session you restarted after launch.' },
+      { type: 'feature', description: 'A development instance can now run alongside your installed copy with fully separate data, ports, and an amber DEV badge, so testing a change can no longer disturb your day-to-day sessions.' },
+      { type: 'fix', description: 'The text cursor is visible and blinking again in shell terminals on Windows and macOS.' },
+      { type: 'fix', description: 'Startup no longer freezes for roughly half a minute: two long synchronous sweeps during boot now run in the background.' },
+      { type: 'fix', description: 'macOS: fixed the "A keychain cannot be found to store" error at launch, which was caused by CCC redirecting your home directory away from your login keychain.' },
+      { type: 'fix', description: 'Multi-account: sessions belonging to a signed-in account whose per-account project folder had been orphaned are recovered, so cross-account resume finds your conversations again.' },
+    ],
+  },
+  {
     version: '2.1.0-beta.1',
     date: '2026-07-17',
     highlights: 'Experimental Linux support — Claude Command Center now runs on Linux as an AppImage, alongside Windows and macOS.',


### PR DESCRIPTION
Version bump for the beta installer refresh.

**Why a bump instead of another rolling re-release:** 13 commits have landed on `beta` since the `v2.1.0-beta.1` tag. Re-publishing at the same version would (a) never reach existing beta users — the updater ranks by semver, so same version = "not newer" — and (b) leave the `v2.1.0-beta.1` release describing a build it no longer contains. See `docs/versioning.md`.

- `package.json` → `2.1.0-beta.2`
- `src/renderer/changelog.ts` — new entry covering the user-facing changes since beta.1: resume-picker overhaul (#133), hooks merge (#138), per-config permission mode + CLI args (#92), session work names + resume card (#124/#130), dev-alongside-prod (#125), terminal caret (#122), boot freeze (#121), macOS keychain (#118), cross-account resume repair (#132)
- `CHANGELOG.md` regenerated (`Changelog in sync` passes); the release workflow builds the GitHub release notes from the same entry

Installers for `v2.1.0-beta.2` are already building from this branch (`release.yml`, `channel=beta`).

Squash-merge.

**Note for the maintainer:** the `release/**` ruleset (verified signatures + no merge commits) makes a `release/vX.Y.Z` branch cut from `beta` un-pushable as-is — `beta`'s history already contains a merge commit (`efbc34e`, PR #72), which trips the no-merge-commits rule regardless of who cuts it. Hence the `chore/` branch name here. Worth reconciling the ruleset with the documented RC-branch process.
