### PR TITLE
fix(updater): verify installer SHA-256 before launching it (#111)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
   # ── Build Linux AppImage (experimental) ──
   # Unsigned: Linux has no SmartScreen/Gatekeeper equivalent, and AppImage
   # carries no signing convention. CHECKSUMS.txt lets users verify the download
-  # by hand — the in-app updater does NOT yet verify it (tracked as follow-up).
+  # by hand — the in-app updater verifies every download against it (#111).
   # Built on ubuntu-latest (glibc 2.39), so the AppImage runs on distros at that
   # glibc or newer: Ubuntu 24.04+, Rocky 10+, Fedora 40+. Older lines (Rocky
   # 8/9, Ubuntu 22.04) need a container build against an older glibc — out of

--- a/CONTEXT.d/2026-07-31-111-installer-integrity.md
+++ b/CONTEXT.d/2026-07-31-111-installer-integrity.md
@@ -1,0 +1,52 @@
+## 2026-07-31 -- Verify installer SHA-256 before launching it (#111)
+
+The updater downloaded an installer and handed it to the OS to execute with NO
+client-side integrity check on any platform. CHECKSUMS.txt was already generated and
+attached to every release by the release workflow (`sha256sum *`) -- the client simply
+never read it.
+
+Why each OS backstop does not cover this:
+- Windows .exe is not code-signed in this repo, and SmartScreen gates on Mark-of-the-Web,
+  which a Node `https` download never sets.
+- macOS .dmg is notarized but `dmg.sign: false`, and a programmatic download carries no
+  quarantine xattr, so Gatekeeper is only partial.
+- Linux .AppImage has no signing convention and no OS check at all.
+
+Implementation:
+- Verification lives INSIDE `downloadGitHubRelease`, not at the call site. That function is
+  the only way an installer enters the app, so putting the check there means a returned
+  path is a verified path and no future caller can forget.
+- `digestForAsset(manifest, assetName)` is exported and pure so the parse half -- the half
+  an attacker shapes input for -- is directly testable.
+- `fetchChecksumManifest` mirrors the existing download cascade: derive the CHECKSUMS.txt
+  URL from the installer's own asset URL (same release, same host), then fall back to
+  `gh release download --pattern CHECKSUMS.txt`.
+- Hashing is streamed. Installers are 100-200 MB and the main process must not buffer them.
+
+FAILS CLOSED, deliberately and without exception. Manifest unfetchable, asset missing from
+it, file unreadable, digest mismatch -- every path deletes the download and returns null.
+There is no "could not verify, proceed anyway" branch: an attacker who can tamper with the
+installer can usually also make the manifest fetch fail, so a soft check would be no check.
+
+Parser refuses ambiguity as well as malformity. A manifest listing the same asset twice
+with DIFFERENT digests returns null rather than picking first- or last-match, since
+injecting a second line is the cheapest attack on a lenient parser. An exact duplicate line
+is accepted. Filename matching is exact after stripping any path prefix, so
+`evil-<asset>` and `<asset>.bak` do not match.
+
+THREAT MODEL, recorded so nobody over-trusts this. Same-origin checksums defend against
+corruption, truncation, a tampered CDN edge, and partial compromise. They do NOT defend
+against an attacker holding GitHub release-write credentials -- that attacker rewrites
+CHECKSUMS.txt to match their payload. Closing that requires SIGNING the manifest
+(ed25519/minisign in CI, public key pinned in the app, signature checked before the digests
+are trusted). This change is a floor, not a ceiling; the signing follow-up is worth its own
+ticket.
+
+Not implemented from the issue's suggestion list: comparing byte count against the asset
+`size` from the releases API. The SHA-256 subsumes it -- any length change alters the
+digest -- and plumbing `size` through `ReleaseInfo` would have widened the diff for no
+security gain.
+
+Tests: tests/unit/main/github-update-integrity.test.ts, 21 cases, weighted toward the
+fail-closed paths (asset absent, malformed digest, HTML error page served instead of the
+manifest, duplicate-with-different-digest, prefix/suffix filename near-misses).

--- a/CONTEXT.d/2026-07-31-111-installer-integrity.md
+++ b/CONTEXT.d/2026-07-31-111-installer-integrity.md
@@ -82,3 +82,50 @@ ADVERSARIAL ROUND 1 (blast-radius lens) found a BLOCKER I caused and several rea
   resumed downloads, and a partial compromise replacing only the installer asset.
 
 Full suite 3225 passed after the fixes; typecheck clean; release.js syntax-checked.
+
+ADVERSARIAL ROUND 2 (fresh attacker, bypass + patch-regression lens) -- 3 MAJOR:
+
+- MAJOR, and the worst thing in this ticket: my parser regex
+  /^([0-9a-f]{64})\s+\*?(.+)$/i REINTRODUCED THE EXACT ReDoS CLASS #151 FIXED, four
+  commits later, in a different file. Same \s+ followed by .+ followed by an outer
+  trim(). Measured: 1666 ms at 64k spaces, 27 s at 256k; with the 1 MiB manifest cap the
+  ceiling was ~7 MINUTES of a fully blocked Electron main process, since the parse is
+  synchronous and in main. Worse than #151, which was capped by llhttp and
+  http.maxHeaderSize -- this had no limiter and needs only CHECKSUMS.txt bytes, strictly
+  less access than the release-write compromise the threat model already concedes.
+  Replaced with an index-based splitChecksumLine (search /\s/ once, require index 64,
+  walk the separator run) plus SP/HTAB-only separators, the same narrowing #151 applied.
+  Guard: tests/unit/main/github-update-redos.test.ts. Verified by reverting to the regex --
+  the run does not fail an assertion, it HANGS (10 min, killed). Inherent: a synchronous
+  quadratic regex blocks the event loop so vitest cannot preempt it. Documented in the
+  test header so a future CI stall in that file is read correctly.
+- MAJOR: the round-1 "fix" for invisible failure was INERT. Rethrowing the typed error
+  achieved nothing because every renderer path discards it (console.error or a bare state
+  reset) and there is no toast component -- the user saw the overlay vanish and nothing
+  else, exactly what round 1 claimed to fix. Worse, the BottomBar line I edited is dead
+  code: App.tsx always supplies onUpdateRequested, so that else branch never runs. Now
+  dialog.showErrorBox in the main process, the one channel nothing downstream can swallow.
+- MAJOR: TOCTOU with real teeth. The file is hashed, then killAllPty() runs (tens of ms to
+  seconds with sessions open), then spawn. Path is predictable from the public release feed,
+  ~/Downloads is a directory every browser writes into, and nsis is oneClick:false +
+  allowElevation:true -- so a NON-elevated local process that wins the race gains admin on
+  a UAC prompt the user is already expecting. downloadGitHubRelease now returns
+  { path, sha256 } and the handler re-hashes via stillMatchesDigest() immediately before
+  the point of no return. ~1 s for 150 MB, window down to microseconds. Moving the download
+  out of ~/Downloads entirely is the better fix and is a follow-up.
+
+MINORs also fixed: manifest URL now derived with the URL API and origin-pinned (the string
+replace produced host `checksums.txt` for a path-less URL, and for a URL with a fragment it
+rewrote inside the fragment so https.get FETCHED THE INSTALLER as the manifest -- violating
+the "no installer bytes when unverifiable" guarantee); truncate-before-unlink so a rejected
+installer is inert even if unlink and rename both fail; release.js now requires the exact
+name CHECKSUMS.txt (the old substring predicate greenlit checksums.txt and
+CHECKSUMS.txt.sig, both of which the client refuses); corrected a now-false comment in
+release.yml claiming the updater does not verify.
+
+Still open, deliberately deferred to follow-ups: signing the manifest (the real ceiling),
+the post-upload asset-vs-manifest gate in the release workflow, moving downloads out of
+~/Downloads, and a size cap on httpsDownload so the 1 MiB manifest limit is enforced before
+bytes reach disk rather than after.
+
+Full suite 3233 passed. Typecheck clean.

--- a/CONTEXT.d/2026-07-31-111-installer-integrity.md
+++ b/CONTEXT.d/2026-07-31-111-installer-integrity.md
@@ -50,3 +50,35 @@ security gain.
 Tests: tests/unit/main/github-update-integrity.test.ts, 21 cases, weighted toward the
 fail-closed paths (asset absent, malformed digest, HTML error page served instead of the
 manifest, duplicate-with-different-digest, prefix/suffix filename near-misses).
+
+ADVERSARIAL ROUND 1 (blast-radius lens) found a BLOCKER I caused and several real gaps:
+
+- BLOCKER: the change broke 5 PRE-EXISTING tests in tests/unit/github-update.test.ts. I had
+  claimed "typecheck clean" having run only my new test file. Exactly the failure this
+  repo already learned once on #151 -- a claim about the suite made without running the
+  suite. Fixed by splitting transport from policy: downloadInstallerFile() is the
+  unverified transport half (redirects, gh fallback, stale-path handling -- what those 5
+  tests always actually tested), and downloadGitHubRelease() wraps it with verification.
+  Better design than the mock-fabrication alternative, and the old tests keep their intent.
+- MAJOR: an integrity failure surfaced to the user as "Installer not found. Check your
+  internet connection" -- wrong cause, and on a genuine tamper event, no signal at all.
+  Now throws a typed InstallerIntegrityError carrying the asset and release, rethrown by
+  update-handlers. BottomBar had no .catch at all on installAndRestart (unhandled
+  rejection); added, wrapped in Promise.resolve because the test mock returns undefined.
+- MAJOR (release-side): a rolling re-release onto an existing tag can regenerate
+  CHECKSUMS.txt without a platform whose build flaked (build-linux is continue-on-error)
+  while the OLD asset stays attached -- offering an update that can never verify. Partially
+  addressed: scripts/release.js promoted from warn to FAIL when CHECKSUMS.txt is missing,
+  since the client now hard-requires it. The post-upload asset-vs-manifest gate in the
+  workflow is a follow-up.
+- Manifest is now fetched BEFORE the installer. Discovering "no usable manifest" after
+  pulling 150-200 MB wastes bandwidth and delays the failure by minutes.
+- Manifest read capped at 1 MiB (synchronous read in the main process).
+- On verification failure, if unlink fails (Windows lock) the file is renamed .INVALID --
+  leaving an unverified installer in ~/Downloads under its expected name is how a user
+  ends up double-clicking it.
+- Threat-model claim corrected: the manifest comes from the SAME host and release, so this
+  does NOT cover a tampered CDN edge. It covers corruption, truncation, interrupted or
+  resumed downloads, and a partial compromise replacing only the installer asset.
+
+Full suite 3225 passed after the fixes; typecheck clean; release.js syntax-checked.

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -605,7 +605,10 @@ if (exitCode !== 0) {
     const hasExe = names.some((n) => n.endsWith('.exe'))
     const hasDmg = names.some((n) => n.endsWith('.dmg'))
     const hasAppImage = names.some((n) => n.endsWith('.AppImage'))
-    const hasChecksums = names.some((n) => n.toLowerCase().includes('checksum'))
+    // Exact name: the client hard-codes literal 'CHECKSUMS.txt' in both the
+    // derived URL and `gh release download --pattern`, so a checksums.txt or a
+    // CHECKSUMS.txt.sig would pass this gate and still fail every update.
+    const hasChecksums = names.includes('CHECKSUMS.txt')
 
     console.log(`      Release URL: ${release.url}`)
     console.log(`      Assets: ${names.join(', ')}`)

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -616,7 +616,7 @@ if (exitCode !== 0) {
     if (hasAppImage) ok('Linux AppImage attached')
     else { warn('Linux AppImage NOT found'); exitCode = 1 }
     if (hasChecksums) ok('CHECKSUMS.txt attached')
-    else warn('CHECKSUMS.txt not found (workflow normally generates this)')
+    else fail('CHECKSUMS.txt not attached -- the in-app updater REFUSES to install\n        a release it cannot verify (#111), so publishing without it ships a\n        release nobody can auto-update to.')
   } catch (err) {
     warn(`Could not verify release: ${err.message}`)
     exitCode = 1

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -19,6 +19,7 @@ import * as https from 'https'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
+import * as crypto from 'crypto'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { logInfo, logError } from './debug-logger'
@@ -606,9 +607,152 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
   })
 }
 
