### PR TITLE
feat(agents): isolate parallel sessions with per-session worktrees + guard hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit|MultiEdit|Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/scripts/session-guard.mjs", "hook"],
+            "timeout": 15,
+            "statusMessage": "Checking session worktree ownership"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ dist/
 # (ADR-009 / 2026-07-30, same reasoning as ADR-004 tracking AGENTS.md.)
 .claude/*
 !.claude/skills/
+# settings.json is repo-owned too: it carries the session-isolation PreToolUse
+# hook that every worktree must inherit (ADR-011). An untracked hook protects
+# nobody but the machine that wrote it. settings.local.json stays personal.
+!.claude/settings.json
 .agents/
 # AGENTS.md is now TRACKED — it is the canonical, cross-tool agent brief
 # (ADR-004 / 2026-07-18). CLAUDE.md imports it via `@AGENTS.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ dist/
 .claude/*
 !.claude/skills/
 # settings.json is repo-owned too: it carries the session-isolation PreToolUse
-# hook that every worktree must inherit (ADR-011). An untracked hook protects
+# hook that every worktree must inherit (ADR-012). An untracked hook protects
 # nobody but the machine that wrote it. settings.local.json stays personal.
 !.claude/settings.json
 .agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ relying on the current directory. Never work in the primary checkout or another
 session's worktree — their branch can change under you and they may hold
 uncommitted work. A `PreToolUse` hook denies writes and mutating git outside the
 worktree you own; `CCC_SESSION_GUARD=off` is the escape hatch. See
-`docs/session-isolation.md` and ADR-011.
+`docs/session-isolation.md` and ADR-012.
 
 ## Build & Run
 
@@ -123,5 +123,5 @@ changelog entry, advisory) is written **after** the fix ships, all at once.
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
 - `docs/versioning.md` — versioning scheme, prerelease suffixes, update channels, rolling re-release vs. version bump.
 - `architecture/decisions/` — ADRs (the *why* behind architectural/tooling calls).
-- `docs/session-isolation.md` — running parallel agents without collisions (`scripts/session-guard.mjs`, the `PreToolUse` hook, ADR-011).
+- `docs/session-isolation.md` — running parallel agents without collisions (`scripts/session-guard.mjs`, the `PreToolUse` hook, ADR-012).
 - `docs/dev-alongside-prod.md`, `docs/USER_GUIDE.md`, `docs/code-signing.md` — operational guides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,22 @@ making changes.
 Multi-session Claude Code terminal orchestrator built with Electron 42 + React 19
 + TypeScript.
 
+## Session isolation — do this FIRST
+
+Several agents run against this repo simultaneously. **One session = one worktree
+= one branch.** Before changing anything, claim your own:
+
+```bash
+node scripts/session-guard.mjs claim --base beta   # or: adopt (already in one)
+```
+
+Work only in the directory it prints, and prefer `git -C "<that dir>" …` over
+relying on the current directory. Never work in the primary checkout or another
+session's worktree — their branch can change under you and they may hold
+uncommitted work. A `PreToolUse` hook denies writes and mutating git outside the
+worktree you own; `CCC_SESSION_GUARD=off` is the escape hatch. See
+`docs/session-isolation.md` and ADR-011.
+
 ## Build & Run
 
 ```bash
@@ -99,4 +115,5 @@ changelog entry, advisory) is written **after** the fix ships, all at once.
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
 - `docs/versioning.md` — versioning scheme, prerelease suffixes, update channels, rolling re-release vs. version bump.
 - `architecture/decisions/` — ADRs (the *why* behind architectural/tooling calls).
+- `docs/session-isolation.md` — running parallel agents without collisions (`scripts/session-guard.mjs`, the `PreToolUse` hook, ADR-011).
 - `docs/dev-alongside-prod.md`, `docs/USER_GUIDE.md`, `docs/code-signing.md` — operational guides.

--- a/CONTEXT.d/2026-07-30-session-isolation-guard.md
+++ b/CONTEXT.d/2026-07-30-session-isolation-guard.md
@@ -1,0 +1,56 @@
+## 2026-07-30 -- Session isolation for parallel agents (session-guard + PreToolUse hook)
+
+Problem observed live, not hypothetical. During one session: the primary
+checkout changed branch three times under us (fix/145 -> docs/148 -> test/154)
+driven by other sessions; a ccc-security worktree appeared mid-session; and
+PR #127's branch was found holding three unrelated, unpushed commits
+(perf(main) + two fix(dev)) that existed on no other branch. Pushing from that
+branch tip would have injected unreviewed code into a PR described as
+"docs + gitignore, no code changes". Separately, ccc-iso reads as disposable
+(0 commits ahead of beta) while holding 32 modified files.
+
+Root cause: a session had no way to tell whether the directory it stood in
+belonged to it, and convention alone does not bind an agent whose context has
+been truncated.
+
+Decision (ADR-011): one session = one worktree = one branch, all branched from a
+shared base. Git already refuses to check out one branch in two worktrees, so
+the branch ref is the hard interlock; the new tooling supplies the bookkeeping
+git has no opinion about.
+
+Added:
+- scripts/session-guard.mjs -- claim / adopt / verify / status / list / reap /
+  release / hook. Leases are one JSON per session under
+  <git-common-dir>/ccc-sessions/ (shared by all linked worktrees, never
+  tracked), keyed by CLAUDE_CODE_SESSION_ID with CLAUDE_PID for liveness.
+- .claude/settings.json -- PreToolUse hook over
+  Edit|Write|NotebookEdit|MultiEdit|Bash|PowerShell that denies writes and
+  mutating git against a worktree of this repo the caller does not own. Honours
+  a -C <path> argument, so `git -C <other-worktree> commit` is caught even when
+  cwd is fine.
+- docs/session-isolation.md, ADR-011, AGENTS.md + docs/agent-conventions.md
+  sections.
+
+Rejected: literal same-branch parallelism via `git worktree add --force` (N
+worktrees, one shared ref -- concurrent commits clobber, which is the original
+problem); a clone per agent (~1GB node_modules each); convention-only (what we
+had, and what failed).
+
+Verified before relying on it: process.kill(pid, 0) on Windows reports liveness,
+leaves the target process running, and throws ESRCH when dead -- checked against
+a real spawned Windows pid, confirming the probe never signals. Hook decisions
+pipe-tested across 12 cases (own worktree, primary checkout, another unmanaged
+worktree, outside the repo, git -C targeting each, read-only verbs, chained
+`&&` commands, worktree add vs remove, PowerShell push) plus live-rival,
+stale-lease, dirty-reap and escape-hatch paths.
+
+Notable design points:
+- adopt refuses the primary checkout outright -- no session may fence others out
+  of the shared tree.
+- reap keeps a dead session's lease when its worktree is dirty, rather than
+  handing a directory with unsaved work to someone else.
+- The guard fails OPEN (bad input / missing script / internal error -> exit 0).
+  It is a collision guard, not a security boundary.
+- Bug caught in testing: claiming from inside a worktree anchored the sibling
+  root to the current worktree, nesting ccc-wt/ccc-wt/. Now anchored to the
+  primary checkout via --git-common-dir.

--- a/CONTEXT.d/2026-07-30-session-isolation-guard.md
+++ b/CONTEXT.d/2026-07-30-session-isolation-guard.md
@@ -13,7 +13,7 @@ Root cause: a session had no way to tell whether the directory it stood in
 belonged to it, and convention alone does not bind an agent whose context has
 been truncated.
 
-Decision (ADR-011): one session = one worktree = one branch, all branched from a
+Decision (ADR-012): one session = one worktree = one branch, all branched from a
 shared base. Git already refuses to check out one branch in two worktrees, so
 the branch ref is the hard interlock; the new tooling supplies the bookkeeping
 git has no opinion about.
@@ -28,7 +28,7 @@ Added:
   mutating git against a worktree of this repo the caller does not own. Honours
   a -C <path> argument, so `git -C <other-worktree> commit` is caught even when
   cwd is fine.
-- docs/session-isolation.md, ADR-011, AGENTS.md + docs/agent-conventions.md
+- docs/session-isolation.md, ADR-012, AGENTS.md + docs/agent-conventions.md
   sections.
 
 Rejected: literal same-branch parallelism via `git worktree add --force` (N

--- a/architecture/decisions/2026-07-30-adr-011-session-isolation-for-parallel-agents.md
+++ b/architecture/decisions/2026-07-30-adr-011-session-isolation-for-parallel-agents.md
@@ -1,0 +1,76 @@
+# ADR-011: Session isolation for parallel agents
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+Several Claude Code sessions run against this repository at the same time, and
+nothing stopped them from landing in the same place. In practice they did:
+
+- The primary checkout changed branch three times during a single session
+  (`fix/145` -> `docs/148` -> `test/154`), driven by other sessions.
+- A new `ccc-security` worktree appeared mid-session, from another session.
+- PR #127's branch was found carrying three commits that belonged to unrelated
+  work (`perf(main)`, two `fix(dev)`), unpushed and on no other branch. Had they
+  been pushed, a PR advertised as "docs + gitignore, no code changes" would have
+  shipped unreviewed code.
+- The `ccc-iso` worktree sat on a branch that was 0 commits ahead of `beta` --
+  it reads as disposable -- while holding 32 modified files.
+
+The shared failure is that a session cannot tell whether the directory it is
+standing in belongs to it. Convention alone does not fix this: an agent whose
+context has been truncated, or that simply never read the rule, will still
+`cd` into the primary checkout and commit.
+
+The requirement is to run many agents in parallel against the same repository,
+on the same line of work, with no possibility of collision.
+
+## Decision
+
+**One session = one worktree = one branch, branched from a shared base.**
+
+Git already refuses to check out one branch in two worktrees, so the branch ref
+is a hard interlock we get for free. Layered on top:
+
+1. **`scripts/session-guard.mjs`** -- claims a worktree + branch
+   (`session/<base>/<session-id>`), records a lease, and answers "do I own this
+   directory?".
+2. **Leases in `<git-common-dir>/ccc-sessions/`** -- one JSON per session, keyed
+   by `CLAUDE_CODE_SESSION_ID`, carrying `CLAUDE_PID` for liveness. The common
+   git dir is shared by every linked worktree and is never tracked, so all
+   sessions see one registry with no repo pollution.
+3. **A `PreToolUse` hook** (`.claude/settings.json`) that denies `Edit`/`Write`/
+   `NotebookEdit` and git-mutating `Bash`/`PowerShell` commands whenever the
+   target is a worktree of this repo that the calling session does not own.
+   The harness enforces it, so it cannot be forgotten or reasoned away.
+
+Rejected alternatives:
+
+- **Literal same-branch parallelism** (`git worktree add --force`, N worktrees
+  on one ref). Separate index and HEAD per worktree, but a single shared branch
+  ref: concurrent commits race and clobber. This reintroduces the exact problem.
+- **A clone per agent.** Full isolation, but ~1 GB of `node_modules` per agent
+  and a native rebuild each; cross-agent sharing has to round-trip the remote.
+- **Convention only** (document the rule in `AGENTS.md`). This is what we had.
+  It is what failed.
+
+## Consequences
+
+- Agents never work in the primary checkout. It stays a stable, human-owned
+  reference, and `session-guard adopt` explicitly refuses to lease it -- no
+  session can fence others out of the shared tree.
+- Integration is unchanged: `session/*` branches PR into `beta` like any other.
+- Unowned worktrees are blocked for writes, which deliberately covers
+  pre-existing ones such as `ccc-iso`. `adopt` is the one-command opt-in, and it
+  also covers worktrees made by Claude Code's own `--worktree`/`EnterWorktree`.
+- Liveness is a PID probe. `process.kill(pid, 0)` was verified non-destructive
+  on Windows before being relied on: it reports liveness, leaves the target
+  running, and throws `ESRCH` when dead.
+- `reap` refuses to clear a dead session's lease while its worktree holds
+  uncommitted changes -- releasing it would invite another session to take a
+  directory with unsaved work in it.
+- The guard fails **open**. A crash, malformed hook input, or missing script
+  exits 0 and allows the action; a bug in the guard must never brick a session.
+  `CCC_SESSION_GUARD=off` disables blocking outright.
+- The hook adds one short-lived `node` process per matched tool call.

--- a/architecture/decisions/2026-07-31-adr-012-session-isolation-for-parallel-agents.md
+++ b/architecture/decisions/2026-07-31-adr-012-session-isolation-for-parallel-agents.md
@@ -1,4 +1,4 @@
-# ADR-011: Session isolation for parallel agents
+# ADR-012: Session isolation for parallel agents
 
 - Status: Accepted
 - Date: 2026-07-30

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -60,7 +60,7 @@ npm run test:e2e     # Playwright
 - Before adding commits to an existing PR branch, check
   `git log --oneline origin/<head>..<local-branch>` — a local ref can carry
   unpushed commits that are not part of that PR.
-- Full guide: `docs/session-isolation.md`; rationale in ADR-011.
+- Full guide: `docs/session-isolation.md`; rationale in ADR-012.
 
 ## Branching & review
 

--- a/docs/agent-conventions.md
+++ b/docs/agent-conventions.md
@@ -46,6 +46,22 @@ npm run test:e2e     # Playwright
   must be a no-op when packaged. New long-lived ports must be split dev/prod (see
   `resolveHooksPort` / `resolveConductorMcpPort` / `resolveCdpPort`). See ADR-001.
 
+## Session isolation (parallel agents)
+
+- **One session = one worktree = one branch.** Several agents run against this
+  repo at once. Claim your own before you change anything:
+  `node scripts/session-guard.mjs claim --base beta` (or `adopt`, if you are
+  already in a worktree made for you).
+- **Never work in the primary checkout or another session's worktree.** Their
+  branch can change under you, and they may hold uncommitted work. A
+  `PreToolUse` hook enforces this — writes and mutating git outside the worktree
+  you own are denied. `CCC_SESSION_GUARD=off` is the escape hatch.
+- Prefer `git -C "<your worktree>" …` over relying on the current directory.
+- Before adding commits to an existing PR branch, check
+  `git log --oneline origin/<head>..<local-branch>` — a local ref can carry
+  unpushed commits that are not part of that PR.
+- Full guide: `docs/session-isolation.md`; rationale in ADR-011.
+
 ## Branching & review
 
 - Branch off `beta`; PR back into `beta`. `beta` is never frozen; releases

--- a/docs/session-isolation.md
+++ b/docs/session-isolation.md
@@ -2,7 +2,7 @@
 
 How to run many Claude Code sessions against this repo at once without them
 colliding. The rationale and the rejected alternatives are in
-`architecture/decisions/2026-07-30-adr-011-session-isolation-for-parallel-agents.md`.
+`architecture/decisions/2026-07-31-adr-012-session-isolation-for-parallel-agents.md`.
 
 ## The rule
 
@@ -110,8 +110,18 @@ shared checkout, and prefer `git -C` at a specific path over changing directory.
 
 ## Notes
 
-- Identity is `CLAUDE_CODE_SESSION_ID`; liveness is `CLAUDE_PID`. Both are
-  provided by Claude Code. Outside a Claude session `claim` refuses to run.
+- Identity is `CLAUDE_CODE_SESSION_ID`. Outside a Claude session `claim` refuses
+  to run.
+- Liveness is a **pid check plus a heartbeat**, and the heartbeat is the part
+  that matters. `CLAUDE_PID` is *not* stable for the life of a session: resuming
+  after `/exit` keeps the same `CLAUDE_CODE_SESSION_ID` but gets a new process,
+  so a pid check on its own reports a live session as dead — and the fix for
+  "dead" is `reap`, which would hand your worktree to someone else. Every guard
+  invocation therefore re-stamps its own lease with the current pid and time, and
+  a lease counts as live if its pid exists **or** it was touched in the last 30
+  minutes. Because the hook runs on every matched tool call, ordinary work is the
+  heartbeat. `reap` never clears a lease inside that window, and never clears
+  your own.
 - Leases live in `<git-common-dir>/ccc-sessions/` -- shared by every linked
   worktree, never tracked by git.
 - Worktree location defaults to `../ccc-wt/` beside the primary checkout;

--- a/docs/session-isolation.md
+++ b/docs/session-isolation.md
@@ -1,0 +1,122 @@
+# Session isolation (parallel agents)
+
+How to run many Claude Code sessions against this repo at once without them
+colliding. The rationale and the rejected alternatives are in
+`architecture/decisions/2026-07-30-adr-011-session-isolation-for-parallel-agents.md`.
+
+## The rule
+
+**One session = one worktree = one branch.** Every session works in its own
+directory, on its own branch, branched from a shared base (normally `beta`).
+Sessions never work in the primary checkout and never share a branch.
+
+```
+beta  (shared base -- no agent ever checks it out)
+  |-- session/beta/55158424  ->  ../ccc-wt/55158424      agent A
+  |-- session/beta/a91f3c02  ->  ../ccc-wt/a91f3c02      agent B
+  `-- session/beta/7d0e11bb  ->  ../ccc-wt/7d0e11bb      agent C
+```
+
+All three work the same line of work in parallel and integrate the normal way:
+`session/*` -> PR -> `beta`.
+
+## Start of session: claim
+
+```bash
+node scripts/session-guard.mjs claim --base beta
+```
+
+Creates `../ccc-wt/<session>` on `session/beta/<session>` branched from
+`origin/beta`, records the lease, and prints the path. Add `--slug docs` to make
+the branch and directory self-describing. Re-running is a no-op that reprints
+your existing worktree.
+
+Already standing in a worktree someone made for you -- by hand, or via Claude
+Code's own `--worktree` / `EnterWorktree`? Take ownership of it instead:
+
+```bash
+node scripts/session-guard.mjs adopt
+```
+
+Then do all your work in that directory. Address git at it explicitly rather
+than relying on the shell's current directory:
+
+```bash
+git -C "<your worktree>" status
+```
+
+## Any time: who owns what
+
+```bash
+node scripts/session-guard.mjs status   # your cwd, your lease, guard state
+node scripts/session-guard.mjs list     # every session, with liveness
+node scripts/session-guard.mjs verify   # exit 0 only if you own the cwd
+```
+
+## End of session: release
+
+```bash
+node scripts/session-guard.mjs release                    # drop the lease
+node scripts/session-guard.mjs release --remove-worktree  # and remove the dir
+node scripts/session-guard.mjs reap                       # clear dead sessions
+```
+
+`release --remove-worktree` refuses while the worktree is dirty. `reap` clears
+leases whose owning process is gone, but keeps any whose worktree still holds
+uncommitted changes -- otherwise it would hand that directory to another
+session with unsaved work in it.
+
+## The hook
+
+`.claude/settings.json` registers a `PreToolUse` hook that runs the guard before
+`Edit`, `Write`, `NotebookEdit`, `Bash`, and `PowerShell`. It denies the call
+when the target is a worktree of this repo that you do not own:
+
+```
+session-guard: BLOCKED -- you (session 55158424) do not own this location.
+  target    .../ccc-iso/package.json
+  worktree  .../ccc-iso
+  leased to session a91f3c02 (pid 4120, ALIVE) on branch fix/128-dev-prod-isolation
+
+That session is running right now. Editing here would collide with it.
+```
+
+What it does **not** block:
+
+- Anything inside the worktree you own.
+- Read-only git (`status`, `log`, `diff`, `show`, `rev-parse`, ...) anywhere.
+- `git worktree add` / `list` -- how a session bootstraps itself.
+- Files outside this repository entirely.
+- Any tool other than the five matched above.
+
+It **does** block, outside your own worktree: file writes, mutating git
+(`commit`, `checkout`, `reset`, `rebase`, `push`, `stash`, `clean`, ...),
+destructive `branch -D` / `tag -d`, and `git worktree remove` / `prune`. A
+`-C <path>` argument is honoured, so `git -C <someone-else's-worktree> commit`
+is caught even when your own cwd is fine.
+
+The guard fails open by design: malformed input, a missing script, or a bug in
+the guard exits 0 and allows the call. It is a collision guard, not a security
+boundary.
+
+## Escape hatch
+
+```bash
+CCC_SESSION_GUARD=off <command>
+```
+
+Disables blocking for that invocation. Use it when you genuinely need to touch a
+shared checkout, and prefer `git -C` at a specific path over changing directory.
+
+## Notes
+
+- Identity is `CLAUDE_CODE_SESSION_ID`; liveness is `CLAUDE_PID`. Both are
+  provided by Claude Code. Outside a Claude session `claim` refuses to run.
+- Leases live in `<git-common-dir>/ccc-sessions/` -- shared by every linked
+  worktree, never tracked by git.
+- Worktree location defaults to `../ccc-wt/` beside the primary checkout;
+  override with `CCC_WT_ROOT`.
+- Worktrees share the primary checkout's object store, so they are cheap. They
+  do **not** share `node_modules`; install per worktree, or junction it if the
+  lockfile matches. Never run a native rebuild against a junctioned
+  `node_modules` -- it mutates the install every other worktree is using.

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -90,6 +90,15 @@ function leaseDir(cwd) {
   return dir
 }
 
+/**
+ * How long a lease stays credible after its last heartbeat, once its recorded
+ * pid is gone. CLAUDE_PID is NOT stable for the life of a session -- resuming
+ * after /exit keeps CLAUDE_CODE_SESSION_ID but gets a new process -- so a pid
+ * check alone declares live sessions dead. Every guard invocation refreshes the
+ * caller's own lease (touchLease), which makes the hook a natural heartbeat.
+ */
+const HEARTBEAT_GRACE_MS = 30 * 60 * 1000
+
 function readLeases(cwd) {
   const dir = leaseDir(cwd)
   if (!dir) return []
@@ -99,7 +108,12 @@ function readLeases(cwd) {
     try {
       const lease = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'))
       lease._file = path.join(dir, f)
-      lease._alive = pidAlive(lease.pid)
+      lease._pidAlive = pidAlive(lease.pid)
+      const beat = Date.parse(lease.renewedAt || lease.createdAt || '')
+      lease._fresh = Number.isFinite(beat) && Date.now() - beat < HEARTBEAT_GRACE_MS
+      // Live if the recorded process is still there OR the lease was touched
+      // recently -- the latter covers a session that changed pid on resume.
+      lease._alive = lease._pidAlive || lease._fresh
       // A worktree the user deleted by hand leaves an orphan lease behind.
       lease._present = !!lease.worktree && fs.existsSync(lease.worktree)
       out.push(lease)
@@ -108,6 +122,29 @@ function readLeases(cwd) {
     }
   }
   return out
+}
+
+/**
+ * Re-stamp this session's own lease with the current pid and timestamp. Called
+ * at the top of every command so any activity keeps the lease credible. Never
+ * touches another session's lease.
+ */
+function touchLease(cwd) {
+  const me = sessionId()
+  if (!me) return
+  try {
+    const dir = leaseDir(cwd)
+    if (!dir) return
+    const file = path.join(dir, `${me}.json`)
+    if (!fs.existsSync(file)) return
+    const lease = JSON.parse(fs.readFileSync(file, 'utf8'))
+    const pid = Number(process.env.CLAUDE_PID) || process.ppid
+    lease.pid = pid
+    lease.renewedAt = new Date().toISOString()
+    fs.writeFileSync(file, JSON.stringify(lease, null, 2))
+  } catch {
+    /* a heartbeat failure must never break the caller */
+  }
 }
 
 /** The worktree root containing p, or null when p is not in a work tree. */
@@ -288,14 +325,15 @@ function explain(o, target) {
   const lines = [`session-guard: BLOCKED -- you (session ${me}) do not own this location.`, `  target  ${target}`]
   if (o.root) lines.push(`  worktree  ${o.root}`)
   if (o.kind === 'other') {
+    const why = o.lease._pidAlive ? `pid ${o.lease.pid}, ALIVE` : `heartbeat ${o.lease.renewedAt || o.lease.createdAt}`
     lines.push(
-      `  leased to  session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, ALIVE) on branch ${o.lease.branch}`,
+      `  leased to  session ${shortId(o.lease.sessionId)} (${why}) on branch ${o.lease.branch}`,
       '',
-      'That session is running right now. Editing here would collide with it.',
+      'That session is active right now. Editing here would collide with it.',
     )
   } else if (o.kind === 'stale') {
     lines.push(
-      `  leased to  session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, not running)`,
+      `  leased to  session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, gone; last heartbeat ${o.lease.renewedAt || o.lease.createdAt || 'unknown'})`,
       '',
       'The lease is stale. Clear dead leases with:',
       '  node scripts/session-guard.mjs reap',
@@ -324,7 +362,8 @@ function cmdList() {
   const rows = leases
     .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))
     .map((l) => {
-      const flags = [l.sessionId === me ? 'you' : null, l._alive ? 'alive' : 'DEAD', l._present ? null : 'MISSING-WT']
+      const live = l._pidAlive ? 'alive' : l._fresh ? 'alive(beat)' : 'DEAD'
+      const flags = [l.sessionId === me ? 'you' : null, live, l._present ? null : 'MISSING-WT']
         .filter(Boolean)
         .join(',')
       return `  ${shortId(l.sessionId).padEnd(10)} ${String(l.pid).padEnd(8)} ${(l.branch || '?').padEnd(34)} ${flags}\n      ${l.worktree}`
@@ -345,7 +384,10 @@ function cmdReap() {
   const leases = readLeases(process.cwd())
   let n = 0
   for (const l of leases) {
+    // _alive already folds in the heartbeat grace, so a session that merely
+    // changed pid on resume is never reaped out from under itself.
     if (l._alive) continue
+    if (l.sessionId === sessionId()) continue // never reap your own
     // Never reap a dead session that still has uncommitted work on disk --
     // dropping the lease would invite another session to take the directory.
     if (l._present) {
@@ -523,6 +565,15 @@ function fail(msg) {
 }
 
 const [, , cmd, ...rest] = process.argv
+// Any invocation is proof of life for this session -- keep its lease credible
+// before anything reads ownership. Cheap, and never touches another lease.
+if (cmd) {
+  try {
+    touchLease(process.cwd())
+  } catch {
+    /* ignore */
+  }
+}
 switch (cmd) {
   case 'claim': cmdClaim(rest); break
   case 'adopt': cmdAdopt(rest); break

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -1,0 +1,538 @@
+#!/usr/bin/env node
+// Session isolation guard.
+//
+// Problem: several Claude Code sessions run against this repo at once. Left
+// alone they land in the same checkout, switch its branch under each other,
+// and commit onto a ref another session is mid-way through. That has already
+// happened here (a PR branch that carried three commits belonging to nobody).
+//
+// Model: one session = one worktree = one branch, all branched from a shared
+// base. Git already refuses to check out one branch in two worktrees, so the
+// branch ref is the hard interlock; this script adds the bookkeeping git has
+// no opinion about -- who owns which worktree, and whether that owner is still
+// alive.
+//
+// Leases live in <git-common-dir>/ccc-sessions/, which every linked worktree
+// shares and git never tracks. Identity is CLAUDE_CODE_SESSION_ID; liveness is
+// CLAUDE_PID.
+//
+//   node scripts/session-guard.mjs claim [--base <ref>] [--slug <s>]
+//   node scripts/session-guard.mjs verify [--path <dir>]
+//   node scripts/session-guard.mjs status | list | reap
+//   node scripts/session-guard.mjs release [--remove-worktree]
+//   node scripts/session-guard.mjs hook            (PreToolUse; JSON on stdin)
+//
+// Escape hatch: CCC_SESSION_GUARD=off disables the hook's blocking.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const GUARD_OFF = (process.env.CCC_SESSION_GUARD || '').toLowerCase() === 'off'
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', opts.quiet ? 'ignore' : 'pipe'],
+    cwd: opts.cwd || process.cwd(),
+  }).trim()
+}
+
+function gitSafe(args, opts = {}) {
+  try {
+    return git(args, { ...opts, quiet: true })
+  } catch {
+    return null
+  }
+}
+
+/** Compare paths the way the filesystem does: real case-insensitively on win/mac. */
+function samePath(a, b) {
+  if (!a || !b) return false
+  const norm = (p) => {
+    let r = path.resolve(p).replace(/[\\/]+$/, '')
+    try {
+      r = fs.realpathSync.native(r)
+    } catch {
+      /* not on disk (yet) -- fall back to the lexical form */
+    }
+    return process.platform === 'win32' || process.platform === 'darwin' ? r.toLowerCase() : r
+  }
+  return norm(a) === norm(b)
+}
+
+function sessionId() {
+  return process.env.CLAUDE_CODE_SESSION_ID || null
+}
+
+function shortId(id) {
+  return (id || '').split('-')[0] || 'unknown'
+}
+
+/** Alive-check that never signals. Verified on Windows: signal 0 does not terminate. */
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    // EPERM = exists but owned by another user, which still counts as alive.
+    return e.code === 'EPERM'
+  }
+}
+
+function leaseDir(cwd) {
+  const common = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd })
+  if (!common) return null
+  const dir = path.join(common, 'ccc-sessions')
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function readLeases(cwd) {
+  const dir = leaseDir(cwd)
+  if (!dir) return []
+  const out = []
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.json')) continue
+    try {
+      const lease = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'))
+      lease._file = path.join(dir, f)
+      lease._alive = pidAlive(lease.pid)
+      // A worktree the user deleted by hand leaves an orphan lease behind.
+      lease._present = !!lease.worktree && fs.existsSync(lease.worktree)
+      out.push(lease)
+    } catch {
+      /* a torn or hand-edited lease is treated as absent */
+    }
+  }
+  return out
+}
+
+/** The worktree root containing p, or null when p is not in a work tree. */
+function worktreeRoot(p) {
+  let probe = path.resolve(p)
+  // Walk up to the nearest existing dir -- a file_path may not exist yet.
+  while (!fs.existsSync(probe) && path.dirname(probe) !== probe) probe = path.dirname(probe)
+  if (!fs.existsSync(probe)) return null
+  if (fs.statSync(probe).isFile()) probe = path.dirname(probe)
+  const top = gitSafe(['rev-parse', '--path-format=absolute', '--show-toplevel'], { cwd: probe })
+  return top || null
+}
+
+/**
+ * Ownership of the worktree containing targetPath.
+ * kind: mine | other | stale | unmanaged | not-a-repo
+ */
+function ownership(targetPath, cwdForGit) {
+  const root = worktreeRoot(targetPath)
+  if (!root) return { kind: 'not-a-repo', root: null }
+  const me = sessionId()
+  const leases = readLeases(cwdForGit || root)
+  const lease = leases.find((l) => samePath(l.worktree, root))
+  if (!lease) return { kind: 'unmanaged', root }
+  if (me && lease.sessionId === me) return { kind: 'mine', root, lease }
+  if (!lease._alive) return { kind: 'stale', root, lease }
+  return { kind: 'other', root, lease }
+}
+
+// ---------------------------------------------------------------- commands
+
+/** True when dir is the repo's primary checkout rather than a linked worktree. */
+function isPrimaryWorktree(dir) {
+  const gitDir = gitSafe(['rev-parse', '--path-format=absolute', '--git-dir'], { cwd: dir })
+  const common = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd: dir })
+  return !!gitDir && !!common && samePath(gitDir, common)
+}
+
+/**
+ * Take ownership of a worktree that already exists -- one made by hand, or by
+ * Claude Code's own --worktree / EnterWorktree. Without this those arrive
+ * "unmanaged" and the hook blocks them forever.
+ */
+function cmdAdopt(args) {
+  const me = sessionId()
+  if (!me) fail('CLAUDE_CODE_SESSION_ID is not set -- cannot identify this session.')
+
+  const target = argValue(args, '--path') || process.cwd()
+  const root = worktreeRoot(target)
+  if (!root) fail(`${target} is not inside a git work tree.`)
+  if (isPrimaryWorktree(root)) {
+    fail(
+      `refusing to adopt ${root} -- that is the repository's primary checkout.\n` +
+        '  Shared checkouts must stay unowned so no session can fence others out of them.\n' +
+        '  Create an isolated one instead:  node scripts/session-guard.mjs claim --base beta',
+    )
+  }
+
+  const existingForMe = readLeases(process.cwd()).find((l) => l.sessionId === me)
+  if (existingForMe && !samePath(existingForMe.worktree, root)) {
+    fail(`this session already holds ${existingForMe.worktree}. Release it first:\n  node scripts/session-guard.mjs release`)
+  }
+
+  const o = ownership(root, process.cwd())
+  if (o.kind === 'mine') {
+    print(renderClaim(o.lease, 'already yours'))
+    return
+  }
+  if (o.kind === 'other') fail(explain(o, root))
+  if (o.kind === 'stale') {
+    print(`  clearing stale lease from session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, not running)`)
+    fs.unlinkSync(o.lease._file)
+  }
+
+  const branch = gitSafe(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root }) || 'HEAD'
+  if (branch === 'HEAD') fail(`${root} is on a detached HEAD -- check out a session branch there first.`)
+
+  const lease = {
+    sessionId: me,
+    multiSessionId: process.env.CLAUDE_MULTI_SESSION_ID || null,
+    pid: Number(process.env.CLAUDE_PID) || process.ppid,
+    worktree: root,
+    branch,
+    base: argValue(args, '--base') || null,
+    startPoint: null,
+    host: os.hostname(),
+    createdAt: new Date().toISOString(),
+    adopted: true,
+  }
+  fs.writeFileSync(path.join(leaseDir(process.cwd()), `${me}.json`), JSON.stringify(lease, null, 2), { flag: 'wx' })
+  print(renderClaim(lease, 'adopted'))
+}
+
+function cmdClaim(args) {
+  const me = sessionId()
+  if (!me) fail('CLAUDE_CODE_SESSION_ID is not set -- cannot identify this session.')
+  if (args.includes('--adopt')) return cmdAdopt(args)
+
+  const base = argValue(args, '--base') || 'beta'
+  const slug = argValue(args, '--slug') || ''
+  const short = shortId(me)
+
+  // Re-claim is a no-op: report the existing worktree instead of making a second.
+  const existing = readLeases(process.cwd()).find((l) => l.sessionId === me)
+  if (existing && existing._present) {
+    print(renderClaim(existing, 'already claimed'))
+    return
+  }
+
+  const mainRoot = gitSafe(['rev-parse', '--path-format=absolute', '--show-toplevel'])
+  if (!mainRoot) fail('run this from inside the repository (or a worktree of it).')
+
+  const branch = slug ? `session/${base}/${short}-${slug}` : `session/${base}/${short}`
+  // Anchor sibling worktrees to the PRIMARY checkout, never to whatever worktree
+  // we happen to be standing in -- otherwise claiming from inside one nests
+  // ccc-wt/ccc-wt/... one level deeper every time.
+  const commonDir = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'])
+  const primaryRoot = commonDir ? path.dirname(commonDir) : mainRoot
+  const wtRoot = process.env.CCC_WT_ROOT || path.join(path.dirname(primaryRoot), 'ccc-wt')
+  const dir = path.join(wtRoot, slug ? `${short}-${slug}` : short)
+
+  // Prefer the remote base so a session never inherits another session's local drift.
+  const startPoint = gitSafe(['rev-parse', '--verify', '--quiet', `origin/${base}`]) ? `origin/${base}` : base
+  if (!gitSafe(['rev-parse', '--verify', '--quiet', startPoint])) fail(`base ref '${base}' does not exist.`)
+
+  fs.mkdirSync(wtRoot, { recursive: true })
+  // `git worktree add -b` is the atomic step: if two sessions race the same
+  // branch, exactly one succeeds and the other lands here.
+  try {
+    git(['worktree', 'add', '-b', branch, dir, startPoint])
+  } catch (e) {
+    fail(`could not create worktree/branch '${branch}':\n${e.stderr || e.message}`)
+  }
+
+  const lease = {
+    sessionId: me,
+    multiSessionId: process.env.CLAUDE_MULTI_SESSION_ID || null,
+    pid: Number(process.env.CLAUDE_PID) || process.ppid,
+    worktree: dir,
+    branch,
+    base,
+    startPoint,
+    host: os.hostname(),
+    createdAt: new Date().toISOString(),
+  }
+  // 'wx' => fail if a lease for this session already exists (no silent clobber).
+  fs.writeFileSync(path.join(leaseDir(process.cwd()), `${me}.json`), JSON.stringify(lease, null, 2), { flag: 'wx' })
+
+  print(renderClaim(lease, 'claimed'))
+}
+
+function renderClaim(lease, verb) {
+  return [
+    `session-guard: ${verb}`,
+    `  worktree  ${lease.worktree}`,
+    `  branch    ${lease.branch}${lease.startPoint || lease.base ? `  (from ${lease.startPoint || lease.base})` : ''}`,
+    `  session   ${shortId(lease.sessionId)}  pid ${lease.pid}`,
+    '',
+    'Work only in that directory. Address git at it explicitly:',
+    `  git -C "${lease.worktree}" status`,
+  ].join('\n')
+}
+
+function cmdVerify(args) {
+  const target = argValue(args, '--path') || process.cwd()
+  const o = ownership(target, process.cwd())
+  const me = shortId(sessionId())
+  if (o.kind === 'mine') {
+    print(`session-guard: OK -- ${o.root} is leased to session ${me} (branch ${o.lease.branch}).`)
+    return
+  }
+  print(explain(o, target), 'stderr')
+  process.exit(1)
+}
+
+function explain(o, target) {
+  const me = shortId(sessionId())
+  const lines = [`session-guard: BLOCKED -- you (session ${me}) do not own this location.`, `  target  ${target}`]
+  if (o.root) lines.push(`  worktree  ${o.root}`)
+  if (o.kind === 'other') {
+    lines.push(
+      `  leased to  session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, ALIVE) on branch ${o.lease.branch}`,
+      '',
+      'That session is running right now. Editing here would collide with it.',
+    )
+  } else if (o.kind === 'stale') {
+    lines.push(
+      `  leased to  session ${shortId(o.lease.sessionId)} (pid ${o.lease.pid}, not running)`,
+      '',
+      'The lease is stale. Clear dead leases with:',
+      '  node scripts/session-guard.mjs reap',
+    )
+  } else if (o.kind === 'unmanaged') {
+    lines.push(
+      '  leased to  nobody -- this is a shared checkout, not a session worktree',
+      '',
+      'Shared checkouts are off limits: another session or the app may switch',
+      'their branch at any moment, and they can hold uncommitted work.',
+    )
+  } else {
+    lines.push('  not inside a git work tree')
+  }
+  lines.push('', 'Claim your own isolated worktree, then work there:', '  node scripts/session-guard.mjs claim --base beta')
+  return lines.join('\n')
+}
+
+function cmdList() {
+  const leases = readLeases(process.cwd())
+  const me = sessionId()
+  if (!leases.length) {
+    print('session-guard: no active session leases.')
+    return
+  }
+  const rows = leases
+    .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))
+    .map((l) => {
+      const flags = [l.sessionId === me ? 'you' : null, l._alive ? 'alive' : 'DEAD', l._present ? null : 'MISSING-WT']
+        .filter(Boolean)
+        .join(',')
+      return `  ${shortId(l.sessionId).padEnd(10)} ${String(l.pid).padEnd(8)} ${(l.branch || '?').padEnd(34)} ${flags}\n      ${l.worktree}`
+    })
+  print(['session-guard: leases', '  SESSION    PID      BRANCH                             FLAGS', ...rows].join('\n'))
+}
+
+function cmdStatus() {
+  const o = ownership(process.cwd(), process.cwd())
+  print(`cwd        ${process.cwd()}`)
+  print(`session    ${shortId(sessionId())}  pid ${process.env.CLAUDE_PID || '?'}`)
+  print(`ownership  ${o.kind}${o.lease ? `  (${o.lease.branch})` : ''}`)
+  print(`guard      ${GUARD_OFF ? 'DISABLED (CCC_SESSION_GUARD=off)' : 'enforcing'}`)
+  cmdList()
+}
+
+function cmdReap() {
+  const leases = readLeases(process.cwd())
+  let n = 0
+  for (const l of leases) {
+    if (l._alive) continue
+    // Never reap a dead session that still has uncommitted work on disk --
+    // dropping the lease would invite another session to take the directory.
+    if (l._present) {
+      const dirty = gitSafe(['status', '--porcelain'], { cwd: l.worktree })
+      if (dirty) {
+        print(`  keeping ${shortId(l.sessionId)} -- dead, but its worktree has uncommitted changes:\n      ${l.worktree}`)
+        continue
+      }
+    }
+    fs.unlinkSync(l._file)
+    n++
+    print(`  reaped ${shortId(l.sessionId)} (pid ${l.pid}) ${l.branch}`)
+  }
+  print(`session-guard: reaped ${n} dead lease(s).`)
+}
+
+function cmdRelease(args) {
+  const me = sessionId()
+  const lease = readLeases(process.cwd()).find((l) => l.sessionId === me)
+  if (!lease) {
+    print('session-guard: nothing to release (no lease for this session).')
+    return
+  }
+  if (args.includes('--remove-worktree')) {
+    const dirty = gitSafe(['status', '--porcelain'], { cwd: lease.worktree })
+    if (dirty) fail(`refusing to remove ${lease.worktree} -- it has uncommitted changes.`)
+    const main = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'])
+    gitSafe(['worktree', 'remove', lease.worktree], { cwd: main ? path.dirname(main) : process.cwd() })
+  }
+  fs.unlinkSync(lease._file)
+  print(`session-guard: released ${lease.branch}.`)
+}
+
+// ------------------------------------------------------------------- hook
+
+// Read-only git verbs are always fine, wherever they run.
+const GIT_READONLY = new Set([
+  'status', 'log', 'diff', 'show', 'rev-parse', 'rev-list', 'ls-files', 'ls-tree', 'cat-file',
+  'branch', 'tag', 'describe', 'blame', 'shortlog', 'config', 'remote', 'grep', 'check-ignore',
+  'range-diff', 'merge-base', 'name-rev', 'reflog', 'whatchanged', 'count-objects', 'var', 'help',
+])
+// Verbs that write to the repo, the index, or the working tree.
+const GIT_MUTATING = new Set([
+  'commit', 'add', 'rm', 'mv', 'restore', 'checkout', 'switch', 'reset', 'merge', 'rebase',
+  'cherry-pick', 'revert', 'stash', 'clean', 'push', 'apply', 'am', 'update-ref', 'update-index',
+  'gc', 'prune', 'filter-branch', 'replace', 'notes', 'submodule', 'sparse-checkout', 'clone', 'init',
+])
+
+function parseGitInvocations(cmd) {
+  const found = []
+  // Split on shell separators so `cd x && git commit` is seen.
+  for (const seg of cmd.split(/\|\||&&|[;|\n]/)) {
+    const m = seg.match(/(?:^|\s)git(?:\.exe)?\s+(.+)/i)
+    if (!m) continue
+    const toks = m[1].match(/"[^"]*"|'[^']*'|\S+/g) || []
+    const clean = toks.map((t) => t.replace(/^["']|["']$/g, ''))
+    let dashC = null
+    let verb = null
+    for (let i = 0; i < clean.length; i++) {
+      if (clean[i] === '-C' && clean[i + 1]) {
+        dashC = clean[i + 1]
+        i++
+        continue
+      }
+      if (clean[i].startsWith('-')) continue
+      verb = clean[i]
+      // `git worktree add` / `git branch -D` need the sub-verb too.
+      const sub = clean.slice(i + 1).find((t) => !t.startsWith('-')) || null
+      found.push({ verb, sub, dashC, argv: clean })
+      break
+    }
+  }
+  return found
+}
+
+function gitInvocationRisk(inv) {
+  const { verb, sub, argv } = inv
+  if (verb === 'worktree') {
+    // Creating and listing are how a session bootstraps itself -- always allow.
+    if (sub === 'add' || sub === 'list' || sub === 'lock' || sub === 'unlock') return 'allow'
+    return 'mutating' // remove / prune / move can destroy another session's tree
+  }
+  if (verb === 'branch') return argv.some((a) => /^-(D|d|m|M|f)$/.test(a)) ? 'mutating' : 'allow'
+  if (verb === 'tag') return argv.some((a) => /^-(d|f)$/.test(a)) ? 'mutating' : 'allow'
+  if (verb === 'fetch') return 'allow' // updates remote refs only
+  if (verb === 'stash' && (sub === 'list' || sub === 'show')) return 'allow'
+  if (GIT_MUTATING.has(verb)) return 'mutating'
+  if (GIT_READONLY.has(verb)) return 'allow'
+  return 'allow'
+}
+
+function hookDecision(input) {
+  const tool = input.tool_name || ''
+  const ti = input.tool_input || {}
+  const cwd = input.cwd || process.cwd()
+
+  if (GUARD_OFF) return null
+
+  // Never block the guard's own bootstrap commands.
+  const raw = typeof ti.command === 'string' ? ti.command : ''
+  if (/session-guard\.mjs/.test(raw)) return null
+
+  if (tool === 'Edit' || tool === 'Write' || tool === 'NotebookEdit' || tool === 'MultiEdit') {
+    const f = ti.file_path || ti.notebook_path || ti.path
+    if (!f) return null
+    const o = ownership(f, cwd)
+    // Only guard files that live inside this repo's worktrees.
+    if (o.kind === 'not-a-repo' || o.kind === 'mine') return null
+    if (o.kind === 'unmanaged' && !isRepoWorktree(o.root, cwd)) return null
+    return explain(o, f)
+  }
+
+  if (tool === 'Bash' || tool === 'PowerShell') {
+    if (!raw) return null
+    for (const inv of parseGitInvocations(raw)) {
+      if (gitInvocationRisk(inv) !== 'mutating') continue
+      const target = inv.dashC || cwd
+      const o = ownership(target, cwd)
+      if (o.kind === 'not-a-repo' || o.kind === 'mine') continue
+      if (o.kind === 'unmanaged' && !isRepoWorktree(o.root, cwd)) continue
+      return explain(o, target)
+    }
+  }
+  return null
+}
+
+/** True when root is a worktree of the same repo the session is operating on. */
+function isRepoWorktree(root, cwd) {
+  if (!root) return false
+  const a = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd: root })
+  const b = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd })
+  return !!a && !!b && samePath(a, b)
+}
+
+async function cmdHook() {
+  let buf = ''
+  for await (const chunk of process.stdin) buf += chunk
+  let input = {}
+  try {
+    input = JSON.parse(buf || '{}')
+  } catch {
+    process.exit(0) // never wedge the session on malformed input
+  }
+  let reason = null
+  try {
+    reason = hookDecision(input)
+  } catch {
+    process.exit(0) // fail open: a guard bug must not brick the session
+  }
+  if (!reason) process.exit(0)
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  )
+  process.exit(0)
+}
+
+// ------------------------------------------------------------------ plumbing
+
+function argValue(args, flag) {
+  const i = args.indexOf(flag)
+  return i >= 0 ? args[i + 1] : null
+}
+function print(s, stream = 'stdout') {
+  process[stream].write(s + '\n')
+}
+function fail(msg) {
+  print(`session-guard: ${msg}`, 'stderr')
+  process.exit(1)
+}
+
+const [, , cmd, ...rest] = process.argv
+switch (cmd) {
+  case 'claim': cmdClaim(rest); break
+  case 'adopt': cmdAdopt(rest); break
+  case 'verify': cmdVerify(rest); break
+  case 'list': cmdList(); break
+  case 'status': cmdStatus(); break
+  case 'reap': cmdReap(); break
+  case 'release': cmdRelease(rest); break
+  case 'hook': await cmdHook(); break
+  default:
+    print('usage: session-guard.mjs claim|verify|status|list|reap|release|hook')
+    process.exit(cmd ? 1 : 0)
+}


