### PR TITLE
fix(spawn): spawn the picker without a shell; harden the extraArgs flag guard

### DIFF
--- a/CONTEXT.d/2026-07-31-launch-shell-hardening.md
+++ b/CONTEXT.d/2026-07-31-launch-shell-hardening.md
@@ -1,0 +1,75 @@
+## 2026-07-31 -- Launch-shell hardening: spawn without a shell, and stop backslash defeating the flag guard
+
+Two hardening changes on the session-launch path, both surfaced by the adversarial pass on
+#176 (#144) as PRE-EXISTING -- neither was introduced by that change. Tracked privately per
+SECURITY.md ("Embargo"); this fragment records WHAT changed and why the shape is right, not a
+repro.
+
+### 1. scripts/resume-picker.js spawns with shell:false
+
+Both spawn sites used `shell: os.platform() === 'win32'`. Node with `shell:true` on Windows
+joins `[file, ...args]` with spaces and hands the result to `cmd.exe /d /s /c` UNESCAPED --
+the documented child_process caveat. Every forwarded argument is therefore re-parsed by
+cmd.exe after the launch shell already parsed it correctly once. Two consequences:
+
+- Metacharacters inside a forwarded VALUE become cmd.exe syntax. `--agents` carries
+  user-authored agent-template text, so that is a code path, not a theoretical one.
+- Spaces inside a path SPLIT it. The default Windows data root is
+  `%LOCALAPPDATA%\Claude Command Center` -- it always contains spaces -- so `--settings` was
+  being truncated on every restored Windows session and the tail was landing as a positional
+  argument, i.e. an accidental initial prompt. That is a live correctness bug independent of
+  the security one, and nobody had reported it because the symptom (a stray prompt) does not
+  look like a quoting failure.
+
+New `buildSpawnTarget()` returns `{file, argv}` and is the only way the picker spawns.
+`shell:false` unconditionally; a `.cmd`/`.bat` shim is routed through `cmd.exe /c` with an
+ARGS ARRAY, the same shape `providers/codex/spawn.ts` already used. cmd.exe still parses the
+shim path, but arguments stay separate argv elements instead of being concatenated.
+
+The first attempt put the helper inside `main()`, so the module export could not see it and
+the test failed with "buildSpawnTarget is not defined" -- hoisted to module scope.
+
+### 2. The extraArgs managed-flag refine collapses backslashes before matching
+
+The refine rejects CCC-managed flags so the escape hatch cannot clobber `--settings` and
+friends. It matched literal flag text, but the value is emitted UNQUOTED and POSIX shells
+strip unquoted backslashes at word expansion -- so a backslash-spelled flag matched nothing,
+passed the guard, and arrived at the CLI as the real flag. Worst case substitutes CCC's
+per-session settings file, and a Claude settings file carries `hooks`, i.e. arbitrary
+commands.
+
+FIRST ATTEMPT WAS WRONG and is worth recording. I removed `\` from the charset outright. The
+full suite caught it: an existing test pins that extraArgs accepts Windows backslash paths,
+which is a legitimate use of an advanced escape hatch. Banning the character to fix a POSIX
+word-expansion quirk would have broken Windows users for no reason -- on Windows the launch
+shell is PowerShell, where backslash is not an escape character at all.
+
+The right fix keeps the character and accounts for its behaviour: the refine now tests a
+backslash-COLLAPSED copy of the value. A trailing backslash is additionally rejected outright
+-- on SSH it turns the launch line into a shell line continuation, so the remote shell prompts
+`>` and swallows the user's next line as arguments while claude never launches.
+
+### 3. agentsConfig bounded, deliberately NOT charset-guarded
+
+The fields were unbounded `z.string()`. Bounded now (name 200, description 2000, prompt 100k,
+array 200). Deliberately no metacharacter charset: `prompt` and `description` are free-form
+natural language, so a charset would break the feature for anyone writing an ordinary English
+sentence. It is the wrong control. The real control is that the value never reaches a shell
+as command TEXT -- which is what change 1 above establishes. These bounds are defence in
+depth against an oversized payload, nothing more.
+
+### Tests
+
+`tests/unit/scripts/resume-picker-spawn-target.test.ts` and
+`tests/unit/main/extra-args-guard.test.ts`.
+
+The extraArgs test initially MIRRORED the schema field rather than importing it, which meant
+reverting the fix in the source left every case green -- a vacuous guard, the fourth time
+this pattern has appeared in two days. It now imports the real exported `spawnOptionsSchema`,
+so the mirror cannot drift. Verified by reverting the collapse in the real source: 10 of 19
+cases fail, and pass again with it restored. The picker test carries a source-level
+assertion that no spawn option is anything but `shell: false`, scoped to code lines so the
+rationale comment (which contains the words "shell: true" while explaining why not to) does
+not trip it.
+
+Full suite 3314 passed; typecheck clean.

--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -591,6 +591,36 @@ async function main() {
 // Forwarded args come via this script's own argv — pty-manager passes
 // things like `--settings <path>` in when the hooks gateway is active.
 // They're appended after `--resume <id>` so the resume verb stays first.
+/**
+ * Build the spawn target for `claude`, WITHOUT handing anything to a shell.
+ *
+ * `shell: true` on Windows is the trap this replaces. Node joins [file,
+ * ...args] with spaces and hands the result to `cmd.exe /d /s /c` UNESCAPED
+ * (the documented child_process caveat, CVE-2024-27980 class). Every argument
+ * this script forwards is therefore re-parsed by cmd.exe:
+ *
+ *  - Any `&`, `|`, `<`, `>` or `%` inside a forwarded value becomes cmd.exe
+ *    syntax. The `--agents` payload is user-authored template text, so that is
+ *    a command-execution path, not a theoretical one.
+ *  - Any SPACE inside a path splits it. The default Windows data root is
+ *    `%LOCALAPPDATA%\Claude Command Center`, which ALWAYS contains spaces, so
+ *    `--settings` was being truncated on every restored Windows session and the
+ *    tail was landing as a positional arg (an accidental initial prompt).
+ *
+ * `shell: false` fixes both: Node passes argv to CreateProcess directly and
+ * quotes each element itself. The only thing shell:true was buying is the
+ * ability to invoke a `.cmd` shim, so do that explicitly through cmd.exe with
+ * an ARGS ARRAY -- the same shape src/main/providers/codex/spawn.ts already
+ * uses. cmd.exe still parses the shim path, but the arguments are passed as
+ * separate argv elements rather than concatenated into one command line.
+ */
+function buildSpawnTarget(cmd, args) {
+  if (os.platform() === 'win32' && /\.(cmd|bat)$/i.test(cmd)) {
+    return { file: 'cmd.exe', argv: ['/c', cmd, ...args] }
+  }
+  return { file: cmd, argv: args }
+}
+
 function getForwardedArgs() {
   // node resume-picker.js [ --settings <path> ] [ other flags ... ]
   return process.argv.slice(2)
@@ -636,11 +666,13 @@ function launchClaude(resumeId, sourceCwd) {
     } catch { /* best-effort */ }
   }
 
+
   // Only override cwd for an actual resume into a different directory. Be
   // FAIL-SAFE: an unresolvable/missing sourceCwd silently falls back to inherit.
   const spawnOpts = {
     stdio: 'inherit',
-    shell: os.platform() === 'win32',
+    // NEVER shell:true here -- see buildSpawnTarget.
+    shell: false,
     windowsHide: false,
   }
   if (resumeId && sourceCwd) {
@@ -651,7 +683,8 @@ function launchClaude(resumeId, sourceCwd) {
     } catch { /* leave cwd inherited */ }
   }
 
-  const result = spawnSync(cmd, args, spawnOpts)
+  const target = buildSpawnTarget(cmd, args)
+  const result = spawnSync(target.file, target.argv, spawnOpts)
 
   // If resume failed (conversation no longer exists), fall back to fresh session.
   // The fresh fallback runs in the SAME (worktree) cwd so it lands where the
@@ -660,11 +693,12 @@ function launchClaude(resumeId, sourceCwd) {
     console.log('\n  Conversation no longer available - starting fresh session...\n')
     const freshOpts = {
       stdio: 'inherit',
-      shell: os.platform() === 'win32',
+      shell: false,
       windowsHide: false,
     }
     if (spawnOpts.cwd) freshOpts.cwd = spawnOpts.cwd
-    const fresh = spawnSync(cmd, forwarded, freshOpts)
+    const freshTarget = buildSpawnTarget(cmd, forwarded)
+    const fresh = spawnSync(freshTarget.file, freshTarget.argv, freshOpts)
     process.exit(fresh.status || 0)
   }
 
@@ -674,6 +708,7 @@ function launchClaude(resumeId, sourceCwd) {
 // Pure-logic exports for unit testing. Guarded so `require()` from the test (or
 // a sanity `node -e "require('./scripts/resume-picker.js')"`) does NOT run main.
 module.exports = {
+  buildSpawnTarget,
   encodeProjectPath,
   resolveProjectDir,
   ensureCompanionDir,

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -48,13 +48,24 @@ export const spawnOptionsSchema = z.object({
     path: ['version'],
     message: 'legacyVersion.version must be valid semver when enabled',
   }).optional(),
+  // Bounded, not charset-guarded. `prompt` and `description` are free-form
+  // natural language -- a metacharacter charset here would break the feature
+  // for anyone writing an ordinary English sentence, so it is the wrong control.
+  //
+  // The real control is that this value never reaches a shell as command TEXT:
+  // it is JSON-stringified and single-quote-escaped for the launch shell, and
+  // scripts/resume-picker.js re-spawns with shell:false so there is no second,
+  // unescaped parse (see buildSpawnTarget there -- shell:true on Windows
+  // concatenated argv into a cmd.exe command line, which made this field a
+  // command-execution path). These bounds are defence in depth against an
+  // oversized payload, not the injection boundary.
   agentsConfig: z.array(z.object({
-    name: z.string(),
-    description: z.string(),
-    prompt: z.string(),
-    model: z.string().optional(),
-    tools: z.array(z.string()).optional(),
-  })).optional(),
+    name: z.string().max(200),
+    description: z.string().max(2000),
+    prompt: z.string().max(100_000),
+    model: z.string().max(64).optional(),
+    tools: z.array(z.string().max(200)).max(200).optional(),
+  })).max(200).optional(),
   // PERMISSIVE by design (spec 2026-06-11 §4): a registry-validated enum here
   // re-creates the restore crash — capping at low/medium/high made a restored
   // xhigh/max/ultracode session throw. Unknown levels flow through to the
@@ -70,9 +81,28 @@ export const spawnOptionsSchema = z.object({
   // every shell metacharacter (; | & $ ` ( ) < > ' " * ? ~ ! % ^ newline), leaving only
   // characters that make up ordinary flags/paths. The refine rejects CCC-managed flags
   // so extraArgs can't clobber --model/--effort/--permission-mode/--settings/etc.
