### PR TITLE
fix(settings): let Check for Updates install the update it finds (#142)

### DIFF
--- a/CONTEXT.d/2026-07-29-settings-install-update.md
+++ b/CONTEXT.d/2026-07-29-settings-install-update.md
@@ -1,0 +1,28 @@
+## 2026-07-29 -- Settings > Check for Updates can install the update (#142)
+
+Bug: `CheckForUpdatesField` (SettingsPage.tsx) reached `status === 'available'` and
+rendered only a TEXT label ("Update available -- vX"). No action — the user had to
+know to find the small green Update pill in the bottom bar to actually install.
+
+- The primary button now BECOMES "Install now" when a check finds an update
+  (the Check/Install states swap; "Check now" returns otherwise), plus a small
+  "Restarts CCC; open sessions are saved." hint.
+- IMPORTANT correctness point: the button must NOT call `update.installAndRestart()`
+  directly. App's `onUpdateRequested` installs immediately only when there are ZERO
+  sessions; with sessions open it opens the `closeDialog === 'update'` flow so
+  session state is saved and pending config writes flushed BEFORE the restart. A
+  direct call would restart on top of live, unsaved sessions.
+- Therefore extracted App's previously-inline BottomBar `onUpdateRequested` arrow
+  into a named `handleUpdateRequested` and passed it to BOTH `BottomBar` and
+  `SettingsPage`; `SettingsPage` forwards it to the field. Direct `installAndRestart`
+  remains only as a no-prop fallback (mirrors BottomBar's existing pattern).
+- Renderer-only; no IPC/main changes (`update:installAndRestart` already existed).
+- `CheckForUpdatesField` is now exported so it can be unit-tested.
+- Tests: tests/unit/renderer/settings-check-for-updates.test.tsx — initial state,
+  Check->Install swap + version shown, up-to-date path, Install routes to
+  onUpdateRequested and NOT installAndRestart, no-prop fallback, repeat-click guard.
+  6/6; full renderer suite 749/749; web typecheck clean.
+
+Changelog: deliberately NOT added here. v2.1.0-beta.2 is already published, and the
+beta.2 changelog entry lives on the still-open bump PR (#141) — so this note belongs
+in the NEXT version's entry rather than being folded into a released one.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -652,6 +652,22 @@ export default function App() {
     }
   }
 
+  // Single entry point for "install the update now", shared by the bottom-bar
+  // Update pill and the Settings > Check for Updates button (#142). Never call
+  // update.installAndRestart() directly from a component: with sessions open the
+  // restart must go through the 'update' close dialog so session state is saved
+  // (and pending config writes flushed) first.
+  const handleUpdateRequested = () => {
+    const state = useSessionStore.getState()
+    if (state.sessions.length === 0) {
+      setIsClosing(true)
+      setIsUpdating(true)
+      window.electronAPI.update.installAndRestart().catch(() => { setIsClosing(false); setIsUpdating(false) })
+    } else {
+      setCloseDialog('update')
+    }
+  }
+
   // Main process sends 'closeRequested' when window close is attempted
   useEffect(() => {
     const handleCloseRequested = () => {
@@ -675,7 +691,7 @@ export default function App() {
   // Render non-session views (shown on top of sessions)
   const renderOverlayView = () => {
     if (view === 'logs') return <GlobalLogsView initialSessionId={pendingLogsSessionId} onInitialSessionConsumed={() => setPendingLogsSessionId(null)} />
-    if (view === 'settings') return <SettingsPage initialTab={pendingSettingsTab ?? undefined} onNavigateToSessions={() => setView('sessions')} />
+    if (view === 'settings') return <SettingsPage initialTab={pendingSettingsTab ?? undefined} onNavigateToSessions={() => setView('sessions')} onUpdateRequested={handleUpdateRequested} />
     if (view === 'insights') return <InsightsPage />
     if (view === 'cloud-agents') return <CloudAgentsPage />
     if (view === 'tokenomics') return <TokenomicsPage />
@@ -1157,16 +1173,7 @@ export default function App() {
             status bar, distinct from the per-session statusline strip which
             lives above the command rows inside the terminal column. */}
         <div className="titlebar-no-drag shrink-0">
-          <BottomBar currentView={view} onViewChange={setView} onUpdateRequested={() => {
-            const state = useSessionStore.getState()
-            if (state.sessions.length === 0) {
-              setIsClosing(true)
-              setIsUpdating(true)
-              window.electronAPI.update.installAndRestart().catch(() => { setIsClosing(false); setIsUpdating(false) })
-            } else {
-              setCloseDialog('update')
-            }
-          }} />
+          <BottomBar currentView={view} onViewChange={setView} onUpdateRequested={handleUpdateRequested} />
         </div>
         {bootGate === 'training' && (
           <TrainingWalkthrough

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -65,9 +65,14 @@ interface SettingsPageProps {
   // Called after the user triggers "Add another account" so the parent can
   // switch the view to Sessions (where the login shell opens).
   onNavigateToSessions?: () => void
+  // Install the pending update. Supplied by App so the Settings button uses the
+  // SAME path as the bottom-bar Update pill — which saves session state via the
+  // 'update' close dialog when sessions are open, instead of restarting on top
+  // of them (#142). Omitted => the field falls back to a direct install.
+  onUpdateRequested?: () => void
 }
 
-export default function SettingsPage({ initialTab, onNavigateToSessions }: SettingsPageProps = {}) {
+export default function SettingsPage({ initialTab, onNavigateToSessions, onUpdateRequested }: SettingsPageProps = {}) {
   const settings = useSettingsStore((s) => s.settings)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
   const updateAppMeta = useAppMetaStore((s) => s.update)
@@ -193,7 +198,7 @@ export default function SettingsPage({ initialTab, onNavigateToSessions }: Setti
                     <option value="system">System -- follow OS preference</option>
                   </select>
                 </Field>
-                <CheckForUpdatesField />
+                <CheckForUpdatesField onUpdateRequested={onUpdateRequested} />
                 <label className="flex items-center gap-2 text-sm text-subtext0 cursor-pointer mt-3">
                   <input
                     type="checkbox"
@@ -859,9 +864,23 @@ function MockRateDots({ label, pct }: { label: string; pct: number }) {
 
 type UpdateCheckStatus = 'idle' | 'checking' | 'up-to-date' | 'available'
 
-function CheckForUpdatesField() {
+export function CheckForUpdatesField({ onUpdateRequested }: { onUpdateRequested?: () => void }) {
   const [status, setStatus] = useState<UpdateCheckStatus>('idle')
   const [foundVersion, setFoundVersion] = useState<string | null>(null)
+  const [installing, setInstalling] = useState(false)
+
+  // Route through App's handler so an install with sessions open goes via the
+  // 'update' close dialog (session state saved first). The direct call is only
+  // a fallback for a parent that didn't pass the prop — same shape as BottomBar.
+  const handleInstall = () => {
+    if (installing) return
+    setInstalling(true)
+    if (onUpdateRequested) {
+      onUpdateRequested()
+      return
+    }
+    window.electronAPI.update.installAndRestart().catch(() => setInstalling(false))
+  }
 
   const handleCheck = async () => {
     if (status === 'checking') return
@@ -894,18 +913,38 @@ function CheckForUpdatesField() {
     status === 'available' ? 'text-yellow' :
     'text-overlay0'
 
+  // Once a check finds an update, the primary button BECOMES the install action
+  // — previously this screen only printed "Update available" and left the user to
+  // hunt for the bottom-bar Update pill (#142).
+  const updateFound = status === 'available'
+
   return (
     <Field label="Check for Updates">
       <div className="flex items-center gap-3">
-        <button
-          onClick={handleCheck}
-          disabled={status === 'checking'}
-          className="px-3 py-1.5 text-sm bg-surface1 hover:bg-surface2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-wait border border-surface0/80"
-        >
-          {status === 'checking' ? 'Checking...' : 'Check now'}
-        </button>
+        {updateFound ? (
+          <button
+            onClick={handleInstall}
+            disabled={installing}
+            title="Install the update and restart -- open sessions are saved first"
+            className="px-3 py-1.5 text-sm rounded-lg transition-colors disabled:opacity-50 disabled:cursor-wait font-medium"
+            style={{ background: 'var(--status-success)', color: 'var(--color-crust)' }}
+          >
+            {installing ? 'Installing...' : 'Install now'}
+          </button>
+        ) : (
+          <button
+            onClick={handleCheck}
+            disabled={status === 'checking'}
+            className="px-3 py-1.5 text-sm bg-surface1 hover:bg-surface2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-wait border border-surface0/80"
+          >
+            {status === 'checking' ? 'Checking...' : 'Check now'}
+          </button>
+        )}
         {statusText && status !== 'checking' && (
           <span className={`text-xs ${statusColor}`}>{statusText}</span>
+        )}
+        {updateFound && !installing && (
+          <span className="text-[10px] text-overlay0">Restarts CCC; open sessions are saved.</span>
         )}
       </div>
     </Field>

--- a/tests/unit/renderer/settings-check-for-updates.test.tsx
+++ b/tests/unit/renderer/settings-check-for-updates.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * Settings > Check for Updates (#142).
+ *
+ * The field used to be a dead end: finding an update only printed "Update
+ * available" and left the user to hunt for the bottom-bar Update pill. The
+ * primary button now BECOMES "Install now", and it routes through App's
+ * onUpdateRequested so an install with sessions open goes via the 'update'
+ * close dialog (session state saved first) rather than restarting on top of
+ * them. installAndRestart() is only the no-prop fallback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { CheckForUpdatesField } = await import('../../../src/renderer/components/SettingsPage')
+
+function renderComponent(ui: React.ReactElement): { container: HTMLElement; unmount: () => void } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  act(() => { root.render(ui) })
+  return {
+    container,
+    unmount: () => {
+      act(() => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+const buttonByText = (container: HTMLElement, label: string) =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find((b) => b.textContent === label)
+
+const click = async (el: HTMLElement) => {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+/** Stub the update IPC surface the field touches. */
+function stubUpdateApi(opts: { available: boolean; version?: string }) {
+  const installAndRestart = vi.fn().mockResolvedValue(true)
+  ;(globalThis as any).window.electronAPI = {
+    update: {
+      check: vi.fn().mockResolvedValue(opts.available),
+      getVersion: vi.fn().mockResolvedValue(opts.version ?? '9.9.9'),
+      installAndRestart,
+    },
+  }
+  return { installAndRestart }
+}
+
+describe('Settings > Check for Updates (#142)', () => {
+  let cleanup: (() => void) | null = null
+  beforeEach(() => { cleanup = null })
+  afterEach(() => {
+    cleanup?.()
+    delete (globalThis as any).window.electronAPI
+  })
+
+  it('starts as "Check now" with no install action', () => {
+    stubUpdateApi({ available: false })
+    const { container, unmount } = renderComponent(<CheckForUpdatesField />)
+    cleanup = unmount
+    expect(buttonByText(container, 'Check now')).toBeTruthy()
+    expect(buttonByText(container, 'Install now')).toBeUndefined()
+  })
+
+  it('when an update is found, the button becomes "Install now" and shows the version', async () => {
+    stubUpdateApi({ available: true, version: '2.1.0-beta.2' })
+    const { container, unmount } = renderComponent(<CheckForUpdatesField />)
+    cleanup = unmount
+
+    await click(buttonByText(container, 'Check now')!)
+
+    expect(buttonByText(container, 'Install now')).toBeTruthy()
+    expect(buttonByText(container, 'Check now')).toBeUndefined()
+    expect(container.textContent).toContain('2.1.0-beta.2')
+  })
+
+  it('stays on "Check now" and reports up to date when there is no update', async () => {
+    stubUpdateApi({ available: false })
+    const { container, unmount } = renderComponent(<CheckForUpdatesField />)
+    cleanup = unmount
+
+    await click(buttonByText(container, 'Check now')!)
+
+    expect(buttonByText(container, 'Install now')).toBeUndefined()
+    expect(container.textContent).toContain('Up to date')
+  })
+
+  it('Install now calls onUpdateRequested (App saves sessions) and NOT installAndRestart', async () => {
+    const { installAndRestart } = stubUpdateApi({ available: true })
+    const onUpdateRequested = vi.fn()
+    const { container, unmount } = renderComponent(
+      <CheckForUpdatesField onUpdateRequested={onUpdateRequested} />,
+    )
+    cleanup = unmount
+
+    await click(buttonByText(container, 'Check now')!)
+    await click(buttonByText(container, 'Install now')!)
+
+    expect(onUpdateRequested).toHaveBeenCalledTimes(1)
+    // Critical: bypassing App would restart with live sessions unsaved.
+    expect(installAndRestart).not.toHaveBeenCalled()
+  })
+
+  it('falls back to installAndRestart when no handler is supplied', async () => {
+    const { installAndRestart } = stubUpdateApi({ available: true })
+    const { container, unmount } = renderComponent(<CheckForUpdatesField />)
+    cleanup = unmount
+
+    await click(buttonByText(container, 'Check now')!)
+    await click(buttonByText(container, 'Install now')!)
+
+    expect(installAndRestart).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores repeat clicks while installing', async () => {
+    const onUpdateRequested = vi.fn()
+    stubUpdateApi({ available: true })
+    const { container, unmount } = renderComponent(
+      <CheckForUpdatesField onUpdateRequested={onUpdateRequested} />,
+    )
+    cleanup = unmount
+
+    await click(buttonByText(container, 'Check now')!)
+    const install = buttonByText(container, 'Install now')!
+    await click(install)
+    await click(install)
+
+    expect(onUpdateRequested).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Fixes #142 — Settings → Check for Updates can now install the update it finds.

## Before
`CheckForUpdatesField` reached `status === 'available'` and rendered only a text label ("Update available -- v2.1.0-beta.2"). No action on that screen; the user had to know to find the small green **Update** pill in the bottom bar.

## After
The primary button **becomes "Install now"** once a check finds an update (states swap; "Check now" returns otherwise), with a small "Restarts CCC; open sessions are saved." hint.

## The correctness bit
The new button does **not** call `update.installAndRestart()` directly. App's `onUpdateRequested` installs immediately only when there are **zero** sessions; with sessions open it opens the `closeDialog === 'update'` flow so session state is saved and pending config writes flushed **before** the restart. A direct call would restart on top of live, unsaved sessions.

So App's previously-inline `BottomBar` arrow is extracted into a named `handleUpdateRequested` and passed to **both** `BottomBar` and `SettingsPage`, which forwards it to the field. Direct install remains only as a no-prop fallback (same shape `BottomBar` already uses).

Renderer-only — no IPC or main-process changes (`update:installAndRestart` already existed).

## Tests
`tests/unit/renderer/settings-check-for-updates.test.tsx` — initial state, Check→Install swap + version shown, up-to-date path, **Install routes to `onUpdateRequested` and NOT `installAndRestart`**, no-prop fallback, repeat-click guard. 6/6; full renderer suite **749/749**; web typecheck clean.

## Note on the changelog
No `changelog.ts` entry here on purpose: `v2.1.0-beta.2` is already published, and its changelog entry lives on the still-open bump PR #141 — so this user-facing note belongs in the **next** version's entry rather than being folded into a released one. Happy to add it once #141 lands.