### PR DESCRIPTION
## Why

Several Claude Code sessions run against this repo at once, and nothing stopped them landing in the same place. All of this happened during one session:

- The primary checkout changed branch three times underneath us (`fix/145` → `docs/148` → `test/154`), driven by other sessions.
- A `ccc-security` worktree appeared mid-session, from another session.
- **PR #127's branch was carrying three unrelated commits** (`perf(main)`, two `fix(dev)`) — unpushed, on no other branch. Committing on that tip would have injected unreviewed code into a PR advertised as "docs + gitignore, no code changes".
- `ccc-iso` reads as disposable (0 commits ahead of `beta`) while holding **32 modified files**.

The shared cause: a session cannot tell whether the directory it is standing in belongs to it. Convention alone does not bind an agent whose context has been truncated — that is what we had, and what failed.

## What

**One session = one worktree = one branch**, branched from a shared base. Git already refuses to check out one branch in two worktrees, so the branch ref is a hard interlock we get for free; this adds the bookkeeping git has no opinion about.

```
beta  (shared base -- no agent ever checks it out)
  |-- session/beta/55158424  ->  ../ccc-wt/55158424      agent A
  |-- session/beta/a91f3c02  ->  ../ccc-wt/a91f3c02      agent B
  `-- session/beta/7d0e11bb  ->  ../ccc-wt/7d0e11bb      agent C