+  //
+  // The managed-flag refine runs on a BACKSLASH-COLLAPSED copy of the value, not
+  // on the raw text. The value is emitted unquoted, and POSIX shells strip
+  // unquoted backslashes at word expansion -- so a spelling like `--setting\s`
+  // matched no literal flag, passed the refine, and arrived at the CLI as the
+  // real `--settings`, substituting CCC's per-session settings file. A Claude
+  // settings file carries `hooks`, i.e. arbitrary commands.
+  //
+  // Collapsing rather than banning the character: Windows users legitimately
+  // pass backslash paths through this escape hatch (pinned by an existing test),
+  // and on Windows the launch shell is PowerShell, where backslash is not an
+  // escape character. So the character is harmless where it is needed and only
+  // its shell-stripping behaviour has to be accounted for.
   extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+[\]]*$/).refine(
-    (v) => !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/.test(v),
-    { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume)' },
+    // Collapse backslashes before matching -- see the note above. Also reject a
+    // trailing backslash outright: it turns the SSH launch line into a shell
+    // line continuation, which hangs the session on a `>` prompt waiting for
+    // input that never comes.
+    (v) => !v.endsWith('\\')
+      && !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/
+        .test(v.replace(/\\/g, '')),
+    { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume), nor end in a backslash' },
   ).optional(),
   disableAutoMemory: z.boolean().optional(),
   enableCodexReview: z.boolean().optional(),