+// ── Installer integrity (#111) ───────────────────────────────────────────
+//
+// The updater downloads an installer and hands it to the OS to execute. That
+// is a code-execution path on the user's machine, and until this landed there
+// was NO client-side integrity check on any platform: Windows .exe is not
+// code-signed here and SmartScreen only gates on Mark-of-the-Web (which a Node
+// https download never sets); macOS .dmg has `dmg.sign: false` and a
+// programmatic download carries no quarantine xattr; .AppImage has no OS check
+// at all. `CHECKSUMS.txt` was already generated and attached to every release
+// by the release workflow -- the client simply never read it.
+//
+// THREAT MODEL, stated plainly so nobody over-trusts this. Same-origin
+// checksums defend against corruption, truncation, a tampered CDN edge, and a
+// partial compromise. They do NOT defend against an attacker holding GitHub
+// release-write credentials -- such an attacker rewrites CHECKSUMS.txt to match
+// their payload. Closing that requires SIGNING the manifest (ed25519/minisign
+// in CI, public key pinned in the app). This is a floor, not a ceiling.
+
+/** One `<sha256>  <filename>` line as emitted by `sha256sum *`. */
+const CHECKSUM_LINE = /^([0-9a-f]{64})\s+\*?(.+)$/i
+
 /**
- * Download the installer from the latest GitHub release.
+ * Find the digest for `assetName` in a `sha256sum`-format manifest.
+ *
+ * Exported for tests. Returns null when the manifest is unparseable or does not
+ * mention the asset -- callers MUST treat null as fatal, never as "skip the
+ * check", or the whole control is bypassed by deleting one line.
+ */
+export function digestForAsset(manifest: string, assetName: string): string | null {
+  if (!manifest || !assetName) return null
+  let found: string | null = null
+  for (const raw of manifest.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const m = CHECKSUM_LINE.exec(line)
+    if (!m) continue
+    // `sha256sum *` emits bare names, but tolerate a path prefix.
+    const name = m[2].trim().replace(/^.*[/\\]/, '')
+    if (name !== assetName) continue
+    // A second line for the same asset means the manifest is ambiguous or
+    // doctored. Refuse rather than pick one.
+    if (found !== null && found !== m[1].toLowerCase()) return null
+    found = m[1].toLowerCase()
+  }
+  return found
+}
+
+/** Stream the file through SHA-256. Streamed, not read into memory: installers
+ *  are 100-200 MB and the main process should not buffer that. */
+function sha256File(filePath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    try {
+      const hash = crypto.createHash('sha256')
+      const stream = fs.createReadStream(filePath)
+      stream.on('error', () => resolve(null))
+      stream.on('data', (chunk) => hash.update(chunk))
+      stream.on('end', () => resolve(hash.digest('hex')))
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** Fetch CHECKSUMS.txt for a release, via the same cascade as the installer. */
+async function fetchChecksumManifest(tagName: string, directUrl?: string | null): Promise<string | null> {
+  const tmpPath = path.join(os.tmpdir(), `ccc-CHECKSUMS-${Date.now()}.txt`)
+  const cleanup = (): void => { try { fs.unlinkSync(tmpPath) } catch { /* best effort */ } }
+
+  // 1. Direct HTTPS, deriving the manifest URL from the installer's own asset
+  //    URL so it comes from the same release, same host.
+  if (directUrl) {
+    const manifestUrl = directUrl.replace(/\/[^/]*$/, '/CHECKSUMS.txt')
+    if (manifestUrl !== directUrl && await httpsDownload(manifestUrl, tmpPath, 60000)) {
+      try {
+        const text = fs.readFileSync(tmpPath, 'utf-8')
+        cleanup()
+        return text
+      } catch { cleanup() }
+    }
+  }
+
+  // 2. gh CLI fallback (private repos, and when the derived URL 404s).
+  const tmpDir = path.join(os.tmpdir(), `ccc-sums-${Date.now()}`)
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true })
+    await execFileAsync(
+      'gh',
+      ['release', 'download', tagName, '--repo', REPO, '--pattern', 'CHECKSUMS.txt', '--dir', tmpDir, '--clobber'],
+      { encoding: 'utf-8', timeout: 60000, windowsHide: true }
+    )
+    const p = path.join(tmpDir, 'CHECKSUMS.txt')
+    if (fs.existsSync(p)) return fs.readFileSync(p, 'utf-8')
+  } catch (err) {
+    logError('[github-update] CHECKSUMS.txt fetch via gh CLI failed:', err)
+  } finally {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+
+  return null
+}
+
+/**
+ * Verify a downloaded installer against the release's CHECKSUMS.txt.
+ *
+ * FAILS CLOSED. Every failure path -- manifest missing, asset absent from it,
+ * unreadable file, digest mismatch -- deletes the download and returns false.
+ * There is deliberately no "could not verify, proceed anyway" branch: an
+ * attacker who can tamper with the installer can usually also make the manifest
+ * fetch fail, so a soft check would be no check.
+ */
+async function verifyInstaller(
+  filePath: string,
+  assetName: string,
+  tagName: string,
+  directUrl?: string | null,
+): Promise<boolean> {
+  const discard = (why: string): false => {
+    logError(`[github-update] INTEGRITY CHECK FAILED (${why}) -- discarding ${assetName}`)
+    try { fs.unlinkSync(filePath) } catch { /* best effort */ }
+    return false
+  }
+
+  const manifest = await fetchChecksumManifest(tagName, directUrl)
+  if (!manifest) return discard('CHECKSUMS.txt could not be fetched')
+
+  const expected = digestForAsset(manifest, assetName)
+  if (!expected) return discard(`no SHA-256 entry for ${assetName} in CHECKSUMS.txt`)
+
+  const actual = await sha256File(filePath)
+  if (!actual) return discard('could not hash the downloaded file')
+
+  if (actual !== expected) {
+    return discard(`sha256 mismatch: expected ${expected}, got ${actual}`)
+  }
+
+  logInfo(`[github-update] Integrity OK: ${assetName} sha256=${actual}`)
+  return true
+}
+
+/**
+ * Download the installer from the latest GitHub release and verify it.
  * Returns the path to the downloaded file, or null on failure.
+ *
+ * Verification happens HERE rather than at the call site so every caller
+ * inherits it -- this function is the only way an installer enters the app, and
+ * a returned path is a verified path.
  */
 export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
   const downloadsDir = path.join(os.homedir(), 'Downloads')
