### PR TITLE
docs(changelog): add the 2.1.0-beta.5 entry (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.5] - 2026-08-02
+
+> A runtime refresh. CCC now runs on Electron 43, with the terminal backend and the local database updated to match. No feature changes: this build exists so the beta channel is actually running what the beta line has been carrying.
+
+### Changed
+- Updated the application runtime to Electron 43, which brings a newer Chromium and Node.js underneath CCC. A foundation update with no feature changes, carrying the browser and platform security fixes released with those versions.
+- Updated the two native components CCC depends on: the terminal backend that runs your sessions, and the local database that stores transcripts and usage. Both were rebuilt against the new runtime and exercised in a real launch before this release. Existing data is unchanged and nothing needs migrating.
+- Updated the screen-capture component used when you attach a screenshot to a session.
+- Updated the build pipeline that produces and publishes the installers. No effect on the application.
+
 ## [2.1.0-beta.4] - 2026-07-31
 
 > Security fixes for the session-launch path, and 1M-context models now launch correctly on macOS. Recommended for everyone on the beta channel.
@@ -942,6 +952,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.5
 [2.1.0-beta.4]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.4
 [2.1.0-beta.3]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.3
 [2.1.0-beta.2]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.2

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,6 +21,17 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.5',
+    date: '2026-08-02',
+    highlights: 'A runtime refresh. CCC now runs on Electron 43, with the terminal backend and the local database updated to match. No feature changes: this build exists so the beta channel is actually running what the beta line has been carrying.',
+    changes: [
+      { type: 'improvement', description: 'Updated the application runtime to Electron 43, which brings a newer Chromium and Node.js underneath CCC. A foundation update with no feature changes, carrying the browser and platform security fixes released with those versions.' },
+      { type: 'improvement', description: 'Updated the two native components CCC depends on: the terminal backend that runs your sessions, and the local database that stores transcripts and usage. Both were rebuilt against the new runtime and exercised in a real launch before this release. Existing data is unchanged and nothing needs migrating.' },
+      { type: 'improvement', description: 'Updated the screen-capture component used when you attach a screenshot to a session.' },
+      { type: 'improvement', description: 'Updated the build pipeline that produces and publishes the installers. No effect on the application.' },
+    ],
+  },
+  {
     version: '2.1.0-beta.4',
     date: '2026-07-31',
     highlights: 'Security fixes for the session-launch path, and 1M-context models now launch correctly on macOS. Recommended for everyone on the beta channel.',


### PR DESCRIPTION
Closes part of #189 -- step 1 of the beta.5 cut (the entry has to be on `beta` before the
release branch is taken off it, so `release.js` and the workflow both read the same source).

`v2.1.0-beta.4` shipped at f4254de. Everything since is dependency work, verified against
the tag rather than inferred from merge order:

| Commit | Change | User-facing? |
| --- | --- | --- |
| f055f15 (#87) | electron 42.4.0 -> 43.2.0 | yes -- the runtime |
| 3f53a14 (#85) | better-sqlite3 12.10.1 -> 13.0.1 | yes -- native, MAJOR |
| f3c2f6a (#86) | node-pty 1.2.0-beta.13 -> beta.14 | yes -- native |
| e8a79ae (#83) | electron-screenshots 0.6.1 -> 0.6.2 | yes |
| 0b35622 (#84) | @playwright/test 1.60.0 -> 1.61.1 | no -- dev only |
| 79-82, 78 | five actions/* majors | no -- build pipeline |
| f4254de, 3578769 | beta.4 version back-port | no code |

Four entries, all `improvement`. Playwright is omitted (dev-only, invisible to a user); the
Actions bumps are folded into one build-pipeline line rather than five.

The `version` and `date` fields are placeholders by design -- `release.js` rewrites both to
the version it bumps to and today's local date (#157), then regenerates `CHANGELOG.md`.

Docs only. `npm run changelog:check` is in sync.
