### PR TITLE
test(terminal): extract keybindings so event-phase ordering is covered (#154)

### DIFF
--- a/CONTEXT.d/2026-07-30-154-terminal-keybinding-tests.md
+++ b/CONTEXT.d/2026-07-30-154-terminal-keybinding-tests.md
@@ -1,0 +1,36 @@
+## 2026-07-30 -- Terminal keybindings extracted so event-phase ordering is testable (#154, #153)
+
+The #145 bug was a keydown handler registered on `document` in the BUBBLE phase.
+xterm's own listener sits on the helper textarea and runs in the TARGET phase, so it
+had already converted Ctrl+V to the raw control byte \x16 and written it to the PTY
+before the handler ran. It typechecked, passed every predicate test, and was dead
+code on the only path that mattered -- it took three attempts plus custom
+instrumentation to find, and nothing in the suite could have caught a repeat.
+
+- New `src/renderer/components/terminal/terminalKeybindings.ts` --
+  `installTerminalKeybindings(opts)` owns BOTH clipboard chords behind ONE
+  capture-phase `document` listener and returns a disposer. Every DOM/Electron
+  dependency is injected (`doc`, `hasModalOpen`, `getActiveElement`, `readText`,
+  `writeText`, `term`), so tests drive the real wiring rather than a copy of it.
+- TerminalView now just calls it; the two inline handlers and their manual
+  add/removeEventListener bookkeeping are gone. `isActive` is passed as a THUNK --
+  the installing effect keys on session identity, so a captured boolean goes stale on
+  tab switches, and the listener is shared by every mounted TerminalView.
+- Fixes #153 in the same change, because the extraction rewrites exactly that
+  registration: the copy chord gained the `isActive` / modal / ordinary-editable gate
+  it never had (it previously ran once per mounted terminal and fired with focus in a
+  text input). Also `isCopyChord` matches case-insensitively -- the old check was
+  `e.key === 'C'` exactly, so copy silently stopped working under caps lock.
+- CRITICAL validation, the point of the whole ticket: flipping the capture flag to
+  `false` makes exactly three tests fail -- "xterm NEVER sees a paste chord", the copy
+  equivalent, and the disposal test (an unmatched capture flag on
+  removeEventListener silently removes nothing). A test that cannot fail would have
+  been worthless here, so this was verified by mutation, not assumed.
+- Tests use a real textarea carrying `xterm-helper-textarea` with its own keydown
+  listener standing in for xterm. 19 cases: phase ordering for both chords, ordinary
+  keys (incl. Ctrl+C = SIGINT) passing through untouched, defaultPrevented, disposal,
+  inactive/modal/ordinary-editable guards, isActive read fresh per keystroke, empty
+  and rejected clipboard reads, Shift+Insert and Cmd+V, an INJECTED chord with no
+  `code` field, and the copy paths incl. caps lock and a rejected write.
+- Verification: typecheck clean; full suite 3182 passed / 4 skipped (19 new
+  keybinding tests + 4 isCopyChord predicate tests).

--- a/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
+++ b/architecture/decisions/2026-07-30-adr-008-terminal-clipboard-keybindings.md
@@ -137,9 +137,16 @@ it would leave paste dependent on a focus race).
   (insecure context, window not focused) is a no-op rather than a double paste.
   The terminal is left unchanged and nothing is reported — consistent with the
   existing right-click behaviour.