@@ -622,6 +766,7 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
     const ok = await httpsDownload(directUrl, destPath)
     if (ok && fs.existsSync(destPath)) {
       logInfo(`[github-update] Downloaded via direct HTTPS: ${destPath}`)
+      if (!await verifyInstaller(destPath, assetName, tagName, directUrl)) return null
       return destPath
     }
     logInfo('[github-update] Direct HTTPS download failed, trying gh CLI')
@@ -636,6 +781,7 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
     )
     if (fs.existsSync(destPath)) {
       logInfo(`[github-update] Downloaded via gh CLI: ${destPath}`)
+      if (!await verifyInstaller(destPath, assetName, tagName, directUrl)) return null
       return destPath
     }
   } catch (err) {

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -607,7 +607,7 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
   })
 }
 
-// ── Installer integrity (#111) ───────────────────────────────────────────
+// -- Installer integrity (#111) -------------------------------------------
 //
 // The updater downloads an installer and hands it to the OS to execute. That
 // is a code-execution path on the user's machine, and until this landed there
@@ -618,15 +618,32 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
 // at all. `CHECKSUMS.txt` was already generated and attached to every release
 // by the release workflow -- the client simply never read it.
 //
-// THREAT MODEL, stated plainly so nobody over-trusts this. Same-origin
-// checksums defend against corruption, truncation, a tampered CDN edge, and a
-// partial compromise. They do NOT defend against an attacker holding GitHub
-// release-write credentials -- such an attacker rewrites CHECKSUMS.txt to match
-// their payload. Closing that requires SIGNING the manifest (ed25519/minisign
-// in CI, public key pinned in the app). This is a floor, not a ceiling.
+// THREAT MODEL, stated narrowly so nobody over-trusts it. The manifest is
+// fetched from the SAME host and the SAME release as the installer, so this
+// does NOT defend against a tampered CDN edge, nor against anyone holding
+// GitHub release-write credentials -- either of those rewrites both files
+// together. What it DOES defend against is corruption, truncation, an
+// interrupted or resumed download, and a partial compromise that replaces only
+// the installer asset. Closing the rest requires SIGNING the manifest
+// (ed25519/minisign in CI, public key pinned in the app). A floor, not a
+// ceiling.
 
 /** One `<sha256>  <filename>` line as emitted by `sha256sum *`. */
 const CHECKSUM_LINE = /^([0-9a-f]{64})\s+\*?(.+)$/i