```

- **`scripts/session-guard.mjs`** — `claim` / `adopt` / `verify` / `status` / `list` / `reap` / `release` / `hook`. Leases are one JSON per session under `<git-common-dir>/ccc-sessions/`, shared by every linked worktree and never tracked. Identity is `CLAUDE_CODE_SESSION_ID`; liveness is `CLAUDE_PID`.
- **`.claude/settings.json`** — a `PreToolUse` hook denying `Edit`/`Write`/`NotebookEdit`/`MultiEdit` and mutating `Bash`/`PowerShell` git against a worktree of this repo the caller does not own. A `-C <path>` argument is honoured, so `git -C <someone-else's-worktree> commit` is caught even when cwd is fine.
- **`.gitignore`** — un-ignore `.claude/settings.json`, the same precedent as the existing `!.claude/skills/`. An untracked hook protects only the machine that wrote it. `settings.local.json` stays personal.
- **ADR-011**, `docs/session-isolation.md`, plus `AGENTS.md` and `docs/agent-conventions.md` sections.

Rejected: literal same-branch parallelism via `git worktree add --force` (N worktrees, one shared ref — concurrent commits clobber, i.e. the original problem); a clone per agent (~1 GB `node_modules` each).

## Design points worth review

- `adopt` **refuses the primary checkout** outright — no session may fence others out of the shared tree. It exists so worktrees made by hand, or by Claude Code's own `--worktree`/`EnterWorktree`, are not blocked forever as "unmanaged".
- `reap` **keeps** a dead session's lease while its worktree is dirty, rather than handing a directory with unsaved work to another session.
- The guard **fails open**: malformed input, missing script, or an internal error exits 0 and allows the call. It is a collision guard, not a security boundary. `CCC_SESSION_GUARD=off` disables it.
- Not blocked: your own worktree, read-only git anywhere, `git worktree add`/`list` (bootstrap), files outside the repo, and every tool other than the five matched.