-- The pre-existing Ctrl+Shift+C copy handler still lacks the `isActive` guard. It
-  is benign today (only one terminal holds a selection) and is intentionally left
-  alone here to keep this change scoped; it should get the same treatment.
+- **Resolved in #154/#153:** the wiring now lives in
+  `components/terminal/terminalKeybindings.ts` (`installTerminalKeybindings`), which
+  owns BOTH chords behind one capture-phase listener and returns a disposer. Copy
+  gained the same `isActive` / modal / ordinary-editable gate it never had. The
+  extraction exists so the REGISTRATION is testable, not just the predicates — the
+  original bug was dead code that passed every predicate test, and a test that
+  mirrors the registration would pass regardless. The suite drives the installer
+  with a stand-in for xterm's textarea listener and asserts xterm never sees the
+  chord; flipping the capture flag to `false` fails exactly those tests, which is
+  the check that the coverage is real.
 - Verified by simulating the real failure mode — clipboard write plus a synthesized
   Ctrl+V from an external process (`SendKeys`) into the CCC window — not only by
   pressing the key by hand, since hand-pressing does not reproduce the

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,15 +14,10 @@ import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
-import {
-  isControlReportOnly,
-  decideContextMenuAction,
-  isPasteChord,
-  shouldHandleTerminalPaste,
-  isOrdinaryEditable,
-} from '../utils/terminalInput'
+import { isControlReportOnly, decideContextMenuAction, isOrdinaryEditable } from '../utils/terminalInput'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
+import { installTerminalKeybindings } from './terminal/terminalKeybindings'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
 import { usePasteHintStore } from '../stores/pasteHintStore'
 import { installInputDiagnostics, describeBytes } from '../utils/inputDiagnostics'
@@ -243,8 +238,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let resizeObserver: ResizeObserver | null = null
     let unsubData: (() => void) | null = null
     let unsubExit: (() => void) | null = null
-    let handleKeyDownCopy: ((e: KeyboardEvent) => void) | null = null
-    let handleKeyDownPaste: ((e: KeyboardEvent) => void) | null = null
+    let disposeKeybindings: (() => void) | null = null
     let handleContextMenu: ((e: MouseEvent) => void) | null = null
     let disposed = false
     let parseTimer: ReturnType<typeof setTimeout> | null = null
@@ -807,85 +801,41 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       })
       resizeObserver.observe(container)
 
-      // Ctrl+Shift+C to copy selected text
-      handleKeyDownCopy = (e: KeyboardEvent) => {
-        if (e.ctrlKey && e.shiftKey && e.key === 'C') {
-          e.preventDefault()
-          const sel = term?.getSelection()
-          if (sel) navigator.clipboard.writeText(sel)
-        }
-      }
-      document.addEventListener('keydown', handleKeyDownCopy)
-
-      // Ctrl+V / Cmd+V / Shift+Insert to paste (#145).
+      // Clipboard keybindings (copy + paste). The wiring lives in
+      // terminalKeybindings.ts so the event-phase registration is unit-testable —
+      // the #145 bug was a bubble-phase listener that xterm beat to the keystroke,
+      // and no predicate test could see it (#154).
       //
-      // CCC owns this keybinding rather than leaving it to the Edit menu's
-      // `role: 'paste'`: the native path pastes into the focused editable element
-      // (xterm's hidden helper textarea), so it silently does nothing whenever that
-      // textarea has lost DOM focus — which is every time an external tool takes
-      // focus and synthesizes a paste (dictation apps, snippet expanders). Reading
-      // the clipboard directly is the same focus-independent route that has always
-      // made right-click paste work.
-      //
-      // `isActiveRef` (not the captured prop) because this effect re-runs on session
-      // identity, not on activation — a captured `isActive` would go stale and this
+      // `isActive` is passed as a THUNK, not a value: this effect keys on session
+      // identity, so a captured boolean would go stale on tab switches, and the
       // listener is on `document`, shared by every mounted TerminalView.
