### PR TITLE
build(release): 2.1.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.3",
+      "version": "2.1.0-beta.4",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Back-port of the version bump from `release/v2.1.0-beta.4`, matching what #177 did for beta.3 — that bump landed on `beta` too, so this keeps the branches from diverging on the version line.

`v2.1.0-beta.4` is published and its `CHECKSUMS.txt` covers all three installers (verified — the #111 client now refuses a release it cannot verify).