--- a/tests/unit/main/extra-args-guard.test.ts
+++ b/tests/unit/main/extra-args-guard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The extraArgs managed-flag refine must survive backslash spellings.
+ *
+ * The refine exists to stop the escape hatch clobbering CCC's own flags. It
+ * matched literal flag text, but the value is emitted UNQUOTED and POSIX shells
+ * strip unquoted backslashes at word expansion -- so `--setting\s` matched no
+ * literal flag, passed the guard, and arrived at the CLI as the real
+ * `--settings`. That substitutes CCC's per-session settings file, and a Claude
+ * settings file carries `hooks`, i.e. arbitrary commands.
+ *
+ * The character itself is NOT banned: Windows users pass backslash paths through
+ * this hatch legitimately, and on Windows the launch shell is PowerShell where
+ * backslash is not an escape character. The refine collapses backslashes before
+ * matching instead.
+ */
+import { describe, it, expect } from 'vitest'
+import { spawnOptionsSchema } from '../../../src/main/ipc/pty-handlers'
+
+// The REAL shipped schema, not a mirror. An earlier draft of this file copied
+// the field definition, which meant reverting the fix in the source left every
+// case here green -- a vacuous guard, the failure mode this repo has now hit
+// three times. Importing the real thing removes the possibility.
+const accepts = (v: string): boolean =>
+  spawnOptionsSchema.safeParse({ extraArgs: v }).success
+
+describe('extraArgs rejects backslash-spelled managed flags', () => {
+  const bypasses = [
+    '--setting\\s /tmp/evil-hooks.json',
+    '\\--model evil-model',
+    '--mo\\del evil-model',
+    '--agent\\s /tmp/x.json',
+    '--resum\\e 11111111-1111-1111-1111-111111111111',
+    '--mcp-confi\\g /tmp/x.json',
+    '--permission-mod\\e bypassPermissions',
+    '--eff\\ort xhigh',
+    // multiple backslashes, and one in the middle of the flag name
+    '--se\\tting\\s /tmp/x.json',
+  ]
+  for (const v of bypasses) {
+    it(`rejects ${JSON.stringify(v)}`, () => {
+      expect(accepts(v)).toBe(false)
+    })
+  }
+
+  it('still rejects the plain unescaped spellings', () => {
+    expect(accepts('--settings /tmp/x.json')).toBe(false)
+    expect(accepts('--model evil')).toBe(false)
+  })
+})
+
+describe('extraArgs rejects a trailing backslash', () => {
+  it('rejects it: on SSH it becomes a shell line continuation', () => {
+    // The remote shell prompts `>` and swallows the user's next line as
+    // arguments; claude never launches.
+    expect(accepts('--verbose \\')).toBe(false)
+    expect(accepts('x\\')).toBe(false)
+  })
+})
+
+describe('extraArgs still accepts what it is for', () => {
+  const ok = [
+    '--verbose',
+    '--debug --verbose',
+    'C:\\Users\\me\\thing.json',
+    '--add-dir C:\\Users\\me\\project',
+    '--add-dir /home/me/project',
+    '--foo=bar',
+    '--tag a,b,c',
+    '',
+  ]
+  for (const v of ok) {
+    it(`accepts ${JSON.stringify(v)}`, () => {
+      expect(accepts(v)).toBe(true)
+    })
+  }
+})