-      handleKeyDownPaste = async (e: KeyboardEvent) => {
-        if (!isPasteChord(e)) return
-        if (!shouldHandleTerminalPaste({
-          isActive: isActiveRef.current,
-          hasModalOpen: !!document.querySelector('[role="dialog"][aria-modal="true"]'),
-          targetIsOrdinaryEditable: isOrdinaryEditable(document.activeElement as HTMLElement | null),
-        })) return
-        // Claim the event before the async read so Chromium's native paste can't
-        // also fire and double-insert.
-        //
-        // stopPropagation is what actually makes this work, and it only works
-        // because the listener is registered in the CAPTURE phase (see below).
-        // xterm's own keydown listener lives on the helper textarea, so in the
-        // bubble phase it runs FIRST and has already turned Ctrl+V into the raw
-        // control byte \x16 (SYN) and written it to the PTY before a
-        // document-level bubble listener is ever called — preventDefault at that
-        // point is far too late. Capture + stopPropagation means xterm never sees
-        // the chord and never emits \x16.
-        e.stopPropagation()
-        e.preventDefault()
-        // Read through the MAIN process, not navigator.clipboard.readText().
-        // The async clipboard API requires the DOCUMENT to be focused and rejects
-        // otherwise — precisely the condition this handler exists to survive, since
-        // an external tool takes focus, writes the clipboard, hands focus back and
-        // synthesizes Ctrl+V. The main-process read has no focus requirement and
-        // retries for Windows delayed-render (the same first-read-empty behaviour
-        // already documented for clipboard images).
-        let text = ''
-        try {
-          text = await window.electronAPI.clipboard.readText()
-        } catch {
-          // IPC unavailable — fall through to the renderer API below.
-        }
-        if (!text) {
+      disposeKeybindings = installTerminalKeybindings({
+        term: {
+          getSelection: () => term?.getSelection() ?? '',
+          paste: (text) => term?.paste(text),
+          clearSelection: () => term?.clearSelection(),
+        },
+        isActive: () => isActiveRef.current,
+        // Main-process clipboard read: focus-independent and retried for Windows
+        // delayed-render, with the renderer API as a fallback if IPC is unavailable.
+        readText: async () => {
           try {
-            text = await navigator.clipboard.readText()
+            const viaMain = await window.electronAPI.clipboard.readText()
+            if (viaMain) return viaMain
+          } catch { /* fall through */ }
+          try {
+            return await navigator.clipboard.readText()
           } catch {
-            text = ''
+            return ''
           }
-        }
-        if (!text) {
-          // Do NOT fail silently. A silent no-op is what let #145 go unnoticed:
-          // Ctrl+V appeared to do nothing with no way to tell whether the chord
-          // was even seen. This hint also makes the failure mode diagnosable — if
-          // a dictation tool pastes nothing and NO hint appears, the tool never
-          // sent a paste chord at all.
+        },
+        writeText: (text) => navigator.clipboard.writeText(text),
+        // Never fail silently — a silent no-op is what let #145 go unnoticed.
+        onNothingToPaste: () => {
           usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
-          return
-        }
-        term?.paste(text)
-      }
-      // CAPTURE phase (the `true`) — not optional, and the whole reason the first
-      // attempt at this fix silently did nothing. Capture on `document` runs
-      // before any listener on a descendant, so this beats xterm's textarea
-      // handler; a bubble-phase listener loses the race every time.
-      document.addEventListener('keydown', handleKeyDownPaste, true)
+        },
+      })
+
 
       // Right-click: context-aware copy or paste depending on mode.
       //
@@ -943,8 +893,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // geometry so a remount doesn't inherit a desynced terminal.
         try { window.electronAPI.pty.resize(sessionId, lastSentCols, lastSentRows) } catch { /* main gone */ }
       }
-      if (handleKeyDownCopy) document.removeEventListener('keydown', handleKeyDownCopy)
-      if (handleKeyDownPaste) document.removeEventListener('keydown', handleKeyDownPaste, true)
+      disposeKeybindings?.()
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       resizeObserver?.disconnect()

