### PR TITLE
docs(changelog): add 2.1.0-beta.4 and correct what beta.3 actually shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.4] - 2026-07-31
+
+> Security fixes for the session-launch path, and 1M-context models now launch correctly on macOS. Recommended for everyone on the beta channel.
+
+### Fixed
+- Selecting a 1M-context model (Opus 1M) now launches correctly on macOS. The model name contains square brackets, which the macOS default shell treats as a filename pattern, so the whole launch command was aborted before the session started and nothing appeared to happen.
+- Restoring a session on Windows no longer mangles the paths CCC passes to Claude. The default data folder contains a space and the relaunch was splitting on it, which could silently drop per-session settings and turn the leftover text into an accidental first prompt.
+- Extra command-line arguments set on a config can no longer override the flags CCC manages for a session, including its per-session settings file. Certain spellings slipped past the existing check.
+- Regenerating the changelog no longer fails when a comment in the source contains an apostrophe. Developer tooling only.
+
 ## [2.1.0-beta.3] - 2026-07-31
 
-> Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — 1M-context models launch correctly on macOS, Check for Updates can install the update it finds, and a broad round of security hardening lands across the launch path, the local tools server and the bundled dependencies.
+> Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — Check for Updates can install the update it finds, and a broad round of security hardening lands across the local tools server, the updater and the bundled dependencies.
 
 ### Changed
 - Updated bundled dependencies to close 12 published security advisories, plus two more found while checking. No feature changes.
@@ -20,14 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.
 - Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.
 - Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.
+- Copying with Ctrl+Shift+C no longer fires for every open terminal at once, and no longer competes with a focused text box.
 - Hardened the authentication check on the local Conductor server that Claude and Codex sessions use to reach the built-in CCC tools. Its token check accepted some malformed credentials it should have rejected, and a crafted request could make the check do far more work than it needed to. Both are fixed. The server still listens only on your own machine, and no session behaviour changes.
 - Session, config, team and agent-template identifiers are now generated with a cryptographic random number generator instead of a predictable one. Existing items keep the identifiers they already have and nothing needs migrating.
-- Selecting a 1M-context model (Opus 1M) now launches correctly on macOS. The model name contains square brackets, which the macOS default shell treats as a filename pattern, so the whole launch command was aborted before the session started and nothing appeared to happen.
-- Restoring a session on Windows no longer mangles the paths CCC passes to Claude. The default data folder contains a space, and the relaunch was splitting on it, which could silently drop per-session settings and turn the leftover text into an accidental first prompt.
-- Transcript paths reported by a remote SSH host are now confined to the transcripts folder. A malformed path could previously point outside it. See advisory GHSA-hw7c-g5pw-w725.
-- Extra command-line arguments set on a config can no longer override the flags CCC manages for a session, including its per-session settings file. Certain spellings slipped past the existing check.
-- Copying with Ctrl+Shift+C no longer fires for every open terminal at once, and no longer competes with a focused text box.
-- Regenerating the changelog no longer fails when a comment in the source contains an apostrophe. Developer tooling only.
 - The in-app updater now verifies every installer it downloads against the SHA-256 checksums published with the release, and refuses to run one that does not match. Previously it launched whatever it downloaded, with no client-side check on any platform. If a download fails the check it is discarded and you are told why, rather than the update silently doing nothing.
 - Fixed a flaw in how a session's conversation transcript was located. A machine you opened an SSH session to could name a file outside the Claude projects folder — a private key or token elsewhere on your drive — and CCC would open it and read its contents into that session's local transcript store. Transcript locations are now confined to the projects folder, and the status information a remote host sends is checked before it is used. Exploiting this needed you to connect to a host the attacker controlled, and the file contents stayed on your own machine. Advisory GHSA-hw7c-g5pw-w725.
 