--- a/tests/unit/scripts/resume-picker-spawn-target.test.ts
+++ b/tests/unit/scripts/resume-picker-spawn-target.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The picker must never hand a command LINE to a shell.
+ *
+ * `shell: true` on Windows makes Node join [file, ...args] with spaces and pass
+ * the result to `cmd.exe /d /s /c` UNESCAPED. Two consequences, both real:
+ *
+ *  - Metacharacters inside a forwarded value (`&`, `|`, `<`, `>`, `%`) become
+ *    cmd.exe syntax. `--agents` carries user-authored template text, so that is
+ *    a command-execution path.
+ *  - Spaces inside a path split it. The default Windows data root is
+ *    `%LOCALAPPDATA%\Claude Command Center` -- it ALWAYS has spaces -- so
+ *    `--settings` was truncated on every restored Windows session.
+ *
+ * These assertions pin the shape (argv array, never a joined string) rather
+ * than the symptom, because the symptom is platform-specific and the shape is
+ * what actually prevents it.
+ */
+import { describe, it, expect } from 'vitest'
+import * as os from 'os'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const picker = require('../../../scripts/resume-picker.js')
+const { buildSpawnTarget } = picker as {
+  buildSpawnTarget: (cmd: string, args: string[]) => { file: string; argv: string[] }
+}
+
+const isWin = os.platform() === 'win32'
+
+describe('buildSpawnTarget keeps arguments as argv elements', () => {
+  it('passes a plain executable straight through', () => {
+    const t = buildSpawnTarget('/usr/bin/claude', ['--model', 'opus'])
+    expect(t.file).toBe('/usr/bin/claude')
+    expect(t.argv).toEqual(['--model', 'opus'])
+  })
+
+  it('keeps a path containing spaces as ONE argv element', () => {
+    const settings = 'C:\\Users\\me\\AppData\\Local\\Claude Command Center\\CONFIG\\s.json'
+    const t = buildSpawnTarget('claude.exe', ['--settings', settings])
+    expect(t.argv).toContain(settings)
+    // The whole point: it must not have been split on the spaces.
+    expect(t.argv.filter((a) => a.includes('Claude Command Center'))).toHaveLength(1)
+  })
+
+  it('keeps cmd.exe metacharacters inside a single argv element', () => {
+    const hostile = '[{"name":"a","prompt":"x & whoami > C:\\\\tmp\\\\marker.txt"}]'
+    const t = buildSpawnTarget('claude.exe', ['--agents', hostile])
+    expect(t.argv).toEqual(['--agents', hostile])
+    // Never collapsed into a command line.
+    expect(t.argv.join(' ')).not.toBe(t.argv[0] + t.argv[1])
+  })
+
+  it.runIf(isWin)('routes a .cmd shim through cmd.exe with an ARGS ARRAY', () => {
+    const t = buildSpawnTarget('C:\\npm\\claude.cmd', ['--model', 'opus[1m]'])
+    expect(t.file).toBe('cmd.exe')
+    expect(t.argv[0]).toBe('/c')
+    expect(t.argv[1]).toBe('C:\\npm\\claude.cmd')
+    // Arguments stay separate elements -- not concatenated into argv[1].
+    expect(t.argv.slice(2)).toEqual(['--model', 'opus[1m]'])
+  })
+
+  it.runIf(isWin)('does NOT route a .exe through cmd.exe', () => {
+    const t = buildSpawnTarget('C:\\bin\\claude.exe', ['--model', 'opus'])
+    expect(t.file).toBe('C:\\bin\\claude.exe')
+    expect(t.argv).toEqual(['--model', 'opus'])
+  })
+})
+
+describe('the picker source never re-enables a shell', () => {
+  it('has no shell:true and no platform-conditional shell option', () => {
+    // A source-level guard on purpose. The failure mode is a one-word edit
+    // (`shell: false` -> `shell: os.platform() === 'win32'`) that no
+    // behavioural test on this machine's platform would necessarily catch.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('fs') as typeof import('fs')
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const path = require('path') as typeof import('path')
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'scripts', 'resume-picker.js'),
+      'utf-8',
+    )
+    // Strip comment lines first: the rationale block above buildSpawnTarget
+    // legitimately contains the words "shell: true" while explaining why not to.
+    const codeLines = src
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => !l.startsWith('*') && !l.startsWith('//') && !l.startsWith('/*'))
+    const spawnOptions = codeLines.join('\n').match(/shell:\s*[^,\n]+/g) ?? []
+    expect(spawnOptions.length, 'expected at least one spawn option').toBeGreaterThan(0)
+    for (const opt of spawnOptions) {
+      expect(
+        opt,
+        'resume-picker must spawn with shell:false — shell:true on Windows ' +
+        'concatenates argv into an unescaped cmd.exe command line',
+      ).toMatch(/shell:\s*false/)
+    }
+  })
+})


