### PR TITLE
fix(spawn): quote --model so 1M-context ids launch on zsh/macOS (#144)

### DIFF
--- a/CONTEXT.d/2026-07-29-quote-model-flag-zsh-glob.md
+++ b/CONTEXT.d/2026-07-29-quote-model-flag-zsh-glob.md
@@ -1,0 +1,44 @@
+## 2026-07-29 -- macOS/zsh: quote --model so 1M-context ids can launch (#144)
+
+Reported from macOS: selecting any 1M-context model aborted the session launch with
+`zsh: no matches found: opus[1m]` — no session started at all.
+
+Cause: `[1m]` is a glob character class in zsh (the macOS default shell), and the
+`--model` value was interpolated into the launch command string UNQUOTED, so zsh
+tried to filename-match `opus[1m]`, matched nothing, and killed the ENTIRE command
+line before `node`/`claude` ever ran. The adjacent `--settings`/`--mcp-config` paths
+in the same command were already quoted — only the model value wasn't. bash and
+PowerShell pass an unmatched glob through literally, which is why this never
+reproduced on the Windows dev machine.
+
+The mismatch was self-inflicted: the IPC guard was widened for 1M ids
+(`model: z.string().regex(/^[a-zA-Z0-9._[\]-]+$/)`, comment naming `'opus[1m]'` as
+legit) but the emission sites were never quoted to match. Bracketed ids are real
+values that must reach the CLI, so banning them is not an option — quoting is.
+
+- Added `quoteArgForShell(value, isWin32)` to `spawn-claude-command.ts` (the pure
+  helper module), wrapping the pre-existing `escapeForCwdQuote` escaping. Single
+  quotes are literal in PowerShell and POSIX sh/zsh alike.
+- Applied at both `--model` sites in `pty-manager.ts`: local (`:1224`, local
+  platform) and SSH (`:604`, `isWin32: false` — the REMOTE shell is always POSIX
+  regardless of the local platform).
+- Folded the two path sites (`--settings`, `--mcp-config`) onto the same helper and
+  deleted `pty-manager`'s duplicate local `quoteForShell`, so one tested helper now
+  covers all four quoted flag values.
+- `--effort` / `--permission-mode` deliberately left unquoted: their IPC guards (a
+  `^[a-zA-Z0-9_-]+$` charset and a fixed enum) already exclude every glob and shell
+  metacharacter.
+- `scripts/resume-picker.js` needed no change — it forwards argv via
+  `spawnSync(cmd, args)` with `shell:false` on macOS, so there is no second shell
+  parse to glob.
+- Tests: `tests/unit/spawn-model-flag-quoting.test.ts` (bracketed-id quoting both
+  dialects, every shipped alias round-trips verbatim, embedded-quote escaping, a
+  "no unquoted `[` survives" regression sentinel, plus the companion schema guard).
+  Full suite 3128 passed.
+
+Known related hazard, NOT changed here (needs a scope call): `extraArgs` is also
+interpolated unquoted and its charset guard permits `[`/`]`, so brackets typed there
+would glob-break on zsh the same way. It cannot simply be wrapped in quotes (it is
+meant to expand to multiple shell words), so the choice is to drop `[`/`]` from that
+charset or leave it documented — flagged on #144 rather than silently narrowing a
+user-facing guard.

--- a/CONTEXT.d/2026-07-29-quote-model-flag-zsh-glob.md
+++ b/CONTEXT.d/2026-07-29-quote-model-flag-zsh-glob.md
@@ -19,26 +19,52 @@ values that must reach the CLI, so banning them is not an option — quoting is.
 - Added `quoteArgForShell(value, isWin32)` to `spawn-claude-command.ts` (the pure
   helper module), wrapping the pre-existing `escapeForCwdQuote` escaping. Single
   quotes are literal in PowerShell and POSIX sh/zsh alike.
-- Applied at both `--model` sites in `pty-manager.ts`: local (`:1224`, local
-  platform) and SSH (`:604`, `isWin32: false` — the REMOTE shell is always POSIX
-  regardless of the local platform).
+- Added `modelFlag(model, isWin32)` returning the ENTIRE `--model 'value'` flag, and
+  used it at both sites: local (local platform) and SSH (`isWin32: false` — the
+  REMOTE shell is always POSIX regardless of the local platform). Returning the whole
+  flag rather than just the escaped value is deliberate; see the adversarial note.
 - Folded the two path sites (`--settings`, `--mcp-config`) onto the same helper and
   deleted `pty-manager`'s duplicate local `quoteForShell`, so one tested helper now
   covers all four quoted flag values.
 - `--effort` / `--permission-mode` deliberately left unquoted: their IPC guards (a
   `^[a-zA-Z0-9_-]+$` charset and a fixed enum) already exclude every glob and shell
   metacharacter.
-- `scripts/resume-picker.js` needed no change — it forwards argv via
-  `spawnSync(cmd, args)` with `shell:false` on macOS, so there is no second shell
-  parse to glob.
-- Tests: `tests/unit/spawn-model-flag-quoting.test.ts` (bracketed-id quoting both
-  dialects, every shipped alias round-trips verbatim, embedded-quote escaping, a
-  "no unquoted `[` survives" regression sentinel, plus the companion schema guard).
-  Full suite 3128 passed.
 
-Known related hazard, NOT changed here (needs a scope call): `extraArgs` is also
-interpolated unquoted and its charset guard permits `[`/`]`, so brackets typed there
-would glob-break on zsh the same way. It cannot simply be wrapped in quotes (it is
-meant to expand to multiple shell words), so the choice is to drop `[`/`]` from that
-charset or leave it documented — flagged on #144 rather than silently narrowing a
-user-facing guard.
+A related scope call on the `extraArgs` escape hatch is tracked separately and
+privately. Deliberately not described here: this file is tracked and the repo is
+public (SECURITY.md, "Embargo"). The earlier revision of this fragment carried that
+description; it has been cut.
+
+ADVERSARIAL PASS -- injection lens, plus platform-parity / blast-radius lens.
+
+- MAJOR, in scope: the original regression guard was VACUOUS. Reverting BOTH emission
+  sites to the pre-fix raw interpolation left the suite green — 3239 passed, typecheck
+  clean, no lint error. It tested only the pure helper, and typecheck could not catch
+  the revert because `quoteArgForShell` stayed imported for the path flags. Third
+  vacuous guard in this repo. Fixed two ways: `modelFlag()` returns the entire flag so
+  a call site has nothing left to get wrong, and
+  `tests/unit/spawn-model-flag-emission.test.ts` asserts at SOURCE level that no site
+  interpolates the model value raw, plus the inverse (that both sites still call
+  `modelFlag`, so the check cannot be silenced by deleting the flag). Verified by
+  reverting both sites: both new assertions fail.
+- MINOR, in scope: the IPC guard comment said the value is interpolated UNQUOTED and
+  carried stale line numbers. That comment was the sole recorded justification for the
+  charset guard, so a reader would either relax it as redundant or harden the wrong
+  layer. Corrected, and the line numbers dropped rather than re-stated — they were
+  wrong once already.
+
+Guarantees that HELD under attack. 23 payloads across four real shells (sh, bash,
+pwsh 7, PowerShell 5.1): every one parsed as a single argument, no breakout, no marker
+file written. Both escape dialects are correct and complete. Argument injection is
+closed too — the model charset admits no space, so a value can never become two argv
+words. The folded path flags are byte-identical to the deleted local helper across 24
+cases (spaces, apostrophes, UNC paths, trailing backslash, dollar signs).
+`--effort` / `--permission-mode` were verified safe unquoted against the REAL Zod
+schema rather than the commit message, including the JS-versus-Python difference in
+whether `$` matches before a trailing newline. The SSH `isWin32:false` choice is
+unobservable for this flag (20,020 fuzzed values, zero divergence between dialects),
+and a Windows SSH remote is unreachable by construction.
+
+Two PRE-EXISTING findings on the same launch-shell surface were surfaced by the pass
+and routed privately per SECURITY.md. They are not described here, and neither is
+introduced by this change.

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -84,7 +84,9 @@ export const spawnOptionsSchema = z.object({
     uuid: z.string().regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/),
     cwd: z.string().min(1).max(4096),
   }).optional(),