+
+/** Refuse a manifest larger than this. A real one is a few hundred bytes, the
+ *  read is synchronous, and it lands in the main process -- so an oversized
+ *  body would be an OOM rather than a parse failure. */
+const MAX_MANIFEST_BYTES = 1024 * 1024
+
+/** Thrown when an installer was fetched but failed verification, so the caller
+ *  can say THAT rather than blaming the user's network connection. */
+export class InstallerIntegrityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InstallerIntegrityError'
+  }
+}
 
 /**
  * Find the digest for `assetName` in a `sha256sum`-format manifest.
@@ -670,6 +687,19 @@ function sha256File(filePath: string): Promise<string | null> {
   })
 }
 
+/** Read a fetched manifest, refusing anything implausibly large. */
+function readManifest(filePath: string): string | null {
+  try {
+    if (fs.statSync(filePath).size > MAX_MANIFEST_BYTES) {
+      logError('[github-update] CHECKSUMS.txt is implausibly large; refusing to parse')
+      return null
+    }
+    return fs.readFileSync(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
 /** Fetch CHECKSUMS.txt for a release, via the same cascade as the installer. */
 async function fetchChecksumManifest(tagName: string, directUrl?: string | null): Promise<string | null> {
   const tmpPath = path.join(os.tmpdir(), `ccc-CHECKSUMS-${Date.now()}.txt`)
@@ -680,11 +710,9 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
   if (directUrl) {
     const manifestUrl = directUrl.replace(/\/[^/]*$/, '/CHECKSUMS.txt')
     if (manifestUrl !== directUrl && await httpsDownload(manifestUrl, tmpPath, 60000)) {
-      try {
-        const text = fs.readFileSync(tmpPath, 'utf-8')
-        cleanup()
-        return text
-      } catch { cleanup() }
+      const text = readManifest(tmpPath)
+      cleanup()
+      if (text) return text
     }
   }
 
@@ -697,8 +725,8 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
       ['release', 'download', tagName, '--repo', REPO, '--pattern', 'CHECKSUMS.txt', '--dir', tmpDir, '--clobber'],
       { encoding: 'utf-8', timeout: 60000, windowsHide: true }
     )
-    const p = path.join(tmpDir, 'CHECKSUMS.txt')
-    if (fs.existsSync(p)) return fs.readFileSync(p, 'utf-8')
+    const manifestPath = path.join(tmpDir, 'CHECKSUMS.txt')
+    if (fs.existsSync(manifestPath)) return readManifest(manifestPath)
   } catch (err) {
     logError('[github-update] CHECKSUMS.txt fetch via gh CLI failed:', err)
   } finally {
@@ -709,52 +737,77 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
 }
 
 /**
- * Verify a downloaded installer against the release's CHECKSUMS.txt.
+ * Resolve the expected SHA-256 for `assetName` BEFORE downloading it.
  *
- * FAILS CLOSED. Every failure path -- manifest missing, asset absent from it,
- * unreadable file, digest mismatch -- deletes the download and returns false.
- * There is deliberately no "could not verify, proceed anyway" branch: an
- * attacker who can tamper with the installer can usually also make the manifest
- * fetch fail, so a soft check would be no check.
+ * Deliberately front-loaded: an installer is 100-200 MB and the manifest a few
+ * hundred bytes, so discovering "this release has no usable manifest" after the
+ * big download wastes the user's bandwidth and delays the failure by minutes.
+ * Returns null when no trustworthy digest exists -- callers must abort.
  */
-async function verifyInstaller(
-  filePath: string,
-  assetName: string,
+async function resolveExpectedDigest(
   tagName: string,
+  assetName: string,
   directUrl?: string | null,
-): Promise<boolean> {
-  const discard = (why: string): false => {
-    logError(`[github-update] INTEGRITY CHECK FAILED (${why}) -- discarding ${assetName}`)
-    try { fs.unlinkSync(filePath) } catch { /* best effort */ }
-    return false
-  }
-
+): Promise<string | null> {
   const manifest = await fetchChecksumManifest(tagName, directUrl)
-  if (!manifest) return discard('CHECKSUMS.txt could not be fetched')
-
-  const expected = digestForAsset(manifest, assetName)
-  if (!expected) return discard(`no SHA-256 entry for ${assetName} in CHECKSUMS.txt`)
-
-  const actual = await sha256File(filePath)
-  if (!actual) return discard('could not hash the downloaded file')
-
-  if (actual !== expected) {
-    return discard(`sha256 mismatch: expected ${expected}, got ${actual}`)
+  if (!manifest) {
+    logError('[github-update] CHECKSUMS.txt could not be fetched for this release')
+    return null
   }
-
-  logInfo(`[github-update] Integrity OK: ${assetName} sha256=${actual}`)
-  return true
+  const expected = digestForAsset(manifest, assetName)
+  if (!expected) {
+    logError(`[github-update] No SHA-256 entry for ${assetName} in CHECKSUMS.txt`)
+    return null
+  }
+  return expected
 }
 
 /**
- * Download the installer from the latest GitHub release and verify it.
- * Returns the path to the downloaded file, or null on failure.
+ * Hash the downloaded file and compare it against the expected digest.
  *
- * Verification happens HERE rather than at the call site so every caller
- * inherits it -- this function is the only way an installer enters the app, and
- * a returned path is a verified path.
+ * FAILS CLOSED. On mismatch or an unreadable file the download is destroyed and
+ * false returned. If unlink fails (Windows file lock) the file is renamed to
+ * `.INVALID` instead -- leaving an unverified installer in ~/Downloads under its
+ * expected name is how a user ends up double-clicking it.
  */
-export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
+async function confirmDigest(filePath: string, assetName: string, expected: string): Promise<boolean> {
+  const actual = await sha256File(filePath)
+  if (actual === expected) {
+    logInfo(`[github-update] Integrity OK: ${assetName} sha256=${actual}`)
+    return true
+  }
+
+  logError(
+    `[github-update] INTEGRITY CHECK FAILED for ${assetName}: ` +
+    `expected ${expected}, got ${actual ?? 'unreadable'} -- discarding`
+  )
+  try {
+    fs.unlinkSync(filePath)
+  } catch {
+    try {
+      fs.renameSync(filePath, `${filePath}.INVALID`)
+      logError(`[github-update] Could not delete it; renamed to ${filePath}.INVALID`)
+    } catch (err) {
+      logError('[github-update] Could not delete OR rename the failed download:', err)
+    }
+  }
+  return false
+}
+
+/** Both integrity failure modes produce the same user-facing advice. */
+function integrityFailure(assetName: string, why: string): InstallerIntegrityError {
+  return new InstallerIntegrityError(
+    `${assetName} ${why}. Install manually from the GitHub release page.`
+  )
+}
+
+/**
+ * Transport half: fetch the asset to ~/Downloads, direct HTTPS first then gh
+ * CLI. Performs NO integrity check -- callers must use downloadGitHubRelease,
+ * which wraps this with verification. Exported only so the download mechanics
+ * are unit-testable on their own.
+ */
+export async function downloadInstallerFile(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
   const downloadsDir = path.join(os.homedir(), 'Downloads')
   try { fs.mkdirSync(downloadsDir, { recursive: true }) } catch {}
   const destPath = path.join(downloadsDir, assetName)
@@ -766,7 +819,6 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
     const ok = await httpsDownload(directUrl, destPath)
     if (ok && fs.existsSync(destPath)) {
       logInfo(`[github-update] Downloaded via direct HTTPS: ${destPath}`)
-      if (!await verifyInstaller(destPath, assetName, tagName, directUrl)) return null
       return destPath
     }
     logInfo('[github-update] Direct HTTPS download failed, trying gh CLI')
@@ -781,7 +833,6 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
     )
     if (fs.existsSync(destPath)) {
       logInfo(`[github-update] Downloaded via gh CLI: ${destPath}`)
-      if (!await verifyInstaller(destPath, assetName, tagName, directUrl)) return null
       return destPath
     }
   } catch (err) {
@@ -789,6 +840,33 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
   }
 
   return null
+}
+
+/**
+ * Download the installer for a release AND verify it. This is the function the
+ * app uses; `downloadInstallerFile` above is the transport half, split out so
+ * the download mechanics (redirects, gh fallback, stale-path handling) stay
+ * testable without standing up a fake CHECKSUMS.txt for every case.
+ *
+ * Returns the verified path, or null if nothing could be downloaded.
+ * Throws {@link InstallerIntegrityError} when the release cannot be verified,
+ * or when a file WAS fetched and failed its digest -- outcomes the caller must
+ * not conflate with "download failed", because the user-facing advice differs.
+ */
+export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
+  // Manifest first -- see resolveExpectedDigest. No digest, no download.
+  const expected = await resolveExpectedDigest(tagName, assetName, directUrl)
+  if (!expected) {
+    throw integrityFailure(assetName, `has no verified SHA-256 in release ${tagName}`)
+  }
+
+  const filePath = await downloadInstallerFile(tagName, assetName, directUrl)
+  if (!filePath) return null
+
+  if (!await confirmDigest(filePath, assetName, expected)) {
+    throw integrityFailure(assetName, 'failed its SHA-256 check and was discarded')
+  }
+  return filePath
 }
 
 /**

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -628,13 +628,67 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
 // (ed25519/minisign in CI, public key pinned in the app). A floor, not a
 // ceiling.
 
-/** One `<sha256>  <filename>` line as emitted by `sha256sum *`. */
-const CHECKSUM_LINE = /^([0-9a-f]{64})\s+\*?(.+)$/i
+/** Hex digest shape. Anchored, fixed length, no quantifier to backtrack on. */
+const HEX64 = /^[0-9a-f]{64}$/i
+
+/**
+ * Split one `sha256sum` line into [digest, filename] without a regex that can
+ * backtrack.
+ *
+ * The obvious pattern -- `/^([0-9a-f]{64})\s+\*?(.+)$/i` -- is QUADRATIC, and
+ * this repo has already paid for that once. A LINE SEPARATOR (U+2028) matches
+ * `\s` but not `.`, so `<digest><many spaces>x\u2028y` forces the greedy `.+`
+ * to fail and `\s+` to give back a character for every position in the run;
+ * the non-whitespace tail defeats the outer `.trim()` that would otherwise
+ * neuter it. Measured on the first version of this file: 1666 ms at 64k spaces,
+ * 27 s at 256k, and the 1 MiB manifest cap put the ceiling around SEVEN MINUTES
+ * of a fully blocked Electron main process -- every terminal frozen.
+ *
+ * That is the same shape as the Authorization-header bug fixed in #151
+ * (`tests/unit/main/conductor-mcp-auth-redos.test.ts`), and it is worse here:
+ * that one was capped by llhttp and `http.maxHeaderSize`, this one has no such
+ * limiter and needs only CHECKSUMS.txt bytes -- strictly less than the
+ * release-write access the threat model already concedes.
+ *
+ * So: index-based. Single pass, no backtracking, linear whatever the input.
+ */
+/** SP or HTAB -- the only separators `sha256sum` emits. */
+function isSpOrHtab(c: string): boolean {
+  return c === ' ' || c === '	'
+}
+
+function splitChecksumLine(line: string): [string, string] | null {
+  const sp = line.search(/\s/)
+  if (sp !== 64) return null
+  const digest = line.slice(0, 64)
+  if (!HEX64.test(digest)) return null
+  let rest = line.slice(64)
+  // Only SP/HTAB separate the digest from the name -- that is what sha256sum
+  // emits. Any OTHER whitespace here means a hand-edited or hostile manifest,
+  // so refuse the line rather than normalise it. Same narrowing as the
+  // Authorization-header separator in #151, and for the same reason: a lenient
+  // separator is one more shape a parser and a reader can disagree about.
+  let i = 0
+  while (i < rest.length && isSpOrHtab(rest[i])) i++
+  if (i === 0) return null
+  if (i < rest.length && /\s/.test(rest[i])) return null
+  rest = rest.slice(i)
+  if (rest.startsWith('*')) rest = rest.slice(1)
+  if (!rest) return null
+  return [digest, rest]
+}
 
 /** Refuse a manifest larger than this. A real one is a few hundred bytes, the
  *  read is synchronous, and it lands in the main process -- so an oversized
  *  body would be an OOM rather than a parse failure. */
 const MAX_MANIFEST_BYTES = 1024 * 1024
+
+/** A downloaded installer whose SHA-256 has been checked against the release
+ *  manifest. Carries the digest so the caller can re-verify just before exec. */
+export interface VerifiedInstaller {
+  path: string
+  sha256: string
+}
 
 /** Thrown when an installer was fetched but failed verification, so the caller
  *  can say THAT rather than blaming the user's network connection. */
@@ -658,15 +712,15 @@ export function digestForAsset(manifest: string, assetName: string): string | nu
   for (const raw of manifest.split('\n')) {
     const line = raw.trim()
     if (!line || line.startsWith('#')) continue
-    const m = CHECKSUM_LINE.exec(line)
-    if (!m) continue
+    const parts = splitChecksumLine(line)
+    if (!parts) continue
     // `sha256sum *` emits bare names, but tolerate a path prefix.
-    const name = m[2].trim().replace(/^.*[/\\]/, '')
+    const name = parts[1].trim().replace(/^.*[/\\]/, '')
     if (name !== assetName) continue
     // A second line for the same asset means the manifest is ambiguous or
     // doctored. Refuse rather than pick one.
-    if (found !== null && found !== m[1].toLowerCase()) return null
-    found = m[1].toLowerCase()
+    if (found !== null && found !== parts[0].toLowerCase()) return null
+    found = parts[0].toLowerCase()
   }
   return found
 }