### PR DESCRIPTION
Two hardening changes on the session-launch path. Both were surfaced as **pre-existing** by the adversarial pass on #176 — neither was introduced by that change. Detail is tracked privately per `SECURITY.md` ("Embargo").

## 1. `resume-picker.js` spawns with `shell: false`

Both spawn sites used `shell: os.platform() === 'win32'`. Node with `shell: true` on Windows joins `[file, ...args]` with spaces and hands the result to `cmd.exe /d /s /c` **unescaped** — the documented `child_process` caveat — so every argument is re-parsed by cmd.exe *after* the launch shell already parsed it correctly.

New `buildSpawnTarget()` returns `{file, argv}` and is the only way the picker spawns. A `.cmd`/`.bat` shim routes through `cmd.exe /c` with an **args array**, the same shape `providers/codex/spawn.ts` already used.

**This also fixes a live correctness bug.** The default Windows data root is `%LOCALAPPDATA%\Claude Command Center` — it always contains spaces — so `--settings` was being truncated on *every* restored Windows session and the tail landed as a positional argument, i.e. an accidental initial prompt. Nobody reported it because the symptom doesn't look like a quoting failure.

## 2. The `extraArgs` managed-flag refine collapses backslashes before matching

The refine rejects CCC-managed flags so the escape hatch can't clobber `--settings` and friends. It matched literal flag text, but the value is emitted unquoted and POSIX shells strip unquoted backslashes at word expansion.

