### PR TITLE
fix(terminal): make Ctrl+V paste into terminals (#145)

### DIFF
--- a/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
+++ b/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
@@ -51,6 +51,35 @@ in a CCC terminal at all**, confirmed with the reporter.
   bug live -- and it doubles as the diagnostic: if an external tool pastes nothing
   and NO hint appears, the handler never ran, so the tool isn't sending a paste
   chord and the mechanism is something else.
+- ROUND 3 -- ACTUAL ROOT CAUSE, measured, superseding both earlier theories.
+  Reporter narrowed it: the same dictation pasted fine into a shell session but not
+  a Claude one. Added opt-in input diagnostics (CCC_INPUT_DEBUG=1) covering both
+  what ARRIVES (DOM events) and what LEAVES (pty writes). The trace settled it:
+    keydown key="v" mods=ctrl trusted=true target=textarea.xterm-helper-textarea
+    pty:write shell  len=1 "\x16"
+    pty:write claude len=1 "\x16"
+  * The tool DOES send a real synthesized Ctrl+V. Injected keystrokes carry
+    `key="v"` and NO `code` (no scan code); human presses carry code=KeyV. Both
+    appeared in one trace, which is how they were separated -- 4 injected, 14 human.
+  * What reached the PTY was \x16 (SYN, raw Ctrl+V) in BOTH session types, so CCC
+    was never pasting at all.
+  * The shell only "worked" because PSReadLine binds Ctrl+V to Paste -- PowerShell
+    did the pasting from the Windows clipboard. claude.exe has no \x16 binding, so
+    nothing happened. That asymmetry is what made it look like a claude.exe bug.
+  * The handler never ran because it was registered on `document` in the BUBBLE
+    phase. xterm's keydown listener is on the helper textarea (target phase), which
+    runs BEFORE a document bubble listener, so xterm had already emitted \x16 --
+    preventDefault there is too late.
+  Fix: register in the CAPTURE phase and stopPropagation() before preventDefault().
+  Capture on document beats any descendant listener, so xterm never sees the chord.
+  stopPropagation (not stopImmediatePropagation) so the diagnostics listener on the
+  same node still records.
+- LESSON worth keeping: rounds 1-2 were reasoned, round 3 was measured. The two
+  earlier fixes (focus-independent handler, main-process clipboard read) are real
+  improvements and stay, but neither was the bug. The instrumentation found it in
+  one run.
+- Also corrected: an earlier reading of "no text and no hint" as "the tool sends no
+  paste chord". It does send one; the handler simply never got to see it first.
 - Verification: typecheck clean; full suite 3147 passed / 4 skipped; 22 tests in
   tests/unit/renderer/terminal-input.test.ts + 7 in tests/unit/main/clipboard-text.test.ts
   (added `clipboard.readText` to the electron mock in tests/unit/setup.ts). Unit tests

--- a/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
+++ b/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
@@ -1,0 +1,41 @@
+## 2026-07-30 -- Ctrl+V now pastes into terminals (#145)
+
+Decision recorded in architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md.
+
+Reported as "Aqua Voice dictation can't paste into CCC -- I have to right-click every
+time". Investigation found the bug is general, not tool-specific: **Ctrl+V did nothing
+in a CCC terminal at all**, confirmed with the reporter.
+
+- Root cause: there was NO app-level Ctrl+V handler for terminal text. Right-click
+  paste (TerminalView `handleContextMenu`) reads the clipboard and calls
+  `term.paste()` directly, never consulting focus -- which is exactly why it worked.
+  Ctrl+V depended on the Electron Edit-menu `role: 'paste'` reaching Chromium's paste
+  command, which targets the focused EDITABLE element = xterm's hidden helper
+  textarea. No focus there -> keystroke dropped, silently, with no feedback. Any tool
+  that steals focus and synthesizes a paste hits that every time.
+- Fix: CCC owns the keybinding. Ctrl+V / Cmd+V / Shift+Insert (+ Ctrl+Shift+V) read
+  the clipboard and `term.paste()` (keeps bracketed-paste correct, per #545), then
+  preventDefault so the native command can't double-insert.
+- `isActive` is a HARD guard: every session's TerminalView stays mounted (App.tsx
+  renders them all with display:none, plus the optional partner terminal) and the
+  listener is on `document`, so without it one Ctrl+V would paste into every open
+  session at once. Read via a ref -- the installing effect keys on session identity,
+  so a captured prop goes stale on tab switches.
+- Ordinary editables (`input`/`textarea`/`select`/contenteditable) are left to the
+  native path so CommandBar/settings/rename keep working. xterm's own helper textarea
+  is explicitly NOT counted as ordinary -- it IS the terminal. Alt+V stays image paste.
+- Also added: restore terminal focus when the WINDOW regains focus. Previously focus
+  was re-grabbed only on session activation, overlay unmount, and mouseup in the
+  terminal -- the sole `window.addEventListener('focus')` in the codebase was
+  BottomBar's update check. This covers tools that synthesize typed CHARACTERS rather
+  than a paste command. Skipped over modals and when focus is in a real input.
+- Guard logic is pure + unit-tested (`isPasteChord`, `shouldHandleTerminalPaste`,
+  `isOrdinaryEditable`) -- the guards are the interesting part, not the clipboard call.
+- KNOWN, LEFT ALONE: the pre-existing Ctrl+Shift+C copy handler has the same missing
+  `isActive` guard. Benign today (only one terminal holds a selection); noted in
+  ADR-008 rather than fixed here, to keep this change scoped.
+- Verification: typecheck clean; full suite 3140 passed / 4 skipped; 22 tests in
+  tests/unit/renderer/terminal-input.test.ts. Unit tests cannot prove this one --
+  validated in the app against a SYNTHESIZED Ctrl+V from an external process
+  (clipboard write + SendKeys into the CCC window), which is what actually reproduces
+  the focus-loss condition; hand-pressing the key does not.

--- a/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
+++ b/CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md
@@ -34,8 +34,26 @@ in a CCC terminal at all**, confirmed with the reporter.
 - KNOWN, LEFT ALONE: the pre-existing Ctrl+Shift+C copy handler has the same missing
   `isActive` guard. Benign today (only one terminal holds a selection); noted in
   ADR-008 rather than fixed here, to keep this change scoped.
-- Verification: typecheck clean; full suite 3140 passed / 4 skipped; 22 tests in
-  tests/unit/renderer/terminal-input.test.ts. Unit tests cannot prove this one --
-  validated in the app against a SYNTHESIZED Ctrl+V from an external process
-  (clipboard write + SendKeys into the CCC window), which is what actually reproduces
-  the focus-loss condition; hand-pressing the key does not.
+- ROUND 2 -- the first cut still failed against Aqua Voice in a dev build that DID
+  contain it (source 00:28, build 08:47, fix branch checked out, no uncommitted
+  changes). Cause: the handler fired but the READ failed, silently.
+  `navigator.clipboard.readText()` requires the DOCUMENT to be focused and rejects
+  otherwise -- the exact condition the handler exists to survive -- and the original
+  catch swallowed it. Compounding it, Windows delayed-render means the first read
+  after a focus change can come back empty anyway.
+  Not speculation: `clipboard-image.ts` already documents this as the cause of the
+  Alt+V image first-attempt miss and already fixes it with a retry. Text had the
+  same flaw.
+  So: added `src/main/clipboard-text.ts` (`readClipboardTextWithRetry`, 6 x 80ms,
+  short-circuits) + `CLIPBOARD_READ_TEXT` IPC. The main-process clipboard has no
+  focus requirement. Renderer API kept only as a fallback.
+- Failure is now VISIBLE (paste hint) instead of silent. Silence is what let this
+  bug live -- and it doubles as the diagnostic: if an external tool pastes nothing
+  and NO hint appears, the handler never ran, so the tool isn't sending a paste
+  chord and the mechanism is something else.
+- Verification: typecheck clean; full suite 3147 passed / 4 skipped; 22 tests in
+  tests/unit/renderer/terminal-input.test.ts + 7 in tests/unit/main/clipboard-text.test.ts
+  (added `clipboard.readText` to the electron mock in tests/unit/setup.ts). Unit tests
+  cannot prove the end-to-end path -- it needs a SYNTHESIZED Ctrl+V from an external
+  process (clipboard write + SendKeys into the CCC window), which is what actually
+  reproduces the focus-loss condition; hand-pressing the key does not.

--- a/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
+++ b/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
@@ -4,7 +4,8 @@
 - **Deciders:** @nubbymong (owner)
 - **Related:** CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md, #145,
   src/renderer/utils/terminalInput.ts,
-  src/renderer/components/TerminalView.tsx, src/main/index.ts (Edit menu roles)
+  src/renderer/components/TerminalView.tsx, src/main/clipboard-text.ts,
+  src/main/clipboard-image.ts (the image precedent), src/main/index.ts (Edit menu roles)
 
 ## Context
 
@@ -53,6 +54,26 @@ fields, never the mechanism for terminals.**
   CommandBar, settings and rename fields keep behaving normally. xterm's own helper
   textarea is explicitly *excluded* from that classification — it IS the terminal.
 - Alt+V stays image paste and is never treated as text.
+- **The clipboard is read in the MAIN process** (`readClipboardTextWithRetry`), not
+  via `navigator.clipboard.readText()`. Two independent reasons, both fatal to the
+  renderer API here:
+  1. The async clipboard API **requires the document to be focused** and rejects
+     with "Document is not focused" otherwise — exactly the condition this handler
+     exists to survive. Depending on document focus would reintroduce the bug in a
+     new place.
+  2. **Windows delayed-render**: the first read after the window gains focus can
+     return empty because the source app materialises the format lazily. This is
+     not speculation — it is the documented cause of the Alt+V *image*
+     first-attempt miss (`clipboard-image.ts`), fixed there with the same retry.
+     Text has no reason to behave differently, so it gets the same treatment
+     (6 tries x 80ms, short-circuiting on the first hit).
+  The renderer API remains as a fallback if the IPC call fails.
+- **Failure is visible, never silent.** An empty or unreadable clipboard shows a
+  paste hint. Silence is what let this bug live: Ctrl+V appeared to do nothing,
+  with no way to tell whether the chord was even received. The hint is also the
+  cheapest available diagnostic — if an external tool pastes nothing and NO hint
+  appears, the handler never ran, which means the tool is not sending a paste
+  chord at all and the mechanism is something else.
 - Separately, terminal focus is now restored when the window regains focus, for
   tools that synthesize *typed characters* rather than a paste command. Skipped
   over modals and when focus sits in a real input, so it cannot steal focus from

--- a/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
+++ b/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
@@ -29,11 +29,51 @@ state. An external app that takes focus and hands it back is the worst case, and
 nothing in CCC restored terminal focus on window focus (focus was re-grabbed only
 on session activation, overlay unmount, and mouseup inside the terminal).
 
+## The measured root cause (supersedes two earlier theories)
+
+Two attempted fixes failed because the mechanism was reasoned about rather than
+measured. Opt-in input diagnostics (`CCC_INPUT_DEBUG=1`) settled it:
+
+```
+keydown key="v" mods=ctrl trusted=true target=textarea.xterm-helper-textarea   <- injected, NO code field
+pty:write shell  len=1 "\x16"
+pty:write claude len=1 "\x16"
+```
+
+- The external tool **does** send a real synthesized Ctrl+V. Injected keystrokes
+  arrive with `key="v"` and **no `code`** (no physical scan code); human presses
+  carry `code=KeyV`. Both were present in one trace, which is how they were told
+  apart.
+- What reached the PTY was `\x16` — **SYN, the raw Ctrl+V control byte** — in
+  BOTH session types. So CCC was never pasting at all.
+- It appeared to work in a shell only because **PSReadLine binds Ctrl+V to Paste**,
+  so PowerShell pasted from the Windows clipboard itself. `claude.exe` has no
+  binding for `\x16`, so nothing happened. That difference is what made this look
+  like a `claude.exe` bug; it was not.
+- The paste handler never ran because it was registered on `document` in the
+  **bubble** phase. xterm's own keydown listener is on the helper textarea, so it
+  runs in the target phase — **before** any document bubble listener — converting
+  the chord to `\x16` and writing it. `preventDefault()` there is already too late.
+
+So the defect was event-phase ordering in CCC, not focus, not the clipboard API,
+not the injecting tool, and not Claude Code.
+
 ## Decision
 
 **Terminal clipboard keybindings are CCC's, handled explicitly and
 focus-independently. The Electron menu roles are a fallback for ordinary input
 fields, never the mechanism for terminals.**
+
+- The keydown listener is registered in the **CAPTURE** phase on `document` and
+  calls `stopPropagation()` before `preventDefault()`. Capture on `document` runs
+  ahead of any listener on a descendant, so xterm never sees the chord and never
+  emits `\x16`. This is not a stylistic detail — in the bubble phase the handler is
+  dead code, which is exactly how the first attempt shipped looking correct.
+  `stopPropagation`, not `stopImmediatePropagation`, so the diagnostics listener on
+  the same node still records the event.
+- `isPasteChord` matches on `key` alone and must never require `code`: injected
+  keystrokes have no `code`, so requiring it would exclude precisely the case this
+  exists to serve.
 
 - Ctrl+V / Cmd+V / Shift+Insert (and Ctrl+Shift+V, which some terminals use) read
   the clipboard and call `term.paste()` — the same route right-click already

--- a/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
+++ b/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
@@ -1,0 +1,85 @@
+# ADR-008: CCC owns terminal clipboard keybindings; never rely on the native paste path
+
+- **Status:** Accepted (2026-07-30)
+- **Deciders:** @nubbymong (owner)
+- **Related:** CONTEXT.d/2026-07-30-145-ctrl-v-terminal-paste.md, #145,
+  src/renderer/utils/terminalInput.ts,
+  src/renderer/components/TerminalView.tsx, src/main/index.ts (Edit menu roles)
+
+## Context
+
+Ctrl+V did nothing in a CCC terminal. Right-click paste worked, so the clipboard
+was reachable only by mouse — and any external tool that delivers text by putting
+it on the clipboard and synthesizing a paste (dictation such as Aqua Voice,
+snippet expanders, macro tools) was unusable.
+
+The two paths were asymmetric:
+
+- **Right-click** read `navigator.clipboard.readText()` and called `term.paste()`
+  directly. It never consulted DOM focus, which is why it always worked.
+- **Ctrl+V** had **no handler at all**. It depended on the Electron Edit menu's
+  `role: 'paste'` (added "so Ctrl+C/V/X/A work in frameless window") reaching
+  Chromium's paste command, which targets the focused **editable element** —
+  xterm.js's hidden helper textarea. Whenever that textarea does not hold DOM
+  focus, the keystroke lands on a non-editable element and is dropped silently.
+
+The native path is therefore only ever as reliable as one hidden element's focus
+state. An external app that takes focus and hands it back is the worst case, and
+nothing in CCC restored terminal focus on window focus (focus was re-grabbed only
+on session activation, overlay unmount, and mouseup inside the terminal).
+
+## Decision
+
+**Terminal clipboard keybindings are CCC's, handled explicitly and
+focus-independently. The Electron menu roles are a fallback for ordinary input
+fields, never the mechanism for terminals.**
+
+- Ctrl+V / Cmd+V / Shift+Insert (and Ctrl+Shift+V, which some terminals use) read
+  the clipboard and call `term.paste()` — the same route right-click already
+  proved — then `preventDefault()` so the native command cannot double-insert.
+  `term.paste()` also keeps bracketed-paste mode correct, as #545 established for
+  right-click.
+- The decision logic is pure and unit-tested (`isPasteChord`,
+  `shouldHandleTerminalPaste`, `isOrdinaryEditable`), because the interesting part
+  is the guards, not the clipboard call.
+- **`isActive` is a hard guard.** Every session's `TerminalView` stays mounted
+  (`App.tsx` renders them all with `display:none`, plus an optional partner
+  terminal) and the listener is on `document`, so without it a single Ctrl+V
+  pastes into every open session simultaneously. It is read through a ref, not the
+  captured prop, because the installing effect keys on session identity and would
+  otherwise go stale on tab switches.
+- **Ordinary editables are left to the native path.** When focus is in a real
+  `<input>`/`<textarea>`/`<select>`/`[contenteditable]`, CCC does not intercept, so
+  CommandBar, settings and rename fields keep behaving normally. xterm's own helper
+  textarea is explicitly *excluded* from that classification — it IS the terminal.
+- Alt+V stays image paste and is never treated as text.
+- Separately, terminal focus is now restored when the window regains focus, for
+  tools that synthesize *typed characters* rather than a paste command. Skipped
+  over modals and when focus sits in a real input, so it cannot steal focus from
+  the user.
+
+Rejected alternatives: **relying on the Edit-menu role** (the status quo — fails
+exactly when an external tool is involved, and fails *silently*, which is why this
+went unnoticed); **`attachCustomKeyEventHandler`** (xterm-scoped, so it only fires
+when xterm already has focus — the case that is already working); **restoring
+focus on window focus alone** (necessary for the typing case but not sufficient:
+it would leave paste dependent on a focus race).
+
+## Consequences
+
+- Ctrl+V works in terminals regardless of which element holds DOM focus, so
+  clipboard-plus-synthesized-paste tools work. This is the fix for #145.
+- CCC now owns a keybinding Chromium would otherwise handle. If a future change
+  needs Ctrl+V to reach some new in-terminal editable surface, it must be added to
+  `isOrdinaryEditable`, not worked around in the handler.
+- `preventDefault()` fires **before** the async clipboard read, so a denied read
+  (insecure context, window not focused) is a no-op rather than a double paste.
+  The terminal is left unchanged and nothing is reported — consistent with the
+  existing right-click behaviour.
+- The pre-existing Ctrl+Shift+C copy handler still lacks the `isActive` guard. It
+  is benign today (only one terminal holds a selection) and is intentionally left
+  alone here to keep this change scoped; it should get the same treatment.
+- Verified by simulating the real failure mode — clipboard write plus a synthesized
+  Ctrl+V from an external process (`SendKeys`) into the CCC window — not only by
+  pressing the key by hand, since hand-pressing does not reproduce the
+  focus-loss condition that external tools create.

--- a/src/main/clipboard-text.ts
+++ b/src/main/clipboard-text.ts
@@ -1,0 +1,54 @@
+import { clipboard } from 'electron'
+
+/**
+ * Read TEXT off the clipboard from the MAIN process, retrying briefly when the
+ * first read comes back empty. The text sibling of readClipboardImageWithRetry.
+ *
+ * Why this exists at all, rather than the renderer calling
+ * `navigator.clipboard.readText()` (#145):
+ *
+ *  1. The async clipboard API requires the DOCUMENT TO BE FOCUSED and rejects
+ *     with "Document is not focused" otherwise. Electron's main-process
+ *     clipboard has no such requirement. That matters because the whole point
+ *     of the terminal paste handler is to work when focus is unsettled — an
+ *     external tool (dictation, snippet expander) takes focus, writes the
+ *     clipboard, hands focus back, then synthesizes Ctrl+V. Depending on
+ *     document focus there reintroduces the very failure being fixed.
+ *  2. Same Windows delayed-render behaviour already documented for images: the
+ *     FIRST read after the window gains focus can come back empty because the
+ *     source app renders the format lazily, so a one-shot read concludes "empty
+ *     clipboard" when text is in fact present. This was the Alt+V
+ *     first-attempt miss for images; text is no different.
+ *
+ * Deterministic and cheap: returns as soon as non-empty text appears and gives
+ * up after `attempts` tries, so a genuinely empty clipboard still resolves ''
+ * promptly. Defaults match readClipboardImageWithRetry (6 x 80ms => up to
+ * ~400ms) because they are outlasting the same 50-200ms Windows sync window.
+ * On success it short-circuits, so the common case costs one read and no delay.
+ *
+ * @param attempts total number of reads to try (>= 1)
+ * @param delayMs  delay between reads in milliseconds
+ * @param sleep    injectable timer (tests pass a no-op resolver)
+ * @returns the first non-empty clipboard text, or '' if every attempt was empty
+ */
+export async function readClipboardTextWithRetry(
+  attempts = 6,
+  delayMs = 80,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<string> {
+  const tries = Math.max(1, attempts)
+  for (let i = 0; i < tries; i++) {
+    // Never let a platform clipboard error propagate: a failed read must degrade
+    // to "nothing to paste", never break the paste keybinding.
+    let text = ''
+    try {
+      text = clipboard.readText() || ''
+    } catch {
+      text = ''
+    }
+    if (text) return text
+    if (i < tries - 1) await sleep(delayMs)
+  }
+  return ''
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -449,6 +449,17 @@ function createWindow(): void {
     return readClipboardTextWithRetry()
   })
 
+  // Input diagnostics (#145). Opt-in via CCC_INPUT_DEBUG=1 so it costs nothing
+  // normally: the renderer asks once and only then attaches listeners. Lines land
+  // in the debug log (<dataDir>/debug/app.log) prefixed [input-diag].
+  // `on`, not `handle` — this is a fire-and-forget stream; a round trip per
+  // keystroke would itself perturb what we are trying to measure.
+  ipcMain.handle(IPC.DEBUG_INPUT_ENABLED, () => process.env.CCC_INPUT_DEBUG === '1')
+  ipcMain.on(IPC.DEBUG_LOG_INPUT, (_e, line: string) => {
+    if (process.env.CCC_INPUT_DEBUG !== '1') return
+    logInfo(`[input-diag] ${String(line).slice(0, 400)}`)
+  })
+
   // Save clipboard image to a unique file in the host screenshots dir and return its
   // bare filename so the renderer can use the conductor MCP fetch_host_screenshot tool.
   // Returns { filename, path } so callers have both the bare name (for the MCP tool)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ import { startEffortTracker } from './effort-tracker'
 import { startAttentionSource } from './attention-source'
 import { startJankDetector } from './jank-detector'
 import { readClipboardImageWithRetry } from './clipboard-image'
+import { readClipboardTextWithRetry } from './clipboard-text'
 import { readClipboardImageFilePath, type PasteableImage } from './clipboard-file'
 import { HooksGateway } from './hooks/hooks-gateway'
 import { setGateway, getGateway } from './hooks'
@@ -438,6 +439,15 @@ function createWindow(): void {
     }
     return img.resize({ height: maxDim, quality: 'good' as const })
   }
+
+  // Clipboard TEXT read for the terminal paste keybinding (#145). Deliberately
+  // main-process: navigator.clipboard.readText() requires the document to be
+  // focused, which is exactly the condition that fails when an external tool
+  // (dictation, snippet expander) takes focus and synthesizes Ctrl+V. Retried
+  // for the same Windows delayed-render reason as the image path below.
+  ipcMain.handle(IPC.CLIPBOARD_READ_TEXT, async (): Promise<string> => {
+    return readClipboardTextWithRetry()
+  })
 
   // Save clipboard image to a unique file in the host screenshots dir and return its
   // bare filename so the renderer can use the conductor MCP fetch_host_screenshot tool.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,6 +44,8 @@ export interface ElectronAPI {
   }
   clipboard: {
     saveImage: () => Promise<{ path: string } | { error: 'no-image' | 'too-large' }>
+    /** Focus-independent clipboard text read, retried for Windows delayed-render (#145). */
+    readText: () => Promise<string>
   }
   credentials: {
     save: (configId: string, password: string) => Promise<boolean>
@@ -509,7 +511,8 @@ const electronAPI: ElectronAPI = {
     openFolder: () => ipcRenderer.invoke(IPC.DIALOG_OPEN_FOLDER)
   },
   clipboard: {
-    saveImage: () => ipcRenderer.invoke(IPC.CLIPBOARD_SAVE_IMAGE)
+    saveImage: () => ipcRenderer.invoke(IPC.CLIPBOARD_SAVE_IMAGE),
+    readText: () => ipcRenderer.invoke(IPC.CLIPBOARD_READ_TEXT)
   },
   credentials: {
     save: (configId, password) => ipcRenderer.invoke(IPC.CREDENTIALS_SAVE, configId, password),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -47,6 +47,11 @@ export interface ElectronAPI {
     /** Focus-independent clipboard text read, retried for Windows delayed-render (#145). */
     readText: () => Promise<string>
   }
+  /** Input diagnostics (#145), gated on CCC_INPUT_DEBUG=1 in the main process. */
+  inputDebug: {
+    enabled: () => Promise<boolean>
+    log: (line: string) => void
+  }
   credentials: {
     save: (configId: string, password: string) => Promise<boolean>
     load: (configId: string) => Promise<string | null>
@@ -513,6 +518,10 @@ const electronAPI: ElectronAPI = {
   clipboard: {
     saveImage: () => ipcRenderer.invoke(IPC.CLIPBOARD_SAVE_IMAGE),
     readText: () => ipcRenderer.invoke(IPC.CLIPBOARD_READ_TEXT)
+  },
+  inputDebug: {
+    enabled: () => ipcRenderer.invoke(IPC.DEBUG_INPUT_ENABLED),
+    log: (line: string) => ipcRenderer.send(IPC.DEBUG_LOG_INPUT, line)
   },
   credentials: {
     save: (configId, password) => ipcRenderer.invoke(IPC.CREDENTIALS_SAVE, configId, password),

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -839,6 +839,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         })) return
         // Claim the event before the async read so Chromium's native paste can't
         // also fire and double-insert.
+        //
+        // stopPropagation is what actually makes this work, and it only works
+        // because the listener is registered in the CAPTURE phase (see below).
+        // xterm's own keydown listener lives on the helper textarea, so in the
+        // bubble phase it runs FIRST and has already turned Ctrl+V into the raw
+        // control byte \x16 (SYN) and written it to the PTY before a
+        // document-level bubble listener is ever called — preventDefault at that
+        // point is far too late. Capture + stopPropagation means xterm never sees
+        // the chord and never emits \x16.
+        e.stopPropagation()
         e.preventDefault()
         // Read through the MAIN process, not navigator.clipboard.readText().
         // The async clipboard API requires the DOCUMENT to be focused and rejects
@@ -871,7 +881,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         }
         term?.paste(text)
       }
