### PR TITLE
build(release): 2.1.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Release prep for v2.1.0-beta.4 — ships the session-launch hardening from #178 and #182 plus the worktree isolation from #166.

Verified on this commit: typecheck (node + web) clean, `npx vitest run` = **3339 passed / 4 skipped**, changelog in sync.