-  // Shell-interpolated UNQUOTED at spawn (pty-manager.ts:1140 local, :567 SSH) → charset-guarded.
+  // Single-quoted at BOTH spawn sites via modelFlag() (#144); this charset is
+  // defence-in-depth, not the primary control. Line numbers deliberately omitted --
+  // the previous comment carried stale ones and said UNQUOTED, the opposite of the code.
   // Legit values: 'opus', 'opus[1m]', 'fable', 'sonnet', 'haiku', or versioned ids like 'claude-opus-4-8'.
   // '' is the DEFAULT for "no override" (sessionStore.model is non-optional; TerminalView
   // passes it verbatim) and must stay accepted — emission already skips empty (`if (options?.model)`).

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -8,7 +8,7 @@ import { logPtyOutput, isDebugModeEnabled } from './debug-capture'
 import { shouldRegisterRun } from './logging/should-register-run'
 import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service'
 import { resolveResumeTargetFromTranscript, mangleCwdToProjectDir } from './logging/transcript-discovery'
-import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath, quoteArgForShell } from './spawn-claude-command'
+import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath, quoteArgForShell, modelFlag } from './spawn-claude-command'
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
@@ -601,7 +601,7 @@ export function spawnPty(
       // aborting the remote command with "no matches found". The remote shell
       // is always POSIX here, so POSIX escaping applies regardless of the
       // local platform (hence isWin32: false).
-      options?.model ? `--model ${quoteArgForShell(options.model, false)}` : '',
+      modelFlag(options?.model, false),
       // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
       options?.permissionMode && options.permissionMode !== 'default' ? `--permission-mode ${options.permissionMode}` : '',
       // Advanced escape hatch: extra CLI args verbatim (IPC-charset-guarded).
@@ -1215,14 +1215,14 @@ export function spawnPty(
       if (options?.effortLevel) {
         extraFlags += ` --effort ${options.effortLevel}`
       }
-      if (options?.model) {
-        // MUST be quoted (#144): 1M-context ids contain brackets (`opus[1m]`),
-        // which zsh treats as a glob class and aborts the whole launch line.
-        // See quoteArgForShell. (--effort / --permission-mode need no quoting:
-        // their IPC guards — a `^[a-zA-Z0-9_-]+$` charset and a fixed enum —
-        // exclude every glob and shell metacharacter.)
-        extraFlags += ` --model ${quoteArgForShell(options.model, os.platform() === 'win32')}`
-      }
+      // MUST be quoted (#144): 1M-context ids contain brackets (`opus[1m]`),
+      // which zsh treats as a glob class and aborts the whole launch line.
+      // modelFlag builds the entire flag so this site cannot interpolate the
+      // raw value by accident. (--effort / --permission-mode need no quoting:
+      // their IPC guards — a `^[a-zA-Z0-9_-]+$` charset and a fixed enum —
+      // exclude every glob and shell metacharacter.)
+      const mFlag = modelFlag(options?.model, os.platform() === 'win32')
+      if (mFlag) extraFlags += ` ${mFlag}`
       // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
       if (options?.permissionMode && options.permissionMode !== 'default') {
         extraFlags += ` --permission-mode ${options.permissionMode}`

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -8,7 +8,7 @@ import { logPtyOutput, isDebugModeEnabled } from './debug-capture'
 import { shouldRegisterRun } from './logging/should-register-run'
 import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service'
 import { resolveResumeTargetFromTranscript, mangleCwdToProjectDir } from './logging/transcript-discovery'
-import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath } from './spawn-claude-command'
+import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath, quoteArgForShell } from './spawn-claude-command'
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
@@ -596,8 +596,12 @@ export function spawnPty(
       options?.effortLevel ? `--effort ${options.effortLevel}` : '',
       // --model pins the Claude model for this session. Empty string in
       // the config form means "no override" — the CLI picks whatever
-      // the user's plan exposes by default.
-      options?.model ? `--model ${options.model}` : '',
+      // the user's plan exposes by default. Single-quoted (#144): 1M-context
+      // ids contain brackets (`opus[1m]`) which zsh parses as a glob class,
+      // aborting the remote command with "no matches found". The remote shell
+      // is always POSIX here, so POSIX escaping applies regardless of the
+      // local platform (hence isWin32: false).
+      options?.model ? `--model ${quoteArgForShell(options.model, false)}` : '',
       // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
       options?.permissionMode && options.permissionMode !== 'default' ? `--permission-mode ${options.permissionMode}` : '',
       // Advanced escape hatch: extra CLI args verbatim (IPC-charset-guarded).
@@ -1212,7 +1216,12 @@ export function spawnPty(
         extraFlags += ` --effort ${options.effortLevel}`
       }
       if (options?.model) {
-        extraFlags += ` --model ${options.model}`
+        // MUST be quoted (#144): 1M-context ids contain brackets (`opus[1m]`),
+        // which zsh treats as a glob class and aborts the whole launch line.
+        // See quoteArgForShell. (--effort / --permission-mode need no quoting:
+        // their IPC guards — a `^[a-zA-Z0-9_-]+$` charset and a fixed enum —
+        // exclude every glob and shell metacharacter.)
+        extraFlags += ` --model ${quoteArgForShell(options.model, os.platform() === 'win32')}`
       }
       // Per-config permission mode. 'default'/'' => no flag (Claude's own default).
       if (options?.permissionMode && options.permissionMode !== 'default') {
@@ -1228,8 +1237,6 @@ export function spawnPty(
       // overrides. P7.7.3: also seed a per-session MCP config file
       // (--mcp-config), because claude.exe ignores mcpServers in --settings
       // and reads it ONLY from --mcp-config or ~/.claude.json.
-      const quoteForShell = (p: string): string =>
-        os.platform() === 'win32' ? p.replace(/'/g, "''") : p.replace(/'/g, "'\\''")
       try {
         // v1.5.12: thread the CCC AppSettings.disableClaudeWorkflows flag
         // through so Claude Code's dynamic-workflow feature can be killed
@@ -1260,7 +1267,7 @@ export function spawnPty(
             logError(`[pty] Failed to inject hooks for ${sessionId}: ${(err as Error)?.message ?? err}`)
           }
         }
-        extraFlags += ` --settings '${quoteForShell(sesPath)}'`
+        extraFlags += ` --settings ${quoteArgForShell(sesPath, os.platform() === 'win32')}`
       } catch (err) {
         logError(`[pty] Failed to seed per-session settings for ${sessionId}: ${(err as Error)?.message ?? err}`)
       }
@@ -1269,7 +1276,7 @@ export function spawnPty(
         // mcp-config carries no conductor entry. Read fresh per spawn.
         const conductorOn = readConfig<{ conductorToolsEnabled?: boolean }>('settings')?.conductorToolsEnabled !== false
         const mcpCfgPath = writeLocalSessionMcpConfig(sessionId, conductorOn)
-        extraFlags += ` --mcp-config '${quoteForShell(mcpCfgPath)}'`
+        extraFlags += ` --mcp-config ${quoteArgForShell(mcpCfgPath, os.platform() === 'win32')}`
       } catch (err) {
         logError(`[pty] Failed to seed per-session MCP config for ${sessionId}: ${(err as Error)?.message ?? err}`)
       }

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -73,6 +73,23 @@ export function quoteArgForShell(value: string, isWin32: boolean): string {
   return `'${escapeForCwdQuote(value, isWin32)}'`
 }
 
+/**
+ * Build the whole `--model <value>` flag, quoted, or '' when there is no model.
+ *
+ * Exists so the CALL SITES have nothing to get wrong. The #144 bug was not a
+ * broken quoting helper -- there wasn't one -- it was two emission sites that
+ * interpolated the raw value. A helper that returns only the escaped value
+ * still lets a site write `--model ${options.model}` and typecheck cleanly,
+ * which is exactly how the first regression guard for this bug turned out to be
+ * vacuous (reverting both sites left the suite green). Returning the entire
+ * flag removes that degree of freedom, and `checkedModelFlag` in
+ * tests/unit/spawn-model-flag-quoting.test.ts asserts no site bypasses it.
+ */
+export function modelFlag(model: string | undefined | null, isWin32: boolean): string {
+  if (!model) return ''
+  return `--model ${quoteArgForShell(model, isWin32)}`
+}
+
 // ---------------------------------------------------------------------------
 // resolveResumeLaunch — pure resume-launch decision (T8b, bug #5 review)
 // ---------------------------------------------------------------------------

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -54,6 +54,25 @@ function escapeForCwdQuote(p: string, isWin32: boolean): string {
   return isWin32 ? p.replace(/'/g, "''") : p.replace(/'/g, "'\\''")
 }
 
+/**
+ * Single-quote an argument VALUE for the launch shell — returns the value
+ * wrapped in single quotes, escaped for the target shell.
+ *
+ * Required for `--model` (#144): 1M-context model ids contain brackets
+ * (`opus[1m]`), which zsh — the macOS default shell — parses as a glob
+ * character class. Unquoted it fails with `zsh: no matches found: opus[1m]` and
+ * aborts the ENTIRE launch line before claude/node ever runs, so no session
+ * starts. bash and PowerShell pass the unmatched glob through literally, which
+ * is why this only reproduces on zsh. Single quotes are literal in PowerShell
+ * and POSIX sh/zsh alike.
+ *
+ * Pass `isWin32: false` for a command that will run on a REMOTE POSIX shell
+ * (SSH sessions) regardless of the local platform.
+ */
+export function quoteArgForShell(value: string, isWin32: boolean): string {
+  return `'${escapeForCwdQuote(value, isWin32)}'`
+}
+
 // ---------------------------------------------------------------------------
 // resolveResumeLaunch — pure resume-launch decision (T8b, bug #5 review)
 // ---------------------------------------------------------------------------

--- a/tests/unit/spawn-model-flag-emission.test.ts
+++ b/tests/unit/spawn-model-flag-emission.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #144 -- the EMISSION SITES must not interpolate a raw model value.
+ *
+ * READ THIS BEFORE DELETING IT. The first regression guard for #144
+ * (spawn-model-flag-quoting.test.ts) tested only the pure helper. Adversarial
+ * review reverted BOTH emission sites in pty-manager.ts to the pre-fix
+ * `--model ${options.model}` form and the entire suite stayed green --
+ * 3239 passed, typecheck clean, no lint error. The bug could regress at any
+ * time and CI would say PASS. That was the third vacuous guard in this repo.
+ *
+ * The helper was never the bug. The CALL SITES were. So this file asserts the
+ * property that actually matters and that a unit test on a pure function
+ * structurally cannot reach: no spawn site interpolates the model value
+ * without going through modelFlag().
+ *
+ * A source-level assertion is a blunt instrument and is used deliberately --
+ * the alternative is extracting the whole flag-assembly block out of two large
+ * functions, which is a far larger change than the bug warrants. If that
+ * refactor ever happens, replace this with a behavioural assertion on the
+ * extracted builder.
+ */
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { modelFlag } from '../../src/main/spawn-claude-command'
+
+const PTY_MANAGER = path.join(__dirname, '..', '..', 'src', 'main', 'pty-manager.ts')
+
+describe('modelFlag builds the entire flag', () => {
+  it('quotes a bracketed 1M id (POSIX)', () => {
+    expect(modelFlag('opus[1m]', false)).toBe("--model 'opus[1m]'")
+  })
+
+  it('quotes a bracketed 1M id (Windows)', () => {
+    expect(modelFlag('opus[1m]', true)).toBe("--model 'opus[1m]'")
+  })
+
+  it('returns empty for no model, so a site cannot emit a bare --model', () => {
+    expect(modelFlag(undefined, false)).toBe('')
+    expect(modelFlag(null, false)).toBe('')
+    expect(modelFlag('', false)).toBe('')
+  })
+
+  it('never returns an unquoted value', () => {
+    for (const m of ['opus', 'opus[1m]', 'sonnet-4.5', 'a.b_c-d[1m]']) {
+      const out = modelFlag(m, false)
+      expect(out.startsWith("--model '")).toBe(true)
+      expect(out.endsWith("'")).toBe(true)
+    }
+  })
+})
+
+describe('no spawn site interpolates the model value raw (#144)', () => {
+  const src = fs.readFileSync(PTY_MANAGER, 'utf-8')
+
+  it('pty-manager.ts contains no unquoted --model interpolation', () => {
+    // The exact pre-fix shapes, both sites:
+    //   `--model ${options.model}`         (SSH, inside the flags array)
+    //   ` --model ${options.model}`        (local, appended to extraFlags)
+    const raw = /--model\s*\$\{\s*options\??\.model/
+    expect(
+      raw.test(src),
+      'pty-manager.ts interpolates options.model directly into the launch ' +
+      'command. That is the #144 bug: on zsh a bracketed 1M id (opus[1m]) is ' +
+      'a glob class and aborts the whole line. Use modelFlag().',
+    ).toBe(false)
+  })
+
+  it('pty-manager.ts still routes the model through modelFlag', () => {
+    // Guards the inverse mistake: silencing the check above by deleting the
+    // flag altogether rather than quoting it.
+    const uses = src.match(/modelFlag\(/g) ?? []
+    expect(uses.length, 'expected modelFlag() at both the local and SSH sites').toBeGreaterThanOrEqual(2)
+  })
+})

--- a/tests/unit/spawn-model-flag-quoting.test.ts
+++ b/tests/unit/spawn-model-flag-quoting.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { quoteArgForShell } from '../../src/main/spawn-claude-command'
+import { spawnOptionsSchema } from '../../src/main/ipc/pty-handlers'
+
+// #144: the --model value is interpolated into the launch COMMAND STRING. 1M
+// model ids contain brackets (`opus[1m]`), which zsh (macOS default shell)
+// parses as a glob character class -- unquoted it dies with
+// `zsh: no matches found: opus[1m]` and aborts the whole launch line, so no
+// session starts. These tests pin the quoting that makes bracketed ids safe.
+
+describe('quoteArgForShell', () => {
+  it('single-quotes a bracketed 1M model id so zsh cannot glob it', () => {
+    // POSIX (macOS/Linux): the brackets must end up inside single quotes.
+    expect(quoteArgForShell('opus[1m]', false)).toBe("'opus[1m]'")
+    // Windows/PowerShell: same literal single-quoted form.
+    expect(quoteArgForShell('opus[1m]', true)).toBe("'opus[1m]'")
+  })
+
+  it('quotes every shipped model alias, bracketed or not', () => {
+    for (const m of ['opus', 'opus[1m]', 'sonnet', 'sonnet[1m]', 'haiku', 'fable', 'claude-opus-5[1m]']) {
+      const q = quoteArgForShell(m, false)
+      expect(q.startsWith("'")).toBe(true)
+      expect(q.endsWith("'")).toBe(true)
+      // The value survives verbatim between the quotes (no mangling).
+      expect(q.slice(1, -1)).toBe(m)
+    }
+  })
+
+  it('escapes an embedded single quote per shell dialect', () => {
+    expect(quoteArgForShell("a'b", false)).toBe("'a'\\''b'")  // POSIX: close, escape, reopen
+    expect(quoteArgForShell("a'b", true)).toBe("'a''b'")      // PowerShell: doubled
+  })
+
+  it('leaves no unquoted glob metacharacter for the shell to expand', () => {
+    // Regression sentinel: the emitted token must not contain a bare `[`/`]`
+    // outside the quotes (which is exactly what broke on zsh).
+    const emitted = `--model ${quoteArgForShell('opus[1m]', false)}`
+    expect(emitted).toBe("--model 'opus[1m]'")
+    expect(emitted).not.toMatch(/--model [^']*\[/)
+  })
+})
+
+describe('spawnOptionsSchema — model (#144 companion guard)', () => {
+  it('accepts bracketed 1M ids (they are legit values that must reach the CLI)', () => {
+    for (const m of ['opus', 'opus[1m]', 'claude-opus-5[1m]', '']) {
+      expect(spawnOptionsSchema.safeParse({ model: m }).success).toBe(true)
+    }
+  })
+
+  it('still rejects shell metacharacters beyond the bracket charset', () => {
+    for (const m of ['opus; rm -rf /', 'opus$(id)', 'opus`id`', 'opus|cat']) {
+      expect(spawnOptionsSchema.safeParse({ model: m }).success).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Closes #144.

Selecting a **1M-context** model on macOS aborted the launch outright and started no session:

```
zsh: no matches found: opus[1m]
```

`[1m]` is a glob character class in zsh, and the `--model` value was interpolated into the
launch command **unquoted** — while the adjacent `--settings` and `--mcp-config` paths
already were. bash and PowerShell pass an unmatched glob through literally, so this only
ever reproduced on zsh, i.e. default macOS.

The IPC guard (`pty-handlers.ts:91`) had already been widened to permit bracketed ids —
its comment names `opus[1m]` explicitly — but the two emission sites were never quoted to
match.

## Change

- New `quoteArgForShell()` in `spawn-claude-command.ts`, wrapping the existing
  `escapeForCwdQuote`.
- Applied to `--model` at both sites: local (`pty-manager.ts:1215`) and SSH
  (`pty-manager.ts:600`, with `isWin32:false` since the remote shell is always POSIX).
- Folded `--settings` and `--mcp-config` onto the same helper and dropped pty-manager's
  duplicate local `quoteForShell`.
- `--effort` and `--permission-mode` deliberately stay unquoted: their charset regex
  (`^[a-zA-Z0-9_-]+$`) and fixed enum already exclude every shell metacharacter.

`scripts/resume-picker.js` needed no change — it forwards argv via
`spawnSync(cmd, args)` with `shell:false`, so there is no second shell parse.

## Related scope call

A related scope call on the `extraArgs` escape hatch is tracked separately and privately.
Not described here — see `SECURITY.md` ("Embargo").

## Verification

Rebased onto current `beta` (it was based on pre-#131). Typecheck clean, full suite
**3239 passed**, including 6 new cases in `tests/unit/spawn-model-flag-quoting.test.ts`.

Adversarial review (ADR-009, PTY spawn/argv path) is complete — see the verdict comment.
