### PR TITLE
docs(context): record the 2.1.0-beta.5 cut (#189)

### DIFF
--- a/CONTEXT.d/2026-08-02-189-release-beta5.md
+++ b/CONTEXT.d/2026-08-02-189-release-beta5.md
@@ -1,0 +1,65 @@
+## 2026-08-02 -- Cut 2.1.0-beta.5: the beta channel was 12 commits behind the beta branch
+
+`beta` had drifted 12 commits past `v2.1.0-beta.4` with `package.json` still reading
+`2.1.0-beta.4`. Nothing in those 12 existed in any published build, and they were not small:
+Electron 42 -> 43, better-sqlite3 12 -> 13 (native, major), node-pty beta.13 -> beta.14
+(native), electron-screenshots 0.6.2, @playwright/test 1.61.1 (dev only), and five
+`actions/*` majors. Tracked as #189.
+
+This is the same failure mode that made beta.4 necessary: `v2.1.0-beta.3` was published
+*before* several security fixes merged, so for a while the advertised beta did not contain
+the fixes its own branch carried. The gap is a release problem, not a code problem, and it
+recurs by default because `beta` is never frozen. Cutting promptly after a batch lands is
+the only thing that closes it.
+
+### Why the dependency majors were shippable
+
+Green CI is not evidence for these. Unit tests mock Electron and there is no real PTY
+(`AGENTS.md`), so a native module can be broken in every way that matters and CI stays green.
+The bumps were exercised by an actual DEV launch in the prior session -- better-sqlite3 and
+node-pty loaded and used *inside* the Electron 43 runtime, via `native-probe.js`. That is the
+check CI structurally cannot make, and it is the reason beta.5 is a legitimate build rather
+than an untested one.
+
+Re-verified on `beta` at db4ffde before cutting: typecheck (node + web) clean, 3339 passed /
+4 skipped across 399 files, `npm audit` 0 vulnerabilities.
+
+### Mechanics
+
+`npm run release` cannot cut this. `nextVersion()` derives the prerelease identifier from the
+BRANCH, and `releaseBranchBase()` only matches `release/vX.Y.Z` -- a bare base version. The
+branch `release/v2.1.0-beta.5` matches neither that nor `beta`, so `preIdForBranch()` returns
+null and the script throws "not a release line". beta.4 hit the same wall; both were cut by
+hand. The steps the script would have done were done manually in the same order:
+
+1. #190 -- hand-authored `2.1.0-beta.5` entry in `src/renderer/changelog.ts`, `npm run
+   changelog`, merged to `beta` FIRST so the release branch and the workflow read one source.
+2. `release/v2.1.0-beta.5` off `beta` -> bump `package.json` + regenerate `package-lock.json`
+   -> `build(release): 2.1.0-beta.5` (eb89f3a).
+3. `gh workflow run release.yml --ref release/v2.1.0-beta.5 -f channel=beta -f skip_vt=false`.
+4. #192 -- cherry-pick the bump back to `beta` so the branches do not diverge on the version
+   line (pattern: #185 / #186 for beta.4, #177 for beta.3).
+
+Worth noting for whoever cuts the next one: the naming is a documented-model violation that
+has now happened twice. `AGENTS.md` and `release.js` reserve `release/vX.Y.Z` for
+stabilization branches carrying `-rc.N`; `release/v2.1.0-beta.N` borrows that namespace for a
+plain beta cut. It works because the workflow reads the version from `package.json`, not the
+branch, but it is why the script refuses the branch. Either teach `releaseBranchBase()` the
+prerelease form or use a name outside `release/**` -- not fixed here, to keep a release cut
+from carrying a tooling change.
+
+### Verified after publish
+
+Tag pinned to eb89f3a, the exact commit CI built (`gh release create --target $GITHUB_SHA`,
+which is what stops a release stranding on a stale commit). `.exe`, `-mac.dmg`,
+`-linux-x86_64.AppImage` and `CHECKSUMS.txt` all attached; `CHECKSUMS.txt` checked by hand to
+cover all three installers plus blockmaps and the three `latest*.yml`. That hand check is the
+gap #173 exists to close -- `scripts/release.js` hard-fails only on a MISSING `CHECKSUMS.txt`
+(#111), not an incomplete one, and `build-linux` is `continue-on-error`, so a flaked Linux
+job can still publish a release the updater rejects for one platform.
+
+### Open
+
+Whether beta.5 or a later build becomes `rc.1` is undecided. beta.5 has been launched and
+published, so it is a legitimate candidate, but promotion is the owner's call and is not
+implied by this cut.


### PR DESCRIPTION
CARP running-log fragment for the beta.5 release (#189).

Records three things the next person cutting a release needs: that green CI is not evidence for a native-module bump (Electron is mocked, no real PTY -- the DEV launch is what cleared these), that \
pm run release\ structurally refuses a \elease/vX.Y.Z-beta.N\ branch so beta cuts are done by hand, and that the \CHECKSUMS.txt\ completeness check is still manual until #173 lands.

Docs only -- one new file under \CONTEXT.d/\, no existing fragment touched.