**My first attempt was wrong and the suite caught it.** I removed `\` from the charset outright — and an existing test pins that `extraArgs` accepts Windows backslash paths, which is a legitimate use of an advanced escape hatch. On Windows the launch shell is PowerShell, where backslash isn't an escape character at all, so banning it would have broken Windows users to fix a POSIX quirk. The refine now tests a backslash-collapsed copy instead, keeping the character.

A trailing backslash is additionally rejected: on SSH it turns the launch line into a shell line continuation, so the remote prompts `>` and swallows the user's next line while `claude` never launches.

## 3. `agentsConfig` bounded, deliberately not charset-guarded

Fields were unbounded `z.string()`. Now bounded (name 200, description 2000, prompt 100k, array 200).

No metacharacter charset, on purpose: `prompt` and `description` are free-form natural language, so a charset would break the feature for anyone writing an ordinary English sentence. It's the wrong control. Change 1 is what keeps the value away from a shell; these bounds are defence in depth against an oversized payload.

## Tests

`tests/unit/scripts/resume-picker-spawn-target.test.ts`, `tests/unit/main/extra-args-guard.test.ts`.

The extraArgs test initially **mirrored** the schema rather than importing it — so reverting the fix in the source left every case green. That's the fourth vacuous guard in two days, and I caught it only because I now check. It imports the real exported `spawnOptionsSchema`. Verified by reverting the collapse in the actual source: **10 of 19 cases fail**, and pass again with it restored.

The picker test carries a source-level assertion that no spawn option is anything but `shell: false`, scoped to code lines so the rationale comment doesn't trip it. Verified it fails when `shell: true` is reintroduced.

Full suite **3314 passed**, typecheck clean.
