### PR TITLE
docs(security): state posture not guarantees and add an embargo rule (#159)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,20 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 - Linux builds on ubuntu-latest → glibc 2.39 floor (Ubuntu 24.04+/Rocky 10+); older distros need a container build. Vision on Linux requires a deb/rpm Chrome/Chromium (snap confinement blocks the CDP profile dir)
 - Never commit secrets, .env files, or personal paths
 
+## Security embargo — read before writing ANY doc about a security finding
+
+**This repository is public. Anything that gets pushed is publication.** If you have found
+or been handed an unfixed vulnerability, it does not go into a `CONTEXT.d/` fragment, an
+ADR, a commit message, a branch name, the changelog, an issue, or a PR — it goes into a
+private GitHub Security Advisory, and the fix is developed in the private fork attached to
+that advisory. See `SECURITY.md` ("Embargo") for the full workflow.
+
+`CONTEXT.d/` is the trap. The running log *feels* like a scratch notebook and is in fact a
+tracked file; a fragment describing a live bug is a disclosure with a repro attached. A
+fragment written during an embargo may say *that* a finding exists and was routed
+privately — never the component, the mechanism, or the repro. The public record (fragment,
+changelog entry, advisory) is written **after** the fix ships, all at once.
+
 ## Documentation protocol (CARP)
 
 - **Running log:** add a dated fragment under `CONTEXT.d/` for your work (see `CONTEXT.d/README.md`). `CONTEXT.md` is generated + gitignored — never commit it.

--- a/CONTEXT.d/2026-07-30-159-security-policy.md
+++ b/CONTEXT.d/2026-07-30-159-security-policy.md
@@ -1,0 +1,54 @@
+## 2026-07-30 -- Security policy rewritten: posture over guarantees, plus an embargo rule (#159)
+
+Triggered by a near-miss during #151. An adversarial-review pass surfaced an unrelated
+pre-existing finding; it was kept out of the issue tracker as SECURITY.md instructed, and
+then written with a full repro into a CONTEXT.d fragment and committed. Caught before any
+push and redacted -- nothing was disclosed -- but the failure was structural, not careless.
+The old policy's only stated control named the issue tracker, which invites the inference
+that other files are safe. They are not: this repo is public, and anything pushed is
+published. Decision and rationale in ADR-010.
+
+What changed in SECURITY.md:
+
+- "Security Design" (six flat guarantees) -> "Security posture", each property marked
+  enforced or conditional. Three corrections, all of them cases where the document was
+  stronger than the code:
+  - Credential storage: distinguishes provider OAuth credentials (OS store) from
+    locally-minted secrets that are on disk by necessity, because a spawned child has to
+    read them. The old "never plaintext" was not accurate.
+  - IPC validation: scoped to the preload bridge. The old "ALL inter-process messages"
+    was a claim about every present and future path; other arrival paths are now named as
+    in scope for reports rather than implied to be covered.
+  - Code execution: acknowledges the vision MCP tools evaluate JS by design. "No remote
+    code execution" read as though authenticated execution tooling did not exist, which
+    would steer a reporter away from the token boundary that actually matters.
+  Verified before writing: contextIsolation/nodeIntegration/sandbox ARE enforced on the
+  app windows (src/main/index.ts), so that bullet was left as an enforced guarantee.
+- New Embargo section listing every tracked artefact -- issues, PRs, commit messages,
+  branch names, CONTEXT.d, ADRs, changelog -- and the private-fork workflow. Regression
+  tests are called out as the deliberate exception: a test pinning the fix describes the
+  bug, so it is written at release time and ships with the fix.
+- Scope now covers what this product actually is: updater/installer integrity (with #111
+  named as known-open so reporters don't spend time on it), prompt injection leading to
+  command execution, malicious MCP upstreams, the loopback MCP server, and local-account
+  boundaries on a shared machine.
+- Response targets made achievable: 7-day ack, 14-day triage, 90-day disclosure default,
+  credit by default, safe-harbour terms. The old 48h/7d-critical SLA was not reachable at
+  this project's capacity, and a missed SLA costs more goodwill than a modest one.
+- Supported-versions table matching the beta/rc/stable channel model.
+- Documents the actual pipeline (CodeQL, Dependabot, adversarial review) and declares the
+  Scope section the source for the skill's path table, so policy and merge gate cannot
+  drift apart silently.
+
+Also confirmed while reviewing: GitHub private vulnerability reporting IS enabled on the
+repo, so the advisory link in the policy works for any reporter without write access. Added
+a no-detail fallback for anyone who cannot reach it.
+
+The embargo rule is mirrored in three files deliberately -- SECURITY.md (reporters),
+AGENTS.md (anyone working the repo), and the adversarial-review skill (the process most
+likely to GENERATE an embargoed finding, added on the #150 branch). Stating it once would
+have left it absent from exactly where the near-miss happened. SECURITY.md is the
+normative text; the other two point at it rather than restating it, to limit drift.
+
+Merge order note: this branch's SECURITY.md references ADR-009 and the skill path, both of
+which land with #150. Merge #150 first.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,33 +2,172 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in Claude Command Center, please report it privately via [GitHub Security Advisories](../../security/advisories/new). Do not file a public issue.
+Report privately via [GitHub Security Advisories](../../security/advisories/new). Private
+reporting is enabled on this repository, so that link works for anyone — you do not need
+write access.
 
-We will acknowledge receipt within 48 hours and aim to provide a fix within 7 days for critical issues.
+**Do not open a public issue, and do not describe the finding in a pull request, commit
+message, or any other file in the repository.** See [Embargo](#embargo) for why that list
+is longer than it looks.
+
+If GitHub advisories are unreachable for you, open a public issue containing **only** the
+words "security report, requesting a private channel" and no detail, and a maintainer will
+open the advisory and invite you to it.
+
+### What to include
+
+A repro is worth more than a description. Ideally: affected version and platform, the
+exact input or sequence, what you expected, what happened, and what an attacker gains.
+If you have a patch, hold it until the advisory exists — see [Embargo](#embargo).
+
+### What to expect
+
+This is a small project. These are honest targets, not a service commitment:
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement | 7 days |
+| Triage and severity assessment | 14 days |
+| Fix, or a written plan and timeline | case by case, communicated at triage |
+| Public disclosure | when the fix ships, or 90 days after the report, whichever is first |
+
+If the 90-day window expires without a fix, we will publish the advisory anyway with the
+current status. You are welcome to disclose after that window; we would appreciate a
+heads-up first. If something is already being actively exploited, say so and we will drop
+everything.
+
+We credit reporters in the advisory by default. Tell us if you would rather not be named.
+
+### Safe harbour
+
+We will not pursue or support legal action against research conducted in good faith under
+this policy: testing against **your own installation**, stopping once you have
+demonstrated the issue, not accessing or exfiltrating anyone else's data, and not
+degrading anyone else's service. Nothing here authorises testing against third parties —
+Anthropic's services, Microsoft's, or anyone's — and this policy cannot grant permission
+that is not ours to give.
+
+## Supported versions
+
+Security fixes land on the current release line only. The channel model is described in
+`docs/versioning.md` and `AGENTS.md`.
+
+| Version | Supported |
+| --- | --- |
+| Latest stable release | Yes |
+| Current beta / rc | Yes |
+| Anything older | No — upgrade |
+
+There are no long-term-support branches. Because the app self-updates, "upgrade" is
+usually a restart.
+
+## Embargo
+
+**A finding stays out of every tracked artefact until its fix has shipped.** Not just the
+issue tracker:
+
+- issues and pull requests
+- commit messages and branch names
+- `CONTEXT.d/` fragments — these are **tracked files in a public repository**
+- ADRs under `architecture/decisions/`
+- `src/renderer/changelog.ts` and `CHANGELOG.md`
+
+`CONTEXT.d/` is the one people get wrong, and it is the one this rule was written for. The
+running log feels like a private notebook. It is not — it is committed, and pushing it
+publishes a diff containing the repro. "Don't file a public issue" is the wrong mental
+model. The right one is: **anything that gets pushed is publication.**
+
+The workflow:
+
+1. The advisory is created first. It is private.
+2. Development happens in the **private fork GitHub attaches to the advisory** — not in a
+   branch on this repo, however innocently named.
+3. The fix merges and releases. Only then is the public record written: the `CONTEXT.d/`
+   fragment, the changelog entry, and the advisory publication, together.
+4. A public issue may be opened at that point to track follow-up hardening.
+
+A fragment written during an embargo may record *that* a finding exists and was routed
+privately. It must not name the component, the mechanism, or the repro.
+
+Regression tests are the one careful exception: a test that pins the fix ships with the
+fix, and its name and comments will describe the bug. That is correct and unavoidable —
+write them at release time, not before.
 
 ## Scope
 
-The following are in scope for security reports:
+The following are in scope:
 
-- Credential storage and encryption (DPAPI/Keychain/libsecret)
-- IPC message handling between main and renderer processes
-- PTY input injection or command injection
-- MCP server access control
-- SSH credential handling
-- Local file access outside intended directories
+- **Update and installer integrity** — the in-app updater downloads and launches
+  installers. This ships code to a user's machine and is the highest-consequence surface
+  in the product. (Checksum verification is tracked in #111 and is not yet complete;
+  reports are welcome, but that specific gap is already known.)
+- **Credential storage and handling** — OS credential store usage, and any place a token
+  or secret is written to disk or handed to a child process
+- **IPC message handling** between main, preload, and renderer
+- **PTY input and command injection** — argument construction for spawned shells
+- **Prompt injection leading to command execution** — CCC runs an agent that acts on
+  untrusted repository content and can spawn shells. Anything that turns content a user
+  merely *opened* into a command the machine *ran* is in scope, and is the threat class we
+  most want reports about.
+- **MCP server access control** — the loopback Conductor server, its auth token, and the
+  tools it exposes. Some exposed tooling executes code by design (browser evaluation via
+  the vision tools); the boundary under test is *authentication and authorisation of that
+  tooling*, not its existence.
+- **Malicious or compromised MCP upstreams** reached through Conductor Proxy
+- **SSH session handling**, including data a remote host can send back to the app
+- **Local file access outside intended directories** — path traversal, symlink handling
+- **Privilege boundaries between local user accounts** on a shared machine
 
-## Out of Scope
+## Out of scope
 
-- Issues in Claude Code CLI itself (report to [Anthropic](https://github.com/anthropics/claude-code))
-- Issues in Electron framework (report to [Electron](https://github.com/electron/electron))
-- Social engineering attacks
-- Attacks requiring physical access to the machine (credentials are machine-bound by design)
+- Issues in Claude Code CLI itself — report to [Anthropic](https://github.com/anthropics/claude-code)
+- Issues in Electron, Node, or Chromium — report upstream
+- Social engineering
+- Attacks requiring physical access to an unlocked machine. Credentials are machine-bound
+  by design; an attacker at the keyboard of an unlocked session has already won.
+- Anything requiring the user to already be running attacker-controlled code under their
+  own account
+- Missing hardening with no demonstrated impact (absent headers, version disclosure, and
+  similar) unless you can show what it buys an attacker
 
-## Security Design
+## Security posture
 
-- **No telemetry** - the app sends no analytics or tracking data
-- **Local-only storage** - all config, logs, and credentials stay on the user's machine
-- **Encrypted credentials** - OS credential store (never plaintext)
-- **Sandboxed renderer** - Electron's contextIsolation and sandbox enabled
-- **IPC validation** - all inter-process messages validated with Zod schemas
-- **No remote code execution** - no eval, no remote script loading
+These are the properties the project is *built for*. They are stated as posture, not as
+guarantees, because the difference matters: an unqualified guarantee tells a reporter a
+boundary is already covered, so they stop looking — which is exactly where bugs
+accumulate. Where a property is conditional, it says so.
+
+- **No telemetry.** The app sends no analytics or tracking data.
+- **Local-only storage.** Config, logs, and session state stay on the machine. Network
+  egress is to provider APIs, hosts you explicitly SSH to, and the update endpoint.
+- **Renderer sandboxing — enforced.** Application windows run with
+  `contextIsolation: true`, `nodeIntegration: false`, and `sandbox: true`. All
+  renderer↔main communication crosses a typed preload bridge.
+- **Credential storage — the OS credential store for the credentials CCC owns.** Provider
+  OAuth credentials are held by the OS store. This is *not* a claim that no secret is ever
+  on disk: the app also mints local secrets (for example the loopback MCP token) that are
+  persisted in the resources directory and passed to child processes, because a spawned
+  session has to be able to read them. Those are local-trust values rather than account
+  credentials, and they are only as protected as the user's own file permissions.
+- **IPC validation — enforced at the preload bridge.** Renderer↔main channels are typed
+  and schema-validated. Data arriving over *other* paths is not uniformly held to the same
+  standard, and hardening those paths is ongoing. Treat them as in scope for reports.
+- **Code execution — no `eval` of remote content, but some tooling executes code by
+  design.** The app loads no remote scripts and does not `eval` untrusted input.
+  Separately and intentionally, the vision MCP tools evaluate JavaScript in the controlled
+  browser instance; that capability sits behind the MCP token. A bypass of that
+  authentication is a vulnerability. The capability itself is a feature.
+
+## How we find these ourselves
+
+So contributors know what bar applies, and reporters know what has already been swept:
+
+- **CodeQL** — static analysis on push and on a schedule. Dismissing an alert is itself a
+  security decision and is reviewed like a code change.
+- **Dependabot** — dependency alerts, with transitive fixes pinned through the `overrides`
+  block in `package.json`.
+- **Adversarial review** (ADR-009) — security-sensitive changes get an independent
+  multi-agent pass that tries to break them before merge, instead of an author re-reading
+  their own diff. The path table deciding when it applies lives in
+  `.claude/skills/adversarial-review/SKILL.md` and is derived from the Scope section
+  above, so this document and that gate stay in step.

--- a/architecture/decisions/2026-07-30-adr-010-security-posture-and-embargo.md
+++ b/architecture/decisions/2026-07-30-adr-010-security-posture-and-embargo.md
@@ -1,0 +1,119 @@
+# ADR-010: State security posture, not guarantees — and embargo findings from every tracked artefact
+
+- **Status:** Accepted (2026-07-30)
+- **Deciders:** @nubbymong (owner)
+- **Related:** #159, SECURITY.md, ADR-009 (adversarial review), CONTEXT.d/2026-07-30-159-security-policy.md, #111 (updater checksum verification)
+
+## Context
+
+Two failures surfaced on the same day, from opposite directions.
+
+**The document overclaimed.** `SECURITY.md`'s "Security Design" section listed six
+properties as flat guarantees — among them "credentials never plaintext", "**all**
+inter-process messages validated with Zod schemas", and "no remote code execution — no
+eval". Checked against the code, some were absolute, some were conditional, and the
+document drew no distinction. The app persists locally-minted secrets to disk by
+necessity; schema validation is enforced at the preload bridge but not uniformly on every
+path data arrives by; and the vision MCP tools evaluate JavaScript in a controlled browser
+by design, behind the MCP token.
+
+None of that is a bug. The *document* was the bug. An unqualified guarantee is an
+instruction to a reporter: this boundary is handled, look elsewhere. It steers attention
+away from precisely the places where assumptions are load-bearing. It also misleads users
+about what they are trusting.
+
+**The process leaked.** While working #151, an adversarial-review pass (ADR-009) surfaced
+an unrelated pre-existing issue. It was correctly kept out of the issue tracker — because
+`SECURITY.md` says "do not file a public issue" — and then written, with a repro, into a
+`CONTEXT.d/` fragment and committed. It was caught before any push and redacted, so
+nothing was disclosed. But the near-miss was structural, not careless: the running log
+*feels* like a private notebook, it is written routinely and often by agents, and the
+policy's only stated control named the issue tracker specifically.
+
+The threat model was also stale. It described a conventional desktop app, and omitted the
+updater (which ships code to users' machines), prompt injection leading to command
+execution (the defining risk of an agentic tool), malicious MCP upstreams, and other local
+accounts on a shared machine. The stated SLA — 48-hour acknowledgement, 7-day critical fix
+— is not achievable at this project's maintenance capacity, and a missed SLA discourages
+the next reporter more than a modest one would.
+
+## Decision
+
+**1. Security claims are stated as posture, with their conditions attached.**
+
+`SECURITY.md` gains a "Security posture" section replacing "Security Design". Each
+property says whether it is *enforced* or *conditional*, and conditional ones state the
+condition. Three specific corrections: credential storage now distinguishes provider OAuth
+credentials (OS store) from locally-minted secrets (on disk, because a spawned child
+process must read them); IPC validation is scoped to the preload bridge with other paths
+named as in scope for reports; and code execution acknowledges that the vision tools
+evaluate JavaScript by design, so the boundary under test is *authentication of that
+capability*, not its existence.
+
+The bar: a reader must not be able to conclude from this document that an area is covered
+when it is only partly covered. Where we are unsure, the document says the area is in
+scope for reports.
+
+**2. An embargo covers every tracked artefact, not the issue tracker.**
+
+A finding stays out of issues, PRs, commit messages, branch names, `CONTEXT.d/` fragments,
+ADRs, and the changelog until its fix has shipped. Development happens in the private fork
+GitHub attaches to the advisory — never in a branch on this repo, however innocently
+named. The public record is written all at once, after release.
+
+The operative reframing, because the old rule was the wrong mental model:
+**anything that gets pushed is publication.** "Do not file a public issue" invites the
+inference that other files are safe. They are not.
+
+A fragment written during an embargo may record *that* a finding exists and was routed
+privately, with no component, mechanism, or repro. Regression tests are the deliberate
+exception — a test pinning the fix necessarily describes the bug, so it is written at
+release time and ships with the fix.
+
+This rule is mirrored in three places on purpose: `SECURITY.md` (for reporters),
+`AGENTS.md` (for anyone working the repo), and the adversarial-review skill (for the
+process most likely to *generate* an embargoed finding). Stating it once would have left
+it exactly where the near-miss happened.
+
+**3. The threat model matches the product.** Scope gains update/installer integrity,
+prompt-injection-to-execution, malicious MCP upstreams, the loopback MCP server, and
+local-account boundaries. Out-of-scope gains the "already running attacker code" and
+"no demonstrated impact" exclusions.
+
+**4. Response targets are honest.** 7-day acknowledgement, 14-day triage, no fixed fix
+deadline, 90-day coordinated-disclosure default, credit by default, and safe-harbour
+terms.
+
+**5. The document names its own tooling** — CodeQL, Dependabot, adversarial review — and
+the scope section is declared the source for the skill's path table, so the policy and the
+merge gate cannot drift apart silently.
+
+## Consequences
+
+**Positive.** Reporters get an accurate map, including an explicit invitation to the two
+areas previously implied to be closed. Users get a description of what they are actually
+trusting. The embargo rule closes a systematic leak on the path agents take most often.
+Naming the pipeline tells contributors what bar applies before they open a PR.
+
+**Negative.** The policy is longer, and longer policies are read less. Honesty about
+conditional properties can read as weakness to someone skimming — a reader who sees "not
+uniformly held to the same standard" may conclude the project is less careful than one
+that flatly claims full validation, when the opposite is true. Accepted deliberately:
+overclaiming buys goodwill from skimmers at the cost of misleading the people who would
+have found real bugs.
+
+Keeping the same rule in three files creates drift risk. Mitigated by making `SECURITY.md`
+the normative text and the other two explicit pointers to it, rather than restatements.
+
+**Rejected alternative — fix the code so the original claims become true, and change
+nothing in the document.** Attractive, and partly correct: some of that hardening is worth
+doing on its own merits and is tracked separately. But it fails as a policy answer. "All
+IPC validated with Zod" is a claim about every present and future path; it would be false
+again the first time someone adds a channel. Posture statements survive contact with a
+changing codebase; absolute guarantees have to be re-earned on every commit and will
+silently rot.
+
+**Rejected alternative — a shorter policy that just says "report privately".** It is the
+current document's failure mode. The specific list of tracked artefacts is the entire
+value here, because the near-miss happened to someone who *had* read "do not file a public
+issue" and complied with it.


### PR DESCRIPTION
Closes #159. **Merge #160 first** — `SECURITY.md` references ADR-009 and the skill path.

### Why

Two failures, same day, opposite directions.

**The document overclaimed.** "Security Design" listed six flat guarantees. Three were
stronger than what the code enforces:

| Claim | Reality |
| --- | --- |
| Credentials "never plaintext" | Provider OAuth is in the OS store, but locally-minted secrets (the loopback MCP token, the hooks token) are on disk by necessity — a spawned child has to read them |
| "**All** IPC validated with Zod" | Enforced at the preload bridge; not uniformly on every path data arrives by |
| "No remote code execution — no eval" | The vision MCP tools evaluate JS by design, behind the MCP token |

Renderer sandboxing was checked against the code (`contextIsolation`/`nodeIntegration`/
`sandbox`, `src/main/index.ts:242`) and kept as an enforced guarantee.

None of that is a code bug. The *document* was the bug: an unqualified guarantee tells a
reporter a boundary is handled, so they stop looking — and two of the three false claims
sat directly over real weaknesses.

**The process leaked.** Working #151, an adversarial pass surfaced an unrelated
pre-existing finding. It was correctly kept out of the issue tracker, because the policy
says "do not file a public issue" — and then written, with a repro, into a `CONTEXT.d/`
fragment and committed. Caught before any push and redacted; nothing was disclosed. But
the near-miss was structural: `CONTEXT.d/` is a tracked file in a public repo, it is
written routinely and often by agents, and the policy's only stated control named the
issue tracker.

### What changed

- **"Security Design" → "Security posture"**, each property marked enforced or
  conditional, with conditions stated.
- **New Embargo section** covering every tracked artefact — issues, PRs, commit messages,
  branch names, `CONTEXT.d/`, ADRs, changelog — plus the private-fork workflow. Regression
  tests are the deliberate exception. The reframing: **anything that gets pushed is
  publication.**
- **Scope matches the product**: updater/installer integrity (#111 named as known-open),
  prompt injection leading to command execution, malicious MCP upstreams, the loopback MCP
  server, local-account boundaries.
- **Achievable targets** — 7-day ack, 14-day triage, 90-day disclosure default, credit by
  default, safe harbour. The old 48h/7d-critical SLA was not reachable.
- Supported-versions table for the beta/rc/stable channels.
- Documents the real pipeline (CodeQL, Dependabot, adversarial review) and declares Scope
  the source for the skill's path table, so policy and merge gate cannot drift silently.
- `AGENTS.md` carries the embargo rule where agents will hit it. ADR-010 records the
  reasoning, including why overclaiming is the worse failure.

Confirmed while reviewing: private vulnerability reporting **is** enabled on the repo, so
the advisory link works for reporters without write access. Added a no-detail fallback.

No runtime code. Docs only.