@@ -700,6 +754,36 @@ function readManifest(filePath: string): string | null {
   }
 }
 
+/**
+ * Derive the CHECKSUMS.txt URL from the installer's own asset URL, pinned to
+ * the same origin.
+ *
+ * A plain `replace(/\/[^/]*$/, ...)` is not safe here: with no path it produces
+ * `https://CHECKSUMS.txt` (a DIFFERENT HOST), and with a fragment or query it
+ * rewrites inside those instead of the path -- `https://h/r/App.exe#/x/y`
+ * becomes `...App.exe#/x/CHECKSUMS.txt`, and since `https.get` drops the
+ * fragment, that FETCHES THE INSTALLER as the manifest. GitHub always supplies
+ * a clean path today, so this is not reachable in production -- but the
+ * function is exported, REPO is registry-overridable, and the guarantee is
+ * stated unconditionally, so parse properly instead of pattern-matching.
+ */
+function deriveManifestUrl(directUrl?: string | null): string | null {
+  if (!directUrl) return null
+  try {
+    const src = new URL(directUrl)
+    const out = new URL(directUrl)
+    out.hash = ''
+    out.search = ''
+    if (!out.pathname.includes('/')) return null
+    out.pathname = out.pathname.replace(/[^/]*$/, 'CHECKSUMS.txt')
+    if (out.origin !== src.origin) return null
+    if (out.href === src.href) return null
+    return out.href
+  } catch {
+    return null
+  }
+}
+
 /** Fetch CHECKSUMS.txt for a release, via the same cascade as the installer. */
 async function fetchChecksumManifest(tagName: string, directUrl?: string | null): Promise<string | null> {
   const tmpPath = path.join(os.tmpdir(), `ccc-CHECKSUMS-${Date.now()}.txt`)
@@ -707,9 +791,9 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
 
   // 1. Direct HTTPS, deriving the manifest URL from the installer's own asset
   //    URL so it comes from the same release, same host.
-  if (directUrl) {
-    const manifestUrl = directUrl.replace(/\/[^/]*$/, '/CHECKSUMS.txt')
-    if (manifestUrl !== directUrl && await httpsDownload(manifestUrl, tmpPath, 60000)) {
+  const manifestUrl = deriveManifestUrl(directUrl)
+  if (manifestUrl) {
+    if (await httpsDownload(manifestUrl, tmpPath, 60000)) {
       const text = readManifest(tmpPath)
       cleanup()
       if (text) return text
@@ -781,6 +865,12 @@ async function confirmDigest(filePath: string, assetName: string, expected: stri
     `[github-update] INTEGRITY CHECK FAILED for ${assetName}: ` +
     `expected ${expected}, got ${actual ?? 'unreadable'} -- discarding`
   )
+  // Truncate FIRST. We just wrote this file, so we can nearly always shrink it,
+  // and a 0-byte file is inert no matter what unlink/rename do next. Without
+  // this, a read-only attribute or a denied ACL leaves the tampered installer
+  // sitting under its expected name -- while the error tells the user it was
+  // discarded and points them at the release page.
+  try { fs.truncateSync(filePath, 0) } catch { /* best effort */ }
   try {
     fs.unlinkSync(filePath)
   } catch {
@@ -853,7 +943,7 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
  * or when a file WAS fetched and failed its digest -- outcomes the caller must
  * not conflate with "download failed", because the user-facing advice differs.
  */
-export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
+export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<VerifiedInstaller | null> {
   // Manifest first -- see resolveExpectedDigest. No digest, no download.
   const expected = await resolveExpectedDigest(tagName, assetName, directUrl)
   if (!expected) {
@@ -866,7 +956,28 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
   if (!await confirmDigest(filePath, assetName, expected)) {
     throw integrityFailure(assetName, 'failed its SHA-256 check and was discarded')
   }
-  return filePath
+  return { path: filePath, sha256: expected }
+}
+
+/**
+ * Re-hash a previously-verified installer immediately before executing it.
+ *
+ * The gap between verification and `spawn` is not small: the caller kills every
+ * PTY in between, which takes tens of milliseconds to seconds. The file sits at
+ * a predictable path in ~/Downloads -- a directory every browser writes into --
+ * and the installer is launched with `allowElevation`, so a NON-elevated local
+ * process that wins that race gains admin on a UAC prompt the user is already
+ * expecting. Re-hashing costs about a second for 150 MB and shrinks the window
+ * to microseconds.
+ */
+export async function stillMatchesDigest(filePath: string, expectedSha256: string): Promise<boolean> {
+  const actual = await sha256File(filePath)
+  if (actual === expectedSha256) return true
+  logError(
+    `[github-update] Installer changed between verification and launch ` +
+    `(expected ${expectedSha256}, got ${actual ?? 'unreadable'})`
+  )
+  return false
 }
 
 /**

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
-import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount } from '../github-update'
+import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
 
@@ -86,11 +86,23 @@ export function registerUpdateHandlers(): void {
     // 2. Download from GitHub if we have release info
     if (cachedRelease?.installerName && cachedRelease?.tagName) {
       logInfo(`[update] Downloading from GitHub: ${cachedRelease.installerName}`)
-      installerPath = await downloadGitHubRelease(
-        cachedRelease.tagName,
-        cachedRelease.installerName,
-        cachedRelease.installerUrl
-      )
+      try {
+        installerPath = await downloadGitHubRelease(
+          cachedRelease.tagName,
+          cachedRelease.installerName,
+          cachedRelease.installerUrl
+        )
+      } catch (err) {
+        // An integrity failure is NOT "installer not found" (#111). Surfacing it
+        // as a network problem sends the user to re-click forever and blame
+        // their connection, and on a genuine tamper event gives them no signal
+        // at all. Rethrow the specific message so the renderer shows the truth.
+        if (err instanceof InstallerIntegrityError) {
+          logError(`[update] ${err.message}`)
+          throw err
+        }
+        throw err
+      }
     }
 
     // 3. Dev-only fallback: look for a locally-built installer in the source folder.

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
 import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
-import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError } from '../github-update'
+import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError, stillMatchesDigest } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
 
@@ -71,6 +71,10 @@ export function registerUpdateHandlers(): void {
     logInfo('[update] Starting update...')
 
     let installerPath: string | null = null
+    // SHA-256 of the installer as verified at download time, kept so it can be
+    // re-checked immediately before exec (#111). Null for the dev-only local
+    // build path, which has no manifest to check against.
+    let verifiedSha256: string | null = null
 
     // 1. Re-check GitHub for the latest release (cached info may be stale)
     try {
@@ -87,19 +91,31 @@ export function registerUpdateHandlers(): void {
     if (cachedRelease?.installerName && cachedRelease?.tagName) {
       logInfo(`[update] Downloading from GitHub: ${cachedRelease.installerName}`)
       try {
-        installerPath = await downloadGitHubRelease(
+        const verified = await downloadGitHubRelease(
           cachedRelease.tagName,
           cachedRelease.installerName,
           cachedRelease.installerUrl
         )
+        if (verified) {
+          installerPath = verified.path
+          verifiedSha256 = verified.sha256
+        }
       } catch (err) {
         // An integrity failure is NOT "installer not found" (#111). Surfacing it
         // as a network problem sends the user to re-click forever and blame
         // their connection, and on a genuine tamper event gives them no signal
-        // at all. Rethrow the specific message so the renderer shows the truth.
+        // at all.
+        //
+        // Adversarial review found the rethrow alone was inert: EVERY renderer
+        // path swallows the error (console.error or a bare state reset), and
+        // there is no toast component -- so the user saw the "Updating..."
+        // overlay vanish and nothing else. showErrorBox is the one channel that
+        // cannot be dropped on the way out.
         if (err instanceof InstallerIntegrityError) {
           logError(`[update] ${err.message}`)
-          throw err
+          try {
+            dialog.showErrorBox('Update blocked - integrity check failed', err.message)
+          } catch { /* never let the dialog itself break the flow */ }
         }
         throw err
       }
@@ -148,6 +164,23 @@ export function registerUpdateHandlers(): void {
     }
 
     logInfo(`[update] Found installer: ${installerPath}`)
+
+    // Re-hash immediately before the point of no return. Verification happened
+    // at download time, but the file then sits at a predictable path in
+    // ~/Downloads while we kill every PTY -- tens of ms to seconds, and every
+    // browser writes into that directory. The installer runs with
+    // `allowElevation`, so a non-elevated local process that wins that race
+    // gains admin on a UAC prompt the user is already expecting. Costs ~1s for
+    // 150 MB and shrinks the window to microseconds (#111).
+    if (verifiedSha256) {
+      if (!await stillMatchesDigest(installerPath, verifiedSha256)) {
+        const msg = `${path.basename(installerPath)} changed on disk after it was verified. `
+          + 'Aborting the update. Install manually from the GitHub release page.'
+        logError('[update] ' + msg)
+        try { dialog.showErrorBox('Update blocked - installer changed after verification', msg) } catch { /* ignore */ }
+        throw new InstallerIntegrityError(msg)
+      }
+    }
 
     // Linux: prepare and VERIFY the AppImage is executable BEFORE we kill the
     // user's terminals and exit. spawn() reports EACCES/ENOENT only via an async

--- a/src/renderer/components/BottomBar.tsx
+++ b/src/renderer/components/BottomBar.tsx
@@ -107,7 +107,7 @@ export default function BottomBar({ currentView, onViewChange, onUpdateRequested
         )}
         {updateAvailable && (
           <button
-            onClick={() => { if (onUpdateRequested) onUpdateRequested(); else window.electronAPI.update.installAndRestart() }}
+            onClick={() => { if (onUpdateRequested) onUpdateRequested(); else void Promise.resolve(window.electronAPI.update.installAndRestart()).catch((e: unknown) => console.error('[update] install failed:', e)) }}
             className="footer-update-pulse px-1.5 py-px rounded-full text-[10px] font-medium focus-ring"
             style={{ color: 'var(--status-success)', background: 'color-mix(in srgb, var(--status-success) 15%, transparent)' }}
             title="Update available -- click to install and restart"

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -145,7 +145,7 @@ vi.mock('../../src/main/debug-logger', () => ({
   logError: vi.fn(),
 }))
 
-import { checkGitHubRelease, downloadGitHubRelease, installerExtForPlatform, prepareLinuxAppImageUpdate, isPathOnNoexecMount } from '../../src/main/github-update'
+import { checkGitHubRelease, downloadGitHubRelease, downloadInstallerFile, InstallerIntegrityError, installerExtForPlatform, prepareLinuxAppImageUpdate, isPathOnNoexecMount } from '../../src/main/github-update'
 
 // Helper to build release fixtures with installers for ALL platforms.
 // checkGitHubRelease returns null if no matching asset exists for the current
@@ -484,13 +484,62 @@ describe('github-update', () => {
     })
   })
 
-  describe('downloadGitHubRelease', () => {
+  describe('downloadGitHubRelease (verified path) -- #111', () => {
+    // The transport half above is deliberately unverified. THIS is the function
+    // the app calls, and its contract is that it never returns a path it has
+    // not checked. Every one of these asserts the fail-closed direction: if a
+    // digest cannot be established, nothing is downloaded and nothing is
+    // returned -- an exception is raised instead, so the caller cannot mistake
+    // it for "no update available".
+    it('throws rather than downloading when CHECKSUMS.txt cannot be fetched', async () => {
+      // Manifest fetch fails (404), gh CLI fallback also fails.
+      httpsState.nextResponse = { statusCode: 404, body: null as any }
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+        cb(new Error('gh not available'), '', '')
+      })
+      await expect(
+        downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      ).rejects.toThrow(InstallerIntegrityError)
+    })
+
+    it('names the asset and the release in the failure, not the network', async () => {
+      httpsState.nextResponse = { statusCode: 404, body: null as any }
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+        cb(new Error('gh not available'), '', '')
+      })
+      // Regression guard for the real complaint in review: an integrity failure
+      // used to surface as "check your internet connection".
+      await expect(
+        downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      ).rejects.toThrow(/ClaudeCommandCenter-Beta-1\.2\.125\.exe.*v1\.2\.125/)
+    })
+
+    it('does not attempt the installer download at all when unverifiable', async () => {
+      httpsState.nextResponse = { statusCode: 404, body: null as any }
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
+        cb(new Error('gh not available'), '', '')
+      })
+      httpsState.callUrls = []
+      await expect(
+        downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      ).rejects.toThrow(InstallerIntegrityError)
+      // Only the CHECKSUMS.txt URL should ever have been requested -- the point
+      // of resolving the digest first is to not pull 150 MB we cannot check.
+      expect(httpsState.callUrls.every((u: string) => u.endsWith('/CHECKSUMS.txt'))).toBe(true)
+    })
+  })
+
+  describe('downloadInstallerFile (transport half)', () => {
+    // #111 split verification out of downloadGitHubRelease. These five cases
+    // always tested the TRANSPORT -- redirects, gh fallback, stale-path
+    // handling -- so they target the transport function directly. Verification
+    // has its own coverage in github-update-integrity.test.ts.
     it('downloads via direct HTTPS when directUrl is provided', async () => {
       httpsState.nextResponse = {
         statusCode: 200,
         bodyBuffer: Buffer.from('fake installer bytes'),
       }
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
       expect(result).not.toBeNull()
       expect(result).toContain('ClaudeCommandCenter-Beta-1.2.125.exe')
       // gh CLI should NOT have been called since direct download succeeded
@@ -504,7 +553,7 @@ describe('github-update', () => {
         { statusCode: 302, headers: { location: 'https://cdn.example.com/real-file.exe' } },
         { statusCode: 200, bodyBuffer: Buffer.from('final bytes') },
       ]
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/redirect.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/redirect.exe')
       expect(result).not.toBeNull()
       // Both URLs should have been called in order
       expect(httpsState.callUrls).toHaveLength(2)
@@ -521,7 +570,7 @@ describe('github-update', () => {
       mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
         cb(new Error('gh not available'), '', '')
       })
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/redirect.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/redirect.exe')
       expect(result).toBeNull()
     })
 
@@ -530,7 +579,7 @@ describe('github-update', () => {
         { statusCode: 302, headers: { location: '/assets/real-file.exe' } },
         { statusCode: 200, bodyBuffer: Buffer.from('final bytes') },
       ]
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://origin.example.com/redirect.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://origin.example.com/redirect.exe')
       expect(result).not.toBeNull()
       expect(httpsState.callUrls[1]).toBe('https://origin.example.com/assets/real-file.exe')
     })
@@ -540,7 +589,7 @@ describe('github-update', () => {
         cb(null, '', '')  // gh exits cleanly
       })
       mockExistsSync.mockReturnValue(true)
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', null)
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', null)
       expect(result).not.toBeNull()
       expect(mockExecFile).toHaveBeenCalled()
       expect(mockExecFile.mock.calls[0][0]).toBe('gh')
@@ -555,7 +604,7 @@ describe('github-update', () => {
       }
       // Simulate that the destination file already exists from a previous attempt
       mockExistsSync.mockReturnValue(true)
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
       expect(result).not.toBeNull()
       // unlink should have been called to remove the stale file before rename
       expect(mockUnlinkSync).toHaveBeenCalled()
@@ -568,7 +617,7 @@ describe('github-update', () => {
       mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => {
         cb(new Error('gh: command not found'), '', '')
       })
-      const result = await downloadGitHubRelease('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/y.exe')
       expect(result).toBeNull()
     })
   })

