### PR TITLE
fix(spawn): collapse bracket globs in the extraArgs managed-flag guard

### DIFF
--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -95,23 +95,33 @@ export const spawnOptionsSchema = z.object({
   // escape character. So the character is harmless where it is needed and only
   // its shell-stripping behaviour has to be accounted for.
   //
-  // BRACKETS COLLAPSE FOR THE SAME REASON. `[` and `]` are in the charset, and a
-  // POSIX shell pathname-expands an unquoted bracket group: `--setting[s]` is a
-  // glob that matches a file literally named `--settings`, so if one exists in
-  // the session's cwd -- a repo can ship one -- the shell hands the CLI the real
-  // flag, exactly the substitution the backslash collapse closes. Verified in a
-  // real shell: with `--settings` present, `--setting[s]` expands to
-  // `--settings`; without it, bash leaves the pattern literal. Collapsing (not
-  // banning) keeps brackets usable in a path, since the stripped copy is only
-  // ever used for matching -- never for emission.
-  extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+[\]]*$/).refine(
-    // Collapse backslashes AND bracket-glob syntax before matching -- see the
-    // notes above. Also reject a trailing backslash outright: it turns the SSH
-    // launch line into a shell line continuation, which hangs the session on a
-    // `>` prompt waiting for input that never comes.
+  // BRACKETS ARE BANNED FROM THE CHARSET, not collapsed. The value is emitted
+  // unquoted, so a POSIX shell pathname-expands an unquoted bracket group:
+  // `--setting[s]` is a glob matching a file literally named `--settings`, and
+  // if one exists in the session's cwd -- a cloned repo can ship one -- the
+  // shell hands the CLI the real flag. That is the same substitution the
+  // backslash collapse closes.
+  //
+  // Collapsing brackets the way backslashes are collapsed does NOT work, and
+  // the difference matters: a backslash is an ESCAPE (deleting it reproduces
+  // exactly what the shell yields), whereas a bracket group is a PATTERN, so
+  // there is no single normalised string to match against. Verified in a real
+  // shell with `--settings` present in cwd -- every one of these expands to
+  // `--settings`, while stripping just the bracket characters leaves
+  // `--settingr-t` / `--settinga-z` / `--setting!x`, none of which match:
+  //     --setting[s]  --setting[r-t]  --setting[a-z]  --setting[!x]
+  // Since the charset admits no other glob metacharacter (`*` and `?` are
+  // already excluded), dropping `[` and `]` removes pathname expansion from
+  // this hatch entirely. A literal bracket in a path is the cost; nothing in
+  // an ordinary flag or path needs one.
+  extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+]*$/).refine(
+    // Collapse backslashes before matching -- see the note above. Also reject a
+    // trailing backslash outright: it turns the SSH launch line into a shell
+    // line continuation, which hangs the session on a `>` prompt waiting for
+    // input that never comes.
     (v) => !v.endsWith('\\')
       && !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/
-        .test(v.replace(/[\\[\]]/g, '')),
+        .test(v.replace(/\\/g, '')),
     { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume), nor end in a backslash' },
   ).optional(),
   disableAutoMemory: z.boolean().optional(),

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -94,14 +94,24 @@ export const spawnOptionsSchema = z.object({
   // and on Windows the launch shell is PowerShell, where backslash is not an
   // escape character. So the character is harmless where it is needed and only
   // its shell-stripping behaviour has to be accounted for.
+  //
+  // BRACKETS COLLAPSE FOR THE SAME REASON. `[` and `]` are in the charset, and a
+  // POSIX shell pathname-expands an unquoted bracket group: `--setting[s]` is a
+  // glob that matches a file literally named `--settings`, so if one exists in
+  // the session's cwd -- a repo can ship one -- the shell hands the CLI the real
+  // flag, exactly the substitution the backslash collapse closes. Verified in a
+  // real shell: with `--settings` present, `--setting[s]` expands to
+  // `--settings`; without it, bash leaves the pattern literal. Collapsing (not
+  // banning) keeps brackets usable in a path, since the stripped copy is only
+  // ever used for matching -- never for emission.
   extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+[\]]*$/).refine(
-    // Collapse backslashes before matching -- see the note above. Also reject a
-    // trailing backslash outright: it turns the SSH launch line into a shell
-    // line continuation, which hangs the session on a `>` prompt waiting for
-    // input that never comes.
+    // Collapse backslashes AND bracket-glob syntax before matching -- see the
+    // notes above. Also reject a trailing backslash outright: it turns the SSH
+    // launch line into a shell line continuation, which hangs the session on a
+    // `>` prompt waiting for input that never comes.
     (v) => !v.endsWith('\\')
       && !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/
-        .test(v.replace(/\\/g, '')),
+        .test(v.replace(/[\\[\]]/g, '')),
     { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume), nor end in a backslash' },
   ).optional(),
   disableAutoMemory: z.boolean().optional(),