-      document.addEventListener('keydown', handleKeyDownPaste)
+      // CAPTURE phase (the `true`) — not optional, and the whole reason the first
+      // attempt at this fix silently did nothing. Capture on `document` runs
+      // before any listener on a descendant, so this beats xterm's textarea
+      // handler; a bubble-phase listener loses the race every time.
+      document.addEventListener('keydown', handleKeyDownPaste, true)
 
       // Right-click: context-aware copy or paste depending on mode.
       //
@@ -930,7 +944,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         try { window.electronAPI.pty.resize(sessionId, lastSentCols, lastSentRows) } catch { /* main gone */ }
       }
       if (handleKeyDownCopy) document.removeEventListener('keydown', handleKeyDownCopy)
-      if (handleKeyDownPaste) document.removeEventListener('keydown', handleKeyDownPaste)
+      if (handleKeyDownPaste) document.removeEventListener('keydown', handleKeyDownPaste, true)
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       resizeObserver?.disconnect()

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -24,6 +24,7 @@ import {
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
+import { usePasteHintStore } from '../stores/pasteHintStore'
 import { ScrollToBottomButton } from './terminal'
 import { useStatuslineSubscription } from '../hooks/useStatuslineSubscription'
 import { useEffortSubscription } from '../hooks/useEffortSubscription'
@@ -806,14 +807,36 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // Claim the event before the async read so Chromium's native paste can't
         // also fire and double-insert.
         e.preventDefault()
+        // Read through the MAIN process, not navigator.clipboard.readText().
+        // The async clipboard API requires the DOCUMENT to be focused and rejects
+        // otherwise — precisely the condition this handler exists to survive, since
+        // an external tool takes focus, writes the clipboard, hands focus back and
+        // synthesizes Ctrl+V. The main-process read has no focus requirement and
+        // retries for Windows delayed-render (the same first-read-empty behaviour
+        // already documented for clipboard images).
+        let text = ''
         try {
-          const text = await navigator.clipboard.readText()
-          if (!text) return
-          term?.paste(text)
+          text = await window.electronAPI.clipboard.readText()
         } catch {
-          // Clipboard read denied (insecure context / window not focused). Nothing
-          // to paste; the terminal is unchanged.
+          // IPC unavailable — fall through to the renderer API below.
         }
+        if (!text) {
+          try {
+            text = await navigator.clipboard.readText()
+          } catch {
+            text = ''
+          }
+        }
+        if (!text) {
+          // Do NOT fail silently. A silent no-op is what let #145 go unnoticed:
+          // Ctrl+V appeared to do nothing with no way to tell whether the chord
+          // was even seen. This hint also makes the failure mode diagnosable — if
+          // a dictation tool pastes nothing and NO hint appears, the tool never
+          // sent a paste chord at all.
+          usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
+          return
+        }
+        term?.paste(text)
       }
       document.addEventListener('keydown', handleKeyDownPaste)
 

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,7 +14,13 @@ import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
-import { isControlReportOnly, decideContextMenuAction } from '../utils/terminalInput'
+import {
+  isControlReportOnly,
+  decideContextMenuAction,
+  isPasteChord,
+  shouldHandleTerminalPaste,
+  isOrdinaryEditable,
+} from '../utils/terminalInput'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
@@ -80,6 +86,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   const attentionAckedRef = useRef(false)
   const [isScrolledUp, setIsScrolledUp] = useState(false)
   const isScrolledUpRef = useRef(false)
