### PR TITLE
docs(security): document the executable embargo procedure (#167)

### DIFF
--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -133,11 +133,18 @@ So, when the pass surfaces an out-of-scope live vulnerability:
 
 1. **Do not put it in the PR verdict.** The verdict may say "the pass surfaced one unrelated
    pre-existing finding, routed privately" -- no component, no mechanism, no repro.
-2. Hand the detail to the maintainer **out of band** and let them open the advisory.
+2. **Open the private advisory yourself.** You do not need to be the repo owner: private
+   vulnerability reporting is enabled, so `POST .../security-advisories/reports` with
+   `start_private_fork: true` files the advisory and creates the private fork in one call.
+   Follow `docs/security-embargo-runbook.md`. Handing it to the maintainer out of band is the
+   *fallback*, not the default -- and note the maintainer endpoint
+   (`POST .../security-advisories`, no `/reports`) 403s without admin, which is NOT evidence
+   that you have no private channel (ADR-011).
 3. The `CONTEXT.d/` fragment for this work follows the same rule: it may record *that* a finding
    exists and was routed privately, and nothing else.
 4. Any fix is developed in the **private fork attached to the advisory**, never in a branch on this
-   repo -- however innocently the branch is named.
+   repo -- however innocently the branch is named. Base it on `beta` and target `beta`: the fork
+   inherits `main` as its default and `main` runs behind.
 5. The public record -- fragment, changelog, advisory publication -- is written together, after the
    fix ships.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,14 @@ RC-branch model (adopted with #89): `beta` is never frozen — features merge th
 or been handed an unfixed vulnerability, it does not go into a `CONTEXT.d/` fragment, an
 ADR, a commit message, a branch name, the changelog, an issue, or a PR — it goes into a
 private GitHub Security Advisory, and the fix is developed in the private fork attached to
-that advisory. See `SECURITY.md` ("Embargo") for the full workflow.
+that advisory. See `SECURITY.md` ("Embargo") for the rule and
+`docs/security-embargo-runbook.md` for the **executable procedure**.
+
+You can do this yourself — you do not need to be the repo owner. Private vulnerability
+reporting is enabled, so any account can file the advisory and get a private fork. The
+obvious API call is the wrong one: `POST .../security-advisories` needs admin and 403s;
+`POST .../security-advisories/reports` is the open one. Do not conclude from that 403 that
+you have no private channel (ADR-011).
 
 `CONTEXT.d/` is the trap. The running log *feels* like a scratch notebook and is in fact a
 tracked file; a fragment describing a live bug is a disclosure with a repro attached. A
@@ -95,6 +102,7 @@ changelog entry, advisory) is written **after** the fix ships, all at once.
 ## Deeper references
 
 - `.claude/skills/adversarial-review/SKILL.md` — the adversarial review pass required for security-sensitive changes (ADR-009), plus the path table that decides when it applies.
+- `docs/security-embargo-runbook.md` — the executable procedure for an unfixed vulnerability: who can do what, the `gh` recipes, the private-fork workflow, and the traps (ADR-011).
 - `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.
 - `docs/versioning.md` — versioning scheme, prerelease suffixes, update channels, rolling re-release vs. version bump.

--- a/CONTEXT.d/2026-07-31-167-security-embargo-runbook.md
+++ b/CONTEXT.d/2026-07-31-167-security-embargo-runbook.md
@@ -1,0 +1,52 @@
+## 2026-07-31 -- Document the embargo procedure; contributors can self-serve (#167)
+
+#159 wrote the embargo RULE correctly and never said who could execute it or how. Its
+workflow is in the passive voice -- "the advisory is created first" -- with no actor. The
+first real run of the process showed what that omission costs. Decision in ADR-011, which
+amends ADR-010 without reversing it; procedure in docs/security-embargo-runbook.md.
+
+What happened, recorded because the mistake is the whole reason the doc exists: working an
+embargoed finding as a `write` collaborator, the obvious endpoint was tried --
+`POST /repos/{owner}/{repo}/security-advisories` -- which 403s with "you must have ...
+administrative/security management rights". The conclusion drawn was that no private
+channel existed for a non-owner, that the policy merged hours earlier was unexecutable by
+anyone but the owner, and that the fix was to grant the security-manager role. All three
+were wrong:
+
+- Private vulnerability reporting is enabled here, so
+  `POST /repos/{owner}/{repo}/security-advisories/reports` is open to ANY account. It is
+  what the /security/advisories/new link in SECURITY.md always pointed at. The two
+  endpoints differ by one path segment and have opposite permission requirements.
+- `start_private_fork: true` on that same call creates the temporary private fork, so a
+  contributor gets somewhere to develop the fix with zero owner involvement.
+- Security manager is an ORGANISATION-level role. This repo is owned by a user account, so
+  it cannot be granted here at all -- the proposed remedy was impossible, and sent the
+  owner to change a setting that does not exist.
+
+Verified capability boundary for a `write` collaborator: file the advisory, get the private
+fork, push to it, open a PR inside it. Only accepting the report out of `triage`, merging,
+and publishing need the owner.
+
+The failure mode is the point, not the individual error. It is the same one #159 exists to
+prevent -- someone holds a live finding, believes there is no private channel available to
+them, and the nearest writable surface is a tracked file. A workflow that is possible but
+not DOCUMENTED as possible fails exactly like one that is impossible.
+
+Changes:
+- NEW docs/security-embargo-runbook.md -- permission matrix (verified against this repo,
+  not quoted from general docs), gh recipes for both paths, private-fork workflow, what
+  must not be written down, publishing order, and a gotcha table.
+- SECURITY.md Embargo section: states plainly that you do not need to be the owner, names
+  both endpoints and why the 403 misleads, links the runbook.
+- AGENTS.md: same correction where agents will hit it.
+- adversarial-review SKILL.md Phase 3.5: previously said "hand the detail to the maintainer
+  and let them open the advisory". Now says open it yourself, with the fallback noted. Also
+  adds the base-branch rule (fix goes on `beta`; the fork inherits `main` as default and
+  main runs behind).
+
+Gotchas captured in the runbook, each of which cost time and none discoverable from the API
+responses: the two endpoints; security manager being org-only; the private fork reporting
+`permissions.push: false` while accepting pushes; the fork defaulting to `main`; PVR
+submissions landing in `triage`; `dismissed_comment` capping at 280 chars; and Dependabot
++ CodeQL tracking the DEFAULT branch, so alerts do not clear on a merge to `beta` -- only
+after promotion, and CodeQL also needs its next scheduled scan.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,6 +86,22 @@ The workflow:
    fragment, the changelog entry, and the advisory publication, together.
 4. A public issue may be opened at that point to track follow-up hardening.
 
+**You do not need to be the repository owner to start this.** Private vulnerability
+reporting is enabled here, so any GitHub account — external reporter, or a contributor who
+tripped over something mid-task — can file the advisory *and* get the private fork to fix
+it in. A contributor with plain `write` access can carry a finding all the way to a
+reviewable PR; only accepting the report, merging, and publishing need the owner.
+
+This is worth stating explicitly because the obvious API call is the wrong one:
+`POST /repos/{owner}/{repo}/security-advisories` is the *maintainer* endpoint and returns
+403 without admin, which reads like "no private channel is available to you". It isn't.
+The endpoint behind the link above is
+`POST /repos/{owner}/{repo}/security-advisories/reports`, and it is open to anyone.
+
+**[`docs/security-embargo-runbook.md`](docs/security-embargo-runbook.md) is the
+step-by-step procedure** — permissions, the `gh` recipes, working in the private fork, and
+the traps. If you are about to write a finding down anywhere, read that first.
+
 A fragment written during an embargo may record *that* a finding exists and was routed
 privately. It must not name the component, the mechanism, or the repro.
 

--- a/architecture/decisions/2026-07-31-adr-011-contributors-self-serve-embargo.md
+++ b/architecture/decisions/2026-07-31-adr-011-contributors-self-serve-embargo.md
@@ -1,0 +1,107 @@
+# ADR-011: Contributors open their own private advisories; the embargo procedure is documented, not inferred
+
+- **Status:** Accepted (2026-07-31)
+- **Amends:** ADR-010 (security posture and embargo) — corrects a factual premise, does not reverse the decision
+- **Deciders:** @nubbymong (owner)
+- **Related:** #167, docs/security-embargo-runbook.md, SECURITY.md, ADR-009, CONTEXT.d/2026-07-31-167-security-embargo-runbook.md
+
+## Context
+
+ADR-010 established the embargo rule: a finding stays out of every tracked artefact until
+its fix ships, and development happens in the private fork GitHub attaches to the
+advisory. That rule is correct and stands.
+
+What ADR-010 never said is **who can start it**. Its workflow reads "the advisory is
+created first" in the passive voice, with no actor. `SECURITY.md` inherited the same gap.
+
+The first real exercise of the process exposed what that omission costs. Working an
+embargoed finding as a `write` collaborator, the obvious API call was tried:
+
+```
+POST /repos/{owner}/{repo}/security-advisories
+403  You must have the repository security advisories scope and
+     administrative/security management rights to create an advisory.
+```
+
+The conclusion drawn — and written up, and acted on — was that no private channel exists
+for a non-owner, that the workflow merged hours earlier was unexecutable by anyone but
+@nubbymong, and that the remedy was to grant a collaborator the security-manager role.
+
+**Every part of that was wrong.**
+
+1. Private vulnerability reporting is enabled on this repository. A *different* endpoint,
+   `POST /repos/{owner}/{repo}/security-advisories/reports`, is open to **any GitHub
+   account**, collaborator or not. It is what the `/security/advisories/new` link in
+   `SECURITY.md` has always pointed at.
+2. `start_private_fork: true` on that call creates the temporary private fork in the same
+   request, so a contributor gets a place to develop the fix without any owner action.
+3. Security manager is an **organization-level** role. This repository is owned by a user
+   account, so it cannot be granted here at all. The proposed remedy was impossible.
+
+The correct capability boundary, verified empirically rather than inferred: a `write`
+collaborator can file the advisory, obtain the private fork, push to it (despite the fork
+reporting `permissions.push: false` — that field is not authoritative for advisory forks),
+and open a PR inside it. Only accepting the report out of `triage`, merging, and
+publishing require the owner.
+
+The failure mode matters more than the specific mistake. It is the same one ADR-010 was
+written to prevent: someone holds a live finding, believes no private channel is available
+to them, and the nearest writable surface is a tracked file. A workflow that is possible
+but not *documented as possible* fails exactly like one that is impossible.
+
+## Decision
+
+**1. Contributors open their own private advisories.** Routing a finding through the owner
+out of band is the fallback, not the default. Anyone who finds something can file it and
+get a private fork immediately, which shortens the window in which an unfixed
+vulnerability exists only in someone's head or on their disk.
+
+**2. The procedure is written down and executable, not inferred from the policy.** A new
+`docs/security-embargo-runbook.md` carries the verified permission matrix, working `gh`
+recipes, the private-fork workflow, and — deliberately — the traps. `SECURITY.md` remains
+the normative rule and links to it.
+
+**3. The traps are documented as first-class content, not footnotes.** Each cost real time
+on the first run, and none is discoverable from the API responses:
+
+- the two near-identically-named endpoints with opposite permission requirements, and the
+  403 whose wording invites the wrong conclusion
+- security manager being org-only, and therefore a dead end here
+- the private fork reporting `permissions.push: false` while accepting pushes
+- the fork defaulting to `main` when this project lands fixes on `beta`
+- PVR submissions landing in `triage` rather than as maintainer drafts
+- `dismissed_comment` on code-scanning alerts capping at 280 characters
+- Dependabot and CodeQL tracking the **default branch**, so alerts do not clear on a merge
+  to `beta` — only after promotion, and CodeQL also needs its next scheduled scan
+
+**4. The rule is repeated in three places, each pointing at the runbook rather than
+restating it:** `SECURITY.md` (reporters), `AGENTS.md` (anyone working the repo), and the
+adversarial-review skill's Phase 3.5 (the process most likely to generate an embargoed
+finding). Phase 3.5 previously said "hand the detail to the maintainer and let them open
+the advisory" — now corrected to say the agent can and should open it itself.
+
+## Consequences
+
+**Positive.** The embargo path is executable by the people most likely to need it. The
+window between discovery and containment shrinks, because containment no longer waits on
+owner availability. The traps are recorded once instead of being rediscovered.
+
+**Negative.** More documentation surface to keep true — `SECURITY.md`, the runbook,
+`AGENTS.md`, and the skill all describe one process. Mitigated by making the runbook the
+single procedural source and the other three pointers to it. The runbook also encodes
+GitHub API behaviour that GitHub may change; the permission matrix should be re-verified
+if a step ever behaves unexpectedly, rather than trusted indefinitely.
+
+**Rejected alternative — grant collaborators elevated repository roles.** The original
+proposal, and impossible as stated: security manager is org-only, and a personal
+repository cannot give a collaborator admin. Even where possible it would be the wrong
+trade, handing out broad repository administration to solve a documentation problem.
+
+**Rejected alternative — move the repository to an organization.** This would make
+security manager grantable and is worth considering on its own merits, but it is a large
+change to fix a gap that documentation closes completely. PVR already provides the needed
+capability.
+
+**Rejected alternative — leave it to the owner and say so.** Honest, and strictly worse.
+It would institutionalise a delay between finding and containment for no benefit, when the
+platform already supports contributor self-service.

--- a/docs/security-embargo-runbook.md
+++ b/docs/security-embargo-runbook.md
@@ -1,0 +1,202 @@
+# Security embargo runbook
+
+How to take a vulnerability from "I just found this" to "the fix has shipped", without
+disclosing it on the way.
+
+`SECURITY.md` is the policy — *what* the rule is. This is the procedure — *how* to execute
+it, and who can. Read the Embargo section of `SECURITY.md` first; it is the normative
+text and this document only tells you how to comply with it.
+
+> **The one-line version.** You do not need to be the repository owner to open a private
+> channel. Private vulnerability reporting is enabled, so any contributor can file a
+> private advisory and get a private fork to fix it in.
+
+## Who can do what
+
+Verified against this repository, not quoted from general documentation.
+
+| Action | Needs | A `write` collaborator? |
+| --- | --- | --- |
+| File a private report (PVR) | Any GitHub account | **Yes** |
+| Get a temporary private fork | Filing the report with `start_private_fork` | **Yes** |
+| Push to that private fork | Being on the advisory | **Yes** |
+| Open a PR inside the private fork | Same | **Yes** |
+| Create a *maintainer* draft advisory | Owner / org owner / admin / security manager | No |
+| Accept a report out of `triage` | Owner or admin | No |
+| Merge the fix and publish | Owner or admin | No |
+
+So a contributor can do everything up to the point of merging. That is the whole job — the
+finding is contained, the fix exists and is reviewable, and the owner's remaining work is
+a review and two clicks.
+
+### The trap that makes people think otherwise
+
+There are two endpoints with nearly the same name and completely different permissions:
+
+```
+POST /repos/{owner}/{repo}/security-advisories          <- MAINTAINER. Needs admin.
+POST /repos/{owner}/{repo}/security-advisories/reports  <- PVR. Anyone.
+```
+
+Hitting the first one as a collaborator returns:
+
+```
+403  You must have the repository security advisories scope and
+     administrative/security management rights to create an advisory.
+```
+
+That message is easy to read as "you cannot open a private channel". It means "you cannot
+use *this* endpoint". The `/security/advisories/new` link in `SECURITY.md` points at the
+second one.
+
+Related dead end: **"security manager" is an organization-only role.** This repository is
+owned by a user account, so it cannot be granted here. Do not spend time on it.
+
+## Path A — you found a vulnerability (any contributor)
+
+### Web
+
+Go to **Security → Advisories → Report a vulnerability**, or straight to
+`/security/advisories/new`. Fill in the summary, description, severity, and affected
+versions. Tick **"Start a temporary private fork"**.
+
+### CLI
+
+Equivalent, and easier to get right for a long description. Write the description to a
+file first so Markdown survives intact:
+
+```sh
+# 1. description in its own file (NOT inside the repo -- see Embargo below)
+#    ~/sec/desc.md
+
+# 2. build the payload
+node -e "
+const fs=require('fs');
+fs.writeFileSync('payload.json', JSON.stringify({
+  summary: 'One line, <=1024 chars',
+  description: fs.readFileSync('desc.md','utf8'),
+  cvss_vector_string: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N',
+  cwe_ids: ['CWE-22'],
+  vulnerabilities: [{
+    package: { ecosystem: 'other', name: 'claude-command-center' },
+    vulnerable_version_range: '<= 2.1.0-beta.2',
+    vulnerable_functions: ['theFunction']
+  }],
+  start_private_fork: true
+}));
+"
+
+# 3. file it
+gh api -X POST \
+  repos/nubbymong/claude-command-center/security-advisories/reports \
+  --input payload.json
+```
+
+`ecosystem: 'other'` is correct — this app is not published to a package registry.
+
+The response carries `ghsa_id`, `state: "triage"`, and `private_fork.full_name`. Keep the
+GHSA id; you need it next. **The report lands in `triage`** — it is a submission awaiting
+the owner, not a maintainer-authored draft. That is expected.
+
+If `start_private_fork` was omitted, create the fork from the advisory page
+("Start a temporary private fork").
+
+## Path B — you are the owner or an admin
+
+Use the maintainer endpoint or the **New draft advisory** button. Everything below is the
+same from here.
+
+## Developing the fix
+
+The temporary private fork is a real repository named
+`<repo>-ghsa-xxxx-xxxx-xxxx`. Work there, never on a branch of the public repo.
+
+```sh
+FORK=https://github.com/nubbymong/claude-command-center-ghsa-xxxx-xxxx-xxxx.git
+git push "$FORK" my-local-fix-branch:fix/short-description
+```
+
+Two things will look wrong and are not:
+
+- **The fork reports `permissions.push: false`.** Push anyway — it works. Advisory
+  collaborator rights override the repository permission field, which is not authoritative
+  for these forks.
+- **The fork's default branch is `main`.** This repository lands fixes on `beta` and
+  promotes to `main` (see `AGENTS.md`, Release Process), and `main` can be many releases
+  behind. **Open the PR against `beta`, not the default.** The fork mirrors every branch,
+  so `beta` is there and is normally identical to the public head:
+
+```sh
+gh pr create --repo nubbymong/claude-command-center-ghsa-xxxx-xxxx-xxxx \
+  --base beta --head fix/short-description \
+  -t "fix(scope): what it does" -F prbody.md
+```
+
+Base your fix commit on `beta` for the same reason.
+
+### Regression tests
+
+Ship them with the fix — this is the one thing that necessarily describes the bug, and it
+is fine because it lands at the same moment the fix does.
+
+**Verify the test fails against the unfixed code.** Revert the fix, run the test, watch it
+fail, restore. A green test proves nothing on its own; this project has already produced
+regression tests that passed against the very code they were written to catch. See the
+adversarial-review skill for why this is a standing rule.
+
+## What must not be written down, and where people slip
+
+Full rule in `SECURITY.md`. The operational summary:
+
+**Anything that gets pushed is publication.** During an embargo, nothing about the finding
+goes in issues, PRs on the public repo, commit messages, branch names, `CONTEXT.d/`
+fragments, ADRs, or the changelog.
+
+`CONTEXT.d/` is the one that catches people, because the running log feels like a private
+notebook and is a tracked file. A fragment for embargoed work may record *that* a finding
+exists and was routed privately — never the component, the mechanism, or the repro.
+
+Two practical habits:
+
+- Keep advisory drafts, patches, and scratch notes **outside the repository**. A
+  `~/sec/` directory, not a gitignored path inside the checkout.
+- Do not cite the GHSA id in any tracked file before publication. It is not resolvable to
+  outsiders, but it signals that an unpublished advisory exists and becomes a live link
+  the moment you publish.
+
+## Publishing, and the public record
+
+In order:
+
+1. Owner accepts the report out of `triage`.
+2. Owner reviews and merges the PR **inside the private fork**.
+3. Owner publishes the advisory. Request a CVE at this point if it warrants one.
+4. **Only now** write the public record, all together:
+   - the `CONTEXT.d/` fragment for the work
+   - the changelog entry in `src/renderer/changelog.ts`, then `npm run changelog`
+   - a public issue for any follow-up hardening
+
+Step 4 last is the whole point. Writing any of it earlier is the disclosure the embargo
+exists to prevent.
+
+## Gotchas
+
+Each of these cost real time on the first run of this process.
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `403` creating an advisory | Wrong endpoint. Use `.../security-advisories/reports` |
+| "Ask for the security manager role" | Org-only. Not grantable on a user-owned repo |
+| Fork shows `permissions.push: false` | Not authoritative. `git push` works |
+| PR wants to target `main` | Retarget to `beta`; `main` is behind |
+| Report sits in `triage` | Normal for PVR. The owner accepts it |
+| `422` dismissing a code-scanning alert | `dismissed_comment` is capped at **280 characters** |
+| A scanner alert stays open after merging to `beta` | Dependabot and CodeQL track the **default branch** (`main`). Alerts clear after promotion, and CodeQL also needs its next scheduled scan |
+
+## See also
+
+- `SECURITY.md` — the policy, including the normative embargo rule
+- `architecture/decisions/2026-07-30-adr-010-security-posture-and-embargo.md`
+- `architecture/decisions/2026-07-31-adr-011-contributors-self-serve-embargo.md`
+- `.claude/skills/adversarial-review/SKILL.md` — Phase 3.5 routes findings into this
+  process


### PR DESCRIPTION
Closes #167.

### The gap

#159 wrote the embargo **rule** correctly and never said who could execute it. Its
workflow is passive-voice — "the advisory is created first" — with no actor.

The first real run showed what that costs. Working an embargoed finding as a `write`
collaborator, the obvious endpoint was tried:

```
POST /repos/{owner}/{repo}/security-advisories
403  You must have the repository security advisories scope and
     administrative/security management rights to create an advisory.
```

The conclusion drawn — and written up, and acted on — was that no private channel exists
for a non-owner, that the policy merged hours earlier was unexecutable by anyone but the
owner, and that the remedy was granting the security-manager role.

**All three were wrong**, and the owner was sent to change a setting that does not exist:

- Private vulnerability reporting is enabled here, so `POST .../security-advisories/reports`
  is open to **any** account. It is what the `/security/advisories/new` link in
  `SECURITY.md` always pointed at. One path segment apart, opposite permissions.
- `start_private_fork: true` on that same call creates the private fork — no owner action
  needed to get somewhere to work.
- Security manager is an **organization** role. This repo is owned by a user account, so it
  is not grantable here at all.

Verified boundary for a `write` collaborator: file the advisory, get the fork, push to it,
open a PR inside it. Only accepting out of `triage`, merging, and publishing need the owner.

The failure mode is the point, not the individual error. It is precisely the one #159
exists to prevent: someone holds a live finding, believes no private channel is available,
and the nearest writable surface is a tracked file. **Possible-but-undocumented fails
exactly like impossible.**

### Changes

- **NEW `docs/security-embargo-runbook.md`** — permission matrix verified against this
  repo rather than quoted from general docs, `gh` recipes for both paths, the private-fork
  workflow, what must not be written down, publishing order, and a gotcha table.
- **`SECURITY.md`** — names both endpoints, explains why the 403 misleads, states plainly
  that you need not be the owner, links the runbook.
- **`AGENTS.md`** — same correction where agents hit it, plus a Deeper-references pointer.
- **`.claude/skills/adversarial-review/SKILL.md`** — Phase 3.5 said "hand the detail to the
  maintainer and let them open the advisory". Now: open it yourself, fallback noted, plus
  the base-on-`beta` rule.
- **ADR-011** amends ADR-010 without reversing it.

### Gotchas now recorded

Each cost real time; none is discoverable from the API responses.

| Trap | Reality |
| --- | --- |
| `POST .../security-advisories` 403s | Maintainer endpoint. PVR is `.../reports` |
| "Grant security manager" | Org-only. Meaningless on a user-owned repo |
| Fork reports `permissions.push: false` | Push works anyway; the field isn't authoritative |
| Fork defaults to `main` | Fixes land on `beta`; retarget or fight the release model |
| PVR report sits in `triage` | Owner accepts it; not a maintainer draft |
| `422` dismissing a CodeQL alert | `dismissed_comment` caps at 280 chars |
| Alerts stay open after merging to `beta` | Both scanners track the **default branch** |

Docs only — no runtime code. Verified no embargoed detail appears in the diff.