--- a/src/renderer/components/terminal/terminalKeybindings.ts
+++ b/src/renderer/components/terminal/terminalKeybindings.ts
@@ -1,0 +1,107 @@
+import { isPasteChord, isCopyChord, shouldHandleTerminalPaste, isOrdinaryEditable } from '../../utils/terminalInput'
+
+/**
+ * Terminal clipboard keybindings (copy + paste), extracted from TerminalView so the
+ * REGISTRATION is testable — not just the predicates (#154).
+ *
+ * Why extraction was the point: the #145 bug was a handler registered on `document`
+ * in the BUBBLE phase. xterm's own keydown listener sits on the helper textarea and
+ * therefore runs in the TARGET phase — before any document bubble listener — so it
+ * had already turned Ctrl+V into the raw control byte \x16 and written it to the PTY.
+ * `preventDefault()` there is far too late.
+ *
+ * That handler typechecked, passed every unit test, and was dead code on the only
+ * path that mattered. The predicates were never wrong; the wiring was. Testing the
+ * predicates could not have caught it, and a test that mirrors the registration
+ * would pass whether or not the real code was right. So the wiring lives here,
+ * behind an injectable seam, and the tests drive THIS function.
+ *
+ * Everything the DOM/Electron world provides is injected, so a test supplies its own
+ * document, clipboard and terminal.
+ */
+
+/** The slice of xterm's Terminal this needs. Keeps tests free of a real terminal. */
+export interface KeybindingTerminal {
+  getSelection: () => string
+  paste: (text: string) => void
+  clearSelection?: () => void
+}
+
+export interface TerminalKeybindingOptions {
+  term: KeybindingTerminal
+  /** Read fresh on every keystroke: every session's TerminalView stays mounted and
+   *  shares this `document` listener, so a captured boolean would go stale. */
+  isActive: () => boolean
+  /** Focus-independent clipboard read (main-process backed in the app). */
+  readText: () => Promise<string>
+  writeText: (text: string) => Promise<void>
+  /** Called when a paste chord was handled but there was nothing to paste, so the
+   *  failure is visible rather than silent — the property that let #145 hide. */
+  onNothingToPaste?: () => void
+  /** Seams, defaulted to the real DOM. */
+  doc?: Document
+  hasModalOpen?: () => boolean
+  getActiveElement?: () => Element | null
+}
+
+/**
+ * Install the copy/paste keybindings. Returns a disposer.
+ *
+ * The `true` capture flag on both add and remove is load-bearing, twice over:
+ * capture is what beats xterm's textarea listener, and an unmatched flag on
+ * `removeEventListener` silently fails to remove anything — leaking a listener that
+ * keeps pasting into a disposed terminal.
+ */
+export function installTerminalKeybindings(opts: TerminalKeybindingOptions): () => void {
+  const doc = opts.doc ?? document
+  const hasModalOpen = opts.hasModalOpen ?? (() => !!doc.querySelector('[role="dialog"][aria-modal="true"]'))
+  const getActiveElement = opts.getActiveElement ?? (() => doc.activeElement)
+
+  const onKeyDown = (ev: Event) => {
+    const e = ev as KeyboardEvent
+    const paste = isPasteChord(e)
+    const copy = !paste && isCopyChord(e)
+    if (!paste && !copy) return
+
+    // Same gate for both chords. Copy previously had NO guard at all: it ran once
+    // per mounted terminal and fired even with focus in a text input.
+    if (!shouldHandleTerminalPaste({
+      isActive: opts.isActive(),
+      hasModalOpen: hasModalOpen(),
+      targetIsOrdinaryEditable: isOrdinaryEditable(getActiveElement() as HTMLElement | null),
+    })) return
+
+    // Claim the event before any async work. stopPropagation is what prevents xterm
+    // from seeing the chord and emitting a raw control byte; preventDefault stops
+    // Chromium's native clipboard command from double-acting.
+    e.stopPropagation()
+    e.preventDefault()
+
+    if (copy) {
+      const sel = opts.term.getSelection()
+      if (!sel) return
+      void opts.writeText(sel).then(
+        () => { opts.term.clearSelection?.() },
+        () => { /* clipboard write denied — selection stays put */ },
+      )
+      return
+    }
+
+    void (async () => {
+      let text = ''
+      try {
+        text = await opts.readText()
+      } catch {
+        text = ''
+      }
+      if (!text) {
+        opts.onNothingToPaste?.()
+        return
+      }
+      opts.term.paste(text)
+    })()
+  }
+
+  doc.addEventListener('keydown', onKeyDown, true)
+  return () => doc.removeEventListener('keydown', onKeyDown, true)
+}

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -50,6 +50,23 @@ export function isPasteChord(e: {
   return false
 }
 
+// Is this keystroke a terminal COPY request? Ctrl+Shift+C — the conventional
+// terminal copy chord, kept distinct from Ctrl+C so it cannot swallow SIGINT.
+//
+// Matched case-insensitively: with shift held Chromium reports 'C', but with caps
+// lock also on it reports 'c'. The old inline check compared `e.key === 'C'`
+// exactly, so copy silently stopped working under caps lock.
+export function isCopyChord(e: {
+  key: string
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}): boolean {
+  if (e.altKey || e.metaKey) return false
+  return e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'c'
+}
+
 // Should THIS TerminalView handle a paste chord itself, rather than leaving it to
 // Chromium's native paste?
 //

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -3,6 +3,7 @@ import {
   isControlReportOnly,
   decideContextMenuAction,
   isPasteChord,
+  isCopyChord,
   shouldHandleTerminalPaste,
   isOrdinaryEditable,
 } from '../../../src/renderer/utils/terminalInput'
@@ -97,6 +98,31 @@ describe('isPasteChord', () => {
     expect(isPasteChord(chord())).toBe(false)
     expect(isPasteChord(chord({ key: 'c', ctrlKey: true }))).toBe(false)
     expect(isPasteChord(chord({ key: 'Insert' }))).toBe(false)
+  })
+})
+
+describe('isCopyChord', () => {
+  it('matches Ctrl+Shift+C in either letter case', () => {
+    // With shift held Chromium reports 'C'; with caps lock ALSO on it reports 'c'.
+    // The old inline check compared `e.key === 'C'` exactly, so copy silently
+    // stopped working under caps lock (#153).
+    expect(isCopyChord(chord({ key: 'C', ctrlKey: true, shiftKey: true }))).toBe(true)
+    expect(isCopyChord(chord({ key: 'c', ctrlKey: true, shiftKey: true }))).toBe(true)
+  })
+
+  it('does NOT match plain Ctrl+C — that is SIGINT and belongs to the shell', () => {
+    expect(isCopyChord(chord({ key: 'c', ctrlKey: true }))).toBe(false)
+  })
+
+  it('ignores alt and meta variants', () => {
+    expect(isCopyChord(chord({ key: 'c', ctrlKey: true, shiftKey: true, altKey: true }))).toBe(false)
+    expect(isCopyChord(chord({ key: 'c', ctrlKey: true, shiftKey: true, metaKey: true }))).toBe(false)
+  })
+
+  it('does not collide with the paste chords', () => {
+    const pasteV = chord({ key: 'v', ctrlKey: true, shiftKey: true })
+    expect(isPasteChord(pasteV)).toBe(true)
+    expect(isCopyChord(pasteV)).toBe(false)
   })
 })
 