## Verification

- **`process.kill(pid, 0)` confirmed non-destructive on Windows** before being relied on — probed a real spawned Windows pid, which reported alive, kept running (`HasExited=False`), and threw `ESRCH` once dead. A liveness check that kills other agents would be worse than no guard.
- Hook decisions pipe-tested across **12 ownership cases**: own worktree, primary checkout, another unmanaged worktree, outside the repo, `git -C` targeting each, read-only verbs, chained `&&` commands, `worktree add` vs `remove`, PowerShell `push`.
- Cross-session paths exercised with a real Windows pid: live rival → blocked as `ALIVE`; same lease after the process dies → reclassified stale; dirty-worktree reap → kept; `CCC_SESSION_GUARD=off` → allowed.
- Three simulated sessions claimed off `beta` concurrently — distinct branches and directories, no contention.
- `npm run typecheck` clean. Dogfooded: this PR was written from `session/beta/55158424`, a worktree claimed by the guard.

**Bug found and fixed during testing:** claiming from *inside* a worktree anchored the sibling root to the current worktree, nesting `ccc-wt/ccc-wt/`. Now anchored to the primary checkout via `--git-common-dir`.

## Note for the reviewer

The hook only takes effect for sessions that start with this settings file present — existing sessions need a restart (or `/hooks`) before it is live. Worth confirming the `${CLAUDE_PROJECT_DIR}` substitution in the `args` form resolves on your setup; if not, the fallback is a shell-form command. Everything else here was verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