+  // Mirror of the isActive prop for `document`-level listeners installed by the
+  // init effect (which keys on session identity, not activation) — reading the
+  // captured prop there would go stale on tab switches. See the paste handler.
+  const isActiveRef = useRef(isActive)
+  isActiveRef.current = isActive
   const updateSession = useSessionStore((s) => s.updateSession)
   const session = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
 
@@ -108,6 +119,30 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       })
     })
   }, [sessionId, ssh])
+
+  // Restore terminal focus when the WINDOW regains focus (#145).
+  //
+  // Terminal focus was previously re-grabbed only on session activation, overlay
+  // unmount, and mouseup inside the terminal — never on window focus. An external
+  // tool that steals focus and then synthesizes *typed characters* (rather than a
+  // paste command) needs the xterm helper textarea focused, or the keystrokes land
+  // on <body> and vanish. The paste handler above is focus-independent by design;
+  // this covers the typing case.
+  //
+  // Only the active session, and never over a modal's focus trap.
+  useEffect(() => {
+    if (!isActive) return
+    const onWindowFocus = () => {
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return
+      // Don't yank focus out of a real input the user is working in.
+      if (isOrdinaryEditable(document.activeElement as HTMLElement | null)) return
+      requestAnimationFrame(() => {
+        try { terminalRef.current?.focus() } catch { /* ignore */ }
+      })
+    }
+    window.addEventListener('focus', onWindowFocus)
+    return () => window.removeEventListener('focus', onWindowFocus)
+  }, [isActive])
 
   // Repaint the terminal whenever the resolved theme changes.
   // Watching data-theme on <html> via MutationObserver covers BOTH:
@@ -185,6 +220,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let unsubData: (() => void) | null = null
     let unsubExit: (() => void) | null = null
     let handleKeyDownCopy: ((e: KeyboardEvent) => void) | null = null
+    let handleKeyDownPaste: ((e: KeyboardEvent) => void) | null = null
     let handleContextMenu: ((e: MouseEvent) => void) | null = null
     let disposed = false
     let parseTimer: ReturnType<typeof setTimeout> | null = null
@@ -747,6 +783,40 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       }
       document.addEventListener('keydown', handleKeyDownCopy)
 
+      // Ctrl+V / Cmd+V / Shift+Insert to paste (#145).
+      //
+      // CCC owns this keybinding rather than leaving it to the Edit menu's
+      // `role: 'paste'`: the native path pastes into the focused editable element
+      // (xterm's hidden helper textarea), so it silently does nothing whenever that
+      // textarea has lost DOM focus — which is every time an external tool takes
+      // focus and synthesizes a paste (dictation apps, snippet expanders). Reading
+      // the clipboard directly is the same focus-independent route that has always
+      // made right-click paste work.
+      //
+      // `isActiveRef` (not the captured prop) because this effect re-runs on session
+      // identity, not on activation — a captured `isActive` would go stale and this
+      // listener is on `document`, shared by every mounted TerminalView.
+      handleKeyDownPaste = async (e: KeyboardEvent) => {
+        if (!isPasteChord(e)) return
+        if (!shouldHandleTerminalPaste({
+          isActive: isActiveRef.current,
+          hasModalOpen: !!document.querySelector('[role="dialog"][aria-modal="true"]'),
+          targetIsOrdinaryEditable: isOrdinaryEditable(document.activeElement as HTMLElement | null),
+        })) return
+        // Claim the event before the async read so Chromium's native paste can't
+        // also fire and double-insert.
+        e.preventDefault()
+        try {
+          const text = await navigator.clipboard.readText()
+          if (!text) return
+          term?.paste(text)
+        } catch {
+          // Clipboard read denied (insecure context / window not focused). Nothing
+          // to paste; the terminal is unchanged.
+        }
+      }
+      document.addEventListener('keydown', handleKeyDownPaste)
+
       // Right-click: context-aware copy or paste depending on mode.
       //
       // Classic mode (classicTerminalCopyPaste, the default): CC's mouse
@@ -804,6 +874,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         try { window.electronAPI.pty.resize(sessionId, lastSentCols, lastSentRows) } catch { /* main gone */ }
       }
       if (handleKeyDownCopy) document.removeEventListener('keydown', handleKeyDownCopy)
+      if (handleKeyDownPaste) document.removeEventListener('keydown', handleKeyDownPaste)
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       resizeObserver?.disconnect()

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -25,6 +25,7 @@ import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
 import { usePasteHintStore } from '../stores/pasteHintStore'
+import { installInputDiagnostics } from '../utils/inputDiagnostics'
 import { ScrollToBottomButton } from './terminal'
 import { useStatuslineSubscription } from '../hooks/useStatuslineSubscription'
 import { useEffortSubscription } from '../hooks/useEffortSubscription'
@@ -159,6 +160,24 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // attaches on first paint instead of returning early when the ref
   // was still null. Without this gate, theme flips never repainted.
   const [terminalReady, setTerminalReady] = useState(false)