@@ -937,6 +942,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.4]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.4
 [2.1.0-beta.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.3
 [2.1.0-beta.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.2
 [2.1.0-beta.1]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.2",
+      "version": "2.1.0-beta.3",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,22 +21,28 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.4',
+    date: '2026-07-31',
+    highlights: 'Security fixes for the session-launch path, and 1M-context models now launch correctly on macOS. Recommended for everyone on the beta channel.',
+    changes: [
+      { type: 'fix', description: 'Selecting a 1M-context model (Opus 1M) now launches correctly on macOS. The model name contains square brackets, which the macOS default shell treats as a filename pattern, so the whole launch command was aborted before the session started and nothing appeared to happen.' },
+      { type: 'fix', description: 'Restoring a session on Windows no longer mangles the paths CCC passes to Claude. The default data folder contains a space and the relaunch was splitting on it, which could silently drop per-session settings and turn the leftover text into an accidental first prompt.' },
+      { type: 'fix', description: 'Extra command-line arguments set on a config can no longer override the flags CCC manages for a session, including its per-session settings file. Certain spellings slipped past the existing check.' },
+      { type: 'fix', description: 'Regenerating the changelog no longer fails when a comment in the source contains an apostrophe. Developer tooling only.' },
+    ],
+  },
+  {
     version: '2.1.0-beta.3',
     date: '2026-07-31',
-    highlights: 'Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — 1M-context models launch correctly on macOS, Check for Updates can install the update it finds, and a broad round of security hardening lands across the launch path, the local tools server and the bundled dependencies.',
+    highlights: 'Ctrl+V pastes into terminals — which also makes voice dictation and text expanders work — Check for Updates can install the update it finds, and a broad round of security hardening lands across the local tools server, the updater and the bundled dependencies.',
     changes: [
       { type: 'fix', description: 'Ctrl+V now pastes into terminals. Previously only right-click pasted: Ctrl+V was passed straight through to the session as a raw control code, which a shell happened to treat as its own paste command, while Claude ignored it entirely. Cmd+V, Shift+Insert and Ctrl+Shift+V work too, and if the clipboard has no text CCC now says so instead of appearing to do nothing.' },
       { type: 'fix', description: 'Voice dictation and text-expander tools now work in terminals. Tools of that kind type into whatever is focused by copying text and sending Ctrl+V, so they were silently doing nothing in a Claude session — the same root cause as above.' },
       { type: 'fix', description: 'Settings -> Check for Updates can now install the update it finds. It used to only report that one existed, leaving you to hunt for the small Update pill in the bottom bar. Open sessions are still saved before CCC restarts.' },
+      { type: 'fix', description: 'Copying with Ctrl+Shift+C no longer fires for every open terminal at once, and no longer competes with a focused text box.' },
       { type: 'fix', description: 'Hardened the authentication check on the local Conductor server that Claude and Codex sessions use to reach the built-in CCC tools. Its token check accepted some malformed credentials it should have rejected, and a crafted request could make the check do far more work than it needed to. Both are fixed. The server still listens only on your own machine, and no session behaviour changes.' },
       { type: 'fix', description: 'Session, config, team and agent-template identifiers are now generated with a cryptographic random number generator instead of a predictable one. Existing items keep the identifiers they already have and nothing needs migrating.' },
       { type: 'improvement', description: 'Updated bundled dependencies to close 12 published security advisories, plus two more found while checking. No feature changes.' },
-      { type: 'fix', description: 'Selecting a 1M-context model (Opus 1M) now launches correctly on macOS. The model name contains square brackets, which the macOS default shell treats as a filename pattern, so the whole launch command was aborted before the session started and nothing appeared to happen.' },
-      { type: 'fix', description: 'Restoring a session on Windows no longer mangles the paths CCC passes to Claude. The default data folder contains a space, and the relaunch was splitting on it, which could silently drop per-session settings and turn the leftover text into an accidental first prompt.' },
-      { type: 'fix', description: 'Transcript paths reported by a remote SSH host are now confined to the transcripts folder. A malformed path could previously point outside it. See advisory GHSA-hw7c-g5pw-w725.' },
-      { type: 'fix', description: 'Extra command-line arguments set on a config can no longer override the flags CCC manages for a session, including its per-session settings file. Certain spellings slipped past the existing check.' },
-      { type: 'fix', description: 'Copying with Ctrl+Shift+C no longer fires for every open terminal at once, and no longer competes with a focused text box.' },
-      { type: 'fix', description: 'Regenerating the changelog no longer fails when a comment in the source contains an apostrophe. Developer tooling only.' },
       { type: 'fix', description: 'The in-app updater now verifies every installer it downloads against the SHA-256 checksums published with the release, and refuses to run one that does not match. Previously it launched whatever it downloaded, with no client-side check on any platform. If a download fails the check it is discarded and you are told why, rather than the update silently doing nothing.' },
       { type: 'fix', description: 'Fixed a flaw in how a session\'s conversation transcript was located. A machine you opened an SSH session to could name a file outside the Claude projects folder — a private key or token elsewhere on your drive — and CCC would open it and read its contents into that session\'s local transcript store. Transcript locations are now confined to the projects folder, and the status information a remote host sends is checked before it is used. Exploiting this needed you to connect to a host the attacker controlled, and the file contents stayed on your own machine. Advisory GHSA-hw7c-g5pw-w725.' },
     ],


### PR DESCRIPTION
`v2.1.0-beta.3` was published at **19:30Z**, before #144, #166, #178, #179 and #181 merged. Verified against the tag rather than inferred from merge order:

```
d528399 (#178 security)  in v2.1.0-beta.3?  NO
2e35651 (#144)           in v2.1.0-beta.3?  NO
3bf73a2 (#166)           in v2.1.0-beta.3?  NO
1c00230 (advisory fix)   in v2.1.0-beta.3?  YES
6e9d54c (#165 -> #153)   in v2.1.0-beta.3?  YES
```

**So the shipped beta.3 is missing the two remaining advisory fixes.** beta.4 is what carries them.

## New: 2.1.0-beta.4

macOS 1M-model launch failure, Windows restore-path mangling, the extraArgs managed-flag guard, changelog tooling fix.

## Corrections to beta.3

Its entry had drifted from what that build actually contains:

- **Removed** the Windows restore-path fix — that's #178, merged after the tag.
- **Removed** a duplicate short transcript-path entry; a longer, more user-meaningful one was already present.
- **Added** the Ctrl+Shift+C fix — `6e9d54c` *is* an ancestor of the tag, so it shipped in beta.3. I had misfiled it into beta.4.
- **Highlights** no longer claim 1M-context models launch on macOS; that lands in beta.4.

Docs only.