### PR TITLE
feat(config): choice-driven session dialog; permanent partner terminal; global codex review

### DIFF
--- a/src/main/codex-review-mcp-tool.ts
+++ b/src/main/codex-review-mcp-tool.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 import * as path from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { z } from 'zod'
 import { runCodexStreaming, readCodexAuthStatus } from './providers/codex/auth'
 import { recordReview } from './codex-review-usage'
@@ -157,7 +157,20 @@ export async function runCodexReview(
   if (!optedInSessions.has(cccSessionId)) {
     return {
       isError: true,
-      text: `Codex review is not enabled for session ${cccSessionId}. Toggle "Enable Codex code review" in the session config.`,
+      text: `Codex review is not enabled for session ${cccSessionId}. It is available to local Claude Code sessions when Codex is enabled in Settings → Codex, and only when the session has a real project directory.`,
+    }
+  }
+
+  // 2.5. SECURITY (adversarial review, #188): defence-in-depth against the
+  // home-directory review root. Registration already refuses when the launch
+  // cwd is os.homedir() (pty-manager), so a home-rooted session should never be
+  // in optedInSessions — but never review the bare home dir even if some future
+  // caller re-introduces it: mode:'paths' containment would otherwise allow
+  // ~/.ssh, ~/.claude, ~/.aws. A real project directory is never os.homedir().
+  if (resolvedCwd === homedir()) {
+    return {
+      isError: true,
+      text: 'Codex review refused: the session has no project directory (its working directory resolved to your home folder). Set a real project directory in the session config.',
     }
   }
 
@@ -296,16 +309,31 @@ export function registerCodexReviewTool(
       timeoutSeconds: zMod.number().int().min(30).max(900).optional().describe('Optional override of the default 5-minute timeout. Allowed range 30-900 seconds. Raise for large diffs that overshoot the default; lower for fast-fail experiments.'),
     },
     async (rawArgs: any) => {
-      // Prefer the transport-bound session id; fall back to the LLM-supplied
-      // arg only when the connection didn't bind one (e.g. in-flight sessions
-      // from a CCC build that pre-dates P7.7.10's URL bake).
-      const sid = getBoundSessionId() ?? rawArgs?.cccSessionId ?? null
-      const cwd = (sid && getCwdForSession(sid)) ?? process.cwd()
-      // Pass cccSessionId only when resolved; null would fail zod validation
-      // (the schema is `z.string().optional()` -- undefined ok, null is not).
-      const mergedArgs: Record<string, unknown> = { ...rawArgs }
-      if (sid != null) mergedArgs.cccSessionId = sid
-      else delete mergedArgs.cccSessionId
+      // SECURITY (adversarial review, #188): trust ONLY the transport-bound
+      // session id. The old code fell back to the LLM-supplied cccSessionId when
+      // the connection hadn't bound one — harmless while the opt-in set was tiny
+      // and user-curated, but once every local session is opted-in that fallback
+      // becomes a cross-session read primitive: a prompt-injected session could
+      // pass ANOTHER session's id, clear the (now-universal) ACL, and have codex
+      // review that session's working tree. Binding the id to the transport URL
+      // (baked in per-session by writeLocalSessionMcpConfig) makes it
+      // unforgeable from inside the model. Legacy in-flight sessions that
+      // pre-date the URL bake self-heal on their next respawn.
+      const sid = getBoundSessionId()
+      if (!sid) {
+        return {
+          content: [{ type: 'text' as const, text: 'Codex review unavailable: this MCP connection has no bound CCC session. Restart the Claude session from inside Conductor.' }],
+          isError: true,
+        }
+      }
+      const cwd = getCwdForSession(sid)
+      if (!cwd) {
+        return {
+          content: [{ type: 'text' as const, text: `Codex review is not enabled for this session. It is available to local Claude Code sessions with a real project directory when Codex is enabled in Settings → Codex.` }],
+          isError: true,
+        }
+      }
+      const mergedArgs: Record<string, unknown> = { ...rawArgs, cccSessionId: sid }
       const result = await runCodexReview(mergedArgs, getOptedIn(), cwd)
       return {
         content: [{ type: 'text' as const, text: result.text }],

--- a/src/main/codex-review-mcp-tool.ts
+++ b/src/main/codex-review-mcp-tool.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, readFileSync, existsSync, statSync } from 'fs'
 import { join } from 'path'
 import * as path from 'path'
-import { tmpdir, homedir } from 'os'
+import { tmpdir } from 'os'
+import { isHomeOrAncestor } from './path-utils'
 import { z } from 'zod'
 import { runCodexStreaming, readCodexAuthStatus } from './providers/codex/auth'
 import { recordReview } from './codex-review-usage'
@@ -162,15 +163,16 @@ export async function runCodexReview(
   }
 
   // 2.5. SECURITY (adversarial review, #188): defence-in-depth against the
-  // home-directory review root. Registration already refuses when the launch
-  // cwd is os.homedir() (pty-manager), so a home-rooted session should never be
-  // in optedInSessions — but never review the bare home dir even if some future
-  // caller re-introduces it: mode:'paths' containment would otherwise allow
-  // ~/.ssh, ~/.claude, ~/.aws. A real project directory is never os.homedir().
-  if (resolvedCwd === homedir()) {
+  // home-directory review root. Registration already refuses when the launch cwd
+  // is home or an ancestor of it (pty-manager), so such a session should never be
+  // in optedInSessions — but re-check here so mode:'paths' can never reach
+  // ~/.ssh, ~/.claude, ~/.aws even if a future caller re-introduces one.
+  // isHomeOrAncestor canonicalises with realpath so a case-variant / \\?\ /
+  // junction form of home is caught, not just the exact string.
+  if (isHomeOrAncestor(resolvedCwd)) {
     return {
       isError: true,
-      text: 'Codex review refused: the session has no project directory (its working directory resolved to your home folder). Set a real project directory in the session config.',
+      text: 'Codex review refused: the session has no project directory (its working directory resolves to your home folder). Set a real project directory in the session config.',
     }
   }
 
@@ -283,12 +285,23 @@ export async function runCodexReview(
 
 /** Register the codex_review tool on a conductor-mcp-server McpServer instance.
  *
- * P7.7.10: the `getBoundSessionId` callback returns the CCC session id parsed
- * from the SSE transport URL (`?cccSessionId=<sid>` query, baked in by the
- * per-session --mcp-config writer). When present it takes precedence over
- * any `cccSessionId` the LLM passes as a tool arg -- prevents Claude from
- * dispatching against a stale id cached from a prior conversation. The arg
- * remains a fallback for in-flight sessions written by older CCC builds.
+ * The session id comes SOLELY from `getBoundSessionId()` — the CCC session id
+ * parsed from the transport URL (`?cccSessionId=<sid>`, baked in per-session by
+ * writeLocalSessionMcpConfig). The `cccSessionId` tool ARG is ignored entirely
+ * (adversarial review, #188): once every local session is opted-in, trusting an
+ * LLM-supplied id would let a session name another session's id and review its
+ * tree. An unbound connection (legacy/in-flight, pre-P7.7.10 URL bake) is refused
+ * and self-heals on the session's next respawn.
+ *
+ * NOTE — this binds the id to the transport URL, not to an unforgeable secret.
+ * The endpoint is still gated only by the loopback token, which is written into
+ * each session's readable ~/.claude/mcp-<sid>.json (a documented local-trust
+ * posture, SECURITY.md). A local process already running as the user could read
+ * that token and POST a chosen ?cccSessionId — but such a process can read the
+ * target files directly and needs no codex_review, so this is not an escalation
+ * over the existing local-trust boundary. Minting a per-session capability token
+ * (so the sid can't be restated in the URL) is tracked as a follow-up; it is a
+ * pre-existing hardening, not introduced by this change.
  */
 export function registerCodexReviewTool(
   server: any,  // McpServer (lazy-typed in conductor-mcp-server.ts)
@@ -301,7 +314,7 @@ export function registerCodexReviewTool(
     'codex_review',
     'Get a Codex (gpt-5.5) code review on a change. Use when the user asks for a "Codex review" or "second opinion". The mode arg picks scope: "working" for uncommitted changes (no extra arg), "range" for a git revision range (provide range, e.g. "HEAD~1..HEAD"), "paths" for specific files (provide paths). Optional focus directs Codex\'s attention. Returns the review markdown plus a residual rate-limit footer so you can self-govern usage. The CCC session id is resolved automatically from the MCP connection -- no need to pass it.',
     {
-      cccSessionId: zMod.string().optional().describe('Internal: normally resolved automatically from the MCP connection. Set this only as a back-compat fallback for legacy / in-flight sessions where the server has not bound a session id; new code should leave it unset.'),
+      cccSessionId: zMod.string().optional().describe('Ignored — the CCC session id is resolved from the MCP connection and cannot be set here. Leave unset.'),
       mode: zMod.enum(['working', 'range', 'paths']).describe('Scope: working diff, git range, or explicit paths'),
       range: zMod.string().optional().describe('Git range (e.g. "HEAD~1..HEAD") -- required when mode === "range"'),
       paths: zMod.array(zMod.string()).optional().describe('File paths -- required when mode === "paths"'),

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -23,7 +23,13 @@ const sshSchema = z.object({
   host: z.string().min(1),
   port: z.number().int().min(1).max(65535),
   username: z.string().min(1),
-  remotePath: z.string().min(1),
+  // Charset-gated at the IPC boundary (mirrors ssh-shim SAFE_REMOTE_PATH_RE):
+  // the remote path is interpolated into the remote setup command, and the
+  // shim's own assertSafeRemotePath throws from inside a setTimeout — which the
+  // global handler re-throws, crashing main. Rejecting here means a bad stored
+  // config fails the spawn cleanly instead of taking the process down
+  // (adversarial review, #188).
+  remotePath: z.string().min(1).regex(/^[~A-Za-z0-9_./-]+$/, 'remote path has invalid characters'),
   postCommand: z.string().optional(),
 }).optional()
 

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -39,6 +39,18 @@ export const spawnOptionsSchema = z.object({
   rows: z.number().int().positive().optional(),
   ssh: sshSchema,
   shellOnly: z.boolean().optional(),
+  // Terminal-only launcher: a command the USER authored, typed into their own
+  // shell on their own machine — running it IS the feature, so a charset guard
+  // would be the wrong control (it is not a privilege boundary being crossed).
+  // Bounds are defence-in-depth against an oversized payload. The secret VALUE
+  // never appears here: only `hasSecretArg` crosses the IPC seam, and main
+  // resolves the value from the OS keychain (see the spawn handler).
+  terminalOptions: z.object({
+    command: z.string().max(4096).optional(),
+    args: z.string().max(4096).optional(),
+    hasSecretArg: z.boolean().optional(),
+    elevated: z.boolean().optional(),
+  }).optional(),
   configId: z.string().optional(),
   configLabel: z.string().max(100).optional(),
   // Task 9: per-config logging opt-out (DEFAULT-TRUE; only false disables).
@@ -173,6 +185,10 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
     rows?: number
     ssh?: RendererSSHOptions
     shellOnly?: boolean
+    terminalOptions?: { command?: string; args?: string; hasSecretArg?: boolean; elevated?: boolean }
+    /** Main-process only — resolved from the OS keychain below and explicitly
+     *  cleared from whatever the renderer sent. Never accepted from outside. */
+    terminalSecret?: string
     configId?: string
     configLabel?: string
     loggingEnabled?: boolean
@@ -216,8 +232,12 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
       }
     }
 
-    // Resolve SSH credentials in the main process (never transit through renderer)
-    let resolvedOptions = options
+    // Resolve SSH credentials in the main process (never transit through renderer).
+    // terminalSecret is stripped up front: this object is forwarded to spawnPty
+    // verbatim (the zod parse result is intentionally discarded), so a field the
+    // schema doesn't declare would otherwise flow straight through from the
+    // renderer. Only the keychain lookup below may set it.
+    let resolvedOptions: typeof options = options ? { ...options, terminalSecret: undefined } : options
     if (options?.ssh && options.configId) {
       const password = loadCredential(options.configId) ?? undefined
       const sudoPassword = loadCredential(options.configId + '_sudo') ?? undefined
@@ -227,6 +247,14 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
         sudoPassword,
       }
       resolvedOptions = { ...options, ssh: sshWithCreds }
+    }
+
+    // Terminal-only secret argument: resolved HERE, in main, straight from the OS
+    // keychain — the value never transits the renderer and is never persisted to
+    // the config file (same posture as the SSH credentials above).
+    if (options?.shellOnly && options.configId && options.terminalOptions?.hasSecretArg) {
+      const argSecret = loadCredential(options.configId + '_argsecret') ?? undefined
+      if (argSecret) resolvedOptions = { ...resolvedOptions, terminalSecret: argSecret }
     }
 
     spawnPty(win, sessionId, resolvedOptions)

--- a/src/main/path-utils.ts
+++ b/src/main/path-utils.ts
@@ -29,3 +29,31 @@ export function resolveCwd(cwd: string | undefined): string {
   }
   return resolved
 }
+
+/**
+ * SECURITY (adversarial review, #188): true when `cwd` IS the user's home
+ * directory or an ANCESTOR of it. codex_review must never register or run against
+ * such a root — mode:'paths' containment would otherwise allow ~/.ssh, ~/.claude,
+ * ~/.aws (they resolve inside the root with no '..').
+ *
+ * A plain `cwd === os.homedir()` string compare is not enough: resolveCwd() falls
+ * back to home for '.', empty and stale paths, but a *configured* path that merely
+ * POINTS at home evades a string compare — a case-variant (`c:\users\me` vs
+ * `C:\Users\me`) on case-insensitive Windows, the `\\?\` extended-length form, or a
+ * junction/symlink to home. Canonicalise both sides with realpath and compare
+ * case-insensitively on win32, then also refuse ancestors of home.
+ */
+export function isHomeOrAncestor(cwd: string): boolean {
+  const canon = (p: string): string => {
+    let out: string
+    try { out = fs.realpathSync.native(p) } catch { out = path.resolve(p) }
+    return process.platform === 'win32' ? out.toLowerCase() : out
+  }
+  const home = canon(os.homedir())
+  const dir = canon(cwd)
+  if (dir === home) return true
+  // home is INSIDE dir (dir is an ancestor of home) → relative path has no '..'
+  // and isn't absolute. home OUTSIDE dir → relative starts with '..'.
+  const rel = path.relative(dir, home)
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+}

--- a/src/main/path-utils.ts
+++ b/src/main/path-utils.ts
@@ -54,7 +54,10 @@ export function isHomeOrAncestor(cwd: string): boolean {
   // so even a canonicalised string compare misses it). statSync collapses them
   // all to the same dev:ino. (adversarial review, #188 rounds 2–3.)
   const idOf = (p: string): string | null => {
-    try { const s = fs.statSync(p); return `${s.dev}:${s.ino}` } catch { return null }
+    // bigint so a large NTFS file-reference number (> 2^53) isn't rounded — a
+    // lossy Number ino could bucket two distinct dirs together and wrongly DENY
+    // a legit project dir (over-deny, never exposure). (adversarial review, #188.)
+    try { const s = fs.statSync(p, { bigint: true }); return `${s.dev}:${s.ino}` } catch { return null }
   }
   const home = real(os.homedir())
   const dir = real(cwd)

--- a/src/main/path-utils.ts
+++ b/src/main/path-utils.ts
@@ -44,16 +44,39 @@ export function resolveCwd(cwd: string | undefined): string {
  * case-insensitively on win32, then also refuse ancestors of home.
  */
 export function isHomeOrAncestor(cwd: string): boolean {
-  const canon = (p: string): string => {
-    let out: string
-    try { out = fs.realpathSync.native(p) } catch { out = path.resolve(p) }
-    return process.platform === 'win32' ? out.toLowerCase() : out
+  const real = (p: string): string => {
+    try { return fs.realpathSync.native(p) } catch { return path.resolve(p) }
   }
-  const home = canon(os.homedir())
-  const dir = canon(cwd)
-  if (dir === home) return true
-  // home is INSIDE dir (dir is an ancestor of home) → relative path has no '..'
-  // and isn't absolute. home OUTSIDE dir → relative starts with '..'.
-  const rel = path.relative(dir, home)
-  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+  // Filesystem IDENTITY (device:inode), not the path string. A string compare
+  // misses the many spellings of one directory on Windows — case-variant, the
+  // \\?\ / \\.\ prefixes, a `subst` drive, a junction/symlink, an 8.3 short
+  // name, and the \\host\C$ admin-share form (which realpath returns verbatim,
+  // so even a canonicalised string compare misses it). statSync collapses them
+  // all to the same dev:ino. (adversarial review, #188 rounds 2–3.)
+  const idOf = (p: string): string | null => {
+    try { const s = fs.statSync(p); return `${s.dev}:${s.ino}` } catch { return null }
+  }
+  const home = real(os.homedir())
+  const dir = real(cwd)
+  const dirId = idOf(dir)
+  if (dirId != null) {
+    // Walk home up to the filesystem root; dir matches home itself or any
+    // ancestor of home when their identities are equal.
+    let cur = home
+    while (true) {
+      if (idOf(cur) === dirId) return true
+      const parent = path.dirname(cur)
+      if (parent === cur) break
+      cur = parent
+    }
+    return false
+  }
+  // Fallback for a path that doesn't exist on disk (statSync failed): a
+  // normalised string comparison. resolveCwd would already have mapped a
+  // non-existent path to home before this is reached, so this is belt-and-braces.
+  const norm = (p: string) => (process.platform === 'win32' ? p.toLowerCase() : p)
+  const h = norm(home), d = norm(dir)
+  if (d === h) return true
+  const rel = path.relative(d, h)
+  return rel !== '' && rel.split(path.sep)[0] !== '..' && !path.isAbsolute(rel)
 }

--- a/src/main/providers/claude/spawn.ts
+++ b/src/main/providers/claude/spawn.ts
@@ -74,6 +74,14 @@ export function buildClaudeLocalSpawn(opts: SpawnOptions): { cmd: string; args: 
 
   if (opts.disableAutoMemory) env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = '1'
 
+  // Terminal-only secret argument. The secret goes in the ENV, and the launch
+  // line references the variable rather than the value, so the plaintext never
+  // reaches the shell's persistent history (PSReadLine writes every submitted
+  // line to disk) or the config file. Same-user processes can still read the
+  // env — that is the existing local-trust boundary, and it is strictly better
+  // than a secret sitting in ConsoleHost_history.txt forever.
+  if (opts.shellOnly && opts.terminalSecret) env.CCC_ARG_SECRET = opts.terminalSecret
+
   const shell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash')
   // POSIX: spawn a LOGIN shell (-l) so PATH picks up Homebrew/nvm/npm-global
   // entries from ~/.zprofile. A Finder/Dock-launched app inherits launchd's

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -10,6 +10,10 @@ export interface SpawnOptions {
   ssh?: SshConfig
   shellOnly?: boolean
   elevated?: boolean
+  /** Terminal-only secret argument, resolved from the OS keychain in main. Placed
+   *  in the spawn ENV (never interpolated into the command text) so it cannot land
+   *  in the shell's on-disk history. See buildSpawnCommand + the shell-only write. */
+  terminalSecret?: string
   configLabel?: string
   useResumePicker?: boolean
   legacyVersion?: LegacyVersion

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -20,7 +20,7 @@ import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-d
 import { getProvider } from './providers'
 import { isSshCapable } from './providers/types'
 import type { TelemetrySource } from './providers/types'
-import { resolveCwd } from './path-utils'
+import { resolveCwd, isHomeOrAncestor } from './path-utils'
 import { dispatchSSHStatuslineUpdate, cleanupStatusFile } from './statusline-watcher'
 import { forgetSession } from './background-context'
 import { decorateStatuslineWithColour } from './account-color'
@@ -1208,8 +1208,8 @@ export function spawnPty(
       // mode:'paths' (containment holds, but the ROOT is wrong). Since universal
       // opt-in removed the per-config gate that used to bound this, block it at
       // the source: no legitimate review targets the bare home dir.
-      if (claudeCwd === os.homedir()) {
-        logWarn(`[pty] codex_review NOT registered for ${sessionId}: launch cwd resolved to the home directory (workingDirectory is '.', empty, or a stale path). Set a real project directory to enable review.`)
+      if (isHomeOrAncestor(claudeCwd)) {
+        logWarn(`[pty] codex_review NOT registered for ${sessionId}: launch cwd resolves to (or above) the home directory (workingDirectory is '.', empty, a stale path, or points at home). Set a real project directory to enable review.`)
       } else {
         registerCodexReviewSession(sessionId, claudeCwd)
       }
@@ -1675,6 +1675,14 @@ function cleanupSessionResources(sessionId: string): void {
     try { flow.destroy() } catch { /* noop */ }
     sshFlows.delete(sessionId)
   }
+  // SECURITY (adversarial review, #188): deregister codex_review here so
+  // registration is strictly RE-ESTABLISHED per spawn. spawnPty calls killPty
+  // (→ this) before it re-registers, so a session that restarts into a
+  // home-rooted, SSH, shell-only or Codex state cannot INHERIT the stale
+  // registration (and stale cwd) from a prior local-Claude spawn — which would
+  // otherwise defeat the home-dir refusal and the "SSH never registers"
+  // invariant. Idempotent: a no-op when the session was never registered.
+  unregisterCodexReviewSession(sessionId)
 }
 
 // U8: grace before killing an SSH PTY so the in-band remote-cleanup command has

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -21,6 +21,7 @@ import { getProvider } from './providers'
 import { isSshCapable } from './providers/types'
 import type { TelemetrySource } from './providers/types'
 import { resolveCwd, isHomeOrAncestor } from './path-utils'
+import { buildTerminalLaunchLine } from './terminal-launch-line'
 import { dispatchSSHStatuslineUpdate, cleanupStatusFile } from './statusline-watcher'
 import { forgetSession } from './background-context'
 import { decorateStatuslineWithColour } from './account-color'
@@ -274,6 +275,10 @@ export function spawnPty(
     rows?: number
     ssh?: SSHOptions
     shellOnly?: boolean
+    /** Terminal-only launcher: command + args run once when the shell opens. */
+    terminalOptions?: { command?: string; args?: string; hasSecretArg?: boolean; elevated?: boolean }
+    /** Secret argument resolved from the OS keychain in the IPC handler (main only). */
+    terminalSecret?: string
     elevated?: boolean
     configLabel?: string
     /** Config id that owns the session. Stamped onto the session-log row for per-config filtering. */
@@ -1024,7 +1029,8 @@ export function spawnPty(
       cols,
       rows,
       shellOnly: options?.shellOnly,
-      elevated: options?.elevated,
+      elevated: options?.elevated ?? options?.terminalOptions?.elevated,
+      terminalSecret: options?.terminalSecret,
       legacyVersion: options?.legacyVersion,
       effortLevel: options?.effortLevel,
       disableAutoMemory: options?.disableAutoMemory,
@@ -1091,17 +1097,32 @@ export function spawnPty(
 
       // Explicitly cd to ensure the shell is in the right directory
       // (PowerShell profiles can change cwd before the user sees the prompt)
+      const isWin = os.platform() === 'win32'
       const escapedShellCwd = resolvedCwd.replace(/'/g, "''")
-      const cdCmd = os.platform() === 'win32'
+      const cdCmd = isWin
         ? `Set-Location '${escapedShellCwd}'`
         : `cd '${resolvedCwd.replace(/'/g, "'\\''")}' 2>/dev/null; clear`
+
+      // Terminal-only first-run command. `{secret}` becomes a REFERENCE to the
+      // CCC_ARG_SECRET env var (set from the keychain in buildClaudeLocalSpawn),
+      // never the secret itself — see terminal-launch-line.ts for the contract.
+      const launchLine = buildTerminalLaunchLine(options?.terminalOptions, isWin)
+
       setTimeout(() => {
         // Liveness guard: a kill / Restart / app-quit can land inside this 300ms
         // window — writing to a dead or already-replaced PTY here would throw
         // inside the timer (uncaught in main). Only write when our PTY is still
         // the registered one.
         if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) return
-        try { ptyProcess.write(cdCmd + '\r') } catch { /* session died mid-launch */ }
+        try {
+          ptyProcess.write(cdCmd + '\r')
+          // Queued straight after the cd: the shell runs them in order, so the
+          // command always starts in the configured directory.
+          if (launchLine) {
+            logInfo(`[pty-manager] shell-only first-run command for ${sessionId}: ${launchLine}`)
+            ptyProcess.write(launchLine + '\r')
+          }
+        } catch { /* session died mid-launch */ }
       }, 300)
     } else {
       // Launch Claude Code interactive mode.

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -646,12 +646,22 @@ export function spawnPty(
         }
       }, SETUP_TIMEOUT_MS)
       setTimeout(() => {
-        const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
-        const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
-          includeStatusLine: s?.statusLineEnabled !== false,
-          includeConductorMcp: s?.conductorToolsEnabled !== false,
-        })
-        ptyProcess.write(setupCmd + '\r')
+        // configureRemoteSettings → assertSafeRemotePath throws on a bad path.
+        // Catch it HERE: an uncaught throw in a setTimeout is re-thrown by the
+        // global handler and crashes main (adversarial review, #188). Fail the
+        // flow instead. The IPC schema already rejects bad paths up front; this
+        // is defence-in-depth for any path that reaches here.
+        try {
+          const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
+          const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
+            includeStatusLine: s?.statusLineEnabled !== false,
+            includeConductorMcp: s?.conductorToolsEnabled !== false,
+          })
+          ptyProcess.write(setupCmd + '\r')
+        } catch (err) {
+          logError(`[ssh] ${sessionId}: host setup failed: ${(err as Error)?.message ?? err}`)
+          setFlowState('failed', 'host setup error')
+        }
       }, 200)
     }
 
@@ -676,12 +686,19 @@ export function spawnPty(
         }
       }, SETUP_TIMEOUT_MS)
       setTimeout(() => {
-        const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
-        const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
-          includeStatusLine: s?.statusLineEnabled !== false,
-          includeConductorMcp: s?.conductorToolsEnabled !== false,
-        })
-        ptyProcess.write(setupCmd + '\r')
+        // See writeHostSetupCmd: a throw here would crash main via the global
+        // handler; fail the flow instead (adversarial review, #188).
+        try {
+          const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
+          const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
+            includeStatusLine: s?.statusLineEnabled !== false,
+            includeConductorMcp: s?.conductorToolsEnabled !== false,
+          })
+          ptyProcess.write(setupCmd + '\r')
+        } catch (err) {
+          logError(`[ssh] ${sessionId}: container setup failed: ${(err as Error)?.message ?? err}`)
+          setFlowState('failed', 'container setup error')
+        }
       }, 300)
     }
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1192,12 +1192,13 @@ export function spawnPty(
       // without a respawn), so the strip/card/statusline follow the new account.
       startWatchingAccountIdentity(sessionId, resolvedProfileId)
 
-      // P6: register for codex_review opt-in if the session config requested it.
-      // Only Claude sessions can opt in; Codex sessions never reach this branch
-      // (they go through the codex provider branch above).
-      if (options?.enableCodexReview) {
-        registerCodexReviewSession(sessionId, resolvedCwd)
-      }
+      // codex_review is authorised globally (2 Aug decision): every LOCAL Claude
+      // session registers. Availability is still governed at tool-registration
+      // time by the global Codex master + conductor tool toggles
+      // (conductor-mcp-server createServer), and SSH sessions never reach this
+      // branch, so the tool keeps running only against paths that exist on this
+      // machine. The per-config enableCodexReview flag is retired (ignored).
+      registerCodexReviewSession(sessionId, resolvedCwd)
 
       // Explicitly cd to the project directory, then launch Claude.
       // The cd is critical — it ensures Claude sees the correct project directory

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1198,7 +1198,21 @@ export function spawnPty(
       // (conductor-mcp-server createServer), and SSH sessions never reach this
       // branch, so the tool keeps running only against paths that exist on this
       // machine. The per-config enableCodexReview flag is retired (ignored).
-      registerCodexReviewSession(sessionId, resolvedCwd)
+      //
+      // SECURITY (adversarial review, #188): register the ACTUAL launch cwd
+      // (`claudeCwd`, post-resume-override) — not the pre-override `resolvedCwd`
+      // — and REFUSE to register when that cwd is the bare home directory. A
+      // config whose workingDirectory is '.', empty, or a stale/deleted path
+      // makes resolveCwd() silently fall back to os.homedir(); registering that
+      // would let a prompt-injected session review ~/.ssh, ~/.claude, ~/.aws via
+      // mode:'paths' (containment holds, but the ROOT is wrong). Since universal
+      // opt-in removed the per-config gate that used to bound this, block it at
+      // the source: no legitimate review targets the bare home dir.
+      if (claudeCwd === os.homedir()) {
+        logWarn(`[pty] codex_review NOT registered for ${sessionId}: launch cwd resolved to the home directory (workingDirectory is '.', empty, or a stale path). Set a real project directory to enable review.`)
+      } else {
+        registerCodexReviewSession(sessionId, claudeCwd)
+      }
 
       // Explicitly cd to the project directory, then launch Claude.
       // The cd is critical — it ensures Claude sees the correct project directory

--- a/src/main/terminal-launch-line.ts
+++ b/src/main/terminal-launch-line.ts
@@ -1,0 +1,38 @@
+/**
+ * Terminal-only launcher: build the line written into the shell after the `cd`.
+ *
+ * Pure + exported so the substitution rule is TESTED AGAINST THE REAL
+ * IMPLEMENTATION rather than a copy of it living in a test file.
+ *
+ * SECURITY CONTRACT: `{secret}` is replaced with a REFERENCE to the
+ * CCC_ARG_SECRET environment variable (set from the OS keychain in
+ * buildClaudeLocalSpawn) — never with the secret value. CCC writes this line
+ * into the PTY exactly as if the user had typed it, and shells persist
+ * submitted lines to disk (PSReadLine's ConsoleHost_history.txt on Windows),
+ * so a substituted plaintext secret would be written to disk forever.
+ */
+export interface TerminalLaunchOptions {
+  command?: string
+  args?: string
+  hasSecretArg?: boolean
+}
+
+/** Shell-appropriate reference to the secret env var. Quoted on POSIX so a
+ *  secret containing spaces or globs stays a single argument; PowerShell does
+ *  not word-split `$env:VAR`, so it needs no quoting. */
+export function secretRef(isWindows: boolean): string {
+  return isWindows ? '$env:CCC_ARG_SECRET' : '"$CCC_ARG_SECRET"'
+}
+
+/**
+ * Returns the command line to run, or '' when nothing should be run.
+ * With no secret stored, `{secret}` collapses to an empty string rather than
+ * leaving a dangling variable name the shell would expand to nothing anyway.
+ */
+export function buildTerminalLaunchLine(opts: TerminalLaunchOptions | undefined, isWindows: boolean): string {
+  const command = (opts?.command ?? '').trim()
+  if (!command) return ''
+  const ref = opts?.hasSecretArg ? secretRef(isWindows) : ''
+  const args = (opts?.args ?? '').replace(/\{secret\}/g, ref).trim()
+  return args ? `${command} ${args}` : command
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -806,7 +806,11 @@ export default function App() {
           <div className="flex-1 flex flex-col" style={{ minWidth: 0, minHeight: 0 }}>
             {sessions.map((session) => {
               const isShowingPartner = partnerActive.has(session.id)
-              const hasPartner = !!session.partnerTerminalPath
+              // Partner terminal is permanent for every config type (2 Aug):
+              // no per-config opt-in. It opens in the working directory for
+              // local sessions and at home for SSH (the working directory
+              // there is a remote path this PC can't resolve).
+              const hasPartner = true
               const partnerPtyId = session.id + '-partner'
               const isShowingWebview = !!webviewBySession[session.id]?.isOpen
               const isShowingExcalidraw = !!excalidrawBySession[session.id]?.isOpen
@@ -863,9 +867,8 @@ export default function App() {
                         key={partnerPtyId + '-' + session.createdAt}
                         sessionId={partnerPtyId}
                         configId={session.configId}
-                        cwd={session.partnerTerminalPath}
+                        cwd={session.sessionType === 'local' ? session.workingDirectory : undefined}
                         shellOnly={true}
-                        elevated={session.partnerElevated}
                         isActive={session.id === activeSessionId && view === 'sessions' && isShowingPartner && !altPaneShowing}
                       />
                     </div>
@@ -908,10 +911,10 @@ export default function App() {
             sessionId={activeSession.id}
             configId={activeSession.configId}
             sessionType={activeSession.sessionType === 'ssh' ? 'ssh' : 'local'}
-            partnerEnabled={!!activeSession.partnerTerminalPath}
+            partnerEnabled={true}
             isPartnerActive={partnerActive.has(activeSession.id)}
             onTogglePartner={() => togglePartner(activeSession.id)}
-            partnerSessionId={activeSession.partnerTerminalPath ? activeSession.id + '-partner' : undefined}
+            partnerSessionId={activeSession.id + '-partner'}
             parentSessionId={activeSession.id}
           />
         )}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -173,6 +173,9 @@ export default function App() {
   const [showHelpPanel, setShowHelpPanel] = useState(false)
   const [showTipModal, setShowTipModal] = useState(false)
   const [partnerActive, setPartnerActive] = useState<Set<string>>(new Set())
+  // Sessions whose partner terminal has been opened at least once — gates the
+  // lazy mount of the partner TerminalView (see togglePartner).
+  const [partnerEverActivated, setPartnerEverActivated] = useState<Set<string>>(new Set())
   const [showMachineNamePrompt, setShowMachineNamePrompt] = useState(false)
   const [machineNameInput, setMachineNameInput] = useState('')
   // Saved sessions awaiting the user's Resume / Don't-open choice (startup gate —
@@ -295,6 +298,13 @@ export default function App() {
       else next.add(sessionId)
       return next
     })
+    // Record first activation so the partner PTY mounts LAZILY. The partner
+    // terminal is available for every session (2 Aug decision), but eagerly
+    // mounting its TerminalView spawned a second PTY per session at creation —
+    // 2N PTYs whether or not the pane was ever opened (adversarial review,
+    // #188). Mount on first toggle instead, and keep it mounted afterwards so
+    // toggling back and forth costs nothing.
+    setPartnerEverActivated(prev => prev.has(sessionId) ? prev : new Set(prev).add(sessionId))
   }
 
   // Load config and hydrate stores after setup is complete
@@ -809,8 +819,10 @@ export default function App() {
               // Partner terminal is permanent for every config type (2 Aug):
               // no per-config opt-in. It opens in the working directory for
               // local sessions and at home for SSH (the working directory
-              // there is a remote path this PC can't resolve).
-              const hasPartner = true
+              // there is a remote path this PC can't resolve). Mounted LAZILY on
+              // first activation so its PTY isn't spawned for every session up
+              // front (adversarial review, #188); once opened it stays mounted.
+              const hasPartner = partnerEverActivated.has(session.id)
               const partnerPtyId = session.id + '-partner'
               const isShowingWebview = !!webviewBySession[session.id]?.isOpen
               const isShowingExcalidraw = !!excalidrawBySession[session.id]?.isOpen

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -547,6 +547,7 @@ export default function App() {
           legacyColor: saved.legacyColor,
           sessionType: saved.sessionType,
           shellOnly: saved.shellOnly,
+          terminalOptions: saved.terminalOptions,
           partnerTerminalPath: saved.partnerTerminalPath,
           partnerElevated: saved.partnerElevated,
           sshConfig: saved.sshConfig,
@@ -852,6 +853,8 @@ export default function App() {
                       configId={session.configId}
                       cwd={session.sessionType === 'local' ? session.workingDirectory : undefined}
                       shellOnly={session.shellOnly}
+                      elevated={session.terminalOptions?.elevated}
+                      terminalOptions={session.terminalOptions}
                       ssh={session.sshConfig}
                       isActive={session.id === activeSessionId && view === 'sessions' && !isShowingPartner && !altPaneShowing}
                       legacyVersion={session.legacyVersion}
@@ -1205,12 +1208,13 @@ export default function App() {
         {showGuidedConfig && (
           <SessionDialog
             onCancel={() => setShowGuidedConfig(false)}
-            onConfirm={async (data, password, sudoPassword) => {
+            onConfirm={async (data, password, sudoPassword, argSecret) => {
               const { generateId } = await import('./utils/id')
               const config = { ...data, id: generateId() }
               useConfigStore.getState().addConfig(config)
               if (password) await window.electronAPI.credentials.save(config.id, password)
               if (sudoPassword) await window.electronAPI.credentials.save(config.id + '_sudo', sudoPassword)
+              if (argSecret) await window.electronAPI.credentials.save(config.id + '_argsecret', argSecret)
               useAppMetaStore.getState().update({ hasCreatedFirstConfig: true })
               trackUsage('sessions.create-config')
               setShowGuidedConfig(false)

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -46,6 +46,9 @@ export const COLOR_SWATCHES = [
  *  arguments and secret argument) is the follow-up PR. */
 type UiProvider = 'claude' | 'codex' | 'terminal'
 
+/** The config's own effort union, derived so it can't drift from ClaudeOptions. */
+type EffortValue = NonNullable<NonNullable<TerminalConfig['claudeOptions']>['effortLevel']>
+
 /** Stronger consequence copy for the two modes that disable safety prompts.
  *  Falls back to the shared PERMISSION_MODES hint for everything else. */
 const DANGEROUS_MODE_COPY: Record<string, string> = {
@@ -111,7 +114,9 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   // silently upgraded Default → opus on every save; same family as the
   // effortLevel wipe).
   const [model, setModel] = useState(initial ? (initialClaude?.model ?? initial?.model ?? '') : 'opus')
-  const [effortLevel, setEffortLevel] = useState(initialClaude?.effortLevel ?? '')
+  // Typed against the config's own effort union (not widened to string) so the
+  // saved claudeOptions.effortLevel stays assignable — '' is the "Default" chip.
+  const [effortLevel, setEffortLevel] = useState<EffortValue | ''>(initialClaude?.effortLevel ?? '')
   const [permissionMode, setPermissionMode] = useState(initialClaude?.permissionMode ?? 'default')
   const [extraArgs, setExtraArgs] = useState(initialClaude?.extraArgs ?? '')
   const [loggingEnabled, setLoggingEnabled] = useState(initialClaude?.loggingEnabled !== false)

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -57,7 +57,10 @@ const DANGEROUS_MODE_COPY: Record<string, string> = {
 }
 
 interface Props {
-  onConfirm: (config: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string) => void
+  /** `argSecret` is the Terminal-only secret argument: handed to the caller so it
+   *  can be written to the OS keychain under `<configId>_argsecret`. It is never
+   *  part of the config object and never persisted to the config file. */
+  onConfirm: (config: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string, argSecret?: string) => void
   onCancel: () => void
   initial?: Partial<TerminalConfig>
 }
@@ -120,6 +123,13 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const [permissionMode, setPermissionMode] = useState(initialClaude?.permissionMode ?? 'default')
   const [extraArgs, setExtraArgs] = useState(initialClaude?.extraArgs ?? '')
   const [loggingEnabled, setLoggingEnabled] = useState(initialClaude?.loggingEnabled !== false)
+
+  // ── Terminal-only startup
+  const [termCommand, setTermCommand] = useState(initial?.terminalOptions?.command ?? '')
+  const [termArgs, setTermArgs] = useState(initial?.terminalOptions?.args ?? '')
+  const [termElevated, setTermElevated] = useState(initial?.terminalOptions?.elevated ?? false)
+  const [secretArg, setSecretArg] = useState('')
+  const [storedSecret, setStoredSecret] = useState(initial?.terminalOptions?.hasSecretArg ?? false)
 
   // ── Session startup (Codex)
   const [codexModel, setCodexModel] = useState(initial?.codexOptions?.model ?? 'gpt-5.5')
@@ -288,6 +298,21 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       loggingEnabled: !loggingEnabled ? false : undefined,
     } : initial?.claudeOptions
 
+    // Terminal-only options. Local only: over SSH the startup command IS the
+    // post-connect command, so we never write a second one here.
+    const isTerminalLocal = uiProvider === 'terminal' && sessionType === 'local'
+    const secretSaved = isTerminalLocal && (secretArg.length > 0 || storedSecret)
+    const terminalOptions = isTerminalLocal
+      ? (termCommand.trim() || termArgs.trim() || secretSaved || termElevated
+          ? {
+              command: termCommand.trim() || undefined,
+              args: termArgs.trim() || undefined,
+              hasSecretArg: secretSaved || undefined,
+              elevated: termElevated || undefined,
+            }
+          : undefined)
+      : initial?.terminalOptions
+
     const codexOptions: CodexOptions | undefined = uiProvider === 'codex' ? {
       model: codexModel,
       reasoningEffort: codexEffort,
@@ -327,6 +352,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       color: resolveIdentityColor(colorKey, 'dark'),  // back-compat shadow; render prefers the key
       sessionType,
       shellOnly,
+      terminalOptions,
       groupId,
       sectionId: groupId ? undefined : sectionId,
       sshConfig: sessionType === 'ssh' ? {
@@ -362,6 +388,9 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     if (initial?.id) {
       if (!passwordSaved) void window.electronAPI.credentials.delete(initial.id)
       if (!sudoSaved) void window.electronAPI.credentials.delete(initial.id + '_sudo')
+      // Same rule for the Terminal-only secret: switching the config away from a
+      // local terminal, or clearing the secret, must not strand it in the keychain.
+      if (!secretSaved) void window.electronAPI.credentials.delete(initial.id + '_argsecret')
     }
 
     onConfirm(
@@ -371,7 +400,8 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       // old dialog stored it regardless — so a password typed into an SSH block
       // that was then switched to Local was persisted for a config with no SSH.
       passwordSaved && sshPassword.length > 0 ? sshPassword : undefined,
-      sudoSaved && sudoPassword.length > 0 ? sudoPassword : undefined
+      sudoSaved && sudoPassword.length > 0 ? sudoPassword : undefined,
+      secretSaved && secretArg.length > 0 ? secretArg : undefined,
     )
   }
 
@@ -514,6 +544,15 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                       Browse
                     </button>
                   </div>
+                  {/* Grandfathered bad value: an existing config keeps saving (we only
+                      block a CHANGED non-absolute path), but say what it actually does
+                      — '.' and friends resolve to the home folder at spawn, which is
+                      what mis-filed transcripts before. */}
+                  {workingDir.trim() && !looksAbsolute(workingDir) && (
+                    <p className="text-[11px] text-yellow mt-1.5">
+                      Not a full path — sessions will start in your home folder. Pick a real project folder.
+                    </p>
+                  )}
                 </div>
               ) : (
                 <div className="space-y-3 mt-1">
@@ -806,6 +845,84 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                 </>
               )}
 
+              {uiProvider === 'terminal' && sessionType === 'local' && (
+                <>
+                  {sectionHead('Terminal startup', 'Terminal only', 'termstart', 'About terminal startup')}
+                  <Hint k="termstart">
+                    No AI here — just a terminal. Anything below runs automatically each time you open this
+                    launcher, so it can start a long-running tool for you.
+                  </Hint>
+                  <div className="space-y-3 mt-1">
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">First-run command</label>
+                        <HelpBtn k="termcmd" label="About the first-run command" />
+                      </div>
+                      <input
+                        value={termCommand}
+                        onChange={(e) => setTermCommand(e.target.value)}
+                        placeholder="npm run dev"
+                        spellCheck={false}
+                        className={inputCls + ' font-mono text-xs'}
+                      />
+                      <Hint k="termcmd">Runs once when the terminal opens. Leave empty for a plain shell.</Hint>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Arguments</label>
+                        <HelpBtn k="termargs" label="About arguments" />
+                      </div>
+                      <input
+                        value={termArgs}
+                        onChange={(e) => setTermArgs(e.target.value)}
+                        placeholder={'--port 4310 --token {secret}'}
+                        spellCheck={false}
+                        className={inputCls + ' font-mono text-xs'}
+                      />
+                      <Hint k="termargs">
+                        Appended to the command above. Saved as plain text in your config file — put tokens and
+                        keys in Secret argument instead.
+                      </Hint>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">Secret argument</label>
+                      <input
+                        type="password"
+                        value={secretArg}
+                        onChange={(e) => setSecretArg(e.target.value)}
+                        placeholder={storedSecret ? '(saved — enter new to change)' : 'Leave empty if not needed'}
+                        className={inputCls}
+                      />
+                      <div className="flex items-center gap-3 mt-1.5">
+                        <p className="text-[11px] text-overlay0">
+                          <span className="text-green">🔒</span> Kept in your OS keychain, never written to the
+                          config file. Type <span className="font-mono text-subtext0">{'{secret}'}</span> in
+                          Arguments to use it.
+                        </p>
+                        {storedSecret && (
+                          <button
+                            type="button"
+                            onClick={() => { setStoredSecret(false); setSecretArg('') }}
+                            className="text-[11px] text-blue underline underline-offset-2 shrink-0"
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    <label className="flex items-center gap-2 text-sm text-subtext0 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={termElevated}
+                        onChange={(e) => setTermElevated(e.target.checked)}
+                        className="rounded border-surface1"
+                      />
+                      {`Run as Administrator (requires ${window.electronPlatform === 'win32' ? 'gsudo' : 'sudo'})`}
+                    </label>
+                  </div>
+                </>
+              )}
+
               {uiProvider === 'terminal' && sessionType === 'ssh' && (
                 <>
                   {sectionHead('Terminal startup', 'Terminal only')}
@@ -816,11 +933,16 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
               )}
 
               {/* ── 4 · ORGANISE (collapsed until needed) ── */}
-              <details className="border-t border-surface1 pt-3 mt-4" open={isEdit && (!!groupId || !!sectionId)}>
-                <summary className="flex items-center gap-2 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
-                  <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Organise</span>
-                  <span className="text-[9px] uppercase tracking-wide text-overlay0 border border-surface2 rounded-full px-1.5 py-px">Optional</span>
-                  <span className="text-[10px] text-overlay0 ml-auto">▸</span>
+              {/* The only expandable section. It must NOT dress its trigger in the
+                  same pill the static scope chips use ("Any provider", "Terminal
+                  only") — that made a clickable row look identical to decoration.
+                  A leading chevron that rotates when open, a hover state and a
+                  plain "(optional)" read as a control instead. */}
+              <details className="group border-t border-surface1 pt-3 mt-4" open={isEdit && (!!groupId || !!sectionId)}>
+                <summary className="flex items-center gap-2 cursor-pointer select-none list-none rounded px-1 -mx-1 py-1 hover:bg-surface1/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue [&::-webkit-details-marker]:hidden">
+                  <span className="text-[10px] text-overlay1 transition-transform group-open:rotate-90">▶</span>
+                  <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium group-hover:text-subtext0">Organise</span>
+                  <span className="text-[11px] text-overlay0 normal-case">(optional — group &amp; section)</span>
                 </summary>
                 <p className="text-[11px] text-overlay0 mt-2">Optional — only tidies the sidebar.</p>
                 <div className="grid grid-cols-2 gap-2 mt-2">

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -91,12 +91,19 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   // Secrets: `stored*` tracks whether the keychain currently holds one (the
   // "Remove stored password" link clears it); `save*` is the honest opt-in —
   // a typed password is only handed to the caller for storage when it's on.
+  // savePassword defaults to true so a freshly-typed password is saved by
+  // default. It must NOT default to `hasPassword ?? true`: after this PR every
+  // key-auth SSH config persists hasPassword:false, and `false ?? true` is
+  // false — which rendered the checkbox unticked, silently dropping a password
+  // the user typed into an existing key-auth config (adversarial review, #188).
+  // The checkbox only renders (and only matters) once there IS a password to
+  // save, so a plain `true` is safe for stored-secret and key-auth cases alike.
   const [sshPassword, setSshPassword] = useState('')
   const [storedPassword, setStoredPassword] = useState(initial?.sshConfig?.hasPassword ?? false)
-  const [savePassword, setSavePassword] = useState(initial?.sshConfig?.hasPassword ?? true)
+  const [savePassword, setSavePassword] = useState(true)
   const [sudoPassword, setSudoPassword] = useState('')
   const [storedSudo, setStoredSudo] = useState(initial?.sshConfig?.hasSudoPassword ?? false)
-  const [saveSudo, setSaveSudo] = useState(initial?.sshConfig?.hasSudoPassword ?? true)
+  const [saveSudo, setSaveSudo] = useState(true)
 
   // ── Session startup (Claude Code)
   // Edit must not rewrite what's stored: a config saved with no model override
@@ -209,21 +216,28 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     setShowNewGroup(false)
   }
 
-  // The footer's validation slot: names the next step instead of letting Save
-  // silently no-op (the old dialog's worst habit).
-  const validationMsg = !uiProvider
-    ? 'Choose what this launcher runs'
-    : !sessionType
-      ? 'Choose where it runs'
-      : !label.trim() && !(sessionType === 'local' && !workingDir.trim()) && !(sessionType === 'ssh' && !sshHost.trim())
-        ? 'Add a label to save'
-        : sessionType === 'local' && !workingDir.trim()
-          ? 'Add a working directory to save'
-          : sessionType === 'ssh' && !sshHost.trim()
-            ? 'Add a host to save'
-            : !label.trim()
-              ? 'Add a label to save'
-              : ''
+  // A working directory must be ABSOLUTE. Rejecting '.', './x', '../x' and bare
+  // relative paths closes the transcript-misfiling incident at the source (the
+  // old '.' fallback), which client validation only half-fixed: an empty field
+  // was blocked but '.' still saved (adversarial review, #188). Accepts a
+  // Windows drive path, a UNC path, a POSIX absolute path, or a ~ home path.
+  const looksAbsolute = (p: string) => /^([a-zA-Z]:[\\/]|\\\\|\/|~)/.test(p.trim())
+
+  // The footer's validation slot: names the next step in a fixed order instead
+  // of letting Save silently no-op (the old dialog's worst habit).
+  const validationMsg = (() => {
+    if (!uiProvider) return 'Choose what this launcher runs'
+    if (!sessionType) return 'Choose where it runs'
+    // A hand-edited or migrated config can carry the Codex×SSH combination the
+    // cards forbid; the disabled cards don't constrain saved state, so guard it
+    // here or the config saves and then hard-throws at spawn.
+    if (uiProvider === 'codex' && sessionType === 'ssh') return "Codex can't run over SSH — pick Claude Code or Terminal only"
+    if (sessionType === 'local' && !workingDir.trim()) return 'Add a working directory to save'
+    if (sessionType === 'local' && !looksAbsolute(workingDir)) return 'Working directory must be a full path (e.g. C:\\projects\\app)'
+    if (sessionType === 'ssh' && !sshHost.trim()) return 'Add a host to save'
+    if (!label.trim()) return 'Add a label to save'
+    return ''
+  })()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -256,8 +270,17 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       permissionsPreset: codexPreset,
     } : undefined
 
-    const passwordSaved = savePassword && (sshPassword.length > 0 || storedPassword)
-    const sudoSaved = saveSudo && (sudoPassword.length > 0 || storedSudo)
+    // SECURITY (adversarial review, #188): every credential decision is gated on
+    // the FINAL sessionType. Without this, switching an SSH config to Local (or
+    // to Terminal-only) drops the SSH block from the UI but leaves savePassword/
+    // storedPassword state untouched — so the config saved with no sshConfig
+    // while its keychain secret survived orphaned, later auto-typed at a
+    // different host. sudo additionally requires a post-connect command: clearing
+    // that command must strand nothing. When these are false and the config
+    // previously had a stored secret, the delete block below removes it.
+    const isSsh = sessionType === 'ssh'
+    const passwordSaved = isSsh && savePassword && (sshPassword.length > 0 || storedPassword)
+    const sudoSaved = isSsh && postCommand.trim().length > 0 && saveSudo && (sudoPassword.length > 0 || storedSudo)
 
     const config: Omit<TerminalConfig, 'id'> = {
       provider,
@@ -305,10 +328,12 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
 
     onConfirm(
       config,
-      // Honest save: a typed password reaches the keychain ONLY with the
-      // checkbox on (the old dialog stored it regardless).
-      savePassword && sshPassword.length > 0 ? sshPassword : undefined,
-      saveSudo && sudoPassword.length > 0 ? sudoPassword : undefined
+      // Honest save, gated on the final sessionType: a typed password reaches the
+      // keychain ONLY when this is still an SSH config AND the checkbox is on. The
+      // old dialog stored it regardless — so a password typed into an SSH block
+      // that was then switched to Local was persisted for a config with no SSH.
+      passwordSaved && sshPassword.length > 0 ? sshPassword : undefined,
+      sudoSaved && sudoPassword.length > 0 ? sudoPassword : undefined
     )
   }
 

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -948,10 +948,11 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                 <div className="grid grid-cols-2 gap-2 mt-2">
                   <div>
                     <div className="flex items-center gap-1.5 mb-1">
-                      <label className="text-xs text-subtext0">Group</label>
+                      <label className="text-xs text-subtext0" htmlFor="ccc-group">Group</label>
                       <HelpBtn k="group" label="About groups" />
                     </div>
                     <select
+                      id="ccc-group"
                       value={showNewGroup ? '__new__' : (groupId || '')}
                       onChange={(e) => handleGroupChange(e.target.value)}
                       className={inputCls}
@@ -985,10 +986,11 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                   </div>
                   <div>
                     <div className="flex items-center gap-1.5 mb-1">
-                      <label className="text-xs text-subtext0">Section</label>
+                      <label className="text-xs text-subtext0" htmlFor="ccc-section">Section</label>
                       <HelpBtn k="section" label="About sections" />
                     </div>
                     <select
+                      id="ccc-section"
                       value={showNewSection ? '__new__' : (sectionId || '')}
                       onChange={(e) => handleSectionChange(e.target.value)}
                       disabled={!!groupId}

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -216,12 +216,24 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     setShowNewGroup(false)
   }
 
-  // A working directory must be ABSOLUTE. Rejecting '.', './x', '../x' and bare
-  // relative paths closes the transcript-misfiling incident at the source (the
-  // old '.' fallback), which client validation only half-fixed: an empty field
-  // was blocked but '.' still saved (adversarial review, #188). Accepts a
-  // Windows drive path, a UNC path, a POSIX absolute path, or a ~ home path.
-  const looksAbsolute = (p: string) => /^([a-zA-Z]:[\\/]|\\\\|\/|~)/.test(p.trim())
+  // A working directory must be ABSOLUTE, platform-appropriately. Rejecting '.',
+  // relative paths, and shape-only lookalikes (`~evil`, `/etc` on Windows) closes
+  // the transcript-misfiling incident at the source: a non-absolute path silently
+  // resolves to $HOME at spawn, which client validation only half-fixed before
+  // (empty was blocked, '.' and friends still saved — adversarial review, #188).
+  const looksAbsolute = (raw: string) => {
+    const p = raw.trim()
+    // Home-relative: only a bare ~ or ~/ ~\ prefix (NOT ~evil).
+    if (p === '~' || p.startsWith('~/') || p.startsWith('~\\')) return true
+    if (window.electronPlatform === 'win32') {
+      return /^([a-zA-Z]:[\\/]|\\\\|\/\/)/.test(p)  // drive path or UNC (either slash)
+    }
+    return p.startsWith('/')  // POSIX absolute
+  }
+  // Mirror ssh-shim.ts SAFE_REMOTE_PATH_RE: main THROWS on a bad remote path
+  // (inside a setTimeout → crashes the main process), so a freely-typed space or
+  // shell char must be caught here, not just at spawn (adversarial review, #188).
+  const safeRemotePath = (p: string) => /^[~A-Za-z0-9_./-]+$/.test(p)
 
   // The footer's validation slot: names the next step in a fixed order instead
   // of letting Save silently no-op (the old dialog's worst habit).
@@ -235,6 +247,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     if (sessionType === 'local' && !workingDir.trim()) return 'Add a working directory to save'
     if (sessionType === 'local' && !looksAbsolute(workingDir)) return 'Working directory must be a full path (e.g. C:\\projects\\app)'
     if (sessionType === 'ssh' && !sshHost.trim()) return 'Add a host to save'
+    if (sessionType === 'ssh' && sshRemotePath.trim() && !safeRemotePath(sshRemotePath.trim())) return 'Remote directory can only use letters, numbers and _ . / - ~'
     if (!label.trim()) return 'Add a label to save'
     return ''
   })()
@@ -278,9 +291,16 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     // different host. sudo additionally requires a post-connect command: clearing
     // that command must strand nothing. When these are false and the config
     // previously had a stored secret, the delete block below removes it.
+    // A stored secret is host-specific: if the user repoints an SSH config at a
+    // DIFFERENT host without retyping, the old password must NOT carry to the new
+    // machine (adversarial review, #188). Treat the stored value as absent in
+    // that case, so it is deleted below and re-entry is required.
     const isSsh = sessionType === 'ssh'
-    const passwordSaved = isSsh && savePassword && (sshPassword.length > 0 || storedPassword)
-    const sudoSaved = isSsh && postCommand.trim().length > 0 && saveSudo && (sudoPassword.length > 0 || storedSudo)
+    const hostChanged = isSsh && !!initial?.sshConfig && initial.sshConfig.host !== sshHost.trim()
+    const keepStoredPw = storedPassword && !hostChanged
+    const keepStoredSudo = storedSudo && !hostChanged
+    const passwordSaved = isSsh && savePassword && (sshPassword.length > 0 || keepStoredPw)
+    const sudoSaved = isSsh && postCommand.trim().length > 0 && saveSudo && (sudoPassword.length > 0 || keepStoredSudo)
 
     const config: Omit<TerminalConfig, 'id'> = {
       provider,
@@ -315,15 +335,16 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       // configs are simply ignored by the app.
     }
 
-    // "Remove stored password" clicked (edit mode only): clear the keychain
-    // entry the moment the change is confirmed, never before.
+    // On edit, delete any keychain entry we are NOT (re)saving. Gated only on
+    // "not saving", NOT on the config's hasPassword flag: the flag can lie
+    // (a config the old dialog left in the divergent state has hasPassword:false
+    // with a live secret), and credentials.delete is idempotent, so an
+    // unconditional delete-when-not-saving both removes intentional "Remove
+    // stored password" entries AND sweeps pre-existing orphans (adversarial
+    // review, #188). Runs on confirm, never before.
     if (initial?.id) {
-      if (!passwordSaved && (initial?.sshConfig?.hasPassword ?? false)) {
-        void window.electronAPI.credentials.delete(initial.id)
-      }
-      if (!sudoSaved && (initial?.sshConfig?.hasSudoPassword ?? false)) {
-        void window.electronAPI.credentials.delete(initial.id + '_sudo')
-      }
+      if (!passwordSaved) void window.electronAPI.credentials.delete(initial.id)
+      if (!sudoSaved) void window.electronAPI.credentials.delete(initial.id + '_sudo')
     }
 
     onConfirm(

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -1,13 +1,11 @@
-import React, { useState, useEffect } from 'react'
-import { TerminalConfig, ConfigGroup, ConfigSection, ProviderId, CodexOptions, useConfigStore } from '../stores/configStore'
-import { useAgentLibraryStore, BUILTIN_TEMPLATES } from '../stores/agentLibraryStore'
-import { ProviderSegmentedControl } from './SessionDialog/ProviderSegmentedControl'
+import React, { useState } from 'react'
+import { TerminalConfig, ProviderId, CodexOptions, useConfigStore } from '../stores/configStore'
 import { CodexFormFields } from './SessionDialog/CodexFormFields'
 import { IDENTITY_COLOR_KEYS, resolveIdentityColor, bucketLegacyColorToKey, type IdentityColorKey } from '../../shared/identity-colors'
 import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegistryStore } from '../stores/registryStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { modelsFromRegistry, PERMISSION_MODES } from '../lib/claude-cli-options'
+import { modelsFromRegistry, effortsFromRegistry, PERMISSION_MODES } from '../lib/claude-cli-options'
 import { generateId } from '../utils/id'
 
 export type SessionType = 'local' | 'ssh'
@@ -41,6 +39,20 @@ export const COLOR_SWATCHES = [
   '#FF1493', '#00FA9A', '#FFD700', '#FF4500',
 ]
 
+/** What the provider cards offer. 'terminal' is a UI-level provider that maps to
+ *  the stored shape `provider: 'claude', shellOnly: true` — the same shape the
+ *  old "Shell only" tickbox produced, so no config migration and no IPC/enum
+ *  widening is needed. A real `provider: 'terminal'` (with first-run command,
+ *  arguments and secret argument) is the follow-up PR. */
+type UiProvider = 'claude' | 'codex' | 'terminal'
+
+/** Stronger consequence copy for the two modes that disable safety prompts.
+ *  Falls back to the shared PERMISSION_MODES hint for everything else. */
+const DANGEROUS_MODE_COPY: Record<string, string> = {
+  bypassPermissions: 'Skips every permission prompt, including file writes and shell commands. Only use this in a folder you could throw away.',
+  dontAsk: "Accepts everything without asking. Same risk as Bypass for anything inside the working directory.",
+}
+
 interface Props {
   onConfirm: (config: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string) => void
   onCancel: () => void
@@ -53,143 +65,101 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const sections = useConfigStore((s) => s.sections)
   const addSection = useConfigStore((s) => s.addSection)
   const registry = useRegistryStore((s) => s.registry)
-  // Read legacy + claudeOptions fields with claudeOptions taking precedence (P1.4 migration)
+  const theme = useResolvedTheme()
   const initialClaude = initial?.claudeOptions
-  const [provider, setProvider] = useState<ProviderId>(initial?.provider ?? 'claude')
+  const isEdit = !!initial
+
+  // Codex master ("Do you use Codex?"): with it off, Codex configs can't launch,
+  // so the card renders disabled with a pointer to Settings → Codex.
+  const codexDisabled = useSettingsStore((s) => s.settings.codexEnabled === false)
+
+  // ── The two driving choices. A NEW config starts with neither chosen and the
+  // dialog reveals itself as they're answered; EDIT opens fully revealed.
+  const [uiProvider, setUiProvider] = useState<UiProvider | null>(
+    initial ? (initial.shellOnly ? 'terminal' : (initial.provider ?? 'claude')) : null
+  )
+  const [sessionType, setSessionType] = useState<SessionType | null>(initial ? (initial.sessionType ?? 'local') : null)
+
+  // ── Workspace
+  const [workingDir, setWorkingDir] = useState(initial?.workingDirectory ?? '')
+  const [sshHost, setSshHost] = useState(initial?.sshConfig?.host ?? '')
+  const [sshPort, setSshPort] = useState(initial?.sshConfig?.port ?? 22)
+  const [sshUser, setSshUser] = useState(initial?.sshConfig?.username ?? '')
+  const [sshRemotePath, setSshRemotePath] = useState(initial?.sshConfig?.remotePath ?? '~')
+  const [machineName, setMachineName] = useState(initial?.machineName ?? '')
+  const [postCommand, setPostCommand] = useState(initial?.sshConfig?.postCommand ?? '')
+  // Secrets: `stored*` tracks whether the keychain currently holds one (the
+  // "Remove stored password" link clears it); `save*` is the honest opt-in —
+  // a typed password is only handed to the caller for storage when it's on.
+  const [sshPassword, setSshPassword] = useState('')
+  const [storedPassword, setStoredPassword] = useState(initial?.sshConfig?.hasPassword ?? false)
+  const [savePassword, setSavePassword] = useState(initial?.sshConfig?.hasPassword ?? true)
+  const [sudoPassword, setSudoPassword] = useState('')
+  const [storedSudo, setStoredSudo] = useState(initial?.sshConfig?.hasSudoPassword ?? false)
+  const [saveSudo, setSaveSudo] = useState(initial?.sshConfig?.hasSudoPassword ?? true)
+
+  // ── Session startup (Claude Code)
+  // Edit must not rewrite what's stored: a config saved with no model override
+  // reopens as "Default", not the new-config 'opus' default (the old dialog
+  // silently upgraded Default → opus on every save; same family as the
+  // effortLevel wipe).
+  const [model, setModel] = useState(initial ? (initialClaude?.model ?? initial?.model ?? '') : 'opus')
+  const [effortLevel, setEffortLevel] = useState(initialClaude?.effortLevel ?? '')
+  const [permissionMode, setPermissionMode] = useState(initialClaude?.permissionMode ?? 'default')
+  const [extraArgs, setExtraArgs] = useState(initialClaude?.extraArgs ?? '')
+  const [loggingEnabled, setLoggingEnabled] = useState(initialClaude?.loggingEnabled !== false)
+
+  // ── Session startup (Codex)
   const [codexModel, setCodexModel] = useState(initial?.codexOptions?.model ?? 'gpt-5.5')
   const [codexEffort, setCodexEffort] = useState<NonNullable<CodexOptions['reasoningEffort']>>(initial?.codexOptions?.reasoningEffort ?? 'medium')
   const [codexPreset, setCodexPreset] = useState<CodexOptions['permissionsPreset']>(initial?.codexOptions?.permissionsPreset ?? 'standard')
-  const [label, setLabel] = useState(initial?.label ?? '')
-  const [workingDir, setWorkingDir] = useState(initial?.workingDirectory ?? '')
-  // v1.5.11: default to the `opus` alias so new sessions land on Opus 4.8
-  // (the latest Opus family member, as of 2026-05-28). The alias resolves
-  // to whichever Opus version Claude Code currently ships, so this
-  // doesn't go stale when Anthropic releases the next one.
-  const [model, setModel] = useState(initialClaude?.model ?? initial?.model ?? 'opus')
-  // Per-config Claude permission mode ('default' => no --permission-mode flag) and
-  // an advanced free-text escape hatch for extra CLI args.
-  const [permissionMode, setPermissionMode] = useState(initialClaude?.permissionMode ?? 'default')
-  const [extraArgs, setExtraArgs] = useState(initialClaude?.extraArgs ?? '')
-  const [colorKey, setColorKey] = useState<IdentityColorKey>(
-    (initial?.identityColorKey as IdentityColorKey) ?? bucketLegacyColorToKey(initial?.color ?? '')
-  )
-  const theme = useResolvedTheme()
-  const [sessionType, setSessionType] = useState<SessionType>(initial?.sessionType ?? 'local')
-  // Codex master ("Do you use Codex?"): with it off the conductor server never
-  // registers codex_review, so the review checkbox below would be a dead control.
-  const codexDisabled = useSettingsStore((s) => s.settings.codexEnabled === false)
-  const [shellOnly, setShellOnly] = useState(initial?.shellOnly ?? false)
+
+  // ── Organise
   const [groupId, setGroupId] = useState<string | undefined>(initial?.groupId)
   const [newGroupName, setNewGroupName] = useState('')
   const [showNewGroup, setShowNewGroup] = useState(false)
   const [sectionId, setSectionId] = useState<string | undefined>(initial?.sectionId)
   const [newSectionName, setNewSectionName] = useState('')
   const [showNewSection, setShowNewSection] = useState(false)
-  const [partnerTerminalPath, setPartnerTerminalPath] = useState(initial?.partnerTerminalPath ?? '')
-  const [partnerElevated, setPartnerElevated] = useState(initial?.partnerElevated ?? false)
 
-  // SSH fields
-  const [sshHost, setSshHost] = useState(initial?.sshConfig?.host ?? '')
-  const [sshPort, setSshPort] = useState(initial?.sshConfig?.port ?? 22)
-  const [sshUser, setSshUser] = useState(initial?.sshConfig?.username ?? '')
-  const [sshRemotePath, setSshRemotePath] = useState(initial?.sshConfig?.remotePath ?? '~')
-  const [sshPassword, setSshPassword] = useState('')
-  const [savePassword, setSavePassword] = useState(initial?.sshConfig?.hasPassword ?? false)
-  const [postCommand, setPostCommand] = useState(initial?.sshConfig?.postCommand ?? '')
-  const [sudoPassword, setSudoPassword] = useState('')
-  const [saveSudoPassword, setSaveSudoPassword] = useState(initial?.sshConfig?.hasSudoPassword ?? false)
+  // ── Identity
+  const [label, setLabel] = useState(initial?.label ?? '')
+  const [colorKey, setColorKey] = useState<IdentityColorKey>(
+    (initial?.identityColorKey as IdentityColorKey) ?? bucketLegacyColorToKey(initial?.color ?? '')
+  )
 
-  // Legacy version fields
-  const [legacyEnabled, setLegacyEnabled] = useState((initialClaude?.legacyVersion ?? initial?.legacyVersion)?.enabled ?? false)
-  const [legacyVersion, setLegacyVersion] = useState((initialClaude?.legacyVersion ?? initial?.legacyVersion)?.version ?? '')
-  const [availableVersions, setAvailableVersions] = useState<string[]>([])
-  const [loadingVersions, setLoadingVersions] = useState(false)
-  const [versionInstalled, setVersionInstalled] = useState(false)
-  const [installing, setInstalling] = useState(false)
-  const [installError, setInstallError] = useState('')
-
-  // Agent fields
-  const agentUserTemplates = useAgentLibraryStore(s => s.templates)
-  const allAgentTemplates = [...agentUserTemplates, ...BUILTIN_TEMPLATES]
-  const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(new Set(initialClaude?.agentIds ?? initial?.agentIds ?? []))
-  const [disableAutoMemory, setDisableAutoMemory] = useState(initialClaude?.disableAutoMemory ?? initial?.disableAutoMemory ?? false)
-  const [enableCodexReview, setEnableCodexReview] = useState(initialClaude?.enableCodexReview ?? false)
-  // T16: per-session indexing toggle. DEFAULT-TRUE: undefined / true → checked.
-  // Storing only false avoids writing an explicit true to every new config.
-  const [loggingEnabled, setLoggingEnabled] = useState(initialClaude?.loggingEnabled !== false)
-  const [machineName, setMachineName] = useState(initial?.machineName ?? '')
-
-  // Fetch available versions when legacy checkbox enabled
-  useEffect(() => {
-    if (!legacyEnabled) return
-    let cancelled = false
-    setLoadingVersions(true)
-    window.electronAPI.legacyVersion.fetchVersions()
-      .then((versions) => {
-        if (cancelled) return
-        setAvailableVersions(versions)
-        if (!legacyVersion && versions.length > 0) {
-          setLegacyVersion(versions[0])
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setAvailableVersions([])
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingVersions(false)
-      })
-    return () => { cancelled = true }
-  }, [legacyEnabled])
-
-  // Check install status when version changes
-  useEffect(() => {
-    if (!legacyEnabled || !legacyVersion) {
-      setVersionInstalled(false)
-      return
-    }
-    window.electronAPI.legacyVersion.isInstalled(legacyVersion)
-      .then(setVersionInstalled)
-      .catch(() => setVersionInstalled(false))
-  }, [legacyEnabled, legacyVersion])
-
-  // Listen for install progress
-  useEffect(() => {
-    if (!installing) return
-    const unsub = window.electronAPI.legacyVersion.onInstallProgress((data) => {
-      // Progress is displayed via the installing state; we just need to know when done
+  // ── Progressive help: every longer explanation lives behind a small "?" so
+  // the default view is short labels only.
+  const [openHelp, setOpenHelp] = useState<Set<string>>(new Set())
+  const toggleHelp = (key: string) => {
+    setOpenHelp((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
     })
-    return unsub
-  }, [installing])
-
-  // Codex is not yet available over SSH -- if user flips sessionType to ssh while
-  // codex is selected, fall back to claude so the form remains usable.
-  useEffect(() => {
-    if (sessionType === 'ssh' && provider === 'codex') {
-      setProvider('claude')
-    }
-  }, [sessionType, provider])
-
-  const handleInstallVersion = async () => {
-    if (!legacyVersion) return
-    setInstalling(true)
-    setInstallError('')
-    const result = await window.electronAPI.legacyVersion.install(legacyVersion)
-    setInstalling(false)
-    if (result.ok) {
-      setVersionInstalled(true)
-    } else {
-      setInstallError(result.error || 'Install failed')
-    }
   }
+  const HelpBtn = ({ k, label: aria }: { k: string; label: string }) => (
+    <button
+      type="button"
+      aria-label={aria}
+      aria-expanded={openHelp.has(k)}
+      onClick={() => toggleHelp(k)}
+      className={`inline-flex items-center justify-center w-4 h-4 rounded-full border text-[10px] font-semibold leading-none shrink-0 transition-colors ${
+        openHelp.has(k) ? 'border-blue text-blue bg-blue/10' : 'border-surface2 text-overlay0 hover:text-subtext0 hover:border-overlay0'
+      }`}
+    >
+      ?
+    </button>
+  )
+  const Hint = ({ k, children }: { k: string; children: React.ReactNode }) =>
+    openHelp.has(k) ? <p className="text-[11px] text-overlay0 mt-1 leading-snug">{children}</p> : null
+
+  const bothChosen = uiProvider !== null && sessionType !== null
 
   const handleBrowse = async () => {
     const path = await window.electronAPI.dialog.openFolder()
     if (path) setWorkingDir(path)
-  }
-
-  const handleBrowsePartner = async () => {
-    const path = await window.electronAPI.dialog.openFolder()
-    if (path) setPartnerTerminalPath(path)
   }
 
   const handleGroupChange = (value: string) => {
@@ -239,42 +209,55 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     setShowNewGroup(false)
   }
 
+  // The footer's validation slot: names the next step instead of letting Save
+  // silently no-op (the old dialog's worst habit).
+  const validationMsg = !uiProvider
+    ? 'Choose what this launcher runs'
+    : !sessionType
+      ? 'Choose where it runs'
+      : !label.trim() && !(sessionType === 'local' && !workingDir.trim()) && !(sessionType === 'ssh' && !sshHost.trim())
+        ? 'Add a label to save'
+        : sessionType === 'local' && !workingDir.trim()
+          ? 'Add a working directory to save'
+          : sessionType === 'ssh' && !sshHost.trim()
+            ? 'Add a host to save'
+            : !label.trim()
+              ? 'Add a label to save'
+              : ''
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!label.trim()) return
-    if (sessionType === 'ssh' && !sshHost.trim()) return
+    if (validationMsg || !uiProvider || !sessionType) return
 
-    const sshConfig: SSHConfig | undefined = sessionType === 'ssh' ? {
-      host: sshHost.trim(),
-      port: sshPort,
-      username: sshUser.trim() || 'root',
-      remotePath: sshRemotePath.trim() || '~'
-    } : undefined
+    const provider: ProviderId = uiProvider === 'codex' ? 'codex' : 'claude'
+    const shellOnly = uiProvider === 'terminal'
 
-    const dir = sessionType === 'ssh' ? sshRemotePath.trim() || '~' : (workingDir.trim() || '.')
+    // No '.' fallback: the empty-directory default is how the transcript
+    // misfiling incident happened; validation above requires a real path.
+    const dir = sessionType === 'ssh' ? (sshRemotePath.trim() || '~') : workingDir.trim()
 
-    const claudeOptions = provider === 'claude' ? {
+    // Spread-then-set preserves stored fields this dialog no longer edits
+    // (legacyVersion, agentIds, disableAutoMemory, enableCodexReview) instead
+    // of wiping them on every save — the bug that ate effortLevel for years.
+    const claudeOptions = uiProvider === 'claude' ? {
+      ...initialClaude,
       model: model || undefined,
+      effortLevel: effortLevel === '' ? undefined : effortLevel,
       // 'default' is the no-op sentinel; persist only a real override.
       permissionMode: permissionMode && permissionMode !== 'default' ? permissionMode : undefined,
       extraArgs: extraArgs.trim() || undefined,
-      legacyVersion: legacyEnabled && legacyVersion ? { enabled: true, version: legacyVersion } : undefined,
-      agentIds: !shellOnly && selectedAgentIds.size > 0 ? Array.from(selectedAgentIds) : undefined,
-      disableAutoMemory: !shellOnly && disableAutoMemory ? true : undefined,
-      // Mirror the display gate: while Codex is off the checkbox renders
-      // unchecked+disabled, so persisting the stale true would silently
-      // re-arm review the moment Codex is re-enabled.
-      enableCodexReview: !shellOnly && enableCodexReview && !codexDisabled ? true : undefined,
       // DEFAULT-TRUE: only write false when the user has turned the toggle off.
-      // Omitting the field (undefined) is equivalent to on, keeps configs clean.
-      loggingEnabled: !shellOnly && !loggingEnabled ? false : undefined,
-    } : undefined
+      loggingEnabled: !loggingEnabled ? false : undefined,
+    } : initial?.claudeOptions
 
-    const codexOptions: CodexOptions | undefined = provider === 'codex' ? {
+    const codexOptions: CodexOptions | undefined = uiProvider === 'codex' ? {
       model: codexModel,
       reasoningEffort: codexEffort,
       permissionsPreset: codexPreset,
     } : undefined
+
+    const passwordSaved = savePassword && (sshPassword.length > 0 || storedPassword)
+    const sudoSaved = saveSudo && (sudoPassword.length > 0 || storedSudo)
 
     const config: Omit<TerminalConfig, 'id'> = {
       provider,
@@ -286,699 +269,623 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
       shellOnly,
       groupId,
       sectionId: groupId ? undefined : sectionId,
-      partnerTerminalPath: !shellOnly && partnerTerminalPath.trim() ? partnerTerminalPath.trim() : undefined,
-      partnerElevated: !shellOnly && partnerTerminalPath.trim() ? partnerElevated : undefined,
-      sshConfig: sshConfig ? {
-        ...sshConfig,
-        hasPassword: savePassword && sshPassword.length > 0,
+      sshConfig: sessionType === 'ssh' ? {
+        // Spread preserves fields the dialog doesn't edit (dockerContainer).
+        ...initial?.sshConfig,
+        host: sshHost.trim(),
+        port: sshPort,
+        username: sshUser.trim() || 'root',
+        remotePath: sshRemotePath.trim() || '~',
+        hasPassword: passwordSaved,
         postCommand: postCommand.trim() || undefined,
-        hasSudoPassword: saveSudoPassword && sudoPassword.length > 0,
+        hasSudoPassword: sudoSaved,
       } : undefined,
       claudeOptions,
       codexOptions,
-      machineName: machineName.trim() || undefined,
+      machineName: sessionType === 'ssh' && machineName.trim() ? machineName.trim() : undefined,
       // Account is no longer a config field -- it's chosen at launch by the
       // pre-spawn account gate. Preserve any pre-existing value on edit so older
       // configs aren't silently rewritten, but never set it from this dialog.
       profileId: initial?.profileId,
+      // Partner terminal is permanent for every config type (2 Aug decision):
+      // the dialog no longer writes a path or elevation. Stored values on old
+      // configs are simply ignored by the app.
+    }
+
+    // "Remove stored password" clicked (edit mode only): clear the keychain
+    // entry the moment the change is confirmed, never before.
+    if (initial?.id) {
+      if (!passwordSaved && (initial?.sshConfig?.hasPassword ?? false)) {
+        void window.electronAPI.credentials.delete(initial.id)
+      }
+      if (!sudoSaved && (initial?.sshConfig?.hasSudoPassword ?? false)) {
+        void window.electronAPI.credentials.delete(initial.id + '_sudo')
+      }
     }
 
     onConfirm(
       config,
-      sshPassword.length > 0 ? sshPassword : undefined,
-      sudoPassword.length > 0 ? sudoPassword : undefined
+      // Honest save: a typed password reaches the keychain ONLY with the
+      // checkbox on (the old dialog stored it regardless).
+      savePassword && sshPassword.length > 0 ? sshPassword : undefined,
+      saveSudo && sudoPassword.length > 0 ? sudoPassword : undefined
     )
   }
+
+  // ── Small shared bits
+  const sectionHead = (title: string, chip: string, helpKey?: string, helpLabel?: string) => (
+    <div className="flex items-center gap-2 border-t border-surface1 pt-3 mt-4 mb-2">
+      <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">{title}</span>
+      <span className="text-[9px] uppercase tracking-wide text-overlay0 border border-surface2 rounded-full px-1.5 py-px">{chip}</span>
+      {helpKey && helpLabel && <HelpBtn k={helpKey} label={helpLabel} />}
+    </div>
+  )
+
+  const providerCard = (id: UiProvider, title: string, sub: string, disabled: boolean) => (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={uiProvider === id}
+      disabled={disabled}
+      onClick={() => setUiProvider(id)}
+      className={`flex-1 text-left rounded-md border px-3 py-2 transition-colors ${
+        disabled
+          ? 'border-surface1 opacity-50 cursor-not-allowed'
+          : uiProvider === id
+            ? 'border-blue bg-blue/10'
+            : 'border-surface1 bg-base hover:border-overlay0'
+      }`}
+    >
+      <span className={`block text-sm font-medium ${disabled ? 'text-overlay0' : 'text-text'}`}>{title}</span>
+      <span className="block text-[10px] text-overlay0 mt-0.5">{sub}</span>
+    </button>
+  )
+
+  const transportCard = (id: SessionType, title: string, sub: string, disabled: boolean) => (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={sessionType === id}
+      disabled={disabled}
+      onClick={() => setSessionType(id)}
+      className={`flex-1 text-left rounded-md border px-3 py-2 transition-colors ${
+        disabled
+          ? 'border-surface1 opacity-50 cursor-not-allowed'
+          : sessionType === id
+            ? 'border-blue bg-blue/10'
+            : 'border-surface1 bg-base hover:border-overlay0'
+      }`}
+    >
+      <span className={`block text-sm font-medium ${disabled ? 'text-overlay0' : 'text-text'}`}>{title}</span>
+      <span className="block text-[10px] text-overlay0 mt-0.5">{sub}</span>
+    </button>
+  )
+
+  const inputCls = 'w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue'
+
+  const permHint = DANGEROUS_MODE_COPY[permissionMode]
+    ?? PERMISSION_MODES.find((m) => m.value === permissionMode)?.hint
+    ?? ''
+  const permDangerous = permissionMode in DANGEROUS_MODE_COPY
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <form
         onSubmit={handleSubmit}
-        className="bg-surface0 rounded-lg p-6 w-[760px] max-h-[90vh] overflow-y-auto shadow-2xl border border-surface1"
+        className="bg-surface0 rounded-lg w-[680px] max-h-[90vh] flex flex-col shadow-2xl border border-surface1"
       >
-        <h3 className="text-base font-semibold text-text mb-1">
-          {initial ? 'Edit Config' : 'New Saved Config'}
-        </h3>
-        <p className="text-[11px] text-overlay0 mb-4 leading-snug">
-          A saved config is a reusable launcher: it stays in the sidebar and every launch starts a fresh session
-          with these settings.
-        </p>
-
-        {/* Session type toggle */}
-        <div className="flex items-center bg-crust rounded-md p-0.5 mb-1">
-          <button
-            type="button"
-            onClick={() => setSessionType('local')}
-            className={`flex-1 px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-              sessionType === 'local' ? 'bg-blue text-crust' : 'text-overlay1 hover:text-text'
-            }`}
-          >
-            Local
-          </button>
-          <button
-            type="button"
-            onClick={() => setSessionType('ssh')}
-            className={`flex-1 px-3 py-1.5 rounded text-xs font-medium transition-colors ${
-              sessionType === 'ssh' ? 'bg-blue text-crust' : 'text-overlay1 hover:text-text'
-            }`}
-          >
-            SSH
-          </button>
+        <div className="px-6 pt-5 pb-3 border-b border-surface1">
+          <h3 className="text-base font-semibold text-text mb-1">
+            {isEdit ? 'Edit config' : 'New saved config'}
+          </h3>
+          <p className="text-[11px] text-overlay0 leading-snug">
+            Every click on this launcher starts a fresh session with these settings.
+          </p>
         </div>
-        <p className="text-[10px] text-overlay0 mb-4">
-          Where sessions run: this machine, or a remote machine over SSH.
-        </p>
 
-        {/* Provider segmented control */}
-        <ProviderSegmentedControl
-          value={provider}
-          onChange={setProvider}
-          sessionType={sessionType}
-          codexMasterOff={codexDisabled}
-        />
+        <div className="px-6 pb-4 overflow-y-auto flex-1">
 
-        {/* Two-column grid */}
-        <div className="grid grid-cols-2 gap-6">
-
-          {/* ============ LEFT COLUMN: Identity + Connection ============ */}
-          <div className="space-y-3">
-
-            {/* -- IDENTITY section (first in column, no border-t) -- */}
-            <div>
-              <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Identity</span>
-            </div>
-
-            <div>
-              <label className="block text-xs text-subtext0 mb-1">Label</label>
-              <input
-                autoFocus
-                value={label}
-                onChange={(e) => setLabel(e.target.value)}
-                placeholder="My project"
-                className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-              />
-              <p className="text-[10px] text-overlay0 mt-1">Names this config in the sidebar and on its session tabs.</p>
-            </div>
-
-            {sessionType === 'ssh' && (
-              <div>
-                <label className="block text-xs text-subtext0 mb-1">Machine Name</label>
-                <input
-                  value={machineName}
-                  onChange={(e) => setMachineName(e.target.value)}
-                  placeholder="e.g. GPU Server, Build Box"
-                  className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                />
-                <p className="text-[10px] text-overlay0 mt-1">Shows in logs and the status line so you can tell machines apart.</p>
-              </div>
-            )}
-
-            {/* Color picker — compact swatches */}
-            <div>
-              <label className="block text-xs text-subtext0 mb-1">Color</label>
-              <div className="flex flex-wrap gap-1.5">
-                {IDENTITY_SWATCHES.map((k) => (
-                  <button
-                    key={k}
-                    type="button"
-                    onClick={() => setColorKey(k)}
-                    className={`w-6 h-6 rounded-md border-2 transition-all ${
-                      colorKey === k ? 'border-text scale-110' : 'border-transparent hover:border-overlay0'
-                    }`}
-                    style={{ backgroundColor: resolveIdentityColor(k, theme) }}
-                    title={k}
-                  />
-                ))}
-              </div>
-              <p className="text-[10px] text-overlay0 mt-1.5">
-                Tints this config's rail, tabs and dots so you can tell sessions apart at a glance.
-              </p>
-            </div>
-
-            {/* -- CONNECTION section -- */}
-            <div className="border-t border-surface1 pt-3 mt-3">
-              <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Connection</span>
-            </div>
-
-            {sessionType === 'local' ? (
-              <div>
-                <label className="block text-xs text-subtext0 mb-1">Working Directory</label>
-                <div className="flex gap-2">
-                  <input
-                    value={workingDir}
-                    onChange={(e) => setWorkingDir(e.target.value)}
-                    placeholder={window.electronPlatform === 'win32' ? 'C:\\path\\to\\project' : '~/path/to/project'}
-                    className="flex-1 bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleBrowse}
-                    className="px-3 py-2 rounded text-sm bg-surface1 text-subtext1 hover:bg-surface2 hover:text-text transition-colors shrink-0"
-                  >
-                    Browse
-                  </button>
-                </div>
-                <p className="text-[10px] text-overlay0 mt-1">
-                  The folder sessions start in. Claude reads and edits files here (with your approval).
-                </p>
-              </div>
-            ) : (
-              <>
-                <div className="grid grid-cols-[1fr_80px] gap-2">
-                  <div>
-                    <label className="block text-xs text-subtext0 mb-1">Host</label>
-                    <input
-                      value={sshHost}
-                      onChange={(e) => setSshHost(e.target.value)}
-                      placeholder="192.168.1.100 or hostname"
-                      className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs text-subtext0 mb-1">Port</label>
-                    <input
-                      type="number"
-                      value={sshPort}
-                      onChange={(e) => setSshPort(parseInt(e.target.value) || 22)}
-                      className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-                    />
-                  </div>
-                </div>
-                <div>
-                  <label className="block text-xs text-subtext0 mb-1">Username</label>
-                  <input
-                    value={sshUser}
-                    onChange={(e) => setSshUser(e.target.value)}
-                    placeholder="root"
-                    className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                  />
-                </div>
-                <div>
-                  <label className="block text-xs text-subtext0 mb-1">
-                    Password
-                    <span className="text-overlay0 ml-1">(encrypted with OS keychain)</span>
-                  </label>
-                  <input
-                    type="password"
-                    value={sshPassword}
-                    onChange={(e) => setSshPassword(e.target.value)}
-                    placeholder={initial?.sshConfig?.hasPassword ? '(saved - enter new to change)' : 'Leave empty for key auth'}
-                    className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                  />
-                  {sshPassword.length > 0 && (
-                    <label className="flex items-center gap-2 mt-1.5 text-xs text-subtext0 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={savePassword}
-                        onChange={(e) => setSavePassword(e.target.checked)}
-                        className="rounded border-surface1"
-                      />
-                      Save password for this config
-                    </label>
-                  )}
-                </div>
-                <div>
-                  <label className="block text-xs text-subtext0 mb-1">Remote Path (cd after connect)</label>
-                  <input
-                    value={sshRemotePath}
-                    onChange={(e) => setSshRemotePath(e.target.value)}
-                    placeholder="~/projects/my-app"
-                    className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                  />
-                </div>
-                <div>
-                  <label className="block text-xs text-subtext0 mb-1">
-                    Post-connect Command
-                    <span className="text-overlay0 ml-1">(runs after SSH connects)</span>
-                  </label>
-                  <input
-                    value={postCommand}
-                    onChange={(e) => setPostCommand(e.target.value)}
-                    placeholder="sudo docker exec -it container bash"
-                    className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue font-mono text-xs"
-                  />
-                </div>
-                {postCommand && (
-                  <div>
-                    <label className="block text-xs text-subtext0 mb-1">
-                      Sudo Password
-                      <span className="text-overlay0 ml-1">(auto-entered if prompted)</span>
-                    </label>
-                    <input
-                      type="password"
-                      value={sudoPassword}
-                      onChange={(e) => setSudoPassword(e.target.value)}
-                      placeholder={initial?.sshConfig?.hasSudoPassword ? '(saved - enter new to change)' : 'Leave empty if not needed'}
-                      className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                    />
-                    {sudoPassword.length > 0 && (
-                      <label className="flex items-center gap-2 mt-1.5 text-xs text-subtext0 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={saveSudoPassword}
-                          onChange={(e) => setSaveSudoPassword(e.target.checked)}
-                          className="rounded border-surface1"
-                        />
-                        Save sudo password for this config
-                      </label>
-                    )}
-                  </div>
-                )}
-                {postCommand && (
-                  <p className="text-[10px] text-overlay0 leading-snug">
-                    After connect you'll get an in-pane button to run this
-                    command. Once the inner shell appears, a second button
-                    launches Claude (or Skip drops you to the shell).
-                  </p>
-                )}
-              </>
-            )}
+          {/* ── 1 · WHAT THIS LAUNCHER RUNS ── */}
+          <div className="flex items-center gap-2 pt-4 mb-2">
+            <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">What this launcher runs</span>
+            <span className="text-[9px] uppercase tracking-wide text-overlay0 border border-surface2 rounded-full px-1.5 py-px">Any provider</span>
+            <HelpBtn k="runs" label="About this section" />
           </div>
-
-          {/* ============ RIGHT COLUMN: Options + Extensions + Agents + Organization ============ */}
-          <div className="space-y-3">
-
-            {/* -- SESSION OPTIONS section (first in column, no border-t) -- */}
-            <div>
-              <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Session Options</span>
-            </div>
-
-            {/* Shell only toggle */}
-            <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={shellOnly}
-                onChange={(e) => {
-                  setShellOnly(e.target.checked)
-                  if (e.target.checked) setPartnerTerminalPath('')
-                }}
-                className="mt-0.5 rounded border-surface1"
-              />
-              <span>
-                Shell only (don't run Claude)
-                <span className="block text-[10px] text-overlay0">
-                  A plain terminal with no AI attached. Handy for servers, builds and logs.
-                </span>
-              </span>
-            </label>
-
-            {/* Partner Terminal */}
-            {!shellOnly && (
-              <div>
-                <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer mb-1.5">
-                  <input
-                    type="checkbox"
-                    checked={!!partnerTerminalPath}
-                    onChange={(e) => setPartnerTerminalPath(e.target.checked ? (workingDir || '.') : '')}
-                    className="mt-0.5 rounded border-surface1"
-                  />
-                  <span>
-                    Partner Terminal
-                    <span className="block text-[10px] text-overlay0">
-                      A second plain terminal beside the session, for running commands yourself while Claude works.
-                    </span>
-                  </span>
-                </label>
-                {partnerTerminalPath && (
-                  <>
-                    <div className="flex gap-2 ml-5">
-                      <input
-                        value={partnerTerminalPath}
-                        onChange={(e) => setPartnerTerminalPath(e.target.value)}
-                        placeholder="Partner terminal path"
-                        className="flex-1 bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                      />
-                      <button
-                        type="button"
-                        onClick={handleBrowsePartner}
-                        className="px-3 py-2 rounded text-sm bg-surface1 text-subtext1 hover:bg-surface2 hover:text-text transition-colors shrink-0"
-                      >
-                        Browse
-                      </button>
-                    </div>
-                    <label className="flex items-center gap-2 text-xs text-subtext0 cursor-pointer ml-5">
-                      <input
-                        type="checkbox"
-                        checked={partnerElevated}
-                        onChange={(e) => setPartnerElevated(e.target.checked)}
-                        className="rounded border-surface1"
-                      />
-                      {`Run as Administrator (requires ${window.electronPlatform === 'win32' ? 'gsudo' : 'sudo'})`}
-                    </label>
-                  </>
-                )}
-              </div>
-            )}
-
-            {provider === 'claude' && (
+          <Hint k="runs">
+            Pick the agent this launcher starts and where it runs — everything below adapts to these two
+            choices. Claude Code signs in with your Claude account; Codex needs its own OpenAI account.
+          </Hint>
+          <div className="flex gap-2 mt-2" role="radiogroup" aria-label="Provider">
+            {providerCard('claude', 'Claude Code', "Anthropic's coding agent", false)}
+            {providerCard('codex', 'Codex', "OpenAI's coding agent", codexDisabled || sessionType === 'ssh')}
+            {providerCard('terminal', 'Terminal only', 'A plain terminal — no AI', false)}
+          </div>
+          {sessionType === 'ssh' && (
+            <p className="text-[11px] text-red mt-1.5">Codex can't run over SSH yet — choose Claude Code or Terminal only.</p>
+          )}
+          {codexDisabled && sessionType !== 'ssh' && (
+            <p className="text-[11px] text-overlay0 mt-1.5">Codex is off — enable it in Settings → Codex to use it here.</p>
+          )}
+          {uiProvider !== null && (
             <>
-            {/* Model override */}
-            <div>
-              <label className="block text-xs text-subtext0 mb-1">
-                Model override
-                <span className="text-overlay0 ml-1">(uses your subscription plan)</span>
-              </label>
-              <select
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-              >
-                <option value="">Default (no override)</option>
-                {modelsFromRegistry(registry).map((m) => (
-                  <option key={m.value} value={m.value}>{m.label}</option>
-                ))}
-              </select>
-              <p className="text-[10px] text-overlay0 mt-1">
-                The model sessions start on. Default follows Claude's own setting; /model inside a session still works.
-              </p>
-            </div>
-
-            {/* Permission mode */}
-            <div>
-              <label className="block text-xs text-subtext0 mb-1">
-                Permission mode
-                <span className="text-overlay0 ml-1">(how Claude asks before actions)</span>
-              </label>
-              <select
-                value={permissionMode}
-                onChange={(e) => setPermissionMode(e.target.value)}
-                className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-              >
-                {PERMISSION_MODES.map((m) => (
-                  <option key={m.value} value={m.value}>{m.label}</option>
-                ))}
-              </select>
-              <p className="text-[10px] text-overlay0 mt-1">
-                Sets --permission-mode at launch, so one config can run Bypass while another runs Don't ask. /permissions inside a session still works.
-              </p>
-            </div>
-
-            {/* Advanced: extra CLI args escape hatch */}
-            <details>
-              <summary className="text-xs text-subtext0 cursor-pointer select-none">Advanced: extra CLI args</summary>
-              <div className="mt-2">
-                <input
-                  type="text"
-                  value={extraArgs}
-                  onChange={(e) => setExtraArgs(e.target.value)}
-                  placeholder="--verbose --add-dir /path/to/dir"
-                  spellCheck={false}
-                  className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text font-mono focus:outline-none focus:border-blue"
-                />
-                <p className="text-[10px] text-overlay0 mt-1">
-                  Appended verbatim to the claude command. Shell metacharacters are blocked, and CCC-managed flags (--model, --effort, --permission-mode, --settings, --mcp-config, --agents, --resume) can't be overridden here.
-                </p>
+              <div className="flex gap-2 mt-2" role="radiogroup" aria-label="Where it runs">
+                {transportCard('local', 'Local', 'Runs on this PC', false)}
+                {transportCard('ssh', 'SSH', 'Runs on another machine', uiProvider === 'codex')}
               </div>
-            </details>
-
-            {/* Disable auto-memory toggle */}
-            {!shellOnly && (
-              <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={disableAutoMemory}
-                  onChange={(e) => setDisableAutoMemory(e.target.checked)}
-                  className="mt-0.5 rounded border-surface1"
-                />
-                <span>
-                  Disable auto-memory
-                  <span className="block text-[10px] text-overlay0">
-                    Claude won't save memories (CLAUDE.md writes) from these sessions.
-                  </span>
-                </span>
-              </label>
-            )}
-
-            {/* P6: Codex code review toggle. Hidden for SSH (the tool is never
-                registered for SSH sessions and would run codex against a local
-                path that only exists on the remote); disabled when Codex is
-                answered off (the MCP server won't register the tool at all). */}
-            {!shellOnly && sessionType !== 'ssh' && (
-              <label
-                className={`flex items-start gap-2 text-sm text-subtext0 ${codexDisabled ? 'opacity-50' : 'cursor-pointer'}`}
-              >
-                <input
-                  type="checkbox"
-                  checked={enableCodexReview && !codexDisabled}
-                  disabled={codexDisabled}
-                  onChange={(e) => setEnableCodexReview(e.target.checked)}
-                  className="mt-0.5 rounded border-surface1"
-                />
-                <span>
-                  Enable Codex code review
-                  <span className="block text-[10px] text-overlay0">
-                    {codexDisabled
-                      ? 'Codex is off. Enable it in Settings → Codex first.'
-                      : 'Lets Claude ask Codex for an independent review of working changes. Each call counts against your Codex budget.'}
-                  </span>
-                </span>
-              </label>
-            )}
-
-            {/* T16: Index conversation logs toggle */}
-            {!shellOnly && (
-              <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={loggingEnabled}
-                  onChange={(e) => setLoggingEnabled(e.target.checked)}
-                  className="mt-0.5 rounded border-surface1"
-                />
-                <span>
-                  Index conversation logs
-                  <span className="block text-[10px] text-overlay0">CCC indexes Claude's own transcripts so you can browse them here. Your conversation always lives in Claude's files (~/.claude/projects); turning this off only stops CCC from indexing it.</span>
-                </span>
-              </label>
-            )}
-
-            {/* -- EXTENSIONS section -- */}
-            <div className="border-t border-surface1 pt-3 mt-3">
-              <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Extensions</span>
-            </div>
-
-            {/* Legacy Claude Version */}
-            <div>
-              <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={legacyEnabled}
-                  onChange={(e) => {
-                    setLegacyEnabled(e.target.checked)
-                    if (!e.target.checked) {
-                      setInstallError('')
-                    }
-                  }}
-                  className="mt-0.5 rounded border-surface1"
-                />
-                <span>
-                  Legacy Claude Version
-                  <span className="block text-[10px] text-overlay0">
-                    Pin these sessions to an older Claude Code release, installed from npm beside your current one.
-                  </span>
-                </span>
-              </label>
-              {legacyEnabled && (
-                <div className="ml-5 mt-2 space-y-2">
-                  <div>
-                    <label className="block text-xs text-subtext0 mb-1">Version</label>
-                    {loadingVersions ? (
-                      <div className="text-xs text-overlay0">Loading versions from npm...</div>
-                    ) : availableVersions.length > 0 ? (
-                      <select
-                        value={legacyVersion}
-                        onChange={(e) => setLegacyVersion(e.target.value)}
-                        className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-                      >
-                        {availableVersions.map((v) => (
-                          <option key={v} value={v}>{v}</option>
-                        ))}
-                      </select>
-                    ) : (
-                      <div className="text-xs text-red">Failed to load versions. Is npm installed?</div>
-                    )}
-                  </div>
-                  {legacyVersion && !loadingVersions && (
-                    <div className="flex items-center gap-2">
-                      {versionInstalled ? (
-                        <span className="text-xs text-green">Installed</span>
-                      ) : installing ? (
-                        <span className="text-xs text-overlay0">Installing...</span>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={handleInstallVersion}
-                          className="px-3 py-1 rounded text-xs bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
-                        >
-                          Install
-                        </button>
-                      )}
-                    </div>
-                  )}
-                  {installError && (
-                    <div className="text-xs text-red">{installError}</div>
-                  )}
-                  <p className="text-[10px] text-overlay0">
-                    Install and use a specific version of Claude CLI. ~80MB per version.
-                    {!versionInstalled && legacyVersion && ' Will auto-install on first launch if not installed.'}
-                  </p>
-                </div>
+              {uiProvider === 'codex' && (
+                <p className="text-[11px] text-overlay0 mt-1.5">Codex runs on this PC only — SSH isn't available.</p>
               )}
-            </div>
-
-            {/* -- AGENTS section -- */}
-            {!shellOnly && allAgentTemplates.length > 0 && (
-              <>
-                <div className="border-t border-surface1 pt-3 mt-3">
-                  <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Agents</span>
-                  <p className="text-[10px] text-overlay0 mt-1">
-                    Subagents Claude can delegate work to in these sessions (via its Task tool). Tick the ones to include.
-                  </p>
-                </div>
-                <div className="max-h-[120px] overflow-y-auto border border-surface1 rounded bg-base">
-                  {allAgentTemplates.map(t => (
-                    <label
-                      key={t.id}
-                      className="flex items-start gap-2 px-2.5 py-1.5 hover:bg-surface0/30 cursor-pointer transition-colors"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedAgentIds.has(t.id)}
-                        onChange={() => {
-                          setSelectedAgentIds(prev => {
-                            const next = new Set(prev)
-                            if (next.has(t.id)) next.delete(t.id)
-                            else next.add(t.id)
-                            return next
-                          })
-                        }}
-                        className="rounded border-surface1 mt-0.5"
-                      />
-                      <div className="min-w-0 flex-1">
-                        <span className="text-xs font-medium text-text font-mono">{t.name}</span>
-                        {t.isBuiltIn && <span className="text-[9px] text-overlay0 ml-1">(built-in)</span>}
-                        <div className="text-[10px] text-overlay1 truncate">{t.description}</div>
-                      </div>
-                    </label>
-                  ))}
-                </div>
-                <p className="text-[10px] text-overlay0 mt-1.5 leading-snug">
-                  Author your own templates in <span className="text-subtext0 font-medium">Agent Hub → Library</span>. Anything you create there appears here automatically.
-                </p>
-              </>
-            )}
             </>
-            )}
+          )}
 
-            {provider === 'codex' && (
-              <CodexFormFields
-                value={{ model: codexModel, reasoningEffort: codexEffort, permissionsPreset: codexPreset }}
-                // Spread-then-set: dropdowns + radios always emit defined values, so we can safely
-                // guard each setter on `!== undefined`. Add explicit-clear logic if future nullable fields land.
-                onChange={(next) => {
-                  if (next.model !== undefined) setCodexModel(next.model)
-                  if (next.reasoningEffort !== undefined) setCodexEffort(next.reasoningEffort)
-                  if (next.permissionsPreset !== undefined) setCodexPreset(next.permissionsPreset)
-                }}
-                onOpenSettings={() => {
-                  // Best-effort: ask the host to navigate Settings to the Codex tab.
-                  // For v1.5.0 we simply open Settings; the user can click the Codex tab.
-                  // P3+ may add a deep-link channel.
-                  window.dispatchEvent(new CustomEvent('app:openSettings', { detail: { tab: 'codex' } }))
-                }}
-              />
-            )}
+          {bothChosen && (
+            <>
+              {/* ── 2 · WORKSPACE ── */}
+              {sectionHead('Workspace', 'Any provider', 'ws', 'About the workspace')}
+              <Hint k="ws">
+                {sessionType === 'local'
+                  ? 'The folder every session starts in. The agent can read and edit files here, with your approval. Every session also gets a second plain terminal from the command bar — no setup needed.'
+                  : "Where sessions land after connecting. Your PC's folders are not visible to this session."}
+              </Hint>
 
-            {/* -- ORGANIZATION section -- */}
-            <div className="border-t border-surface1 pt-3 mt-3">
-              <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Organization</span>
-              <p className="text-[10px] text-overlay0 mt-1">
-                Optional. Both just organise the sidebar; skip them until you have a few configs.
-              </p>
-            </div>
-
-            {/* Group assignment */}
-            <div>
-              <label className="block text-xs text-subtext0 mb-1">Group</label>
-              <select
-                value={showNewGroup ? '__new__' : (groupId || '')}
-                onChange={(e) => handleGroupChange(e.target.value)}
-                className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-              >
-                <option value="">No group</option>
-                {groups.map((g) => (
-                  <option key={g.id} value={g.id}>{g.name}</option>
-                ))}
-                <option value="__new__">+ New Group...</option>
-              </select>
-              <p className="text-[10px] text-overlay0 mt-1">
-                Grouped configs collapse together in the sidebar and can all launch with one click.
-              </p>
-              {showNewGroup && (
-                <div className="flex gap-2 mt-1.5">
-                  <input
-                    autoFocus
-                    value={newGroupName}
-                    onChange={(e) => setNewGroupName(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateGroup() } }}
-                    placeholder="Group name"
-                    className="flex-1 bg-base border border-surface1 rounded px-3 py-1.5 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleCreateGroup}
-                    className="px-3 py-1.5 rounded text-xs bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
-                  >
-                    Create
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Section assignment (only when ungrouped) */}
-            {!groupId && (
-              <div>
-                <label className="block text-xs text-subtext0 mb-1">Section</label>
-                <select
-                  value={showNewSection ? '__new__' : (sectionId || '')}
-                  onChange={(e) => handleSectionChange(e.target.value)}
-                  className="w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-blue"
-                >
-                  <option value="">No section</option>
-                  {sections.map((s) => (
-                    <option key={s.id} value={s.id}>{s.name}</option>
-                  ))}
-                  <option value="__new__">+ New Section...</option>
-                </select>
-                <p className="text-[10px] text-overlay0 mt-1">
-                  A labelled heading this config sits under in the sidebar; sections can also launch all their configs at once.
-                </p>
-                {showNewSection && (
-                  <div className="flex gap-2 mt-1.5">
+              {sessionType === 'local' ? (
+                <div className="mt-1">
+                  <label className="block text-xs text-subtext0 mb-1">Working directory <span className="text-peach">*</span></label>
+                  <div className="flex gap-2">
                     <input
-                      autoFocus
-                      value={newSectionName}
-                      onChange={(e) => setNewSectionName(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateSection() } }}
-                      placeholder="Section name"
-                      className="flex-1 bg-base border border-surface1 rounded px-3 py-1.5 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue"
+                      value={workingDir}
+                      onChange={(e) => setWorkingDir(e.target.value)}
+                      placeholder={window.electronPlatform === 'win32' ? 'C:\\path\\to\\project' : '~/path/to/project'}
+                      className={inputCls.replace('w-full', 'flex-1')}
                     />
                     <button
                       type="button"
-                      onClick={handleCreateSection}
-                      className="px-3 py-1.5 rounded text-xs bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
+                      onClick={handleBrowse}
+                      className="px-3 py-2 rounded text-sm bg-surface1 text-subtext1 hover:bg-surface2 hover:text-text transition-colors shrink-0"
                     >
-                      Create
+                      Browse
                     </button>
                   </div>
-                )}
-              </div>
-            )}
-          </div>
+                </div>
+              ) : (
+                <div className="space-y-3 mt-1">
+                  <div className="grid grid-cols-[1fr_90px] gap-2">
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Host <span className="text-peach">*</span></label>
+                        <HelpBtn k="host" label="About host" />
+                      </div>
+                      <input
+                        value={sshHost}
+                        onChange={(e) => setSshHost(e.target.value)}
+                        placeholder="192.168.1.100"
+                        className={inputCls}
+                      />
+                      <Hint k="host">IP address or hostname of the machine to connect to.</Hint>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">Port <span className="text-peach">*</span></label>
+                      <input
+                        type="number"
+                        value={sshPort}
+                        onChange={(e) => setSshPort(parseInt(e.target.value) || 22)}
+                        className={inputCls}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">User</label>
+                      <input
+                        value={sshUser}
+                        onChange={(e) => setSshUser(e.target.value)}
+                        placeholder="root"
+                        className={inputCls}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">Password</label>
+                      <input
+                        type="password"
+                        value={sshPassword}
+                        onChange={(e) => setSshPassword(e.target.value)}
+                        placeholder={storedPassword ? '(saved — enter new to change)' : 'Leave empty if you use an SSH key'}
+                        className={inputCls}
+                      />
+                      {(sshPassword.length > 0 || storedPassword) && (
+                        <div className="flex items-center gap-3 mt-1.5">
+                          <label className="flex items-center gap-2 text-xs text-subtext0 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={savePassword}
+                              onChange={(e) => setSavePassword(e.target.checked)}
+                              className="rounded border-surface1"
+                            />
+                            Save password
+                          </label>
+                          {storedPassword && (
+                            <button
+                              type="button"
+                              onClick={() => { setStoredPassword(false); setSavePassword(false); setSshPassword('') }}
+                              className="text-[11px] text-blue underline underline-offset-2"
+                            >
+                              Remove stored password
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Remote directory</label>
+                        <HelpBtn k="rdir" label="About the remote directory" />
+                      </div>
+                      <input
+                        value={sshRemotePath}
+                        onChange={(e) => setSshRemotePath(e.target.value)}
+                        placeholder="~"
+                        className={inputCls}
+                      />
+                      <Hint k="rdir">Where sessions land after connecting. Defaults to the home directory (~).</Hint>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Machine name</label>
+                        <HelpBtn k="mname" label="About machine name" />
+                      </div>
+                      <input
+                        value={machineName}
+                        onChange={(e) => setMachineName(e.target.value)}
+                        placeholder="e.g. Unix 185"
+                        className={inputCls}
+                      />
+                      <Hint k="mname">Optional display name, shown in logs and the status line so you can tell machines apart.</Hint>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-xs text-subtext0">After connecting, run</label>
+                      <HelpBtn k="postcmd" label="About the post-connect command" />
+                    </div>
+                    <input
+                      value={postCommand}
+                      onChange={(e) => setPostCommand(e.target.value)}
+                      placeholder="sudo docker exec -it container bash"
+                      className={inputCls + ' font-mono text-xs'}
+                    />
+                    <Hint k="postcmd">
+                      Optional. A command to run once the connection is up — for example dropping into a Docker
+                      container. CCC gives you a button to run it, then a second button to launch the agent.
+                    </Hint>
+                  </div>
+                  {postCommand.trim() && (
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">Sudo password</label>
+                      <input
+                        type="password"
+                        value={sudoPassword}
+                        onChange={(e) => setSudoPassword(e.target.value)}
+                        placeholder={storedSudo ? '(saved — enter new to change)' : 'Only needed if the command above uses sudo'}
+                        className={inputCls}
+                      />
+                      {(sudoPassword.length > 0 || storedSudo) && (
+                        <div className="flex items-center gap-3 mt-1.5">
+                          <label className="flex items-center gap-2 text-xs text-subtext0 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={saveSudo}
+                              onChange={(e) => setSaveSudo(e.target.checked)}
+                              className="rounded border-surface1"
+                            />
+                            Save password
+                          </label>
+                          {storedSudo && (
+                            <button
+                              type="button"
+                              onClick={() => { setStoredSudo(false); setSaveSudo(false); setSudoPassword('') }}
+                              className="text-[11px] text-blue underline underline-offset-2"
+                            >
+                              Remove stored password
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
 
+              {/* ── 3 · SESSION STARTUP (Claude Code / Codex; a Terminal-only
+                     launcher has nothing to configure here yet) ── */}
+              {uiProvider === 'claude' && (
+                <>
+                  {sectionHead('Session startup', 'Claude Code only', 'startup', 'About session startup')}
+                  <Hint k="startup">
+                    Starting values only — sessions begin here, and you can change any of them mid-session
+                    with /model, /effort and /permissions.
+                  </Hint>
+                  <div className="space-y-3 mt-1">
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Starting model</label>
+                        <HelpBtn k="model" label="About the starting model" />
+                      </div>
+                      <select
+                        value={model}
+                        onChange={(e) => setModel(e.target.value)}
+                        className={inputCls}
+                      >
+                        <option value="">Default — follows your Claude plan</option>
+                        {modelsFromRegistry(registry).map((m) => (
+                          <option key={m.value} value={m.value}>{m.label}</option>
+                        ))}
+                      </select>
+                      <Hint k="model">
+                        Which model sessions start on — change it anytime with /model. Names always point at
+                        the newest model in each family.
+                      </Hint>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Starting effort</label>
+                        <HelpBtn k="effort" label="About the starting effort" />
+                      </div>
+                      <div className="flex flex-wrap gap-1.5" role="radiogroup" aria-label="Starting effort">
+                        <button
+                          type="button"
+                          role="radio"
+                          aria-checked={effortLevel === ''}
+                          onClick={() => setEffortLevel('')}
+                          className={`px-2.5 py-1 rounded-full border text-xs transition-colors ${
+                            effortLevel === '' ? 'border-blue bg-blue/10 text-text' : 'border-surface1 bg-base text-subtext0 hover:border-overlay0'
+                          }`}
+                        >
+                          Default
+                        </button>
+                        {effortsFromRegistry(registry).map((ef) => (
+                          <button
+                            key={ef.value}
+                            type="button"
+                            role="radio"
+                            aria-checked={effortLevel === ef.value}
+                            onClick={() => setEffortLevel(ef.value as typeof effortLevel)}
+                            className={`px-2.5 py-1 rounded-full border text-xs transition-colors ${
+                              effortLevel === ef.value ? 'border-blue bg-blue/10 text-text' : 'border-surface1 bg-base text-subtext0 hover:border-overlay0'
+                            }`}
+                          >
+                            {ef.label}
+                          </button>
+                        ))}
+                      </div>
+                      <Hint k="effort">
+                        How hard Claude thinks before answering — change it anytime with /effort. Higher is
+                        slower and uses more of your quota.
+                      </Hint>
+                    </div>
+                    <div>
+                      <label className="block text-xs text-subtext0 mb-1">Permission mode</label>
+                      <select
+                        value={permissionMode}
+                        onChange={(e) => setPermissionMode(e.target.value)}
+                        className={inputCls}
+                      >
+                        {PERMISSION_MODES.map((m) => (
+                          <option key={m.value} value={m.value}>{m.label}</option>
+                        ))}
+                      </select>
+                      {permHint && (
+                        <p className={`text-[11px] mt-1 ${permDangerous ? 'text-red' : 'text-overlay0'}`}>{permHint}</p>
+                      )}
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <label className="text-xs text-subtext0">Extra CLI arguments</label>
+                        <HelpBtn k="xargs" label="About extra CLI arguments" />
+                      </div>
+                      <input
+                        type="text"
+                        value={extraArgs}
+                        onChange={(e) => setExtraArgs(e.target.value)}
+                        placeholder={sessionType === 'ssh' ? '--add-dir /srv/shared' : '--verbose --add-dir F:\\shared_libs'}
+                        spellCheck={false}
+                        className={inputCls + ' font-mono text-xs'}
+                      />
+                      <Hint k="xargs">
+                        Advanced. Appended to the claude command exactly as typed. Shell characters are blocked
+                        and CCC's own flags (--model, --effort, --permission-mode, --settings, --mcp-config,
+                        --agents, --resume) can't be overridden here.
+                      </Hint>
+                    </div>
+                    {sessionType === 'local' && (
+                      <div>
+                        <div className="flex items-center gap-1.5">
+                          <label className="flex items-center gap-2 text-sm text-subtext0 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={loggingEnabled}
+                              onChange={(e) => setLoggingEnabled(e.target.checked)}
+                              className="rounded border-surface1"
+                            />
+                            Index conversation logs
+                          </label>
+                          <HelpBtn k="logs" label="About conversation logs" />
+                        </div>
+                        <Hint k="logs">
+                          Lets you browse this session's transcript inside CCC. Your conversation is always
+                          saved by Claude Code either way (~/.claude/projects) — this only controls whether
+                          CCC indexes it.
+                        </Hint>
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+
+              {uiProvider === 'codex' && (
+                <>
+                  {sectionHead('Session startup', 'Codex only', 'startup-cx', 'About session startup')}
+                  <Hint k="startup-cx">
+                    Starting values only — Codex signs in with its own OpenAI account, separate from Claude.
+                  </Hint>
+                  <div className="mt-1">
+                    <CodexFormFields
+                      value={{ model: codexModel, reasoningEffort: codexEffort, permissionsPreset: codexPreset }}
+                      onChange={(next) => {
+                        if (next.model !== undefined) setCodexModel(next.model)
+                        if (next.reasoningEffort !== undefined) setCodexEffort(next.reasoningEffort)
+                        if (next.permissionsPreset !== undefined) setCodexPreset(next.permissionsPreset)
+                      }}
+                      onOpenSettings={() => {
+                        window.dispatchEvent(new CustomEvent('app:openSettings', { detail: { tab: 'codex' } }))
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+
+              {uiProvider === 'terminal' && sessionType === 'ssh' && (
+                <>
+                  {sectionHead('Terminal startup', 'Terminal only')}
+                  <p className="text-[11px] text-overlay0 leading-snug">
+                    Over SSH, set the startup command in Workspace above — <span className="text-subtext0 font-medium">"After connecting, run"</span>.
+                  </p>
+                </>
+              )}
+
+              {/* ── 4 · ORGANISE (collapsed until needed) ── */}
+              <details className="border-t border-surface1 pt-3 mt-4" open={isEdit && (!!groupId || !!sectionId)}>
+                <summary className="flex items-center gap-2 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+                  <span className="text-[10px] uppercase tracking-wider text-overlay1 font-medium">Organise</span>
+                  <span className="text-[9px] uppercase tracking-wide text-overlay0 border border-surface2 rounded-full px-1.5 py-px">Optional</span>
+                  <span className="text-[10px] text-overlay0 ml-auto">▸</span>
+                </summary>
+                <p className="text-[11px] text-overlay0 mt-2">Optional — only tidies the sidebar.</p>
+                <div className="grid grid-cols-2 gap-2 mt-2">
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-xs text-subtext0">Group</label>
+                      <HelpBtn k="group" label="About groups" />
+                    </div>
+                    <select
+                      value={showNewGroup ? '__new__' : (groupId || '')}
+                      onChange={(e) => handleGroupChange(e.target.value)}
+                      className={inputCls}
+                    >
+                      <option value="">None</option>
+                      {groups.map((g) => (
+                        <option key={g.id} value={g.id}>{g.name}</option>
+                      ))}
+                      <option value="__new__">+ New group…</option>
+                    </select>
+                    <Hint k="group">A bundle that collapses into one sidebar row and can launch all its configs with one click.</Hint>
+                    {showNewGroup && (
+                      <div className="flex gap-2 mt-1.5">
+                        <input
+                          autoFocus
+                          value={newGroupName}
+                          onChange={(e) => setNewGroupName(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateGroup() } }}
+                          placeholder="Group name"
+                          className={inputCls.replace('w-full', 'flex-1')}
+                        />
+                        <button
+                          type="button"
+                          onClick={handleCreateGroup}
+                          className="px-3 py-1.5 rounded text-xs bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
+                        >
+                          Create
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-xs text-subtext0">Section</label>
+                      <HelpBtn k="section" label="About sections" />
+                    </div>
+                    <select
+                      value={showNewSection ? '__new__' : (sectionId || '')}
+                      onChange={(e) => handleSectionChange(e.target.value)}
+                      disabled={!!groupId}
+                      className={inputCls + (groupId ? ' opacity-50 cursor-not-allowed' : '')}
+                    >
+                      <option value="">None</option>
+                      {sections.map((s) => (
+                        <option key={s.id} value={s.id}>{s.name}</option>
+                      ))}
+                      <option value="__new__">+ New section…</option>
+                    </select>
+                    <Hint k="section">A labelled heading this config sits under. You can launch everything in a section at once.</Hint>
+                    {showNewSection && !groupId && (
+                      <div className="flex gap-2 mt-1.5">
+                        <input
+                          autoFocus
+                          value={newSectionName}
+                          onChange={(e) => setNewSectionName(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateSection() } }}
+                          placeholder="Section name"
+                          className={inputCls.replace('w-full', 'flex-1')}
+                        />
+                        <button
+                          type="button"
+                          onClick={handleCreateSection}
+                          className="px-3 py-1.5 rounded text-xs bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
+                        >
+                          Create
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                {groupId && (
+                  <p className="text-[11px] text-yellow mt-2">Grouped configs can't also sit under a section — clear the group to pick one.</p>
+                )}
+              </details>
+
+              {/* ── 5 · IDENTITY ── */}
+              {sectionHead('Identity', 'Any provider', 'identity', 'About identity')}
+              <Hint k="identity">
+                Names and colours this config so you can tell its sessions apart in the sidebar and tab strip
+                when several are running.
+              </Hint>
+              <div className="grid grid-cols-2 gap-4 mt-1">
+                <div>
+                  <label className="block text-xs text-subtext0 mb-1">Label <span className="text-peach">*</span></label>
+                  <input
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="e.g. App Dev"
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-subtext0 mb-1">Colour</label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {IDENTITY_SWATCHES.map((k) => (
+                      <button
+                        key={k}
+                        type="button"
+                        onClick={() => setColorKey(k)}
+                        className={`w-6 h-6 rounded-md border-2 transition-all ${
+                          colorKey === k ? 'border-text scale-110' : 'border-transparent hover:border-overlay0'
+                        }`}
+                        style={{ backgroundColor: resolveIdentityColor(k, theme) }}
+                        title={k}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
         </div>
 
-        {/* Buttons — full-width below grid */}
-        <div className="flex justify-end gap-2 mt-5">
+        {/* Footer: the validation slot names the next step; Save can never
+            silently no-op again. */}
+        <div className="flex items-center gap-2 px-6 py-3 border-t border-surface1 bg-base/40">
+          <span className="text-xs text-yellow mr-auto">{validationMsg}</span>
           <button
             type="button"
             onClick={onCancel}
@@ -988,9 +895,12 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
           </button>
           <button
             type="submit"
-            className="px-4 py-1.5 rounded text-sm bg-blue text-crust font-medium hover:bg-blue/90 transition-colors"
+            disabled={!!validationMsg}
+            className={`px-4 py-1.5 rounded text-sm font-medium transition-colors ${
+              validationMsg ? 'bg-surface1 text-overlay0 cursor-not-allowed' : 'bg-blue text-crust hover:bg-blue/90'
+            }`}
           >
-            {initial ? 'Save' : 'Create'}
+            {isEdit ? 'Save changes' : 'Create config'}
           </button>
         </div>
       </form>

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -245,7 +245,13 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     // here or the config saves and then hard-throws at spawn.
     if (uiProvider === 'codex' && sessionType === 'ssh') return "Codex can't run over SSH — pick Claude Code or Terminal only"
     if (sessionType === 'local' && !workingDir.trim()) return 'Add a working directory to save'
-    if (sessionType === 'local' && !looksAbsolute(workingDir)) return 'Working directory must be a full path (e.g. C:\\projects\\app)'
+    // Enforce the absolute-path rule only on a CHANGED value: an imported or
+    // synced config with a foreign-platform absolute path (e.g. a macOS
+    // /Users/... path opened on Windows) can still have its label/colour/model
+    // edited without being forced to fix the path (adversarial review, #188).
+    if (sessionType === 'local' && workingDir.trim() !== (initial?.workingDirectory ?? '').trim() && !looksAbsolute(workingDir)) {
+      return 'Working directory must be a full path (e.g. C:\\projects\\app)'
+    }
     if (sessionType === 'ssh' && !sshHost.trim()) return 'Add a host to save'
     if (sessionType === 'ssh' && sshRemotePath.trim() && !safeRemotePath(sshRemotePath.trim())) return 'Remote directory can only use letters, numbers and _ . / - ~'
     if (!label.trim()) return 'Add a label to save'
@@ -291,14 +297,20 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     // different host. sudo additionally requires a post-connect command: clearing
     // that command must strand nothing. When these are false and the config
     // previously had a stored secret, the delete block below removes it.
-    // A stored secret is host-specific: if the user repoints an SSH config at a
-    // DIFFERENT host without retyping, the old password must NOT carry to the new
-    // machine (adversarial review, #188). Treat the stored value as absent in
-    // that case, so it is deleted below and re-entry is required.
+    // A stored secret is ENDPOINT-specific: if the user repoints an SSH config at
+    // a different host, PORT, or username without retyping, the old password must
+    // NOT carry to the new endpoint (adversarial review, #188 — host, port and
+    // username all change the principal being authenticated). Treat the stored
+    // value as absent in that case, so it is deleted below and re-entry required.
     const isSsh = sessionType === 'ssh'
-    const hostChanged = isSsh && !!initial?.sshConfig && initial.sshConfig.host !== sshHost.trim()
-    const keepStoredPw = storedPassword && !hostChanged
-    const keepStoredSudo = storedSudo && !hostChanged
+    const prevSsh = initial?.sshConfig
+    const endpointChanged = isSsh && !!prevSsh && (
+      (prevSsh.host ?? '').trim() !== sshHost.trim() ||
+      prevSsh.port !== sshPort ||
+      (prevSsh.username ?? '').trim() !== (sshUser.trim() || 'root')
+    )
+    const keepStoredPw = storedPassword && !endpointChanged
+    const keepStoredSudo = storedSudo && !endpointChanged
     const passwordSaved = isSsh && savePassword && (sshPassword.length > 0 || keepStoredPw)
     const sudoSaved = isSsh && postCommand.trim().length > 0 && saveSudo && (sudoPassword.length > 0 || keepStoredSudo)
 

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -384,44 +384,49 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
     </div>
   )
 
+  // Native radio inputs styled as cards: the browser then provides the ARIA
+  // radiogroup keyboard pattern for free (roving tabindex, arrow-key navigation,
+  // skip-disabled) instead of the hand-rolled role="radio" buttons that claimed
+  // radio semantics but only responded to Tab/Enter (Copilot review, #188).
+  const cardCls = (selected: boolean, disabled: boolean) =>
+    `flex-1 text-left rounded-md border px-3 py-2 transition-colors focus-within:outline focus-within:outline-2 focus-within:outline-blue ${
+      disabled
+        ? 'border-surface1 opacity-50 cursor-not-allowed'
+        : selected
+          ? 'border-blue bg-blue/10 cursor-pointer'
+          : 'border-surface1 bg-base hover:border-overlay0 cursor-pointer'
+    }`
+
   const providerCard = (id: UiProvider, title: string, sub: string, disabled: boolean) => (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={uiProvider === id}
-      disabled={disabled}
-      onClick={() => setUiProvider(id)}
-      className={`flex-1 text-left rounded-md border px-3 py-2 transition-colors ${
-        disabled
-          ? 'border-surface1 opacity-50 cursor-not-allowed'
-          : uiProvider === id
-            ? 'border-blue bg-blue/10'
-            : 'border-surface1 bg-base hover:border-overlay0'
-      }`}
-    >
+    <label className={cardCls(uiProvider === id, disabled)}>
+      <input
+        type="radio"
+        name="ccc-provider"
+        className="sr-only"
+        value={id}
+        checked={uiProvider === id}
+        disabled={disabled}
+        onChange={() => setUiProvider(id)}
+      />
       <span className={`block text-sm font-medium ${disabled ? 'text-overlay0' : 'text-text'}`}>{title}</span>
       <span className="block text-[10px] text-overlay0 mt-0.5">{sub}</span>
-    </button>
+    </label>
   )
 
   const transportCard = (id: SessionType, title: string, sub: string, disabled: boolean) => (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={sessionType === id}
-      disabled={disabled}
-      onClick={() => setSessionType(id)}
-      className={`flex-1 text-left rounded-md border px-3 py-2 transition-colors ${
-        disabled
-          ? 'border-surface1 opacity-50 cursor-not-allowed'
-          : sessionType === id
-            ? 'border-blue bg-blue/10'
-            : 'border-surface1 bg-base hover:border-overlay0'
-      }`}
-    >
+    <label className={cardCls(sessionType === id, disabled)}>
+      <input
+        type="radio"
+        name="ccc-transport"
+        className="sr-only"
+        value={id}
+        checked={sessionType === id}
+        disabled={disabled}
+        onChange={() => setSessionType(id)}
+      />
       <span className={`block text-sm font-medium ${disabled ? 'text-overlay0' : 'text-text'}`}>{title}</span>
       <span className="block text-[10px] text-overlay0 mt-0.5">{sub}</span>
-    </button>
+    </label>
   )
 
   const inputCls = 'w-full bg-base border border-surface1 rounded px-3 py-2 text-sm text-text placeholder:text-overlay0 focus:outline-none focus:border-blue'
@@ -696,30 +701,23 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                         <HelpBtn k="effort" label="About the starting effort" />
                       </div>
                       <div className="flex flex-wrap gap-1.5" role="radiogroup" aria-label="Starting effort">
-                        <button
-                          type="button"
-                          role="radio"
-                          aria-checked={effortLevel === ''}
-                          onClick={() => setEffortLevel('')}
-                          className={`px-2.5 py-1 rounded-full border text-xs transition-colors ${
-                            effortLevel === '' ? 'border-blue bg-blue/10 text-text' : 'border-surface1 bg-base text-subtext0 hover:border-overlay0'
-                          }`}
-                        >
-                          Default
-                        </button>
-                        {effortsFromRegistry(registry).map((ef) => (
-                          <button
-                            key={ef.value}
-                            type="button"
-                            role="radio"
-                            aria-checked={effortLevel === ef.value}
-                            onClick={() => setEffortLevel(ef.value as typeof effortLevel)}
-                            className={`px-2.5 py-1 rounded-full border text-xs transition-colors ${
+                        {[{ value: '', label: 'Default' }, ...effortsFromRegistry(registry)].map((ef) => (
+                          <label
+                            key={ef.value || 'default'}
+                            className={`px-2.5 py-1 rounded-full border text-xs cursor-pointer transition-colors focus-within:outline focus-within:outline-2 focus-within:outline-blue ${
                               effortLevel === ef.value ? 'border-blue bg-blue/10 text-text' : 'border-surface1 bg-base text-subtext0 hover:border-overlay0'
                             }`}
                           >
+                            <input
+                              type="radio"
+                              name="ccc-effort"
+                              className="sr-only"
+                              value={ef.value}
+                              checked={effortLevel === ef.value}
+                              onChange={() => setEffortLevel(ef.value as EffortValue | '')}
+                            />
                             {ef.label}
-                          </button>
+                          </label>
                         ))}
                       </div>
                       <Hint k="effort">

--- a/src/renderer/components/SessionStatusStrip.tsx
+++ b/src/renderer/components/SessionStatusStrip.tsx
@@ -59,7 +59,12 @@ export default function SessionStatusStrip({ sessionId }: SessionStatusStripProp
   // telemetry band; the Claude controls cluster (Mode/Model/Restart/account)
   // stays regardless. Absent (pre-upgrade config) means on.
   const statusLineEnabled = useSettingsStore((s) => s.settings.statusLineEnabled ?? true)
-  const codexReview = useCodexReviewUsage(session?.enableCodexReview ? sessionId : null)
+  // Codex review is authorised globally (2 Aug decision): every local Claude
+  // session registers for it, so the usage pill polls whenever this session
+  // qualifies — the gate is the global Codex master, not a per-config flag.
+  const codexReviewOn = useSettingsStore((s) => s.settings.codexEnabled !== false)
+  const codexReviewEligible = codexReviewOn && session?.provider === 'claude' && !session?.shellOnly && session?.sessionType !== 'ssh'
+  const codexReview = useCodexReviewUsage(codexReviewEligible ? sessionId : null)
   const { restart } = useRestartSession(session, false)
   const switchAccount = useSwitchAccount(session)
   const theme = useResolvedTheme()

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -178,7 +178,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
 
-  const handleCreateConfig = async (data: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string) => {
+  const handleCreateConfig = async (data: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string, argSecret?: string) => {
     const config: TerminalConfig = { ...data, id: generateId() }
     addConfig(config)
     // Same stamps as the guided first-config path (App.tsx): without them the
@@ -193,11 +193,14 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
     if (sudoPassword) {
       await window.electronAPI.credentials.save(config.id + '_sudo', sudoPassword)
     }
+    if (argSecret) {
+      await window.electronAPI.credentials.save(config.id + '_argsecret', argSecret)
+    }
     setShowNewDialog(false)
     launchFromConfig(config)
   }
 
-  const handleEditConfig = async (data: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string) => {
+  const handleEditConfig = async (data: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string, argSecret?: string) => {
     if (!editingConfig) return
     updateConfig(editingConfig.id, data)
     sessions.forEach((s) => {
@@ -212,15 +215,20 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
     if (sudoPassword) {
       await window.electronAPI.credentials.save(editingConfig.id + '_sudo', sudoPassword)
     }
+    if (argSecret) {
+      await window.electronAPI.credentials.save(editingConfig.id + '_argsecret', argSecret)
+    }
     setEditingConfig(null)
   }
 
   const handleDeleteConfig = async (configId: string) => {
     removeConfig(configId)
     await window.electronAPI.credentials.delete(configId)
-    // The sudo password lives under its own key; without this it stays
-    // orphaned in the OS keychain forever (pre-2.1.0-beta.5 bug).
+    // The sudo password and the Terminal-only secret argument live under their
+    // own keys; without these they stay orphaned in the OS keychain forever
+    // (pre-2.1.0-beta.5 bug).
     await window.electronAPI.credentials.delete(configId + '_sudo')
+    await window.electronAPI.credentials.delete(configId + '_argsecret')
   }
 
   const launchFromConfig = async (config: TerminalConfig) => {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -218,6 +218,9 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
   const handleDeleteConfig = async (configId: string) => {
     removeConfig(configId)
     await window.electronAPI.credentials.delete(configId)
+    // The sudo password lives under its own key; without this it stays
+    // orphaned in the OS keychain forever (pre-2.1.0-beta.5 bug).
+    await window.electronAPI.credentials.delete(configId + '_sudo')
   }
 
   const launchFromConfig = async (config: TerminalConfig) => {

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -28,7 +28,7 @@ import { useAccountIdentitySubscription } from '../hooks/useAccountIdentitySubsc
 import { useActiveTabEffect } from '../hooks/useActiveTabEffect'
 import { useCursorLayerVisibility } from '../hooks/useCursorLayerVisibility'
 import { useAgentLibraryStore, BUILTIN_TEMPLATES } from '../stores/agentLibraryStore'
-import type { ProviderId, CodexOptions } from '../../shared/types'
+import type { ProviderId, CodexOptions, TerminalOptions } from '../../shared/types'
 
 // Re-export for consumers
 export { killSessionPty } from '../ptyTracker'
@@ -73,9 +73,12 @@ interface Props {
   provider?: ProviderId
   /** Codex sub-options (only meaningful when provider === 'codex'). */
   codexOptions?: CodexOptions
+  /** Terminal-only launcher options (only meaningful when shellOnly). The secret
+   *  VALUE is never carried here — main resolves it from the keychain at spawn. */
+  terminalOptions?: TerminalOptions
 }
 
-export default function TerminalView({ sessionId, configId, cwd, shellOnly, elevated, ssh, isActive = true, legacyVersion, agentIds, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions }: Props) {
+export default function TerminalView({ sessionId, configId, cwd, shellOnly, elevated, ssh, isActive = true, legacyVersion, agentIds, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, terminalOptions }: Props) {
   const xtermContainerRef = useRef<HTMLDivElement>(null)
   const terminalRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -489,7 +492,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               resumeNudgeGated = true
             }
             window.electronAPI.pty
-              .spawn(sessionId, { cwd, cols, rows, ssh, shellOnly, elevated, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
+              .spawn(sessionId, { cwd, cols, rows, ssh, shellOnly, elevated, terminalOptions, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
               .catch((err: unknown) => {
                 // BUG-2: spawn was fire-and-forget, so a main-process throw (e.g.
                 // "Codex CLI not found on PATH") became a silent unhandled

--- a/src/renderer/components/conductor-mcp/CodexReviewSubTool.tsx
+++ b/src/renderer/components/conductor-mcp/CodexReviewSubTool.tsx
@@ -20,7 +20,7 @@ export default function CodexReviewSubTool() {
       icon={codexIcon}
       statusLabel="Available"
       statusColor="green"
-      description='Opt in per Claude session via SessionDialog -> "Enable Codex code review". Calls aggregate into Tokenomics > Codex review row.'
+      description='Available to every local Claude Code session while Codex is enabled (Settings -> Codex). Calls aggregate into Tokenomics > Codex review row.'
       toolList={['codex_review']}
     />
   )

--- a/src/renderer/hooks/useLaunchConfig.ts
+++ b/src/renderer/hooks/useLaunchConfig.ts
@@ -40,6 +40,7 @@ export function useLaunchConfig(): (config: TerminalConfig) => string {
       createdAt: Date.now(),
       sessionType: config.sessionType,
       shellOnly: config.shellOnly,
+      terminalOptions: config.terminalOptions,
       // Partner terminal is permanent for every config type (2 Aug decision):
       // stored partnerTerminalPath/partnerElevated are no longer consumed.
       sshConfig: config.sshConfig ? {

--- a/src/renderer/hooks/useLaunchConfig.ts
+++ b/src/renderer/hooks/useLaunchConfig.ts
@@ -40,8 +40,8 @@ export function useLaunchConfig(): (config: TerminalConfig) => string {
       createdAt: Date.now(),
       sessionType: config.sessionType,
       shellOnly: config.shellOnly,
-      partnerTerminalPath: config.partnerTerminalPath,
-      partnerElevated: config.partnerElevated,
+      // Partner terminal is permanent for every config type (2 Aug decision):
+      // stored partnerTerminalPath/partnerElevated are no longer consumed.
       sshConfig: config.sshConfig ? {
         host: config.sshConfig.host,
         port: config.sshConfig.port,
@@ -58,7 +58,11 @@ export function useLaunchConfig(): (config: TerminalConfig) => string {
       permissionMode: config.claudeOptions?.permissionMode,
       extraArgs: config.claudeOptions?.extraArgs,
       disableAutoMemory: config.claudeOptions?.disableAutoMemory,
-      enableCodexReview: config.claudeOptions?.enableCodexReview,
+      // Launch must carry the indexing opt-out or the spawn never sees it
+      // (pre-2.1.0-beta.5 bug: this path dropped it, so the toggle was inert
+      // for sidebar launches). enableCodexReview is retired — the tool is
+      // authorised globally now, not per config.
+      loggingEnabled: config.claudeOptions?.loggingEnabled,
       provider: config.provider,
       profileId: config.profileId,
       codexOptions: config.codexOptions,

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -21,6 +21,7 @@ export function buildSessionState(): SessionState {
     legacyColor: s.legacyColor,
     sessionType: s.sessionType,
     shellOnly: s.shellOnly,
+    terminalOptions: s.terminalOptions,
     partnerTerminalPath: s.partnerTerminalPath,
     partnerElevated: s.partnerElevated,
     sshConfig: s.sshConfig

--- a/src/renderer/stores/configStore.ts
+++ b/src/renderer/stores/configStore.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand'
 import { saveConfigNow, saveConfigDebounced } from '../utils/config-saver'
-import type { ProviderId, ClaudeOptions, CodexOptions } from '../../shared/types'
+import type { ProviderId, ClaudeOptions, CodexOptions, TerminalOptions } from '../../shared/types'
 import type { IdentityColorKey } from '../../shared/identity-colors'
 import { generateId } from '../utils/id'
 
 // Re-export provider types so callers can import from a single place
-export type { ProviderId, ClaudeOptions, CodexOptions }
+export type { ProviderId, ClaudeOptions, CodexOptions, TerminalOptions }
 
 export interface TerminalConfig {
   id: string
@@ -18,6 +18,8 @@ export interface TerminalConfig {
   legacyColor?: string
   sessionType: 'local' | 'ssh'
   shellOnly?: boolean  // Don't run Claude, just open a shell
+  /** Terminal-only launcher options (command / args / secret / elevated). */
+  terminalOptions?: TerminalOptions
   groupId?: string     // Group this config belongs to
   sectionId?: string   // Section this config belongs to (only used when ungrouped)
   partnerTerminalPath?: string  // Optional partner shell terminal path

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { ProviderId, CodexOptions } from '../../shared/types'
+import type { ProviderId, CodexOptions, TerminalOptions } from '../../shared/types'
 import type { IdentityColorKey } from '../../shared/identity-colors'
 
 export type SessionStatus = 'idle' | 'working' | 'complete' | 'error' | 'disconnected'
@@ -37,6 +37,7 @@ export interface Session {
   createdAt: number
   sessionType: SessionType
   shellOnly?: boolean  // Don't run Claude, just open a shell
+  terminalOptions?: TerminalOptions  // Terminal-only command / args / secret / elevated
   partnerTerminalPath?: string  // Optional partner shell terminal path
   partnerElevated?: boolean     // Run partner terminal as admin (requires gsudo)
   sshConfig?: SSHConfig
@@ -238,7 +239,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
  */
 export const STRUCTURAL_SESSION_FIELDS = [
   'id', 'createdAt', 'configId', 'label', 'customName', 'workingDirectory', 'sessionType',
-  'shellOnly', 'sshConfig', 'partnerTerminalPath', 'partnerElevated',
+  'shellOnly', 'terminalOptions', 'sshConfig', 'partnerTerminalPath', 'partnerElevated',
   'legacyVersion', 'agentIds', 'effortLevel', 'permissionMode', 'extraArgs', 'disableAutoMemory',
   'enableCodexReview', 'loggingEnabled', 'model', 'provider', 'codexOptions',
   'identityColorKey', 'color', 'githubIntegration',

--- a/src/renderer/tips-library.ts
+++ b/src/renderer/tips-library.ts
@@ -207,9 +207,7 @@ export const TIPS_LIBRARY: Tip[] = [
       primary: {
         shortText: '🔀 Add a partner shell next to Claude',
         title: 'Partner Terminal',
-        body: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set a Partner Terminal Path. Path examples below.',
-        bodyMac: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set Partner Terminal Path to `/bin/zsh` or `/bin/bash`.',
-        bodyWin: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click toggles between them.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nEdit your config and set Partner Terminal Path to `powershell.exe` or `cmd.exe`. You can also tick **Elevated** to run it as admin (requires `gsudo`).',
+        body: 'A **partner terminal** is a second shell that runs in the same session tab, alongside Claude. One click on the Partner button in the command bar toggles between them — every session has one, no setup needed.\n\nUse it to:\n• Run `npm run dev` while Claude edits code\n• Keep a test watcher running\n• Run git commands without Claude\'s interference\n• Tail a log file\n\nIt opens in the session\'s working directory (home for SSH sessions).',
       },
       postUse: {
         shortText: '🎯 Route command buttons to your partner shell',

--- a/src/renderer/training-steps.ts
+++ b/src/renderer/training-steps.ts
@@ -256,24 +256,22 @@ export const trainingSteps: TrainingStep[] = [
     summary:
       'Run Claude and a regular shell side-by-side in the same session. Useful when you want to watch logs, run quick git commands, or babysit a long-running build without spawning a second session.',
     highlights: [
-      'Configure a partner terminal path (cmd, pwsh, bash) per saved config',
-      'Both shells share the same working directory at spawn',
+      'Every session has a partner terminal — no setup, any config type',
+      'Opens in the working directory locally, at home over SSH',
       'Quick command buttons can target Claude or partner explicitly',
       'Resize the split bar to favour whichever pane is active',
-      'Optional elevated partner -- runs as admin via gsudo on Windows',
     ],
     howToTrigger: [
-      { label: 'Configure', value: 'Edit Config → Partner terminal path' },
+      { label: 'Toggle', value: 'Partner button in the command bar' },
       { label: 'Quick commands', value: 'Custom command → Target = Partner' },
       { label: 'Resize', value: 'Drag the vertical bar between panes' },
     ],
     proTip:
-      'Set partner = pwsh.exe on Windows or bash on macOS so you have a familiar shell ready for quick sanity checks while Claude does the heavy lifting in the other pane.',
+      'Keep a test watcher or dev server running in the partner pane for quick sanity checks while Claude does the heavy lifting in the other pane.',
     bullets: [
       '**Side-by-side** Claude + regular shell in the same session',
-      'Configure a **partner terminal** path in the session config',
+      'Always available — **no per-config setup**',
       '**Quick commands** can target either pane (Claude or Partner)',
-      'Optional **elevated partner** for admin tasks (Windows: gsudo)',
     ],
     screenshotFilename: 'step-combined.jpg',
   },

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -145,6 +145,7 @@ export interface ElectronAPI {
       }
       shellOnly?: boolean
       elevated?: boolean
+      terminalOptions?: { command?: string; args?: string; hasSecretArg?: boolean; elevated?: boolean }
       configId?: string
       configLabel?: string
       loggingEnabled?: boolean

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -79,9 +79,9 @@ export interface ClaudeOptions {
   legacyVersion?: LegacyVersion
   disableAutoMemory?: boolean
   agentIds?: string[]
-  /** v1.5 P6: when true, the Claude PTY is registered into the codex_review opt-in set
-   *  and the SessionDialog toggle is persisted. Tool description still appears to all
-   *  Claude sessions (soft ACL); this flag controls authorisation server-side. */
+  /** RETIRED 2.1.0-beta.5 (was v1.5 P6): codex_review is authorised globally now —
+   *  every local Claude session registers, gated by the global Codex master switch.
+   *  The field remains only so stored configs round-trip; nothing reads it. */
   enableCodexReview?: boolean
   /** T16: per-session CCC indexing opt-out. DEFAULT-TRUE (undefined / true = on).
    *  When false, CCC does not index this session's transcript for the Logs viewer.
@@ -114,6 +114,8 @@ export interface SavedSession {
   legacyColor?: string
   sessionType: 'local' | 'ssh'
   shellOnly?: boolean
+  /** RETIRED 2.1.0-beta.5: the partner terminal is permanent for every config type
+   *  (working directory locally, home over SSH). Fields remain for round-trip only. */
   partnerTerminalPath?: string
   partnerElevated?: boolean
   sshConfig?: SshConfig

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,6 +89,23 @@ export interface ClaudeOptions {
   loggingEnabled?: boolean
 }
 
+/** Terminal-only ("no AI") launcher options. Local sessions: the command runs
+ *  once when the terminal opens. Over SSH the equivalent is sshConfig.postCommand
+ *  ("After connecting, run"), so these are not used there. */
+export interface TerminalOptions {
+  /** Command run once when the terminal opens. Empty = a plain shell. */
+  command?: string
+  /** Arguments appended to `command`. The literal token `{secret}` is replaced at
+   *  launch with a reference to the secret argument (never the value itself —
+   *  see hasSecretArg). Stored in plain text, so secrets belong in the keychain. */
+  args?: string
+  /** True when a secret argument is stored in the OS keychain under
+   *  `<configId>_argsecret`. The value NEVER touches the config file. */
+  hasSecretArg?: boolean
+  /** Run the terminal elevated (gsudo on Windows, sudo elsewhere). */
+  elevated?: boolean
+}
+
 export interface CodexOptions {
   /** gpt-5.5 / gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex / gpt-5.3-codex-spark / gpt-5.2 */
   model?: string
@@ -114,6 +131,8 @@ export interface SavedSession {
   legacyColor?: string
   sessionType: 'local' | 'ssh'
   shellOnly?: boolean
+  /** Terminal-only launcher options (command / args / secret / elevated). */
+  terminalOptions?: TerminalOptions
   /** RETIRED 2.1.0-beta.5: the partner terminal is permanent for every config type
    *  (working directory locally, home over SSH). Fields remain for round-trip only. */
   partnerTerminalPath?: string

--- a/tests/e2e/helpers/electron-app.ts
+++ b/tests/e2e/helpers/electron-app.ts
@@ -116,10 +116,21 @@ export async function launchIsolatedApp(): Promise<IsolatedApp> {
 
 export async function closeIsolatedApp(a: IsolatedApp | undefined): Promise<void> {
   if (!a) return
+  // A graceful close can hang indefinitely when the test left a live PTY session
+  // running (the shell keeps the app alive), which blows the afterAll hook
+  // timeout and fails an otherwise-passing run. Race it, then kill.
   try {
-    await a.app.close()
+    await Promise.race([
+      a.app.close(),
+      new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+    ])
   } catch {
     /* ignore */
+  }
+  try {
+    a.app.process().kill()
+  } catch {
+    /* already gone */
   }
   // Remove ONLY the unique mkdtemp dir we created — never a parent/shared path.
   try {

--- a/tests/e2e/helpers/electron-app.ts
+++ b/tests/e2e/helpers/electron-app.ts
@@ -19,6 +19,7 @@ import os from 'os'
 import { changelog } from '../../../src/renderer/changelog'
 import { emptyGitHubConfig } from '../../../src/shared/github-constants'
 import { currentTrainingVersion } from '../../../src/renderer/training-steps'
+import { STEPS, ONBOARDING_VERSION } from '../../../src/renderer/onboarding/steps'
 
 const APP_PATH = path.resolve(__dirname, '../../../out/main/index.js')
 
@@ -61,6 +62,15 @@ function seedCleanConfig(dataDir: string): void {
         lastTrainingVersion: currentTrainingVersion(),
         hasCreatedFirstConfig: true,
         accountGateDecided: true,
+        // The v2 onboarding harness (bootGates priority 1.5) outranks every gate
+        // seeded above, so without these three keys it blocked EVERY e2e run and
+        // the suite became vacuous. Mark the flow finished: all steps completed,
+        // at the current ONBOARDING_VERSION, stamped with this app version so
+        // shouldReonboardForBeta() doesn't re-fire it on the beta channel.
+        // Derived from STEPS so a new step can't silently re-break the suite.
+        completedSteps: Object.fromEntries(STEPS.map((s) => [s.id, '2026-01-01T00:00:00.000Z'])),
+        onboardingCompletedVersion: ONBOARDING_VERSION,
+        onboardingAppVersion: appVersion,
       },
       null,
       2,
@@ -89,9 +99,11 @@ export async function launchIsolatedApp(): Promise<IsolatedApp> {
   })
   const page = await app.firstWindow()
   await page.waitForLoadState('domcontentloaded')
-  // Deterministic readiness: the sidebar Settings button renders once the
+  // Deterministic readiness: the sidebar's new-config button renders once the
   // shell has hydrated and setup is complete (env hook → isSetupComplete).
-  await page.waitForSelector('button[title="Settings"]', { timeout: 20000 })
+  // NOT button[title="Settings"] — that title no longer exists on the nav item,
+  // so the wait could only ever time out.
+  await page.waitForSelector('[data-tour="new-config"]', { timeout: 20000 })
   // Belt-and-suspenders: dismiss any first-run boot-gate modal (what's-new /
   // training) the seed didn't fully suppress, so its backdrop can't intercept
   // clicks in tests.

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -24,6 +24,8 @@ test.beforeAll(async () => {
 })
 
 test.afterAll(async () => {
+  // Tearing down with a live PTY session can exceed the 30s hook default.
+  test.setTimeout(120000)
   await closeIsolatedApp(ctx)
 })
 
@@ -191,6 +193,8 @@ test.describe('Terminal-only config actually runs its command', () => {
     expect(shown).toContain('--token|E2E-SECRET-9f3a')
     // …and it ran in the configured working directory (the cd landed first).
     expect(shown.toLowerCase()).toContain(probeDir.toLowerCase())
-    fs.rmSync(probeDir, { recursive: true, force: true })
+    // Best-effort: the spawned shell is still live with this as its cwd, so
+    // Windows holds a lock on it. Leaving a temp dir behind must not fail the run.
+    try { fs.rmSync(probeDir, { recursive: true, force: true }) } catch { /* shell still owns it */ }
   })
 })

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * E2E: the rebuilt SessionDialog, driven in the REAL packaged app.
+ *
+ * Covers every provider × transport permutation of the choice-driven flow, and
+ * — the part unit tests cannot reach — actually LAUNCHES a Terminal-only config
+ * and asserts its first-run command ran in the spawned PTY with the secret
+ * argument resolved from the OS keychain.
+ *
+ * Runs against an isolated temp data dir (helpers/electron-app), so it never
+ * touches real user config.
+ */
+import { test, expect } from '@playwright/test'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+let ctx: IsolatedApp
+let page: IsolatedApp['page']
+
+test.beforeAll(async () => {
+  ctx = await launchIsolatedApp()
+  page = ctx.page
+})
+
+test.afterAll(async () => {
+  await closeIsolatedApp(ctx)
+})
+
+/** Open a fresh New-config dialog (Escape first so a previous one can't stack). */
+async function openDialog() {
+  await page.keyboard.press('Escape').catch(() => {})
+  await page.locator('[data-tour="new-config"]').first().click()
+  await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
+}
+
+const provider = (v: string) => page.locator(`[role="radiogroup"][aria-label="Provider"] input[value="${v}"]`)
+const transport = (v: string) => page.locator(`[role="radiogroup"][aria-label="Where it runs"] input[value="${v}"]`)
+
+test.describe('SessionDialog — driven flow permutations', () => {
+  test('a new config reveals itself: nothing until a provider is picked', async () => {
+    await openDialog()
+    // Transport is hidden until a provider is chosen, and the footer names the step.
+    await expect(page.locator('[role="radiogroup"][aria-label="Where it runs"]')).toHaveCount(0)
+    await expect(page.locator('text=Choose what this launcher runs')).toBeVisible()
+    await expect(page.locator('text=Workspace')).toHaveCount(0)
+
+    await provider('claude').click()
+    await expect(page.locator('[role="radiogroup"][aria-label="Where it runs"]')).toBeVisible()
+    await expect(page.locator('text=Choose where it runs')).toBeVisible()
+    // Still nothing below until the transport is chosen.
+    await expect(page.locator('text=Workspace')).toHaveCount(0)
+
+    await transport('local').click()
+    await expect(page.locator('text=Workspace')).toBeVisible()
+    await expect(page.locator('text=Session startup')).toBeVisible()
+    await expect(page.locator('text=Identity')).toBeVisible()
+  })
+
+  test('Claude Code × Local shows model/effort/permission, and GitHub only after a directory', async () => {
+    await openDialog()
+    await provider('claude').click()
+    await transport('local').click()
+    await expect(page.locator('text=Starting model')).toBeVisible()
+    await expect(page.locator('text=Starting effort')).toBeVisible()
+    await expect(page.locator('text=Permission mode')).toBeVisible()
+    await expect(page.locator('text=Index conversation logs')).toBeVisible()
+    // GitHub is driven by the working directory.
+    await expect(page.locator('text=GitHub')).toHaveCount(0)
+    await page.locator('input[placeholder*="path"]').first().fill('C:\\temp\\proj')
+    await expect(page.locator('text=GitHub')).toBeVisible()
+  })
+
+  test('Claude Code × SSH swaps in the SSH fields and drops local-only sections', async () => {
+    await openDialog()
+    await provider('claude').click()
+    await transport('ssh').click()
+    await expect(page.locator('text=Remote directory')).toBeVisible()
+    await expect(page.locator('text=After connecting, run')).toBeVisible()
+    await expect(page.locator('text=Machine name')).toBeVisible()
+    // Local-only: indexing never registers over SSH, GitHub detection shells local git.
+    await expect(page.locator('text=Index conversation logs')).toHaveCount(0)
+    await expect(page.locator('text=GitHub')).toHaveCount(0)
+    // Exactly ONE directory field (the old dialog's dead local path is gone).
+    await expect(page.locator('text=Working directory')).toHaveCount(0)
+  })
+
+  test('Codex × SSH is blocked in BOTH directions', async () => {
+    await openDialog()
+    // SSH first → Codex card disabled.
+    await provider('claude').click()
+    await transport('ssh').click()
+    await expect(provider('codex')).toBeDisabled()
+    await expect(page.locator("text=Codex can't run over SSH yet")).toBeVisible()
+    // Codex first → SSH card disabled.
+    await transport('local').click()
+    await provider('codex').click()
+    await expect(transport('ssh')).toBeDisabled()
+    await expect(page.locator('text=Codex runs on this PC only')).toBeVisible()
+  })
+
+  test('Terminal only × Local shows the command / arguments / secret fields', async () => {
+    await openDialog()
+    await provider('terminal').click()
+    await transport('local').click()
+    await expect(page.locator('text=Terminal startup')).toBeVisible()
+    await expect(page.locator('text=First-run command')).toBeVisible()
+    await expect(page.locator('text=Secret argument')).toBeVisible()
+    await expect(page.locator('text=Run as Administrator')).toBeVisible()
+    // No AI settings for a plain terminal.
+    await expect(page.locator('text=Starting model')).toHaveCount(0)
+  })
+
+  test('Terminal only × SSH points at the post-connect command instead', async () => {
+    await openDialog()
+    await provider('terminal').click()
+    await transport('ssh').click()
+    await expect(page.locator('text=After connecting, run')).toBeVisible()
+    await expect(page.locator('text=First-run command')).toHaveCount(0)
+  })
+
+  test('Organise is a real disclosure, not a decorative pill', async () => {
+    await openDialog()
+    await provider('claude').click()
+    await transport('local').click()
+    // Collapsed by default; the group/section selects appear only once opened.
+    await expect(page.locator('text=(optional — group & section)')).toBeVisible()
+    await expect(page.locator('select#group')).toHaveCount(0)
+    await page.locator('summary:has-text("Organise")').click()
+    await expect(page.locator('select#group')).toBeVisible()
+  })
+})
+
+test.describe('Terminal-only config actually runs its command', () => {
+  test('creates, launches, and the PTY runs the first-run command with the secret', async () => {
+    await openDialog()
+    await provider('terminal').click()
+    await transport('local').click()
+
+    await page.locator('input[placeholder*="path"]').first().fill(process.env.TEMP || 'C:\\temp')
+    await page.locator('input[placeholder="npm run dev"]').fill('echo')
+    await page.locator('input[placeholder*="--port 4310"]').fill('CCC_E2E_MARKER {secret}')
+    await page.locator('input[type="password"]').first().fill('E2E-SECRET-9f3a')
+    await page.locator('input[placeholder="e.g. App Dev"]').fill('E2E Terminal')
+
+    await page.locator('button:has-text("Create config")').click()
+
+    // Creating from the sidebar launches the config straight away; the PTY runs
+    // `echo CCC_E2E_MARKER $env:CCC_ARG_SECRET` after the cd, so the terminal
+    // must show the marker AND the secret resolved from the keychain.
+    const term = page.locator('.xterm-screen').first()
+    await expect(term).toBeVisible({ timeout: 20000 })
+    await expect
+      .poll(async () => (await page.locator('.xterm-rows').first().innerText().catch(() => '')) || '',
+        { timeout: 30000, intervals: [500] })
+      .toContain('CCC_E2E_MARKER')
+    const shown = await page.locator('.xterm-rows').first().innerText()
+    expect(shown).toContain('E2E-SECRET-9f3a')
+  })
+})

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -10,6 +10,9 @@
  * touches real user config.
  */
 import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
 
 let ctx: IsolatedApp
@@ -77,7 +80,7 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await expect(page.locator('text=Starting effort')).toBeVisible()
     await expect(page.locator('text=Permission mode')).toBeVisible()
     await expect(page.locator('text=Index conversation logs')).toBeVisible()
-    await expect(page.locator('text=Working directory')).toBeVisible()
+    await expect(page.locator('text=Working directory').first()).toBeVisible()
     // The GitHub section is deliberately NOT in this dialog yet (it needs the
     // account picker + autoDetected state); repo binding still happens through
     // the auto-detect banner. Pinned so re-adding it is a conscious change.
@@ -146,35 +149,48 @@ test.describe('SessionDialog — driven flow permutations', () => {
 })
 
 test.describe('Terminal-only config actually runs its command', () => {
-  // Spawning a PTY and waiting for shell output needs more than the 30s default.
+  // Spawning a PTY and waiting for a real process needs more than the 30s default.
   test('creates, launches, and the PTY runs the first-run command with the secret', async () => {
-    test.setTimeout(120000)
+    test.setTimeout(180000)
+
+    // A probe that records the argv it was launched with. Asserting on a FILE
+    // rather than xterm's output is both stronger (it proves the secret arrived
+    // as a real argv element, not just as pixels) and immune to xterm rendering
+    // to a canvas, where there is no DOM text to read.
+    const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-e2e-probe-'))
+    const probeJs = path.join(probeDir, 'probe.js')
+    const probeOut = path.join(probeDir, 'argv.txt')
+    fs.writeFileSync(
+      probeJs,
+      `require('fs').writeFileSync(${JSON.stringify(probeOut)}, 'ARGV=' + process.argv.slice(2).join('|') + '\\nCWD=' + process.cwd())`,
+    )
+
     await openDialog()
     await providerCard('terminal').click()
     await transportCard('local').click()
 
-    await page.locator('input[placeholder*="path"]').first().fill(process.env.TEMP || 'C:\\temp')
-    await page.locator('input[placeholder="npm run dev"]').fill('echo')
-    await page.locator('input[placeholder*="--port 4310"]').fill('CCC_E2E_MARKER {secret}')
+    await page.locator('input[placeholder*="path"]').first().fill(probeDir)
+    await page.locator('input[placeholder="npm run dev"]').fill('node')
+    await page.locator('input[placeholder*="--port 4310"]').fill(`${probeJs.replace(/\\/g, '/')} --token {secret}`)
     await page.locator('input[type="password"]').first().fill('E2E-SECRET-9f3a')
     await page.locator('input[placeholder="e.g. App Dev"]').fill('E2E Terminal')
 
     await page.locator('button:has-text("Create config")').click()
 
-    // Creating from the sidebar launches the config straight away; the PTY runs
-    // `echo CCC_E2E_MARKER $env:CCC_ARG_SECRET` after the cd, so the terminal
-    // must show the marker AND the secret resolved from the keychain.
-    // The session tab appears first, then the PTY spawns and the shell echoes.
+    // Creating from the sidebar launches the config immediately.
     await expect(page.locator('text=E2E Terminal').first()).toBeVisible({ timeout: 30000 })
-    const term = page.locator('.xterm-screen').first()
-    await expect(term).toBeVisible({ timeout: 30000 })
+
     await expect
-      .poll(async () => (await page.locator('.xterm-rows').first().innerText().catch(() => '')) || '',
-        { timeout: 60000, intervals: [1000] })
-      .toContain('CCC_E2E_MARKER')
-    const shown = await page.locator('.xterm-rows').first().innerText()
-    // The secret came from the OS keychain via CCC_ARG_SECRET — never from the
-    // config file, and never as plaintext in the line CCC typed.
-    expect(shown).toContain('E2E-SECRET-9f3a')
+      .poll(() => (fs.existsSync(probeOut) ? fs.readFileSync(probeOut, 'utf8') : ''),
+        { timeout: 90000, intervals: [1000] })
+      .toContain('ARGV=')
+
+    const shown = fs.readFileSync(probeOut, 'utf8')
+    // The secret reached the process as a REAL argv element, resolved from the
+    // OS keychain via CCC_ARG_SECRET — never stored in the config file.
+    expect(shown).toContain('--token|E2E-SECRET-9f3a')
+    // …and it ran in the configured working directory (the cd landed first).
+    expect(shown.toLowerCase()).toContain(probeDir.toLowerCase())
+    fs.rmSync(probeDir, { recursive: true, force: true })
   })
 })

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -31,8 +31,13 @@ async function openDialog() {
   await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
 }
 
+// The radios are visually-hidden (sr-only) inputs inside styled <label> cards —
+// that's what gives them the native ARIA radiogroup keyboard behaviour. A user
+// clicks the CARD, so tests click the label and assert on the input.
 const provider = (v: string) => page.locator(`[role="radiogroup"][aria-label="Provider"] input[value="${v}"]`)
 const transport = (v: string) => page.locator(`[role="radiogroup"][aria-label="Where it runs"] input[value="${v}"]`)
+const providerCard = (v: string) => page.locator(`[role="radiogroup"][aria-label="Provider"] label:has(input[value="${v}"])`)
+const transportCard = (v: string) => page.locator(`[role="radiogroup"][aria-label="Where it runs"] label:has(input[value="${v}"])`)
 
 test.describe('SessionDialog — driven flow permutations', () => {
   test('a new config reveals itself: nothing until a provider is picked', async () => {
@@ -42,13 +47,13 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await expect(page.locator('text=Choose what this launcher runs')).toBeVisible()
     await expect(page.locator('text=Workspace')).toHaveCount(0)
 
-    await provider('claude').click()
+    await providerCard('claude').click()
     await expect(page.locator('[role="radiogroup"][aria-label="Where it runs"]')).toBeVisible()
     await expect(page.locator('text=Choose where it runs')).toBeVisible()
     // Still nothing below until the transport is chosen.
     await expect(page.locator('text=Workspace')).toHaveCount(0)
 
-    await transport('local').click()
+    await transportCard('local').click()
     await expect(page.locator('text=Workspace')).toBeVisible()
     await expect(page.locator('text=Session startup')).toBeVisible()
     await expect(page.locator('text=Identity')).toBeVisible()
@@ -56,8 +61,8 @@ test.describe('SessionDialog — driven flow permutations', () => {
 
   test('Claude Code × Local shows model/effort/permission, and GitHub only after a directory', async () => {
     await openDialog()
-    await provider('claude').click()
-    await transport('local').click()
+    await providerCard('claude').click()
+    await transportCard('local').click()
     await expect(page.locator('text=Starting model')).toBeVisible()
     await expect(page.locator('text=Starting effort')).toBeVisible()
     await expect(page.locator('text=Permission mode')).toBeVisible()
@@ -70,8 +75,8 @@ test.describe('SessionDialog — driven flow permutations', () => {
 
   test('Claude Code × SSH swaps in the SSH fields and drops local-only sections', async () => {
     await openDialog()
-    await provider('claude').click()
-    await transport('ssh').click()
+    await providerCard('claude').click()
+    await transportCard('ssh').click()
     await expect(page.locator('text=Remote directory')).toBeVisible()
     await expect(page.locator('text=After connecting, run')).toBeVisible()
     await expect(page.locator('text=Machine name')).toBeVisible()
@@ -85,21 +90,21 @@ test.describe('SessionDialog — driven flow permutations', () => {
   test('Codex × SSH is blocked in BOTH directions', async () => {
     await openDialog()
     // SSH first → Codex card disabled.
-    await provider('claude').click()
-    await transport('ssh').click()
+    await providerCard('claude').click()
+    await transportCard('ssh').click()
     await expect(provider('codex')).toBeDisabled()
     await expect(page.locator("text=Codex can't run over SSH yet")).toBeVisible()
     // Codex first → SSH card disabled.
-    await transport('local').click()
-    await provider('codex').click()
+    await transportCard('local').click()
+    await providerCard('codex').click()
     await expect(transport('ssh')).toBeDisabled()
     await expect(page.locator('text=Codex runs on this PC only')).toBeVisible()
   })
 
   test('Terminal only × Local shows the command / arguments / secret fields', async () => {
     await openDialog()
-    await provider('terminal').click()
-    await transport('local').click()
+    await providerCard('terminal').click()
+    await transportCard('local').click()
     await expect(page.locator('text=Terminal startup')).toBeVisible()
     await expect(page.locator('text=First-run command')).toBeVisible()
     await expect(page.locator('text=Secret argument')).toBeVisible()
@@ -110,16 +115,16 @@ test.describe('SessionDialog — driven flow permutations', () => {
 
   test('Terminal only × SSH points at the post-connect command instead', async () => {
     await openDialog()
-    await provider('terminal').click()
-    await transport('ssh').click()
+    await providerCard('terminal').click()
+    await transportCard('ssh').click()
     await expect(page.locator('text=After connecting, run')).toBeVisible()
     await expect(page.locator('text=First-run command')).toHaveCount(0)
   })
 
   test('Organise is a real disclosure, not a decorative pill', async () => {
     await openDialog()
-    await provider('claude').click()
-    await transport('local').click()
+    await providerCard('claude').click()
+    await transportCard('local').click()
     // Collapsed by default; the group/section selects appear only once opened.
     await expect(page.locator('text=(optional — group & section)')).toBeVisible()
     await expect(page.locator('select#group')).toHaveCount(0)
@@ -131,8 +136,8 @@ test.describe('SessionDialog — driven flow permutations', () => {
 test.describe('Terminal-only config actually runs its command', () => {
   test('creates, launches, and the PTY runs the first-run command with the secret', async () => {
     await openDialog()
-    await provider('terminal').click()
-    await transport('local').click()
+    await providerCard('terminal').click()
+    await transportCard('local').click()
 
     await page.locator('input[placeholder*="path"]').first().fill(process.env.TEMP || 'C:\\temp')
     await page.locator('input[placeholder="npm run dev"]').fill('echo')

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -24,9 +24,19 @@ test.afterAll(async () => {
   await closeIsolatedApp(ctx)
 })
 
-/** Open a fresh New-config dialog (Escape first so a previous one can't stack). */
+/**
+ * Open a fresh New-config dialog. These specs share one app instance, so an
+ * already-open dialog would block the sidebar button — close it via Cancel.
+ * (Escape does NOT close this dialog today; deliberately not added here since a
+ * bare Escape-to-close would make silent data loss easier without the
+ * unsaved-changes confirm.)
+ */
 async function openDialog() {
-  await page.keyboard.press('Escape').catch(() => {})
+  const cancel = page.locator('button:has-text("Cancel")').first()
+  if (await cancel.isVisible().catch(() => false)) {
+    await cancel.click()
+    await expect(page.locator('text=New saved config')).toHaveCount(0)
+  }
   await page.locator('[data-tour="new-config"]').first().click()
   await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
 }
@@ -126,15 +136,17 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await providerCard('claude').click()
     await transportCard('local').click()
     // Collapsed by default; the group/section selects appear only once opened.
-    await expect(page.locator('text=(optional — group & section)')).toBeVisible()
-    await expect(page.locator('select#group')).toHaveCount(0)
+    await expect(page.locator('#ccc-group')).toHaveCount(0)
     await page.locator('summary:has-text("Organise")').click()
-    await expect(page.locator('select#group')).toBeVisible()
+    await expect(page.locator('#ccc-group')).toBeVisible()
+    await expect(page.locator('#ccc-section')).toBeVisible()
   })
 })
 
 test.describe('Terminal-only config actually runs its command', () => {
+  // Spawning a PTY and waiting for shell output needs more than the 30s default.
   test('creates, launches, and the PTY runs the first-run command with the secret', async () => {
+    test.setTimeout(120000)
     await openDialog()
     await providerCard('terminal').click()
     await transportCard('local').click()

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -69,7 +69,7 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await expect(page.locator('text=Identity')).toBeVisible()
   })
 
-  test('Claude Code × Local shows model/effort/permission, and GitHub only after a directory', async () => {
+  test('Claude Code × Local shows model / effort / permission / logging', async () => {
     await openDialog()
     await providerCard('claude').click()
     await transportCard('local').click()
@@ -77,10 +77,11 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await expect(page.locator('text=Starting effort')).toBeVisible()
     await expect(page.locator('text=Permission mode')).toBeVisible()
     await expect(page.locator('text=Index conversation logs')).toBeVisible()
-    // GitHub is driven by the working directory.
-    await expect(page.locator('text=GitHub')).toHaveCount(0)
-    await page.locator('input[placeholder*="path"]').first().fill('C:\\temp\\proj')
-    await expect(page.locator('text=GitHub')).toBeVisible()
+    await expect(page.locator('text=Working directory')).toBeVisible()
+    // The GitHub section is deliberately NOT in this dialog yet (it needs the
+    // account picker + autoDetected state); repo binding still happens through
+    // the auto-detect banner. Pinned so re-adding it is a conscious change.
+    await expect(page.locator('text=Repository')).toHaveCount(0)
   })
 
   test('Claude Code × SSH swaps in the SSH fields and drops local-only sections', async () => {
@@ -88,7 +89,7 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await providerCard('claude').click()
     await transportCard('ssh').click()
     await expect(page.locator('text=Remote directory')).toBeVisible()
-    await expect(page.locator('text=After connecting, run')).toBeVisible()
+    await expect(page.locator('text=After connecting, run').first()).toBeVisible()
     await expect(page.locator('text=Machine name')).toBeVisible()
     // Local-only: indexing never registers over SSH, GitHub detection shells local git.
     await expect(page.locator('text=Index conversation logs')).toHaveCount(0)
@@ -127,7 +128,7 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await openDialog()
     await providerCard('terminal').click()
     await transportCard('ssh').click()
-    await expect(page.locator('text=After connecting, run')).toBeVisible()
+    await expect(page.locator('text=After connecting, run').first()).toBeVisible()
     await expect(page.locator('text=First-run command')).toHaveCount(0)
   })
 
@@ -135,8 +136,9 @@ test.describe('SessionDialog — driven flow permutations', () => {
     await openDialog()
     await providerCard('claude').click()
     await transportCard('local').click()
-    // Collapsed by default; the group/section selects appear only once opened.
-    await expect(page.locator('#ccc-group')).toHaveCount(0)
+    // Collapsed by default. <details> keeps its content in the DOM, so assert
+    // VISIBILITY rather than presence.
+    await expect(page.locator('#ccc-group')).toBeHidden()
     await page.locator('summary:has-text("Organise")').click()
     await expect(page.locator('#ccc-group')).toBeVisible()
     await expect(page.locator('#ccc-section')).toBeVisible()
@@ -162,13 +164,17 @@ test.describe('Terminal-only config actually runs its command', () => {
     // Creating from the sidebar launches the config straight away; the PTY runs
     // `echo CCC_E2E_MARKER $env:CCC_ARG_SECRET` after the cd, so the terminal
     // must show the marker AND the secret resolved from the keychain.
+    // The session tab appears first, then the PTY spawns and the shell echoes.
+    await expect(page.locator('text=E2E Terminal').first()).toBeVisible({ timeout: 30000 })
     const term = page.locator('.xterm-screen').first()
-    await expect(term).toBeVisible({ timeout: 20000 })
+    await expect(term).toBeVisible({ timeout: 30000 })
     await expect
       .poll(async () => (await page.locator('.xterm-rows').first().innerText().catch(() => '')) || '',
-        { timeout: 30000, intervals: [500] })
+        { timeout: 60000, intervals: [1000] })
       .toContain('CCC_E2E_MARKER')
     const shown = await page.locator('.xterm-rows').first().innerText()
+    // The secret came from the OS keychain via CCC_ARG_SECRET — never from the
+    // config file, and never as plaintext in the line CCC typed.
     expect(shown).toContain('E2E-SECRET-9f3a')
   })
 })

--- a/tests/unit/main/codex-review-mcp-tool.test.ts
+++ b/tests/unit/main/codex-review-mcp-tool.test.ts
@@ -349,6 +349,23 @@ describe('codex_review tool', () => {
     }
   })
 
+  // SECURITY (adversarial review, #188): defence-in-depth against the
+  // home-directory review root. A config whose workingDirectory is '.', empty,
+  // or a stale/deleted path makes resolveCwd() fall back to os.homedir();
+  // registration already refuses that, and runCodexReview refuses it again so
+  // mode:'paths' can never reach ~/.ssh, ~/.claude, ~/.aws even if some future
+  // caller re-introduces a home-rooted session into the opted-in set.
+  it('refuses when resolvedCwd is the home directory (no project dir)', async () => {
+    const home = require('os').homedir()
+    const result = await runCodexReview(
+      { cccSessionId: 'sess-allowed', mode: 'paths', paths: ['.ssh/id_rsa'] },
+      optedIn, home,
+    )
+    expect(result.isError).toBe(true)
+    expect(result.text).toMatch(/home folder|no project directory/i)
+    expect(runCodexStreaming).not.toHaveBeenCalled()
+  })
+
   // P7.7.10 -- cccSessionId is now optional in the zod schema (resolved
   // server-side from the MCP transport URL). runCodexReview itself still
   // requires it -- the tool wrapper is responsible for merging in the
@@ -382,6 +399,7 @@ describe('registerCodexReviewTool resolver (P7.7.10 transport binding)', () => {
   }
   let optedInSet: Set<string>
   let sessionCwds: Map<string, string>
+  let boundCwd: string
 
   beforeEach(() => {
     resolver = null
@@ -393,10 +411,22 @@ describe('registerCodexReviewTool resolver (P7.7.10 transport binding)', () => {
       planType: 'plus', hasOpenAiApiKeyEnv: false,
     })
     optedInSet = new Set<string>(['bound-sid', 'arg-sid'])
-    sessionCwds = new Map<string, string>()
+    // A real temp dir so the resolver's `!cwd` guard passes and mode:'paths'
+    // containment resolves against a genuine directory (never os.homedir()).
+    boundCwd = mkdtempSync(join(tmpdir(), 'ccc-codex-review-bound-'))
+    sessionCwds = new Map<string, string>([['bound-sid', boundCwd], ['arg-sid', mkdtempSync(join(tmpdir(), 'ccc-codex-review-arg-'))]])
   })
 
-  it('prefers the transport-bound sessionId over the LLM-supplied arg', async () => {
+  afterEach(() => {
+    rmSync(boundCwd, { recursive: true, force: true })
+  })
+
+  // SECURITY (adversarial review, #188): the tool trusts ONLY the
+  // transport-bound session id. The LLM-supplied cccSessionId arg is ignored
+  // entirely — otherwise, now that every local session is opted-in, a
+  // prompt-injected session could pass another session's id, clear the ACL, and
+  // review that session's working tree (cross-session read).
+  it('uses the transport-bound sessionId and its cwd, ignoring the LLM-supplied arg', async () => {
     registerCodexReviewTool(
       mockServer,
       mockZ,
@@ -405,19 +435,22 @@ describe('registerCodexReviewTool resolver (P7.7.10 transport binding)', () => {
       () => 'bound-sid',
     )
     expect(resolver).not.toBeNull()
-    runCodexStreaming.mockImplementation(async () => ({
-      code: -1, stderr: '', timedOut: true,  // bail early; we only care about which sid ran the ACL.
-    }))
-    // LLM passes a DIFFERENT sid -- bound should win, ACL passes against bound.
+    let capturedCwd = ''
+    runCodexStreaming.mockImplementation(async (args: string[]) => {
+      const i = args.indexOf('--cd')
+      capturedCwd = args[i + 1]
+      return { code: -1, stderr: '', timedOut: true }  // bail after argv capture
+    })
+    // LLM passes a DIFFERENT opted-in sid -- it must be ignored; the bound sid's
+    // cwd is what codex runs against.
     const out = await resolver!({ cccSessionId: 'arg-sid', mode: 'paths', paths: ['x'] })
-    // ACL passed (bound-sid in set) so we got past it; failure is the
-    // mocked timeout from runCodexStreaming, NOT "not enabled for arg-sid".
     expect(out.isError).toBe(true)
-    expect(out.content[0].text).toContain('timed out')
+    expect(out.content[0].text).toContain('timed out')  // got past ACL with bound-sid
     expect(out.content[0].text).not.toContain('not enabled')
+    expect(capturedCwd).toBe(boundCwd)  // bound sid's cwd, NOT arg-sid's
   })
 
-  it('falls back to the LLM-supplied arg when no sessionId is bound', async () => {
+  it('REFUSES when no sessionId is bound (arg fallback removed)', async () => {
     registerCodexReviewTool(
       mockServer,
       mockZ,
@@ -426,33 +459,15 @@ describe('registerCodexReviewTool resolver (P7.7.10 transport binding)', () => {
       () => null,  // no transport binding -- legacy/in-flight connection
     )
     expect(resolver).not.toBeNull()
-    runCodexStreaming.mockImplementation(async () => ({
-      code: -1, stderr: '', timedOut: true,
-    }))
+    // Even though the LLM supplies a valid opted-in sid, an unbound connection
+    // is refused outright — the arg is never trusted.
     const out = await resolver!({ cccSessionId: 'arg-sid', mode: 'paths', paths: ['x'] })
-    // Arg sid is in the opted-in set so ACL passes; failure is the mocked
-    // timeout (proves we got past ACL with the arg-supplied sid).
     expect(out.isError).toBe(true)
-    expect(out.content[0].text).toContain('timed out')
-    expect(out.content[0].text).not.toContain('not enabled')
-  })
-
-  it('returns "no CCC session id bound" when neither bound nor arg sid is present', async () => {
-    registerCodexReviewTool(
-      mockServer,
-      mockZ,
-      () => optedInSet,
-      (sid: string) => sessionCwds.get(sid) ?? null,
-      () => null,
-    )
-    expect(resolver).not.toBeNull()
-    const out = await resolver!({ mode: 'paths', paths: ['x'] })
-    expect(out.isError).toBe(true)
-    expect(out.content[0].text).toContain('no CCC session id bound')
+    expect(out.content[0].text).toContain('no bound CCC session')
     expect(runCodexStreaming).not.toHaveBeenCalled()
   })
 
-  it('uses default null-returning getBoundSessionId when caller omits it (back-compat)', async () => {
+  it('REFUSES when getBoundSessionId is omitted (default null, back-compat)', async () => {
     registerCodexReviewTool(
       mockServer,
       mockZ,
@@ -461,11 +476,24 @@ describe('registerCodexReviewTool resolver (P7.7.10 transport binding)', () => {
       // getBoundSessionId omitted -- default returns null
     )
     expect(resolver).not.toBeNull()
-    runCodexStreaming.mockImplementation(async () => ({
-      code: -1, stderr: '', timedOut: true,
-    }))
     const out = await resolver!({ cccSessionId: 'arg-sid', mode: 'paths', paths: ['x'] })
     expect(out.isError).toBe(true)
-    expect(out.content[0].text).toContain('timed out')
+    expect(out.content[0].text).toContain('no bound CCC session')
+    expect(runCodexStreaming).not.toHaveBeenCalled()
+  })
+
+  it('REFUSES a bound sid with no cwd mapping (never falls back to process.cwd)', async () => {
+    registerCodexReviewTool(
+      mockServer,
+      mockZ,
+      () => optedInSet,
+      () => null,  // sid resolves to no cwd (desynced/stale)
+      () => 'bound-sid',
+    )
+    expect(resolver).not.toBeNull()
+    const out = await resolver!({ mode: 'paths', paths: ['x'] })
+    expect(out.isError).toBe(true)
+    expect(out.content[0].text).toContain('not enabled')
+    expect(runCodexStreaming).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/main/path-utils-home.test.ts
+++ b/tests/unit/main/path-utils-home.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import * as os from 'os'
+import * as path from 'path'
+import { isHomeOrAncestor } from '../../../src/main/path-utils'
+
+/**
+ * SECURITY (adversarial review, #188): isHomeOrAncestor is the guard that keeps
+ * codex_review off the home directory and its ancestors — a `===` string compare
+ * was bypassable on Windows by a case-variant or junction form of home.
+ */
+describe('isHomeOrAncestor', () => {
+  const home = os.homedir()
+
+  it('is true for the exact home directory', () => {
+    expect(isHomeOrAncestor(home)).toBe(true)
+  })
+
+  it('is true for an ancestor of home (parent dir)', () => {
+    const parent = path.dirname(home)
+    // Only assert when home genuinely has a parent (not a drive root).
+    if (parent !== home) expect(isHomeOrAncestor(parent)).toBe(true)
+  })
+
+  it('is false for a subdirectory of home (a real project dir)', () => {
+    expect(isHomeOrAncestor(path.join(home, 'some-project'))).toBe(false)
+  })
+
+  it('is false for an unrelated temp directory', () => {
+    const tmp = os.tmpdir()
+    // tmp is only a valid negative if it isn't itself an ancestor of home.
+    if (!home.toLowerCase().startsWith(tmp.toLowerCase())) {
+      expect(isHomeOrAncestor(tmp)).toBe(false)
+    }
+  })
+
+  it('catches a case-variant of home on case-insensitive platforms (Windows)', () => {
+    if (process.platform !== 'win32') return
+    const variant = home.toLowerCase()
+    if (variant !== home) expect(isHomeOrAncestor(variant)).toBe(true)
+  })
+
+  it('catches the trailing-separator form of home', () => {
+    expect(isHomeOrAncestor(home + path.sep)).toBe(true)
+  })
+})

--- a/tests/unit/main/path-utils-home.test.ts
+++ b/tests/unit/main/path-utils-home.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as os from 'os'
 import * as path from 'path'
+import * as fs from 'fs'
 import { isHomeOrAncestor } from '../../../src/main/path-utils'
 
 /**
@@ -41,5 +42,17 @@ describe('isHomeOrAncestor', () => {
 
   it('catches the trailing-separator form of home', () => {
     expect(isHomeOrAncestor(home + path.sep)).toBe(true)
+  })
+
+  it('catches the UNC admin-share form of home on Windows (identity, not string)', () => {
+    if (process.platform !== 'win32') return
+    const m = /^([A-Za-z]):\\(.*)$/.exec(home)
+    if (!m) return
+    const unc = `\\\\localhost\\${m[1]}$\\${m[2]}`  // \\localhost\C$\Users\me
+    // Only assert when the admin share is actually reachable in this environment;
+    // its dev:ino must match the drive-letter form, which the string compare missed.
+    let reachable = false
+    try { reachable = fs.statSync(unc).isDirectory() } catch { reachable = false }
+    if (reachable) expect(isHomeOrAncestor(unc)).toBe(true)
   })
 })

--- a/tests/unit/main/terminal-secret-env.test.ts
+++ b/tests/unit/main/terminal-secret-env.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { buildClaudeLocalSpawn } from '../../../src/main/providers/claude/spawn'
+import { buildTerminalLaunchLine } from '../../../src/main/terminal-launch-line'
+
+/**
+ * 2.1.0-beta.6 — Terminal-only secret argument.
+ *
+ * SECURITY CONTRACT: the secret VALUE goes into the spawn ENV only. It must
+ * never be interpolated into the command text, because CCC writes that text
+ * into the PTY and every submitted line is recorded by the shell's persistent
+ * history (PSReadLine's ConsoleHost_history.txt on Windows) — a plaintext
+ * credential on disk, forever. The launch line references $env:CCC_ARG_SECRET
+ * instead; substitution is asserted in the sibling test below.
+ */
+describe('terminal-only secret argument → spawn env', () => {
+  const base = { sessionId: 's1', cols: 80, rows: 24 } as any
+
+  it('puts the secret in CCC_ARG_SECRET for a shell-only spawn', () => {
+    const { env } = buildClaudeLocalSpawn({ ...base, shellOnly: true, terminalSecret: 'sk-supersecret' })
+    expect(env.CCC_ARG_SECRET).toBe('sk-supersecret')
+  })
+
+  it('never sets the secret env for a NON shell-only (Claude) spawn', () => {
+    const { env } = buildClaudeLocalSpawn({ ...base, shellOnly: false, terminalSecret: 'sk-supersecret' })
+    expect(env.CCC_ARG_SECRET).toBeUndefined()
+  })
+
+  it('sets nothing when no secret is stored', () => {
+    const { env } = buildClaudeLocalSpawn({ ...base, shellOnly: true })
+    expect(env.CCC_ARG_SECRET).toBeUndefined()
+  })
+
+  it('keeps the secret out of the spawn command and argv entirely', () => {
+    const { cmd, args } = buildClaudeLocalSpawn({ ...base, shellOnly: true, terminalSecret: 'sk-supersecret' })
+    expect(cmd).not.toContain('sk-supersecret')
+    expect(args.join(' ')).not.toContain('sk-supersecret')
+  })
+
+  it('still elevates when asked (gsudo/sudo wraps the shell)', () => {
+    const { cmd, args } = buildClaudeLocalSpawn({ ...base, shellOnly: true, elevated: true })
+    expect(cmd).toMatch(/^(gsudo|sudo)$/)
+    expect(args.length).toBeGreaterThan(0)
+  })
+})
+
+/** Exercises the REAL builder used by the shell-only spawn path — not a copy. */
+describe('buildTerminalLaunchLine — {secret} substitution', () => {
+  const win = (o: any) => buildTerminalLaunchLine(o, true)
+  const posix = (o: any) => buildTerminalLaunchLine(o, false)
+
+  it('substitutes an env REFERENCE, never the value (Windows)', () => {
+    const out = win({ command: 'openclaw', args: '--token {secret}', hasSecretArg: true })
+    expect(out).toBe('openclaw --token $env:CCC_ARG_SECRET')
+  })
+
+  it('substitutes a quoted env reference on POSIX', () => {
+    expect(posix({ command: 'openclaw', args: '--token {secret}', hasSecretArg: true }))
+      .toBe('openclaw --token "$CCC_ARG_SECRET"')
+  })
+
+  it('collapses the token to empty when no secret is stored (no dangling var)', () => {
+    expect(win({ command: 'openclaw', args: '--token {secret}' })).toBe('openclaw --token')
+  })
+
+  it('replaces every occurrence', () => {
+    expect(win({ command: 'x', args: '{secret} and {secret}', hasSecretArg: true }))
+      .toBe('x $env:CCC_ARG_SECRET and $env:CCC_ARG_SECRET')
+  })
+
+  it('leaves arguments without the token untouched', () => {
+    expect(win({ command: 'openclaw', args: '--port 4310' })).toBe('openclaw --port 4310')
+  })
+
+  it('returns the bare command when there are no arguments', () => {
+    expect(win({ command: 'openclaw' })).toBe('openclaw')
+  })
+
+  it('returns EMPTY when no command is set (a plain shell, nothing typed)', () => {
+    expect(win({ args: '--port 4310', hasSecretArg: true })).toBe('')
+    expect(win(undefined)).toBe('')
+    expect(win({ command: '   ' })).toBe('')
+  })
+})

--- a/tests/unit/renderer/agentpicker-codex-gate.test.ts
+++ b/tests/unit/renderer/agentpicker-codex-gate.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 /**
- * P5.6 regression: SessionDialog agent picker is gated to Claude provider only.
- * The picker MUST NOT appear in the DOM when provider='codex'.
+ * 2.1.0-beta.5: the SessionDialog agent picker is REMOVED (0 real configs used
+ * it; the --agents plumbing still honours agentIds stored on old configs).
+ * These tests encode the two halves of that contract:
+ *   1. The picker never renders, for any provider.
+ *   2. Stored claudeOptions.agentIds SURVIVE an edit+save — the dialog's
+ *      spread-then-set save path must not wipe fields it no longer edits
+ *      (the bug that silently ate effortLevel for years).
  */
 import React from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -9,8 +14,6 @@ import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
-
-let mockUserTemplates: any[] = []
 
 vi.mock('../../../src/renderer/stores/configStore', () => ({
   useConfigStore: (sel: any) => sel({
@@ -21,34 +24,21 @@ vi.mock('../../../src/renderer/stores/configStore', () => ({
   }),
 }))
 
-vi.mock('../../../src/renderer/stores/agentLibraryStore', () => ({
-  useAgentLibraryStore: (sel: any) => sel({
-    templates: mockUserTemplates,
-  }),
-  BUILTIN_TEMPLATES: [
-    {
-      id: 'builtin-test',
-      name: 'Test Agent',
-      description: 'A test agent',
-      model: 'inherit',
-      tools: [],
-      isBuiltIn: true,
-    },
-  ],
-}))
-
 // Mock window.electronAPI
 if (typeof window !== 'undefined') {
   (window as any).electronAPI = {
     debug: {
       isEnabled: vi.fn().mockResolvedValue(false),
     },
+    dialog: { openFolder: vi.fn().mockResolvedValue(null) },
+    credentials: { save: vi.fn(), delete: vi.fn() },
   }
+  ;(window as any).electronPlatform = 'win32'
 }
 
 import SessionDialog from '../../../src/renderer/components/SessionDialog'
 
-describe('SessionDialog agent picker provider gate', () => {
+describe('SessionDialog agent picker removal', () => {
   let container: HTMLDivElement
   let root: Root
 
@@ -56,7 +46,6 @@ describe('SessionDialog agent picker provider gate', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
-    mockUserTemplates = []
   })
 
   afterEach(() => {
@@ -64,7 +53,7 @@ describe('SessionDialog agent picker provider gate', () => {
     container.remove()
   })
 
-  it('does NOT render the agent picker section when provider is codex', () => {
+  it('does NOT render an agent picker for codex configs', () => {
     act(() => {
       root.render(
         React.createElement(SessionDialog, {
@@ -74,21 +63,46 @@ describe('SessionDialog agent picker provider gate', () => {
         }),
       )
     })
-    // The "Agents" section label only appears in the Claude branch (line 692 of SessionDialog)
     expect((container.textContent ?? '')).not.toContain('Agents')
   })
 
-  it('DOES render the agent picker section when provider is claude', () => {
+  it('does NOT render an agent picker for claude configs (removed in beta.5)', () => {
     act(() => {
       root.render(
         React.createElement(SessionDialog, {
-          initial: { provider: 'claude' },
+          initial: { provider: 'claude', workingDirectory: 'C:\\proj', label: 'x' },
           onConfirm: vi.fn(),
           onCancel: vi.fn(),
         }),
       )
     })
-    // The "Agents" label appears when Claude branch is active and templates exist
-    expect((container.textContent ?? '')).toContain('Agents')
+    expect((container.textContent ?? '')).not.toContain('Agents')
+  })
+
+  it('stored agentIds survive an edit+save (spread-then-set, no field wipe)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: {
+            provider: 'claude',
+            label: 'legacy',
+            workingDirectory: 'C:\\proj',
+            claudeOptions: { agentIds: ['tpl-1', 'tpl-2'], legacyVersion: { enabled: true, version: '1.0.0' } },
+          },
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    act(() => {
+      form!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.claudeOptions?.agentIds).toEqual(['tpl-1', 'tpl-2'])
+    expect(config.claudeOptions?.legacyVersion).toEqual({ enabled: true, version: '1.0.0' })
   })
 })

--- a/tests/unit/renderer/codex-review-sub-tool.test.ts
+++ b/tests/unit/renderer/codex-review-sub-tool.test.ts
@@ -23,12 +23,14 @@ describe('CodexReviewSubTool (P7.4)', () => {
     container.remove()
   })
 
-  it('renders the Available status + opt-in description', () => {
+  it('renders the Available status + global-availability description', () => {
     act(() => { root.render(React.createElement(CodexReviewSubTool)) })
     const text = container.textContent ?? ''
     expect(text).toContain('Codex review (Claude-driven)')
     expect(text).toContain('Available')
-    expect(text).toContain('Enable Codex code review')
+    // 2.1.0-beta.5: the per-config opt-in is retired — the card describes the
+    // global gate (Codex master switch) instead.
+    expect(text).toContain('every local Claude Code session')
     expect(text).toContain('codex_review')
   })
 })

--- a/tests/unit/renderer/session-dialog-credentials.test.tsx
+++ b/tests/unit/renderer/session-dialog-credentials.test.tsx
@@ -200,6 +200,30 @@ describe('SessionDialog credential hygiene (#188)', () => {
     expect(credDelete).toHaveBeenCalledWith('cfgAAA') // old secret removed
   })
 
+  it('R3: changing only the PORT drops the stored password (endpoint changed)', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    const port = Array.from(container.querySelectorAll('input[type="number"]'))[0] as HTMLInputElement
+    setValue(port, '2222')
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.hasPassword).toBe(false)
+    expect(password).toBeUndefined()
+    expect(credDelete).toHaveBeenCalledWith('cfgAAA')
+  })
+
+  it('R3: changing only the USERNAME drops the stored password (different principal)', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    const user = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).value === 'root') as HTMLInputElement
+    setValue(user, 'someoneelse')
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.hasPassword).toBe(false)
+    expect(password).toBeUndefined()
+    expect(credDelete).toHaveBeenCalledWith('cfgAAA')
+  })
+
   it('R2-F3: the delete is idempotent — a non-saving edit always sweeps, regardless of the (possibly-lying) flag', () => {
     const onConfirm = vi.fn()
     // A config the OLD dialog left divergent: hasPassword:false but a secret is
@@ -244,18 +268,34 @@ describe('SessionDialog validation gates (#188)', () => {
     expect(onConfirm).not.toHaveBeenCalled()
   })
 
-  it("a '.' working directory is rejected (transcript-misfiling incident)", () => {
+  it("newly typing '.' as a working directory is rejected (transcript-misfiling incident)", () => {
     const onConfirm = vi.fn()
     act(() => {
       root.render(React.createElement(SessionDialog, {
-        initial: { id: 'y', provider: 'claude', sessionType: 'local', label: 'dot', workingDirectory: '.' },
+        initial: { id: 'y', provider: 'claude', sessionType: 'local', label: 'dot', workingDirectory: 'C:\\proj' },
         onConfirm, onCancel: vi.fn(),
       }))
     })
+    const wdir = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).value === 'C:\\proj') as HTMLInputElement
+    setValue(wdir, '.')
     expect(saveBtn().disabled).toBe(true)
     expect(container.textContent).toContain('full path')
     submit(container)
     expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('an UNCHANGED foreign-platform path stays editable (does not block unrelated edits)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        // A macOS path opened on this Windows machine — the user is only renaming it.
+        initial: { id: 'f', provider: 'claude', sessionType: 'local', label: 'mac', workingDirectory: '/Users/me/proj' },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(false)
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
   })
 
   it('an absolute working directory saves fine', () => {
@@ -271,14 +311,16 @@ describe('SessionDialog validation gates (#188)', () => {
     expect(onConfirm).toHaveBeenCalledOnce()
   })
 
-  it('rejects the ~evil shape-only lookalike (not a real home path)', () => {
+  it('rejects the ~evil shape-only lookalike when newly typed (not a real home path)', () => {
     const onConfirm = vi.fn()
     act(() => {
       root.render(React.createElement(SessionDialog, {
-        initial: { id: 'w', provider: 'claude', sessionType: 'local', label: 'x', workingDirectory: '~evil' },
+        initial: { id: 'w', provider: 'claude', sessionType: 'local', label: 'x', workingDirectory: 'C:\\proj' },
         onConfirm, onCancel: vi.fn(),
       }))
     })
+    const wdir = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).value === 'C:\\proj') as HTMLInputElement
+    setValue(wdir, '~evil')
     expect(saveBtn().disabled).toBe(true)
     submit(container)
     expect(onConfirm).not.toHaveBeenCalled()

--- a/tests/unit/renderer/session-dialog-credentials.test.tsx
+++ b/tests/unit/renderer/session-dialog-credentials.test.tsx
@@ -59,10 +59,12 @@ function submit(container: HTMLElement) {
   act(() => { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })) })
 }
 
-function cardIn(container: HTMLElement, groupLabel: string, text: string): HTMLButtonElement {
+// Provider/transport are native radios styled as cards: <label><input radio>.
+// Return the input so .click() selects it.
+function cardIn(container: HTMLElement, groupLabel: string, text: string): HTMLInputElement {
   const group = container.querySelector(`[role="radiogroup"][aria-label="${groupLabel}"]`)!
-  const btn = Array.from(group.querySelectorAll('button')).find((b) => b.textContent?.startsWith(text))
-  return btn as HTMLButtonElement
+  const lab = Array.from(group.querySelectorAll('label')).find((l) => l.textContent?.startsWith(text))
+  return lab!.querySelector('input[type="radio"]') as HTMLInputElement
 }
 
 function inputByPlaceholder(container: HTMLElement, ph: string): HTMLInputElement | undefined {

--- a/tests/unit/renderer/session-dialog-credentials.test.tsx
+++ b/tests/unit/renderer/session-dialog-credentials.test.tsx
@@ -171,6 +171,45 @@ describe('SessionDialog credential hygiene (#188)', () => {
     expect(password).toBeUndefined()
     expect(credDelete).toHaveBeenCalledWith('cfgAAA')
   })
+
+  it('R2-F1: a label-only edit keeps the stored password and fires NO delete', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    // Change only the label; leave host + password untouched.
+    const label = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).value === 'prod box') as HTMLInputElement
+    setValue(label, 'prod box renamed')
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.hasPassword).toBe(true)   // kept
+    expect(password).toBeUndefined()                  // not re-sent (unchanged)
+    // The main password key is preserved. The idempotent `_sudo` sweep may fire
+    // (harmless orphan cleanup) — what must NOT happen is deleting the password.
+    expect(credDelete).not.toHaveBeenCalledWith('cfgAAA')
+  })
+
+  it('R2-F2: changing the Host without retyping drops the stored password (not walked to a new host)', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    const host = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).value === '10.0.0.5') as HTMLInputElement
+    setValue(host, '203.0.113.9')  // repoint at a DIFFERENT machine
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.host).toBe('203.0.113.9')
+    expect(config.sshConfig.hasPassword).toBe(false)  // old password does NOT carry
+    expect(password).toBeUndefined()
+    expect(credDelete).toHaveBeenCalledWith('cfgAAA') // old secret removed
+  })
+
+  it('R2-F3: the delete is idempotent — a non-saving edit always sweeps, regardless of the (possibly-lying) flag', () => {
+    const onConfirm = vi.fn()
+    // A config the OLD dialog left divergent: hasPassword:false but a secret is
+    // actually live in the keychain. Editing + saving must still delete it.
+    const DIVERGENT = { ...SSH_WITH_PW, id: 'cfgDIV', sshConfig: { ...SSH_WITH_PW.sshConfig, hasPassword: false } }
+    act(() => { root.render(React.createElement(SessionDialog, { initial: DIVERGENT, onConfirm, onCancel: vi.fn() })) })
+    submit(container)
+    expect(credDelete).toHaveBeenCalledWith('cfgDIV')
+    expect(credDelete).toHaveBeenCalledWith('cfgDIV_sudo')
+  })
 })
 
 describe('SessionDialog validation gates (#188)', () => {
@@ -230,5 +269,35 @@ describe('SessionDialog validation gates (#188)', () => {
     expect(saveBtn().disabled).toBe(false)
     submit(container)
     expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('rejects the ~evil shape-only lookalike (not a real home path)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        initial: { id: 'w', provider: 'claude', sessionType: 'local', label: 'x', workingDirectory: '~evil' },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(true)
+    submit(container)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('rejects an SSH remote directory with a space (would crash main at spawn)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        initial: {
+          id: 'r', provider: 'claude', sessionType: 'ssh', label: 'x', workingDirectory: '/srv/my project',
+          sshConfig: { host: '10.0.0.5', port: 22, username: 'root', remotePath: '/srv/my project' },
+        },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(true)
+    expect(container.textContent).toContain('Remote directory can only use')
+    submit(container)
+    expect(onConfirm).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/renderer/session-dialog-credentials.test.tsx
+++ b/tests/unit/renderer/session-dialog-credentials.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+/**
+ * 2.1.0-beta.5 credential-hygiene regressions (adversarial review, #188).
+ *
+ * Every credential decision in SessionDialog must be gated on the FINAL
+ * sessionType. Three MAJOR findings, each pinned here:
+ *   1. Switching an SSH config to Local orphaned the stored secret (flag
+ *      vanished, no keychain delete) — later auto-typed at a different host.
+ *   2. A password typed into an SSH block that was then switched to Local was
+ *      still written to the keychain for a config with no SSH.
+ *   3. `hasPassword ?? true` default rendered the Save checkbox unticked for a
+ *      key-auth config (which now persists hasPassword:false), silently
+ *      dropping a freshly-typed password.
+ * Plus the two validation gaps: the Codex×SSH combination and a '.' working
+ * directory must both be unsaveable.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/configStore', () => ({
+  useConfigStore: (sel: any) => sel({
+    groups: [],
+    addGroup: vi.fn(),
+    sections: [],
+    addSection: vi.fn(),
+  }),
+}))
+
+const credDelete = vi.fn()
+const credSave = vi.fn()
+
+if (typeof window !== 'undefined') {
+  ;(window as any).electronAPI = {
+    debug: { isEnabled: vi.fn().mockResolvedValue(false) },
+    dialog: { openFolder: vi.fn().mockResolvedValue(null) },
+    credentials: { save: credSave, delete: credDelete },
+  }
+  ;(window as any).electronPlatform = 'win32'
+}
+
+import SessionDialog from '../../../src/renderer/components/SessionDialog'
+
+function setValue(el: HTMLInputElement, value: string) {
+  const proto = el.type === 'checkbox' ? null : Object.getPrototypeOf(el)
+  const setter = proto && Object.getOwnPropertyDescriptor(proto, 'value')?.set
+  act(() => {
+    if (setter) setter.call(el, value)
+    else el.value = value
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function submit(container: HTMLElement) {
+  const form = container.querySelector('form')!
+  act(() => { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })) })
+}
+
+function cardIn(container: HTMLElement, groupLabel: string, text: string): HTMLButtonElement {
+  const group = container.querySelector(`[role="radiogroup"][aria-label="${groupLabel}"]`)!
+  const btn = Array.from(group.querySelectorAll('button')).find((b) => b.textContent?.startsWith(text))
+  return btn as HTMLButtonElement
+}
+
+function inputByPlaceholder(container: HTMLElement, ph: string): HTMLInputElement | undefined {
+  return Array.from(container.querySelectorAll('input')).find(
+    (i) => (i as HTMLInputElement).placeholder?.includes(ph),
+  ) as HTMLInputElement | undefined
+}
+
+function saveCheckbox(container: HTMLElement, which = 0): HTMLInputElement | undefined {
+  const boxes = Array.from(container.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[]
+  const labelled = boxes.filter((b) => b.parentElement?.textContent?.includes('Save password'))
+  return labelled[which]
+}
+
+const SSH_WITH_PW = {
+  id: 'cfgAAA',
+  provider: 'claude' as const,
+  label: 'prod box',
+  sessionType: 'ssh' as const,
+  workingDirectory: '~',
+  sshConfig: { host: '10.0.0.5', port: 22, username: 'root', remotePath: '~', hasPassword: true },
+}
+
+const SSH_KEY_AUTH = {
+  id: 'cfgKEY',
+  provider: 'claude' as const,
+  label: 'key box',
+  sessionType: 'ssh' as const,
+  workingDirectory: '~',
+  // The shape EVERY key-auth SSH config now saves as: hasPassword explicitly false.
+  sshConfig: { host: '10.0.0.9', port: 22, username: 'root', remotePath: '~', hasPassword: false },
+}
+
+describe('SessionDialog credential hygiene (#188)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    credDelete.mockClear(); credSave.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+  afterEach(() => { act(() => { root.unmount() }); container.remove() })
+
+  it('F1: switching an SSH config with a stored password to Local deletes the secret and saves no SSH', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    // Switch transport to Local, give it a valid absolute working directory.
+    act(() => { cardIn(container, 'Where it runs', 'Local').click() })
+    const wdir = inputByPlaceholder(container, ':\\')  // the win32 working-directory placeholder
+    expect(wdir).toBeTruthy()
+    setValue(wdir!, 'C:\\proj')
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig).toBeUndefined()
+    expect(password).toBeUndefined()
+    // The orphaned keychain entry is deleted on confirm.
+    expect(credDelete).toHaveBeenCalledWith('cfgAAA')
+  })
+
+  it('F2: a password typed into SSH then abandoned by switching to Local is never saved', () => {
+    const onConfirm = vi.fn()
+    // New config.
+    act(() => { root.render(React.createElement(SessionDialog, { onConfirm, onCancel: vi.fn() })) })
+    act(() => { cardIn(container, 'Provider', 'Claude Code').click() })
+    act(() => { cardIn(container, 'Where it runs', 'SSH').click() })
+    setValue(inputByPlaceholder(container, '192.168')!, '10.0.0.5')
+    const pw = Array.from(container.querySelectorAll('input[type="password"]'))[0] as HTMLInputElement
+    setValue(pw, 'hunter2')
+    // Change mind: switch to Local.
+    act(() => { cardIn(container, 'Where it runs', 'Local').click() })
+    setValue(inputByPlaceholder(container, ':\\')!, 'C:\\proj')
+    const label = Array.from(container.querySelectorAll('input')).find((i) => (i as HTMLInputElement).placeholder === 'e.g. App Dev') as HTMLInputElement
+    setValue(label, 'oops')
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig).toBeUndefined()
+    expect(password).toBeUndefined()  // the abandoned SSH password is NOT handed to the keychain
+  })
+
+  it('F3: typing a password into a key-auth (hasPassword:false) config saves it (checkbox defaults ticked)', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_KEY_AUTH, onConfirm, onCancel: vi.fn() })) })
+    const pw = Array.from(container.querySelectorAll('input[type="password"]'))[0] as HTMLInputElement
+    setValue(pw, 'newsecret')
+    const box = saveCheckbox(container)!
+    expect(box.checked).toBe(true)  // must default ticked, not `false ?? true` = false
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.hasPassword).toBe(true)
+    expect(password).toBe('newsecret')
+  })
+
+  it('untick Save on a stored password still deletes the keychain entry (baseline held)', () => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial: SSH_WITH_PW, onConfirm, onCancel: vi.fn() })) })
+    const box = saveCheckbox(container)!
+    expect(box.checked).toBe(true)
+    act(() => { box.click() })
+    submit(container)
+    const [config, password] = onConfirm.mock.calls[0]
+    expect(config.sshConfig.hasPassword).toBe(false)
+    expect(password).toBeUndefined()
+    expect(credDelete).toHaveBeenCalledWith('cfgAAA')
+  })
+})
+
+describe('SessionDialog validation gates (#188)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+  afterEach(() => { act(() => { root.unmount() }); container.remove() })
+
+  function saveBtn(): HTMLButtonElement {
+    return Array.from(container.querySelectorAll('button')).find(
+      (b) => /^(Create config|Save changes)$/.test(b.textContent?.trim() ?? ''),
+    ) as HTMLButtonElement
+  }
+
+  it('a hand-edited Codex×SSH config cannot be saved', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        initial: { id: 'x', provider: 'codex', sessionType: 'ssh', label: 'bad', workingDirectory: '~',
+          sshConfig: { host: '10.0.0.1', port: 22, username: 'root', remotePath: '~' } },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(true)
+    expect(container.textContent).toContain("Codex can't run over SSH")
+    submit(container)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it("a '.' working directory is rejected (transcript-misfiling incident)", () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        initial: { id: 'y', provider: 'claude', sessionType: 'local', label: 'dot', workingDirectory: '.' },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(true)
+    expect(container.textContent).toContain('full path')
+    submit(container)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('an absolute working directory saves fine', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(React.createElement(SessionDialog, {
+        initial: { id: 'z', provider: 'claude', sessionType: 'local', label: 'ok', workingDirectory: 'C:\\proj' },
+        onConfirm, onCancel: vi.fn(),
+      }))
+    })
+    expect(saveBtn().disabled).toBe(false)
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/unit/renderer/session-dialog-effort.test.tsx
+++ b/tests/unit/renderer/session-dialog-effort.test.tsx
@@ -45,11 +45,13 @@ function submit(container: HTMLElement) {
   })
 }
 
-function effortChip(container: HTMLElement, label: string): HTMLButtonElement | null {
+// The effort control is native radios styled as chips: each option is a
+// <label> wrapping <input type="radio">. Return the input so .click() drives it.
+function effortChip(container: HTMLElement, label: string): HTMLInputElement | null {
   const group = container.querySelector('[role="radiogroup"][aria-label="Starting effort"]')
   if (!group) return null
-  for (const btn of Array.from(group.querySelectorAll('button'))) {
-    if (btn.textContent?.trim() === label) return btn as HTMLButtonElement
+  for (const lab of Array.from(group.querySelectorAll('label'))) {
+    if (lab.textContent?.trim() === label) return lab.querySelector('input[type="radio"]') as HTMLInputElement
   }
   return null
 }
@@ -81,6 +83,7 @@ describe('SessionDialog starting effort', () => {
     })
     expect(container.textContent).toContain('Starting effort')
     expect(effortChip(container, 'Default')).not.toBeNull()
+    expect(effortChip(container, 'Default')!.checked).toBe(true)
   })
 
   it('picking an effort persists claudeOptions.effortLevel on submit', () => {
@@ -98,9 +101,9 @@ describe('SessionDialog starting effort', () => {
     expect(group).not.toBeNull()
     // First registry chip after "Default" — value comes from the live registry,
     // so the test doesn't hardcode a level name.
-    const chips = Array.from(group!.querySelectorAll('button'))
+    const chips = Array.from(group!.querySelectorAll('input[type="radio"]'))
     expect(chips.length).toBeGreaterThan(1)
-    act(() => { (chips[1] as HTMLButtonElement).click() })
+    act(() => { (chips[1] as HTMLInputElement).click() })
     submit(container)
     expect(onConfirm).toHaveBeenCalledOnce()
     const [config] = onConfirm.mock.calls[0]
@@ -142,6 +145,27 @@ describe('SessionDialog starting effort', () => {
     submit(container)
     const [config] = onConfirm.mock.calls[0]
     expect(config.claudeOptions?.effortLevel).toBeUndefined()
+  })
+
+  it('provider, transport and effort are native radios grouped by name (a11y — #188 Copilot)', () => {
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: CLAUDE_LOCAL,
+          onConfirm: vi.fn(),
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    // Native <input type="radio"> get the ARIA radiogroup keyboard pattern
+    // (roving tabindex, arrow-key nav, skip-disabled) from the browser — the
+    // hand-rolled role="radio" buttons did not.
+    const named = (n: string) => container.querySelectorAll(`input[type="radio"][name="${n}"]`).length
+    expect(named('ccc-provider')).toBe(3)   // Claude Code / Codex / Terminal only
+    expect(named('ccc-transport')).toBe(2)  // Local / SSH
+    expect(named('ccc-effort')).toBeGreaterThan(1)  // Default + registry levels
+    // No leftover fake-radio buttons claiming radio semantics.
+    expect(container.querySelectorAll('button[role="radio"]').length).toBe(0)
   })
 
   it('an untouched edit keeps a stored "Default" model as Default (no silent opus upgrade)', () => {

--- a/tests/unit/renderer/session-dialog-effort.test.tsx
+++ b/tests/unit/renderer/session-dialog-effort.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+/**
+ * 2.1.0-beta.5: "Starting effort" control. Before this, per-config effort was
+ * plumbed end-to-end (--effort at spawn) but UNREACHABLE: the dialog had no
+ * control and its save path rebuilt claudeOptions without an effortLevel key,
+ * wiping any stored value on every edit. These tests pin both halves:
+ *   1. Picking an effort persists claudeOptions.effortLevel on submit.
+ *   2. An edit that doesn't touch effort keeps the stored value (no wipe).
+ *   3. "Default" persists as undefined (no --effort flag at spawn).
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/configStore', () => ({
+  useConfigStore: (sel: any) => sel({
+    groups: [],
+    addGroup: vi.fn(),
+    sections: [],
+    addSection: vi.fn(),
+  }),
+}))
+
+if (typeof window !== 'undefined') {
+  ;(window as any).electronAPI = {
+    debug: { isEnabled: vi.fn().mockResolvedValue(false) },
+    dialog: { openFolder: vi.fn().mockResolvedValue(null) },
+    credentials: { save: vi.fn(), delete: vi.fn() },
+  }
+  ;(window as any).electronPlatform = 'win32'
+}
+
+import SessionDialog from '../../../src/renderer/components/SessionDialog'
+
+const CLAUDE_LOCAL = { provider: 'claude' as const, label: 'test', workingDirectory: 'C:\\proj' }
+
+function submit(container: HTMLElement) {
+  const form = container.querySelector('form')
+  expect(form).not.toBeNull()
+  act(() => {
+    form!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+  })
+}
+
+function effortChip(container: HTMLElement, label: string): HTMLButtonElement | null {
+  const group = container.querySelector('[role="radiogroup"][aria-label="Starting effort"]')
+  if (!group) return null
+  for (const btn of Array.from(group.querySelectorAll('button'))) {
+    if (btn.textContent?.trim() === label) return btn as HTMLButtonElement
+  }
+  return null
+}
+
+describe('SessionDialog starting effort', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  it('renders the effort control with a Default chip for Claude configs', () => {
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: CLAUDE_LOCAL,
+          onConfirm: vi.fn(),
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    expect(container.textContent).toContain('Starting effort')
+    expect(effortChip(container, 'Default')).not.toBeNull()
+  })
+
+  it('picking an effort persists claudeOptions.effortLevel on submit', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: CLAUDE_LOCAL,
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    const group = container.querySelector('[role="radiogroup"][aria-label="Starting effort"]')
+    expect(group).not.toBeNull()
+    // First registry chip after "Default" — value comes from the live registry,
+    // so the test doesn't hardcode a level name.
+    const chips = Array.from(group!.querySelectorAll('button'))
+    expect(chips.length).toBeGreaterThan(1)
+    act(() => { (chips[1] as HTMLButtonElement).click() })
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config] = onConfirm.mock.calls[0]
+    expect(typeof config.claudeOptions?.effortLevel).toBe('string')
+    expect(config.claudeOptions?.effortLevel!.length).toBeGreaterThan(0)
+  })
+
+  it('an untouched edit keeps the stored effortLevel (regression: the wipe bug)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: { ...CLAUDE_LOCAL, claudeOptions: { effortLevel: 'xhigh' } },
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.claudeOptions?.effortLevel).toBe('xhigh')
+  })
+
+  it('Default persists as undefined so the spawn emits no --effort flag', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: { ...CLAUDE_LOCAL, claudeOptions: { effortLevel: 'max' } },
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    const def = effortChip(container, 'Default')
+    expect(def).not.toBeNull()
+    act(() => { def!.click() })
+    submit(container)
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.claudeOptions?.effortLevel).toBeUndefined()
+  })
+
+  it('an untouched edit keeps a stored "Default" model as Default (no silent opus upgrade)', () => {
+    const onConfirm = vi.fn()
+    act(() => {
+      root.render(
+        React.createElement(SessionDialog, {
+          initial: { ...CLAUDE_LOCAL, claudeOptions: {} },
+          onConfirm,
+          onCancel: vi.fn(),
+        }),
+      )
+    })
+    submit(container)
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.claudeOptions?.model).toBeUndefined()
+  })
+})

--- a/tests/unit/renderer/session-dialog-logging-toggle.test.tsx
+++ b/tests/unit/renderer/session-dialog-logging-toggle.test.tsx
@@ -146,7 +146,9 @@ describe('SessionDialog indexing toggle', () => {
     act(() => {
       root.render(
         React.createElement(SessionDialog, {
-          initial: { provider: 'claude', label: 'test' },
+          // workingDirectory required since the validation slot landed — an
+          // empty directory blocks submit (the '.' fallback is gone).
+          initial: { provider: 'claude', label: 'test', workingDirectory: 'C:\\proj' },
           onConfirm,
           onCancel: vi.fn(),
         }),
@@ -177,7 +179,7 @@ describe('SessionDialog indexing toggle', () => {
     act(() => {
       root.render(
         React.createElement(SessionDialog, {
-          initial: { provider: 'claude', label: 'test' },
+          initial: { provider: 'claude', label: 'test', workingDirectory: 'C:\\proj' },
           onConfirm,
           onCancel: vi.fn(),
         }),

--- a/tests/unit/renderer/session-dialog-terminal-options.test.tsx
+++ b/tests/unit/renderer/session-dialog-terminal-options.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+/**
+ * 2.1.0-beta.6: Terminal-only launcher options (first-run command, arguments,
+ * secret argument, Run as Administrator). These were drawn in the approved
+ * mockup but shipped without a backend in beta.5 — this pins the dialog half:
+ *   1. The fields render for a LOCAL Terminal-only config, and not for Claude
+ *      Code / Codex / SSH.
+ *   2. They persist into config.terminalOptions on submit.
+ *   3. The secret argument NEVER enters the config object — it is handed to the
+ *      caller as a separate argument for the OS keychain.
+ *   4. Clearing the secret (or switching away from a local terminal) deletes the
+ *      stored keychain entry rather than stranding it.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/configStore', () => ({
+  useConfigStore: (sel: any) => sel({
+    groups: [], addGroup: vi.fn(), sections: [], addSection: vi.fn(),
+  }),
+}))
+
+const credDelete = vi.fn()
+const credSave = vi.fn()
+
+if (typeof window !== 'undefined') {
+  ;(window as any).electronAPI = {
+    debug: { isEnabled: vi.fn().mockResolvedValue(false) },
+    dialog: { openFolder: vi.fn().mockResolvedValue(null) },
+    credentials: { save: credSave, delete: credDelete },
+  }
+  ;(window as any).electronPlatform = 'win32'
+}
+
+import SessionDialog from '../../../src/renderer/components/SessionDialog'
+
+function setValue(el: HTMLInputElement, value: string) {
+  const proto = el.type === 'checkbox' ? null : Object.getPrototypeOf(el)
+  const setter = proto && Object.getOwnPropertyDescriptor(proto, 'value')?.set
+  act(() => {
+    if (setter) setter.call(el, value)
+    else el.value = value
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function submit(container: HTMLElement) {
+  const form = container.querySelector('form')!
+  act(() => { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })) })
+}
+
+function byPlaceholder(container: HTMLElement, ph: string): HTMLInputElement | undefined {
+  return Array.from(container.querySelectorAll('input')).find(
+    (i) => (i as HTMLInputElement).placeholder?.includes(ph),
+  ) as HTMLInputElement | undefined
+}
+
+const TERMINAL_LOCAL = {
+  id: 'cfgT',
+  provider: 'claude' as const,
+  shellOnly: true,
+  sessionType: 'local' as const,
+  label: 'OpenClaw',
+  workingDirectory: 'C:\\proj',
+}
+
+describe('SessionDialog terminal-only options', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    credDelete.mockClear(); credSave.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+  afterEach(() => { act(() => { root.unmount() }); container.remove() })
+
+  const render = (initial: any) => {
+    const onConfirm = vi.fn()
+    act(() => { root.render(React.createElement(SessionDialog, { initial, onConfirm, onCancel: vi.fn() })) })
+    return onConfirm
+  }
+
+  it('renders the command / arguments / secret fields for a local Terminal-only config', () => {
+    render(TERMINAL_LOCAL)
+    expect(container.textContent).toContain('Terminal startup')
+    expect(container.textContent).toContain('First-run command')
+    expect(container.textContent).toContain('Arguments')
+    expect(container.textContent).toContain('Secret argument')
+    expect(container.textContent).toContain('Run as Administrator')
+  })
+
+  it('does NOT render them for a Claude Code config', () => {
+    render({ ...TERMINAL_LOCAL, shellOnly: false })
+    expect(container.textContent).not.toContain('First-run command')
+    expect(container.textContent).not.toContain('Secret argument')
+  })
+
+  it('does NOT render them over SSH (the post-connect command owns that)', () => {
+    render({
+      ...TERMINAL_LOCAL, sessionType: 'ssh',
+      sshConfig: { host: '10.0.0.5', port: 22, username: 'root', remotePath: '~' },
+    })
+    expect(container.textContent).not.toContain('First-run command')
+    expect(container.textContent).toContain('After connecting, run')
+  })
+
+  it('persists command, args and elevated into config.terminalOptions', () => {
+    const onConfirm = render(TERMINAL_LOCAL)
+    setValue(byPlaceholder(container, 'npm run dev')!, 'openclaw')
+    setValue(byPlaceholder(container, '--port 4310')!, '--serve {secret}')
+    const elevate = Array.from(container.querySelectorAll('input[type="checkbox"]')).find(
+      (c) => c.parentElement?.textContent?.includes('Run as Administrator'),
+    ) as HTMLInputElement
+    act(() => { elevate.click() })
+    submit(container)
+    expect(onConfirm).toHaveBeenCalledOnce()
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.terminalOptions).toMatchObject({
+      command: 'openclaw',
+      args: '--serve {secret}',
+      elevated: true,
+    })
+  })
+
+  it('hands the secret to the caller for the keychain and keeps it OUT of the config', () => {
+    const onConfirm = render(TERMINAL_LOCAL)
+    setValue(byPlaceholder(container, 'npm run dev')!, 'openclaw')
+    const secret = Array.from(container.querySelectorAll('input[type="password"]'))[0] as HTMLInputElement
+    setValue(secret, 'sk-supersecret')
+    submit(container)
+    const [config, password, sudo, argSecret] = onConfirm.mock.calls[0]
+    expect(argSecret).toBe('sk-supersecret')
+    expect(password).toBeUndefined()
+    expect(sudo).toBeUndefined()
+    // Only the FLAG is persisted — never the value, anywhere in the config.
+    expect(config.terminalOptions.hasSecretArg).toBe(true)
+    expect(JSON.stringify(config)).not.toContain('sk-supersecret')
+  })
+
+  it('removing a stored secret deletes the keychain entry', () => {
+    const onConfirm = render({ ...TERMINAL_LOCAL, terminalOptions: { command: 'openclaw', hasSecretArg: true } })
+    const remove = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Remove')!
+    act(() => { remove.click() })
+    submit(container)
+    const [config, , , argSecret] = onConfirm.mock.calls[0]
+    expect(config.terminalOptions?.hasSecretArg).toBeUndefined()
+    expect(argSecret).toBeUndefined()
+    expect(credDelete).toHaveBeenCalledWith('cfgT_argsecret')
+  })
+
+  it('switching a terminal config to Claude Code deletes the orphaned secret', () => {
+    const onConfirm = render({ ...TERMINAL_LOCAL, terminalOptions: { command: 'openclaw', hasSecretArg: true } })
+    const claudeCard = container.querySelector('[role="radiogroup"][aria-label="Provider"] input[value="claude"]') as HTMLInputElement
+    act(() => { claudeCard.click() })
+    submit(container)
+    expect(credDelete).toHaveBeenCalledWith('cfgT_argsecret')
+    const [config] = onConfirm.mock.calls[0]
+    expect(config.shellOnly).toBe(false)
+  })
+})

--- a/tests/unit/renderer/use-launch-config.test.tsx
+++ b/tests/unit/renderer/use-launch-config.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+/**
+ * 2.1.0-beta.5 (adversarial review, #188): the sidebar/empty-state launch path
+ * (`useLaunchConfig`) must copy `loggingEnabled` from the config's claudeOptions
+ * onto the new session — otherwise the "Index conversation logs" opt-out never
+ * reaches the spawn for a launched-from-config session (it was dropped before
+ * this fix). This test fails if `loggingEnabled: config.claudeOptions?.loggingEnabled`
+ * is reverted. It also pins that the retired `enableCodexReview` is NOT copied.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const addSession = vi.fn()
+
+vi.mock('../../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: (sel: any) => sel({ addSession }),
+}))
+vi.mock('../../../src/renderer/stores/settingsStore', () => ({
+  useSettingsStore: Object.assign((sel: any) => sel({ settings: { codexEnabled: true } }), {
+    getState: () => ({ settings: { codexEnabled: true } }),
+  }),
+}))
+vi.mock('../../../src/renderer/utils/resumePicker', () => ({
+  markSessionForResumePicker: vi.fn(),
+}))
+
+import { useLaunchConfig } from '../../../src/renderer/hooks/useLaunchConfig'
+
+function launchWith(config: any): any {
+  let captured: any = null
+  function Harness() {
+    const launch = useLaunchConfig()
+    React.useEffect(() => { launch(config) }, [])
+    return null
+  }
+  const container = document.createElement('div')
+  const root: Root = createRoot(container)
+  act(() => { root.render(React.createElement(Harness)) })
+  captured = addSession.mock.calls[0]?.[0]
+  act(() => { root.unmount() })
+  return captured
+}
+
+describe('useLaunchConfig loggingEnabled mapping (#188)', () => {
+  beforeEach(() => { addSession.mockClear() })
+
+  const base = {
+    id: 'cfg1',
+    label: 'x',
+    workingDirectory: 'C:\\proj',
+    color: '#fff',
+    sessionType: 'local' as const,
+    provider: 'claude' as const,
+  }
+
+  it('copies loggingEnabled: false onto the session (the opt-out reaches the spawn)', () => {
+    const session = launchWith({ ...base, claudeOptions: { loggingEnabled: false } })
+    expect(session).toBeTruthy()
+    expect(session.loggingEnabled).toBe(false)
+  })
+
+  it('copies loggingEnabled: true onto the session', () => {
+    const session = launchWith({ ...base, claudeOptions: { loggingEnabled: true } })
+    expect(session.loggingEnabled).toBe(true)
+  })
+
+  it('leaves loggingEnabled undefined (default-on) when unset', () => {
+    const session = launchWith({ ...base, claudeOptions: {} })
+    expect(session.loggingEnabled).toBeUndefined()
+  })
+
+  it('does NOT copy the retired enableCodexReview flag onto the session', () => {
+    const session = launchWith({ ...base, claudeOptions: { enableCodexReview: true } })
+    expect(session.enableCodexReview).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Rebuilds the saved-config dialog to the owner-approved rev-6 mockup (`F:\CLAUDE_MULTI_APP_RESOURCES\session-dialog-mockup-v2.html`, reviewed by 5 adversarial agents + 3 owner review rounds), and lands the app-side changes the settled decisions imply.

## The dialog (SessionDialog.tsx, full rebuild)

- **Choice-driven create flow**: a new config opens with one question — what does this launcher run? Provider → Local/SSH → everything else reveals as you answer. Edit opens fully revealed. The footer is a validation slot that names the next step — Save can no longer silently no-op (the old dialog's early-return).
- **Provider cards**: Claude Code / Codex / **Terminal only**. Terminal maps to the existing `provider:'claude', shellOnly:true` shape — no migration, no IPC enum change (the real `provider:'terminal'` with first-run command/arguments/secret argument is the staged follow-up). Codex and SSH veto each other in both directions, with inline notes.
- **One directory field** that renames per transport ("Working directory" / "Remote directory"). The `'.'` fallback is gone — the free-typed empty default is how the transcript-misfiling incident happened; a real path is now required to save.
- **Session startup** section (owner's framing): **Starting model** + new **Starting effort** control built from the model registry (all six levels + Default), permission mode with a live consequence line (strengthened copy for Bypass / Don't ask), extra CLI args, Index conversation logs (local only — SSH sessions never register).
- **Quiet by default**: helper copy lives behind per-field/section `?` reveals; the default view is short labels only.
- **Removed controls** (all reviewed safe / settled): Shell Only tickbox (→ Terminal card), partner terminal fields, Enable Codex code review, Legacy Claude version, Agents picker, disable-auto-memory. Stored fields round-trip untouched.

## Bug fixes

| Bug | Fix |
|---|---|
| Per-config **effort was unreachable** — no control existed, and every save wiped stored `effortLevel` (claudeOptions rebuilt without the key) while the spawn plumbing (`--effort`) sat unused | New control; save is now **spread-then-set**, preserving every field the dialog doesn't edit (`dockerContainer`, `agentIds`, `legacyVersion`, …) |
| Editing a config with model = Default silently re-saved it as `opus` | Edit initialises from stored value, not the new-config default |
| `useLaunchConfig` dropped `loggingEnabled` — the indexing opt-out never reached the spawn on sidebar launches | Copied through |
| Save-password checkbox didn't control saving (password stored whenever typed) | Password only reaches the keychain when ticked; **Remove stored password** deletes the entry on confirm |
| Deleting a config orphaned its `_sudo` keychain entry forever | Both entries deleted |

## App-side changes (settled owner decisions, 2 Aug)

- **Partner terminal is permanent for every config type** — pane + command-bar button no longer gate on `partnerTerminalPath`; opens in the working directory locally, at home over SSH; `partnerElevated` retired (all 18 stored values were `false`).
- **codex_review is authorised globally** — every local Claude session registers into the opt-in set (`pty-manager`); the per-config `enableCodexReview` flag is ignored. Gating remains: global Codex master + conductor tool toggles at tool-registration time, per connection. SSH sessions still never register (the registration lives in the local spawn branch). Status-strip usage pill follows the same rule.
- Stale copy updated: training walkthrough (Combined Mode), partner tip, Codex-review subtool card.

## ⚠️ Security-relevant (ADR-009)

The codex_review change **relaxes a per-config authorisation gate** on the Conductor MCP server's opt-in set — owner-directed ("it's baked into the app, globally people can use it if they wish", accepting the OpenAI-spend implication), but it needs the adversarial-review pass before merge. I'll run `/adversarial-review` on this PR and record the verdict here.

## Verification

- `tsc --noEmit` clean; **full** `npx vitest run`: 3345 passed / 4 skipped (9 new tests: effort control persistence + wipe regression, agentIds/legacyVersion preservation, model-Default preservation); `electron-vite build` clean.
- Not yet done (will do before beta.5 is cut): live app launch on Electron 43 — nobody has launched the app since #87 landed; unit tests don't exercise PTY spawn/WebGL/vision.

## Follow-ups (staged, per the approved plan)

1. Real `provider:'terminal'` + first-run command/arguments (enum widening + shellOnly migration).
2. Secret argument (keychain scheme + `{secret}` substitution).
3. GitHub section in the dialog (repository + account picker) — auto-detect banner flow unchanged meanwhile.
4. Esc/unsaved-changes confirm; filesystem validation of the working directory.
5. Full removal of retired plumbing (`enableCodexReview`/partner fields pass-through) once beta.5 soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Himi7YWFhDUuxVashfmFr