+
+  // Input diagnostics (#145), opt-in via CCC_INPUT_DEBUG=1. Active session only,
+  // so one dictation run yields one readable trace rather than N interleaved
+  // copies. Answers what an external tool ACTUALLY sends — see
+  // inputDiagnostics.ts for why measuring had to replace reasoning here.
+  useEffect(() => {
+    if (!isActive || !terminalReady) return
+    const container = xtermContainerRef.current
+    if (!container) return
+    let dispose: (() => void) | null = null
+    let cancelled = false
+    void window.electronAPI.inputDebug.enabled().then((on) => {
+      if (!on || cancelled) return
+      dispose = installInputDiagnostics(container, (line) => window.electronAPI.inputDebug.log(`[${sessionId}] ${line}`))
+    }).catch(() => { /* diagnostics are never load-bearing */ })
+    return () => { cancelled = true; dispose?.() }
+  }, [isActive, terminalReady, sessionId])
+
   useEffect(() => {
     if (!terminalReady) return
     const term = terminalRef.current

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -25,7 +25,7 @@ import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
 import { usePasteHintStore } from '../stores/pasteHintStore'
-import { installInputDiagnostics } from '../utils/inputDiagnostics'
+import { installInputDiagnostics, describeBytes } from '../utils/inputDiagnostics'
 import { ScrollToBottomButton } from './terminal'
 import { useStatuslineSubscription } from '../hooks/useStatuslineSubscription'
 import { useEffortSubscription } from '../hooks/useEffortSubscription'
@@ -93,6 +93,9 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // captured prop there would go stale on tab switches. See the paste handler.
   const isActiveRef = useRef(isActive)
   isActiveRef.current = isActive
+  // Whether #145 input diagnostics are on, readable from the init effect's
+  // long-lived onData closure.
+  const inputDiagRef = useRef(false)
   const updateSession = useSessionStore((s) => s.updateSession)
   const session = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
 
@@ -173,9 +176,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let cancelled = false
     void window.electronAPI.inputDebug.enabled().then((on) => {
       if (!on || cancelled) return
+      inputDiagRef.current = true
       dispose = installInputDiagnostics(container, (line) => window.electronAPI.inputDebug.log(`[${sessionId}] ${line}`))
     }).catch(() => { /* diagnostics are never load-bearing */ })
-    return () => { cancelled = true; dispose?.() }
+    return () => { cancelled = true; inputDiagRef.current = false; dispose?.() }
   }, [isActive, terminalReady, sessionId])
 
   useEffect(() => {
@@ -565,6 +569,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // comes from PTY output; un-ack on real keystrokes. Provider sessions use
         // the hook-driven attention source (attention-source.ts) instead.
         if (shellOnly && !isControlReportOnly(data)) attentionAckedRef.current = false
+        // #145 diagnostics: record what actually leaves for the PTY. The write path
+        // is identical for shell and Claude sessions, so when the same dictation
+        // lands in PowerShell but not in Claude, this line is what proves whether
+        // the bytes handed to claude.exe were correct and complete. Control reports
+        // are skipped — they'd bury the real input.
+        if (inputDiagRef.current && !isControlReportOnly(data)) {
+          window.electronAPI.inputDebug.log(
+            `[${sessionId}] pty:write ${shellOnly ? 'shell' : 'claude'} ${describeBytes(data)}`,
+          )
+        }
         window.electronAPI.pty.write(sessionId, data)
       })
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -117,6 +117,8 @@ export interface ElectronAPI {
   }
   clipboard: {
     saveImage: () => Promise<{ path: string } | { error: 'no-image' | 'too-large' }>
+    /** Focus-independent clipboard text read, retried for Windows delayed-render (#145). */
+    readText: () => Promise<string>
   }
   credentials: {
     save: (configId: string, password: string) => Promise<boolean>

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -120,6 +120,11 @@ export interface ElectronAPI {
     /** Focus-independent clipboard text read, retried for Windows delayed-render (#145). */
     readText: () => Promise<string>
   }
+  /** Input diagnostics (#145), gated on CCC_INPUT_DEBUG=1 in the main process. */
+  inputDebug: {
+    enabled: () => Promise<boolean>
+    log: (line: string) => void
+  }
   credentials: {
     save: (configId: string, password: string) => Promise<boolean>
     load: (configId: string) => Promise<string | null>

--- a/src/renderer/utils/inputDiagnostics.ts
+++ b/src/renderer/utils/inputDiagnostics.ts
@@ -1,0 +1,169 @@
+// Input diagnostics for #145 — answers "what does this external tool ACTUALLY
+// send?" instead of guessing.
+//
+// Two rounds of fixes for Aqua Voice failed because the injection mechanism was
+// assumed rather than measured: first the xterm helper textarea's focus, then the
+// document's focus. The third outcome — dictation producing NO text and NO paste
+// hint — proves no paste chord arrives at all, which rules out the whole keyboard
+// class and leaves possibilities that cannot be distinguished by reasoning
+// (UI Automation value-set, posted WM_CHAR, synthesized typing that lands
+// elsewhere).
+//
+// So: log every input-ish event with enough detail to identify the mechanism, and
+// separately poll the helper textarea's value, because a PROGRAMMATIC `.value`
+// assignment fires no event at all and would otherwise be invisible.
+//
+// Off unless CCC_INPUT_DEBUG=1 is set for the main process, so it costs nothing
+// in normal use.
+
+export interface DiagEvent {
+  kind: string
+  key?: string
+  code?: string
+  mods?: string
+  isTrusted?: boolean
+  inputType?: string
+  data?: string | null
+  target?: string
+  active?: string
+  valueLen?: number
+  note?: string
+}
+
+/** Compact single-line rendering, so a dictation run is greppable in app.log. */
+export function formatDiagEvent(e: DiagEvent): string {
+  const parts: string[] = [e.kind]
+  if (e.key !== undefined) parts.push(`key=${JSON.stringify(e.key)}`)
+  if (e.code) parts.push(`code=${e.code}`)
+  if (e.mods) parts.push(`mods=${e.mods}`)
+  if (e.inputType) parts.push(`inputType=${e.inputType}`)
+  if (e.data !== undefined && e.data !== null) parts.push(`data=${JSON.stringify(e.data)}`)
+  if (e.isTrusted !== undefined) parts.push(`trusted=${e.isTrusted}`)
+  if (e.target) parts.push(`target=${e.target}`)
+  if (e.active) parts.push(`active=${e.active}`)
+  if (e.valueLen !== undefined) parts.push(`valueLen=${e.valueLen}`)
+  if (e.note) parts.push(`note=${e.note}`)
+  return parts.join(' ')
+}
+
+/** `div.xterm-screen` / `textarea.xterm-helper-textarea` / `BODY` — enough to tell
+ *  which surface an event hit without dumping the whole element. */
+export function describeNode(n: EventTarget | null): string {
+  const el = n as (Element & { tagName?: string }) | null
+  if (!el) return 'null'
+  if (!el.tagName) return String((n as { constructor?: { name?: string } })?.constructor?.name ?? 'unknown')
+  const tag = el.tagName.toLowerCase()
+  const cls = typeof el.className === 'string' && el.className ? `.${el.className.trim().split(/\s+/).join('.')}` : ''
+  return `${tag}${cls}`.slice(0, 120)
+}
+
+function mods(e: KeyboardEvent): string {
+  return [e.ctrlKey && 'ctrl', e.altKey && 'alt', e.shiftKey && 'shift', e.metaKey && 'meta']
+    .filter(Boolean)
+    .join('+') || 'none'
+}
+
+/**
+ * Attach diagnostics. Returns a disposer.
+ *
+ * @param container the terminal container element
+ * @param log       sink for formatted lines (goes to main's app.log over IPC)
+ * @param now       injectable clock so the poll is testable
+ */
+export function installInputDiagnostics(
+  container: HTMLElement,
+  log: (line: string) => void,
+  opts: { pollMs?: number } = {},
+): () => void {
+  const emit = (e: DiagEvent) => {
+    try { log(formatDiagEvent({ ...e, active: describeNode(document.activeElement) })) } catch { /* never break input */ }
+  }
+
+  const onKey = (ev: Event) => {
+    const e = ev as KeyboardEvent
+    emit({
+      kind: e.type,
+      key: e.key,
+      code: e.code,
+      mods: mods(e),
+      isTrusted: e.isTrusted,
+      target: describeNode(e.target),
+    })
+  }
+
+  const onInput = (ev: Event) => {
+    const e = ev as InputEvent & { target: HTMLTextAreaElement | null }
+    emit({
+      kind: e.type,
+      inputType: (e as InputEvent).inputType,
+      data: (e as InputEvent).data,
+      isTrusted: e.isTrusted,
+      target: describeNode(e.target),
+      valueLen: typeof e.target?.value === 'string' ? e.target.value.length : undefined,
+    })
+  }
+
+  const onComposition = (ev: Event) => {
+    const e = ev as CompositionEvent
+    emit({ kind: e.type, data: e.data, isTrusted: e.isTrusted, target: describeNode(e.target) })
+  }
+
+  const onPaste = (ev: Event) => {
+    const e = ev as ClipboardEvent
+    const text = e.clipboardData?.getData('text/plain') ?? ''
+    emit({
+      kind: 'paste',
+      isTrusted: e.isTrusted,
+      target: describeNode(e.target),
+      valueLen: text.length,
+      note: `types=${(e.clipboardData?.types ?? []).join(',') || 'none'}`,
+    })
+  }
+
+  const onFocusEvt = (ev: Event) => emit({ kind: ev.type, target: describeNode(ev.target) })
+  const onWindowFocus = () => emit({ kind: 'window:focus' })
+  const onWindowBlur = () => emit({ kind: 'window:blur' })
+
+  const KEY_EVENTS = ['keydown', 'keyup'] as const
+  const INPUT_EVENTS = ['beforeinput', 'input'] as const
+  const COMP_EVENTS = ['compositionstart', 'compositionupdate', 'compositionend'] as const
+  const FOCUS_EVENTS = ['focusin', 'focusout'] as const
+
+  // Capture phase on `document` so nothing can stop propagation before we see it.
+  for (const t of KEY_EVENTS) document.addEventListener(t, onKey, true)
+  for (const t of INPUT_EVENTS) document.addEventListener(t, onInput, true)
+  for (const t of COMP_EVENTS) document.addEventListener(t, onComposition, true)
+  for (const t of FOCUS_EVENTS) document.addEventListener(t, onFocusEvt, true)
+  document.addEventListener('paste', onPaste, true)
+  document.addEventListener('textInput', onInput, true)
+  window.addEventListener('focus', onWindowFocus)
+  window.addEventListener('blur', onWindowBlur)
+
+  // Poll the helper textarea's value. A tool that assigns `.value` directly (or
+  // via UI Automation's SetValue) can leave text sitting there having fired NO
+  // event — the one mechanism the listeners above cannot see.
+  let lastValue = ''
+  const pollMs = opts.pollMs ?? 250
+  const timer = setInterval(() => {
+    const ta = container.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null
+    const v = ta?.value ?? ''
+    if (v !== lastValue) {
+      lastValue = v
+      if (v) emit({ kind: 'poll:textareaValue', valueLen: v.length, data: v.slice(0, 80), note: 'value changed with no matching event above => programmatic set' })
+    }
+  }, pollMs)
+
+  log('[input-diag] installed')
+
+  return () => {
+    clearInterval(timer)
+    for (const t of KEY_EVENTS) document.removeEventListener(t, onKey, true)
+    for (const t of INPUT_EVENTS) document.removeEventListener(t, onInput, true)
+    for (const t of COMP_EVENTS) document.removeEventListener(t, onComposition, true)
+    for (const t of FOCUS_EVENTS) document.removeEventListener(t, onFocusEvt, true)
+    document.removeEventListener('paste', onPaste, true)
+    document.removeEventListener('textInput', onInput, true)
+    window.removeEventListener('focus', onWindowFocus)
+    window.removeEventListener('blur', onWindowBlur)
+  }
+}

--- a/src/renderer/utils/inputDiagnostics.ts
+++ b/src/renderer/utils/inputDiagnostics.ts
@@ -46,6 +46,35 @@ export function formatDiagEvent(e: DiagEvent): string {
   return parts.join(' ')
 }
 
+/**
+ * Render a PTY payload readably: control bytes as \xNN, escape sequences visible.
+ *
+ * This is the other half of the diagnosis. Renderer events tell us what ARRIVED;
+ * this tells us what LEFT for the PTY. When the same dictation works in a
+ * PowerShell session but not a Claude session, CCC's write path is identical
+ * (term.onData -> pty.write for both), so the question becomes whether the bytes
+ * handed to claude.exe are correct and complete. If they are, the divergence is
+ * entirely inside the PTY consumer and not CCC's to fix.
+ *
+ * Bracketed-paste markers are the specific thing to look for: \x1b[200~ ... \x1b[201~
+ * means xterm sent a PASTE (which right-click proves Claude handles correctly),
+ * whereas a stream of bare characters means it sent TYPING.
+ */
+export function describeBytes(data: string, max = 120): string {
+  const shown = data.slice(0, max)
+  const escaped = shown.replace(/[\x00-\x1f\x7f]/g, (c) => {
+    const code = c.charCodeAt(0)
+    if (c === '\x1b') return '\\e'
+    if (c === '\r') return '\\r'
+    if (c === '\n') return '\\n'
+    if (c === '\t') return '\\t'
+    return `\\x${code.toString(16).padStart(2, '0')}`
+  })
+  const bracketed = data.includes('\x1b[200~') ? ' BRACKETED_PASTE' : ''
+  const truncated = data.length > max ? ` +${data.length - max}more` : ''
+  return `len=${data.length} "${escaped}"${truncated}${bracketed}`
+}
+
 /** `div.xterm-screen` / `textarea.xterm-helper-textarea` / `BODY` — enough to tell
  *  which surface an event hit without dumping the whole element. */
 export function describeNode(n: EventTarget | null): string {

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -30,3 +30,67 @@ export function decideContextMenuAction(hasSelection: boolean, classicMode: bool
   }
   return 'paste'
 }
+
+// Is this keystroke a terminal paste request? Ctrl+V (Win/Linux), Cmd+V (macOS),
+// and Shift+Insert (the other long-standing terminal convention).
+//
+// Ctrl+Shift+V is deliberately included: some terminals use it as "paste as plain
+// text", and users coming from them press it out of habit.
+export function isPasteChord(e: {
+  key: string
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}): boolean {
+  if (e.altKey) return false // Alt+V is CCC's image paste — never text.
+  const key = e.key.toLowerCase()
+  if (key === 'v' && (e.ctrlKey || e.metaKey)) return true
+  if (e.key === 'Insert' && e.shiftKey && !e.ctrlKey && !e.metaKey) return true
+  return false
+}
+
+// Should THIS TerminalView handle a paste chord itself, rather than leaving it to
+// Chromium's native paste?
+//
+// Why CCC has to own the keybinding at all (#145): the native path pastes into the
+// focused *editable element* — xterm's hidden helper textarea — so it silently does
+// nothing whenever that textarea has lost DOM focus. An external tool that takes
+// focus and synthesizes Ctrl+V (dictation, snippet expanders) hits that every time.
+// Right-click paste always worked precisely because it reads the clipboard directly
+// and never consults focus, so this makes Ctrl+V take the same route.
+//
+// The guards, in order, and why each one matters:
+//   - `isActive`: EVERY session's TerminalView stays mounted (App.tsx renders them
+//     with display:none), and the listener is on `document`. Without this, one
+//     Ctrl+V pastes into every open session at once.
+//   - `hasModalOpen`: a dialog is up; pasting into the terminal behind it is wrong.
+//     Mirrors the existing focus-restore guard.
+//   - `targetIsOrdinaryEditable`: focus is in a real input (CommandBar, settings,
+//     rename) — leave Chromium's native paste alone so those keep working. xterm's
+//     OWN textarea must not count as ordinary, or we'd never handle the common case.
+export function shouldHandleTerminalPaste(opts: {
+  isActive: boolean
+  hasModalOpen: boolean
+  targetIsOrdinaryEditable: boolean
+}): boolean {
+  if (!opts.isActive) return false
+  if (opts.hasModalOpen) return false
+  if (opts.targetIsOrdinaryEditable) return false
+  return true
+}
+
+// Classifies the current focus target for shouldHandleTerminalPaste. An element is
+// an "ordinary editable" if it accepts typed text AND is not the xterm helper
+// textarea (xterm marks its own with class `xterm-helper-textarea`).
+export function isOrdinaryEditable(el: {
+  tagName?: string
+  isContentEditable?: boolean
+  classList?: { contains: (c: string) => boolean }
+} | null): boolean {
+  if (!el) return false
+  if (el.classList?.contains('xterm-helper-textarea')) return false
+  const tag = (el.tagName || '').toLowerCase()
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true
+  return !!el.isContentEditable
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -28,6 +28,10 @@ export const IPC = {
 
   // Clipboard
   CLIPBOARD_SAVE_IMAGE: 'clipboard:saveImage',
+  // Main-process clipboard text read (#145). Focus-independent, unlike the
+  // renderer's navigator.clipboard.readText(), and retried for Windows
+  // delayed-render. Used by the terminal paste keybinding.
+  CLIPBOARD_READ_TEXT: 'clipboard:readText',
 
   // Credentials
   CREDENTIALS_SAVE: 'credentials:save',

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -32,6 +32,10 @@ export const IPC = {
   // renderer's navigator.clipboard.readText(), and retried for Windows
   // delayed-render. Used by the terminal paste keybinding.
   CLIPBOARD_READ_TEXT: 'clipboard:readText',
+  // Input diagnostics (#145): identify what an external tool actually sends.
+  // Enabled only when CCC_INPUT_DEBUG=1 is set for the main process.
+  DEBUG_INPUT_ENABLED: 'debug:inputEnabled',
+  DEBUG_LOG_INPUT: 'debug:logInput',
 
   // Credentials
   CREDENTIALS_SAVE: 'credentials:save',

--- a/tests/unit/main/clipboard-text.test.ts
+++ b/tests/unit/main/clipboard-text.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { clipboard } from 'electron'
+import { readClipboardTextWithRetry } from '../../../src/main/clipboard-text'
+
+const readText = clipboard.readText as unknown as ReturnType<typeof vi.fn>
+// No-op sleep so the retry loop doesn't actually wait in tests.
+const noSleep = () => Promise.resolve()
+
+describe('readClipboardTextWithRetry (#145 terminal paste)', () => {
+  beforeEach(() => {
+    readText.mockReset()
+  })
+
+  it('returns text when the very first read is non-empty', async () => {
+    readText.mockReturnValue('hello')
+
+    expect(await readClipboardTextWithRetry(3, 20, noSleep)).toBe('hello')
+    // Short-circuits: the common case must cost one read and no delay.
+    expect(readText).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries and succeeds when the first read is empty but a later one is not', async () => {
+    // The Windows delayed-render case, same as the image path: the source app
+    // renders the format lazily, so the FIRST read after the window gains focus
+    // comes back empty even though text is present. A one-shot read concludes
+    // "nothing to paste" — which is the bug.
+    readText.mockReturnValueOnce('').mockReturnValueOnce('dictated text')
+
+    expect(await readClipboardTextWithRetry(3, 20, noSleep)).toBe('dictated text')
+    expect(readText).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up and returns empty string when every attempt is empty', async () => {
+    readText.mockReturnValue('')
+
+    expect(await readClipboardTextWithRetry(4, 20, noSleep)).toBe('')
+    expect(readText).toHaveBeenCalledTimes(4)
+  })
+
+  it('treats a thrown platform clipboard error as empty and keeps retrying', async () => {
+    // A failed read must degrade to "nothing to paste", never break the paste
+    // keybinding or reject into the renderer.
+    readText
+      .mockImplementationOnce(() => { throw new Error('clipboard busy') })
+      .mockReturnValueOnce('recovered')
+
+    expect(await readClipboardTextWithRetry(3, 20, noSleep)).toBe('recovered')
+  })
+
+  it('resolves empty when the clipboard throws on every attempt', async () => {
+    readText.mockImplementation(() => { throw new Error('clipboard busy') })
+
+    await expect(readClipboardTextWithRetry(2, 20, noSleep)).resolves.toBe('')
+  })
+
+  it('coerces a null/undefined read to empty string', async () => {
+    readText.mockReturnValue(undefined)
+
+    expect(await readClipboardTextWithRetry(1, 20, noSleep)).toBe('')
+  })
+
+  it('always reads at least once even if given a nonsense attempt count', async () => {
+    readText.mockReturnValue('x')
+
+    expect(await readClipboardTextWithRetry(0, 20, noSleep)).toBe('x')
+    expect(readText).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/input-diagnostics.test.ts
+++ b/tests/unit/renderer/input-diagnostics.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { formatDiagEvent, describeNode } from '../../../src/renderer/utils/inputDiagnostics'
+
+// #145: after two fixes built on assumed injection mechanisms, these lines are the
+// evidence that replaces the guessing. They must stay greppable and lossless about
+// the fields that discriminate one mechanism from another.
+describe('formatDiagEvent', () => {
+  it('renders a keystroke with the fields that identify the mechanism', () => {
+    const line = formatDiagEvent({
+      kind: 'keydown',
+      key: 'v',
+      code: 'KeyV',
+      mods: 'ctrl',
+      isTrusted: true,
+      target: 'textarea.xterm-helper-textarea',
+    })
+    expect(line).toBe('keydown key="v" code=KeyV mods=ctrl trusted=true target=textarea.xterm-helper-textarea')
+  })
+
+  it('quotes key and data so whitespace and empty strings stay visible', () => {
+    // A synthesized space or an empty-string data payload is meaningful signal;
+    // unquoted it would be invisible in the log.
+    expect(formatDiagEvent({ kind: 'keydown', key: ' ' })).toContain('key=" "')
+    expect(formatDiagEvent({ kind: 'input', data: '' })).toContain('data=""')
+  })
+
+  it('omits absent fields rather than printing undefined', () => {
+    expect(formatDiagEvent({ kind: 'window:focus' })).toBe('window:focus')
+  })
+
+  it('keeps trusted=false, which is how injected input betrays itself', () => {
+    expect(formatDiagEvent({ kind: 'keydown', key: 'a', isTrusted: false })).toContain('trusted=false')
+  })
+
+  it('renders a zero valueLen (distinct from absent)', () => {
+    // valueLen=0 means "the event fired but carried nothing" — a different
+    // diagnosis from the field being missing entirely.
+    expect(formatDiagEvent({ kind: 'paste', valueLen: 0 })).toContain('valueLen=0')
+  })
+
+  it('includes the note used to flag a programmatic value set', () => {
+    const line = formatDiagEvent({ kind: 'poll:textareaValue', valueLen: 5, note: 'programmatic set' })
+    expect(line).toContain('note=programmatic set')
+  })
+})
+
+describe('describeNode', () => {
+  const el = (tagName: string, className = '') => ({ tagName, className }) as unknown as EventTarget
+
+  it('renders tag plus dotted classes', () => {
+    expect(describeNode(el('TEXTAREA', 'xterm-helper-textarea'))).toBe('textarea.xterm-helper-textarea')
+    expect(describeNode(el('DIV', 'a b'))).toBe('div.a.b')
+  })
+
+  it('renders a bare tag when there is no class', () => {
+    expect(describeNode(el('BODY'))).toBe('body')
+  })
+
+  it('handles null and non-element targets without throwing', () => {
+    expect(describeNode(null)).toBe('null')
+    // window/document targets have no tagName.
+    expect(describeNode({} as EventTarget)).toBe('Object')
+  })
+
+  it('tolerates a non-string className (SVG animated class)', () => {
+    const svgish = { tagName: 'svg', className: { baseVal: 'x' } } as unknown as EventTarget
+    expect(describeNode(svgish)).toBe('svg')
+  })
+})

--- a/tests/unit/renderer/input-diagnostics.test.ts
+++ b/tests/unit/renderer/input-diagnostics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDiagEvent, describeNode } from '../../../src/renderer/utils/inputDiagnostics'
+import { formatDiagEvent, describeNode, describeBytes } from '../../../src/renderer/utils/inputDiagnostics'
 
 // #145: after two fixes built on assumed injection mechanisms, these lines are the
 // evidence that replaces the guessing. They must stay greppable and lossless about
@@ -65,5 +65,38 @@ describe('describeNode', () => {
   it('tolerates a non-string className (SVG animated class)', () => {
     const svgish = { tagName: 'svg', className: { baseVal: 'x' } } as unknown as EventTarget
     expect(describeNode(svgish)).toBe('svg')
+  })
+})
+
+// The shell-vs-Claude discriminator: CCC's write path is identical for both, so
+// what matters is whether the bytes leaving for the PTY are correct — and above
+// all whether they were sent as a PASTE or as TYPING.
+describe('describeBytes', () => {
+  it('flags a bracketed paste, which right-click proves Claude handles', () => {
+    const line = describeBytes('\x1b[200~hello world\x1b[201~')
+    expect(line).toContain('BRACKETED_PASTE')
+    expect(line).toContain('\\e[200~')
+  })
+
+  it('does NOT flag plain typed characters', () => {
+    const line = describeBytes('hello')
+    expect(line).not.toContain('BRACKETED_PASTE')
+    expect(line).toBe('len=5 "hello"')
+  })
+
+  it('escapes control bytes so they are visible rather than swallowed', () => {
+    expect(describeBytes('\r')).toBe('len=1 "\\r"')
+    expect(describeBytes('\x03')).toBe('len=1 "\\x03"')
+    expect(describeBytes('a\tb\n')).toBe('len=4 "a\\tb\\n"')
+  })
+
+  it('reports the true length and marks truncation', () => {
+    const line = describeBytes('x'.repeat(200), 10)
+    expect(line).toContain('len=200')
+    expect(line).toContain('+190more')
+  })
+
+  it('handles empty input', () => {
+    expect(describeBytes('')).toBe('len=0 ""')
   })
 })

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -84,6 +84,15 @@ describe('isPasteChord', () => {
     expect(isPasteChord(chord({ ctrlKey: true, altKey: true }))).toBe(false)
   })
 
+  it('matches an INJECTED Ctrl+V that carries no code field', () => {
+    // Measured from a real Aqua Voice dictation (#145 diagnostics): synthesized
+    // keystrokes arrive as `key="v" mods=ctrl` with NO `code`, because there is no
+    // physical scan code behind them. Human presses carry code=KeyV. Matching on
+    // `key` alone is therefore load-bearing — requiring `code` would silently
+    // exclude every injected paste, which is the entire bug.
+    expect(isPasteChord({ key: 'v', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false })).toBe(true)
+  })
+
   it('ignores a bare v, and other modified keys', () => {
     expect(isPasteChord(chord())).toBe(false)
     expect(isPasteChord(chord({ key: 'c', ctrlKey: true }))).toBe(false)

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { isControlReportOnly, decideContextMenuAction } from '../../../src/renderer/utils/terminalInput'
+import {
+  isControlReportOnly,
+  decideContextMenuAction,
+  isPasteChord,
+  shouldHandleTerminalPaste,
+  isOrdinaryEditable,
+} from '../../../src/renderer/utils/terminalInput'
 
 describe('isControlReportOnly', () => {
   it('treats focus in/out reports as control-only (not input)', () => {
@@ -45,5 +51,103 @@ describe('decideContextMenuAction', () => {
     it('returns paste even when text is selected', () => {
       expect(decideContextMenuAction(true, false)).toBe('paste')
     })
+  })
+})
+
+// #145: Ctrl+V did nothing in terminals because CCC had no handler and the native
+// path only pastes into the focused editable element (xterm's hidden textarea).
+const chord = (over: Partial<Parameters<typeof isPasteChord>[0]> = {}) => ({
+  key: 'v',
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...over,
+})
+
+describe('isPasteChord', () => {
+  it('matches Ctrl+V and Cmd+V, in either letter case', () => {
+    expect(isPasteChord(chord({ ctrlKey: true }))).toBe(true)
+    expect(isPasteChord(chord({ metaKey: true }))).toBe(true)
+    // Chromium reports 'V' when shift is held.
+    expect(isPasteChord(chord({ key: 'V', ctrlKey: true, shiftKey: true }))).toBe(true)
+  })
+
+  it('matches Shift+Insert, the other terminal paste convention', () => {
+    expect(isPasteChord(chord({ key: 'Insert', shiftKey: true }))).toBe(true)
+  })
+
+  it('ignores Alt+V — that is CCC image paste, never text', () => {
+    // Alt+V routes clipboard IMAGES through saveImage; treating it as text paste
+    // would double-handle the shortcut.
+    expect(isPasteChord(chord({ altKey: true }))).toBe(false)
+    expect(isPasteChord(chord({ ctrlKey: true, altKey: true }))).toBe(false)
+  })
+
+  it('ignores a bare v, and other modified keys', () => {
+    expect(isPasteChord(chord())).toBe(false)
+    expect(isPasteChord(chord({ key: 'c', ctrlKey: true }))).toBe(false)
+    expect(isPasteChord(chord({ key: 'Insert' }))).toBe(false)
+  })
+})
+
+describe('isOrdinaryEditable', () => {
+  const el = (tagName: string, over: Record<string, unknown> = {}) => ({
+    tagName,
+    isContentEditable: false,
+    classList: { contains: () => false },
+    ...over,
+  })
+
+  it('treats real inputs as ordinary editables', () => {
+    expect(isOrdinaryEditable(el('INPUT'))).toBe(true)
+    expect(isOrdinaryEditable(el('TEXTAREA'))).toBe(true)
+    expect(isOrdinaryEditable(el('SELECT'))).toBe(true)
+    expect(isOrdinaryEditable(el('DIV', { isContentEditable: true }))).toBe(true)
+  })
+
+  it("does NOT treat xterm's own helper textarea as ordinary", () => {
+    // The whole point: that textarea IS the terminal, so a paste chord landing on
+    // it must be handled by us, not deferred to the native path.
+    const helper = el('TEXTAREA', { classList: { contains: (c: string) => c === 'xterm-helper-textarea' } })
+    expect(isOrdinaryEditable(helper)).toBe(false)
+  })
+
+  it('treats plain elements and null as not editable', () => {
+    expect(isOrdinaryEditable(el('DIV'))).toBe(false)
+    expect(isOrdinaryEditable(el('BODY'))).toBe(false)
+    expect(isOrdinaryEditable(null)).toBe(false)
+  })
+})
+
+describe('shouldHandleTerminalPaste', () => {
+  const opts = (over: Partial<Parameters<typeof shouldHandleTerminalPaste>[0]> = {}) => ({
+    isActive: true,
+    hasModalOpen: false,
+    targetIsOrdinaryEditable: false,
+    ...over,
+  })
+
+  it('handles the paste for the active terminal', () => {
+    expect(shouldHandleTerminalPaste(opts())).toBe(true)
+  })
+
+  it('NEVER handles it for an inactive terminal', () => {
+    // Every session's TerminalView stays mounted and the listener is on `document`,
+    // so without this guard one Ctrl+V pastes into every open session at once.
+    expect(shouldHandleTerminalPaste(opts({ isActive: false }))).toBe(false)
+  })
+
+  it('defers while a modal is open', () => {
+    expect(shouldHandleTerminalPaste(opts({ hasModalOpen: true }))).toBe(false)
+  })
+
+  it('defers to the native paste when focus is in an ordinary input', () => {
+    // CommandBar / settings / rename fields must keep working normally.
+    expect(shouldHandleTerminalPaste(opts({ targetIsOrdinaryEditable: true }))).toBe(false)
+  })
+
+  it('stays false when several guards apply at once', () => {
+    expect(shouldHandleTerminalPaste({ isActive: false, hasModalOpen: true, targetIsOrdinaryEditable: true })).toBe(false)
   })
 })

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -28,7 +28,7 @@ vi.mock('electron', () => ({
     show: vi.fn(),
   })),
   dialog: { showOpenDialog: vi.fn() },
-  clipboard: { readImage: vi.fn() },
+  clipboard: { readImage: vi.fn(), readText: vi.fn() },
   safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
   Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
 }))


### PR DESCRIPTION
Closes #145.

Ctrl+V did nothing in a CCC terminal, so the clipboard was reachable only by right-click. That
also made external tools that dictate/inject text unusable — reported against **Aqua Voice**,
but the bug hit every user and every session type.

## Root cause (measured, after two wrong theories)

The first two attempts reasoned about the mechanism and both missed. Opt-in input diagnostics
settled it in one run:

```
keydown key="v" mods=ctrl trusted=true target=textarea.xterm-helper-textarea   <- injected, NO code
pty:write shell  len=1 "\x16"
pty:write claude len=1 "\x16"
```

- The tool **does** send a genuine synthesized Ctrl+V. Injected keystrokes carry `key="v"` with
  **no `code`** (no physical scan code); human presses carry `code=KeyV`. One trace held both
  (4 injected, 14 human), which is how they were separated.
- What reached the PTY was **`\x16` — SYN, the raw Ctrl+V control byte** — in *both* session
  types. CCC was never pasting at all.
- It only *appeared* to work in a shell because **PSReadLine binds Ctrl+V to Paste**, so
  PowerShell pasted from the Windows clipboard itself. `claude.exe` has no `\x16` binding, so
  nothing happened. That asymmetry is what made this look like a `claude.exe` bug. It wasn't.
- The handler never ran because it was registered on `document` in the **bubble** phase. xterm's
  keydown listener is on the helper textarea, so it fires in the **target** phase — before any
  document bubble listener — and had already emitted `\x16`. `preventDefault()` there is far too
  late. In the bubble phase the handler was dead code that looked correct.

## The fix

**Capture phase + `stopPropagation()` before `preventDefault()`.** Capture on `document` runs
ahead of every descendant listener, so xterm never sees the chord and never emits `\x16`.
`stopPropagation`, not `stopImmediatePropagation`, so the diagnostics listener on the same node
still records.

Supporting changes, each a real defect found on the way:

1. **CCC owns the keybinding** — Ctrl+V / Cmd+V / Shift+Insert / Ctrl+Shift+V read the clipboard
   and `term.paste()` (keeps bracketed-paste correct, per #545) instead of relying on the Edit
   menu's `role: 'paste'`, which only pastes into the focused *editable element*.
2. **`isActive` is a hard guard** — every session's `TerminalView` stays mounted (`App.tsx`
   renders them all with `display:none`, plus the partner terminal) and the listener is on
   `document`. Without it, one Ctrl+V pastes into every open session at once. Read via a ref, since
   the installing effect keys on session identity and a captured prop goes stale on tab switches.
3. **Ordinary inputs are left to the native path** — CommandBar/settings/rename keep working.
   xterm's own helper textarea is deliberately excluded from that check: it *is* the terminal.
4. **Clipboard read moved to the main process** (`src/main/clipboard-text.ts`) —
   `navigator.clipboard.readText()` requires the *document* to be focused and rejects otherwise,
   which is the very condition this handler exists to survive. Retried for Windows delayed-render,
   mirroring `readClipboardImageWithRetry`, whose comment already documents this exact behaviour as
   the cause of the Alt+V *image* first-attempt miss.
5. **Failure is visible, never silent** — an empty/unreadable clipboard shows a paste hint.
   Silence is why this bug survived: Ctrl+V appeared to do nothing with no way to tell whether the
   chord was even received.
6. **Terminal focus restored on window focus** — previously only on session activation, overlay
   unmount, and mouseup in the terminal.
7. **Opt-in input diagnostics** (`CCC_INPUT_DEBUG=1`, free when off) — DOM events *and* PTY writes,
   with `isTrusted` and bracketed-paste markers. This is what found the bug after reasoning failed
   three times; recommend keeping it.

## Verification

- `npm run typecheck` clean; `npx vitest run` **3163 passed / 4 skipped / 0 failed**.
- Desktop-verified by @ssbn: Aqua Voice dictation now pastes into a Claude session.
- Regression test pins that `isPasteChord` must never require `code` — injected keystrokes have
  none, so requiring it would exclude exactly the case this serves.

## Reviewer notes

- **Behaviour change:** in shell sessions Ctrl+V is now handled by CCC rather than falling through
  to PSReadLine. Should be indistinguishable, but it changes something that already worked.
- **Known coverage gap:** the event-phase ordering itself has no automated test — precisely the
  class of bug the unit tests missed here. A jsdom test mirroring the registration would be
  self-fulfilling, so it is called out rather than faked.
- **Left alone deliberately:** the pre-existing Ctrl+Shift+C copy handler has the same missing
  `isActive` guard, and is also bubble-phase. Benign today (only one terminal holds a selection,
  and xterm does not consume that chord). Recorded in ADR-008 rather than fixed here.

Rationale in ADR-008; running-log fragment in `CONTEXT.d/`.

Squash-merge.