--- a/tests/unit/main/github-update-integrity.test.ts
+++ b/tests/unit/main/github-update-integrity.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #111 -- installer integrity verification.
+ *
+ * The updater hands a downloaded file to the OS to execute. Before this, no
+ * platform did a client-side integrity check. `digestForAsset` is the parse
+ * half of the control, and it is the half an attacker shapes input for: the
+ * manifest is a text file fetched over the network.
+ *
+ * The critical property is FAIL CLOSED -- every ambiguous or malformed case
+ * must return null, because the caller treats null as "discard the download".
+ * A parser that returns a digest it is not sure about is worse than no parser.
+ */
+import { describe, it, expect } from 'vitest'
+import { digestForAsset } from '../../../src/main/github-update'
+
+const A = 'a'.repeat(64)
+const B = 'b'.repeat(64)
+const ASSET = 'ClaudeCommandCenter-Beta-2.1.0.exe'
+
+describe('digestForAsset -- accepts real sha256sum output', () => {
+  it('parses the two-space form sha256sum emits', () => {
+    expect(digestForAsset(`${A}  ${ASSET}`, ASSET)).toBe(A)
+  })
+
+  it('parses the binary-mode form (asterisk prefix)', () => {
+    expect(digestForAsset(`${A} *${ASSET}`, ASSET)).toBe(A)
+  })
+
+  it('picks the right line out of a multi-asset manifest', () => {
+    const manifest = [
+      `${B}  ClaudeCommandCenter-Beta-2.1.0-mac.dmg`,
+      `${A}  ${ASSET}`,
+      `${B}  ClaudeCommandCenter-Beta-2.1.0.AppImage`,
+    ].join('\n')
+    expect(digestForAsset(manifest, ASSET)).toBe(A)
+  })
+
+  it('tolerates CRLF, blank lines and comments', () => {
+    const manifest = `# generated\r\n\r\n${A}  ${ASSET}\r\n`
+    expect(digestForAsset(manifest, ASSET)).toBe(A)
+  })
+
+  it('normalises an upper-case digest', () => {
+    expect(digestForAsset(`${A.toUpperCase()}  ${ASSET}`, ASSET)).toBe(A)
+  })
+
+  it('strips a path prefix on the filename', () => {
+    expect(digestForAsset(`${A}  ./artifacts/${ASSET}`, ASSET)).toBe(A)
+  })
+})
+
+describe('digestForAsset -- fails closed', () => {
+  const mustBeNull: [string, string][] = [
+    ['empty manifest', ''],
+    ['asset absent -- the one-line-deletion bypass', `${B}  some-other-file.dmg`],
+    ['digest too short', `${'a'.repeat(63)}  ${ASSET}`],
+    ['digest too long', `${'a'.repeat(65)}  ${ASSET}`],
+    ['digest not hex', `${'z'.repeat(64)}  ${ASSET}`],
+    ['no separator', `${A}${ASSET}`],
+    ['filename only', ASSET],
+    ['digest only', A],
+    ['html error page served instead of the manifest', '<!DOCTYPE html><html>404</html>'],
+  ]
+
+  for (const [label, manifest] of mustBeNull) {
+    it(`returns null: ${label}`, () => {
+      expect(digestForAsset(manifest, ASSET)).toBeNull()
+    })
+  }
+
+  it('returns null when the asset name is empty', () => {
+    expect(digestForAsset(`${A}  ${ASSET}`, '')).toBeNull()
+  })
+
+  it('refuses a manifest listing the SAME asset twice with DIFFERENT digests', () => {
+    // Injecting a second line is the cheapest way to attack a parser that
+    // takes first-match or last-match. Ambiguous means refuse.
+    const manifest = `${A}  ${ASSET}\n${B}  ${ASSET}`
+    expect(digestForAsset(manifest, ASSET)).toBeNull()
+  })
+
+  it('accepts a benign exact duplicate line', () => {
+    expect(digestForAsset(`${A}  ${ASSET}\n${A}  ${ASSET}`, ASSET)).toBe(A)
+  })
+})
+
+describe('digestForAsset -- name matching is exact, not fuzzy', () => {
+  it('does not match a filename that merely contains the asset name', () => {
+    expect(digestForAsset(`${A}  evil-${ASSET}`, ASSET)).toBeNull()
+  })
+
+  it('does not match a filename the asset name is a prefix of', () => {
+    expect(digestForAsset(`${A}  ${ASSET}.bak`, ASSET)).toBeNull()
+  })
+
+  it('is case-sensitive on the filename', () => {
+    expect(digestForAsset(`${A}  ${ASSET.toUpperCase()}`, ASSET)).toBeNull()
+  })
+})

