### PR TITLE
fix(changelog): make the literal scanner comment-aware (#156)

### DIFF
--- a/CONTEXT.d/2026-07-31-156-changelog-scanner.md
+++ b/CONTEXT.d/2026-07-31-156-changelog-scanner.md
@@ -1,0 +1,31 @@
+## 2026-07-31 -- gen-changelog: make the literal scanner comment-aware (#156)
+
+`loadChangelog()` slices the `changelog` array out of the TS source by bracket-matching so
+the generator needs no TS toolchain. It tracked string quotes but had NO notion of comments,
+so a single apostrophe in a `//` comment inside the array -- "the entry's version", the most
+natural English to write -- opened a phantom string. Depth tracking stopped, the slice ended
+in the wrong place, and it died as:
+
+    SyntaxError: Unexpected token ')'   at new Function (<anonymous>)
+
+pointing at generated code, with nothing suggesting the real cause. That cost time twice: the
+source file carries a NOTE telling authors not to write an apostrophe in a comment, which is
+a workaround standing in for a fix.
+
+- Scanner now tracks `//` and block comments. Comment detection sits AFTER the inString
+  branch on purpose, so a `//` inside a URL in a description does not open a comment.
+- Extracted the scanner as a pure exported `sliceArrayLiteral(src, anchor)`. The bug is
+  invisible against the real changelog.ts -- which happens not to contain such a comment
+  today -- so the tests run on synthetic sources. A test against the real file would have
+  passed either way and proved nothing.
+- The `new Function` eval is wrapped: a failure now names the source file, says the array
+  must stay a pure data literal, and points at comments as the usual cause, instead of
+  surfacing a raw SyntaxError against `<anonymous_script>`.
+- Unterminated-literal error message likewise names the likely cause.
+
+Verified behaviour-preserving: `npm run changelog` produces a byte-identical CHANGELOG.md.
+Verified discriminating: reverting the comment awareness fails 3 of 12 cases, including the
+issue's exact repro.
+
+The NOTE in src/renderer/changelog.ts can now be relaxed, but is deliberately left in place --
+it also warns against non-literal expressions in the array, which is still a real constraint.

--- a/scripts/gen-changelog.js
+++ b/scripts/gen-changelog.js
@@ -39,30 +39,62 @@ const SECTIONS = [
  * The array is a pure data literal (strings/arrays/objects, no runtime calls),
  * so we slice out the literal by bracket-matching and evaluate it in isolation.
  */
-function loadChangelog() {
-  const src = fs.readFileSync(SOURCE, 'utf-8')
-  const anchor = src.indexOf('changelog: ChangelogEntry[] =')
-  if (anchor === -1) {
-    throw new Error(`Could not find "changelog: ChangelogEntry[] =" in ${SOURCE}`)
-  }
+/**
+ * Slice a bracket-matched array literal out of JS/TS source.
+ *
+ * Pure and exported so the scanner can be unit-tested on synthetic input --
+ * the bug this guards (#156) is invisible against the real changelog file,
+ * which happens not to contain a comment with an apostrophe today.
+ *
+ * Returns the literal text, or throws with a message that names the likely
+ * cause rather than surfacing a raw SyntaxError from generated code.
+ */
+function sliceArrayLiteral(src, anchorText) {
+  const anchor = src.indexOf(anchorText)
+  if (anchor === -1) throw new Error(`Could not find "${anchorText}"`)
   // Start AFTER the `=` — searching from `anchor` would match the `[` in the
   // `ChangelogEntry[]` type annotation instead of the array literal.
   const eq = src.indexOf('=', anchor)
   const start = src.indexOf('[', eq)
-  if (start === -1) throw new Error('Could not find start of changelog array')
+  if (start === -1) throw new Error('Could not find start of array literal')
 
-  // Bracket-match, ignoring brackets that appear inside string literals.
+  // Bracket-match, ignoring brackets inside string literals AND comments.
+  //
+  // Comment handling is not optional pedantry (#156): the scanner used to
+  // track only quotes, so one apostrophe in a `//` comment inside the array --
+  // "the entry's version", the most natural English -- opened a phantom
+  // string. Depth tracking stopped, the slice ended in the wrong place, and it
+  // failed as `SyntaxError: Unexpected token ')'` pointing at generated code,
+  // with nothing to suggest the real cause. That cost time twice.
   let depth = 0
   let end = -1
   let inString = false
   let quote = ''
+  let inLineComment = false
+  let inBlockComment = false
   for (let i = start; i < src.length; i++) {
     const ch = src[i]
+    const next = src[i + 1]
+
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false
+      continue
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') { inBlockComment = false; i++ }
+      continue
+    }
     if (inString) {
       if (ch === '\\') { i++; continue } // skip escaped char
       if (ch === quote) inString = false
       continue
     }
+
+    // Comments only start OUTSIDE a string, so a `//` inside a URL in a
+    // description does not open one. Hence this sits after the inString branch.
+    if (ch === '/' && next === '/') { inLineComment = true; i++; continue }
+    if (ch === '/' && next === '*') { inBlockComment = true; i++; continue }
+
     if (ch === '"' || ch === "'" || ch === '`') { inString = true; quote = ch; continue }
     if (ch === '[') depth++
     else if (ch === ']') {
@@ -70,11 +102,39 @@ function loadChangelog() {
       if (depth === 0) { end = i; break }
     }
   }
-  if (end === -1) throw new Error('Could not find end of changelog array')
+  if (end === -1) {
+    throw new Error(
+      'Could not find the end of the array literal. An unterminated string or ' +
+      'comment inside it is the usual cause.',
+    )
+  }
+  return src.slice(start, end + 1)
+}
 
-  const literal = src.slice(start, end + 1)
-  // eslint-disable-next-line no-new-func — trusted, in-repo data literal only.
-  const entries = new Function(`return (${literal})`)()
+/**
+ * Pull the `changelog` array out of the TS source without a TS toolchain.
+ * The array is a pure data literal (strings/arrays/objects, no runtime calls),
+ * so we slice out the literal by bracket-matching and evaluate it in isolation.
+ */
+function loadChangelog() {
+  const src = fs.readFileSync(SOURCE, 'utf-8')
+  const literal = sliceArrayLiteral(src, 'changelog: ChangelogEntry[] =')
+  let entries
+  try {
+    // eslint-disable-next-line no-new-func — trusted, in-repo data literal only.
+    entries = new Function(`return (${literal})`)()
+  } catch (err) {
+    // Without this, the raw SyntaxError points at <anonymous_script> line N of
+    // generated code and says nothing about the file the author actually edited.
+    throw new Error(
+      `Failed to evaluate the changelog literal from ${SOURCE}.\n` +
+      `  ${err.message}\n` +
+      '  The array must stay a PURE DATA LITERAL: strings, arrays and objects ' +
+      'only, no runtime calls.\n' +
+      '  If you just added a comment inside the array, check it for an ' +
+      'unbalanced bracket.',
+    )
+  }
   if (!Array.isArray(entries) || entries.length === 0) {
     throw new Error('Parsed changelog is empty or not an array')
   }
@@ -180,3 +240,6 @@ function main() {
 }
 
 main()
+
+// Pure-logic export for unit testing.
+module.exports = { sliceArrayLiteral }

--- a/tests/unit/scripts/gen-changelog-scanner.test.ts
+++ b/tests/unit/scripts/gen-changelog-scanner.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #156 -- the changelog literal scanner must understand comments.
+ *
+ * `sliceArrayLiteral` bracket-matches the `changelog` array out of the TS source
+ * so the generator needs no TS toolchain. It tracked string quotes but had no
+ * notion of comments, so ONE apostrophe in a `//` comment inside the array --
+ * "the entry's version", the most natural English to write -- opened a phantom
+ * string. Depth tracking stopped, the slice ended in the wrong place, and the
+ * failure surfaced as:
+ *
+ *     SyntaxError: Unexpected token ')'   at new Function (<anonymous>)
+ *
+ * pointing at generated code, with nothing to suggest the real cause.
+ *
+ * These cases run on SYNTHETIC sources on purpose. The real changelog.ts happens
+ * not to contain a comment with an apostrophe today (it carries a NOTE warning
+ * authors not to write one), so a test against the real file would pass either
+ * way and prove nothing.
+ */
+import { describe, it, expect } from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { sliceArrayLiteral } = require('../../../scripts/gen-changelog.js') as {
+  sliceArrayLiteral: (src: string, anchor: string) => string
+}
+
+const ANCHOR = 'changelog: ChangelogEntry[] ='
+const wrap = (body: string): string =>
+  `export const ${ANCHOR}\n[\n${body}\n]\n\nexport const after = 1\n`
+
+const parse = (src: string): unknown =>
+  // eslint-disable-next-line no-new-func
+  new Function(`return (${sliceArrayLiteral(src, ANCHOR)})`)()
+
+describe('scanner ignores comments', () => {
+  it('survives an apostrophe in a line comment -- the #156 repro', () => {
+    const src = wrap(`  // rewrites the first entry's version\n  { version: '1.0.0' },`)
+    expect(parse(src)).toEqual([{ version: '1.0.0' }])
+  })
+
+  it('survives a backtick in a line comment', () => {
+    const src = wrap('  // run `npm run changelog` after editing\n  { version: \'1.0.0\' },')
+    expect(parse(src)).toEqual([{ version: '1.0.0' }])
+  })
+
+  it('survives a double quote in a line comment', () => {
+    const src = wrap('  // the "What\'s New" modal reads this\n  { version: \'1.0.0\' },')
+    expect(parse(src)).toEqual([{ version: '1.0.0' }])
+  })
+
+  it('survives an apostrophe in a block comment', () => {
+    const src = wrap("  /* the entry's date is not synced here */\n  { version: '1.0.0' },")
+    expect(parse(src)).toEqual([{ version: '1.0.0' }])
+  })
+
+  it('ignores a bracket inside a comment', () => {
+    const src = wrap('  // a stray ] and [ in prose\n  { version: \'1.0.0\' },')
+    expect(parse(src)).toEqual([{ version: '1.0.0' }])
+  })
+})
+
+describe('scanner still respects strings', () => {
+  it('does NOT treat // inside a string as a comment', () => {
+    // The regression risk of the fix: a URL in a description would truncate
+    // the literal if comment detection ran before the string check.
+    const src = wrap("  { version: '1.0.0', url: 'https://example.com/a]b' },")
+    expect(parse(src)).toEqual([{ version: '1.0.0', url: 'https://example.com/a]b' }])
+  })
+
+  it('does NOT treat /* inside a string as a comment', () => {
+    const src = wrap("  { version: '1.0.0', note: 'glob /* matches' },")
+    expect(parse(src)).toEqual([{ version: '1.0.0', note: 'glob /* matches' }])
+  })
+
+  it('still ignores brackets inside strings', () => {
+    const src = wrap("  { version: '1.0.0', note: 'array ] literal [' },")
+    expect(parse(src)).toEqual([{ version: '1.0.0', note: 'array ] literal [' }])
+  })
+
+  it('handles an escaped quote inside a string', () => {
+    // The scanned source must literally read:  note: 'it\'s fine'
+    const src = wrap("  { version: '1.0.0', note: 'it\\'s fine' },")
+    expect(src).toContain("'it\\'s fine'")
+    expect(parse(src)).toEqual([{ version: '1.0.0', note: "it's fine" }])
+  })
+})
+
+describe('scanner slices the right span', () => {
+  it('stops at the matching bracket, not the first one', () => {
+    const src = wrap("  { version: '1.0.0', tags: ['a', 'b'] },")
+    expect(parse(src)).toEqual([{ version: '1.0.0', tags: ['a', 'b'] }])
+  })
+
+  it('throws a message naming the likely cause when unterminated', () => {
+    const src = `export const ${ANCHOR}\n[\n  { version: '1.0.0' },\n`
+    expect(() => sliceArrayLiteral(src, ANCHOR)).toThrow(/unterminated string or comment/i)
+  })
+
+  it('throws when the anchor is absent', () => {
+    expect(() => sliceArrayLiteral('const x = [1]', ANCHOR)).toThrow(/Could not find/)
+  })
+})


### PR DESCRIPTION
Closes #156.

`loadChangelog()` bracket-matches the `changelog` array out of the TS source so the generator needs no TS toolchain. It tracked string quotes but had **no notion of comments**, so one apostrophe in a `//` comment inside the array — *"the entry's version"*, the most natural English to write — opened a phantom string. Depth tracking stopped, the slice ended in the wrong place, and it failed as:

```
SyntaxError: Unexpected token ')'   at new Function (<anonymous>)
```

pointing at generated code, with nothing to suggest the real cause. **This cost time twice** — I hit it myself writing the beta.3 entries. The source file carries a NOTE telling authors not to write an apostrophe in a comment, which is a workaround standing in for a fix.

## Changes

- The scanner tracks line and block comments. Comment detection sits **after** the `inString` branch on purpose, so a `//` inside a URL in a description doesn't open one.
- Extracted as a pure exported `sliceArrayLiteral(src, anchor)`. The bug is invisible against the real `changelog.ts` — which happens not to contain such a comment today — so the tests run on **synthetic** sources. A test against the real file would have passed either way and proved nothing.
- The `new Function` eval is wrapped: a failure now names the source file, says the array must stay a pure data literal, and points at comments as the usual cause.

## Verification

**Behaviour-preserving:** `npm run changelog` produces a byte-identical `CHANGELOG.md`.

**Discriminating:** reverting the comment awareness fails 3 of 12 cases, including the issue's exact repro. Checked rather than assumed — this repo has shipped four vacuous guards in two days.