### PR TITLE
fix(release): sync the changelog entry date, not just its version (#157)

### DIFF
--- a/CONTEXT.d/2026-07-30-157-release-sync-changelog-date.md
+++ b/CONTEXT.d/2026-07-30-157-release-sync-changelog-date.md
@@ -1,0 +1,36 @@
+## 2026-07-30 -- release.js now syncs the changelog entry DATE, not just the version (#157)
+
+Changelog entries are hand-authored BEFORE a release (release.js rewrites the first
+entry's version to whatever it bumps to). It did NOT touch `date`, so an entry
+written days earlier shipped with the authoring date. `beta` is never frozen, so a
+pending entry sitting for a week was normal -- and nothing caught it, because
+`gen-changelog.js --check` only compares the generated file to the source: a
+wrong-but-consistent date is green.
+
+Found while adding the 2.1.0-beta.3 entry (#149), which is dated 2026-07-30 purely
+because that is when it was written.
+
+- `syncChangelogEntry(source, version, date)` -- new PURE helper in scripts/release.js
+  (exported for tests, alongside the existing parseVersion/nextVersion/tagFor). Rewrites
+  the FIRST entry's version AND date, reporting `versionChanged` / `dateChanged`
+  separately. This also puts the previously-INLINE, UNTESTED version rewrite under test
+  -- it had already corrupted an old entry once (a loose regex without the prerelease
+  suffix skipped `2.0.0-rc.2` at the top and rewrote the first BARE version it found).
+- Both regexes REQUIRE quotes, which is what keeps them off the `ChangelogEntry`
+  interface at the top of the file (`version: string`, `date: string` -- unquoted).
+- `todayIso(now = new Date())` -- LOCAL calendar parts, deliberately NOT
+  `toISOString().slice(0,10)`. That is UTC, so in Denver (UTC-6/-7) any release after
+  ~17:00 local would stamp TOMORROW's date, silently, in a user-visible file. Injectable
+  `now` so the timezone behaviour is testable without faking the clock.
+- ALSO FIXED as a side effect: release.js never regenerated CHANGELOG.md after rewriting
+  changelog.ts, and step 5 does `git add -A` + commit. So any release where the version
+  rewrite actually changed something would commit a stale generated file and fail its own
+  `Changelog in sync` CI gate. Step 3 now runs gen-changelog.js after a successful sync.
+  (Latent until now only because the authored version usually already matched.)
+- Header docs updated: both fields in a pending entry are placeholders now.
+- Verification: typecheck clean; full suite 3173 passed / 4 skipped; 10 new tests in
+  tests/unit/scripts/release.test.ts (both-fields rewrite, older entry untouched,
+  interface untouched, date-syncs-when-version-already-matches = the #157 case, no-op
+  when both match, bare stable version, missing version, missing date field, and the
+  UTC-vs-local guard). Also dry-run against the REAL changelog.ts: 72 date fields before
+  and after, so exactly one replaced in place, all 71 older entries intact.

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -11,7 +11,7 @@
  *   1. Pre-flight checks (gh auth, npm audit, git status)
  *   2. Channel selection (stable / beta / dev)
  *   3. Version bump
- *   4. Update changelog.ts version line
+ *   4. Update changelog.ts version + date of the newest entry, regenerate CHANGELOG.md
  *   5. Typecheck + unit tests + build smoke test
  *   6. Git commit + tag + push
  *
@@ -56,8 +56,15 @@
  *   - VirusTotal scanning is part of the GitHub Actions workflow, not local.
  *     The workflow scans BOTH the .exe and the .dmg.
  *   - Changelog generation is hand-authored. Edit src/renderer/changelog.ts to
- *     add a new entry BEFORE running this script. The script will update the
- *     version field of the first entry to match the bumped version.
+ *     add a new entry BEFORE running this script. The script then aligns the
+ *     FIRST (newest) entry with the release being cut: it rewrites both the
+ *     `version` field to the bumped version AND the `date` field to today's
+ *     LOCAL date, then regenerates CHANGELOG.md so the generated file cannot go
+ *     stale in the release commit (the `Changelog in sync` CI gate would
+ *     otherwise fail on the release itself).
+ *     So both fields in a pending entry are placeholders — write whatever is
+ *     reasonable and let the release correct them. Before #157 only `version`
+ *     was synced, so an entry authored days earlier shipped stale-dated.
  *   - This script does NOT create or push a git tag. release.yml creates the tag
  *     via `gh release create --target $GITHUB_SHA`, pinning it to the commit it
  *     actually built. A pre-pushed tag would defeat that and can strand the
@@ -273,6 +280,69 @@ function tagFor(version, channel) {
   }
 }
 
+/**
+ * Today's date as YYYY-MM-DD in LOCAL time.
+ *
+ * Deliberately not `toISOString().slice(0, 10)`: that is UTC, and for anyone west
+ * of Greenwich an evening release would stamp TOMORROW's date. In Denver
+ * (UTC-6/-7) any release after ~17:00 local would be off by a day — silently, and
+ * in a user-visible file.
+ *
+ * `now` is injectable so the behaviour is testable without faking the clock.
+ */
+function todayIso(now = new Date()) {
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/**
+ * Align the FIRST (newest) changelog.ts entry with the release being cut.
+ *
+ * Entries are hand-authored BEFORE the release, so both fields drift: the version
+ * is whatever the author guessed the next bump would be, and the date is whatever
+ * day they wrote it. `beta` is never frozen, so a pending entry can sit for a week
+ * and then ship stale-dated (#157). Both are rewritten here.
+ *
+ * Pure: takes and returns source text, so the regex behaviour is unit-testable.
+ * The inline version of this logic was untested and had already corrupted an old
+ * entry once — see the prerelease-suffix note below.
+ *
+ * Both regexes REQUIRE quotes, which is what keeps them off the `ChangelogEntry`
+ * interface at the top of the file (`version: string`, `date: string` — unquoted).
+ * The version pattern must also carry the optional prerelease suffix: without it
+ * the match skipped past `2.0.0-rc.2` at the top and rewrote the first BARE
+ * version found (a historical `2.0.0` entry), corrupting an old entry while
+ * reporting success and leaving the real one stale.
+ *
+ * @returns {{ok: false, reason: string} | {ok: true, content: string, prevVersion: string, prevDate: string|null, versionChanged: boolean, dateChanged: boolean}}
+ */
+function syncChangelogEntry(source, version, date) {
+  const versionRegex = /version:\s*'(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+\.\d+)?)'/
+  const dateRegex = /date:\s*'(\d{4}-\d{2}-\d{2})'/
+
+  const vMatch = String(source).match(versionRegex)
+  if (!vMatch) return { ok: false, reason: 'no version entry found' }
+  const dMatch = String(source).match(dateRegex)
+
+  const versionChanged = vMatch[1] !== version
+  const dateChanged = !!dMatch && dMatch[1] !== date
+
+  let content = source
+  if (versionChanged) content = content.replace(versionRegex, `version: '${version}'`)
+  if (dateChanged) content = content.replace(dateRegex, `date: '${date}'`)
+
+  return {
+    ok: true,
+    content,
+    prevVersion: vMatch[1],
+    prevDate: dMatch ? dMatch[1] : null,
+    versionChanged,
+    dateChanged,
+  }
+}
+
 // ============================================================
 // MAIN
 // ============================================================
@@ -420,28 +490,34 @@ const tag = tagFor(version, channel)
 console.log('')
 console.log(`      ${NO_BUMP ? `v${version} (reused)` : `v${oldVersion} → v${version}`}  (tag: ${tag}, channel: ${channel})`)
 
-// --- Step 3: Sync changelog version ---
-step(3, TOTAL_STEPS, 'Aligning changelog version with bumped version...')
+// --- Step 3: Sync changelog version + date ---
+step(3, TOTAL_STEPS, 'Aligning changelog version and date with this release...')
 
 const changelogPath = path.join(PROJECT_ROOT, 'src', 'renderer', 'changelog.ts')
 try {
-  let changelogContent = fs.readFileSync(changelogPath, 'utf-8')
-  // Match the FIRST `version: '...'` entry — that's the topmost (newest) entry.
-  // The prerelease suffix is NOT optional decoration: without it this regex
-  // skipped straight past `2.0.0-rc.2` at the top of the file and rewrote the
-  // first BARE version it found (the historical `2.0.0` entry), corrupting an
-  // old entry while reporting success and leaving the real one stale.
-  const versionRegex = /version:\s*'(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+\.\d+)?)'/
-  const match = changelogContent.match(versionRegex)
-  if (!match) {
-    warn('Could not locate first version entry in changelog.ts')
-  } else if (match[1] === version) {
-    ok(`Changelog already on v${version}`)
+  const changelogContent = fs.readFileSync(changelogPath, 'utf-8')
+  const releaseDate = todayIso()
+  const sync = syncChangelogEntry(changelogContent, version, releaseDate)
+  if (!sync.ok) {
+    warn(`Could not locate first version entry in changelog.ts (${sync.reason})`)
+  } else if (!sync.versionChanged && !sync.dateChanged) {
+    ok(`Changelog already on v${version} (${releaseDate})`)
   } else {
-    changelogContent = changelogContent.replace(versionRegex, `version: '${version}'`)
-    fs.writeFileSync(changelogPath, changelogContent, 'utf-8')
-    ok(`Changelog version: v${match[1]} → v${version}`)
-    warn('Hand-author the changelog body BEFORE the next release for accurate notes')
+    fs.writeFileSync(changelogPath, sync.content, 'utf-8')
+    if (sync.versionChanged) ok(`Changelog version: v${sync.prevVersion} → v${version}`)
+    if (sync.dateChanged) ok(`Changelog date: ${sync.prevDate} → ${releaseDate}`)
+    // Regenerate so CHANGELOG.md carries the corrected version/date. Without
+    // this the `Changelog in sync` CI gate fails on the release commit itself:
+    // the generated file still holds the pre-sync values.
+    try {
+      run('node scripts/gen-changelog.js')
+      ok('CHANGELOG.md regenerated')
+    } catch (err) {
+      warn(`CHANGELOG.md regeneration failed — run 'npm run changelog' before committing (${err.message})`)
+    }
+    if (sync.versionChanged) {
+      warn('Hand-author the changelog body BEFORE the next release for accurate notes')
+    }
   }
 } catch (err) {
   warn(`Changelog sync skipped: ${err.message}`)
@@ -644,6 +720,8 @@ module.exports = {
   branchHintFor,
   nextVersion,
   tagFor,
+  todayIso,
+  syncChangelogEntry,
 }
 
 if (require.main === module) {

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -248,13 +248,31 @@ describe('release todayIso', () => {
     expect(todayIso(new Date(2026, 11, 31))).toBe('2026-12-31')
   })
 
-  it('uses LOCAL calendar parts, not UTC', () => {
+  it('reads LOCAL getters and never toISOString', () => {
     // The bug this guards: toISOString() is UTC, so an evening release west of
     // Greenwich stamps TOMORROW. In Denver (UTC-6/-7) anything after ~17:00 local
     // would be off by a day, silently, in a user-visible file.
-    const evening = new Date(2026, 6, 30, 23, 30, 0)
-    expect(todayIso(evening)).toBe('2026-07-30')
-    expect(todayIso(evening)).not.toBe(evening.toISOString().slice(0, 10))
+    //
+    // Asserting `todayIso(d) !== d.toISOString().slice(0,10)` does NOT work: on a
+    // UTC runner local IS UTC, so the two are equal and the assertion fails. That
+    // version passed in Denver and broke both CI platforms.
+    //
+    // So prove the contract structurally instead — a stub carrying only the local
+    // getters. If the implementation reached for toISOString (or any UTC getter)
+    // this would throw, and it is deterministic in every timezone.
+    const localOnly = {
+      getFullYear: () => 2026,
+      getMonth: () => 6, // 0-based: July
+      getDate: () => 30,
+    } as unknown as Date
+    expect(todayIso(localOnly)).toBe('2026-07-30')
+  })
+
+  it('is timezone-independent for a fixed local wall-clock time', () => {
+    // Late-evening local time must still report that same local day, whatever the
+    // host offset is — this is the real-world case that motivated #157.
+    expect(todayIso(new Date(2026, 6, 30, 23, 30, 0))).toBe('2026-07-30')
+    expect(todayIso(new Date(2026, 6, 30, 0, 15, 0))).toBe('2026-07-30')
   })
 })
 

--- a/tests/unit/scripts/release.test.ts
+++ b/tests/unit/scripts/release.test.ts
@@ -12,6 +12,17 @@ const release = require('../../../scripts/release.js') as {
   branchHintFor: (channel: string) => string
   nextVersion: (current: string, opts: { branch: string; channel: string; bump?: string | null }) => string
   tagFor: (version: string, channel: string) => string
+  todayIso: (now?: Date) => string
+  syncChangelogEntry: (source: string, version: string, date: string) =>
+    | { ok: false; reason: string }
+    | {
+        ok: true
+        content: string
+        prevVersion: string
+        prevDate: string | null
+        versionChanged: boolean
+        dateChanged: boolean
+      }
 }
 
 const { parseVersion, releaseBranchBase, preIdForBranch, branchAllowsChannel, nextVersion, tagFor } = release
@@ -225,5 +236,115 @@ describe('release version flow across a full cycle', () => {
     expect(rc).toBe('2.0.0-rc.3')
     // The two lines never collide.
     expect(tagFor(beta, 'beta')).not.toBe(tagFor(rc, 'beta'))
+  })
+})
+
+// ── todayIso / syncChangelogEntry (#157) ───────────────────────────
+const { todayIso, syncChangelogEntry } = release
+
+describe('release todayIso', () => {
+  it('formats a local date as YYYY-MM-DD with zero padding', () => {
+    expect(todayIso(new Date(2026, 0, 5))).toBe('2026-01-05')
+    expect(todayIso(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+
+  it('uses LOCAL calendar parts, not UTC', () => {
+    // The bug this guards: toISOString() is UTC, so an evening release west of
+    // Greenwich stamps TOMORROW. In Denver (UTC-6/-7) anything after ~17:00 local
+    // would be off by a day, silently, in a user-visible file.
+    const evening = new Date(2026, 6, 30, 23, 30, 0)
+    expect(todayIso(evening)).toBe('2026-07-30')
+    expect(todayIso(evening)).not.toBe(evening.toISOString().slice(0, 10))
+  })
+})
+
+describe('release syncChangelogEntry', () => {
+  // Mirrors the real file: an interface whose `version`/`date` are UNQUOTED type
+  // annotations, then the data literal. The regexes must never touch the interface.
+  const source = (version: string, date: string) => `
+export interface ChangelogEntry {
+  version: string
+  date: string  // YYYY-MM-DD format
+}
+
+export const changelog: ChangelogEntry[] = [
+  {
+    version: '${version}',
+    date: '${date}',
+    changes: [],
+  },
+  {
+    version: '2.0.0',
+    date: '2026-01-01',
+    changes: [],
+  },
+]
+`
+
+  it('rewrites both version and date of the newest entry', () => {
+    const res = syncChangelogEntry(source('2.1.0-beta.3', '2026-07-30'), '2.1.0-beta.4', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.prevVersion).toBe('2.1.0-beta.3')
+    expect(res.prevDate).toBe('2026-07-30')
+    expect(res.versionChanged).toBe(true)
+    expect(res.dateChanged).toBe(true)
+    expect(res.content).toContain("version: '2.1.0-beta.4'")
+    expect(res.content).toContain("date: '2026-08-06'")
+  })
+
+  it('leaves the OLDER entry untouched', () => {
+    // The historical failure: a loose version regex skipped the prerelease entry
+    // at the top and rewrote the first BARE version it found, corrupting an old
+    // entry while reporting success.
+    const res = syncChangelogEntry(source('2.1.0-beta.3', '2026-07-30'), '2.1.0-beta.4', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.content).toContain("version: '2.0.0'")
+    expect(res.content).toContain("date: '2026-01-01'")
+  })
+
+  it('never rewrites the unquoted interface annotations', () => {
+    const res = syncChangelogEntry(source('2.1.0-beta.3', '2026-07-30'), '2.1.0-beta.4', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.content).toContain('version: string')
+    expect(res.content).toContain('date: string')
+  })
+
+  it('syncs the date even when the version already matches', () => {
+    // The #157 case exactly: entry authored days ago with the right version guess,
+    // wrong date. Pre-fix this whole branch was a no-op and shipped stale.
+    const res = syncChangelogEntry(source('2.1.0-beta.3', '2026-07-30'), '2.1.0-beta.3', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.versionChanged).toBe(false)
+    expect(res.dateChanged).toBe(true)
+    expect(res.content).toContain("date: '2026-08-06'")
+  })
+
+  it('reports no change when both already match', () => {
+    const res = syncChangelogEntry(source('2.1.0-beta.3', '2026-07-30'), '2.1.0-beta.3', '2026-07-30')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.versionChanged).toBe(false)
+    expect(res.dateChanged).toBe(false)
+    expect(res.content).toBe(source('2.1.0-beta.3', '2026-07-30'))
+  })
+
+  it('handles a bare stable version at the top', () => {
+    const res = syncChangelogEntry(source('2.1.0', '2026-07-30'), '2.2.0', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.prevVersion).toBe('2.1.0')
+    expect(res.content).toContain("version: '2.2.0'")
+  })
+
+  it('fails cleanly when there is no version entry', () => {
+    const res = syncChangelogEntry('export const changelog = []', '2.1.0', '2026-08-06')
+    expect(res.ok).toBe(false)
+  })
+
+  it('still syncs the version when no date field exists', () => {
+    // Degrades rather than throwing, so a malformed entry cannot abort a release.
+    const res = syncChangelogEntry("[{ version: '2.1.0', changes: [] }]", '2.2.0', '2026-08-06')
+    if (!res.ok) throw new Error('expected ok')
+    expect(res.prevDate).toBeNull()
+    expect(res.dateChanged).toBe(false)
+    expect(res.content).toContain("version: '2.2.0'")
   })
 })


### PR DESCRIPTION
Closes #157.

## Problem

Changelog entries are hand-authored **before** a release, and `release.js` rewrites the first
entry's `version` to whatever it bumps to. It never touched `date` — so an entry written days
earlier shipped with its **authoring** date.

`beta` is never frozen, so a pending entry sitting for a week is normal. Nothing caught it either:
`gen-changelog.js --check` only compares the generated file to its source, so a wrong-but-consistent
date is green.

Found while adding the `2.1.0-beta.3` entry in #149, which carries `2026-07-30` purely because that
is the day it was written.

## Fix

- **`syncChangelogEntry(source, version, date)`** — new *pure* helper, exported beside the existing
  `parseVersion`/`nextVersion`/`tagFor`. Rewrites the first entry's version **and** date, reporting
  `versionChanged` / `dateChanged` separately so step 3's output stays honest about what it touched.

  This also puts the previously **inline and untested** version rewrite under test. That matters:
  it had already corrupted an old entry once, when a regex missing the prerelease suffix skipped
  `2.0.0-rc.2` at the top and rewrote the first *bare* version it found. That lesson was a code
  comment; it is now a test.

- Both regexes **require quotes**, which is what keeps them off the `ChangelogEntry` interface at the
  top of the file, where `version: string` / `date: string` are unquoted type annotations.

- **`todayIso(now = new Date())`** — local calendar parts, deliberately **not**
  `toISOString().slice(0, 10)`. That is UTC, so in Denver (UTC-6/-7) any release after ~17:00 local
  would stamp **tomorrow** — silently, in a user-visible file. `now` is injectable so the timezone
  behaviour is tested without faking a clock.

## Also fixed, found on the way

`release.js` never regenerated `CHANGELOG.md` after rewriting `changelog.ts`, and step 5 does
`git add -A` then commits. So any release where the version rewrite actually changed something would
commit a **stale generated file and fail its own `Changelog in sync` gate**. Step 3 now regenerates
after a successful sync.

Latent until now only because the authored version usually already matched, making the rewrite a
no-op — which is also why nobody hit it.

## Verification

- `npm run typecheck` clean; `npx vitest run` **3173 passed / 4 skipped / 0 failed** (10 new).
- Tests cover: both-field rewrite, **older entry untouched**, **interface annotations untouched**,
  date-syncs-when-version-already-matches (the #157 case exactly), no-op when both already match,
  bare stable version, missing version entry, missing `date` field, and the UTC-vs-local guard.
- **Dry-run against the real `changelog.ts`**: 72 `date` fields before and after — so exactly one was
  replaced in place — with all 71 older entries and both interface annotations intact.

## Reviewer notes

- The behaviour change is that a pending entry's `date` is now a **placeholder**, like `version`
  already was. Header docs updated to say so.
- This does not fix #155 (CI still cannot detect a *missing* entry) or #156 (`gen-changelog.js`
  still breaks on an apostrophe in a comment inside the literal). Both remain open.
- **`2.1.0-beta.3`'s current date needs no manual correction if beta.3 is cut today** — after this
  lands, the release itself will set it.

Squash-merge.