--- a/tests/unit/main/github-update-redos.test.ts
+++ b/tests/unit/main/github-update-redos.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #111 -- the CHECKSUMS.txt parser must be LINEAR.
+ *
+ * READ THIS BEFORE CHANGING splitChecksumLine.
+ *
+ * The first version of this parser used `/^([0-9a-f]{64})\s+\*?(.+)$/i`, which
+ * is quadratic. Adversarial review measured 1666 ms at 64k spaces and 27 s at
+ * 256k; with the 1 MiB manifest cap the ceiling was around SEVEN MINUTES of a
+ * fully blocked Electron main process, because the parse is synchronous and in
+ * main. Every terminal frozen, force-kill required.
+ *
+ * The payload needs two ingredients, both non-obvious:
+ *   1. U+2028 LINE SEPARATOR -- matches `\s` but NOT `.`, so the greedy `.+`
+ *      fails and `\s+` must give back a character for every position in the run.
+ *   2. a non-whitespace tail, so the caller's `line.trim()` cannot eat the run.
+ *
+ * This is the same shape as the Authorization-header bug fixed in #151 (see
+ * conductor-mcp-auth-redos.test.ts) -- reintroduced four commits later in a
+ * different file. It is WORSE here: that one was capped by llhttp and
+ * http.maxHeaderSize, this one has no limiter and needs only CHECKSUMS.txt
+ * bytes, which is strictly less access than the release-write compromise the
+ * threat model already concedes.
+ *
+ * HOW A REGRESSION SHOWS UP: verified by reverting splitChecksumLine to the
+ * regex -- this file then HANGS the whole vitest run rather than failing an
+ * assertion (10 min, killed manually). That is inherent, not a flaw in the
+ * test: a synchronous quadratic regex blocks the event loop, so the runner
+ * cannot preempt it and the per-test timeout never fires. If CI ever stalls in
+ * this file, the parser has gone non-linear -- that IS the signal.
+ */
+import { describe, it, expect } from 'vitest'
+import { digestForAsset } from '../../../src/main/github-update'
+
+const ASSET = 'ClaudeCommandCenter-Beta-2.1.0.exe'
+const DIGEST = 'a'.repeat(64)
+const LS = String.fromCharCode(0x2028) // LINE SEPARATOR: matches s, not .
+
+/** The quadratic payload. Do not "simplify" this -- both parts are load-bearing. */
+function redosLine(spaces: number): string {
+  return DIGEST + ' '.repeat(spaces) + 'x' + LS + 'y'
+}
+
+function timeMs(fn: () => void): number {
+  let best = Infinity
+  for (let i = 0; i < 3; i++) {
+    const t0 = performance.now()
+    fn()
+    best = Math.min(best, performance.now() - t0)
+  }
+  return best
+}
+
+describe('checksum parsing is linear (#111)', () => {
+  it('handles the quadratic payload in well under the vulnerable time', () => {
+    const line = redosLine(64_000)
+    // Correctness first: this is not a valid entry for our asset.
+    expect(digestForAsset(line, ASSET)).toBeNull()
+    // Pre-fix measured 1666 ms at this size. Linear is sub-millisecond.
+    expect(timeMs(() => digestForAsset(line, ASSET))).toBeLessThan(200)
+  })
+
+  it('does not blow up super-linearly as the run grows', () => {
+    const small = redosLine(16_000)
+    const large = redosLine(64_000)
+    const tSmall = timeMs(() => digestForAsset(small, ASSET))
+    const tLarge = timeMs(() => digestForAsset(large, ASSET))
+    // 4x input. Linear ~4x; the vulnerable regex measured ~16x (102 -> 1666 ms).
+    expect(tLarge).toBeLessThan(Math.max(tSmall * 10, 200))
+  })
+
+  it('stays linear on a full-size manifest at the 1 MiB cap', () => {
+    const line = redosLine(500_000)
+    expect(timeMs(() => digestForAsset(line, ASSET))).toBeLessThan(500)
+  })
+
+  it('a real entry hidden behind a hostile line is still found', () => {
+    // The parser must not be made "safe" by bailing out of the whole manifest.
+    const manifest = `${redosLine(20_000)}\n${'b'.repeat(64)}  ${ASSET}`
+    expect(digestForAsset(manifest, ASSET)).toBe('b'.repeat(64))
+  })
+})
+
+describe('U+2028 and friends do not confuse the separator (#111)', () => {
+  it('rejects a line whose separator run contains a line separator', () => {
+    expect(digestForAsset(`${DIGEST}${LS}${ASSET}`, ASSET)).toBeNull()
+  })
+
+  it('still accepts the ordinary two-space form', () => {
+    expect(digestForAsset(`${DIGEST}  ${ASSET}`, ASSET)).toBe(DIGEST)
+  })
+
+  it('still accepts the binary-mode asterisk form', () => {
+    expect(digestForAsset(`${DIGEST} *${ASSET}`, ASSET)).toBe(DIGEST)
+  })
+
+  it('rejects a digest that is not exactly 64 chars before the separator', () => {
+    expect(digestForAsset(`${'a'.repeat(63)}  ${ASSET}`, ASSET)).toBeNull()
+    expect(digestForAsset(`${'a'.repeat(65)}  ${ASSET}`, ASSET)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #111.

The updater downloaded an installer and handed it to the OS to execute with **no
client-side integrity check on any platform**. `CHECKSUMS.txt` was already generated and
attached to every release by the workflow (`sha256sum *`) — the client never read it.

No OS backstop covers this:

| Platform | Why it isn't covered |
| --- | --- |
| Windows `.exe` | Not code-signed here, and SmartScreen gates on Mark-of-the-Web, which a Node `https` download never sets |
| macOS `.dmg` | Notarized, but `dmg.sign: false` and a programmatic download carries no quarantine xattr |
| Linux `.AppImage` | No signing convention, no OS check at all |

## Approach

**Verification lives inside `downloadGitHubRelease`, not at the call site.** That function
is the only way an installer enters the app, so a returned path is now a verified path and
no future caller can forget to check.

- `digestForAsset()` is exported and pure — the parse half is the half an attacker shapes
  input for, so it is directly testable.
- The manifest fetch mirrors the existing cascade: derive the `CHECKSUMS.txt` URL from the
  installer's own asset URL (same release, same host), then fall back to
  `gh release download --pattern CHECKSUMS.txt`.
- Hashing is streamed — installers are 100–200 MB and the main process must not buffer them.

## Fails closed, with no exception

Manifest unfetchable, asset missing from it, file unreadable, digest mismatch — every path
deletes the download and returns `null`. There is deliberately **no** "could not verify,
proceed anyway" branch: an attacker who can tamper with the installer can usually also make
the manifest fetch fail, so a soft check would be no check.

The parser refuses **ambiguity**, not just malformity. A manifest listing the same asset
twice with *different* digests returns null rather than taking first- or last-match —
injecting a second line is the cheapest attack on a lenient parser. Filename matching is
exact after stripping a path prefix, so `evil-<asset>` and `<asset>.bak` do not match.

## Threat model — read before trusting this

Same-origin checksums defend against corruption, truncation, a tampered CDN edge, and
partial compromise. **They do not defend against an attacker holding GitHub release-write
credentials** — that attacker rewrites `CHECKSUMS.txt` to match their payload.

Closing that requires a **signed** manifest (ed25519/minisign in CI, public key pinned in
the app, signature verified before the digests are trusted). This PR is a floor, not a
ceiling; I'll open the signing follow-up separately.

## Not implemented

The issue also suggested comparing byte count against the asset `size` from the releases
API. The SHA-256 subsumes it — any length change alters the digest — and plumbing `size`
through `ReleaseInfo` would widen the diff for no security gain.

## Verification

21 unit tests, weighted toward the fail-closed paths (asset absent, malformed digest, an
HTML error page served instead of the manifest, duplicate-with-different-digest,
prefix/suffix filename near-misses). Typecheck clean.

Adversarial-review pass required by ADR-009 (updater verification path) — running now,
verdict to follow as a comment. **Do not merge before it lands.**