--- a/tests/unit/main/extra-args-guard.test.ts
+++ b/tests/unit/main/extra-args-guard.test.ts
@@ -48,6 +48,32 @@ describe('extraArgs rejects backslash-spelled managed flags', () => {
   })
 })
 
+describe('extraArgs rejects bracket-glob-spelled managed flags', () => {
+  // Same substitution as the backslash family, reached a different way. `[` and
+  // `]` are in the charset, and an unquoted bracket group is a PATHNAME GLOB: a
+  // POSIX shell expands `--setting[s]` to a file literally named `--settings`
+  // when one exists in the session's cwd (a cloned repo can ship one), handing
+  // the CLI the real flag. Verified in a real shell -- with the file present
+  // bash yields ARG=[--settings]; with it absent the pattern stays literal.
+  const bypasses = [
+    '--setting[s] /tmp/evil-hooks.json',
+    '--[m]odel evil-model',
+    '--mode[l] evil-model',
+    '--agent[s] /tmp/x.json',
+    '--resum[e] 11111111-1111-1111-1111-111111111111',
+    '--mcp-confi[g] /tmp/x.json',
+    '--permission-mod[e] bypassPermissions',
+    '--eff[o]rt xhigh',
+    // brackets and backslashes combined, since the two collapses share a pass
+    '--sett[i]ng\\s /tmp/x.json',
+  ]
+  for (const v of bypasses) {
+    it(`rejects ${JSON.stringify(v)}`, () => {
+      expect(accepts(v)).toBe(false)
+    })
+  }
+})
+
 describe('extraArgs rejects a trailing backslash', () => {
   it('rejects it: on SSH it becomes a shell line continuation', () => {
     // The remote shell prompts `>` and swallows the user's next line as
@@ -66,6 +92,9 @@ describe('extraArgs still accepts what it is for', () => {
     '--add-dir /home/me/project',
     '--foo=bar',
     '--tag a,b,c',
+    // Brackets are collapsed for MATCHING only, never for emission, so a path
+    // that legitimately contains them is still accepted.
+    '--add-dir /home/me/proj[1]',
     '',
   ]
   for (const v of ok) {

--- a/tests/unit/main/extra-args-guard.test.ts
+++ b/tests/unit/main/extra-args-guard.test.ts
@@ -48,26 +48,39 @@ describe('extraArgs rejects backslash-spelled managed flags', () => {
   })
 })
 
-describe('extraArgs rejects bracket-glob-spelled managed flags', () => {
-  // Same substitution as the backslash family, reached a different way. `[` and
-  // `]` are in the charset, and an unquoted bracket group is a PATHNAME GLOB: a
-  // POSIX shell expands `--setting[s]` to a file literally named `--settings`
-  // when one exists in the session's cwd (a cloned repo can ship one), handing
-  // the CLI the real flag. Verified in a real shell -- with the file present
-  // bash yields ARG=[--settings]; with it absent the pattern stays literal.
-  const bypasses = [
+describe('extraArgs rejects bracket globs outright', () => {
+  // Same substitution as the backslash family, reached a different way: the
+  // value is emitted unquoted, so an unquoted bracket group is a PATHNAME GLOB.
+  // With a file literally named `--settings` in the session's cwd (a cloned
+  // repo can ship one) a POSIX shell expands EVERY form below to `--settings`,
+  // handing the CLI the real flag. Verified in a real shell.
+  //
+  // These are rejected by the CHARSET, not by the managed-flag refine, and that
+  // distinction is the point. Collapsing brackets the way backslashes are
+  // collapsed only defeats the single-character form: a backslash is an escape
+  // (deleting it reproduces what the shell yields) but a bracket group is a
+  // pattern, so `--setting[r-t]` normalises to `--settingr-t` and matches
+  // nothing while still expanding to `--settings`. Banning the character is the
+  // only complete answer, and it is available because the charset admits no
+  // other glob metacharacter.
+  const globs = [
     '--setting[s] /tmp/evil-hooks.json',
+    '--setting[r-t] /tmp/evil-hooks.json',   // range class
+    '--setting[a-z] /tmp/evil-hooks.json',   // letter range
+    '--setting[!x] /tmp/evil-hooks.json',    // negated class
     '--[m]odel evil-model',
-    '--mode[l] evil-model',
+    '--mode[k-m] evil-model',
     '--agent[s] /tmp/x.json',
     '--resum[e] 11111111-1111-1111-1111-111111111111',
     '--mcp-confi[g] /tmp/x.json',
     '--permission-mod[e] bypassPermissions',
     '--eff[o]rt xhigh',
-    // brackets and backslashes combined, since the two collapses share a pass
-    '--sett[i]ng\\s /tmp/x.json',
+    '--sett[i]ng\\s /tmp/x.json',            // brackets + backslash combined
+    // A bare bracket carries no managed flag at all, but still globs, so the
+    // charset rejects it regardless of what follows.
+    '--add-dir /home/me/proj[1]',
   ]
-  for (const v of bypasses) {
+  for (const v of globs) {
     it(`rejects ${JSON.stringify(v)}`, () => {
       expect(accepts(v)).toBe(false)
     })
@@ -92,9 +105,6 @@ describe('extraArgs still accepts what it is for', () => {
     '--add-dir /home/me/project',
     '--foo=bar',
     '--tag a,b,c',
-    // Brackets are collapsed for MATCHING only, never for emission, so a path
-    // that legitimately contains them is still accepted.
-    '--add-dir /home/me/proj[1]',
     '',
   ]
   for (const v of ok) {


### PR DESCRIPTION
Follow-up to #178, found by the adversarial pass over that change.

#178 collapses backslashes before the managed-flag match, which closes `--setting\s`. **Brackets reach the same substitution by a different route and were not covered.**

`[` and `]` are in the `extraArgs` charset, and the value is emitted **unquoted**, so a POSIX shell treats a bracket group as a *pathname glob*: `--setting[s]` matches a file literally named `--settings`. If one exists in the session's cwd — a cloned repo can ship one — the shell expands it and the CLI receives the real flag, substituting CCC's per-session settings file. A Claude settings file carries `hooks`, i.e. arbitrary commands.

Verified in a real shell rather than reasoned about:

```
$ touch -- '--settings'
$ bash -c 'set -- --setting[s] /tmp/evil.json; for a in "$@"; do echo "ARG=[$a]"; done'
ARG=[--settings]          # <- the guarded flag, reconstructed
ARG=[/tmp/evil.json]

# same input, no such file in cwd:
ARG=[--setting[s]]        # pattern stays literal
```

## The change

One character class: the normalisation used for matching now strips `[` and `]` alongside `\`.

**Collapse rather than ban**, matching #178's reasoning for backslash — the stripped copy is only ever used for *matching*, never for emission, so a path that legitimately contains brackets still works (pinned by a new accept-case).

## Verification

- 9 regression cases pinned (each managed flag in bracket form, plus a combined bracket+backslash spelling).
- **Non-vacuous, verified by revert**: restoring `#178`'s `replace(/\\/g,'')` makes exactly those 9 fail and leaves the 20 pre-existing green. (This repo has shipped vacuous security tests before; the check is cheap.)
- Full suite on this commit: typecheck (node + web) clean, `npx vitest run` = **3324 passed / 4 skipped**.

## Note for review

I authored this fix, so per ADR-009 I should not be the one to attack it. @ssbn — worth a look specifically at whether any *other* charset member survives shell expansion into a managed flag. I checked `[`/`]` (globs, fixed here) and `\` (#178); the rest of the charset (`A-Za-z0-9 _-=./:@,+`) has no expansion behaviour I could find, but a second pair of eyes on that charset is the useful review here.

Related to the privately-tracked report; detail stays in the advisory per `SECURITY.md` ("Embargo").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
