### PR TITLE
fix(security): resolve the open CodeQL alerts (#151)

### DIFF
--- a/CONTEXT.d/2026-07-30-151-codeql-alerts.md
+++ b/CONTEXT.d/2026-07-30-151-codeql-alerts.md
@@ -1,0 +1,55 @@
+## 2026-07-30 -- CodeQL alert remediation, worked through adversarial review (#151)
+
+First real exercise of the adversarial-review skill adopted in #150. Four independent
+attacker sub-agents, then two bounded fix -> re-attack rounds. The pass paid for itself:
+the code fixes were sound, but almost every GUARD around them was not.
+
+Alert dispositions:
+- Alert 8 (js/polynomial-redos, conductor-mcp-server.ts) -- FIXED. `/^bearer\s+(.+)$/i`
+  replaced by a linear prefix parse.
+- Alerts 9/10 (js/insecure-randomness) -- FIXED. New `src/shared/id.ts` (`randomId`,
+  crypto.getRandomValues); all 13 duplicated inline `Date.now()+Math.random()` generators
+  converged onto it.
+- Alert 6 (js/insufficient-password-hash, account-color.ts) -- FALSE POSITIVE, dismissal
+  justified with a traced root cause: CodeQL's `maybePassword()` heuristic in
+  SensitiveDataHeuristics.qll contains the literal alternative `oauth`, which matches the
+  containing property name `oauthAccount` at both taint origins. The field itself,
+  `emailAddress`, matches no heuristic. Not yet dismissed on GitHub -- pending.
+
+What the attackers found that a self-review would not have:
+- BOTH regression tests were VACUOUS, and one of them twice. The ReDoS flood was
+  `'bearer ' + spaces`, which `authHeader.trim()` reduces to the 6-char string `'bearer'`
+  -- and which the vulnerable regex MATCHES anyway in one backtrack. It passed at 0.15ms
+  against the very code it was supposed to catch. The quadratic path needs a
+  LineTerminator `.` cannot cross plus a non-whitespace tail surviving trim:
+  `'bearer' + SP*n + 'X\nY'`, which fails at 2270ms. Then the round-2 tri-state test
+  repeated the mistake -- `Bearer wrong` is not a refusal under ANY implementation.
+  Both are now verified by reverting the parser and confirming they fail.
+- A real gap in round 1's fix: the separator check looked only at the FIRST character, and
+  the following `slice().trim()` absorbed the rest, so `Bearer<SP><NBSP><token>` was
+  accepted. One legal space defeated the whole narrowing. Now scans the run.
+- `timingSafeEqual(<empty>,<empty>)` is true and `?token=` yields `''` not null, so an
+  empty `expectedSecret` authorized every request. Latent (the provider always mints 64
+  hex) but the gate must not trust its own input.
+- 32-char ids moved the Windows MAX_PATH cliff 18 chars closer for
+  `<resourcesDir>/status/<id>.json`, whose write is a bare `catch {}` inside an emitted
+  script -- the symptom would be a silently blank ContextBar. ID_BYTES 16 -> 12.
+- Three factually wrong claims in my own comments, corrected: the ReDoS is NOT reachable
+  through Node's HTTP parser (llhttp 400s bare CR/LF, maxHeaderSize caps at 16 KB); RFC
+  9110 section 11.4 gives `auth-scheme 1*SP`, so accepting HTAB is MORE permissive than
+  the RFC, not "the only legal form"; and Codex IS a header-only client
+  (`bearer_token_env_var`, no `?token=`), so the Authorization header is its sole
+  credential channel.
+
+Process lesson worth keeping: the attackers found no bypass in 211k+ attempts, but found
+that the tests certifying the fix were worthless. A vacuous guard is worse than no guard,
+because it will be trusted. "Verify the test fails against the unfixed code" is now the
+minimum bar for any security regression test here.
+
+SEPARATE FINDING, ROUTED PRIVATELY -- the adversarial pass surfaced one unrelated,
+pre-existing issue while tracing the alert-6 taint path. It is NOT described here.
+Deliberately: this file is tracked and this repo is public, so a running-log fragment is
+a disclosure channel exactly like an issue is. It has been handed to the maintainer for
+a private advisory under SECURITY.md. Nothing about it -- component, mechanism, or repro
+-- belongs in a tracked file, a commit message, an ADR, or the changelog until a fix has
+shipped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.2",
+      "version": "2.1.0-beta.1",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.1",
+      "version": "2.1.0-beta.2",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/src/main/channel-storage.ts
+++ b/src/main/channel-storage.ts
@@ -43,7 +43,10 @@ export function readJsonFile<T>(name: string, seedDefaults: () => T): T {
   try {
     return JSON.parse(readFileSync(fp, 'utf-8')) as T
   } catch (err) {
-    const corruptPath = `${fp}.corrupt-${Date.now()}-${randomId()}`
+    // A collision-breaker on an already-timestamped name, not an identifier --
+    // 8 hex chars is plenty, and the full 32 would push an already-long
+    // quarantine path 24 chars closer to Windows MAX_PATH for no benefit.
+    const corruptPath = `${fp}.corrupt-${Date.now()}-${randomId().slice(0, 8)}`
     try { renameSync(fp, corruptPath); logError(`[channels] ${name} unreadable, moved to ${corruptPath}`) }
     catch (e) { logError(`[channels] could not quarantine ${name}: ${String(e)}`) }
     return seedDefaults()

--- a/src/main/channel-storage.ts
+++ b/src/main/channel-storage.ts
@@ -44,8 +44,8 @@ export function readJsonFile<T>(name: string, seedDefaults: () => T): T {
     return JSON.parse(readFileSync(fp, 'utf-8')) as T
   } catch (err) {
     // A collision-breaker on an already-timestamped name, not an identifier --
-    // 8 hex chars is plenty, and the full 32 would push an already-long
-    // quarantine path 24 chars closer to Windows MAX_PATH for no benefit.
+    // 8 hex chars is plenty, and the full 24 would push an already-long
+    // quarantine path 16 chars closer to Windows MAX_PATH for no benefit.
     const corruptPath = `${fp}.corrupt-${Date.now()}-${randomId().slice(0, 8)}`
     try { renameSync(fp, corruptPath); logError(`[channels] ${name} unreadable, moved to ${corruptPath}`) }
     catch (e) { logError(`[channels] could not quarantine ${name}: ${String(e)}`) }

--- a/src/main/channel-storage.ts
+++ b/src/main/channel-storage.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync, ren
 import { join } from 'path'
 import { getResourcesDirectory } from './ipc/setup-handlers'
 import { logInfo, logError } from './debug-logger'
+import { randomId } from '../shared/id'
 
 const SUBDIR = 'conductor-channels'
 
@@ -42,7 +43,7 @@ export function readJsonFile<T>(name: string, seedDefaults: () => T): T {
   try {
     return JSON.parse(readFileSync(fp, 'utf-8')) as T
   } catch (err) {
-    const corruptPath = `${fp}.corrupt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const corruptPath = `${fp}.corrupt-${Date.now()}-${randomId()}`
     try { renameSync(fp, corruptPath); logError(`[channels] ${name} unreadable, moved to ${corruptPath}`) }
     catch (e) { logError(`[channels] could not quarantine ${name}: ${String(e)}`) }
     return seedDefaults()

--- a/src/main/cloud-agent-manager.ts
+++ b/src/main/cloud-agent-manager.ts
@@ -13,6 +13,7 @@ import { resolveVersionBinary, isVersionInstalled, installVersion } from './lega
 import { isValidLegacyVersion } from '../shared/legacy-version'
 import { getProfileConfigDir, getPrimaryProfileId, setupProfileLinks, listProfiles } from './account-profiles'
 import { withProfileHome } from './pty-manager'
+import { randomId } from '../shared/id'
 
 export interface CloudAgentData {
   id: string
@@ -85,7 +86,7 @@ let agents: CloudAgentData[] = []
 let getWindow: () => BrowserWindow | null = () => null
 
 function generateId(): string {
-  return 'ca-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+  return randomId('ca-')
 }
 
 function persist(): void {

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -117,6 +117,28 @@ export function getConductorMcpSecret(): string {
   return _conductorMcpSecret
 }
 
+const BEARER_SCHEME = 'bearer'
+
+/** Parse `Bearer <token>` from an Authorization header value, or null.
+ *
+ *  Deliberately NOT a regex. The obvious `/^bearer\s+(.+)$/i` backtracks in
+ *  polynomial time on `"bearer "` followed by many spaces (CodeQL
+ *  js/polynomial-redos, #151) -- and this runs on an attacker-controlled header
+ *  on a listening socket BEFORE authentication, so it is reachable by anyone who
+ *  can reach the port. Prefix-compare the scheme, require one whitespace
+ *  separator, then take the remainder: single pass, no backtracking, linear in
+ *  the header length whatever the input. */
+function parseBearerToken(authHeader: string): string | null {
+  const trimmed = authHeader.trim()
+  if (trimmed.length <= BEARER_SCHEME.length) return null
+  if (trimmed.slice(0, BEARER_SCHEME.length).toLowerCase() !== BEARER_SCHEME) return null
+  // The separator must be whitespace, else `bearerX` would parse as scheme `bearer`.
+  const sep = trimmed[BEARER_SCHEME.length]
+  if (sep !== ' ' && sep !== '\t') return null
+  const token = trimmed.slice(BEARER_SCHEME.length + 1).trim()
+  return token.length > 0 ? token : null
+}
+
 /** Extract the presented token from either an `Authorization: Bearer <token>`
  *  header or a `?token=<token>` query param, then compare against the expected
  *  secret in constant time. The header is checked first (cheaper, and the
@@ -131,8 +153,7 @@ export function isAuthorizedMcpRequest(
 ): boolean {
   let presented: string | null = null
   if (authHeader) {
-    const m = /^bearer\s+(.+)$/i.exec(authHeader.trim())
-    if (m) presented = m[1]
+    presented = parseBearerToken(authHeader)
   }
   if (presented === null && reqUrl) {
     try {

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -119,23 +119,58 @@ export function getConductorMcpSecret(): string {
 
 const BEARER_SCHEME = 'bearer'
 
-/** Parse `Bearer <token>` from an Authorization header value, or null.
+/** Parse `Bearer <token>` from an Authorization header value.
  *
- *  Deliberately NOT a regex. The obvious `/^bearer\s+(.+)$/i` backtracks in
- *  polynomial time on `"bearer "` followed by many spaces (CodeQL
- *  js/polynomial-redos, #151) -- and this runs on an attacker-controlled header
- *  on a listening socket BEFORE authentication, so it is reachable by anyone who
- *  can reach the port. Prefix-compare the scheme, require one whitespace
- *  separator, then take the remainder: single pass, no backtracking, linear in
- *  the header length whatever the input. */
-function parseBearerToken(authHeader: string): string | null {
+ *  Three-state return, because "no Bearer credential was offered" and "a Bearer
+ *  credential was offered and we refused to parse it" must not be conflated:
+ *    - string    -- a well-formed Bearer token
+ *    - undefined -- not a Bearer header at all (absent, or another scheme such
+ *                   as Basic). The caller may fall through to `?token=`.
+ *    - null      -- a Bearer header we REFUSED (bad separator, empty token).
+ *                   The caller must treat this as fatal; falling through would
+ *                   let a mangled header silently downgrade to a weaker channel.
+ *
+ *  Deliberately NOT a regex. The obvious `/^bearer\s+(.+)$/i` is quadratic on
+ *  `"bearer" + <long run of spaces> + <line terminator> + x`: the trailing
+ *  LineTerminator is what `.` cannot cross, which forces `\s+` to give a
+ *  character back and retry for every position in the run (CodeQL
+ *  js/polynomial-redos, #151).
+ *
+ *  Reachability, stated honestly: that payload does NOT arrive through Node's
+ *  HTTP parser today. llhttp rejects bare CR/LF in a header value with a 400
+ *  before any handler runs, header values decode as latin-1 (so U+2028/U+2029
+ *  cannot appear as single code units), `http.maxHeaderSize` caps the value at
+ *  16 KB, and llhttp strips trailing OWS. So this is a static-analysis finding
+ *  mitigated in depth, not a live loopback DoS. It is fixed anyway because the
+ *  parser is a policy dependency that must not rely on a *different* component's
+ *  input filtering to be safe, and because `isAuthorizedMcpRequest` is exported
+ *  and callable with anything.
+ *
+ *  Prefix-compare the scheme, require exactly one SP/HTAB separator, take the
+ *  remainder: single pass, no backtracking, linear whatever the input.
+ *
+ *  On the separator: RFC 9110's ABNF for `credentials` is `auth-scheme 1*SP
+ *  token68`, so SP is the only RFC-legal separator here -- HTAB is NOT (OWS/BWS
+ *  govern whitespace around field delimiters, not this position). HTAB is
+ *  accepted anyway for backward compatibility with the `\s` this replaced. All
+ *  other whitespace `\s` used to accept is now rejected; no token writer in this
+ *  repo emits anything but a single SP (the registration paths use `?token=`
+ *  and never a header at all), so nothing real regresses. */
+function parseBearerToken(authHeader: string): string | null | undefined {
   const trimmed = authHeader.trim()
-  if (trimmed.length <= BEARER_SCHEME.length) return null
-  if (trimmed.slice(0, BEARER_SCHEME.length).toLowerCase() !== BEARER_SCHEME) return null
-  // The separator must be whitespace, else `bearerX` would parse as scheme `bearer`.
+  if (trimmed.length <= BEARER_SCHEME.length) return undefined
+  if (trimmed.slice(0, BEARER_SCHEME.length).toLowerCase() !== BEARER_SCHEME) return undefined
   const sep = trimmed[BEARER_SCHEME.length]
-  if (sep !== ' ' && sep !== '\t') return null
+  if (sep !== ' ' && sep !== '\t') {
+    // Not whitespace at all -> this is a DIFFERENT scheme whose name merely
+    // starts with "bearer" (e.g. `bearerX`), so no Bearer credential was
+    // offered. Whitespace that is not SP/HTAB -> a Bearer header we refuse.
+    return /\s/.test(sep) ? null : undefined
+  }
   const token = trimmed.slice(BEARER_SCHEME.length + 1).trim()
+  // Unreachable while the outer `.trim()` above stands (trimmed cannot end in
+  // whitespace, and sep IS whitespace, so the remainder always has a non-space
+  // char). Kept as defence in depth against an edit that drops that trim.
   return token.length > 0 ? token : null
 }
 
@@ -151,9 +186,19 @@ export function isAuthorizedMcpRequest(
   authHeader: string | undefined,
   expectedSecret: string,
 ): boolean {
+  // A secret shorter than the real 64-hex one means the provider is broken or
+  // absent. Refuse rather than authenticate: `?token=` yields '' for an empty
+  // query value, and timingSafeEqual(<empty>, <empty>) is true -- so without
+  // this guard an empty expectedSecret authorizes every request (#151).
+  if (!expectedSecret || expectedSecret.length < 32) return false
+
   let presented: string | null = null
   if (authHeader) {
-    presented = parseBearerToken(authHeader)
+    const fromHeader = parseBearerToken(authHeader)
+    // A Bearer header we refused to parse is fatal. Only "no Bearer credential
+    // offered" (undefined) falls through to the weaker query-param channel.
+    if (fromHeader === null) return false
+    if (fromHeader !== undefined) presented = fromHeader
   }
   if (presented === null && reqUrl) {
     try {

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -119,6 +119,16 @@ export function getConductorMcpSecret(): string {
 
 const BEARER_SCHEME = 'bearer'
 
+/** Single-character whitespace test. Linear by construction -- no quantifier,
+ *  so there is nothing to backtrack. Matches the set `String.prototype.trim()`
+ *  strips, which is what keeps the separator scan below consistent with the
+ *  outer trim. */
+const WHITESPACE = /\s/
+
+function isSpOrTab(c: string): boolean {
+  return c === ' ' || c === '\t'
+}
+
 /** Parse `Bearer <token>` from an Authorization header value.
  *
  *  Three-state return, because "no Bearer credential was offered" and "a Bearer
@@ -126,9 +136,15 @@ const BEARER_SCHEME = 'bearer'
  *    - string    -- a well-formed Bearer token
  *    - undefined -- not a Bearer header at all (absent, or another scheme such
  *                   as Basic). The caller may fall through to `?token=`.
- *    - null      -- a Bearer header we REFUSED (bad separator, empty token).
- *                   The caller must treat this as fatal; falling through would
- *                   let a mangled header silently downgrade to a weaker channel.
+ *    - null      -- a Bearer header we REFUSED: the whitespace run separating
+ *                   the scheme from the token contains something other than
+ *                   SP/HTAB. The caller must treat this as fatal; falling
+ *                   through would let a mangled header silently downgrade to a
+ *                   weaker channel.
+ *
+ *  (There is deliberately no "empty token" refusal state: the outer `.trim()`
+ *  makes `'Bearer '` collapse to the bare scheme, which is `undefined` -- no
+ *  Bearer credential offered -- long before any token check.)
  *
  *  Deliberately NOT a regex. The obvious `/^bearer\s+(.+)$/i` is quadratic on
  *  `"bearer" + <long run of spaces> + <line terminator> + x`: the trailing
@@ -149,28 +165,50 @@ const BEARER_SCHEME = 'bearer'
  *  Prefix-compare the scheme, require exactly one SP/HTAB separator, take the
  *  remainder: single pass, no backtracking, linear whatever the input.
  *
- *  On the separator: RFC 9110's ABNF for `credentials` is `auth-scheme 1*SP
- *  token68`, so SP is the only RFC-legal separator here -- HTAB is NOT (OWS/BWS
- *  govern whitespace around field delimiters, not this position). HTAB is
- *  accepted anyway for backward compatibility with the `\s` this replaced. All
- *  other whitespace `\s` used to accept is now rejected; no token writer in this
- *  repo emits anything but a single SP (the registration paths use `?token=`
- *  and never a header at all), so nothing real regresses. */
+ *  On the separator: RFC 9110 section 11.4 gives
+ *  `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, so SP is the
+ *  only RFC-legal separator here -- HTAB is NOT (OWS/BWS govern whitespace
+ *  around field delimiters, not this position). HTAB is accepted anyway for
+ *  backward compatibility with the `\s` this replaced. Every OTHER whitespace
+ *  character `\s` used to accept is rejected, anywhere in the separator run --
+ *  the run is scanned, not just its first character, because
+ *  `slice(...).trim()` would otherwise silently absorb a rejected character
+ *  that merely sat behind a legal one (`Bearer<SP><NBSP><token>`).
+ *
+ *  Blast radius of that narrowing: the SSE/HTTP registration writers all embed
+ *  `?token=` and send no header at all, so they are unaffected. The one
+ *  header-only client is Codex -- `providers/codex/spawn.ts` sets
+ *  `mcp_servers.conductor.bearer_token_env_var=CONDUCTOR_MCP_TOKEN` with no
+ *  `?token=` in its URL, so the Authorization header is its ONLY credential
+ *  channel. Its rmcp client formats `Bearer ` with a single SP, so it is
+ *  unaffected too -- but a future change here breaks Codex outright with no
+ *  fallback, which is why this paragraph exists. */
 function parseBearerToken(authHeader: string): string | null | undefined {
   const trimmed = authHeader.trim()
   if (trimmed.length <= BEARER_SCHEME.length) return undefined
   if (trimmed.slice(0, BEARER_SCHEME.length).toLowerCase() !== BEARER_SCHEME) return undefined
-  const sep = trimmed[BEARER_SCHEME.length]
-  if (sep !== ' ' && sep !== '\t') {
+  if (!isSpOrTab(trimmed[BEARER_SCHEME.length])) {
     // Not whitespace at all -> this is a DIFFERENT scheme whose name merely
     // starts with "bearer" (e.g. `bearerX`), so no Bearer credential was
     // offered. Whitespace that is not SP/HTAB -> a Bearer header we refuse.
-    return /\s/.test(sep) ? null : undefined
+    return WHITESPACE.test(trimmed[BEARER_SCHEME.length]) ? null : undefined
   }
-  const token = trimmed.slice(BEARER_SCHEME.length + 1).trim()
-  // Unreachable while the outer `.trim()` above stands (trimmed cannot end in
-  // whitespace, and sep IS whitespace, so the remainder always has a non-space
-  // char). Kept as defence in depth against an edit that drops that trim.
+
+  // Walk the whole separator run. Stopping at the first character would let
+  // `Bearer<SP><NBSP><token>` through, because the slice+trim below absorbs any
+  // leading whitespace the check did not look at -- so the narrowing would be
+  // defeated by one legal space in front of an illegal one. Single pass, so
+  // this stays linear.
+  let i = BEARER_SCHEME.length
+  while (i < trimmed.length && WHITESPACE.test(trimmed[i])) {
+    if (!isSpOrTab(trimmed[i])) return null
+    i++
+  }
+
+  const token = trimmed.slice(i)
+  // Unreachable while the outer `.trim()` above stands: trimmed cannot end in
+  // whitespace, so the separator run always terminates on a real character.
+  // Kept as defence in depth against an edit that drops that trim.
   return token.length > 0 ? token : null
 }
 

--- a/src/main/team-manager.ts
+++ b/src/main/team-manager.ts
@@ -10,6 +10,7 @@ import { dispatchAgent, cancelAgent, getAgentOutput, onAgentCompletion, CloudAge
 import { logInfo, logError } from './debug-logger'
 import type { TeamTemplate, TeamRun, TeamRunStep, TeamRunStatus, TeamStep } from '../shared/types'
 import { IPC } from '../shared/ipc-channels'
+import { randomId } from '../shared/id'
 
 const MAX_CONTEXT_BYTES = 50 * 1024 // 50KB per prior step output
 
@@ -21,11 +22,11 @@ let getWindow: () => BrowserWindow | null = () => null
 const agentToRun = new Map<string, string>()
 
 function generateTeamId(): string {
-  return 'team-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+  return randomId('team-')
 }
 
 function generateRunId(): string {
-  return 'tr-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+  return randomId('tr-')
 }
 
 function persistTeams(): void {

--- a/src/renderer/components/AgentLibrary.tsx
+++ b/src/renderer/components/AgentLibrary.tsx
@@ -4,6 +4,7 @@ import type { AgentTemplate } from '../types/electron'
 import AgentTemplateDialog from './AgentTemplateDialog'
 import { useRegistryStore } from '../stores/registryStore'
 import { resolveModelInfo } from '../../shared/model-registry'
+import { generateId } from '../utils/id'
 
 interface ContextMenuState {
   x: number
@@ -88,7 +89,7 @@ export default function AgentLibrary() {
   }
 
   const handleSaveNew = (data: Omit<AgentTemplate, 'id'>) => {
-    const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+    const id = generateId()
     addTemplate({ ...data, id })
     setShowDialog(false)
   }

--- a/src/renderer/components/ProjectBrowser.tsx
+++ b/src/renderer/components/ProjectBrowser.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useSessionStore, Session } from '../stores/sessionStore'
 import { markSessionForResumePicker } from '../utils/resumePicker'
 import { COLOR_SWATCHES } from './SessionDialog'
+import { generateId } from '../utils/id'
 
 interface DiscoveredProject {
   path: string
@@ -52,7 +53,7 @@ export default function ProjectBrowser() {
 
   const resumeSession = (ds: DiscoveredSession, projectPath: string) => {
     const session: Session = {
-      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 8),
+      id: generateId(),
       label: ds.firstMessage.slice(0, 40) || 'Resumed session',
       workingDirectory: projectPath,
       model: ds.model || '',

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -8,6 +8,7 @@ import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegistryStore } from '../stores/registryStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { modelsFromRegistry, PERMISSION_MODES } from '../lib/claude-cli-options'
+import { generateId } from '../utils/id'
 
 export type SessionType = 'local' | 'ssh'
 
@@ -222,7 +223,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
 
   const handleCreateSection = () => {
     if (!newSectionName.trim()) return
-    const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 6)
+    const id = generateId()
     addSection({ id, name: newSectionName.trim() })
     setSectionId(id)
     setNewSectionName('')
@@ -231,7 +232,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
 
   const handleCreateGroup = () => {
     if (!newGroupName.trim()) return
-    const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 6)
+    const id = generateId()
     addGroup({ id, name: newGroupName.trim() })
     setGroupId(id)
     setNewGroupName('')

--- a/src/renderer/components/TeamBuilder.tsx
+++ b/src/renderer/components/TeamBuilder.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from 'react'
 import { useTeamStore } from '../stores/teamStore'
 import { useAgentLibraryStore, BUILTIN_TEMPLATES } from '../stores/agentLibraryStore'
 import type { TeamTemplate, TeamStep, TeamStepMode } from '../types/electron'
+import { generateId } from '../utils/id'
 
 function generateStepId(): string {
-  return 'ts-' + Math.random().toString(36).slice(2, 10)
+  return 'ts-' + generateId()
 }
 
 function generateTeamId(): string {
-  return 'team-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+  return 'team-' + generateId()
 }
 
 export default function TeamBuilder({ onClose }: { onClose: () => void }) {

--- a/src/renderer/stores/agentLibraryStore.ts
+++ b/src/renderer/stores/agentLibraryStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { AgentTemplate, AgentModelOverride } from '../types/electron'
+import { generateId } from '../utils/id'
 
 // ── Built-in Templates ──
 
@@ -109,7 +110,7 @@ export const useAgentLibraryStore = create<AgentLibraryState>((set, get) => ({
     const all = [...state.templates, ...BUILTIN_TEMPLATES]
     const original = all.find(t => t.id === id)
     if (!original) return undefined
-    const newId = Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+    const newId = generateId()
     const copy: AgentTemplate = {
       ...original,
       id: newId,

--- a/src/renderer/stores/configStore.ts
+++ b/src/renderer/stores/configStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { saveConfigNow, saveConfigDebounced } from '../utils/config-saver'
 import type { ProviderId, ClaudeOptions, CodexOptions } from '../../shared/types'
 import type { IdentityColorKey } from '../../shared/identity-colors'
+import { generateId } from '../utils/id'
 
 // Re-export provider types so callers can import from a single place
 export type { ProviderId, ClaudeOptions, CodexOptions }
@@ -253,7 +254,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
     const state = useConfigStore.getState()
     const original = state.configs.find((c) => c.id === configId)
     if (!original) return undefined
-    const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+    const id = generateId()
     const copy: TerminalConfig = {
       ...original,
       id,

--- a/src/renderer/utils/id.ts
+++ b/src/renderer/utils/id.ts
@@ -1,3 +1,8 @@
+import { randomId } from '../../shared/id'
+
+/** Renderer-side opaque id. Thin alias over the shared generator so the ~20
+ *  existing call sites keep their import; see src/shared/id.ts for why this is
+ *  not Math.random (#151). */
 export function generateId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+  return randomId()
 }

--- a/src/shared/id.ts
+++ b/src/shared/id.ts
@@ -20,7 +20,22 @@
  * (statusline-watcher.ts).
  */
 
-const ID_BYTES = 16 // 128 bits
+/**
+ * 12 bytes -> 24 hex chars, not the reflexive 16/32.
+ *
+ * Session ids become filenames at `<resourcesDir>/status/<sessionId>.json`, and
+ * the resources dir is user-selected and can be deep. The old ids were 14 chars,
+ * so 32 would have moved the legacy Windows MAX_PATH cliff 18 chars closer for a
+ * user who has long paths disabled -- and the write that would fail is a bare
+ * `catch {}` inside the emitted statusline bridge script, so the symptom is a
+ * permanently blank ContextBar with nothing logged.
+ *
+ * 96 bits is not a compromise on the security property: it is ~7.9e28 values,
+ * unguessable by any margin that matters locally, with a birthday bound around
+ * 2^48 draws. The property CodeQL flagged is unpredictability, and 96 bits has
+ * it; 128 would only have bought path length.
+ */
+const ID_BYTES = 12
 
 /** A cryptographically random, path-safe opaque id, optionally prefixed. */
 export function randomId(prefix = ''): string {

--- a/src/shared/id.ts
+++ b/src/shared/id.ts
@@ -1,0 +1,32 @@
+/**
+ * Opaque identifier generation, shared by main and renderer.
+ *
+ * Every id in the app used to be `Date.now().toString(36) + Math.random()...`,
+ * duplicated inline in ~15 places. `Math.random()` is not a CSPRNG: V8 seeds a
+ * xorshift128+ stream whose internal state is recoverable from a handful of
+ * outputs, so subsequent ids are predictable -- and `Date.now()` contributes no
+ * entropy at all, it just makes the prefix look unique. CodeQL flagged the two
+ * account add / re-auth login flows specifically (js/insecure-randomness, #151);
+ * rather than harden two call sites and leave thirteen copies of the same
+ * generator behind, all of them route here.
+ *
+ * `crypto.getRandomValues` (not `crypto.randomUUID`) is the primitive: it is a
+ * WebCrypto global in both the Electron main process (Node 18+) and the
+ * renderer, and unlike `randomUUID` it does not require a secure context, so it
+ * cannot fail depending on how the renderer happens to be loaded.
+ *
+ * Output is lowercase hex, so an id is always safe to use as a path segment --
+ * session ids reach the filesystem as `<resourcesDir>/status/<sessionId>.json`
+ * (statusline-watcher.ts).
+ */
+
+const ID_BYTES = 16 // 128 bits
+
+/** A cryptographically random, path-safe opaque id, optionally prefixed. */
+export function randomId(prefix = ''): string {
+  const bytes = new Uint8Array(ID_BYTES)
+  globalThis.crypto.getRandomValues(bytes)
+  let hex = ''
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0')
+  return prefix + hex
+}

--- a/tests/unit/main/conductor-mcp-auth-redos.test.ts
+++ b/tests/unit/main/conductor-mcp-auth-redos.test.ts
@@ -1,16 +1,30 @@
 /**
  * #151 / CodeQL js/polynomial-redos -- regression guard for the Bearer parser.
  *
- * `isAuthorizedMcpRequest` used `/^bearer\s+(.+)$/i` on the raw Authorization
- * header. That pattern backtracks in polynomial time on `"bearer "` followed by
- * a long run of whitespace, and it runs on an attacker-controlled header on a
- * listening loopback socket BEFORE authentication -- so anything that can reach
- * the port can burn main-process CPU with a single request. The parser is now
- * a linear prefix compare (see parseBearerToken in conductor-mcp-server.ts).
+ * `isAuthorizedMcpRequest` used `/^bearer\s+(.+)$/i` on the Authorization
+ * header. Replaced with a linear prefix parse (parseBearerToken).
  *
- * The timing assertion here is deliberately loose. It is not a benchmark; it
- * only has to fail if someone reintroduces a super-linear pattern, and the
- * quadratic blow-up is orders of magnitude, not percent.
+ * READ THIS BEFORE EDITING THE PAYLOAD. The first version of this file was
+ * VACUOUS -- it flooded with `'bearer ' + ' '.repeat(n)` and asserted a time
+ * bound. Two independent adversarial reviewers found that all of its timing
+ * assertions PASS against the vulnerable regex, so it guarded nothing:
+ *
+ *   1. `isAuthorizedMcpRequest` calls `authHeader.trim()` BEFORE parsing, so a
+ *      trailing whitespace run is deleted -- `'bearer ' + ' '.repeat(100_000)`
+ *      trims to the 6-char string `'bearer'`.
+ *   2. Even untrimmed, that input MATCHES: `\s+` takes one space, `(.+)` eats
+ *      the rest, `$` hits. One backtrack. Linear.
+ *
+ * The quadratic path needs the match to FAIL after the whitespace run, which
+ * needs a LineTerminator that `.` cannot cross -- and a non-whitespace tail so
+ * the outer `.trim()` cannot eat it. Hence `'bearer' + SP*n + 'X\nY'`. Measured
+ * against the pre-fix regex: n=20k 128ms, n=40k 549ms, n=80k 2209ms (clean
+ * n^2). The linear parser is flat and sub-millisecond at every size.
+ *
+ * Reachability, for honesty: this payload does not survive Node's HTTP parser
+ * (llhttp 400s bare CR/LF in a header value, and http.maxHeaderSize caps the
+ * value at 16 KB). The fix and this guard stand anyway -- the exported function
+ * must not depend on another component's input filtering to be safe.
  */
 import { describe, it, expect } from 'vitest'
 import {
@@ -20,6 +34,11 @@ import {
 
 const SECRET = getConductorMcpSecret()
 
+/** The payload that actually forces backtracking. Do not "simplify" this. */
+function redosPayload(spaces: number): string {
+  return 'bearer' + ' '.repeat(spaces) + 'X\nY'
+}
+
 function timeMs(fn: () => void): number {
   const t0 = performance.now()
   fn()
@@ -27,25 +46,33 @@ function timeMs(fn: () => void): number {
 }
 
 describe('Bearer parsing is linear in the header length (#151)', () => {
-  it('rejects a whitespace-flood header fast and does not hang', () => {
-    const flood = 'bearer ' + ' '.repeat(100_000)
+  it('rejects the quadratic payload in well under the vulnerable time', () => {
     const elapsed = timeMs(() => {
-      expect(isAuthorizedMcpRequest('/sse', flood, SECRET)).toBe(false)
+      expect(isAuthorizedMcpRequest('/sse', redosPayload(80_000), SECRET)).toBe(false)
     })
-    // The vulnerable regex took seconds at this size; linear parsing is sub-ms.
-    expect(elapsed).toBeLessThan(500)
+    // Pre-fix: 2209 ms at this size. Post-fix: sub-millisecond. A 50 ms bound
+    // is ~44x margin over the fix and ~44x under the bug -- it cannot be passed
+    // by a reintroduced regex, and it cannot flake on a loaded CI box.
+    expect(elapsed).toBeLessThan(50)
   })
 
-  it('does not blow up super-linearly as the flood grows', () => {
+  it('does not blow up super-linearly as the payload grows', () => {
     const small = timeMs(() => {
-      isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(20_000), SECRET)
+      isAuthorizedMcpRequest('/sse', redosPayload(20_000), SECRET)
     })
     const large = timeMs(() => {
-      isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(160_000), SECRET)
+      isAuthorizedMcpRequest('/sse', redosPayload(80_000), SECRET)
     })
-    // 8x the input. Linear would be ~8x; quadratic ~64x. Allow generous slack
-    // for timer noise on a loaded CI box, but catch an order-of-magnitude jump.
-    expect(large).toBeLessThan(Math.max(small * 25, 500))
+    // 4x the input. Linear ~4x; the vulnerable regex measured ~17x (128->2209ms).
+    // Generous slack for timer noise, but an order-of-magnitude jump fails.
+    expect(large).toBeLessThan(Math.max(small * 10, 50))
+  })
+
+  it('also stays linear on a trailing whitespace flood (the trimmed case)', () => {
+    const elapsed = timeMs(() => {
+      expect(isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(200_000), SECRET)).toBe(false)
+    })
+    expect(elapsed).toBeLessThan(50)
   })
 
   it('a whitespace-only token is not a token', () => {
@@ -74,19 +101,65 @@ describe('Bearer parsing preserves the pre-fix contract (#151)', () => {
     expect(isAuthorizedMcpRequest('/sse', `BeArEr ${SECRET}`, SECRET)).toBe(true)
   })
 
-  it('rejects a scheme that merely starts with "bearer" (no separator)', () => {
-    expect(isAuthorizedMcpRequest('/sse', `bearerX ${SECRET}`, SECRET)).toBe(false)
-  })
-
   it('rejects the bare scheme with no token', () => {
     expect(isAuthorizedMcpRequest('/sse', 'bearer', SECRET)).toBe(false)
   })
+})
 
-  it('rejects a different auth scheme carrying the secret', () => {
-    expect(isAuthorizedMcpRequest('/sse', `Basic ${SECRET}`, SECRET)).toBe(false)
+/**
+ * The separator narrowed from `\s` (any whitespace) to SP/HTAB. That is the
+ * entire semantic delta of the fix, and it was originally UNTESTED -- a future
+ * "let's be lenient again" refactor back to `\s` would have passed the suite.
+ * RFC 9110 gives `auth-scheme 1*SP token68`, so SP is the only legal separator;
+ * HTAB is kept purely for backward compatibility.
+ */
+describe('separator narrowing is pinned (#151)', () => {
+  // Escapes, not literals: invisible characters in source do not survive
+  // copy/paste review. These are every whitespace class `\s` used to accept.
+  const NON_SP_WHITESPACE = [
+    '\u000a', '\u000b', '\u000c', '\u000d', '\u00a0', '\u1680', '\u2000',
+    '\u2028', '\u2029', '\u202f', '\u205f', '\u3000', '\ufeff',
+  ]
+
+  for (const ws of NON_SP_WHITESPACE) {
+    const label = `U+${ws.codePointAt(0)!.toString(16).padStart(4, '0')}`
+    it(`rejects ${label} as a scheme separator even with the correct secret`, () => {
+      expect(isAuthorizedMcpRequest('/sse', `Bearer${ws}${SECRET}`, SECRET)).toBe(false)
+    })
+  }
+
+  it('a refused Bearer header is FATAL -- it does not fall through to ?token=', () => {
+    // Pre-review this returned true: the malformed header parsed to null, which
+    // was indistinguishable from "no header", so the query param took over.
+    expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, `Bearer wrong`, SECRET)).toBe(false)
   })
 
-  it('falls back to the query param when the header is not a Bearer header', () => {
+  it('a NON-Bearer scheme is not a refusal -- ?token= still works', () => {
+    // `Basic ...` offers no Bearer credential at all, so the query param is
+    // still the presented credential. Distinct from the fatal case above.
     expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, 'Basic zzz', SECRET)).toBe(true)
   })
+
+  it('a scheme merely starting with "bearer" is not a refusal', () => {
+    expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, 'bearerX zzz', SECRET)).toBe(true)
+  })
+
+  it('rejects a different auth scheme carrying the secret in the header', () => {
+    expect(isAuthorizedMcpRequest('/sse', `Basic ${SECRET}`, SECRET)).toBe(false)
+  })
+})
+
+/**
+ * timingSafeEqual(<empty>, <empty>) is true, and `?token=` yields '' rather
+ * than null -- so an empty expectedSecret authorized every request. The live
+ * provider always mints 64 hex chars, but the gate must not trust its own input.
+ */
+describe('a missing or degenerate expected secret fails closed (#151)', () => {
+  for (const bad of ['', 'short', 'a'.repeat(31)]) {
+    it(`refuses to authenticate against a ${bad.length}-char secret`, () => {
+      expect(isAuthorizedMcpRequest('/sse?token=', undefined, bad)).toBe(false)
+      expect(isAuthorizedMcpRequest(`/sse?token=${bad}`, undefined, bad)).toBe(false)
+      expect(isAuthorizedMcpRequest('/sse', `Bearer ${bad}`, bad)).toBe(false)
+    })
+  }
 })

--- a/tests/unit/main/conductor-mcp-auth-redos.test.ts
+++ b/tests/unit/main/conductor-mcp-auth-redos.test.ts
@@ -39,40 +39,45 @@ function redosPayload(spaces: number): string {
   return 'bearer' + ' '.repeat(spaces) + 'X\nY'
 }
 
+/** Best-of-3 elapsed time. Round-2 review measured occasional 80ms excursions
+ *  under heavy CPU load, because payload allocation sat INSIDE the timed window
+ *  and a GC pause landed in the measurement. Callers now build the payload
+ *  first and this takes the minimum of three runs. Discriminating power is
+ *  ~2270ms vs ~0.5ms, so nothing is lost by being generous. */
 function timeMs(fn: () => void): number {
-  const t0 = performance.now()
-  fn()
-  return performance.now() - t0
+  let best = Infinity
+  for (let i = 0; i < 3; i++) {
+    const t0 = performance.now()
+    fn()
+    best = Math.min(best, performance.now() - t0)
+  }
+  return best
 }
 
 describe('Bearer parsing is linear in the header length (#151)', () => {
   it('rejects the quadratic payload in well under the vulnerable time', () => {
-    const elapsed = timeMs(() => {
-      expect(isAuthorizedMcpRequest('/sse', redosPayload(80_000), SECRET)).toBe(false)
-    })
-    // Pre-fix: 2209 ms at this size. Post-fix: sub-millisecond. A 50 ms bound
-    // is ~44x margin over the fix and ~44x under the bug -- it cannot be passed
-    // by a reintroduced regex, and it cannot flake on a loaded CI box.
-    expect(elapsed).toBeLessThan(50)
+    const payload = redosPayload(80_000)
+    expect(isAuthorizedMcpRequest('/sse', payload, SECRET)).toBe(false)
+    // Pre-fix: ~2270 ms at this size (measured). Post-fix: sub-millisecond.
+    // 250 ms sits ~9x under the bug signal and ~500x over the fixed path -- a
+    // reintroduced regex cannot pass it, and a slow shared runner has room.
+    expect(timeMs(() => isAuthorizedMcpRequest('/sse', payload, SECRET))).toBeLessThan(250)
   })
 
   it('does not blow up super-linearly as the payload grows', () => {
-    const small = timeMs(() => {
-      isAuthorizedMcpRequest('/sse', redosPayload(20_000), SECRET)
-    })
-    const large = timeMs(() => {
-      isAuthorizedMcpRequest('/sse', redosPayload(80_000), SECRET)
-    })
+    const smallPayload = redosPayload(20_000)
+    const largePayload = redosPayload(80_000)
+    const small = timeMs(() => isAuthorizedMcpRequest('/sse', smallPayload, SECRET))
+    const large = timeMs(() => isAuthorizedMcpRequest('/sse', largePayload, SECRET))
     // 4x the input. Linear ~4x; the vulnerable regex measured ~17x (128->2209ms).
     // Generous slack for timer noise, but an order-of-magnitude jump fails.
-    expect(large).toBeLessThan(Math.max(small * 10, 50))
+    expect(large).toBeLessThan(Math.max(small * 10, 250))
   })
 
   it('also stays linear on a trailing whitespace flood (the trimmed case)', () => {
-    const elapsed = timeMs(() => {
-      expect(isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(200_000), SECRET)).toBe(false)
-    })
-    expect(elapsed).toBeLessThan(50)
+    const flood = 'bearer ' + ' '.repeat(200_000)
+    expect(isAuthorizedMcpRequest('/sse', flood, SECRET)).toBe(false)
+    expect(timeMs(() => isAuthorizedMcpRequest('/sse', flood, SECRET))).toBeLessThan(250)
   })
 
   it('a whitespace-only token is not a token', () => {
@@ -128,10 +133,28 @@ describe('separator narrowing is pinned (#151)', () => {
     })
   }
 
+  // ROUND-2 NOTE. The first version of this used `Bearer wrong` as the payload.
+  // That is NOT a refusal -- SP separator, non-empty token -- so it parses cleanly
+  // under the pre-fix regex, round 1 and round 2 alike, and the assertion
+  // discriminated nothing (its comment claimed the opposite, wrongly). A real
+  // refusal needs a separator that `\s` accepted and SP/HTAB does not. U+00A0 is
+  // the one such character that survives Node's HTTP parser (obs-text, decoded as
+  // latin-1), so it is the honest payload. Escape, never a literal.
   it('a refused Bearer header is FATAL -- it does not fall through to ?token=', () => {
-    // Pre-review this returned true: the malformed header parsed to null, which
-    // was indistinguishable from "no header", so the query param took over.
-    expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, `Bearer wrong`, SECRET)).toBe(false)
+    const nbsp = '\u00a0'
+    expect(
+      isAuthorizedMcpRequest(`/sse?token=${SECRET}`, `Bearer${nbsp}${SECRET}`, SECRET),
+    ).toBe(false)
+  })
+
+  it('a rejected separator hiding behind a legal one is still fatal', () => {
+    // If only the FIRST separator char were checked, `slice().trim()` would absorb
+    // the rest -- so one leading space would defeat the entire narrowing.
+    for (const ws of NON_SP_WHITESPACE) {
+      expect(isAuthorizedMcpRequest('/sse', `Bearer ${ws}${SECRET}`, SECRET)).toBe(false)
+      expect(isAuthorizedMcpRequest('/sse', `Bearer\t${ws} ${SECRET}`, SECRET)).toBe(false)
+      expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, `Bearer ${ws}x`, SECRET)).toBe(false)
+    }
   })
 
   it('a NON-Bearer scheme is not a refusal -- ?token= still works', () => {

--- a/tests/unit/main/conductor-mcp-auth-redos.test.ts
+++ b/tests/unit/main/conductor-mcp-auth-redos.test.ts
@@ -1,0 +1,92 @@
+/**
+ * #151 / CodeQL js/polynomial-redos -- regression guard for the Bearer parser.
+ *
+ * `isAuthorizedMcpRequest` used `/^bearer\s+(.+)$/i` on the raw Authorization
+ * header. That pattern backtracks in polynomial time on `"bearer "` followed by
+ * a long run of whitespace, and it runs on an attacker-controlled header on a
+ * listening loopback socket BEFORE authentication -- so anything that can reach
+ * the port can burn main-process CPU with a single request. The parser is now
+ * a linear prefix compare (see parseBearerToken in conductor-mcp-server.ts).
+ *
+ * The timing assertion here is deliberately loose. It is not a benchmark; it
+ * only has to fail if someone reintroduces a super-linear pattern, and the
+ * quadratic blow-up is orders of magnitude, not percent.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  isAuthorizedMcpRequest,
+  getConductorMcpSecret,
+} from '../../../src/main/conductor-mcp-server'
+
+const SECRET = getConductorMcpSecret()
+
+function timeMs(fn: () => void): number {
+  const t0 = performance.now()
+  fn()
+  return performance.now() - t0
+}
+
+describe('Bearer parsing is linear in the header length (#151)', () => {
+  it('rejects a whitespace-flood header fast and does not hang', () => {
+    const flood = 'bearer ' + ' '.repeat(100_000)
+    const elapsed = timeMs(() => {
+      expect(isAuthorizedMcpRequest('/sse', flood, SECRET)).toBe(false)
+    })
+    // The vulnerable regex took seconds at this size; linear parsing is sub-ms.
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('does not blow up super-linearly as the flood grows', () => {
+    const small = timeMs(() => {
+      isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(20_000), SECRET)
+    })
+    const large = timeMs(() => {
+      isAuthorizedMcpRequest('/sse', 'bearer ' + ' '.repeat(160_000), SECRET)
+    })
+    // 8x the input. Linear would be ~8x; quadratic ~64x. Allow generous slack
+    // for timer noise on a loaded CI box, but catch an order-of-magnitude jump.
+    expect(large).toBeLessThan(Math.max(small * 25, 500))
+  })
+
+  it('a whitespace-only token is not a token', () => {
+    expect(isAuthorizedMcpRequest('/sse', 'bearer      ', SECRET)).toBe(false)
+  })
+})
+
+describe('Bearer parsing preserves the pre-fix contract (#151)', () => {
+  it('still accepts the correct token', () => {
+    expect(isAuthorizedMcpRequest('/sse', `Bearer ${SECRET}`, SECRET)).toBe(true)
+  })
+
+  it('still tolerates multiple spaces between scheme and token', () => {
+    expect(isAuthorizedMcpRequest('/sse', `Bearer    ${SECRET}`, SECRET)).toBe(true)
+  })
+
+  it('still tolerates a tab separator', () => {
+    expect(isAuthorizedMcpRequest('/sse', `Bearer\t${SECRET}`, SECRET)).toBe(true)
+  })
+
+  it('still tolerates surrounding whitespace on the whole header', () => {
+    expect(isAuthorizedMcpRequest('/sse', `   Bearer ${SECRET}   `, SECRET)).toBe(true)
+  })
+
+  it('still matches the scheme case-insensitively', () => {
+    expect(isAuthorizedMcpRequest('/sse', `BeArEr ${SECRET}`, SECRET)).toBe(true)
+  })
+
+  it('rejects a scheme that merely starts with "bearer" (no separator)', () => {
+    expect(isAuthorizedMcpRequest('/sse', `bearerX ${SECRET}`, SECRET)).toBe(false)
+  })
+
+  it('rejects the bare scheme with no token', () => {
+    expect(isAuthorizedMcpRequest('/sse', 'bearer', SECRET)).toBe(false)
+  })
+
+  it('rejects a different auth scheme carrying the secret', () => {
+    expect(isAuthorizedMcpRequest('/sse', `Basic ${SECRET}`, SECRET)).toBe(false)
+  })
+
+  it('falls back to the query param when the header is not a Bearer header', () => {
+    expect(isAuthorizedMcpRequest(`/sse?token=${SECRET}`, 'Basic zzz', SECRET)).toBe(true)
+  })
+})

--- a/tests/unit/shared/id.test.ts
+++ b/tests/unit/shared/id.test.ts
@@ -13,12 +13,12 @@ afterEach(() => {
 })
 
 describe('randomId', () => {
-  it('is 32 lowercase hex chars (128 bits)', () => {
-    expect(randomId()).toMatch(/^[0-9a-f]{32}$/)
+  it('is 24 lowercase hex chars (96 bits) -- see ID_BYTES rationale', () => {
+    expect(randomId()).toMatch(/^[0-9a-f]{24}$/)
   })
 
   it('applies a prefix without disturbing the hex body', () => {
-    expect(randomId('ca-')).toMatch(/^ca-[0-9a-f]{32}$/)
+    expect(randomId('ca-')).toMatch(/^ca-[0-9a-f]{24}$/)
   })
 
   it('is path-safe -- ids reach the filesystem as <statusDir>/<id>.json', () => {
@@ -28,11 +28,9 @@ describe('randomId', () => {
     }
   })
 
-  it('does not collide across a large sample', () => {
-    const seen = new Set<string>()
-    for (let i = 0; i < 20_000; i++) seen.add(randomId())
-    expect(seen.size).toBe(20_000)
-  })
+  // Deliberately no "does not collide over N draws" test. Adversarial review
+  // pointed out that 20k draws over a 2^128 space measures nothing -- the OLD
+  // Math.random generator passed it too, so it had no discriminating power.
 
   it('does NOT use Math.random', () => {
     const spy = vi.spyOn(Math, 'random')
@@ -46,9 +44,21 @@ describe('randomId', () => {
     expect(spy).toHaveBeenCalledOnce()
   })
 
-  it('is not derived from the clock -- ids minted in the same tick differ', () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
-    expect(randomId()).not.toBe(randomId())
+  // The obvious version of this test -- mock Date.now, assert two ids differ --
+  // is vacuous: the OLD clock+Math.random generator passes it, because the
+  // Math.random tail still differs. Adversarial review caught that. Invert it
+  // instead: pin the randomness and assert the CLOCK contributes nothing, which
+  // fails loudly on any implementation that mixes Date.now back in.
+  it('is not derived from the clock -- output is clock-independent', () => {
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(((a: Uint8Array) => {
+      a.fill(0xab)
+      return a
+    }) as typeof globalThis.crypto.getRandomValues)
+
+    vi.spyOn(Date, 'now').mockReturnValue(1)
+    const atEpoch = randomId()
+    vi.spyOn(Date, 'now').mockReturnValue(9_999_999_999_999)
+    expect(randomId()).toBe(atEpoch)
   })
 
   it('pads low bytes rather than dropping them (fixed length always)', () => {
@@ -56,6 +66,6 @@ describe('randomId', () => {
       a.fill(0x05)
       return a
     }) as typeof globalThis.crypto.getRandomValues)
-    expect(randomId()).toBe('05'.repeat(16))
+    expect(randomId()).toBe('05'.repeat(12))
   })
 })

--- a/tests/unit/shared/id.test.ts
+++ b/tests/unit/shared/id.test.ts
@@ -1,0 +1,61 @@
+/**
+ * #151 / CodeQL js/insecure-randomness -- regression guard for id generation.
+ *
+ * Ids were `Date.now().toString(36) + Math.random().toString(36).slice(2, 8)`.
+ * CodeQL flagged the account add / re-auth login flows; the whole family now
+ * routes through randomId(), which is backed by crypto.getRandomValues.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { randomId } from '../../../src/shared/id'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('randomId', () => {
+  it('is 32 lowercase hex chars (128 bits)', () => {
+    expect(randomId()).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('applies a prefix without disturbing the hex body', () => {
+    expect(randomId('ca-')).toMatch(/^ca-[0-9a-f]{32}$/)
+  })
+
+  it('is path-safe -- ids reach the filesystem as <statusDir>/<id>.json', () => {
+    for (let i = 0; i < 200; i++) {
+      const id = randomId()
+      expect(id).not.toMatch(/[/\\:*?"<>|.]/)
+    }
+  })
+
+  it('does not collide across a large sample', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 20_000; i++) seen.add(randomId())
+    expect(seen.size).toBe(20_000)
+  })
+
+  it('does NOT use Math.random', () => {
+    const spy = vi.spyOn(Math, 'random')
+    randomId()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('draws from crypto.getRandomValues', () => {
+    const spy = vi.spyOn(globalThis.crypto, 'getRandomValues')
+    randomId()
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('is not derived from the clock -- ids minted in the same tick differ', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    expect(randomId()).not.toBe(randomId())
+  })
+
+  it('pads low bytes rather than dropping them (fixed length always)', () => {
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(((a: Uint8Array) => {
+      a.fill(0x05)
+      return a
+    }) as typeof globalThis.crypto.getRandomValues)
+    expect(randomId()).toBe('05'.repeat(16))
+  })
+})


### PR DESCRIPTION
Closes #151. Resolves the four open CodeQL alerts. Worked through the adversarial-review
skill (#160) — its first real run.

### Alert dispositions

| Alert | Rule | Disposition |
| --- | --- | --- |
| 8 | `js/polynomial-redos` | **Fixed.** `/^bearer\s+(.+)$/i` on the MCP auth path replaced with a linear prefix parse |
| 9, 10 | `js/insecure-randomness` | **Fixed.** New `src/shared/id.ts` (`randomId`, `crypto.getRandomValues`); all 13 duplicated inline `Date.now()+Math.random()` generators converged onto it |
| 6 | `js/insufficient-password-hash` | **False positive** — dismissal pending, rationale below |

**Alert 6 root cause, traced rather than asserted:** `js/insufficient-password-hash` needs
a source classified `SensitiveDataClassification::password()`. That comes from
`maybePassword()` in `SensitiveDataHeuristics.qll`, whose regex contains the literal
alternative `oauth` — which matches the *containing property name* `oauthAccount` at both
taint origins. The field itself, `emailAddress`, matches no heuristic. The SHA-256 sink is
correctly identified; the source classification is wrong. The digest is reduced to
`hash[0] % 10`, a UI palette index that is never stored, logged, compared, or used in any
decision.

### What the adversarial pass found

Four attackers, two bounded fix→re-attack rounds. **No bypass in 211k+ attempts — but
both regression tests guarding the fix were vacuous, and one of them twice.**

- The ReDoS flood was `'bearer ' + spaces`, which `authHeader.trim()` reduces to the
  6-char string `"bearer"` — and which the vulnerable regex matches anyway in one
  backtrack. It passed at **0.15 ms** against the code it was written to catch. The real
  payload needs a line terminator `.` cannot cross plus a tail surviving trim:
  `'bearer' + SP×n + 'X\nY'` → **2270 ms**.
- Round 2's tri-state test repeated the mistake: `Bearer wrong` is not a refusal under any
  implementation.
- Both are now verified by reverting the parser and confirming they fail.

Round 2 also found a **real gap in the round-1 fix**: the separator check looked only at
the first character, and the following `slice().trim()` absorbed the rest — so
`Bearer<SP><NBSP><token>` was accepted. One legal space defeated the whole narrowing.

Also fixed: an empty `expectedSecret` authorized every request
(`timingSafeEqual(<empty>,<empty>)` is true and `?token=` yields `''`, not null); a
refused Bearer header silently fell through to the weaker query channel; `ID_BYTES`
reduced 16→12 because 32-char ids moved the Windows MAX_PATH cliff 18 chars closer for
`<resourcesDir>/status/<id>.json`, whose write is a bare `catch {}`.

Three factually wrong claims in my own comments were corrected: the ReDoS is **not**
reachable through Node's HTTP parser (llhttp 400s bare CR/LF, `maxHeaderSize` caps at
16 KB); RFC 9110 §11.4 gives `auth-scheme 1*SP`, so accepting HTAB is *more* permissive
than the RFC; and Codex **is** a header-only client, so the Authorization header is its
only credential channel.

### Verification

`npm run typecheck` clean. Full suite **3173 passed**. Guards verified by reverting each
fix and confirming failure, not merely that they are green.

`ADVERSARIAL-REVIEW v1 | PASS | 0 blockers, 0 majors open`

### Not verified

Not yet exercised in the desktop app.
