### PR TITLE
chore(agents): adopt the adversarial-review skill for security-sensitive changes (#150)

### DIFF
--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: adversarial-review
+description: Run an independent multi-agent adversarial pass that tries to BREAK a change before it is approved. Triggers on `/adversarial-review <target>`, "attack this", "adversarially review", "try to break this", or automatically for any change touching a security-sensitive path (see Phase 0). Fans out independent attacker sub-agents with distinct lenses (injection, bypass, blast-radius, design+coverage), synthesizes findings, drives a bounded fix -> re-attack loop, and records an audited PASS/FINDINGS verdict on the PR. Never lets the author self-review a security boundary. The human still approves and merges.
+---
+
+You are the **adversarial-review orchestrator**. Your job is to make a change *prove it cannot be
+broken* before it earns an approval -- by dispatching **independent attackers**, not by re-reading
+the diff yourself. You are invoked directly (`/adversarial-review <target>`) or automatically when a
+change touches a security-sensitive path.
+
+**INPUT (target):** a PR number (`#147`/`147`), a commit range (`origin/beta..HEAD`), the working
+diff, or a path set. If none given, default to the current branch's diff vs `beta` (this repo's
+integration branch -- see AGENTS.md "Release Process").
+
+## Phase 0 -- Scope the target + risk
+
+Resolve the changed files:
+
+```
+git diff --stat origin/beta...HEAD        # branch / working tree
+gh pr diff <n>                            # a specific PR
+```
+
+A change is **security-sensitive (adversarial review REQUIRED)** if it touches any of:
+
+| Path / concern | Why |
+| --- | --- |
+| `src/main/ipc/**`, `src/preload/**`, `src/shared/ipc-channels*` | the renderer<->main trust boundary; Zod validation is the only gate |
+| `src/main/conductor-mcp-server.ts`, `src/main/vision*`, MCP/proxy upstream code | a locally-listening HTTP server with a bearer-token auth path |
+| PTY spawn / argv / shell construction (`src/main/pty*`, launcher arg building, `ccc` scripts) | command + argument injection into a real shell |
+| credential / token / keychain / DPAPI / account-profile code | secret handling |
+| updater + installer verification (`src/main/updater*`, checksum logic) | code-execution path on the user's machine |
+| file-path resolution that crosses a user-selected resources dir | path traversal |
+| Electron `webPreferences`, `contextIsolation`, `sandbox`, CSP, `will-navigate` handlers | the sandbox itself |
+| dependency bumps that change a **runtime** package's major version | new attack surface, silently |
+
+Docs-only, changelog-only, or pure-styling changes -> **tell the caller no adversarial pass is
+needed and stop.** Unsure -> treat as required (fail closed).
+
+Then identify the **boundary** under attack and its **claimed guarantees** -- read the code, the
+relevant ADR under `architecture/decisions/`, and the "Scope" / "Security Design" sections of
+`SECURITY.md`. The attackers will try to violate exactly those claims.
+
+## Phase 1 -- Fan out independent attackers (the core)
+
+Dispatch **independent sub-agents in parallel** (one Agent call per lens, all in a single message),
+each told: *your job is to find the bypass, not to bless the code; exercise the code empirically;
+report concrete repros.* Use at least these lenses for a security boundary, scaled up for higher
+risk:
+
+- **Injection / evasion** -- escape the boundary via shell metacharacters, quoting, globbing (note
+  the zsh/glob class of bug already seen in #144), encoding, Unicode, path separators -- whatever
+  the downstream interpreter (shell, PTY, URL parser, filesystem) re-parses.
+- **Allowlist / bypass** -- slip a denied action past a validator: alternate channels, casing,
+  abbreviations, aliases, alternate paths, denylist gaps. *Denylists are guilty until proven
+  complete.*
+- **Blast-radius / correctness** -- what the change actually does vs. what it claims; downstream
+  breakage; the fail-open vs fail-closed posture on bad input, missing config, or a thrown error.
+- **Design & coverage** -- implementation vs. stated guarantees; untested branches; missing tests.
+- **Platform parity** (add when the change touches spawn, paths, or the shell) -- does the defense
+  hold on Windows *and* macOS *and* Linux? Backslashes, `%5C`, drive letters, `cmd.exe` vs `zsh`.
+
+Give each attacker: the file path(s), the claimed guarantees, the exact way to run the code, and the
+required output shape.
+
+Run commands available to attackers:
+
+```
+npm run typecheck
+npx vitest run <path>
+npm run test:e2e
+```
+
+Required output shape from each attacker -- a findings list of:
+
+`SEVERITY (BLOCKER/MAJOR/MINOR/NONE) - title - exact repro - why exploitable (or why the defense
+holds) - suggested fix`
+
+plus a one-line verdict.
+
+**Hard rules for Phase 1:**
+
+- **The author of the change is never an attacker.** If you wrote the code, you orchestrate; the
+  sub-agents attack. Independent by construction.
+- Sub-agents are **read-only**: they make no commits, no GitHub writes, no label or issue changes.
+  You own all lifecycle and recording.
+- A sub-agent that reports "looks fine" without having run anything has not produced a finding --
+  send it back.
+
+## Phase 2 -- Synthesize
+
+Collect findings, dedup across lenses, assign a verdict:
+
+- **PASS** -- no unresolved BLOCKER or MAJOR.
+- **FINDINGS** -- at least one BLOCKER or MAJOR open.
+
+Note the architectural root cause when several findings share one (e.g. "denylist in a
+deny-by-default system" -> recommend an allowlist).
+
+## Phase 3 -- Fix -> re-attack (if FINDINGS)
+
+After fixing, run a **second independent pass against the patched code**: confirm each fix holds AND
+hunt for new gaps the fix introduced. **Add a regression test for every confirmed repro** (unit test
+in `tests/unit/`, e2e in `tests/e2e/`). Do not trust the first patch.
+
+- **Interactive caller:** repeat fix -> re-attack until a pass returns clean.
+- **Unattended / loop caller: BOUNDED to 2 fix -> re-attack rounds.** The attacker is always fresh
+  and never the author. If a PASS is not reached in 2 rounds, **do not force it and never lower the
+  bar** -- return the still-open FINDINGS verdict and quarantine (Phase 5). Bounding the rounds, not
+  the rigor, is the control.
+
+## Phase 3.5 -- Embargo triage (do this BEFORE you write anything down)
+
+An adversarial pass is the process most likely to turn up a vulnerability that is **not** the change
+under review: pre-existing, unfixed, and live in every shipped build. The instant that happens, stop
+and sort your findings into two piles, because they get written to different places:
+
+| Finding | Where it goes |
+| --- | --- |
+| A defect in **the change under review**, not yet merged | The PR verdict (Phase 4). Normal. |
+| A **pre-existing, unfixed** vulnerability in shipped code | A **private advisory**. Nowhere else. |
+
+For the second pile, **this repository is public and anything that gets pushed is publication.** The
+embargo covers the PR verdict comment, the commit message, the branch name, the `CONTEXT.d/`
+fragment, any ADR, and the changelog -- see `SECURITY.md` ("Embargo") for the workflow.
+
+`CONTEXT.d/` is the one that catches people, and it is the reason this phase exists. The running log
+feels like a scratch notebook; it is a tracked file, and a fragment describing a live bug is a
+disclosure with a repro attached. That near-miss is real -- it happened on the first run of this
+skill (#151) and was caught only before a push.
+
+So, when the pass surfaces an out-of-scope live vulnerability:
+
+1. **Do not put it in the PR verdict.** The verdict may say "the pass surfaced one unrelated
+   pre-existing finding, routed privately" -- no component, no mechanism, no repro.
+2. Hand the detail to the maintainer **out of band** and let them open the advisory.
+3. The `CONTEXT.d/` fragment for this work follows the same rule: it may record *that* a finding
+   exists and was routed privately, and nothing else.
+4. Any fix is developed in the **private fork attached to the advisory**, never in a branch on this
+   repo -- however innocently the branch is named.
+5. The public record -- fragment, changelog, advisory publication -- is written together, after the
+   fix ships.
+
+Sub-agents are read-only and never write to GitHub anyway, but they **do** return repros in their
+reports. Those reports are yours to handle: treat an attacker's write-up of a pre-existing
+vulnerability as embargoed material the moment you read it.
+
+## Phase 4 -- Record the audited verdict
+
+Post a value-free verdict on the PR: the lenses run, findings by severity, fixes + regression tests,
+and the verdict. **Never echo a secret found in the diff** -- name it and require rotation at
+source. Apply the Phase 3.5 split: nothing about an embargoed finding goes in this comment.
+
+Get the machine-readable marker line -- pre-filled with the PR number, head sha, and the
+content-address of the reviewed diff -- from:
+
+```
+sh .claude/skills/adversarial-review/adv-marker.sh PASS
+```
+
+Copy that line verbatim as the **first line** of the comment and append the severity tail:
+
+```
+ADVERSARIAL-REVIEW v1 | PASS | pr=#147 | head=<40hex> | content=<64hex> | 0 blockers, 0 majors open
+```
+
+Use `FINDINGS` instead of `PASS` while blockers/majors are open -- that does **not** clear the bar.
+Post it with:
+
+```
+gh pr comment <n> --body-file <file>
+```
+
+The `content=` field content-addresses the verdict to the **post-image content of each reviewed
+(non-generated) changed file** on the current head. A rebase or a regeneration of a generated file
+(`CONTEXT.md`, `CHANGELOG.md`) leaves it unchanged, so the PASS **carries forward** without a
+re-attack. Any real content change to a reviewed file changes the address and **does** force a fresh
+pass -- you only re-run when the change actually changed.
+
+## Phase 5 -- Hand back
+
+Return the verdict to the caller. A required pass sitting at FINDINGS means **do not recommend
+merge**. A **human still approves and merges** (see the standing rule: nothing is pushed or merged
+until the user OKs it and the change has been exercised in the desktop app) -- you are the
+first-pass filter, never the final authority.
+
+**Unattended caller, no PASS in 2 rounds -> QUARANTINE, never force:** label the PR
+`needs-review`, leave the branch pushed but unmerged, comment the FINDINGS verdict with a link to
+the open findings, and move on. A single quarantined change never halts the queue and is never
+merged past the bar.
+
+## Rules
+
+- **Never self-review a security boundary.** If you wrote it, you are not its reviewer.
+- **Independent + parallel.** Distinct lenses, separate sub-agents; diversity catches what
+  redundancy cannot.
+- **Empirical over assertion.** Attackers run the code and show repros; "looks fine" is not a
+  finding.
+- **Fail closed.** Unsure whether a path is sensitive -> required. Unsure whether a finding is real
+  -> open until disproven.
+- **Central lifecycle.** Sub-agents never write to GitHub; the orchestrator records once, audited.
+- **A dismissed scanner alert is a finding too.** Dismissing a CodeQL or Dependabot alert as a false
+  positive is a security decision -- it goes through the same attacker pass, and the dismissal
+  comment cites the repro that failed.
+- **Anything that gets pushed is publication.** A pre-existing, unfixed vulnerability goes to a
+  private advisory and to no tracked file -- not the PR comment, not the commit message, not the
+  branch name, not `CONTEXT.d/`. "Don't file a public issue" is the wrong mental model and is how
+  this rule got written. See Phase 3.5.
+- **A test that cannot fail is worse than no test.** Before you accept a regression test as a guard,
+  revert the fix and watch it fail. On the first run of this skill, two separate guards passed
+  against the very code they were written to catch -- and a passing guard gets trusted.

--- a/.claude/skills/adversarial-review/adv-marker.sh
+++ b/.claude/skills/adversarial-review/adv-marker.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+# Print the machine-readable ADVERSARIAL-REVIEW marker line for the current
+# branch / PR. Copy the output verbatim as the FIRST line of the PR verdict
+# comment, then append the severity tail (e.g. "0 blockers, 0 majors open").
+#
+#   sh .claude/skills/adversarial-review/adv-marker.sh [PASS|FINDINGS] [base]
+#
+# The content= field content-addresses the verdict to the POST-IMAGE CONTENT of
+# every reviewed (non-generated) changed file on the current head -- not to the
+# diff text. A rebase, or a regen of a generated file, leaves it unchanged, so a
+# PASS carries forward. Any real content change to a reviewed file changes it and
+# forces a fresh adversarial pass.
+#
+# GENERATED-FILE REGISTRY (closed -- do not widen to a docs/*.md glob):
+#   CONTEXT.md    aggregate rendered from CONTEXT.d/ fragments (gitignored)
+#   CHANGELOG.md  generated from src/renderer/changelog.ts by `npm run changelog`
+set -eu
+
+VERDICT="${1:-PASS}"
+BASE="${2:-origin/beta}"
+
+HEAD_SHA="$(git rev-parse HEAD)"
+PR="$(gh pr view --json number -q .number 2>/dev/null || echo '-')"
+
+CONTENT="$(
+  git diff --name-only "$BASE...HEAD" \
+    | grep -vE '^(CONTEXT\.md|CHANGELOG\.md)$' \
+    | LC_ALL=C sort \
+    | while IFS= read -r f; do
+        printf '%s %s\n' "$f" "$(git rev-parse "HEAD:$f" 2>/dev/null || echo DELETED)"
+      done \
+    | sha256sum | cut -d' ' -f1
+)"
+
+printf 'ADVERSARIAL-REVIEW v1 | %s | pr=#%s | head=%s | content=%s | ' \
+  "$VERDICT" "$PR" "$HEAD_SHA" "$CONTENT"
+echo

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,13 @@ dist/
 .secrets/
 .env
 
-# Personal/local config
-.claude/
+# Personal/local config. `.claude/*` (not `.claude/`) so the shared, repo-owned
+# agent skills under .claude/skills/ can be un-ignored below; git will not
+# descend into a wholly-excluded directory. Everything else in .claude/ --
+# settings.local.json, session state, caches -- stays personal and untracked.
+# (ADR-009 / 2026-07-30, same reasoning as ADR-004 tracking AGENTS.md.)
+.claude/*
+!.claude/skills/
 .agents/
 # AGENTS.md is now TRACKED — it is the canonical, cross-tool agent brief
 # (ADR-004 / 2026-07-18). CLAUDE.md imports it via `@AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 - Promote to stable: merge `release/vX.Y.Z` → `main`, run the release workflow from `main` with `channel=stable`, then delete the release branch
 - Changelog is generated from `src/renderer/changelog.ts` (single source; also drives the in-app "What's New" modal). Before a release, add the version's entry there, run `npm run changelog` to refresh `CHANGELOG.md`, and commit both. `release.js` already syncs the version line; the release workflow auto-populates the GitHub release notes from the same file (`scripts/gen-changelog.js --notes <version>`) — no hand-pasting. CI (`Changelog in sync`) fails on drift
 - Commits/PR titles follow Conventional Commits, enforced by a Husky `commit-msg` hook and the `PR Title` workflow (`commitlint.config.js`)
+- **Security-sensitive changes need an adversarial-review PASS before merge is recommended** (ADR-009). Touching IPC/preload, the Conductor MCP server, PTY argv construction, credential/keychain code, the updater's verification path, Electron `webPreferences`, or bumping a *runtime* dependency's major version? Run `/adversarial-review` — independent attacker sub-agents, not a re-read of your own diff. The author never attacks their own change. Docs/styling/changelog-only work is exempt. Unsure → it's required (fail closed). Dismissing a CodeQL/Dependabot alert as a false positive goes through the same pass
 - Issue lifecycle: label an issue `in-beta` (don't close it) when its fix merges to `beta`. Closing on promotion to `main` is AUTOMATIC (`.github/workflows/close-in-beta-on-promotion.yml`, #134) and keys off that label — an unlabeled issue is never closed by a promotion, so applying the label is the step that matters. See CONTRIBUTING.md ("Issue lifecycle")
 - GitHub Actions builds Windows (.exe) + macOS (.dmg) + Linux (.AppImage, experimental) installers; the release job tags the exact built commit (`--target`) so the in-app updater orders releases correctly
 - Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
@@ -79,6 +80,7 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 
 ## Deeper references
 
+- `.claude/skills/adversarial-review/SKILL.md` — the adversarial review pass required for security-sensitive changes (ADR-009), plus the path table that decides when it applies.
 - `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
 - `docs/versioning.md` — versioning scheme, prerelease suffixes, update channels, rolling re-release vs. version bump.

--- a/CONTEXT.d/2026-07-30-150-adversarial-review-skill.md
+++ b/CONTEXT.d/2026-07-30-150-adversarial-review-skill.md
@@ -1,0 +1,50 @@
+## 2026-07-30 -- Adopt the adversarial-review skill as a repo-owned asset (#150)
+
+Ported the aai-core `adversarial-review` skill into this repo and made it tracked, so
+security-sensitive changes stop being self-reviewed. Decision + rationale in ADR-009.
+
+- `.claude/skills/adversarial-review/SKILL.md` -- retargeted from the aai-core original:
+  `gh` / GitHub PRs replace `glab` + `aai mr` + Jira; `beta` replaces `dev` as the base
+  branch; the security-sensitive path table is rebuilt from THIS repo's `SECURITY.md`
+  scope (IPC/preload, conductor-mcp-server, PTY argv, credential/keychain, updater
+  verification, resources-dir path resolution, Electron webPreferences, runtime-dep
+  majors) rather than the generic aai one.
+- Added a **platform-parity lens** that the original does not have. #144 (zsh
+  glob-expands an unquoted `--model opus[1m]`) is exactly that bug class and got through
+  review because the reviewer ran Windows. A lens that asks "does this hold on the other
+  two platforms" is cheap and would have caught it.
+- Added the rule that **dismissing a scanner alert is itself a security decision** --
+  it goes through the same attacker pass, and the dismissal cites the repro that failed.
+  Prompted by CodeQL alert 6, which is a genuine false positive but was one keystroke
+  away from being dismissed with no record of why.
+- `adv-marker.sh` replaces `aai mr adv-marker` (no `aai` CLI here). It content-addresses
+  the verdict to the post-image CONTENT of the reviewed files, not the diff text, so a
+  rebase or a `CHANGELOG.md` regen carries a PASS forward while a real code change forces
+  a fresh pass. Generated-file registry is deliberately CLOSED (`CONTEXT.md`,
+  `CHANGELOG.md`) -- not a `docs/*.md` glob, which would let a hand-written doc slip past
+  the address.
+- `.gitignore`: `.claude/` -> `.claude/*` + `!.claude/skills/`. The `/*` form is required
+  because git will not descend into a wholly-excluded directory, so `!.claude/skills/`
+  alone would not work. Verified with `git check-ignore -v`. Personal `.claude` state
+  stays ignored. Same reasoning as ADR-004 un-ignoring `AGENTS.md`.
+- Phase 3.5 (embargo triage) and two Rules bullets added after the skill's FIRST run
+  (#151) taught two lessons the hard way. (a) An adversarial pass is the process most
+  likely to surface a PRE-EXISTING live vulnerability, and the natural place to write it
+  down -- the CONTEXT.d fragment -- is a tracked file in a public repo. That near-miss
+  happened and was caught only before a push; see #159 / ADR-010. (b) Two separate
+  regression guards passed against the very code they were written to catch, so "revert
+  the fix and watch the test fail" is now a stated rule, not an assumption.
+- `AGENTS.md`: added the review-bar line under Release Process and a "Deeper references"
+  pointer. Structural (a new review convention), so it qualifies under the
+  README/AGENTS-on-structural-change-only rule.
+
+Process note, recorded because it cost time: this work started in the primary
+`claude-command-center` worktree while a CONCURRENT session was committing #148 there.
+HEAD moved under it (fix/145 -> beta -> docs/148-changelog-beta3) and the in-flight skill
+files were swept into that session's changelog commit before being reset out. Moved to a
+dedicated `git worktree` (`../ccc-security`) off `beta`. Takeaway: security work gets its
+own worktree, not the shared tree.
+
+Companion tickets opened from the same review: #151 (4 open CodeQL alerts) and #152 (12
+open Dependabot alerts, all transitive, 11 closable via the existing `overrides` block).
+Both will be worked THROUGH this skill -- it is the first real exercise of it.

--- a/architecture/decisions/2026-07-30-adr-009-adversarial-review-for-security-changes.md
+++ b/architecture/decisions/2026-07-30-adr-009-adversarial-review-for-security-changes.md
@@ -1,0 +1,107 @@
+# ADR-009: Security-sensitive changes require an independent adversarial-review pass
+
+- **Status:** Accepted (2026-07-30)
+- **Deciders:** @nubbymong (owner)
+- **Related:** #150, CONTEXT.d/2026-07-30-150-adversarial-review-skill.md, SECURITY.md, ADR-004 (the same un-ignore reasoning applied to `AGENTS.md`), #116 (contributor/agent workflow)
+
+## Context
+
+`SECURITY.md` names six things as in-scope for this project's threat model:
+credential storage and encryption, IPC message handling between main and
+renderer, PTY input/command injection, MCP server access control, SSH credential
+handling, and local file access outside intended directories. Every one of those
+is a **boundary** — code whose entire value is that it holds under hostile input.
+
+The review process that guards them is the same one that guards a Tailwind class
+change: the author reads their own diff, CI runs typecheck and tests, an owner
+approves. That is self-review of a security boundary, and it fails in a specific,
+predictable way — an author cannot find the case they were blind to when they
+wrote the code, because the blindness is the bug. Tests have the same problem:
+they encode the cases the author thought of.
+
+The evidence is already in the repo's own history. #144 (`--model opus[1m]` is
+glob-expanded by zsh) survived review by a Windows author for whom the input was
+inert. That is not carelessness; it is the structural limit of single-perspective
+review. Nothing in the current process would have caught it.
+
+Meanwhile CodeQL and Dependabot generate alerts (16 open as of this ADR) whose
+*dismissal* is also a security decision, taken today with no review at all — a
+false-positive call is one keystroke and leaves no cited reasoning behind.
+
+The aai-core framework already solves this with an `adversarial-review` skill,
+but it is written against `glab` / `aai mr` / Jira and a GitLab MR lifecycle.
+
+## Decision
+
+**Adopt a repo-owned `adversarial-review` agent skill, and require a passing
+adversarial pass before any security-sensitive change is recommended for merge.**
+
+1. **The skill lives in the repo, tracked.** `.claude/skills/adversarial-review/`.
+   `.gitignore` changes `.claude/` to `.claude/*` plus `!.claude/skills/` — git
+   will not descend into a wholly-excluded directory, so the negation requires
+   the `/*` form. Personal `.claude` state (`settings.local.json`, session state,
+   caches) stays ignored. This is the same call ADR-004 made for `AGENTS.md`: a
+   file that defines shared process belongs to the repo, not to one workstation.
+
+2. **Independent attackers, not a re-read.** The orchestrator dispatches parallel
+   sub-agents, each with a distinct lens — injection/evasion, allowlist bypass,
+   blast-radius, design+coverage, and **platform parity** (Windows / macOS /
+   Linux; added specifically because of #144). Diversity of perspective is the
+   mechanism; a single more-careful reader is not a substitute.
+
+3. **The author is never an attacker.** If you wrote it, you orchestrate. This is
+   the rule the whole ADR exists to enforce.
+
+4. **Empirical over assertion.** An attacker runs the code and shows a repro.
+   "Looks fine" is not a finding and is sent back.
+
+5. **A closed, written classification rule.** The skill carries a path table
+   (IPC/preload, the Conductor MCP server, PTY argv construction, credential and
+   keychain code, the updater's installer-verification path, path resolution
+   across the resources dir, Electron `webPreferences`/CSP, and **runtime**
+   dependency major bumps). Docs/styling/changelog-only changes are explicitly
+   exempt. Unsure means required — fail closed.
+
+6. **Dismissing a scanner alert is a reviewed security decision.** A CodeQL or
+   Dependabot false-positive call goes through the same pass, and the dismissal
+   comment cites the repro that failed to work.
+
+7. **The verdict is content-addressed.** `adv-marker.sh` hashes the post-image
+   content of every reviewed non-generated changed file, not the diff text. A
+   rebase, or a regeneration of `CONTEXT.md` / `CHANGELOG.md`, leaves the address
+   unchanged and the PASS carries forward; any real content change to a reviewed
+   file forces a fresh pass. This is what makes the requirement affordable —
+   re-review is triggered by actual change, not by branch churn.
+
+8. **Bounded when unattended, never lowered.** An interactive caller loops
+   fix -> re-attack until clean. An unattended caller is capped at two rounds and
+   then *quarantines* — FINDINGS stands, the branch stays unmerged. The bound is
+   on the rounds, never on the bar.
+
+9. **The human still approves and merges.** The pass is a first-pass filter, not
+   an authority. It composes with — does not replace — owner review and CI.
+
+## Consequences
+
+**Positive.** Security-boundary changes get a perspective the author structurally
+cannot supply. Alert dismissals leave cited reasoning behind instead of a
+keystroke. The classification rule is written down, so "is this security-
+sensitive?" stops being decided ad hoc per PR. The skill is versioned with the
+code it guards, so a new contributor or a fresh clone inherits the bar.
+
+**Negative.** A security-sensitive PR costs more wall-clock and more tokens.
+There is a real risk the pass degrades into theatre if attackers are allowed to
+report impressions instead of repros — rule 4 is the only thing standing against
+that, and it has to be enforced by whoever reads the verdict.
+
+**Rejected alternative — rely on CodeQL and Dependabot alone.** Scanners find
+pattern-matchable defects. They cannot reason about whether an allowlist is
+complete, whether a defense holds on a platform the author does not run, or
+whether a change fails open. Alert 6 in the current backlog (SHA-256 of an email
+mapped to a UI colour, flagged as insecure password hashing) shows the inverse
+failure too: a scanner cannot tell a secret from an email address. Both
+directions need judgment applied adversarially.
+
+**Rejected alternative — a review checklist in CONTRIBUTING.md.** A checklist is
+read by the same author with the same blind spot. It changes what they look for,
+not who is looking.


### PR DESCRIPTION
Closes #150.

Adopts a repo-owned **adversarial-review** skill: security-sensitive changes get an
independent multi-agent pass that tries to break them, instead of the author re-reading
their own diff. Ported from the aai-core skill and retargeted to this repo.

### What's here

- `.claude/skills/adversarial-review/SKILL.md` — `gh`/GitHub PRs instead of `glab`/Jira,
  `beta` as base, and a security-sensitive path table derived from this repo's
  `SECURITY.md` scope.
- `.claude/skills/adversarial-review/adv-marker.sh` — content-addresses the verdict to the
  post-image content of reviewed files, so a rebase or a `CHANGELOG.md` regen carries a
  PASS forward while a real code change forces a fresh pass.
- `.gitignore`: `.claude/` → `.claude/*` + `!.claude/skills/`. Git will not descend into a
  wholly-excluded directory, hence the `/*` form. Personal `.claude` state stays ignored.
  Same call ADR-004 made for `AGENTS.md`.
- ADR-009, a `CONTEXT.d/` fragment, and `AGENTS.md` pointers.

### Additions over the original

- **Platform-parity lens.** #144 (zsh glob-expands an unquoted `--model opus[1m]`) is
  exactly the bug class a Windows-only reviewer cannot see.
- **Dismissing a scanner alert is a reviewed security decision**, with the failed repro
  cited in the dismissal.
- **Phase 3.5 (embargo triage)** and a "test that cannot fail is worse than no test" rule,
  both added after the skill's first real run — see #151 and #159.

### Why it earned its place immediately

First run (#151) found no bypass in 211k+ attempts, but proved **both** regression tests
guarding the fix were vacuous — they passed against the very code they were written to
catch. That is the class of defect self-review structurally cannot find.

No runtime code. Docs and tooling only.