--- a/tests/unit/renderer/terminal-keybindings.test.ts
+++ b/tests/unit/renderer/terminal-keybindings.test.ts
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { installTerminalKeybindings } from '../../../src/renderer/components/terminal/terminalKeybindings'
+
+// #154. The #145 bug was a keydown handler registered on `document` in the BUBBLE
+// phase: xterm's own listener lives on the helper textarea and fires in the TARGET
+// phase, so it had already converted Ctrl+V to the raw control byte \x16 and written
+// it to the PTY before the handler ran. It typechecked and passed every predicate
+// test while being dead code on the only path that mattered.
+//
+// These tests drive the REAL installer and use a listener on the textarea as a
+// stand-in for xterm. "xterm never sees the chord" is the assertion that would have
+// failed before the fix, and it fails again if anyone drops the capture flag.
+
+const chord = (init: Partial<KeyboardEventInit> & { key: string }) =>
+  new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+
+function harness(over: Record<string, unknown> = {}) {
+  // A real textarea carrying xterm's marker class, so isOrdinaryEditable treats it
+  // as "the terminal" rather than an ordinary input.
+  const textarea = document.createElement('textarea')
+  textarea.className = 'xterm-helper-textarea'
+  document.body.appendChild(textarea)
+
+  // Stands in for xterm's own keydown handler.
+  const xtermSaw: string[] = []
+  textarea.addEventListener('keydown', (e) => { xtermSaw.push((e as KeyboardEvent).key) })
+
+  const term = {
+    getSelection: vi.fn(() => ''),
+    paste: vi.fn(),
+    clearSelection: vi.fn(),
+  }
+  const readText = vi.fn(async () => 'CLIP')
+  const writeText = vi.fn(async () => {})
+  const onNothingToPaste = vi.fn()
+
+  const dispose = installTerminalKeybindings({
+    term,
+    isActive: () => true,
+    readText,
+    writeText,
+    onNothingToPaste,
+    hasModalOpen: () => false,
+    getActiveElement: () => textarea,
+    ...over,
+  } as Parameters<typeof installTerminalKeybindings>[0])
+
+  return { textarea, xtermSaw, term, readText, writeText, onNothingToPaste, dispose }
+}
+
+beforeEach(() => { document.body.innerHTML = '' })
+
+describe('installTerminalKeybindings — event-phase ordering (the #145 regression)', () => {
+  it('xterm NEVER sees a paste chord', async () => {
+    // THE test. Pre-fix this failed: xterm saw 'v', emitted \x16, and nothing pasted.
+    const h = harness()
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(h.xtermSaw).toEqual([])
+    expect(h.term.paste).toHaveBeenCalledWith('CLIP')
+    h.dispose()
+  })
+
+  it('xterm NEVER sees a copy chord', async () => {
+    const h = harness({ term: { getSelection: () => 'picked', paste: vi.fn(), clearSelection: vi.fn() } })
+    h.textarea.dispatchEvent(chord({ key: 'C', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve()
+
+    expect(h.xtermSaw).toEqual([])
+    h.dispose()
+  })
+
+  it('lets every other keystroke through to xterm untouched', async () => {
+    // Guard against over-reach: intercepting ordinary typing would break the terminal.
+    const h = harness()
+    h.textarea.dispatchEvent(chord({ key: 'a' }))
+    h.textarea.dispatchEvent(chord({ key: 'c', ctrlKey: true }))   // Ctrl+C = SIGINT
+    h.textarea.dispatchEvent(chord({ key: 'Enter' }))
+    await Promise.resolve()
+
+    expect(h.xtermSaw).toEqual(['a', 'c', 'Enter'])
+    expect(h.term.paste).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('marks the paste chord handled so the native command cannot double-act', () => {
+    const h = harness()
+    const e = chord({ key: 'v', ctrlKey: true })
+    h.textarea.dispatchEvent(e)
+    expect(e.defaultPrevented).toBe(true)
+    h.dispose()
+  })
+})
+
+describe('installTerminalKeybindings — disposal', () => {
+  it('stops intercepting after dispose, and xterm gets the chord back', async () => {
+    // A capture-flag mismatch on removeEventListener silently removes nothing,
+    // leaking a listener that keeps pasting into a disposed terminal.
+    const h = harness()
+    h.dispose()
+
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(h.term.paste).not.toHaveBeenCalled()
+    expect(h.xtermSaw).toEqual(['v'])
+  })
+})
+
+describe('installTerminalKeybindings — guards', () => {
+  it('does nothing for an INACTIVE terminal', async () => {
+    // Every session's TerminalView stays mounted and shares this document listener,
+    // so without this one Ctrl+V would paste into every open session at once.
+    const h = harness({ isActive: () => false })
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(h.term.paste).not.toHaveBeenCalled()
+    expect(h.xtermSaw).toEqual(['v']) // not ours to claim — left alone entirely
+    h.dispose()
+  })
+
+  it('reads isActive fresh on every keystroke, not once at install', async () => {
+    // The stale-capture trap: the installing effect keys on session identity, so a
+    // captured boolean would never see a tab switch.
+    let active = false
+    const h = harness({ isActive: () => active })
+
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).not.toHaveBeenCalled()
+
+    active = true
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).toHaveBeenCalledWith('CLIP')
+    h.dispose()
+  })
+
+  it('defers while a modal is open', async () => {
+    const h = harness({ hasModalOpen: () => true })
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('defers to the native paste when focus is in an ordinary input', async () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    const h = harness({ getActiveElement: () => input })
+
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+
+    expect(h.term.paste).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('still handles the chord when focus is on xterm own helper textarea', async () => {
+    // That textarea IS the terminal, so it must not count as an ordinary editable.
+    const h = harness()
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).toHaveBeenCalledWith('CLIP')
+    h.dispose()
+  })
+})
+
+describe('installTerminalKeybindings — paste behaviour', () => {
+  it('reports rather than silently doing nothing when the clipboard is empty', async () => {
+    const h = harness({ readText: async () => '' })
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+
+    expect(h.term.paste).not.toHaveBeenCalled()
+    expect(h.onNothingToPaste).toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('treats a rejected clipboard read as nothing to paste, without throwing', async () => {
+    const h = harness({ readText: async () => { throw new Error('denied') } })
+    h.textarea.dispatchEvent(chord({ key: 'v', ctrlKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+
+    expect(h.term.paste).not.toHaveBeenCalled()
+    expect(h.onNothingToPaste).toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('accepts Shift+Insert and Cmd+V as well', async () => {
+    const h = harness()
+    h.textarea.dispatchEvent(chord({ key: 'Insert', shiftKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).toHaveBeenCalledTimes(1)
+
+    h.textarea.dispatchEvent(chord({ key: 'v', metaKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).toHaveBeenCalledTimes(2)
+    h.dispose()
+  })
+
+  it('handles an INJECTED chord that carries no code field', async () => {
+    // Measured from real dictation input (#145): synthesized keystrokes have no
+    // physical scan code, so `code` is absent. Requiring it would exclude them.
+    const h = harness()
+    h.textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true, cancelable: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.term.paste).toHaveBeenCalledWith('CLIP')
+    h.dispose()
+  })
+})
+
+describe('installTerminalKeybindings — copy behaviour', () => {
+  it('copies the selection and clears it', async () => {
+    const term = { getSelection: () => 'picked', paste: vi.fn(), clearSelection: vi.fn() }
+    const h = harness({ term })
+    h.textarea.dispatchEvent(chord({ key: 'C', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+
+    expect(h.writeText).toHaveBeenCalledWith('picked')
+    expect(term.clearSelection).toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('does nothing when there is no selection', async () => {
+    const h = harness()
+    h.textarea.dispatchEvent(chord({ key: 'C', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve()
+    expect(h.writeText).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('does NOT copy for an inactive terminal', async () => {
+    // The #153 defect: the old copy handler had no isActive guard, so it ran once per
+    // mounted terminal.
+    const term = { getSelection: () => 'picked', paste: vi.fn(), clearSelection: vi.fn() }
+    const h = harness({ term, isActive: () => false })
+    h.textarea.dispatchEvent(chord({ key: 'C', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve()
+    expect(h.writeText).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('copies under caps lock, where the key arrives lowercase', async () => {
+    // The old check compared `e.key === 'C'` exactly, so copy silently stopped
+    // working with caps lock on.
+    const term = { getSelection: () => 'picked', paste: vi.fn(), clearSelection: vi.fn() }
+    const h = harness({ term })
+    h.textarea.dispatchEvent(chord({ key: 'c', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(h.writeText).toHaveBeenCalledWith('picked')
+    h.dispose()
+  })
+
+  it('survives a rejected clipboard write without clearing the selection', async () => {
+    const term = { getSelection: () => 'picked', paste: vi.fn(), clearSelection: vi.fn() }
+    const h = harness({ term, writeText: async () => { throw new Error('denied') } })
+    h.textarea.dispatchEvent(chord({ key: 'C', ctrlKey: true, shiftKey: true }))
+    await Promise.resolve(); await Promise.resolve()
+    expect(term.clearSelection).not.toHaveBeenCalled()
+    h.dispose()
+  })
+})


### PR DESCRIPTION
Closes #154. Closes #153.

## Why

The #145 bug was a keydown handler registered on `document` in the **bubble** phase. xterm's own
listener sits on the helper textarea and runs in the **target** phase — so it had already converted
Ctrl+V to the raw control byte `\x16` and written it to the PTY before the handler ran.

It typechecked. It passed every predicate test. It was **dead code on the only path that mattered**,
and it took three attempts plus custom instrumentation to find. Nothing in the suite could catch a
repeat: flipping `true` to `false` on that registration is a silent regression with a green suite.

**The predicates were never wrong — the wiring was.** So the wiring moves somewhere it can be driven
directly.

## What

- **`src/renderer/components/terminal/terminalKeybindings.ts`** — `installTerminalKeybindings()` owns
  **both** clipboard chords behind one capture-phase `document` listener and returns a disposer.
  Every DOM/Electron dependency is injected (`doc`, `hasModalOpen`, `getActiveElement`, `readText`,
  `writeText`, `term`), so tests exercise the **real** registration rather than a copy of it. A test
  that mirrors the registration passes whether or not production is right — exactly the trap #154 was
  filed to avoid.
- **`TerminalView`** just calls it. Both inline handlers and their manual
  `add`/`removeEventListener` bookkeeping are gone. `isActive` is passed as a **thunk**: the
  installing effect keys on session identity, so a captured boolean goes stale on tab switches.

## Closes #153 too, deliberately

The extraction rewrites precisely the registration #153 is about, and leaving it half-done would be
worse than either state. The copy chord gained the `isActive` / modal / ordinary-editable gate it
never had — it previously ran **once per mounted terminal** and fired with focus in a text input.

`isCopyChord` also now matches case-insensitively: the old check was `e.key === 'C'` exactly, so
**copy silently stopped working under caps lock** (with shift held Chromium reports `C`; with caps
lock also on it reports `c`).

## Validated by mutation — the actual point

Flipping the capture flag to `false` fails **exactly three** tests:

```
× xterm NEVER sees a paste chord
× xterm NEVER sees a copy chord
× stops intercepting after dispose, and xterm gets the chord back
```

That third one matters independently: an unmatched capture flag on `removeEventListener` silently
removes nothing, leaking a listener that keeps pasting into a disposed terminal.

Coverage that cannot fail would have been worthless here, so this was verified rather than assumed.

## Coverage

19 keybinding cases plus 4 `isCopyChord` predicate tests:

- Phase ordering for both chords; ordinary keys — including **Ctrl+C (SIGINT)** — passing through to
  xterm untouched; `defaultPrevented`; disposal.
- Guards: inactive terminal, modal open, focus in an ordinary input, and focus on xterm's own helper
  textarea (which must **not** count as ordinary — it *is* the terminal).
- `isActive` read fresh on every keystroke, not once at install.
- Empty clipboard and rejected clipboard read both report instead of failing silently.
- Shift+Insert and Cmd+V; an **injected** chord carrying no `code` field (measured from real dictation
  input — requiring `code` would exclude every injected paste).
- Copy: selection copied and cleared, no-selection no-op, inactive terminal, caps lock, and a
  rejected write leaving the selection intact.

## Verification

`npm run typecheck` clean; `npx vitest run` **3186 passed / 4 skipped / 0 failed**.

ADR-008 updated — it previously recorded the copy handler as knowingly left alone.

## Reviewer note

Behaviour changes are limited to the two #153 fixes (copy now respects the guards; copy works under
caps lock). Paste behaviour is unchanged from what shipped in #147 — same chords, same guards, same
main-process clipboard read, same paste hint.

Squash-merge.