### PR TITLE
docs(changelog): add the security entries for 2.1.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0-beta.3] - 2026-07-30
 
-> Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — and Check for Updates can install the update it finds.
+> Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — Check for Updates can install the update it finds, and a round of security hardening lands across the local tools server and the bundled dependencies.
+
+### Changed
+- Updated bundled dependencies to close 12 published security advisories, plus two more found while checking. No feature changes.
 
 ### Fixed
 - Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.
 - Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.
 - Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.
+- Hardened the authentication check on the local Conductor server that Claude and Codex sessions use to reach the built-in CCC tools. Its token check accepted some malformed credentials it should have rejected, and a crafted request could make the check do far more work than it needed to. Both are fixed. The server still listens only on your own machine, and no session behaviour changes.
+- Session, config, team and agent-template identifiers are now generated with a cryptographic random number generator instead of a predictable one. Existing items keep the identifiers they already have and nothing needs migrating.
 
 ## [2.1.0-beta.2] - 2026-07-29
 

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -23,11 +23,14 @@ export const changelog: ChangelogEntry[] = [
   {
     version: '2.1.0-beta.3',
     date: '2026-07-30',
-    highlights: 'Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — and Check for Updates can install the update it finds.',
+    highlights: 'Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — Check for Updates can install the update it finds, and a round of security hardening lands across the local tools server and the bundled dependencies.',
     changes: [
       { type: 'fix', description: 'Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.' },
       { type: 'fix', description: 'Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.' },
       { type: 'fix', description: 'Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.' },
+      { type: 'fix', description: 'Hardened the authentication check on the local Conductor server that Claude and Codex sessions use to reach the built-in CCC tools. Its token check accepted some malformed credentials it should have rejected, and a crafted request could make the check do far more work than it needed to. Both are fixed. The server still listens only on your own machine, and no session behaviour changes.' },
+      { type: 'fix', description: 'Session, config, team and agent-template identifiers are now generated with a cryptographic random number generator instead of a predictable one. Existing items keep the identifiers they already have and nothing needs migrating.' },
+      { type: 'improvement', description: 'Updated bundled dependencies to close 12 published security advisories, plus two more found while checking. No feature changes.' },
     ],
   },
   {


### PR DESCRIPTION
Adds user-facing changelog entries for the security work merged into `beta` for 2.1.0-beta.3 — #151 (MCP auth hardening), #152 (dependency advisories), and the CSPRNG identifier change.

Governance work (#150, #159, #167) is deliberately **not** in the changelog: it is contributor-facing process, not a user-visible change, and the changelog drives the in-app What's New modal.

Descriptions contain no apostrophes on purpose. `scripts/gen-changelog.js` extracts the array by bracket-matching and tracks string quotes by hand, so an escaped apostrophe is a real hazard — the file already carries a NOTE about the same class of parse failure.

`npm run changelog` regenerated `CHANGELOG.md`; typecheck clean.