### PR TITLE
fix(update): stage installers privately and bound the manifest download (#174)

### DIFF
--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -841,14 +841,7 @@ function deriveManifestUrl(directUrl?: string | null): string | null {
  * This is the file that decides which digest counts as "verified", so it is the
  * last one that should have been left in a shared directory.
  */
-async function fetchChecksumManifest(tagName: string, directUrl?: string | null): Promise<string | null> {
-  let stageDir: string
-  try {
-    stageDir = createInstallerDir()
-  } catch (err) {
-    logError('[github-update] Could not create a private directory for the manifest:', err)
-    return null
-  }
+async function fetchChecksumManifest(tagName: string, stageDir: string, directUrl?: string | null): Promise<string | null> {
   const tmpPath = path.join(stageDir, 'CHECKSUMS.txt')
 
   try {
@@ -878,7 +871,9 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
   } catch (err) {
     logError('[github-update] CHECKSUMS.txt fetch via gh CLI failed:', err)
   } finally {
-    try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
+    // Only the manifest file. The directory is the caller's, and the installer
+    // is about to be downloaded into it.
+    try { fs.unlinkSync(tmpPath) } catch { /* best effort */ }
   }
 
   return null
@@ -895,9 +890,10 @@ async function fetchChecksumManifest(tagName: string, directUrl?: string | null)
 async function resolveExpectedDigest(
   tagName: string,
   assetName: string,
+  stageDir: string,
   directUrl?: string | null,
 ): Promise<string | null> {
-  const manifest = await fetchChecksumManifest(tagName, directUrl)
+  const manifest = await fetchChecksumManifest(tagName, stageDir, directUrl)
   if (!manifest) {
     logError('[github-update] CHECKSUMS.txt could not be fetched for this release')
     return null
@@ -1009,6 +1005,13 @@ export function assertPrivateDir(dir: string): void {
   if (!st.isDirectory()) {
     throw new Error(`${dir} is not a directory (symlink or file) — refusing to stage an installer there`)
   }
+  // NOTE ON COVERAGE: on every platform a planted redirect (POSIX symlink,
+  // Windows junction) fails the check above, because lstat reports it as a link
+  // rather than a directory. The realpath comparison below therefore has no
+  // portable test -- the input that needs it (a bind mount or volume mount point
+  // AT the final component, where lstat says "directory" and realpath diverges)
+  // cannot be created without root. It is kept as the belt to that braces, not
+  // because a test pins it.
   const resolvedParent = fs.realpathSync(path.dirname(dir))
   const expected = path.join(resolvedParent, path.basename(dir))
   const actual = fs.realpathSync(dir)
@@ -1037,7 +1040,27 @@ export function assertPrivateDir(dir: string): void {
  * already reports as a failed update.
  */
 export function installerRoot(): string {
-  const dir = path.join(getDataDirectory(), 'updates')
+  return privateSubdir('updates')
+}
+
+/**
+ * `<dataDir>/<name>`, created and validated.
+ *
+ * The data directory itself is checked for a planted redirect too -- not with
+ * the full ownership/mode test (it may legitimately live on a mount or a share
+ * whose uid differs), but enough to refuse a symlink or junction dropped in its
+ * place. Relocating a live data directory already gives an attacker the config,
+ * sessions and transcripts, so this is the cheap half of a bigger problem rather
+ * than the boundary; the point is that it must not ALSO silently redirect a file
+ * we are about to execute.
+ */
+function privateSubdir(name: string): string {
+  const base = getDataDirectory()
+  fs.mkdirSync(base, { recursive: true })
+  if (!fs.lstatSync(base).isDirectory()) {
+    throw new Error(`${base} is not a directory (symlink or file) — refusing to stage an installer under it`)
+  }
+  const dir = path.join(base, name)
   fs.mkdirSync(dir, { recursive: true })
   assertPrivateDir(dir)
   return dir
@@ -1112,9 +1135,11 @@ export function pruneStaleInstallerDirs(root: string, keep?: string): number {
  * orphaning any .desktop entry or dock pin.
  */
 function appImageParkingPath(downloadedPath: string): string {
-  const dir = path.join(getDataDirectory(), 'bin')
-  fs.mkdirSync(dir, { recursive: true })
-  return path.join(dir, path.basename(downloadedPath))
+  // VALIDATED, like the staging root. This is the directory CCC will EXECUTE
+  // from, so leaving it as a bare recursive mkdir would reintroduce the exact
+  // plantable-redirect hole assertPrivateDir exists to close -- at the worst
+  // possible place.
+  return path.join(privateSubdir('bin'), path.basename(downloadedPath))
 }
 
 /**
@@ -1123,7 +1148,7 @@ function appImageParkingPath(downloadedPath: string): string {
  * downloadGitHubRelease, which wraps this with verification. Exported only so
  * the download mechanics are unit-testable on their own.
  */
-export async function downloadInstallerFile(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
+export async function downloadInstallerFile(tagName: string, assetName: string, directUrl?: string | null, existingStageDir?: string): Promise<string | null> {
   // The asset name comes from the release feed and is interpolated into a
   // filesystem path, so a name carrying a separator would escape the staging
   // directory and undo the point of it. REFUSE rather than silently basename it
@@ -1137,15 +1162,18 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
     return null
   }
 
+  // downloadGitHubRelease creates ONE staging directory and passes it in, so the
+  // manifest and the installer share it: two independent directories meant the
+  // installer's prune could delete the one the manifest fetch was still using.
   let stageDir: string
-  const root = installerRoot()
   try {
-    stageDir = createInstallerDir(root)
+    const root = installerRoot()
+    stageDir = existingStageDir || createInstallerDir(root)
+    pruneStaleInstallerDirs(root, stageDir)
   } catch (err) {
     logError('[github-update] Could not create a staging directory for the download:', err)
     return null
   }
-  pruneStaleInstallerDirs(root, stageDir)
 
   const destPath = path.join(stageDir, safeName)
 
@@ -1193,20 +1221,44 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
  * not conflate with "download failed", because the user-facing advice differs.
  */
 export async function downloadGitHubRelease(tagName: string, assetName: string, directUrl?: string | null): Promise<VerifiedInstaller | null> {
+  // ONE staging directory for the manifest and the installer.
+  //
+  // Created here, and a failure raises a PLAIN Error rather than an
+  // InstallerIntegrityError. That distinction is user-facing: when the manifest
+  // fetch owned its own directory, a disk-full mkdtemp or an unwritable data dir
+  // returned null and the caller showed "Update blocked - integrity check
+  // failed" -- reporting a local storage problem as a release TAMPER event.
+  // False tamper signals are how real ones get ignored.
+  let stageDir: string
+  try {
+    stageDir = createInstallerDir()
+  } catch (err) {
+    throw new Error(
+      `Could not prepare a private folder to download the update into: ${(err as Error).message}. `
+      + 'Check free disk space and that the data directory is writable.'
+    )
+  }
+
+  const discard = (): void => {
+    try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+
   // Manifest first -- see resolveExpectedDigest. No digest, no download.
-  const expected = await resolveExpectedDigest(tagName, assetName, directUrl)
+  const expected = await resolveExpectedDigest(tagName, assetName, stageDir, directUrl)
   if (!expected) {
+    discard()
     throw integrityFailure(assetName, `has no verified SHA-256 in release ${tagName}`)
   }
 
-  const filePath = await downloadInstallerFile(tagName, assetName, directUrl)
-  if (!filePath) return null
+  const filePath = await downloadInstallerFile(tagName, assetName, directUrl, stageDir)
+  if (!filePath) {
+    discard()
+    return null
+  }
 
   if (!await confirmDigest(filePath, assetName, expected)) {
-    // confirmDigest destroys the file; take its now-empty staging directory too.
-    // downloadInstallerFile has already returned by this point, so its own
-    // cleanup cannot reach this path (#174).
-    try { fs.rmSync(path.dirname(filePath), { recursive: true, force: true }) } catch { /* best effort */ }
+    // confirmDigest destroys the file; take the now-empty directory too.
+    discard()
     throw integrityFailure(assetName, 'failed its SHA-256 check and was discarded')
   }
   return { path: filePath, sha256: expected }
@@ -1327,11 +1379,17 @@ export function prepareLinuxAppImageUpdate(
   const park = (): string => {
     // Only files actually sitting in a staging directory need moving. A
     // re-download straight onto the running AppImage's own path, or any other
-    // location, is already outside the prune root — copying it would be a
-    // pointless 200 MB write.
-    if (!path.basename(path.dirname(downloadedPath)).startsWith(INSTALLER_DIR_PREFIX)) {
-      return downloadedPath
-    }
+    // location, is already outside the prune root -- copying it would be a
+    // pointless 200 MB write. Checked against the prune root's LOCATION, not by
+    // name alone, so a legitimate `~/ccc-upd-backup/App.AppImage` does not
+    // trigger a spurious copy. Derived from the same `getDataDirectory() +
+    // 'updates'` as installerRoot() so the two cannot drift -- but WITHOUT
+    // calling it, because this must not depend on the root validating: a hostile
+    // root would otherwise silently switch parking off.
+    const parent = path.dirname(downloadedPath)
+    const pruneRoot = path.join(getDataDirectory(), 'updates')
+    if (path.resolve(path.dirname(parent)) !== path.resolve(pruneRoot)) return downloadedPath
+    if (!path.basename(parent).startsWith(INSTALLER_DIR_PREFIX)) return downloadedPath
     try {
       const parked = appImageParkingPath(downloadedPath)
       if (path.resolve(parked) === path.resolve(downloadedPath)) return downloadedPath

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -1076,9 +1076,32 @@ function privateSubdir(name: string): string {
   // change exists to add would have doubled as an update-killer. chmod is not
   // umask-masked, so this is what actually holds. It also repairs a directory an
   // older build left loose.
+  // Unguarded by platform: chmod is a documented no-op on Windows (the same
+  // reason createInstallerDir does it unguarded), and guarding it meant the line
+  // could only be covered by a POSIX-only test.
+  try { fs.chmodSync(dir, 0o700) } catch { /* validated below either way */ }
+
+  // A filesystem with no POSIX mode bits (exFAT/vfat, CIFS with a fixed
+  // dir_mode, a 9p/virtiofs VM share) accepts the chmod and changes nothing, so
+  // the validation below would refuse with "group- or world-writable" and no hint
+  // that we tried. The data directory is user-chosen at first run, so "on an
+  // external drive or a network share" is a supported configuration -- say what
+  // is actually wrong and what to do about it.
   if (process.platform !== 'win32') {
-    try { fs.chmodSync(dir, 0o700) } catch { /* validated below either way */ }
+    try {
+      if ((fs.statSync(dir).mode & 0o022) !== 0) {
+        throw new Error(
+          `${dir} is on a filesystem that cannot restrict permissions, so an installer `
+          + 'cannot be staged there privately. Choose a data directory on a local disk in '
+          + 'Settings, or install the update manually from the GitHub release page.'
+        )
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('cannot restrict permissions')) throw err
+      // A stat failure is assertPrivateDir's problem, not ours.
+    }
   }
+
   assertPrivateDir(dir)
   return dir
 }
@@ -1447,6 +1470,12 @@ export async function prepareLinuxAppImageUpdate(
     }
   } catch { return park() }
 
+  // Declared outside the try so the catch can reclaim it. Randomising the name
+  // removed the only thing that used to bound the leak (the pre-emptive unlink of
+  // a FIXED `.new`), so without this a failed copy/chmod/rename leaves a ~200 MB
+  // orphan next to the running AppImage that nothing ever cleans -- prune only
+  // walks `ccc-upd-*` inside <dataDir>/updates.
+  let staged: string | null = null
   try {
     const runningName = path.basename(real)
     const keepName = !/\d+\.\d+\.\d+/.test(runningName)   // unversioned = user's custom stable name
@@ -1467,12 +1496,10 @@ export async function prepareLinuxAppImageUpdate(
     // pre-plant a symlink at, which copyFileSync would follow, verify would hash
     // THROUGH, and renameSync would then move onto the launcher path. The unlink
     // stays as belt for the (now vanishingly unlikely) collision.
-    const staged = `${target}.new-${crypto.randomBytes(6).toString('hex')}`
-    try { fs.unlinkSync(staged) } catch { /* no leftover */ }
+    staged = `${target}.new-${crypto.randomBytes(6).toString('hex')}`
     fs.copyFileSync(downloadedPath, staged)
     fs.chmodSync(staged, 0o755)
     if (verify && !await verify(staged)) {
-      try { fs.unlinkSync(staged) } catch { /* best effort */ }
       throw new Error(`the copy at ${staged} did not match the verified installer`)
     }
 
@@ -1484,6 +1511,7 @@ export async function prepareLinuxAppImageUpdate(
       try { fs.unlinkSync(real) } catch { /* the rename recreates it */ }
     }
     fs.renameSync(staged, target)
+    staged = null   // committed; no longer an orphan to reclaim
     fs.chmodSync(target, 0o755)
 
     if (path.resolve(target) !== path.resolve(real)) {
@@ -1500,6 +1528,9 @@ export async function prepareLinuxAppImageUpdate(
     // Includes a failed verification of the staged copy. The user's installed
     // AppImage was never touched in that case, so falling back to a parked copy
     // of the (already-verified) download is safe.
+    if (staged) {
+      try { fs.unlinkSync(staged) } catch { /* best effort */ }
+    }
     logError('[github-update] In-place AppImage update failed — launching from a parked copy:', err)
     return park()
   }

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -1195,9 +1195,16 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
   // down: a real asset never contains a separator, so a name that needs
   // sanitising means the feed is wrong and downloading whatever is left of it is
   // not the right recovery.
+  // Both separators, on every platform. `path.basename` is platform-aware: on
+  // POSIX a backslash is an ordinary filename character, so `..\evil.exe` came
+  // back unchanged and passed the `safeName !== rawName` test. It stayed inside
+  // the staging directory there (POSIX reads it as one long filename), so nothing
+  // escaped -- but a guard whose verdict depends on the host is a guard that will
+  // be wrong on one of them. The macOS CI leg caught this; the Windows leg could
+  // not. A real asset name contains neither separator.
   const rawName = String(assetName || '')
   const safeName = path.basename(rawName)
-  if (!safeName || safeName !== rawName || safeName === '.' || safeName === '..') {
+  if (!safeName || safeName !== rawName || /[/\\]/.test(rawName) || safeName === '.' || safeName === '..') {
     logError(`[github-update] Refusing to download an asset with an unusable name: ${JSON.stringify(rawName)}`)
     return null
   }

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -1035,9 +1035,11 @@ export function assertPrivateDir(dir: string): void {
  *
  * There is deliberately no fallback chain. Every candidate a fallback could
  * reach is either shared (/tmp) or roaming (%APPDATA%), so "try the next one"
- * means "silently downgrade to the state this change exists to leave". A throw
- * here surfaces as `downloadInstallerFile` returning null, which the caller
- * already reports as a failed update.
+ * means "silently downgrade to the state this change exists to leave".
+ *
+ * A throw propagates: `downloadGitHubRelease` turns it into a plain Error (never
+ * an InstallerIntegrityError -- a local storage problem is not a tamper event),
+ * and `update-handlers` shows it in an "Update could not be downloaded" dialog.
  */
 export function installerRoot(): string {
   return privateSubdir('updates')
@@ -1046,13 +1048,17 @@ export function installerRoot(): string {
 /**
  * `<dataDir>/<name>`, created and validated.
  *
- * The data directory itself is checked for a planted redirect too -- not with
- * the full ownership/mode test (it may legitimately live on a mount or a share
- * whose uid differs), but enough to refuse a symlink or junction dropped in its
- * place. Relocating a live data directory already gives an attacker the config,
- * sessions and transcripts, so this is the cheap half of a bigger problem rather
- * than the boundary; the point is that it must not ALSO silently redirect a file
- * we are about to execute.
+ * The data directory's OWN final component is lstat-checked too -- not the full
+ * ownership/mode test (it may legitimately live on a mount or share whose uid
+ * differs), just enough to refuse a symlink or junction dropped in its place.
+ * That check is load-bearing rather than redundant: with the data directory
+ * itself junctioned, `assertPrivateDir` on the subdirectory PASSES, because both
+ * realpath calls resolve through the same junction and therefore agree.
+ *
+ * A redirect at a HIGHER component (e.g. %LOCALAPPDATA%) is not caught, and is
+ * not meant to be: an attacker who can relocate the live data directory already
+ * has the config, sessions and transcripts. The point is only that a file we are
+ * about to EXECUTE must not be written through a redirect we could have seen.
  */
 function privateSubdir(name: string): string {
   const base = getDataDirectory()
@@ -1204,8 +1210,11 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
     logError('[github-update] gh CLI download failed:', err)
   }
 
-  // Nothing usable landed -- take the empty staging directory with us.
-  try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  // Nothing usable landed. Only clean up a directory WE created: when the caller
+  // supplied one it owns the lifetime (and may have other files in it).
+  if (!existingStageDir) {
+    try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
   return null
 }
 
@@ -1365,10 +1374,11 @@ export function isPathOnNoexecMount(targetPath: string, procMounts?: string): bo
  * never block the update on the tidy-up. `currentAppImage` is a parameter
  * (defaulting to $APPIMAGE) so tests can exercise all paths on any platform.
  */
-export function prepareLinuxAppImageUpdate(
+export async function prepareLinuxAppImageUpdate(
   downloadedPath: string,
   currentAppImage: string | undefined = process.env.APPIMAGE,
-): string {
+  verify?: (candidate: string) => Promise<boolean>,
+): Promise<string> {
   try { fs.chmodSync(downloadedPath, 0o755) } catch (err) {
     logError('[github-update] chmod +x on downloaded AppImage failed:', err)
   }
@@ -1436,14 +1446,28 @@ export function prepareLinuxAppImageUpdate(
     // prune-eligible. Park it.
     if (path.resolve(target) === path.resolve(downloadedPath)) return park()
 
+    // VERIFY BEFORE COMMIT. Copy to a sibling `.new`, hash THAT, and only then
+    // move it into place. The old order copied straight onto the target and let
+    // the caller re-hash afterwards -- which detects a swap but cannot undo it:
+    // the bad bytes are already at the user's .desktop/dock-pinned path and run
+    // on next launch, while the UI says the update was "blocked".
+    const staged = `${target}.new`
+    try { fs.unlinkSync(staged) } catch { /* no leftover */ }
+    fs.copyFileSync(downloadedPath, staged)
+    fs.chmodSync(staged, 0o755)
+    if (verify && !await verify(staged)) {
+      try { fs.unlinkSync(staged) } catch { /* best effort */ }
+      throw new Error(`the copy at ${staged} did not match the verified installer`)
+    }
+
     // Unlink before writing when reusing the running file's own path: truncating
     // a mounted AppImage in place can corrupt the running mount, whereas removing
-    // the directory entry is safe (the mount keeps the inode) and lets copy
+    // the directory entry is safe (the mount keeps the inode) and lets the rename
     // recreate the file cleanly.
     if (path.resolve(target) === path.resolve(real)) {
-      try { fs.unlinkSync(real) } catch { /* copy recreates it */ }
+      try { fs.unlinkSync(real) } catch { /* the rename recreates it */ }
     }
-    fs.copyFileSync(downloadedPath, target)
+    fs.renameSync(staged, target)
     fs.chmodSync(target, 0o755)
 
     if (path.resolve(target) !== path.resolve(real)) {
@@ -1457,6 +1481,9 @@ export function prepareLinuxAppImageUpdate(
     logInfo(`[github-update] AppImage updated in place: ${target}`)
     return target
   } catch (err) {
+    // Includes a failed verification of the staged copy. The user's installed
+    // AppImage was never touched in that case, so falling back to a parked copy
+    // of the (already-verified) download is safe.
     logError('[github-update] In-place AppImage update failed — launching from a parked copy:', err)
     return park()
   }

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -25,6 +25,7 @@ import { promisify } from 'util'
 import { logInfo, logError } from './debug-logger'
 import { readConfig } from './config-manager'
 import { readRegistry } from './registry'
+import { getDataDirectory } from './data-paths'
 
 const execFileAsync = promisify(execFile)
 
@@ -501,7 +502,7 @@ export async function checkGitHubRelease(): Promise<ReleaseInfo | null> {
  *  - Cleans up the .part file on every failure path.
  *  - Aborts the active HTTP request when something fails mid-stream.
  */
-function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promise<boolean> {
+function httpsDownload(url: string, destPath: string, timeoutMs = 300000, maxBytes?: number): Promise<boolean> {
   return new Promise((resolve) => {
     const tmpPath = destPath + '.part'
     let file: fs.WriteStream
@@ -555,7 +556,13 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
           // Follow redirects — resolve against the current URL so relative
           // Location headers work, and re-validate the protocol on each hop.
           if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-            res.resume()
+            // destroy(), not resume(). resume() DRAINS the redirect body and
+            // discards it -- uncounted against maxBytes and, because activeReq
+            // is nulled just below, no longer reachable by fail(). A 3xx with an
+            // endless body then makes the main process read and throw away data
+            // forever, on up to `hopsLeft` leaked sockets, past the point the
+            // promise has already settled.
+            res.destroy()
             activeReq = null
             let nextUrl: string
             try {
@@ -571,6 +578,29 @@ function httpsDownload(url: string, destPath: string, timeoutMs = 300000): Promi
             res.resume()
             fail(new Error(`HTTP ${res.statusCode}`))
             return
+          }
+          // Enforce the byte limit ON THE WIRE, not after landing (#174).
+          // readManifest checks MAX_MANIFEST_BYTES by stat-ing the finished
+          // file, which is too late: a hostile manifest endpoint can fill the
+          // disk before that check ever runs. Content-Length is a fast reject
+          // when honest; the running count is what actually holds, because the
+          // header is attacker-supplied and a chunked response has none.
+          if (maxBytes !== undefined) {
+            const declared = Number(res.headers['content-length'])
+            if (Number.isFinite(declared) && declared > maxBytes) {
+              res.resume()
+              fail(new Error(`response declares ${declared} bytes, over the ${maxBytes}-byte limit`))
+              return
+            }
+            let received = 0
+            res.on('data', (chunk: Buffer | string) => {
+              received += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length
+              if (received > maxBytes) {
+                // fail() destroys the request and unlinks the .part file, so
+                // nothing past the limit is kept and the socket stops.
+                fail(new Error(`response exceeded the ${maxBytes}-byte limit`))
+              }
+            })
           }
           res.on('error', (err) => fail(err))
           res.pipe(file)
@@ -687,6 +717,16 @@ function splitChecksumLine(line: string): [string, string] | null {
  *  refuses is a release that passes CI and cannot be installed. */
 export const MAX_MANIFEST_BYTES = 1024 * 1024
 
+/**
+ * Ceiling on the INSTALLER download. Generous on purpose -- the current assets
+ * are 170-215 MB and this only exists so an unbounded response cannot fill the
+ * disk before the digest check (which necessarily runs after the whole body has
+ * landed) gets a chance to reject it. Sized so no plausible future build trips it
+ * while still bounding the damage; the digest, not this, is what decides whether
+ * the bytes are trustworthy.
+ */
+export const MAX_INSTALLER_BYTES = 1024 * 1024 * 1024
+
 /** A downloaded installer whose SHA-256 has been checked against the release
  *  manifest. Carries the digest so the caller can re-verify just before exec. */
 export interface VerifiedInstaller {
@@ -788,37 +828,57 @@ function deriveManifestUrl(directUrl?: string | null): string | null {
   }
 }
 
-/** Fetch CHECKSUMS.txt for a release, via the same cascade as the installer. */
+/**
+ * Fetch CHECKSUMS.txt for a release, via the same cascade as the installer.
+ *
+ * Staged in the SAME kind of private mkdtemp directory as the installer (#174),
+ * not `os.tmpdir()` under a `Date.now()` name. That old shape was worse than the
+ * installer's, not better: on a multi-user POSIX box /tmp's sticky bit stops
+ * another user UNLINKING our entry but not their pre-planting a SYMLINK at a
+ * millisecond-guessable name, and `createWriteStream` opens without O_NOFOLLOW,
+ * so the write follows the link -- and `renameSync` then moves the LINK to the
+ * destination, leaving the attacker in control of the bytes `readManifest` reads.
+ * This is the file that decides which digest counts as "verified", so it is the
+ * last one that should have been left in a shared directory.
+ */
 async function fetchChecksumManifest(tagName: string, directUrl?: string | null): Promise<string | null> {
-  const tmpPath = path.join(os.tmpdir(), `ccc-CHECKSUMS-${Date.now()}.txt`)
-  const cleanup = (): void => { try { fs.unlinkSync(tmpPath) } catch { /* best effort */ } }
-
-  // 1. Direct HTTPS, deriving the manifest URL from the installer's own asset
-  //    URL so it comes from the same release, same host.
-  const manifestUrl = deriveManifestUrl(directUrl)
-  if (manifestUrl) {
-    if (await httpsDownload(manifestUrl, tmpPath, 60000)) {
-      const text = readManifest(tmpPath)
-      cleanup()
-      if (text) return text
-    }
-  }
-
-  // 2. gh CLI fallback (private repos, and when the derived URL 404s).
-  const tmpDir = path.join(os.tmpdir(), `ccc-sums-${Date.now()}`)
+  let stageDir: string
   try {
-    fs.mkdirSync(tmpDir, { recursive: true })
+    stageDir = createInstallerDir()
+  } catch (err) {
+    logError('[github-update] Could not create a private directory for the manifest:', err)
+    return null
+  }
+  const tmpPath = path.join(stageDir, 'CHECKSUMS.txt')
+
+  try {
+    // 1. Direct HTTPS, deriving the manifest URL from the installer's own asset
+    //    URL so it comes from the same release, same host.
+    const manifestUrl = deriveManifestUrl(directUrl)
+    if (manifestUrl) {
+      if (await httpsDownload(manifestUrl, tmpPath, 60000, MAX_MANIFEST_BYTES)) {
+        const text = readManifest(tmpPath)
+        if (text) return text
+      }
+      try { fs.unlinkSync(tmpPath) } catch { /* best effort */ }
+    }
+
+    // 2. gh CLI fallback (private repos, and when the derived URL 404s).
+    //    gh writes the whole body before we can see it, so readManifest's
+    //    stat-based MAX_MANIFEST_BYTES check is the only limit on this leg --
+    //    the post-hoc shape the direct leg no longer uses. Acceptable: it takes
+    //    release-write access to publish an oversized CHECKSUMS.txt, which the
+    //    threat model already concedes.
     await execFileAsync(
       'gh',
-      ['release', 'download', tagName, '--repo', REPO, '--pattern', 'CHECKSUMS.txt', '--dir', tmpDir, '--clobber'],
+      ['release', 'download', tagName, '--repo', REPO, '--pattern', 'CHECKSUMS.txt', '--dir', stageDir, '--clobber'],
       { encoding: 'utf-8', timeout: 60000, windowsHide: true }
     )
-    const manifestPath = path.join(tmpDir, 'CHECKSUMS.txt')
-    if (fs.existsSync(manifestPath)) return readManifest(manifestPath)
+    if (fs.existsSync(tmpPath)) return readManifest(tmpPath)
   } catch (err) {
     logError('[github-update] CHECKSUMS.txt fetch via gh CLI failed:', err)
   } finally {
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+    try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
   }
 
   return null
@@ -855,8 +915,10 @@ async function resolveExpectedDigest(
  *
  * FAILS CLOSED. On mismatch or an unreadable file the download is destroyed and
  * false returned. If unlink fails (Windows file lock) the file is renamed to
- * `.INVALID` instead -- leaving an unverified installer in ~/Downloads under its
- * expected name is how a user ends up double-clicking it.
+ * `.INVALID` instead -- leaving an unverified installer under its expected name
+ * is how someone ends up double-clicking it. Since #174 it is staged in a
+ * private directory rather than ~/Downloads, which makes that far less likely to
+ * be stumbled upon, but the file is still destroyed rather than trusted.
  */
 async function confirmDigest(filePath: string, assetName: string, expected: string): Promise<boolean> {
   const actual = await sha256File(filePath)
@@ -895,22 +957,203 @@ function integrityFailure(assetName: string, why: string): InstallerIntegrityErr
   )
 }
 
+// -- Where an installer is staged (#174) ----------------------------------
+//
+// NOT ~/Downloads. The updater verifies the installer, kills every PTY, then
+// spawns it with `allowElevation`, so the user is about to approve a UAC prompt
+// for whatever sits at that path. In ~/Downloads the path is fully PREDICTABLE
+// (the asset name is public in the release feed) and the directory is one every
+// browser writes into.
+//
+// BE PRECISE ABOUT WHAT THIS BUYS. The stated attacker is a non-elevated process
+// in the USER'S OWN SESSION -- which means it is the owner, so it does not have
+// to guess the name: it can watch the root and see the new directory appear in
+// milliseconds, and 0700 excludes only OTHER users. What moving out of
+// ~/Downloads removes is the code-execution-free variant (a hostile page driving
+// a browser download onto the publicly-known asset name), collisions with
+// anything else writing that directory, and the chance of someone stumbling on a
+// stale unverified installer and double-clicking it. `stillMatchesDigest`
+// remains the control of record for the verify->spawn race. Do not read this as
+// making the re-hash redundant.
+//
+// `updates/` under the app's OWN data directory (`getDataDirectory()`), not
+// Electron's `userData` and not the system temp dir:
+//   - not `temp`: on Linux that is the shared, world-writable /tmp, and it is
+//     `noexec` on hardened boxes -- for a file we intend to EXECUTE.
+//   - not `app.getPath('userData')`: on Windows that is %APPDATA%, which ROAMS.
+//     Staging a 200 MB installer there syncs it to a file share at sign-out and
+//     can trip a profile quota. `getDataDirectory()` uses %LOCALAPPDATA%, which
+//     is what the rest of this app already uses for bulk data.
+//   - and it honours CCC_DEV_DATA_DIR / CCC_E2E_DATA_DIR, so a dev instance
+//     stages inside its own data root instead of the installed copy's.
+
+const INSTALLER_DIR_PREFIX = 'ccc-upd-'
+
 /**
- * Transport half: fetch the asset to ~/Downloads, direct HTTPS first then gh
- * CLI. Performs NO integrity check -- callers must use downloadGitHubRelease,
- * which wraps this with verification. Exported only so the download mechanics
- * are unit-testable on their own.
+ * Assert `dir` is a real directory, at the path we asked for, owned by us and
+ * not group/other-writable.
+ *
+ * The parent of the staging directory is what an attacker actually needs: with
+ * write access to it they can `rename()` the 0700 leaf away and substitute their
+ * own. `mkdirSync(..., {recursive: true})` swallows EEXIST, so without this a
+ * pre-planted SYMLINK (POSIX) or JUNCTION (Windows -- no admin required) at
+ * `<dataDir>/updates` is followed silently and every future installer is staged
+ * inside a directory the planter controls. Plant once, harvest every update.
+ *
+ * Only the FINAL component is checked against realpath: legitimate symlinks
+ * higher up are normal (macOS /var -> /private/var), and rejecting those would
+ * break the update for no security gain.
+ */
+export function assertPrivateDir(dir: string): void {
+  const st = fs.lstatSync(dir)
+  if (!st.isDirectory()) {
+    throw new Error(`${dir} is not a directory (symlink or file) — refusing to stage an installer there`)
+  }
+  const resolvedParent = fs.realpathSync(path.dirname(dir))
+  const expected = path.join(resolvedParent, path.basename(dir))
+  const actual = fs.realpathSync(dir)
+  if (path.resolve(actual) !== path.resolve(expected)) {
+    throw new Error(`${dir} resolves to ${actual} — refusing to stage an installer through a redirected path`)
+  }
+  // POSIX only: Windows has no mode bits worth reading here (see chmod note in
+  // createInstallerDir) and the profile ACL is what scopes it.
+  if (process.platform !== 'win32' && typeof process.getuid === 'function') {
+    if (st.uid !== process.getuid()) {
+      throw new Error(`${dir} is owned by uid ${st.uid}, not ${process.getuid()} — refusing to stage an installer there`)
+    }
+    if ((st.mode & 0o022) !== 0) {
+      throw new Error(`${dir} is group- or world-writable (mode ${(st.mode & 0o777).toString(8)}) — refusing to stage an installer there`)
+    }
+  }
+}
+
+/**
+ * The staging root. THROWS rather than falling back.
+ *
+ * There is deliberately no fallback chain. Every candidate a fallback could
+ * reach is either shared (/tmp) or roaming (%APPDATA%), so "try the next one"
+ * means "silently downgrade to the state this change exists to leave". A throw
+ * here surfaces as `downloadInstallerFile` returning null, which the caller
+ * already reports as a failed update.
+ */
+export function installerRoot(): string {
+  const dir = path.join(getDataDirectory(), 'updates')
+  fs.mkdirSync(dir, { recursive: true })
+  assertPrivateDir(dir)
+  return dir
+}
+
+/**
+ * A fresh, owner-only, unpredictably-named directory to stage one download in.
+ *
+ * `mkdtemp` supplies the unpredictable name. 0700 keeps it to the owner on
+ * POSIX. On Windows `chmod` is a documented NO-OP -- it succeeds and changes
+ * nothing, so the catch never fires -- and containment there comes from the
+ * inherited per-user profile ACL instead.
+ *
+ * `root` is injectable so tests can use a real scratch directory.
+ */
+export function createInstallerDir(root?: string): string {
+  const base = root || installerRoot()
+  const dir = fs.mkdtempSync(path.join(base, INSTALLER_DIR_PREFIX))
+  try { fs.chmodSync(dir, 0o700) } catch { /* no-op on Windows */ }
+  return dir
+}
+
+/**
+ * Remove staging directories from previous updates, keeping `keep`.
+ *
+ * The successful path cannot clean up after itself: CCC spawns the installer and
+ * exits, so the file must outlive the process. Pruning on the way IN bounds the
+ * accumulation instead. Best-effort throughout -- a running installer holds a
+ * lock on Windows, and a leftover directory is untidy, never unsafe. The inner
+ * catch is load-bearing: the call site is not wrapped, so a throw here would
+ * abort the whole update over a tidy-up.
+ *
+ * An entry that is NOT a real directory is unlinked, never recursed into. Node's
+ * rimraf happens to lstat first and do the same, but this is a recursive delete
+ * driven by `readdir` of a directory the attacker can write to, so the guard is
+ * explicit here rather than inherited from an implementation detail: a
+ * `ccc-upd-evil` symlink pointing at $HOME must cost the link, not the home
+ * directory.
+ */
+export function pruneStaleInstallerDirs(root: string, keep?: string): number {
+  let removed = 0
+  let entries: string[]
+  try { entries = fs.readdirSync(root) } catch { return 0 }
+  for (const name of entries) {
+    if (!name.startsWith(INSTALLER_DIR_PREFIX)) continue
+    const full = path.join(root, name)
+    if (keep && path.resolve(full) === path.resolve(keep)) continue
+    try {
+      if (!fs.lstatSync(full).isDirectory()) {
+        fs.unlinkSync(full)
+        removed += 1
+        continue
+      }
+      fs.rmSync(full, { recursive: true, force: true })
+      removed += 1
+    } catch { /* locked by a running installer, or gone already */ }
+  }
+  return removed
+}
+
+/**
+ * Where a launched AppImage is parked so the next update's prune cannot delete
+ * the running application.
+ *
+ * `prepareLinuxAppImageUpdate` relocates the AppImage next to the running one
+ * when $APPIMAGE is set, but returns the DOWNLOAD path unchanged when it cannot
+ * (dev/extracted runs, an unwritable target, $APPIMAGE pointing at something
+ * that is not a plain .AppImage). Before #174 that download path was
+ * ~/Downloads, which nothing pruned. Inside the staging root it is
+ * prune-eligible, so update N+1 would unlink the very file the user is running
+ * -- and the app's location would change to a fresh random name every time,
+ * orphaning any .desktop entry or dock pin.
+ */
+function appImageParkingPath(downloadedPath: string): string {
+  const dir = path.join(getDataDirectory(), 'bin')
+  fs.mkdirSync(dir, { recursive: true })
+  return path.join(dir, path.basename(downloadedPath))
+}
+
+/**
+ * Transport half: fetch the asset into a private staging directory, direct HTTPS
+ * first then gh CLI. Performs NO integrity check -- callers must use
+ * downloadGitHubRelease, which wraps this with verification. Exported only so
+ * the download mechanics are unit-testable on their own.
  */
 export async function downloadInstallerFile(tagName: string, assetName: string, directUrl?: string | null): Promise<string | null> {
-  const downloadsDir = path.join(os.homedir(), 'Downloads')
-  try { fs.mkdirSync(downloadsDir, { recursive: true }) } catch {}
-  const destPath = path.join(downloadsDir, assetName)
+  // The asset name comes from the release feed and is interpolated into a
+  // filesystem path, so a name carrying a separator would escape the staging
+  // directory and undo the point of it. REFUSE rather than silently basename it
+  // down: a real asset never contains a separator, so a name that needs
+  // sanitising means the feed is wrong and downloading whatever is left of it is
+  // not the right recovery.
+  const rawName = String(assetName || '')
+  const safeName = path.basename(rawName)
+  if (!safeName || safeName !== rawName || safeName === '.' || safeName === '..') {
+    logError(`[github-update] Refusing to download an asset with an unusable name: ${JSON.stringify(rawName)}`)
+    return null
+  }
 
-  logInfo(`[github-update] Downloading ${assetName} to ${destPath}`)
+  let stageDir: string
+  const root = installerRoot()
+  try {
+    stageDir = createInstallerDir(root)
+  } catch (err) {
+    logError('[github-update] Could not create a staging directory for the download:', err)
+    return null
+  }
+  pruneStaleInstallerDirs(root, stageDir)
+
+  const destPath = path.join(stageDir, safeName)
+
+  logInfo(`[github-update] Downloading ${safeName} to ${destPath}`)
 
   // 1. Try direct HTTPS download (works for public repo)
   if (directUrl) {
-    const ok = await httpsDownload(directUrl, destPath)
+    const ok = await httpsDownload(directUrl, destPath, 300000, MAX_INSTALLER_BYTES)
     if (ok && fs.existsSync(destPath)) {
       logInfo(`[github-update] Downloaded via direct HTTPS: ${destPath}`)
       return destPath
@@ -922,7 +1165,7 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
   try {
     await execFileAsync(
       'gh',
-      ['release', 'download', tagName, '--repo', REPO, '--pattern', assetName, '--dir', downloadsDir, '--clobber'],
+      ['release', 'download', tagName, '--repo', REPO, '--pattern', safeName, '--dir', stageDir, '--clobber'],
       { encoding: 'utf-8', timeout: 300000, windowsHide: true }
     )
     if (fs.existsSync(destPath)) {
@@ -933,6 +1176,8 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
     logError('[github-update] gh CLI download failed:', err)
   }
 
+  // Nothing usable landed -- take the empty staging directory with us.
+  try { fs.rmSync(stageDir, { recursive: true, force: true }) } catch { /* best effort */ }
   return null
 }
 
@@ -958,6 +1203,10 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
   if (!filePath) return null
 
   if (!await confirmDigest(filePath, assetName, expected)) {
+    // confirmDigest destroys the file; take its now-empty staging directory too.
+    // downloadInstallerFile has already returned by this point, so its own
+    // cleanup cannot reach this path (#174).
+    try { fs.rmSync(path.dirname(filePath), { recursive: true, force: true }) } catch { /* best effort */ }
     throw integrityFailure(assetName, 'failed its SHA-256 check and was discarded')
   }
   return { path: filePath, sha256: expected }
@@ -967,12 +1216,17 @@ export async function downloadGitHubRelease(tagName: string, assetName: string, 
  * Re-hash a previously-verified installer immediately before executing it.
  *
  * The gap between verification and `spawn` is not small: the caller kills every
- * PTY in between, which takes tens of milliseconds to seconds. The file sits at
- * a predictable path in ~/Downloads -- a directory every browser writes into --
- * and the installer is launched with `allowElevation`, so a NON-elevated local
- * process that wins that race gains admin on a UAC prompt the user is already
- * expecting. Re-hashing costs about a second for 150 MB and shrinks the window
- * to microseconds.
+ * PTY in between, which takes tens of milliseconds to seconds. The installer is
+ * launched with `allowElevation`, so a local process that wins that race gains
+ * admin on a UAC prompt the user is already expecting. Re-hashing costs about a
+ * second for 150 MB and shrinks the window to microseconds.
+ *
+ * #174 moved staging out of ~/Downloads but did NOT retire this. The attacker in
+ * this model runs as the user, so an unpredictable directory name buys nothing
+ * against it: the attacker owns the root and can watch it. What #174 removed is
+ * the drive-by variant (a hostile page steering a browser download onto the
+ * publicly-known asset name in a directory every browser writes into). THIS is
+ * the control of record for the verify->spawn race.
  */
 export async function stillMatchesDigest(filePath: string, expectedSha256: string): Promise<boolean> {
   const actual = await sha256File(filePath)
@@ -988,8 +1242,10 @@ export async function stillMatchesDigest(filePath: string, expectedSha256: strin
  * Best-effort check: is `targetPath` on a filesystem mounted `noexec`?
  *
  * `fs.accessSync(X_OK)` inspects the file's permission bits, not the mount, so
- * on a hardened box where ~/Downloads (or /home) is mounted `noexec` a freshly
- * chmod'd AppImage passes the access check yet `execve` fails EACCES at launch.
+ * on a hardened box where the staging directory (or /home, or /tmp) is mounted
+ * `noexec` a freshly chmod'd AppImage passes the access check yet `execve` fails
+ * EACCES at launch. This is also why #174 stages under userData rather than the
+ * system temp dir: /tmp is `noexec` far more often than $HOME.
  * Because CCC holds a single-instance lock, we cannot verify the relaunch by
  * spawning it first (the new instance can't start until we exit), so the update
  * flow uses this to abort BEFORE killing the user's terminals rather than after.
@@ -1032,7 +1288,8 @@ export function isPathOnNoexecMount(targetPath: string, procMounts?: string): bo
  *
  * Unlike Windows (the .exe IS an installer that installs over the old copy),
  * a downloaded AppImage is just a file: it arrives without the execute bit,
- * and launching it from ~/Downloads would leave the user's "real" copy stale.
+ * and launching it from the staging directory would leave the user's "real" copy
+ * stale.
  * So: chmod +x always; then, when we're running AS an AppImage (AppImage
  * runtimes export $APPIMAGE = the file's own path), replace it in place.
  *
@@ -1064,13 +1321,39 @@ export function prepareLinuxAppImageUpdate(
     logError('[github-update] chmod +x on downloaded AppImage failed:', err)
   }
 
-  if (!currentAppImage) return downloadedPath
+  // Every early return below hands back a path OUTSIDE the prune-eligible
+  // staging root -- see appImageParkingPath. Returning `downloadedPath` itself
+  // would leave the running application in a directory the next update deletes.
+  const park = (): string => {
+    // Only files actually sitting in a staging directory need moving. A
+    // re-download straight onto the running AppImage's own path, or any other
+    // location, is already outside the prune root — copying it would be a
+    // pointless 200 MB write.
+    if (!path.basename(path.dirname(downloadedPath)).startsWith(INSTALLER_DIR_PREFIX)) {
+      return downloadedPath
+    }
+    try {
+      const parked = appImageParkingPath(downloadedPath)
+      if (path.resolve(parked) === path.resolve(downloadedPath)) return downloadedPath
+      fs.copyFileSync(downloadedPath, parked)
+      fs.chmodSync(parked, 0o755)
+      logInfo(`[github-update] AppImage parked outside the staging root: ${parked}`)
+      return parked
+    } catch (err) {
+      // Launching from the staging dir still works TODAY; it is the next
+      // update's prune that would remove it. Never block the update on tidy-up.
+      logError('[github-update] Could not park the AppImage outside the staging root:', err)
+      return downloadedPath
+    }
+  }
+
+  if (!currentAppImage) return park()
 
   // Resolve symlinks / `..`: the AppImage runtime sets $APPIMAGE to the real
   // mounted file, but a user may launch via a stable symlink whose target we
   // must replace (and whose link we must not leave dangling).
   let real: string
-  try { real = fs.realpathSync(currentAppImage) } catch { return downloadedPath }
+  try { real = fs.realpathSync(currentAppImage) } catch { return park() }
 
   // Only ever replace a plain *.AppImage FILE — never unlink a directory or a
   // non-AppImage file (e.g. a wrapper that set $APPIMAGE to some unrelated
@@ -1080,17 +1363,20 @@ export function prepareLinuxAppImageUpdate(
   try {
     const st = fs.lstatSync(real)
     if (!st.isFile() || !path.basename(real).endsWith('.AppImage')) {
-      logError(`[github-update] $APPIMAGE (${real}) is not an AppImage file — launching from download location`)
-      return downloadedPath
+      logError(`[github-update] $APPIMAGE (${real}) is not an AppImage file — launching from a parked copy`)
+      return park()
     }
-  } catch { return downloadedPath }
+  } catch { return park() }
 
   try {
     const runningName = path.basename(real)
     const keepName = !/\d+\.\d+\.\d+/.test(runningName)   // unversioned = user's custom stable name
     const target = keepName ? real : path.join(path.dirname(real), path.basename(downloadedPath))
 
-    if (path.resolve(target) === path.resolve(downloadedPath)) return downloadedPath
+    // target == the download means $APPIMAGE already points into the staging
+    // root, so relocating is a no-op but launching from there is still
+    // prune-eligible. Park it.
+    if (path.resolve(target) === path.resolve(downloadedPath)) return park()
 
     // Unlink before writing when reusing the running file's own path: truncating
     // a mounted AppImage in place can corrupt the running mount, whereas removing
@@ -1113,7 +1399,7 @@ export function prepareLinuxAppImageUpdate(
     logInfo(`[github-update] AppImage updated in place: ${target}`)
     return target
   } catch (err) {
-    logError('[github-update] In-place AppImage update failed — launching from download location:', err)
-    return downloadedPath
+    logError('[github-update] In-place AppImage update failed — launching from a parked copy:', err)
+    return park()
   }
 }

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -1067,7 +1067,18 @@ function privateSubdir(name: string): string {
     throw new Error(`${base} is not a directory (symlink or file) — refusing to stage an installer under it`)
   }
   const dir = path.join(base, name)
-  fs.mkdirSync(dir, { recursive: true })
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  // TIGHTEN, then validate. `mkdirSync`'s mode is masked by the process umask,
+  // so on a umask-002 box (per-user-group setups, many container images) the
+  // directory lands 0775 -- and assertPrivateDir's group-write check then
+  // rejects it. Because there is deliberately no fallback, that turned into a
+  // PERMANENT, unrecoverable update failure for those users: the control this
+  // change exists to add would have doubled as an update-killer. chmod is not
+  // umask-masked, so this is what actually holds. It also repairs a directory an
+  // older build left loose.
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(dir, 0o700) } catch { /* validated below either way */ }
+  }
   assertPrivateDir(dir)
   return dir
 }
@@ -1451,7 +1462,12 @@ export async function prepareLinuxAppImageUpdate(
     // the caller re-hash afterwards -- which detects a swap but cannot undo it:
     // the bad bytes are already at the user's .desktop/dock-pinned path and run
     // on next launch, while the UI says the update was "blocked".
-    const staged = `${target}.new`
+    // Random suffix, not a fixed `.new`: a fixed name both clobbers whatever the
+    // user happened to have there and gives an attacker a predictable path to
+    // pre-plant a symlink at, which copyFileSync would follow, verify would hash
+    // THROUGH, and renameSync would then move onto the launcher path. The unlink
+    // stays as belt for the (now vanishingly unlikely) collision.
+    const staged = `${target}.new-${crypto.randomBytes(6).toString('hex')}`
     try { fs.unlinkSync(staged) } catch { /* no leftover */ }
     fs.copyFileSync(downloadedPath, staged)
     fs.chmodSync(staged, 0o755)

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -130,12 +130,21 @@ export function registerUpdateHandlers(): void {
         // there is no toast component -- so the user saw the "Updating..."
         // overlay vanish and nothing else. showErrorBox is the one channel that
         // cannot be dropped on the way out.
-        if (err instanceof InstallerIntegrityError) {
-          logError(`[update] ${err.message}`)
-          try {
+        logError(`[update] ${(err as Error).message}`)
+        try {
+          if (err instanceof InstallerIntegrityError) {
             dialog.showErrorBox('Update blocked - integrity check failed', err.message)
-          } catch { /* never let the dialog itself break the flow */ }
-        }
+          } else {
+            // NOT an integrity failure: a staging failure (disk full, unwritable
+            // data directory, a redirected staging root) or a network error. It
+            // still has to reach the user, and this is the only channel that
+            // does -- the rethrow escapes before the launch try/catch below, and
+            // every renderer call site swallows it. Reporting a storage problem
+            // as a tamper event was wrong; reporting it as nothing at all is
+            // worse (#174 adversarial review, rounds 2 and 3).
+            dialog.showErrorBox('Update could not be downloaded', (err as Error).message)
+          }
+        } catch { /* never let the dialog itself break the flow */ }
         throw err
       }
     }
@@ -187,6 +196,7 @@ export function registerUpdateHandlers(): void {
     if (!installerPath || !fs.existsSync(installerPath)) {
       const msg = 'Installer not found. Check your internet connection or update channel.'
       logError('[update] ' + msg)
+      try { dialog.showErrorBox('Update could not be downloaded', msg) } catch { /* ignore */ }
       throw new Error(msg)
     }
 
@@ -219,11 +229,18 @@ export function registerUpdateHandlers(): void {
     // Fail here instead — the outer catch surfaces it and the app stays alive.
     let linuxLaunchPath: string | null = null
     if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
-      linuxLaunchPath = prepareLinuxAppImageUpdate(installerPath)
       // The file we verified is NOT the file we are about to spawn: this call
-      // copies the AppImage somewhere else. Re-hash the COPY. Without this, the
-      // digest check covers a file that is then never executed, and everything
-      // between the copy and the spawn is unverified (#174 adversarial review).
+      // copies the AppImage somewhere else. The verifier is passed IN so the copy
+      // is checked BEFORE it is moved onto the user's launcher path -- checking
+      // afterwards detects a swap but cannot undo it.
+      linuxLaunchPath = await prepareLinuxAppImageUpdate(
+        installerPath,
+        undefined,
+        verifiedSha256 ? (candidate) => stillMatchesDigest(candidate, verifiedSha256!) : undefined,
+      )
+      // Belt to that braces: whatever path came back, hash it before spawning.
+      // Covers the parked-copy and already-in-place branches, which the
+      // pre-commit check above does not reach.
       if (verifiedSha256 && linuxLaunchPath !== installerPath) {
         if (!await stillMatchesDigest(linuxLaunchPath, verifiedSha256)) {
           const msg = `${path.basename(linuxLaunchPath)} does not match the verified installer after being copied into place. `

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -2,9 +2,8 @@ import { ipcMain, app, dialog } from 'electron'
 import { spawn } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
-import * as os from 'os'
 import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
-import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError, stillMatchesDigest } from '../github-update'
+import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError, stillMatchesDigest, createInstallerDir } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
 
@@ -147,12 +146,20 @@ export function registerUpdateHandlers(): void {
 
         const src = candidates.find((p) => fs.existsSync(p))
         if (src) {
-          const downloadsDir = path.join(os.homedir(), 'Downloads')
-          try { fs.mkdirSync(downloadsDir, { recursive: true }) } catch {}
-          const dest = path.join(downloadsDir, path.basename(src))
-          fs.copyFileSync(src, dest)
-          installerPath = dest
-          logInfo(`[update] Copied local installer to ${dest}`)
+          // Same private staging directory as a real download (#174), not
+          // ~/Downloads. This path is dev-only, but it ends in the same
+          // spawn-with-elevation, so it gets the same directory -- and the same
+          // guard, so a staging failure reads as "installer not found" below
+          // rather than an unhandled ENOENT the renderer silently swallows.
+          try {
+            const stageDir = createInstallerDir()
+            const dest = path.join(stageDir, path.basename(src))
+            fs.copyFileSync(src, dest)
+            installerPath = dest
+            logInfo(`[update] Copied local installer to ${dest}`)
+          } catch (err) {
+            logError('[update] Could not stage the local installer:', err)
+          }
         }
       }
     }
@@ -166,12 +173,14 @@ export function registerUpdateHandlers(): void {
     logInfo(`[update] Found installer: ${installerPath}`)
 
     // Re-hash immediately before the point of no return. Verification happened
-    // at download time, but the file then sits at a predictable path in
-    // ~/Downloads while we kill every PTY -- tens of ms to seconds, and every
-    // browser writes into that directory. The installer runs with
-    // `allowElevation`, so a non-elevated local process that wins that race
-    // gains admin on a UAC prompt the user is already expecting. Costs ~1s for
-    // 150 MB and shrinks the window to microseconds (#111).
+    // at download time, but the file then sits on disk while we kill every PTY
+    // -- tens of ms to seconds. The installer runs with `allowElevation`, so a
+    // local process that wins that race gains admin on a UAC prompt the user is
+    // already expecting. Costs ~1s for 150 MB and shrinks the window to
+    // microseconds (#111). #174 did NOT make this redundant: the attacker in
+    // that model runs as the user, so it does not have to guess the staging
+    // directory -- it can watch the root and see it appear. This re-hash is the
+    // control of record for the race; #174 removed the drive-by variant.
     if (verifiedSha256) {
       if (!await stillMatchesDigest(installerPath, verifiedSha256)) {
         const msg = `${path.basename(installerPath)} changed on disk after it was verified. `
@@ -184,7 +193,7 @@ export function registerUpdateHandlers(): void {
 
     // Linux: prepare and VERIFY the AppImage is executable BEFORE we kill the
     // user's terminals and exit. spawn() reports EACCES/ENOENT only via an async
-    // 'error' event, so a doomed launch (a noexec ~/Downloads mount, a failed
+    // 'error' event, so a doomed launch (a noexec staging mount, a failed
     // chmod on vfat/exfat, an unwritable $APPIMAGE dir) would otherwise kill
     // every PTY, exit the app, and leave nothing running with no error shown.
     // Fail here instead — the outer catch surfaces it and the app stays alive.
@@ -197,8 +206,10 @@ export function registerUpdateHandlers(): void {
       } catch (err) {
         throw new Error(`Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`)
       }
-      // ...and the mount, which accessSync can't see: a noexec ~/Downloads (the
-      // fallback launch location) would pass the bit check yet fail execve. The
+      // ...and the mount, which accessSync can't see: a noexec staging dir (the
+      // fallback launch location when $APPIMAGE is unset) would pass the bit
+      // check yet fail execve. This is why #174 stages under userData rather
+      // than /tmp, which is noexec on hardened systems far more often. The
       // single-instance lock means we can't confirm the relaunch by spawning it
       // first, so catch this here — before the PTYs are killed — not after.
       if (isPathOnNoexecMount(linuxLaunchPath)) {
@@ -231,8 +242,21 @@ export function registerUpdateHandlers(): void {
           setTimeout(() => settle(resolve), 3000)
         })
       } else {
+        // Wait for the child to actually start, as the Linux branch does. spawn
+        // reports EACCES/ENOENT only via an async 'error' event, and `app.exit(0)`
+        // two statements below runs first -- so a blocked launch used to kill
+        // every PTY and exit with nothing on screen. That matters more since #174
+        // moved staging out of ~/Downloads: %LOCALAPPDATA% is a common target for
+        // "block executables outside Program Files" policies, and the user no
+        // longer has a file in Downloads to fall back on.
         const proc = spawn(installerPath, [], { detached: true, stdio: 'ignore' })
-        proc.unref()
+        await new Promise<void>((resolve, reject) => {
+          let done = false
+          const settle = (fn: () => void) => { if (!done) { done = true; proc.unref(); fn() } }
+          proc.once('spawn', () => settle(resolve))
+          proc.once('error', (err) => settle(() => reject(err)))
+          setTimeout(() => settle(resolve), 3000)
+        })
       }
 
       markUpdateInstalled()
@@ -243,6 +267,18 @@ export function registerUpdateHandlers(): void {
       return true
     } catch (err) {
       logError('[update] Failed:', err)
+      // Every PTY is already dead by the time we get here, and the renderer
+      // swallows this rejection at all four call sites -- so showErrorBox is the
+      // only channel that reaches the user. Name the staged path: since #174 the
+      // installer is in a deliberately unpredictable directory, so without this
+      // there is nothing for them to run by hand (#174 adversarial review).
+      try {
+        dialog.showErrorBox(
+          'Update could not be launched',
+          `${(err as Error).message}\n\nThe verified installer is at:\n${installerPath}\n\n`
+          + 'Run it manually, or install from the GitHub release page.'
+        )
+      } catch { /* never let the dialog itself break the flow */ }
       throw err
     }
   })

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -258,7 +258,8 @@ export function registerUpdateHandlers(): void {
         // These two throws are OUTSIDE the launch try/catch below, so they reach
         // no dialog on their own -- the same "reported to nobody" defect the
         // download path had. Say it here.
-        const msg = `Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`
+        const msg = `Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}\n\n`
+          + `The verified installer is at:\n${installerPath}\n\nRun it manually, or install from the GitHub release page.`
         logError('[update] ' + msg)
         try { dialog.showErrorBox('Update could not be launched', msg) } catch { /* ignore */ }
         throw new Error(msg)

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -226,7 +226,8 @@ export function registerUpdateHandlers(): void {
     // 'error' event, so a doomed launch (a noexec staging mount, a failed
     // chmod on vfat/exfat, an unwritable $APPIMAGE dir) would otherwise kill
     // every PTY, exit the app, and leave nothing running with no error shown.
-    // Fail here instead — the outer catch surfaces it and the app stays alive.
+    // Fail here instead, with a dialog of its own: this block sits OUTSIDE the
+    // launch try/catch, so it has no catch to fall back on.
     let linuxLaunchPath: string | null = null
     if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
       // The file we verified is NOT the file we are about to spawn: this call
@@ -254,7 +255,13 @@ export function registerUpdateHandlers(): void {
       try {
         fs.accessSync(linuxLaunchPath, fs.constants.X_OK)
       } catch (err) {
-        throw new Error(`Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`)
+        // These two throws are OUTSIDE the launch try/catch below, so they reach
+        // no dialog on their own -- the same "reported to nobody" defect the
+        // download path had. Say it here.
+        const msg = `Updated AppImage is not executable (${linuxLaunchPath}) — aborting before restart: ${(err as Error).message}`
+        logError('[update] ' + msg)
+        try { dialog.showErrorBox('Update could not be launched', msg) } catch { /* ignore */ }
+        throw new Error(msg)
       }
       // ...and the mount, which accessSync can't see: a noexec staging dir (the
       // fallback launch location when $APPIMAGE is unset) would pass the bit
@@ -263,7 +270,11 @@ export function registerUpdateHandlers(): void {
       // single-instance lock means we can't confirm the relaunch by spawning it
       // first, so catch this here — before the PTYs are killed — not after.
       if (isPathOnNoexecMount(linuxLaunchPath)) {
-        throw new Error(`Updated AppImage is on a noexec mount (${linuxLaunchPath}) — cannot relaunch. Move the app to a filesystem that allows execution, or update manually.`)
+        const msg = `Updated AppImage is on a noexec mount (${linuxLaunchPath}) — cannot relaunch. `
+          + 'Move the app to a filesystem that allows execution, or update manually.'
+        logError('[update] ' + msg)
+        try { dialog.showErrorBox('Update could not be launched', msg) } catch { /* ignore */ }
+        throw new Error(msg)
       }
     }
 

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -10,6 +10,9 @@ import { logInfo, logError } from '../debug-logger'
 // Cache the latest release info from GitHub so installAndRestart can use it without a re-check
 let cachedRelease: { version: string; tagName: string; installerName: string | null; installerUrl: string | null } | null = null
 
+/** Reentrancy latch for update:installAndRestart — see the handler. */
+let updateInProgress = false
+
 export function registerUpdateHandlers(): void {
   ipcMain.handle('update:check', async () => {
     // In dev mode, check the local source watcher first (live-reload workflow).
@@ -67,6 +70,23 @@ export function registerUpdateHandlers(): void {
   })
 
   ipcMain.handle('update:installAndRestart', async () => {
+    // ipcMain.handle serialises nothing. Two concurrent runs each prune the
+    // staging root keeping only THEIR OWN directory, so each deletes the other's
+    // in-flight installer. The renderer latches on `isUpdating`, but that is one
+    // frame of protection and a scripted invoke has none.
+    if (updateInProgress) {
+      logInfo('[update] Ignoring a second install request — one is already running')
+      throw new Error('An update is already in progress.')
+    }
+    updateInProgress = true
+    try {
+      return await runInstallAndRestart()
+    } finally {
+      updateInProgress = false
+    }
+  })
+
+  async function runInstallAndRestart(): Promise<boolean> {
     logInfo('[update] Starting update...')
 
     let installerPath: string | null = null
@@ -200,6 +220,19 @@ export function registerUpdateHandlers(): void {
     let linuxLaunchPath: string | null = null
     if (process.platform === 'linux' && installerPath.endsWith('.AppImage')) {
       linuxLaunchPath = prepareLinuxAppImageUpdate(installerPath)
+      // The file we verified is NOT the file we are about to spawn: this call
+      // copies the AppImage somewhere else. Re-hash the COPY. Without this, the
+      // digest check covers a file that is then never executed, and everything
+      // between the copy and the spawn is unverified (#174 adversarial review).
+      if (verifiedSha256 && linuxLaunchPath !== installerPath) {
+        if (!await stillMatchesDigest(linuxLaunchPath, verifiedSha256)) {
+          const msg = `${path.basename(linuxLaunchPath)} does not match the verified installer after being copied into place. `
+            + 'Aborting the update. Install manually from the GitHub release page.'
+          logError('[update] ' + msg)
+          try { dialog.showErrorBox('Update blocked - installer changed after verification', msg) } catch { /* ignore */ }
+          throw new InstallerIntegrityError(msg)
+        }
+      }
       // Permission bits (fast, catches a failed chmod on vfat/exfat)...
       try {
         fs.accessSync(linuxLaunchPath, fs.constants.X_OK)
@@ -222,18 +255,11 @@ export function registerUpdateHandlers(): void {
       killAllPty()
 
       logInfo('[update] Launching installer...')
-      if (process.platform === 'darwin' && installerPath.endsWith('.dmg')) {
-        // On macOS, open the DMG in Finder — user drags to Applications manually.
-        // Auto-installing a DMG over a running app is not supported.
-        spawn('open', [installerPath], { detached: true, stdio: 'ignore' }).unref()
-      } else if (linuxLaunchPath) {
-        logInfo(`[update] Launching updated AppImage: ${linuxLaunchPath}`)
-        const child = spawn(linuxLaunchPath, [], { detached: true, stdio: 'ignore' })
-        // Wait for the child to actually start before exiting — spawn surfaces
-        // exec failures asynchronously, so exiting immediately would hide a
-        // failure and strand the user with no running app. On 'spawn' we exit;
-        // on 'error' we abort (outer catch surfaces it); a short timeout is the
-        // safety net so we never hang the update forever.
+      // Every branch waits for the child to actually start. spawn reports
+      // EACCES/ENOENT only via an async 'error' event, and `app.exit(0)` below
+      // runs first -- and with no 'error' listener at all that event is an
+      // UNCAUGHT EXCEPTION in the main process, after every PTY is already dead.
+      const awaitLaunch = async (child: ReturnType<typeof spawn>): Promise<void> => {
         await new Promise<void>((resolve, reject) => {
           let done = false
           const settle = (fn: () => void) => { if (!done) { done = true; child.unref(); fn() } }
@@ -241,22 +267,21 @@ export function registerUpdateHandlers(): void {
           child.once('error', (err) => settle(() => reject(err)))
           setTimeout(() => settle(resolve), 3000)
         })
+      }
+
+      if (process.platform === 'darwin' && installerPath.endsWith('.dmg')) {
+        // On macOS, open the DMG in Finder — user drags to Applications manually.
+        // Auto-installing a DMG over a running app is not supported.
+        await awaitLaunch(spawn('open', [installerPath], { detached: true, stdio: 'ignore' }))
+      } else if (linuxLaunchPath) {
+        logInfo(`[update] Launching updated AppImage: ${linuxLaunchPath}`)
+        await awaitLaunch(spawn(linuxLaunchPath, [], { detached: true, stdio: 'ignore' }))
       } else {
-        // Wait for the child to actually start, as the Linux branch does. spawn
-        // reports EACCES/ENOENT only via an async 'error' event, and `app.exit(0)`
-        // two statements below runs first -- so a blocked launch used to kill
-        // every PTY and exit with nothing on screen. That matters more since #174
-        // moved staging out of ~/Downloads: %LOCALAPPDATA% is a common target for
-        // "block executables outside Program Files" policies, and the user no
-        // longer has a file in Downloads to fall back on.
-        const proc = spawn(installerPath, [], { detached: true, stdio: 'ignore' })
-        await new Promise<void>((resolve, reject) => {
-          let done = false
-          const settle = (fn: () => void) => { if (!done) { done = true; proc.unref(); fn() } }
-          proc.once('spawn', () => settle(resolve))
-          proc.once('error', (err) => settle(() => reject(err)))
-          setTimeout(() => settle(resolve), 3000)
-        })
+        // %LOCALAPPDATA% is a common target for "block executables outside
+        // Program Files" policies, and since #174 the user no longer has a file
+        // in ~/Downloads to fall back on — so a blocked launch has to be
+        // reported, not swallowed.
+        await awaitLaunch(spawn(installerPath, [], { detached: true, stdio: 'ignore' }))
       }
 
       markUpdateInstalled()
@@ -281,5 +306,5 @@ export function registerUpdateHandlers(): void {
       } catch { /* never let the dialog itself break the flow */ }
       throw err
     }
-  })
+  }
 }

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -9,12 +9,14 @@ type MockResponse = {
   statusCode: number
   body?: unknown              // JSON body (stringified + emitted as data event)
   bodyBuffer?: Buffer         // Raw buffer for streaming downloads
+  bodyChunks?: Buffer[]       // Multi-chunk body — exercises mid-stream aborts
   headers?: Record<string, string>
 }
 const httpsState = vi.hoisted(() => ({
   nextResponse: { statusCode: 200, body: [] } as MockResponse,
   responses: [] as MockResponse[],   // When non-empty, used per-call in order
   callUrls: [] as string[],          // Track URLs that were requested
+  destroyed: 0,                      // res.destroy() calls — abandoned hops
 }))
 
 vi.mock('https', () => {
@@ -29,25 +31,40 @@ vi.mock('https', () => {
     res.statusCode = resp.statusCode
     res.headers = resp.headers || {}
     res.resume = () => {}
+    res.__aborted = false
+    // A real IncomingMessage is a stream and has destroy(). #174 destroys a
+    // redirect response instead of resume()-ing it, so the mock needs this or
+    // every redirect test hangs on a TypeError inside the callback.
+    res.destroy = () => { res.__aborted = true; httpsState.destroyed += 1 }
     res.pipe = (stream: any) => {
-      // Simulate streaming bytes from response into the write stream
+      // Emit 'data' per chunk as the real stream does, THEN write it on. The
+      // old mock wrote bodyBuffer straight into the stream without emitting,
+      // which meant a `res.on('data')` byte counter in production code could
+      // never be exercised (#174's wire-level size cap is exactly that).
+      // Stopping on __aborted models `req.destroy()`: once the consumer aborts,
+      // no further chunks arrive and 'finish' never fires.
       setImmediate(() => {
-        if (resp.bodyBuffer) {
-          stream.write?.(resp.bodyBuffer)
+        const chunks: Buffer[] = resp.bodyChunks ?? (resp.bodyBuffer ? [resp.bodyBuffer] : [])
+        for (const chunk of chunks) {
+          if (res.__aborted) return
+          res.emit('data', chunk)
+          if (res.__aborted) return
+          stream.write?.(chunk)
         }
+        if (res.__aborted) return
         stream.emit?.('finish')
       })
       return stream
     }
     setImmediate(() => {
       callback(res)
-      if (resp.body !== undefined && resp.body !== null && !resp.bodyBuffer) {
+      if (resp.body !== undefined && resp.body !== null && !resp.bodyBuffer && !resp.bodyChunks) {
         res.emit('data', Buffer.from(JSON.stringify(resp.body)))
       }
       res.emit('end')
     })
     const req = new EE() as any
-    req.destroy = () => {}
+    req.destroy = () => { res.__aborted = true }
     return req
   }
   return { default: { get }, get }
@@ -87,8 +104,29 @@ const mockCreateWriteStream = vi.fn()
 const mockChmodSync = vi.fn()
 const mockCopyFileSync = vi.fn()
 const mockRealpathSync = vi.fn((p: string) => p)                 // identity: no symlink
-const mockLstatSync = vi.fn(() => ({ isFile: () => true }))      // regular file
+/** A stat that satisfies both the AppImage file guard and assertPrivateDir. */
+const statLike = (over: Record<string, unknown> = {}) => ({
+  isFile: () => true,
+  isDirectory: () => true,
+  mode: 0o700,
+  uid: typeof process.getuid === 'function' ? process.getuid() : 0,
+  ...over,
+})
+const mockLstatSync = vi.fn(() => statLike())
 const mockSymlinkSync = vi.fn()
+// #174 stages downloads in a private mkdtemp directory instead of ~/Downloads,
+// so the transport half now touches mkdtemp/readdir/rm. Deterministic suffix:
+// several tests assert on the returned path.
+const mockMkdtempSync = vi.fn((prefix: string) => `${prefix}TEST`)
+const mockReaddirSync = vi.fn((): string[] => [])
+const mockRmSync = vi.fn()
+const mockStatSync = vi.fn(() => ({ size: 256 }))
+const mockReadFileSync = vi.fn()
+// Bytes actually written into the .part file across all streams this test made.
+// #174's cap has to hold ON THE WIRE, so "how much landed" is the observable
+// that distinguishes an abort from a post-hoc size check.
+const writtenBytes = { total: 0 }
+const mockWriteStreamBytes = (): number => writtenBytes.total
 vi.mock('fs', () => {
   const { EventEmitter: EE } = require('events')
   return {
@@ -98,14 +136,17 @@ vi.mock('fs', () => {
     lstatSync: (...a: any[]) => mockLstatSync(...a),
     symlinkSync: (...a: any[]) => mockSymlinkSync(...a),
     existsSync: (...a: any[]) => mockExistsSync(...a),
-    readFileSync: vi.fn(),
+    readFileSync: (...a: any[]) => mockReadFileSync(...a),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     createWriteStream: (path: string) => {
       mockCreateWriteStream(path)
       const stream = new EE() as any
       stream.closed = false
-      stream.write = vi.fn()
+      stream.write = vi.fn((chunk: Buffer | string) => {
+        writtenBytes.total += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length
+        return true
+      })
       stream.close = (cb?: () => void) => {
         stream.closed = true
         if (cb) cb()
@@ -114,6 +155,11 @@ vi.mock('fs', () => {
     },
     unlinkSync: (...a: any[]) => mockUnlinkSync(...a),
     renameSync: (...a: any[]) => mockRenameSync(...a),
+    mkdtempSync: (...a: any[]) => mockMkdtempSync(...(a as [string])),
+    readdirSync: (...a: any[]) => mockReaddirSync(...a),
+    rmSync: (...a: any[]) => mockRmSync(...a),
+    statSync: (...a: any[]) => mockStatSync(...a),
+    truncateSync: vi.fn(),
   }
 })
 
@@ -137,6 +183,12 @@ vi.mock('electron', async () => {
     },
   }
 })
+// #174 stages installers under the app's own data dir (not Electron's userData:
+// that is %APPDATA%, which roams).
+vi.mock('../../src/main/data-paths', () => ({
+  getDataDirectory: () => '/mock/dataDir',
+}))
+
 vi.mock('../../src/main/config-manager', () => ({
   readConfig: vi.fn(() => ({ updateChannel: currentChannel })),
 }))
@@ -170,9 +222,178 @@ describe('github-update', () => {
     httpsState.nextResponse = { statusCode: 200, body: [] }
     httpsState.responses = []
     httpsState.callUrls = []
+    httpsState.destroyed = 0
     currentChannel = 'stable'
     mockReadRegistry.mockReturnValue(null)
     mockExistsSync.mockReturnValue(true)
+    mockMkdtempSync.mockImplementation((prefix: string) => `${prefix}TEST`)
+    mockReaddirSync.mockReturnValue([])
+    mockStatSync.mockReturnValue({ size: 256 })
+    mockReadFileSync.mockReturnValue('')
+    writtenBytes.total = 0
+  })
+
+  // ── #174: where a download is staged, and how big it is allowed to get ──
+  describe('installer staging directory (#174)', () => {
+    const ASSET = 'ClaudeCommandCenter-Beta-1.2.125.exe'
+
+    it('does NOT stage the installer in ~/Downloads', async () => {
+      // The whole point of #174. The file is about to be spawned with
+      // allowElevation, and ~/Downloads is a predictable path in a directory
+      // every browser writes into, so any local process can drop a payload
+      // there and win the verify->spawn race for admin.
+      httpsState.nextResponse = { statusCode: 200, bodyBuffer: Buffer.from('installer bytes') }
+      const result = await downloadInstallerFile('v1.2.125', ASSET, 'https://x/y.exe')
+      expect(result).not.toBeNull()
+      expect(result!.replace(/\\/g, '/').toLowerCase()).not.toContain('/downloads/')
+    })
+
+    it('stages it in an owner-only mkdtemp directory under the app data dir', async () => {
+      httpsState.nextResponse = { statusCode: 200, bodyBuffer: Buffer.from('installer bytes') }
+      const result = await downloadInstallerFile('v1.2.125', ASSET, 'https://x/y.exe')
+      expect(mockMkdtempSync).toHaveBeenCalled()
+      // mkdtemp, not a fixed name: the asset name is public, so a predictable
+      // directory would hand the race straight back.
+      expect(mockMkdtempSync.mock.calls[0][0].replace(/\\/g, '/')).toContain('/updates/ccc-upd-')
+      expect(mockChmodSync).toHaveBeenCalledWith(expect.stringContaining('ccc-upd-'), 0o700)
+      expect(result!.replace(/\\/g, '/')).toContain('/ccc-upd-')
+      expect(result).toContain(ASSET)
+    })
+
+    it('passes the staging directory, not ~/Downloads, to the gh CLI fallback', async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => cb(null, '', ''))
+      const result = await downloadInstallerFile('v1.2.125', ASSET, null)
+      expect(result).not.toBeNull()
+      const args = mockExecFile.mock.calls[0][1] as string[]
+      const dir = args[args.indexOf('--dir') + 1]
+      expect(dir.replace(/\\/g, '/')).toContain('/ccc-upd-')
+      expect(dir.replace(/\\/g, '/').toLowerCase()).not.toContain('/downloads/')
+    })
+
+    it('refuses an asset name that would escape the staging directory', async () => {
+      // assetName comes from the release feed and is interpolated into a path.
+      // A separator in it would write outside the private directory and undo
+      // the containment.
+      for (const bad of ['../evil.exe', 'sub/dir/evil.exe', '..\\evil.exe', '', '.', '..']) {
+        const result = await downloadInstallerFile('v1.2.125', bad, 'https://x/y.exe')
+        expect(result, `accepted ${JSON.stringify(bad)}`).toBeNull()
+      }
+    })
+
+    it('prunes staging directories left by earlier updates, keeping the current one', async () => {
+      // The success path cannot clean up after itself — CCC spawns the installer
+      // and exits — so pruning on the way in is what bounds the accumulation.
+      mockReaddirSync.mockReturnValue(['ccc-upd-OLD1', 'ccc-upd-OLD2', 'ccc-upd-TEST', 'something-else'])
+      httpsState.nextResponse = { statusCode: 200, bodyBuffer: Buffer.from('installer bytes') }
+      await downloadInstallerFile('v1.2.125', ASSET, 'https://x/y.exe')
+      const removed = mockRmSync.mock.calls.map((c) => String(c[0]).replace(/\\/g, '/'))
+      expect(removed.some((p) => p.endsWith('ccc-upd-OLD1'))).toBe(true)
+      expect(removed.some((p) => p.endsWith('ccc-upd-OLD2'))).toBe(true)
+      // Never the directory this download is using, and never an unrelated one.
+      expect(removed.some((p) => p.endsWith('ccc-upd-TEST'))).toBe(false)
+      expect(removed.some((p) => p.endsWith('something-else'))).toBe(false)
+    })
+
+    it('removes its own staging directory when nothing could be downloaded', async () => {
+      httpsState.nextResponse = { statusCode: 500 }
+      mockExistsSync.mockReturnValue(false)
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => cb(new Error('gh missing'), '', ''))
+      const result = await downloadInstallerFile('v1.2.125', ASSET, 'https://x/y.exe')
+      expect(result).toBeNull()
+      const removed = mockRmSync.mock.calls.map((c) => String(c[0]).replace(/\\/g, '/'))
+      expect(removed.some((p) => p.endsWith('ccc-upd-TEST'))).toBe(true)
+    })
+  })
+
+  describe('manifest download size cap (#174)', () => {
+    const ASSET = 'ClaudeCommandCenter-Beta-1.2.125.exe'
+    const MiB = 1024 * 1024
+
+    // The manifest fetch is the capped one: readManifest enforced
+    // MAX_MANIFEST_BYTES by stat-ing the FINISHED file, so a hostile endpoint
+    // could fill the disk before the check ever ran. Driven through
+    // downloadGitHubRelease rather than a helper, because the cap has to hold at
+    // the call site that actually fetches.
+    const failGh = () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: any, cb: any) => cb(new Error('gh missing'), '', ''))
+    }
+
+    it('aborts a manifest that exceeds the cap mid-stream, before it lands', async () => {
+      failGh()
+      const chunk = Buffer.alloc(512 * 1024, 0x61)
+      httpsState.nextResponse = { statusCode: 200, bodyChunks: [chunk, chunk, chunk, chunk] } // 2 MiB
+      await expect(
+        downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      ).rejects.toThrow(InstallerIntegrityError)
+      // Enforced ON THE WIRE: the stream is destroyed partway, so not every
+      // chunk reaches the file. Landing 2 MiB and then rejecting it would pass a
+      // stat-based check just as well and is exactly what this replaced.
+      const written = mockWriteStreamBytes()
+      expect(written).toBeGreaterThan(0)
+      expect(written).toBeLessThan(4 * 512 * 1024)
+      expect(written).toBeLessThanOrEqual(MiB + chunk.length)
+    })
+
+    it('rejects an oversized Content-Length without reading any body', async () => {
+      failGh()
+      httpsState.nextResponse = {
+        statusCode: 200,
+        headers: { 'content-length': String(50 * MiB) },
+        bodyChunks: [Buffer.alloc(1024, 0x61)],
+      }
+      await expect(
+        downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      ).rejects.toThrow(InstallerIntegrityError)
+      expect(mockWriteStreamBytes()).toBe(0)
+    })
+
+    it('stages CHECKSUMS.txt in a private directory, not the shared temp dir', async () => {
+      // The manifest decides WHICH DIGEST counts as verified, so it was the last
+      // file that should have been left at a Date.now()-guessable name in a
+      // shared /tmp: the sticky bit stops another user unlinking our entry, not
+      // pre-planting a symlink that createWriteStream (no O_NOFOLLOW) follows —
+      // after which renameSync moves the LINK to the destination and the
+      // attacker still owns the bytes readManifest reads.
+      failGh()
+      httpsState.nextResponse = { statusCode: 200, bodyBuffer: Buffer.from('nope') }
+      await expect(
+        downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      ).rejects.toThrow(InstallerIntegrityError)
+      const manifestWrites = mockCreateWriteStream.mock.calls
+        .map((c) => String(c[0]).replace(/\\/g, '/'))
+        .filter((p) => p.includes('CHECKSUMS.txt'))
+      expect(manifestWrites.length).toBeGreaterThan(0)
+      for (const p of manifestWrites) expect(p).toContain('/ccc-upd-')
+    })
+
+    it('does NOT apply the manifest cap to the installer download', async () => {
+      // The cap's SCOPE, pinned. Real installers are 170-215 MB; applying
+      // MAX_MANIFEST_BYTES (1 MiB) to them is a one-token change that breaks
+      // 100% of updates — and every other download test here uses a 15-byte
+      // body, so nothing else in the suite could tell the difference.
+      const chunk = Buffer.alloc(512 * 1024, 0x62)
+      httpsState.nextResponse = { statusCode: 200, bodyChunks: [chunk, chunk, chunk, chunk, chunk, chunk] } // 3 MiB
+      const result = await downloadInstallerFile('v1.2.125', ASSET, 'https://x/y.exe')
+      expect(result).not.toBeNull()
+      expect(mockWriteStreamBytes()).toBe(6 * 512 * 1024)
+    })
+
+    it('still accepts a normal manifest', async () => {
+      // Guards the cap against being so eager it blocks every real release.
+      const digest = 'a'.repeat(64)
+      const manifest = `${digest}  ${ASSET}\n`
+      mockReadFileSync.mockReturnValue(manifest)
+      mockStatSync.mockReturnValue({ size: manifest.length })
+      httpsState.responses = [
+        { statusCode: 200, bodyBuffer: Buffer.from(manifest) },   // CHECKSUMS.txt
+        { statusCode: 200, bodyBuffer: Buffer.from('installer') }, // the installer
+      ]
+      // sha256 of the body will not match `digest`, so this must fail on the
+      // DIGEST, not on the size — proving the manifest was fetched and parsed.
+      await expect(
+        downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      ).rejects.toThrow(/failed its SHA-256 check/)
+    })
   })
 
   describe('channel matching', () => {
@@ -574,6 +795,21 @@ describe('github-update', () => {
       expect(result).toBeNull()
     })
 
+    it('DESTROYS an abandoned redirect response instead of draining it', async () => {
+      // resume() drains a 3xx body and discards it — uncounted against maxBytes,
+      // and unreachable by fail() because activeReq is nulled before recursing.
+      // A 3xx with an endless body would then have the main process read and
+      // throw away data forever, on up to `hopsLeft` leaked sockets, past the
+      // point the promise settled. (#174 adversarial review.)
+      httpsState.responses = [
+        { statusCode: 302, headers: { location: 'https://cdn.example.com/real.exe' }, bodyChunks: [Buffer.alloc(4096, 0x63)] },
+        { statusCode: 200, bodyBuffer: Buffer.from('final bytes') },
+      ]
+      const result = await downloadInstallerFile('v1.2.125', 'ClaudeCommandCenter-Beta-1.2.125.exe', 'https://x/redirect.exe')
+      expect(result).not.toBeNull()
+      expect(httpsState.destroyed).toBeGreaterThanOrEqual(1)
+    })
+
     it('resolves relative redirect against the source URL', async () => {
       httpsState.responses = [
         { statusCode: 302, headers: { location: '/assets/real-file.exe' } },
@@ -653,7 +889,11 @@ describe('github-update', () => {
   })
 
   describe('prepareLinuxAppImageUpdate', () => {
-    const downloaded = '/home/u/Downloads/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
+    // A post-#174 download path: inside a private ccc-upd- staging directory,
+    // which is prune-eligible. The `ccc-upd-` component is load-bearing — it is
+    // what tells prepareLinuxAppImageUpdate the file must be parked elsewhere
+    // before the next update's prune deletes it.
+    const downloaded = '/mock/dataDir/updates/ccc-upd-AbC123/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
     const running = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.1-linux-x86_64.AppImage'
 
     beforeEach(() => {
@@ -664,7 +904,7 @@ describe('github-update', () => {
       mockUnlinkSync.mockReset()
       mockSymlinkSync.mockReset()
       mockRealpathSync.mockReset().mockImplementation((p: string) => p)
-      mockLstatSync.mockReset().mockReturnValue({ isFile: () => true })
+      mockLstatSync.mockReset().mockReturnValue(statLike())
     })
 
     it('always chmods the download executable (downloads arrive without +x)', () => {
@@ -672,11 +912,24 @@ describe('github-update', () => {
       expect(mockChmodSync).toHaveBeenCalledWith(downloaded, 0o755)
     })
 
-    it('without $APPIMAGE (extracted/dev run), launches from the download location', () => {
+    it('without $APPIMAGE (extracted/dev run), parks the AppImage OUTSIDE the staging root', () => {
+      // #174 made this matter: the download now lands in a prune-eligible
+      // ccc-upd- directory, so returning it unchanged would have the NEXT
+      // update delete the running application. Parked under the data dir
+      // instead, at a stable name so a .desktop entry or dock pin survives.
       const result = prepareLinuxAppImageUpdate(downloaded, undefined)
-      expect(result).toBe(downloaded)
-      expect(mockCopyFileSync).not.toHaveBeenCalled()
+      expect(result?.replace(/\\/g, '/')).toBe(`/mock/dataDir/bin/${downloaded.split('/').pop()}`)
+      expect(result?.replace(/\\/g, '/')).not.toContain('/ccc-upd-')
+      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, result)
+      // The running AppImage is never touched on this path — there isn't one.
       expect(mockUnlinkSync).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the download location when parking itself fails', () => {
+      // Never block an update on tidy-up: launching from the staging dir works
+      // today, it is only the next prune that would remove it.
+      mockCopyFileSync.mockImplementation(() => { throw new Error('EACCES') })
+      expect(prepareLinuxAppImageUpdate(downloaded, undefined)).toBe(downloaded)
     })
 
     it('versioned running name: writes the new versioned file and removes the old', () => {
@@ -717,27 +970,30 @@ describe('github-update', () => {
       expect(symLink).toBe(link)
     })
 
-    it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (no delete, no copy)', () => {
+    it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (never writes to it)', () => {
       const stranger = '/home/u/important.txt'
       mockRealpathSync.mockReturnValue(stranger)
       const result = prepareLinuxAppImageUpdate(downloaded, stranger)
-      expect(result).toBe(downloaded)
+      // Parked, not left in the staging root (#174) — but the stranger file is
+      // still never unlinked and never written to, which is the guarantee.
+      expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
       expect(mockUnlinkSync).not.toHaveBeenCalled()
-      expect(mockCopyFileSync).not.toHaveBeenCalled()
+      expect(mockCopyFileSync.mock.calls.some(([, dest]) => dest === stranger)).toBe(false)
     })
 
     it('finding #4 — refuses a $APPIMAGE that is a directory', () => {
-      mockLstatSync.mockReturnValue({ isFile: () => false })
+      mockLstatSync.mockReturnValue(statLike({ isFile: () => false }))
       const result = prepareLinuxAppImageUpdate(downloaded, '/home/u/Apps')
-      expect(result).toBe(downloaded)
+      expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
       expect(mockUnlinkSync).not.toHaveBeenCalled()
+      expect(mockCopyFileSync.mock.calls.some(([, dest]) => String(dest).includes('/home/u/Apps'))).toBe(false)
     })
 
-    it('when $APPIMAGE no longer resolves (realpath throws), launches from the download', () => {
+    it('when $APPIMAGE no longer resolves (realpath throws), parks the download', () => {
       mockRealpathSync.mockImplementation(() => { throw new Error('ENOENT') })
       const result = prepareLinuxAppImageUpdate(downloaded, running)
-      expect(result).toBe(downloaded)
-      expect(mockCopyFileSync).not.toHaveBeenCalled()
+      expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
+      expect(mockCopyFileSync.mock.calls.some(([, dest]) => dest === running)).toBe(false)
     })
 
     it('degrades to the download location when the copy fails (unwritable dir)', () => {

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -1034,10 +1034,9 @@ describe('github-update', () => {
       expect(stagedName).toMatch(/\.new-[0-9a-f]{12}$/)
       expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, stagedName)
       expect(mockRenameSync).toHaveBeenCalledWith(stagedName, custom)
-      // unlink-before-rename on the same path (avoids truncating the mounted image)
+      // unlink-before-rename on the same path (avoids truncating the mounted image),
+      // exactly once — never a second unlink of the TARGET, since target === running.
       expect(mockUnlinkSync).toHaveBeenCalledWith(custom)
-      // Two unlinks: the pre-emptive `.new` cleanup, then the running file.
-      // Never a second unlink of the TARGET, since target === running.
       expect(mockUnlinkSync.mock.calls.filter(([p]) => p === custom)).toHaveLength(1)
     })
 

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -1010,8 +1010,12 @@ describe('github-update', () => {
       // VERIFY BEFORE COMMIT: the bytes go to a sibling `.new` and are renamed
       // into place, so a failed check never leaves them at the launcher path.
       expect(mockCopyFileSync).toHaveBeenCalledTimes(1)
-      expect(String(mockCopyFileSync.mock.calls[0][1]).replace(/\\/g, '/')).toBe(`${expectedTarget}.new`)
-      expect(String(mockRenameSync.mock.calls[0][0]).replace(/\\/g, '/')).toBe(`${expectedTarget}.new`)
+      // A RANDOMISED sibling name: a fixed `.new` both clobbers whatever the user
+      // had there and gives an attacker a predictable path to plant a symlink at.
+      const stagedName = String(mockCopyFileSync.mock.calls[0][1]).replace(/\\/g, '/')
+      expect(stagedName).toMatch(/\.new-[0-9a-f]{12}$/)
+      expect(stagedName.startsWith(expectedTarget)).toBe(true)
+      expect(String(mockRenameSync.mock.calls[0][0]).replace(/\\/g, '/')).toBe(stagedName)
       expect(String(mockRenameSync.mock.calls[0][1]).replace(/\\/g, '/')).toBe(expectedTarget)
       expect(mockChmodSync).toHaveBeenCalledTimes(3) // download + .new + target
       // Old version file removed (safe on Linux: mounted inode outlives the unlink)
@@ -1026,8 +1030,10 @@ describe('github-update', () => {
       const result = await prepareLinuxAppImageUpdate(downloaded, custom)
       expect(result?.replace(/\\/g, '/')).toBe(custom)
       // Staged next to the target, then renamed onto it.
-      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, `${custom}.new`)
-      expect(mockRenameSync).toHaveBeenCalledWith(`${custom}.new`, custom)
+      const stagedName = String(mockCopyFileSync.mock.calls[0][1])
+      expect(stagedName).toMatch(/\.new-[0-9a-f]{12}$/)
+      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, stagedName)
+      expect(mockRenameSync).toHaveBeenCalledWith(stagedName, custom)
       // unlink-before-rename on the same path (avoids truncating the mounted image)
       expect(mockUnlinkSync).toHaveBeenCalledWith(custom)
       // Two unlinks: the pre-emptive `.new` cleanup, then the running file.

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -127,6 +127,9 @@ const mockReadFileSync = vi.fn()
 // that distinguishes an abort from a post-hoc size check.
 const writtenBytes = { total: 0 }
 const mockWriteStreamBytes = (): number => writtenBytes.total
+// What actually landed at each path, so createReadStream can serve it back and
+// the SUCCESS path of downloadGitHubRelease (digest match included) is reachable.
+const fileBodies = new Map<string, Buffer>()
 vi.mock('fs', () => {
   const { EventEmitter: EE } = require('events')
   return {
@@ -141,10 +144,13 @@ vi.mock('fs', () => {
     mkdirSync: vi.fn(),
     createWriteStream: (path: string) => {
       mockCreateWriteStream(path)
+      fileBodies.set(path, Buffer.alloc(0))
       const stream = new EE() as any
       stream.closed = false
       stream.write = vi.fn((chunk: Buffer | string) => {
-        writtenBytes.total += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length
+        const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+        writtenBytes.total += buf.length
+        fileBodies.set(path, Buffer.concat([fileBodies.get(path) ?? Buffer.alloc(0), buf]))
         return true
       })
       stream.close = (cb?: () => void) => {
@@ -153,8 +159,22 @@ vi.mock('fs', () => {
       }
       return stream
     },
-    unlinkSync: (...a: any[]) => mockUnlinkSync(...a),
-    renameSync: (...a: any[]) => mockRenameSync(...a),
+    createReadStream: (path: string) => {
+      const stream = new EE() as any
+      const body = fileBodies.get(path)
+      setImmediate(() => {
+        if (body === undefined) { stream.emit('error', new Error('ENOENT')); return }
+        stream.emit('data', body)
+        stream.emit('end')
+      })
+      return stream
+    },
+    unlinkSync: (...a: any[]) => { fileBodies.delete(String(a[0])); return mockUnlinkSync(...a) },
+    renameSync: (...a: any[]) => {
+      const body = fileBodies.get(String(a[0]))
+      if (body !== undefined) { fileBodies.set(String(a[1]), body); fileBodies.delete(String(a[0])) }
+      return mockRenameSync(...a)
+    },
     mkdtempSync: (...a: any[]) => mockMkdtempSync(...(a as [string])),
     readdirSync: (...a: any[]) => mockReaddirSync(...a),
     rmSync: (...a: any[]) => mockRmSync(...a),
@@ -231,6 +251,7 @@ describe('github-update', () => {
     mockStatSync.mockReturnValue({ size: 256 })
     mockReadFileSync.mockReturnValue('')
     writtenBytes.total = 0
+    fileBodies.clear()
   })
 
   // ── #174: where a download is staged, and how big it is allowed to get ──
@@ -360,6 +381,41 @@ describe('github-update', () => {
       const p = downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
       await expect(p).rejects.toThrow(/disk space|writable|private folder/i)
       await expect(p).rejects.not.toBeInstanceOf(InstallerIntegrityError)
+    })
+
+    it('verifies and returns the installer, staged beside the manifest in ONE directory', async () => {
+      // The "one staging directory" invariant, driven all the way to SUCCESS.
+      // Two independent directories meant the installer's prune could delete the
+      // one the manifest fetch was using; over-cleaning the shared one (rmSync of
+      // the directory instead of unlinking just the manifest) removes the
+      // directory the installer's own .part file is about to land in, and breaks
+      // the direct-HTTPS leg of every real update.
+      const body = Buffer.from('the real installer bytes')
+      const digest = require('crypto').createHash('sha256').update(body).digest('hex')
+      const manifest = `${digest}  ${ASSET}\n`
+      mockReadFileSync.mockReturnValue(manifest)
+      mockStatSync.mockReturnValue({ size: manifest.length })
+      // existsSync must be false for the pre-rename unlink and true after, so
+      // just report "absent" — httpsDownload tolerates it and renames anyway.
+      mockExistsSync.mockImplementation((p: string) => !String(p).endsWith('.part'))
+      httpsState.responses = [
+        { statusCode: 200, bodyBuffer: Buffer.from(manifest) },
+        { statusCode: 200, bodyBuffer: body },
+      ]
+
+      const verified = await downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      expect(verified).not.toBeNull()
+      expect(verified!.sha256).toBe(digest)
+
+      const written = mockCreateWriteStream.mock.calls.map((c) => String(c[0]).replace(/\\/g, '/'))
+      const manifestDir = written.find((p) => p.includes('CHECKSUMS.txt'))!.replace(/\/[^/]*$/, '')
+      const installerDir = written.find((p) => p.includes(ASSET))!.replace(/\/[^/]*$/, '')
+      expect(installerDir).toBe(manifestDir)
+      expect(mockMkdtempSync).toHaveBeenCalledTimes(1)
+      // And the staging directory SURVIVES: the installer has to outlive this
+      // process, and the manifest cleanup must not take the directory with it.
+      const rmTargets = mockRmSync.mock.calls.map((c) => String(c[0]).replace(/\\/g, '/'))
+      expect(rmTargets).not.toContain(installerDir)
     })
 
     it('stages CHECKSUMS.txt in a private directory, not the shared temp dir', async () => {
@@ -922,17 +978,17 @@ describe('github-update', () => {
       mockLstatSync.mockReset().mockReturnValue(statLike())
     })
 
-    it('always chmods the download executable (downloads arrive without +x)', () => {
-      prepareLinuxAppImageUpdate(downloaded, undefined)
+    it('always chmods the download executable (downloads arrive without +x)', async () => {
+      await prepareLinuxAppImageUpdate(downloaded, undefined)
       expect(mockChmodSync).toHaveBeenCalledWith(downloaded, 0o755)
     })
 
-    it('without $APPIMAGE (extracted/dev run), parks the AppImage OUTSIDE the staging root', () => {
+    it('without $APPIMAGE (extracted/dev run), parks the AppImage OUTSIDE the staging root', async () => {
       // #174 made this matter: the download now lands in a prune-eligible
       // ccc-upd- directory, so returning it unchanged would have the NEXT
       // update delete the running application. Parked under the data dir
       // instead, at a stable name so a .desktop entry or dock pin survives.
-      const result = prepareLinuxAppImageUpdate(downloaded, undefined)
+      const result = await prepareLinuxAppImageUpdate(downloaded, undefined)
       expect(result?.replace(/\\/g, '/')).toBe(`/mock/dataDir/bin/${downloaded.split('/').pop()}`)
       expect(result?.replace(/\\/g, '/')).not.toContain('/ccc-upd-')
       expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, result)
@@ -940,41 +996,49 @@ describe('github-update', () => {
       expect(mockUnlinkSync).not.toHaveBeenCalled()
     })
 
-    it('falls back to the download location when parking itself fails', () => {
+    it('falls back to the download location when parking itself fails', async () => {
       // Never block an update on tidy-up: launching from the staging dir works
       // today, it is only the next prune that would remove it.
       mockCopyFileSync.mockImplementation(() => { throw new Error('EACCES') })
-      expect(prepareLinuxAppImageUpdate(downloaded, undefined)).toBe(downloaded)
+      expect(await prepareLinuxAppImageUpdate(downloaded, undefined)).toBe(downloaded)
     })
 
-    it('versioned running name: writes the new versioned file and removes the old', () => {
-      const result = prepareLinuxAppImageUpdate(downloaded, running)
+    it('versioned running name: writes the new versioned file and removes the old', async () => {
+      const result = await prepareLinuxAppImageUpdate(downloaded, running)
       const expectedTarget = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
       expect(result?.replace(/\\/g, '/')).toBe(expectedTarget)
+      // VERIFY BEFORE COMMIT: the bytes go to a sibling `.new` and are renamed
+      // into place, so a failed check never leaves them at the launcher path.
       expect(mockCopyFileSync).toHaveBeenCalledTimes(1)
-      expect(mockChmodSync).toHaveBeenCalledTimes(2) // download + target
+      expect(String(mockCopyFileSync.mock.calls[0][1]).replace(/\\/g, '/')).toBe(`${expectedTarget}.new`)
+      expect(String(mockRenameSync.mock.calls[0][0]).replace(/\\/g, '/')).toBe(`${expectedTarget}.new`)
+      expect(String(mockRenameSync.mock.calls[0][1]).replace(/\\/g, '/')).toBe(expectedTarget)
+      expect(mockChmodSync).toHaveBeenCalledTimes(3) // download + .new + target
       // Old version file removed (safe on Linux: mounted inode outlives the unlink)
       expect(mockUnlinkSync).toHaveBeenCalledWith(running)
     })
 
-    it('finding #1 — custom UNVERSIONED name is preserved: overwrites the SAME path', () => {
+    it('finding #1 — custom UNVERSIONED name is preserved: overwrites the SAME path', async () => {
       // The user renamed their AppImage to a stable name a .desktop/dock/alias
       // points at. Writing a new versioned name would orphan that launcher, so
       // we overwrite in place and keep their filename.
       const custom = '/home/u/Apps/ClaudeCommandCenter.AppImage'
-      const result = prepareLinuxAppImageUpdate(downloaded, custom)
+      const result = await prepareLinuxAppImageUpdate(downloaded, custom)
       expect(result?.replace(/\\/g, '/')).toBe(custom)
-      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, custom)
-      // unlink-before-write on the same path (avoids truncating the mounted image)
+      // Staged next to the target, then renamed onto it.
+      expect(mockCopyFileSync).toHaveBeenCalledWith(downloaded, `${custom}.new`)
+      expect(mockRenameSync).toHaveBeenCalledWith(`${custom}.new`, custom)
+      // unlink-before-rename on the same path (avoids truncating the mounted image)
       expect(mockUnlinkSync).toHaveBeenCalledWith(custom)
-      // ...and NOT a second unlink, since target === running
-      expect(mockUnlinkSync).toHaveBeenCalledTimes(1)
+      // Two unlinks: the pre-emptive `.new` cleanup, then the running file.
+      // Never a second unlink of the TARGET, since target === running.
+      expect(mockUnlinkSync.mock.calls.filter(([p]) => p === custom)).toHaveLength(1)
     })
 
-    it('finding #1 — symlink launcher: resolves realpath and re-points the link', () => {
+    it('finding #1 — symlink launcher: resolves realpath and re-points the link', async () => {
       const link = '/home/u/bin/ccc'          // what the user launches
       mockRealpathSync.mockReturnValue(running) // resolves to the real versioned file
-      const result = prepareLinuxAppImageUpdate(downloaded, link)
+      const result = await prepareLinuxAppImageUpdate(downloaded, link)
       const expectedTarget = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
       expect(result?.replace(/\\/g, '/')).toBe(expectedTarget)
       expect(mockUnlinkSync).toHaveBeenCalledWith(running)  // real old file removed
@@ -985,12 +1049,12 @@ describe('github-update', () => {
       expect(symLink).toBe(link)
     })
 
-    it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (never writes to it)', () => {
+    it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (never writes to it)', async () => {
       const stranger = '/home/u/important.txt'
       // Identity realpath is enough — $APPIMAGE IS the stranger. A blanket
       // mockReturnValue would also redirect the parking directory's own
       // validation and mask the assertion below.
-      const result = prepareLinuxAppImageUpdate(downloaded, stranger)
+      const result = await prepareLinuxAppImageUpdate(downloaded, stranger)
       // Parked, not left in the staging root (#174) — but the stranger file is
       // still never unlinked and never written to, which is the guarantee.
       expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
@@ -998,41 +1062,41 @@ describe('github-update', () => {
       expect(mockCopyFileSync.mock.calls.some(([, dest]) => dest === stranger)).toBe(false)
     })
 
-    it('finding #4 — refuses a $APPIMAGE that is a directory', () => {
+    it('finding #4 — refuses a $APPIMAGE that is a directory', async () => {
       mockLstatSync.mockReturnValue(statLike({ isFile: () => false }))
-      const result = prepareLinuxAppImageUpdate(downloaded, '/home/u/Apps')
+      const result = await prepareLinuxAppImageUpdate(downloaded, '/home/u/Apps')
       expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
       expect(mockUnlinkSync).not.toHaveBeenCalled()
       expect(mockCopyFileSync.mock.calls.some(([, dest]) => String(dest).includes('/home/u/Apps'))).toBe(false)
     })
 
-    it('when $APPIMAGE no longer resolves (realpath throws), parks the download', () => {
+    it('when $APPIMAGE no longer resolves (realpath throws), parks the download', async () => {
       // Throw only for $APPIMAGE. A blanket throw would also break the parking
       // directory's validation, so the test would pass for the wrong reason.
       mockRealpathSync.mockImplementation((p: string) => {
         if (p === running) throw new Error('ENOENT')
         return p
       })
-      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      const result = await prepareLinuxAppImageUpdate(downloaded, running)
       expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
       expect(mockCopyFileSync.mock.calls.some(([, dest]) => dest === running)).toBe(false)
     })
 
-    it('degrades to the download location when the copy fails (unwritable dir)', () => {
+    it('degrades to the download location when the copy fails (unwritable dir)', async () => {
       mockCopyFileSync.mockImplementation(() => { throw new Error('EACCES: permission denied') })
-      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      const result = await prepareLinuxAppImageUpdate(downloaded, running)
       expect(result).toBe(downloaded)
     })
 
-    it('failure to remove the old version is non-fatal (still returns the new path)', () => {
+    it('failure to remove the old version is non-fatal (still returns the new path)', async () => {
       mockUnlinkSync.mockImplementation(() => { throw new Error('EBUSY') })
-      const result = prepareLinuxAppImageUpdate(downloaded, running)
+      const result = await prepareLinuxAppImageUpdate(downloaded, running)
       expect(result?.replace(/\\/g, '/')).toBe('/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage')
     })
 
-    it('re-download of the exact same file is a no-op replace', () => {
+    it('re-download of the exact same file is a no-op replace', async () => {
       const samePath = '/home/u/Apps/ClaudeCommandCenter-2.1.0-beta.2-linux-x86_64.AppImage'
-      const result = prepareLinuxAppImageUpdate(samePath, samePath)
+      const result = await prepareLinuxAppImageUpdate(samePath, samePath)
       expect(result).toBe(samePath)
       expect(mockCopyFileSync).not.toHaveBeenCalled()
       expect(mockUnlinkSync).not.toHaveBeenCalled()

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -347,6 +347,21 @@ describe('github-update', () => {
       expect(mockWriteStreamBytes()).toBe(0)
     })
 
+    it('reports a local staging failure as a STORAGE problem, not a tamper event', async () => {
+      // A disk-full mkdtemp or an unwritable data dir used to surface as
+      // "Update blocked - integrity check failed ... has no verified SHA-256",
+      // i.e. a release TAMPER claim. False tamper signals are how real ones get
+      // ignored, so this must not be an InstallerIntegrityError.
+      mockMkdtempSync.mockImplementation(() => {
+        const err = new Error('ENOSPC: no space left on device') as Error & { code?: string }
+        err.code = 'ENOSPC'
+        throw err
+      })
+      const p = downloadGitHubRelease('v1.2.125', ASSET, 'https://h/r/download/v1.2.125/' + ASSET)
+      await expect(p).rejects.toThrow(/disk space|writable|private folder/i)
+      await expect(p).rejects.not.toBeInstanceOf(InstallerIntegrityError)
+    })
+
     it('stages CHECKSUMS.txt in a private directory, not the shared temp dir', async () => {
       // The manifest decides WHICH DIGEST counts as verified, so it was the last
       // file that should have been left at a Date.now()-guessable name in a
@@ -972,7 +987,9 @@ describe('github-update', () => {
 
     it('finding #4 — refuses a $APPIMAGE that is not an AppImage file (never writes to it)', () => {
       const stranger = '/home/u/important.txt'
-      mockRealpathSync.mockReturnValue(stranger)
+      // Identity realpath is enough — $APPIMAGE IS the stranger. A blanket
+      // mockReturnValue would also redirect the parking directory's own
+      // validation and mask the assertion below.
       const result = prepareLinuxAppImageUpdate(downloaded, stranger)
       // Parked, not left in the staging root (#174) — but the stranger file is
       // still never unlinked and never written to, which is the guarantee.
@@ -990,7 +1007,12 @@ describe('github-update', () => {
     })
 
     it('when $APPIMAGE no longer resolves (realpath throws), parks the download', () => {
-      mockRealpathSync.mockImplementation(() => { throw new Error('ENOENT') })
+      // Throw only for $APPIMAGE. A blanket throw would also break the parking
+      // directory's validation, so the test would pass for the wrong reason.
+      mockRealpathSync.mockImplementation((p: string) => {
+        if (p === running) throw new Error('ENOENT')
+        return p
+      })
       const result = prepareLinuxAppImageUpdate(downloaded, running)
       expect(result?.replace(/\\/g, '/')).toContain('/mock/dataDir/bin/')
       expect(mockCopyFileSync.mock.calls.some(([, dest]) => dest === running)).toBe(false)

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -1,0 +1,269 @@
+/**
+ * #174 -- the private staging directory an installer is downloaded into.
+ *
+ * Deliberately NOT mocking `fs`. The properties that matter here are properties
+ * of the real filesystem: that mkdtemp gives an unpredictable name, that 0700
+ * actually lands on POSIX, and that pruning removes what it should and nothing
+ * else. A mocked `fs` would only prove the code calls the functions the test
+ * expects it to call, which is the same test written twice.
+ *
+ * The sibling suite in tests/unit/github-update.test.ts drives these through
+ * `downloadInstallerFile` with the network mocked; this one checks the
+ * primitives against a real directory.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+// installerRoot() derives the staging root from the app's own data directory,
+// which is what keeps it off %APPDATA% (roaming) and out of a shared /tmp, and
+// what makes a dev instance stage inside its own data root. Point it at a
+// scratch dir so the real thing can be exercised end to end.
+const dataDir = vi.hoisted(() => ({ path: '' }))
+vi.mock('../../../src/main/data-paths', () => ({
+  getDataDirectory: () => dataDir.path,
+}))
+
+import { createInstallerDir, pruneStaleInstallerDirs, assertPrivateDir, installerRoot } from '../../../src/main/github-update'
+
+let root: string
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-staging-test-'))
+  dataDir.path = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-datadir-test-'))
+})
+
+afterEach(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }) } catch { /* best effort */ }
+  try { fs.rmSync(dataDir.path, { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+/** A symlink where allowed, otherwise a Windows junction (no admin needed). */
+function linkDir(from: string, to: string): boolean {
+  for (const type of ['junction', 'dir'] as const) {
+    try { fs.symlinkSync(to, from, type); return true } catch { /* try the next */ }
+  }
+  return false
+}
+
+describe('installerRoot — the parent of the staging directory', () => {
+  it('creates <dataDir>/updates and returns it', () => {
+    const r = installerRoot()
+    expect(path.resolve(r)).toBe(path.resolve(path.join(dataDir.path, 'updates')))
+    expect(fs.statSync(r).isDirectory()).toBe(true)
+  })
+
+  it('is derived from the app data dir, so it never lands in a roaming profile or a shared /tmp', () => {
+    // Pinning the BASE, not just the suffix. Electron's userData is %APPDATA%
+    // on Windows, which roams — staging 200 MB there syncs it to a file share
+    // at sign-out. getDataDirectory() uses %LOCALAPPDATA% and honours
+    // CCC_DEV_DATA_DIR, which is why it is the base.
+    const r = installerRoot().replace(/\\/g, '/')
+    expect(r.startsWith(dataDir.path.replace(/\\/g, '/'))).toBe(true)
+    expect(r).not.toContain(os.tmpdir().replace(/\\/g, '/') + '/updates')
+  })
+
+  it('REFUSES a pre-planted link at <dataDir>/updates', () => {
+    // The attack this guard exists for. mkdirSync(..., {recursive: true})
+    // swallows EEXIST, so without the check a link planted once redirects every
+    // future staged installer into a directory the planter controls — and the
+    // parent is what they need to rename the 0700 leaf away and substitute
+    // their own payload. No admin required for a junction on Windows.
+    const attacker = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-attacker-'))
+    if (!linkDir(path.join(dataDir.path, 'updates'), attacker)) return
+    try {
+      expect(() => installerRoot()).toThrow(/not a directory|redirected/i)
+    } finally {
+      fs.rmSync(attacker, { recursive: true, force: true })
+    }
+  })
+
+  it('REFUSES a file where the staging root should be, instead of falling back', () => {
+    // There is deliberately no fallback chain: every candidate a fallback could
+    // reach is shared (/tmp) or roaming (%APPDATA%), so "try the next one" means
+    // silently downgrading to the state this change exists to leave.
+    fs.writeFileSync(path.join(dataDir.path, 'updates'), 'not a directory')
+    expect(() => installerRoot()).toThrow()
+  })
+})
+
+describe('assertPrivateDir', () => {
+  it('accepts a normal owner-only directory', () => {
+    expect(() => assertPrivateDir(createInstallerDir(root))).not.toThrow()
+  })
+
+  it('rejects a symlink or junction', () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-target-'))
+    const link = path.join(root, 'linked')
+    if (!linkDir(link, target)) return
+    try {
+      expect(() => assertPrivateDir(link)).toThrow(/not a directory|redirected/i)
+    } finally {
+      fs.rmSync(target, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a group- or world-writable directory on POSIX', () => {
+    if (process.platform === 'win32') return
+    const loose = path.join(root, 'loose')
+    fs.mkdirSync(loose, { recursive: true })
+    fs.chmodSync(loose, 0o777)
+    expect(() => assertPrivateDir(loose)).toThrow(/writable/i)
+  })
+
+  it('tolerates a legitimate symlink higher up the path', () => {
+    // macOS resolves /var -> /private/var, and os.tmpdir() often sits under it.
+    // Only the FINAL component is checked, so a real deployment does not fail.
+    const realParent = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-realparent-'))
+    const linkedParent = path.join(root, 'linked-parent')
+    if (!linkDir(linkedParent, realParent)) return
+    const inner = path.join(linkedParent, 'updates')
+    fs.mkdirSync(inner, { recursive: true })
+    try {
+      expect(() => assertPrivateDir(inner)).not.toThrow()
+    } finally {
+      fs.rmSync(realParent, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('createInstallerDir', () => {
+  it('creates a real directory under the given root', () => {
+    const dir = createInstallerDir(root)
+    expect(fs.existsSync(dir)).toBe(true)
+    expect(fs.statSync(dir).isDirectory()).toBe(true)
+    expect(path.dirname(dir)).toBe(root)
+  })
+
+  it('uses the ccc-upd- prefix so pruning can recognise it', () => {
+    // pruneStaleInstallerDirs matches on this prefix. If the two ever disagree,
+    // staging dirs accumulate forever and nothing fails.
+    expect(path.basename(createInstallerDir(root)).startsWith('ccc-upd-')).toBe(true)
+  })
+
+  it('gives an UNPREDICTABLE name each time', () => {
+    // The security property. The asset name is public in the release feed, so a
+    // fixed directory would put the installer back at a guessable path and hand
+    // the verify->spawn race straight back to a local attacker.
+    const names = new Set(Array.from({ length: 20 }, () => path.basename(createInstallerDir(root))))
+    expect(names.size).toBe(20)
+    // And the suffix is not a counter or a timestamp anyone can compute.
+    for (const n of names) expect(n).toMatch(/^ccc-upd-[A-Za-z0-9]{6,}$/)
+  })
+
+  it('is owner-only on POSIX', () => {
+    // Windows has no mode bits to assert; the userData tree is already
+    // per-user there and chmod is a documented no-op.
+    if (process.platform === 'win32') return
+    const dir = createInstallerDir(root)
+    expect(fs.statSync(dir).mode & 0o777).toBe(0o700)
+  })
+
+  it('throws rather than falling back to a shared directory when the root is unusable', () => {
+    // Fail closed. Silently degrading to a world-writable location is the exact
+    // state this change exists to leave.
+    expect(() => createInstallerDir(path.join(root, 'does', 'not', 'exist'))).toThrow()
+  })
+})
+
+describe('pruneStaleInstallerDirs — hostile entries', () => {
+  it('unlinks a ccc-upd- link instead of deleting through it', () => {
+    // This function is a recursive delete driven by readdir of a directory the
+    // attacker can write to. A `ccc-upd-evil` link pointing at $HOME must cost
+    // the link, not the home directory. Node's rimraf happens to lstat first,
+    // but that is an implementation detail — the guard is explicit in the code
+    // and this is what pins it.
+    const victim = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-victim-'))
+    fs.writeFileSync(path.join(victim, 'precious.txt'), 'do not delete me')
+    const link = path.join(root, 'ccc-upd-evil')
+    if (!linkDir(link, victim)) return // platform denies both primitives
+    try {
+      expect(pruneStaleInstallerDirs(root)).toBe(1)
+      expect(fs.existsSync(link)).toBe(false)
+      expect(fs.existsSync(path.join(victim, 'precious.txt'))).toBe(true)
+    } finally {
+      fs.rmSync(victim, { recursive: true, force: true })
+    }
+  })
+
+  it('does not throw when an entry cannot be removed', () => {
+    // The call site is NOT wrapped in a try/catch, so a throw here would abort
+    // the whole update over a tidy-up -- turning "a leftover directory" into
+    // "the update fails". Production hits this whenever a previous installer is
+    // still running and Windows holds the lock.
+    const doomed = createInstallerDir(root)
+    fs.writeFileSync(path.join(doomed, 'locked.bin'), 'x')
+    const cwd = process.cwd()
+    if (process.platform === 'win32') {
+      // Windows refuses to remove a directory that is a process's CWD (EBUSY) —
+      // deterministic, and no ACL surgery needed.
+      process.chdir(doomed)
+    } else {
+      fs.chmodSync(root, 0o500) // no write on the parent -> unlink denied
+    }
+    try {
+      expect(() => pruneStaleInstallerDirs(root)).not.toThrow()
+      // ...and it did not silently succeed either, which would make the test
+      // pass for the wrong reason.
+      expect(fs.existsSync(doomed)).toBe(true)
+    } finally {
+      if (process.platform === 'win32') process.chdir(cwd)
+      else fs.chmodSync(root, 0o700)
+    }
+  })
+})
+
+describe('pruneStaleInstallerDirs', () => {
+  it('removes staging directories from earlier updates', () => {
+    const a = createInstallerDir(root)
+    const b = createInstallerDir(root)
+    expect(pruneStaleInstallerDirs(root)).toBe(2)
+    expect(fs.existsSync(a)).toBe(false)
+    expect(fs.existsSync(b)).toBe(false)
+  })
+
+  it('keeps the directory the current download is using', () => {
+    // The success path cannot clean up after itself -- CCC spawns the installer
+    // and exits -- so deleting the live one here would delete the installer out
+    // from under the update.
+    const old = createInstallerDir(root)
+    const live = createInstallerDir(root)
+    fs.writeFileSync(path.join(live, 'installer.exe'), 'bytes')
+    expect(pruneStaleInstallerDirs(root, live)).toBe(1)
+    expect(fs.existsSync(old)).toBe(false)
+    expect(fs.existsSync(path.join(live, 'installer.exe'))).toBe(true)
+  })
+
+  it('touches nothing that is not a staging directory', () => {
+    const keepFile = path.join(root, 'unrelated.txt')
+    const keepDir = path.join(root, 'some-other-dir')
+    fs.writeFileSync(keepFile, 'x')
+    fs.mkdirSync(keepDir)
+    createInstallerDir(root)
+    expect(pruneStaleInstallerDirs(root)).toBe(1)
+    expect(fs.existsSync(keepFile)).toBe(true)
+    expect(fs.existsSync(keepDir)).toBe(true)
+  })
+
+  it('does not match a directory that merely contains the prefix', () => {
+    const decoy = path.join(root, 'not-ccc-upd-anything')
+    fs.mkdirSync(decoy)
+    expect(pruneStaleInstallerDirs(root)).toBe(0)
+    expect(fs.existsSync(decoy)).toBe(true)
+  })
+
+  it('returns 0 for a root that does not exist instead of throwing', () => {
+    // Runs on the download path, where an unreadable root must not abort the
+    // update -- a leftover directory is untidy, never unsafe.
+    expect(pruneStaleInstallerDirs(path.join(root, 'nope'))).toBe(0)
+  })
+
+  it('recurses into a populated staging directory', () => {
+    const dir = createInstallerDir(root)
+    fs.mkdirSync(path.join(dir, 'nested'))
+    fs.writeFileSync(path.join(dir, 'nested', 'big.exe'), 'bytes')
+    expect(pruneStaleInstallerDirs(root)).toBe(1)
+    expect(fs.existsSync(dir)).toBe(false)
+  })
+})

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -79,6 +79,31 @@ describe('installerRoot — the parent of the staging directory', () => {
     }
   })
 
+  it('TIGHTENS a group-writable updates dir instead of refusing it', async () => {
+    // The umask trap. mkdirSync's mode is masked by the process umask, so on a
+    // umask-002 box the directory lands 0775 -- and assertPrivateDir's
+    // group-write check then rejects it. With no fallback by design, that is a
+    // PERMANENT unrecoverable update failure: the control this change adds would
+    // have doubled as an update-killer. Nothing in CI has a loose umask, so this
+    // test creates the condition explicitly.
+    if (process.platform === 'win32') return
+    const loose = path.join(dataDir.path, 'updates')
+    fs.mkdirSync(loose, { recursive: true })
+    fs.chmodSync(loose, 0o775)
+    expect(() => installerRoot()).not.toThrow()
+    expect(fs.statSync(loose).mode & 0o777).toBe(0o700)
+  })
+
+  it('creates the updates dir 0700 regardless of umask', async () => {
+    if (process.platform === 'win32') return
+    const previous = process.umask(0o002)
+    try {
+      expect(fs.statSync(installerRoot()).mode & 0o777).toBe(0o700)
+    } finally {
+      process.umask(previous)
+    }
+  })
+
   it('REFUSES a link planted at the DATA DIRECTORY itself', async () => {
     // Load-bearing, not redundant: with the data dir junctioned, both of
     // assertPrivateDir's realpath calls resolve THROUGH the same junction and
@@ -187,8 +212,8 @@ describe('the AppImage parking directory', () => {
 
     // The installed file is untouched...
     expect(fs.readFileSync(running, 'utf-8')).toBe('the original installed app')
-    // ...no `.new` was left behind...
-    expect(fs.existsSync(`${running}.new`)).toBe(false)
+    // ...no staging sibling was left behind...
+    expect(fs.readdirSync(dataDir.path).filter((n) => n.includes('.new'))).toEqual([])
     // ...and it degraded to a parked copy of the (already-verified) download.
     expect(path.resolve(result)).toBe(path.resolve(path.join(dataDir.path, 'bin', path.basename(staged))))
   })
@@ -203,10 +228,26 @@ describe('the AppImage parking directory', () => {
 
     expect(path.resolve(result)).toBe(path.resolve(running))
     expect(fs.readFileSync(running, 'utf-8')).toBe('appimage bytes')
-    // The verifier saw the STAGED sibling, not the final path — that is what
-    // makes it a pre-commit check.
-    expect(seen).toEqual([`${running}.new`])
-    expect(fs.existsSync(`${running}.new`)).toBe(false)
+    // The verifier saw a STAGED SIBLING, not the final path — that is what makes
+    // it a pre-commit check. The name is randomised so it cannot clobber a
+    // user's file, and so an attacker cannot pre-plant a symlink at it that
+    // copyFileSync would follow and renameSync would then move into place.
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatch(/\.new-[0-9a-f]{12}$/)
+    expect(seen[0]).not.toBe(running)
+    expect(fs.readdirSync(dataDir.path).filter((n) => n.includes('.new'))).toEqual([])
+  })
+
+  it('does not destroy an unrelated file sitting at a plausible staging name', async () => {
+    const staged = stagedAppImage()
+    const running = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(running, 'installed')
+    const bystander = `${running}.new`
+    fs.writeFileSync(bystander, 'someone elses data')
+
+    await prepareLinuxAppImageUpdate(staged, running, async () => true)
+
+    expect(fs.readFileSync(bystander, 'utf-8')).toBe('someone elses data')
   })
 })
 

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -48,13 +48,13 @@ function linkDir(from: string, to: string): boolean {
 }
 
 describe('installerRoot — the parent of the staging directory', () => {
-  it('creates <dataDir>/updates and returns it', () => {
+  it('creates <dataDir>/updates and returns it', async () => {
     const r = installerRoot()
     expect(path.resolve(r)).toBe(path.resolve(path.join(dataDir.path, 'updates')))
     expect(fs.statSync(r).isDirectory()).toBe(true)
   })
 
-  it('is derived from the app data dir, so it never lands in a roaming profile or a shared /tmp', () => {
+  it('is derived from the app data dir, so it never lands in a roaming profile or a shared /tmp', async () => {
     // Pinning the BASE, not just the suffix. Electron's userData is %APPDATA%
     // on Windows, which roams — staging 200 MB there syncs it to a file share
     // at sign-out. getDataDirectory() uses %LOCALAPPDATA% and honours
@@ -64,7 +64,7 @@ describe('installerRoot — the parent of the staging directory', () => {
     expect(r).not.toContain(os.tmpdir().replace(/\\/g, '/') + '/updates')
   })
 
-  it('REFUSES a pre-planted link at <dataDir>/updates', () => {
+  it('REFUSES a pre-planted link at <dataDir>/updates', async () => {
     // The attack this guard exists for. mkdirSync(..., {recursive: true})
     // swallows EEXIST, so without the check a link planted once redirects every
     // future staged installer into a directory the planter controls — and the
@@ -79,7 +79,29 @@ describe('installerRoot — the parent of the staging directory', () => {
     }
   })
 
-  it('REFUSES a file where the staging root should be, instead of falling back', () => {
+  it('REFUSES a link planted at the DATA DIRECTORY itself', async () => {
+    // Load-bearing, not redundant: with the data dir junctioned, both of
+    // assertPrivateDir's realpath calls resolve THROUGH the same junction and
+    // therefore agree, so assertPrivateDir on the subdirectory passes. The
+    // lstat on the base is the only thing that catches it.
+    const attacker = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-attacker-'))
+    const realBase = dataDir.path
+    fs.rmSync(realBase, { recursive: true, force: true })
+    if (!linkDir(realBase, attacker)) {
+      dataDir.path = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-datadir-test-'))
+      return
+    }
+    try {
+      expect(() => installerRoot()).toThrow(/not a directory/i)
+      expect(fs.existsSync(path.join(attacker, 'updates'))).toBe(false)
+    } finally {
+      try { fs.unlinkSync(realBase) } catch { try { fs.rmSync(realBase, { recursive: true, force: true }) } catch { /* */ } }
+      fs.rmSync(attacker, { recursive: true, force: true })
+      dataDir.path = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-datadir-test-'))
+    }
+  })
+
+  it('REFUSES a file where the staging root should be, instead of falling back', async () => {
     // There is deliberately no fallback chain: every candidate a fallback could
     // reach is shared (/tmp) or roaming (%APPDATA%), so "try the next one" means
     // silently downgrading to the state this change exists to leave.
@@ -97,14 +119,14 @@ describe('the AppImage parking directory', () => {
     return file
   }
 
-  it('parks a staged AppImage under <dataDir>/bin', () => {
+  it('parks a staged AppImage under <dataDir>/bin', async () => {
     const staged = stagedAppImage()
-    const result = prepareLinuxAppImageUpdate(staged, undefined)
+    const result = await prepareLinuxAppImageUpdate(staged, undefined)
     expect(path.resolve(result)).toBe(path.resolve(path.join(dataDir.path, 'bin', path.basename(staged))))
     expect(fs.readFileSync(result, 'utf-8')).toBe('appimage bytes')
   })
 
-  it('REFUSES to park through a link planted at <dataDir>/bin', () => {
+  it('REFUSES to park through a link planted at <dataDir>/bin', async () => {
     // This is the directory CCC EXECUTES from, so it needs the same validation
     // as the staging root — leaving it a bare recursive mkdir put the
     // plantable-redirect hole back at the worst possible place.
@@ -115,30 +137,76 @@ describe('the AppImage parking directory', () => {
       // Degrades to launching from the staging directory rather than writing
       // into the attacker's: never block an update on tidy-up, never execute
       // out of a redirected directory.
-      expect(prepareLinuxAppImageUpdate(staged, undefined)).toBe(staged)
+      expect(await prepareLinuxAppImageUpdate(staged, undefined)).toBe(staged)
       expect(fs.readdirSync(attacker)).toEqual([])
     } finally {
       fs.rmSync(attacker, { recursive: true, force: true })
     }
   })
 
-  it('leaves an AppImage that is already outside the prune root alone', () => {
+  it('leaves an AppImage that is already outside the prune root alone', async () => {
     // No spurious 200 MB copy for a file that is not prune-eligible.
     const elsewhere = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
     fs.writeFileSync(elsewhere, 'bytes')
-    expect(prepareLinuxAppImageUpdate(elsewhere, undefined)).toBe(elsewhere)
+    expect(await prepareLinuxAppImageUpdate(elsewhere, undefined)).toBe(elsewhere)
     expect(fs.existsSync(path.join(dataDir.path, 'bin'))).toBe(false)
   })
 
-  it('does not park a file merely because its folder is NAMED like a staging dir', () => {
+  it('does not park a file merely because its folder is NAMED like a staging dir', async () => {
     // A name test alone would copy 200 MB out of anyone's `~/ccc-upd-backup/`.
     // Prune-eligibility is about LOCATION: directly under <dataDir>/updates.
     const decoy = path.join(root, 'ccc-upd-backup')
     fs.mkdirSync(decoy, { recursive: true })
     const file = path.join(decoy, 'ClaudeCommandCenter.AppImage')
     fs.writeFileSync(file, 'bytes')
-    expect(prepareLinuxAppImageUpdate(file, undefined)).toBe(file)
+    expect(await prepareLinuxAppImageUpdate(file, undefined)).toBe(file)
     expect(fs.existsSync(path.join(dataDir.path, 'bin'))).toBe(false)
+  })
+
+  it('does not park a file under the updates root whose folder is not a staging dir', async () => {
+    // The other half: right LOCATION, wrong NAME. pruneStaleInstallerDirs only
+    // touches `ccc-upd-*`, so anything else under updates/ is not at risk and
+    // must not be copied. Both halves of the test are load-bearing.
+    const other = path.join(installerRoot(), 'not-a-stage')
+    fs.mkdirSync(other, { recursive: true })
+    const file = path.join(other, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(file, 'bytes')
+    expect(await prepareLinuxAppImageUpdate(file, undefined)).toBe(file)
+    expect(fs.existsSync(path.join(dataDir.path, 'bin'))).toBe(false)
+  })
+
+  it('VERIFIES the copy before moving it onto the running AppImage', async () => {
+    // Verify-before-commit. Checking afterwards detects a swap but cannot undo
+    // it: the bad bytes would already be at the user's .desktop/dock-pinned
+    // path, running on next launch, while the UI says the update was blocked.
+    const staged = stagedAppImage()
+    const running = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(running, 'the original installed app')
+
+    const result = await prepareLinuxAppImageUpdate(staged, running, async () => false)
+
+    // The installed file is untouched...
+    expect(fs.readFileSync(running, 'utf-8')).toBe('the original installed app')
+    // ...no `.new` was left behind...
+    expect(fs.existsSync(`${running}.new`)).toBe(false)
+    // ...and it degraded to a parked copy of the (already-verified) download.
+    expect(path.resolve(result)).toBe(path.resolve(path.join(dataDir.path, 'bin', path.basename(staged))))
+  })
+
+  it('commits the copy when the verifier passes', async () => {
+    const staged = stagedAppImage()
+    const running = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(running, 'the original installed app')
+    const seen: string[] = []
+
+    const result = await prepareLinuxAppImageUpdate(staged, running, async (c) => { seen.push(c); return true })
+
+    expect(path.resolve(result)).toBe(path.resolve(running))
+    expect(fs.readFileSync(running, 'utf-8')).toBe('appimage bytes')
+    // The verifier saw the STAGED sibling, not the final path — that is what
+    // makes it a pre-commit check.
+    expect(seen).toEqual([`${running}.new`])
+    expect(fs.existsSync(`${running}.new`)).toBe(false)
   })
 })
 

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../../src/main/data-paths', () => ({
   getDataDirectory: () => dataDir.path,
 }))
 
-import { createInstallerDir, pruneStaleInstallerDirs, assertPrivateDir, installerRoot } from '../../../src/main/github-update'
+import { createInstallerDir, pruneStaleInstallerDirs, assertPrivateDir, installerRoot, prepareLinuxAppImageUpdate } from '../../../src/main/github-update'
 
 let root: string
 
@@ -85,6 +85,60 @@ describe('installerRoot — the parent of the staging directory', () => {
     // silently downgrading to the state this change exists to leave.
     fs.writeFileSync(path.join(dataDir.path, 'updates'), 'not a directory')
     expect(() => installerRoot()).toThrow()
+  })
+})
+
+describe('the AppImage parking directory', () => {
+  /** A downloaded AppImage sitting in a real staging directory. */
+  function stagedAppImage(): string {
+    const stage = createInstallerDir(installerRoot())
+    const file = path.join(stage, 'ClaudeCommandCenter-2.1.0-linux-x86_64.AppImage')
+    fs.writeFileSync(file, 'appimage bytes')
+    return file
+  }
+
+  it('parks a staged AppImage under <dataDir>/bin', () => {
+    const staged = stagedAppImage()
+    const result = prepareLinuxAppImageUpdate(staged, undefined)
+    expect(path.resolve(result)).toBe(path.resolve(path.join(dataDir.path, 'bin', path.basename(staged))))
+    expect(fs.readFileSync(result, 'utf-8')).toBe('appimage bytes')
+  })
+
+  it('REFUSES to park through a link planted at <dataDir>/bin', () => {
+    // This is the directory CCC EXECUTES from, so it needs the same validation
+    // as the staging root — leaving it a bare recursive mkdir put the
+    // plantable-redirect hole back at the worst possible place.
+    const attacker = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-attacker-'))
+    const staged = stagedAppImage()
+    if (!linkDir(path.join(dataDir.path, 'bin'), attacker)) return
+    try {
+      // Degrades to launching from the staging directory rather than writing
+      // into the attacker's: never block an update on tidy-up, never execute
+      // out of a redirected directory.
+      expect(prepareLinuxAppImageUpdate(staged, undefined)).toBe(staged)
+      expect(fs.readdirSync(attacker)).toEqual([])
+    } finally {
+      fs.rmSync(attacker, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves an AppImage that is already outside the prune root alone', () => {
+    // No spurious 200 MB copy for a file that is not prune-eligible.
+    const elsewhere = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(elsewhere, 'bytes')
+    expect(prepareLinuxAppImageUpdate(elsewhere, undefined)).toBe(elsewhere)
+    expect(fs.existsSync(path.join(dataDir.path, 'bin'))).toBe(false)
+  })
+
+  it('does not park a file merely because its folder is NAMED like a staging dir', () => {
+    // A name test alone would copy 200 MB out of anyone's `~/ccc-upd-backup/`.
+    // Prune-eligibility is about LOCATION: directly under <dataDir>/updates.
+    const decoy = path.join(root, 'ccc-upd-backup')
+    fs.mkdirSync(decoy, { recursive: true })
+    const file = path.join(decoy, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(file, 'bytes')
+    expect(prepareLinuxAppImageUpdate(file, undefined)).toBe(file)
+    expect(fs.existsSync(path.join(dataDir.path, 'bin'))).toBe(false)
   })
 })
 

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -238,6 +238,19 @@ describe('the AppImage parking directory', () => {
     expect(fs.readdirSync(dataDir.path).filter((n) => n.includes('.new'))).toEqual([])
   })
 
+  it('reclaims the staging sibling when the commit fails', async () => {
+    // Randomising the name removed the only thing that used to bound this: the
+    // pre-emptive unlink of a FIXED `.new`. Without cleanup a failed
+    // copy/chmod/rename leaves a ~200 MB orphan next to the running AppImage,
+    // once per attempt, that prune never walks.
+    const staged = stagedAppImage()
+    const running = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')
+    fs.writeFileSync(running, 'installed')
+    await prepareLinuxAppImageUpdate(staged, running, async () => { throw new Error('verifier blew up') })
+    expect(fs.readdirSync(dataDir.path).filter((n) => n.includes('.new-'))).toEqual([])
+    expect(fs.readFileSync(running, 'utf-8')).toBe('installed')
+  })
+
   it('does not destroy an unrelated file sitting at a plausible staging name', async () => {
     const staged = stagedAppImage()
     const running = path.join(dataDir.path, 'ClaudeCommandCenter.AppImage')

--- a/tests/unit/main/github-update-staging-dir.test.ts
+++ b/tests/unit/main/github-update-staging-dir.test.ts
@@ -226,7 +226,11 @@ describe('the AppImage parking directory', () => {
 
     const result = await prepareLinuxAppImageUpdate(staged, running, async (c) => { seen.push(c); return true })
 
-    expect(path.resolve(result)).toBe(path.resolve(running))
+    // realpath, not resolve: on macOS os.tmpdir() is under /var, which is a
+    // symlink to /private/var, and the code resolves it while the test fixture
+    // does not. Comparing resolved-but-unresolved paths passes on Windows and
+    // fails on macOS — which is what the macOS CI leg caught.
+    expect(fs.realpathSync(result)).toBe(fs.realpathSync(running))
     expect(fs.readFileSync(running, 'utf-8')).toBe('appimage bytes')
     // The verifier saw a STAGED SIBLING, not the final path — that is what makes
     // it a pre-commit check. The name is randomised so it cannot clobber a

--- a/tests/unit/main/update-handlers.test.ts
+++ b/tests/unit/main/update-handlers.test.ts
@@ -58,6 +58,7 @@ const gh = vi.hoisted(() => ({
   stillMatchesCalls: [] as string[],
   appImageResult: null as string | null,
   noexec: false,
+  appImageVerifiers: [] as Array<((c: string) => Promise<boolean>) | undefined>,
 }))
 
 // Hoisted with the mock factory, which vitest lifts above the imports.
@@ -77,19 +78,25 @@ vi.mock('../../../src/main/github-update', () => ({
     gh.stillMatchesCalls.push(p)
     return gh.stillMatches.length ? gh.stillMatches.shift()! : true
   },
-  prepareLinuxAppImageUpdate: (p: string) => gh.appImageResult ?? p,
+  prepareLinuxAppImageUpdate: async (p: string, _cur: string | undefined, verify?: (c: string) => Promise<boolean>) => {
+    gh.appImageVerifiers.push(verify)
+    return gh.appImageResult ?? p
+  },
   isPathOnNoexecMount: () => gh.noexec,
   createInstallerDir: () => '/mock/dataDir/updates/ccc-upd-DEV',
   InstallerIntegrityError: FakeIntegrityError,
 }))
 
 // ── everything else the module pulls in ────────────────────────────────
+const fsState = vi.hoisted(() => ({ accessThrows: false }))
 vi.mock('fs', () => ({
   existsSync: () => true,
   readFileSync: () => '{"version":"2.1.1"}',
   copyFileSync: vi.fn(),
   mkdirSync: vi.fn(),
-  accessSync: vi.fn(),
+  accessSync: () => {
+    if (fsState.accessThrows) throw new Error('EACCES: permission denied')
+  },
   constants: { X_OK: 1 },
 }))
 // update-watcher owns the "an update was installed" bookkeeping and reaches for
@@ -99,6 +106,11 @@ vi.mock('../../../src/main/update-watcher', () => ({
   markUpdateInstalled: vi.fn(),
   getProjectRootPath: () => '/mock/project',
   setSourcePathInRegistry: vi.fn(),
+  // Present so the "no installer" branch is REACHABLE. Omitting these made
+  // vitest throw "No export is defined on the mock" the moment a test drove
+  // `gh.verified = null`, which is why nothing covered that path.
+  isPackagedApp: () => true,
+  hasSourcePath: () => false,
 }))
 vi.mock('../../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
 vi.mock('../../../src/main/pty-manager', () => ({ killAllPty: vi.fn() }))
@@ -128,6 +140,8 @@ beforeEach(() => {
   gh.stillMatchesCalls = []
   gh.appImageResult = null
   gh.noexec = false
+  gh.appImageVerifiers = []
+  fsState.accessThrows = false
   registerUpdateHandlers()
 })
 
@@ -217,6 +231,26 @@ describe('update:installAndRestart — verification', () => {
     }
   })
 
+  it('hands prepareLinuxAppImageUpdate a verifier so the copy is checked BEFORE it lands', async () => {
+    // Without the passthrough the copy is only checked after it has already
+    // overwritten the user's installed AppImage — detect, not prevent.
+    const staged = '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage'
+    gh.verified = { path: staged, sha256: 'a'.repeat(64) }
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    try {
+      await invoke()
+      expect(gh.appImageVerifiers).toHaveLength(1)
+      expect(typeof gh.appImageVerifiers[0]).toBe('function')
+      // And it really is the digest check, bound to the verified hash.
+      gh.stillMatchesCalls = []
+      await gh.appImageVerifiers[0]!('/some/candidate')
+      expect(gh.stillMatchesCalls).toEqual(['/some/candidate'])
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
   it('aborts when the AppImage copy does not match the verified digest', async () => {
     const staged = '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage'
     gh.verified = { path: staged, sha256: 'a'.repeat(64) }
@@ -230,6 +264,62 @@ describe('update:installAndRestart — verification', () => {
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
     }
+  })
+
+  it('tells the user when a local STORAGE failure stopped the download', async () => {
+    // A disk-full mkdtemp or an unwritable data dir raises a plain Error, which
+    // is not an InstallerIntegrityError -- so before this it reached the user
+    // through NO channel at all: the overlay vanished and nothing was shown.
+    // A wrong message became silence, which is worse.
+    gh.downloadError = new Error('Could not prepare a private folder to download the update into: ENOSPC')
+    await expect(invoke()).rejects.toThrow(/ENOSPC/)
+    expect(shownErrorBoxes).toHaveLength(1)
+    expect(shownErrorBoxes[0][0]).toMatch(/could not be downloaded/i)
+    expect(shownErrorBoxes[0][1]).toContain('ENOSPC')
+  })
+
+  it('tells the user when no installer could be found at all', async () => {
+    gh.verified = null
+    await expect(invoke()).rejects.toThrow(/Installer not found/)
+    expect(shownErrorBoxes).toHaveLength(1)
+    expect(spawnState.calls).toHaveLength(0)
+  })
+
+  it('aborts before killing the PTYs when the AppImage is not executable', async () => {
+    // The round-1 guard: spawn reports EACCES only asynchronously, and the
+    // single-instance lock means we cannot test-launch first, so this has to fail
+    // BEFORE the terminals are killed.
+    gh.verified = { path: '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage', sha256: 'a'.repeat(64) }
+    fsState.accessThrows = true
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    try {
+      await expect(invoke()).rejects.toThrow(/not executable/)
+      expect(spawnState.calls).toHaveLength(0)
+      expect(exitCalls).toEqual([])
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('aborts before killing the PTYs when the AppImage is on a noexec mount', async () => {
+    // accessSync inspects permission BITS, not the mount, so a chmod'd AppImage
+    // on a noexec filesystem passes that check and still fails execve.
+    gh.verified = { path: '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage', sha256: 'a'.repeat(64) }
+    gh.noexec = true
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    try {
+      await expect(invoke()).rejects.toThrow(/noexec/)
+      expect(spawnState.calls).toHaveLength(0)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('unrefs the child so it outlives the app', async () => {
+    await invoke()
+    expect(spawnState.unrefs).toBe(1)
   })
 
   it('shows the integrity dialog, and only that one, on an integrity failure', async () => {

--- a/tests/unit/main/update-handlers.test.ts
+++ b/tests/unit/main/update-handlers.test.ts
@@ -297,6 +297,10 @@ describe('update:installAndRestart — verification', () => {
       await expect(invoke()).rejects.toThrow(/not executable/)
       expect(spawnState.calls).toHaveLength(0)
       expect(exitCalls).toEqual([])
+      // This block sits OUTSIDE the launch try/catch, so without its own dialog
+      // the abort reaches the user through nothing at all.
+      expect(shownErrorBoxes).toHaveLength(1)
+      expect(shownErrorBoxes[0][0]).toMatch(/could not be launched/i)
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
     }
@@ -312,6 +316,8 @@ describe('update:installAndRestart — verification', () => {
     try {
       await expect(invoke()).rejects.toThrow(/noexec/)
       expect(spawnState.calls).toHaveLength(0)
+      expect(shownErrorBoxes).toHaveLength(1)
+      expect(shownErrorBoxes[0][1]).toMatch(/noexec/)
     } finally {
       Object.defineProperty(process, 'platform', { value: original, configurable: true })
     }

--- a/tests/unit/main/update-handlers.test.ts
+++ b/tests/unit/main/update-handlers.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `update:installAndRestart` -- the handler that kills every PTY and hands a
+ * verified installer to the OS with elevation.
+ *
+ * This file exists because the adversarial pass on #174 found it did not: the
+ * change added a spawn handshake on two platforms, two error dialogs, a
+ * reentrancy latch and a post-copy digest re-check, and NOTHING could have
+ * caught their removal. That matters more here than almost anywhere else in the
+ * app, because the renderer swallows this handler's rejection at every call site
+ * -- so a regression is invisible by construction, not merely untested.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+// ── Captured handler + electron surface ────────────────────────────────
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+const shownErrorBoxes: Array<[string, string]> = []
+const exitCalls: number[] = []
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: unknown[]) => unknown) => { handlers.set(ch, fn) } },
+  dialog: {
+    showErrorBox: (title: string, body: string) => { shownErrorBoxes.push([title, body]) },
+    showOpenDialog: vi.fn(),
+  },
+  app: { exit: (code: number) => { exitCalls.push(code) }, getVersion: () => '2.1.0', getPath: () => '/mock/userData' },
+  BrowserWindow: { getAllWindows: () => [] },
+}))
+
+// ── spawn ──────────────────────────────────────────────────────────────
+type SpawnScript = { emit: 'spawn' | 'error' | 'nothing'; error?: Error; throwSync?: Error }
+const spawnState = vi.hoisted(() => ({
+  calls: [] as Array<{ cmd: string; args: string[] }>,
+  script: { emit: 'spawn' } as SpawnScript,
+  unrefs: 0,
+}))
+
+vi.mock('child_process', () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnState.calls.push({ cmd, args })
+    if (spawnState.script.throwSync) throw spawnState.script.throwSync
+    const child = new EventEmitter() as EventEmitter & { unref: () => void }
+    child.unref = () => { spawnState.unrefs += 1 }
+    if (spawnState.script.emit === 'spawn') setImmediate(() => child.emit('spawn'))
+    if (spawnState.script.emit === 'error') setImmediate(() => child.emit('error', spawnState.script.error))
+    return child
+  },
+  execFile: vi.fn(),
+  spawnSync: vi.fn(),
+}))
+
+// ── github-update ──────────────────────────────────────────────────────
+const gh = vi.hoisted(() => ({
+  release: { version: '2.1.1', tagName: 'v2.1.1', installerName: 'CCC-2.1.1.exe', installerUrl: 'https://h/CCC-2.1.1.exe', channel: 'beta' } as unknown,
+  verified: { path: '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.exe', sha256: 'a'.repeat(64) } as { path: string; sha256: string } | null,
+  downloadError: null as Error | null,
+  stillMatches: [] as boolean[],
+  stillMatchesCalls: [] as string[],
+  appImageResult: null as string | null,
+  noexec: false,
+}))
+
+// Hoisted with the mock factory, which vitest lifts above the imports.
+const { FakeIntegrityError } = vi.hoisted(() => ({
+  FakeIntegrityError: class extends Error {
+    constructor(m: string) { super(m); this.name = 'InstallerIntegrityError' }
+  },
+}))
+
+vi.mock('../../../src/main/github-update', () => ({
+  checkGitHubRelease: async () => gh.release,
+  downloadGitHubRelease: async () => {
+    if (gh.downloadError) throw gh.downloadError
+    return gh.verified
+  },
+  stillMatchesDigest: async (p: string) => {
+    gh.stillMatchesCalls.push(p)
+    return gh.stillMatches.length ? gh.stillMatches.shift()! : true
+  },
+  prepareLinuxAppImageUpdate: (p: string) => gh.appImageResult ?? p,
+  isPathOnNoexecMount: () => gh.noexec,
+  createInstallerDir: () => '/mock/dataDir/updates/ccc-upd-DEV',
+  InstallerIntegrityError: FakeIntegrityError,
+}))
+
+// ── everything else the module pulls in ────────────────────────────────
+vi.mock('fs', () => ({
+  existsSync: () => true,
+  readFileSync: () => '{"version":"2.1.1"}',
+  copyFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}))
+// update-watcher owns the "an update was installed" bookkeeping and reaches for
+// app.getAppPath()/hashes. Not what this suite is about.
+vi.mock('../../../src/main/update-watcher', () => ({
+  checkForUpdatesOnDemand: vi.fn(),
+  markUpdateInstalled: vi.fn(),
+  getProjectRootPath: () => '/mock/project',
+  setSourcePathInRegistry: vi.fn(),
+}))
+vi.mock('../../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+vi.mock('../../../src/main/pty-manager', () => ({ killAllPty: vi.fn() }))
+vi.mock('../../../src/main/registry', () => ({ readRegistry: () => null, writeRegistry: () => true }))
+vi.mock('../../../src/main/data-paths', () => ({ getDataDirectory: () => '/mock/dataDir' }))
+
+import { registerUpdateHandlers } from '../../../src/main/ipc/update-handlers'
+
+const INSTALLER = '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.exe'
+
+function invoke(): Promise<unknown> {
+  const fn = handlers.get('update:installAndRestart')
+  if (!fn) throw new Error('handler not registered')
+  return Promise.resolve(fn())
+}
+
+beforeEach(() => {
+  handlers.clear()
+  shownErrorBoxes.length = 0
+  exitCalls.length = 0
+  spawnState.calls.length = 0
+  spawnState.script = { emit: 'spawn' }
+  spawnState.unrefs = 0
+  gh.verified = { path: INSTALLER, sha256: 'a'.repeat(64) }
+  gh.downloadError = null
+  gh.stillMatches = []
+  gh.stillMatchesCalls = []
+  gh.appImageResult = null
+  gh.noexec = false
+  registerUpdateHandlers()
+})
+
+describe('update:installAndRestart — launch handshake', () => {
+  it('waits for the child to start before exiting the app', async () => {
+    await expect(invoke()).resolves.toBe(true)
+    expect(spawnState.calls).toHaveLength(1)
+    expect(spawnState.calls[0].cmd).toBe(INSTALLER)
+    expect(exitCalls).toEqual([0])
+  })
+
+  it('does NOT exit, and tells the user, when the launch fails asynchronously', async () => {
+    // spawn reports EACCES/ENOENT only via an async 'error' event. Without the
+    // handshake, app.exit(0) runs first and the user is left with every PTY
+    // dead, no running app, and nothing on screen. Worse: with no 'error'
+    // listener the event is an UNCAUGHT EXCEPTION in the main process.
+    spawnState.script = { emit: 'error', error: new Error('spawn EACCES') }
+    await expect(invoke()).rejects.toThrow(/EACCES/)
+    expect(exitCalls).toEqual([])
+    expect(shownErrorBoxes).toHaveLength(1)
+    expect(shownErrorBoxes[0][0]).toMatch(/could not be launched/i)
+  })
+
+  it('names the staged installer path so the user can run it by hand', async () => {
+    // #174 moved staging out of ~/Downloads into a deliberately unpredictable
+    // directory. Without this the user has nothing to fall back on.
+    spawnState.script = { emit: 'error', error: new Error('spawn EACCES') }
+    await expect(invoke()).rejects.toThrow()
+    expect(shownErrorBoxes[0][1]).toContain(INSTALLER)
+  })
+
+  it('surfaces a synchronous spawn throw the same way', async () => {
+    spawnState.script = { emit: 'nothing', throwSync: new Error('spawn UNKNOWN') }
+    await expect(invoke()).rejects.toThrow(/UNKNOWN/)
+    expect(exitCalls).toEqual([])
+    expect(shownErrorBoxes).toHaveLength(1)
+  })
+
+  it('uses `open` for a macOS .dmg, and waits for it too', async () => {
+    gh.verified = { path: '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1-mac.dmg', sha256: 'a'.repeat(64) }
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    try {
+      spawnState.script = { emit: 'error', error: new Error('open failed') }
+      await expect(invoke()).rejects.toThrow(/open failed/)
+      expect(spawnState.calls[0].cmd).toBe('open')
+      // The whole point: the darwin branch was the one left without a handshake
+      // or an 'error' listener, so this failure used to crash the main process.
+      expect(exitCalls).toEqual([])
+      expect(shownErrorBoxes).toHaveLength(1)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+})
+
+describe('update:installAndRestart — verification', () => {
+  it('re-hashes the installer immediately before launching it', async () => {
+    await invoke()
+    expect(gh.stillMatchesCalls).toContain(INSTALLER)
+  })
+
+  it('aborts without launching when the file changed after verification', async () => {
+    gh.stillMatches = [false]
+    await expect(invoke()).rejects.toThrow(/changed on disk/)
+    expect(spawnState.calls).toHaveLength(0)
+    expect(exitCalls).toEqual([])
+  })
+
+  it('re-hashes the AppImage COPY, not just the staged original', async () => {
+    // prepareLinuxAppImageUpdate copies the AppImage somewhere else, so the file
+    // that was verified is not the file that gets spawned. Checking only the
+    // staged original leaves everything between the copy and the launch
+    // unverified (#174 adversarial review).
+    const staged = '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage'
+    const parked = '/mock/dataDir/bin/CCC-2.1.1.AppImage'
+    gh.verified = { path: staged, sha256: 'a'.repeat(64) }
+    gh.appImageResult = parked
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    try {
+      await invoke()
+      expect(gh.stillMatchesCalls).toContain(parked)
+      expect(spawnState.calls[0].cmd).toBe(parked)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('aborts when the AppImage copy does not match the verified digest', async () => {
+    const staged = '/mock/dataDir/updates/ccc-upd-XYZ/CCC-2.1.1.AppImage'
+    gh.verified = { path: staged, sha256: 'a'.repeat(64) }
+    gh.appImageResult = '/mock/dataDir/bin/CCC-2.1.1.AppImage'
+    gh.stillMatches = [true, false] // staged ok, copy not
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    try {
+      await expect(invoke()).rejects.toThrow(/does not match the verified installer/)
+      expect(spawnState.calls).toHaveLength(0)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true })
+    }
+  })
+
+  it('shows the integrity dialog, and only that one, on an integrity failure', async () => {
+    // The download-time integrity dialog fires before the launch try/catch, so
+    // it must not be joined by a second "could not be launched" box.
+    gh.downloadError = new FakeIntegrityError('CCC-2.1.1.exe has no verified SHA-256 in release v2.1.1')
+    await expect(invoke()).rejects.toThrow(/no verified SHA-256/)
+    expect(shownErrorBoxes).toHaveLength(1)
+    expect(shownErrorBoxes[0][0]).toMatch(/integrity check failed/i)
+    expect(spawnState.calls).toHaveLength(0)
+  })
+})
+
+describe('update:installAndRestart — reentrancy', () => {
+  it('refuses a second concurrent install', async () => {
+    // Two concurrent runs each prune the staging root keeping only THEIR OWN
+    // directory, so each deletes the other's in-flight installer.
+    spawnState.script = { emit: 'nothing' } // first call parks on the 3s timeout
+    const first = invoke()
+    await expect(invoke()).rejects.toThrow(/already in progress/)
+    expect(spawnState.calls).toHaveLength(1)
+    await first
+  }, 10000)
+
+  it('releases the latch so a later install can run', async () => {
+    spawnState.script = { emit: 'error', error: new Error('boom') }
+    await expect(invoke()).rejects.toThrow()
+    spawnState.script = { emit: 'spawn' }
+    await expect(invoke()).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #174.

## 1. Installers no longer land in `~/Downloads`

The updater verifies an installer, kills every PTY, then spawns it with
`allowElevation` — so the user approves a UAC prompt for whatever is at that path. In
`~/Downloads` that path is fully predictable (the asset name is public in the release feed)
in a directory every browser writes into.

Staging is now a `mkdtemp` `ccc-upd-XXXX` directory, 0700, under the app's own data
directory, pruned on the way in.

**Be precise about what this buys.** The attacker in this model runs as the *user*, so it
does not guess the directory name — it watches the root and sees it appear. What moves is
the drive-by variant (a hostile page steering a browser download onto the known asset
name), collisions with anything else writing that directory, and the chance of someone
double-clicking a stale unverified installer. `stillMatchesDigest` remains the control of
record for the verify→spawn race, and the comments now say so rather than claiming the
exposure is removed.

**Why the app data dir and not the two obvious alternatives.** `app.getPath('userData')` is
`%APPDATA%` on Windows, which **roams** — a 200 MB installer would sync to a file share at
sign-out and can trip a profile quota. `app.getPath('temp')` on Linux is the shared,
world-writable `/tmp`, which is `noexec` on hardened boxes — for a file we intend to
*execute*. `getDataDirectory()` is `%LOCALAPPDATA%` on Windows and honours
`CCC_DEV_DATA_DIR`, so a dev instance stages inside its own data root.

**The root is verified before use.** `mkdirSync(…, {recursive: true})` swallows `EEXIST`, so
a symlink or Windows junction (no admin needed) planted at `<dataDir>/updates` would
silently redirect every future installer into a directory the planter controls — and the
*parent* is what they need to rename the 0700 leaf away and substitute their own payload.
`assertPrivateDir` rejects a non-directory, a redirected final component, foreign ownership
and group/world write. There is deliberately **no fallback chain**: every candidate a
fallback could reach is shared or roaming.

Also: an asset name that `path.basename` would alter is refused rather than sanitised, and
prune unlinks a non-directory entry instead of recursing, so a `ccc-upd-evil` link costs the
link and not the home directory.

## 2. `httpsDownload` is bounded on the wire

`readManifest` enforced `MAX_MANIFEST_BYTES` by `stat`-ing the *finished* file, so a hostile
endpoint could fill the disk before the check ran. `Content-Length` is a fast reject; the
running byte count is what holds, since the header is attacker-supplied and a chunked
response has none. The installer leg gets a 1 GiB ceiling — **pinned by test**, because
capping it at the manifest limit is a one-token change that breaks every real update while
every other download test uses a 15-byte body.

An abandoned redirect is `destroy()`ed rather than `resume()`d: draining discards the body
uncounted and, since `activeReq` is nulled before recursing, `fail()` can no longer reach
it — so a 3xx with an endless body had the main process reading and discarding forever on
leaked sockets.

`CHECKSUMS.txt` is staged in the same private directory. It sat at a `Date.now()`-guessable
name in the shared temp dir, which is *worse* than the installer was: the sticky bit stops
another user unlinking our entry, not pre-planting a symlink that `createWriteStream`
follows without `O_NOFOLLOW` — and `renameSync` then moves the **link**, leaving the
attacker owning the bytes that decide which digest counts as verified.

## 3. Things the review found that the issue did not ask about

- **Linux: the verified file was not the spawned file.** `prepareLinuxAppImageUpdate` copies
  the AppImage elsewhere, and nothing re-hashed the copy. It is now `async` and takes a
  verifier: it copies to a randomly-named sibling, hashes **that**, and only renames into
  place on success. Verify-then-commit — checking afterwards detects a swap but cannot undo
  it, because the bad bytes are already at the user's `.desktop`/dock-pinned path.
- **Linux: the next update deleted the running app.** When it cannot relocate, that function
  used to return the download path — previously `~/Downloads`, which nothing pruned. Inside
  the staging root it is prune-eligible. It is now parked under `<dataDir>/bin` first.
- **A local storage failure was reported as a release tamper event.** A disk-full `mkdtemp`
  surfaced as "Update blocked — integrity check failed … has no verified SHA-256". False
  tamper signals are how real ones get ignored. It now raises a plain `Error` and an "Update
  could not be downloaded" dialog. On a filesystem with no mode bits the refusal names the
  cause and the remedy, since the data directory is user-chosen.
- **Failures reached the user through no channel.** The renderer swallows this handler's
  rejection at all four call sites, so `showErrorBox` is the only channel that survives. The
  macOS `.dmg` branch had no spawn handshake *and no `'error'` listener at all*, making a
  failed `open` an uncaught main-process exception after every PTY was dead. All three
  branches now share one `awaitLaunch`, and every abort names the staged installer path —
  which matters more since the file is no longer somewhere the user can find.
- **A umask trap of my own making.** `mkdirSync`'s mode is umask-masked, so on a umask-002
  box `<dataDir>/updates` landed 0775 and `assertPrivateDir` then *rejected* it. With no
  fallback that is a permanent unrecoverable update failure — the security control would
  have doubled as an update-killer on Linux. The directory is chmod'd 0700 before it is
  validated, which also repairs one an older build left loose.
- **Reentrancy.** Two concurrent installs each prune the staging root keeping only their own
  directory, so each deletes the other's in-flight installer. Latched.

## Adversarial review (ADR-009)

**Five rounds, 8 independent attackers.** Rounds 1–4 each returned FINDINGS; round 5 returned
MERGEABLE. **2 BLOCKERs and 14 MAJORs raised, 0 open.** Every blocker after round 1 was
introduced by the previous round's fix — the `--draft`-shaped mistake of fixing a real
problem and creating a worse one, four times over, which is exactly what the repeated passes
were for.

Per the house rule that a test which cannot fail is worse than no test, guards were verified
by reverting them on an **isolated copy** (not the worktree) and watching the named test go
red. Across rounds 2–5 that is **60+ mutations**; the last full battery killed 27 of 30, and
the three survivors are documented as redundant-by-construction rather than quietly ignored.

`tests/unit/main/update-handlers.test.ts` is **new**: the file had zero tests, so both spawn
handshakes, every dialog, the latch and the digest re-check could all be deleted with the
suite green. Adding `createReadStream` to the fs mock also made `downloadGitHubRelease`'s
**success** path reachable for the first time.

## Verified

- `npm run typecheck` clean; `npx vitest run` **3510 passed / 4 skipped**, 114 in the three
  updater suites.
- Real asset sizes checked (171–213 MB) against the staging location, the roaming-profile
  question and the 1 GiB cap.

## Follow-ups, not in scope

- `httpsDownload`'s `gh` fallback leg still relies on the post-hoc `statSync` for the
  manifest size. It takes release-write access to publish an oversized `CHECKSUMS.txt`,
  which the threat model already concedes.
- A redirect planted at a component *above* the data directory is not caught, deliberately:
  an attacker who can relocate a live data directory already has the config, sessions and
  transcripts.

**Apply `ci-run`** so the macOS leg executes the POSIX-only mode tests.
