### PR TITLE
docs(changelog): add the 2.1.0-beta.3 entry for #143 and #145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.3] - 2026-07-30
+
+> Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — and Check for Updates can install the update it finds.
+
+### Fixed
+- Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.
+- Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.
+- Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.
+
 ## [2.1.0-beta.2] - 2026-07-29
 
 > Resuming your work is far easier to read, your own Claude hooks now run in CCC sessions, and each config can set its own permission mode and CLI arguments.
@@ -915,6 +924,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.3
 [2.1.0-beta.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.2
 [2.1.0-beta.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.1
 [2.0.0-rc.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.0.0-rc.2

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -13,7 +13,23 @@ export interface ChangelogEntry {
   }[]
 }
 
+// NOTE: keep this array a PURE DATA LITERAL — no comments inside it. Comments are
+// authored BEFORE a release (scripts/release.js rewrites the first entry's version
+// to whatever it bumps to; it does not sync date), so it is tempting to annotate
+// the pending entry inline. Don't: scripts/gen-changelog.js extracts the array by
+// bracket-matching and tracks string quotes but NOT comments, so an apostrophe or
+// a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
+  {
+    version: '2.1.0-beta.3',
+    date: '2026-07-30',
+    highlights: 'Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — and Check for Updates can install the update it finds.',
+    changes: [
+      { type: 'fix', description: 'Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.' },
+      { type: 'fix', description: 'Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.' },
+      { type: 'fix', description: 'Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.' },
+    ],
+  },
   {
     version: '2.1.0-beta.2',
     date: '2026-07-29',


### PR DESCRIPTION
Closes #148.

Two user-facing changes had landed on `beta` with **no `changelog.ts` entry**, so they would have
shipped silently in `2.1.0-beta.3` and never appeared in the in-app "What's New".

| Change | Status |
|---|---|
| **#143** — Check for Updates can install the update it finds | Merged `76820cb`, *after* the beta.2 release commit `8ee06de` |
| **#145** — Ctrl+V pastes into terminals | PR #147 (CI green, pending merge) |

`changelog.ts` had not been touched since `8ee06de`.

**#143's entry was deliberately deferred, not forgotten.** Its author wrote: *"belongs in the next
version's entry rather than being folded into a released one — happy to add it once #141 lands."*
#141 has landed, so this executes that stated plan.

## Why CI could not catch it

`Changelog in sync` runs `gen-changelog.js --check`, which only verifies `CHANGELOG.md` matches
`changelog.ts`. A **missing** entry leaves the two perfectly in sync, so the gate is green and
silent. Worth being clear: beta.2's own coverage was in fact *complete* — every user-facing commit
in `v2.1.0-beta.1..8ee06de` is documented. The failure mode is not sloppiness, it is that nothing
watches the window **between** one release commit and the next. #148 notes an `in-beta`-label-driven
completeness check as a possible follow-up.

## Mechanics

Authored ahead of the release, which is the sanctioned order per `scripts/release.js`:

> *"Edit `src/renderer/changelog.ts` to add a new entry BEFORE running this script. The script will
> update the version field of the first entry to match the bumped version."*

So `2.1.0-beta.3` here is **provisional** — the release script rewrites it to whatever it bumps to.
It does **not** sync `date`, so please update that at release time if this sits unreleased for a
while.

## A trap worth knowing about

`gen-changelog.js` extracts the array by bracket-matching and tracks **string quotes but not
comments**. My first attempt put an explanatory comment inside the literal; the apostrophe in
`entry's` and the backticks around `` `date` `` opened phantom strings, threw off the bracket depth,
and the build died with an opaque `SyntaxError: Unexpected token ')'` pointing at generated code.

Fixed by moving the note **above** `export const changelog`, where it now warns future editors to
keep the array a pure data literal. The generator itself is untouched — hardening it to skip
comments would be a reasonable follow-up, but it is not this PR.

## Verification

- `npm run changelog` regenerates cleanly (72 versions).
- `node scripts/gen-changelog.js --check` reports in sync, exit 0 — same command as the CI gate.
- Two files only: `changelog.ts` + generated `CHANGELOG.md`.

## Note for the reviewer

Your uncommitted `.gitignore` change (un-ignoring `.claude/skills/` so shared agent skills can be
tracked) and the `.claude/skills/adversarial-review/` files were sitting in the working tree when I
branched. A `git add -A` briefly swept them into a commit; I removed them and **left them untouched
on disk** — they are your in-flight work, not part of this change.

Squash-merge.