### PR TITLE
build(release): 2.1.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.4",
+  "version": "2.1.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.4",
+      "version": "2.1.0-beta.5",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.4",
+  "version": "2.1.0-beta.5",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Back-port of the version bump from `release/v2.1.0-beta.5` (#189), matching what #185 / #186
did for beta.4 and #177 for beta.3. Without it `beta` keeps saying `2.1.0-beta.4` while a
`2.1.0-beta.5` build is published, and the next cut computes its bump from a stale base.

Cherry-pick of eb89f3a -- `package.json` + `package-lock.json` version line only, no code.

`v2.1.0-beta.5` is published and verified:

- tag pinned to eb89f3a, the exact commit CI built (`--target $GITHUB_SHA`)
- `.exe`, `-mac.dmg`, `-linux-x86_64.AppImage`, `CHECKSUMS.txt` all attached
- `CHECKSUMS.txt` covers all three installers plus the blockmaps and the three `latest*.yml`
  -- checked by hand, since the completeness gate (#173) is not built yet
- release notes auto-populated from `src/renderer/changelog.ts`

Release: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.5
