### PR TITLE
fix(hooks): shape-filter the transcript_path hook POSTs carry, and share one filter with the sentinel (#180)

### DIFF
--- a/CONTEXT.d/2026-08-03-180-hooks-gateway-audit.md
+++ b/CONTEXT.d/2026-08-03-180-hooks-gateway-audit.md
@@ -1,0 +1,51 @@
+## 2026-08-03 -- Audit the second transcript_path source into the binder (#180)
+
+GHSA-hw7c-g5pw-w725 fixed `canonicalizeTranscriptPath` and traced ONE source path into it:
+the SSH statusline sentinel, which also got a shape filter. The hooks gateway lifts the same
+field out of a hook POST body, reaches the same binder, and is read BEFORE redaction -- and
+it never got the same look. That is #180, and this is the audit.
+
+### What the audit found
+
+The containment fix holds from this entry point. That is not luck: it was put at the choke
+point rather than the call site precisely so it would cover callers nobody had enumerated,
+and this is the caller nobody had enumerated. Nothing was reachable past it.
+
+What was missing is the SHAPE half. The value reached the binder through a bare
+`typeof x === 'string'`, unbounded and unfiltered, on a route whose body is remote-influenced.
+So: `sanitiseTranscriptPath` bounds it at 4096 and rejects an embedded NUL or any C0/DEL
+control character. Containment is deliberately NOT re-implemented there -- two copies of a
+containment rule is how the two copies drift, and the choke point is the right place for it.
+A dropped path is logged (length and type only, never the value: this runs before redaction)
+because a silently dropped path looks identical to "Claude did not send one", and the two have
+very different diagnoses.
+
+Also noted in the issue and fixed here: the per-session token was compared with `!==` while
+the MCP server on the same machine uses `timingSafeEqual` for its equivalent check. Low
+impact -- a loopback token with 122 bits of CSPRNG entropy is not realistically recoverable by
+timing -- but "low" argues for consistency, not against it. `tokensMatch` is now the same
+shape as `conductor-mcp-server.ts`, length-guarded first because `timingSafeEqual` throws on
+unequal-length buffers, and refusing an empty expected secret because
+`timingSafeEqual('','')` is TRUE.
+
+### The test is the point of the issue
+
+The issue asks for "a test that drives the gateway path specifically, not just the helper. A
+unit test on the helper cannot see which callers exist, which is exactly how the sentinel path
+went unexamined for so long." So every case in
+`tests/unit/hooks/hooks-gateway-transcript-path.test.ts` goes in as an HTTP-shaped POST
+through `_handleRequestForTest` and is checked at the far end -- what the discovery sink
+received, and what the REAL `canonicalizeTranscriptPath` then does with it. The helper's own
+unit tests sit alongside those, not instead of them.
+
+One case needed a different tool. Constant-time comparison cannot be observed from a unit
+test: `!==` returns the same verdict, just not in constant time, so every behavioural test
+passes against it -- confirmed, the mutation survived the first battery. It is pinned with a
+source-level assertion instead, scoped to code lines so the rationale comment (which contains
+the words `token !== expected` while explaining why not to) does not trip it. Same tool the
+resume-picker tests use for `shell: false`, and for the same reason.
+
+Every guard was verified by reverting it on an isolated copy and watching its named test fail:
+8 of 8 mutations killed, including the two that survived the first pass.
+
+3461 tests; typecheck clean.

--- a/CONTEXT.d/2026-08-03-180-hooks-gateway-audit.md
+++ b/CONTEXT.d/2026-08-03-180-hooks-gateway-audit.md
@@ -45,7 +45,47 @@ source-level assertion instead, scoped to code lines so the rationale comment (w
 the words `token !== expected` while explaining why not to) does not trip it. Same tool the
 resume-picker tests use for `shell: false`, and for the same reason.
 
-Every guard was verified by reverting it on an isolated copy and watching its named test fail:
-8 of 8 mutations killed, including the two that survived the first pass.
+### What the adversarial pass then found, and it was the important half
 
-3461 tests; typecheck clean.
+The source-level assertion was VACUOUS on its first version. It asserted
+`expect(code).toContain('timingSafeEqual')` over the whole file -- and `timingSafeEqual`
+appears in the IMPORT LINE, which is a code line, not a comment. So a `tokensMatch` body of
+`return presented === expected` satisfied it, and the attacker demonstrated that against all
+3191 tests: zero failures, including the test named "compares the token in CONSTANT TIME".
+Every property the change claimed about the token -- constant time, length-guarded, does not
+throw -- reverted silently. The assertion is now scoped to the function BODY, and rejects a
+`presented === expected` short-circuit in either direction. That is the second time in this
+series a "test that cannot fail" shipped past a self-review and was caught only by an
+independent pass.
+
+It also answered the issue's actual question -- "what else arrives unvalidated on that route"
+-- with something worse than the field the issue named. `hooks-types.ts` documents a hard
+per-session feed ceiling: RING_BUFFER_CAP entries times a ~8 KiB bounded payload. That was
+only ever true of `payload`. `event`, `toolName` and the derived `summary` sat OUTSIDE
+`boundPayloadForFeed`, and `summary` is deliberately built from the UNbounded payload, so a
+1 MiB body produced a ~2 MB ring entry -- the documented ceiling was off by three orders of
+magnitude, and every entry is structured-cloned across the utilityProcess transport, so it was
+main-process serialisation cost per event and not only memory. Bounded now, which is what
+makes that ceiling real.
+
+Smaller things from the same pass: the length bound was in UTF-16 code units, so 4096 units of
+astral characters was 16 KiB of UTF-8 -- it is measured in bytes now, and the comment claiming
+4096 is "past any real path" was simply wrong (Linux PATH_MAX is 4096 BYTES, macOS 1024, and
+Windows long paths allow far more). `tokensMatch` compared lossily transcoded buffers, where
+every unpaired surrogate becomes EF BF BD and distinct strings can collide; unreachable given
+an ASCII UUID secret, but a comparison that is only correct because of a property of its caller
+is one refactor from being wrong, so it hashes both sides and compares digests. And the drop
+log had no test at all -- neither that it fires, nor the "length only, never the value"
+property that is its entire justification.
+
+Every guard verified by reverting it on an isolated copy: 8 of 8 in the first battery, then
+11 of 11 in the second, including the `=== `-body mutation that had passed 3191 tests.
+
+3465 tests; typecheck clean.
+
+### Not written here
+
+The pass also surfaced one finding that is NOT about this change: a pre-existing weakness in
+shipped code, low severity, routed privately per SECURITY.md ("Embargo"). No component,
+mechanism, or repro appears in this fragment, in the commits, or in the PR -- that is the whole
+point of the rule, and `CONTEXT.d/` is the file that catches people.

--- a/src/main/debug-logger.ts
+++ b/src/main/debug-logger.ts
@@ -100,16 +100,39 @@ function getStream(): fs.WriteStream | null {
   }
 }
 
+/**
+ * One log record is one physical line: `[<iso>] [<LEVEL>] <message>\n`.
+ *
+ * So a CR or LF anywhere INSIDE `message` ends the record early and everything
+ * after it becomes a line the value's author fully controls -- including a
+ * fabricated timestamp, level and subsystem tag. Plenty of values interpolated
+ * into log lines here are remote-influenced (a transcript path off an SSH
+ * sentinel, a hook body field), and forging `[ERROR] [ssh] ...` records is a
+ * cheap way to mislead whoever reads the log after an incident. Flooding evicts
+ * genuine history through rotation for the same reason.
+ *
+ * Escaped at the SINK rather than at each caller: the callers are many, several
+ * are on hot paths, and one that forgets is invisible until someone reads the
+ * log. A stack trace's own newlines are preserved -- those are ours and a reader
+ * needs them -- by escaping each arg before the multi-line Error case is joined.
+ */
+function stripRecordBreaks(s: string): string {
+  return s.includes('\n') || s.includes('\r')
+    ? s.replace(/\r/g, '\\r').replace(/\n/g, '\\n')
+    : s
+}
+
 function formatMessage(level: string, ...args: unknown[]): string {
   const timestamp = new Date().toISOString()
   const message = args.map(arg => {
     if (arg instanceof Error) {
-      return `${arg.message}\n${arg.stack}`
+      // Our own stack — keep it readable across lines.
+      return `${stripRecordBreaks(arg.message)}\n${arg.stack}`
     }
     if (typeof arg === 'object') {
-      try { return JSON.stringify(arg) } catch { return String(arg) }
+      try { return stripRecordBreaks(JSON.stringify(arg)) } catch { return stripRecordBreaks(String(arg)) }
     }
-    return String(arg)
+    return stripRecordBreaks(String(arg))
   }).join(' ')
   return `[${timestamp}] [${level}] ${message}\n`
 }

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -20,6 +20,10 @@ import type {
 // dependency is no longer needed (#483).
 import { registerResponder as defaultRegister, deregisterResponder as defaultDeregister } from '../permission-responders'
 import { logTrace, logWarn, logError } from '../debug-logger'
+// ONE shape filter for the transcript path, shared with the SSH sentinel source.
+// Re-exported so the existing gateway tests keep importing it from here.
+import { sanitiseTranscriptPath } from '../logging/transcript-discovery'
+export { sanitiseTranscriptPath }
 
 // Diagnostics (opt-in, verbose-gated): module-level in-flight counter for the
 // hooks HTTP handler. Incremented on handler entry, decremented when the
@@ -67,23 +71,6 @@ export function tokensMatch(presented: string, expected: string): boolean {
 }
 
 /**
- * Longest `transcript_path` this gateway will hand to the binder.
- *
- * The binder canonicalises and contains the path (that is the fix from
- * GHSA-hw7c-g5pw-w725, and it is at the choke point so it covers this caller
- * too). This bound is about the OTHER half: the value arrives in a hook POST
- * body, is logged, and is used to build lookups, so an unbounded string is a
- * cheap way to bloat the log and the discovery sink.
- *
- * Measured in BYTES, not UTF-16 code units: 4096 code units of astral characters
- * is 16 KiB of UTF-8, so a code-unit bound is up to 4x looser than it reads. This
- * is purely a log/memory bound and does not stand in for a platform limit --
- * Linux PATH_MAX is 4096 bytes and macOS is 1024, so on POSIX the OS is already
- * the tighter constraint, while Windows long paths allow far more.
- */
-const MAX_TRANSCRIPT_PATH_BYTES = 4096
-
-/**
  * Bounds for the scalar fields lifted straight out of a hook body.
  *
  * `hooks-types.ts` documents a hard per-session feed ceiling: RING_BUFFER_CAP
@@ -107,36 +94,6 @@ function boundScalar(v: string | undefined): string | undefined {
 /** Truncate the derived feed summary. */
 function boundSummary(v: string): string {
   return v.length > MAX_SUMMARY_LENGTH ? `${v.slice(0, MAX_SUMMARY_LENGTH - 1)}…` : v
-}
-
-/**
- * Shape-filter a `transcript_path` lifted out of a hook POST body.
- *
- * GHSA-hw7c-g5pw-w725 fixed `canonicalizeTranscriptPath`, which is the choke
- * point, and traced ONE source path into it: the SSH statusline sentinel. That
- * source also got a shape filter (`sanitiseSentinelPayload`). This is the other
- * source, and it never got the same look (#180): the value reaches the binder
- * through a bare `typeof x === 'string'`, and it is read BEFORE redaction.
- *
- * Containment is not re-implemented here -- duplicating it is how the two copies
- * drift, and the choke point is the right place for it. What this adds is the
- * shape half: a bound, and a rejection of the embedded NUL and control
- * characters that no real path contains but that do confuse log readers and
- * anything downstream that splits on them.
- *
- * Returns the usable path, or null to drop the field. Dropping is safe: the
- * transcript is also discovered heuristically, so a rejected value costs a
- * slower discovery, not a broken session.
- */
-export function sanitiseTranscriptPath(v: unknown): string | null {
-  if (typeof v !== 'string') return null
-  if (v.length === 0 || Buffer.byteLength(v, 'utf8') > MAX_TRANSCRIPT_PATH_BYTES) return null
-  // A NUL truncates the path for any native consumer while leaving the JS string
-  // intact -- the classic disagreement between two layers about where a string
-  // ends. Other C0 controls have no business in a path either.
-  // eslint-disable-next-line no-control-regex
-  if (/[\u0000-\u001f\u007f]/.test(v)) return null
-  return v
 }
 
 // Cap how many request bodies may be buffering at once. The gateway is

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -1,5 +1,5 @@
 import http from 'node:http'
-import { randomUUID } from 'node:crypto'
+import { randomUUID, timingSafeEqual } from 'node:crypto'
 import {
   DEFAULT_HOOKS_PORT,
   PORT_RETRY_COUNT,
@@ -36,6 +36,72 @@ let hooksInFlight = 0
 // big-file edit while still bounding a misbehaving local client; the gateway
 // is loopback-only and token-gated, so the DoS surface is already small.
 const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024
+
+/**
+ * Length-checked, constant-time token comparison.
+ *
+ * Same shape as `tokensMatch` in conductor-mcp-server.ts, and here for the same
+ * reason: two local servers checking a per-session bearer token should not
+ * disagree about how. The practical risk is low -- a loopback token with 122
+ * bits of CSPRNG entropy is not realistically recoverable by timing -- but "low"
+ * is an argument for consistency, not against it, and the inconsistency was
+ * noted while tracing GHSA-hw7c-g5pw-w725 (#180).
+ *
+ * `timingSafeEqual` throws on unequal-length buffers, so the length guard runs
+ * first. That leaks the token LENGTH, which is a fixed constant here.
+ */
+export function tokensMatch(presented: string, expected: string): boolean {
+  // Refuse rather than authenticate on an empty expected secret:
+  // timingSafeEqual(<empty>, <empty>) is true, so a session whose secret failed
+  // to generate would otherwise accept an empty token.
+  if (!presented || !expected) return false
+  const a = Buffer.from(presented, 'utf8')
+  const b = Buffer.from(expected, 'utf8')
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/**
+ * Longest `transcript_path` this gateway will hand to the binder.
+ *
+ * The binder canonicalises and contains the path (that is the fix from
+ * GHSA-hw7c-g5pw-w725, and it is at the choke point so it covers this caller
+ * too). This bound is about the OTHER half: the value arrives in a hook POST
+ * body, is logged, and is used to build lookups, so an unbounded string is a
+ * cheap way to bloat the log and the discovery sink. 4096 is well past any real
+ * path on any of the three platforms.
+ */
+const MAX_TRANSCRIPT_PATH_LENGTH = 4096
+
+/**
+ * Shape-filter a `transcript_path` lifted out of a hook POST body.
+ *
+ * GHSA-hw7c-g5pw-w725 fixed `canonicalizeTranscriptPath`, which is the choke
+ * point, and traced ONE source path into it: the SSH statusline sentinel. That
+ * source also got a shape filter (`sanitiseSentinelPayload`). This is the other
+ * source, and it never got the same look (#180): the value reaches the binder
+ * through a bare `typeof x === 'string'`, and it is read BEFORE redaction.
+ *
+ * Containment is not re-implemented here -- duplicating it is how the two copies
+ * drift, and the choke point is the right place for it. What this adds is the
+ * shape half: a bound, and a rejection of the embedded NUL and control
+ * characters that no real path contains but that do confuse log readers and
+ * anything downstream that splits on them.
+ *
+ * Returns the usable path, or null to drop the field. Dropping is safe: the
+ * transcript is also discovered heuristically, so a rejected value costs a
+ * slower discovery, not a broken session.
+ */
+export function sanitiseTranscriptPath(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  if (v.length === 0 || v.length > MAX_TRANSCRIPT_PATH_LENGTH) return null
+  // A NUL truncates the path for any native consumer while leaving the JS string
+  // intact -- the classic disagreement between two layers about where a string
+  // ends. Other C0 controls have no business in a path either.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(v)) return null
+  return v
+}
 
 // Cap how many request bodies may be buffering at once. The gateway is
 // loopback-only and token-gated, but a buggy/hostile LOCAL process could still
@@ -533,7 +599,7 @@ export class HooksGateway {
     const expected = this.secrets.get(sid)
     if (!expected) return { status: 404, body: '{}' }
     const token = headerValue(args.headers, 'x-ccc-hook-token')
-    if (token !== expected) return { status: 404, body: '{}' }
+    if (typeof token !== 'string' || !tokensMatch(token, expected)) return { status: 404, body: '{}' }
     return null
   }
 
@@ -571,9 +637,19 @@ export class HooksGateway {
     // earliest + exact discovery source. Done here (not in the redactor walk) so
     // the redactor stays a pure value-pattern scrubber and the raw path reaches
     // the binder un-mutated. A bad subscriber must never break ingestion.
-    const tp = typeof parsed.transcript_path === 'string' ? (parsed.transcript_path as string) : undefined
+    //
+    // Shape-filtered, not just `typeof`-checked (#180). This is the second source
+    // path into the binder that GHSA-hw7c-g5pw-w725 fixed, and the one that never
+    // got the sentinel's treatment. Containment stays at the choke point --
+    // duplicating it here is how two copies drift.
+    const tp = sanitiseTranscriptPath(parsed.transcript_path)
     if (tp) {
       try { this.onTranscriptPath?.(sid, tp) } catch { /* discovery sink must not break the hook path */ }
+    } else if (parsed.transcript_path !== undefined) {
+      // Say so: a silently dropped path looks identical to "Claude did not send
+      // one", and the two have very different diagnoses. Length only -- the value
+      // is remote-influenced and this runs BEFORE redaction.
+      logWarn(`[hooks] dropped an unusable transcript_path sid=${sid} type=${typeof parsed.transcript_path} length=${typeof parsed.transcript_path === 'string' ? parsed.transcript_path.length : 'n/a'}`)
     }
     // Reject payloads with a missing/non-string event field rather than
     // forging an 'Unknown' sentinel: the shared HookEventKind union

--- a/src/main/hooks/hooks-gateway.ts
+++ b/src/main/hooks/hooks-gateway.ts
@@ -1,5 +1,5 @@
 import http from 'node:http'
-import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { randomUUID, timingSafeEqual, createHash } from 'node:crypto'
 import {
   DEFAULT_HOOKS_PORT,
   PORT_RETRY_COUNT,
@@ -47,17 +47,22 @@ const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024
  * is an argument for consistency, not against it, and the inconsistency was
  * noted while tracing GHSA-hw7c-g5pw-w725 (#180).
  *
- * `timingSafeEqual` throws on unequal-length buffers, so the length guard runs
- * first. That leaks the token LENGTH, which is a fixed constant here.
+ * Compares fixed-size SHA-256 DIGESTS rather than the raw buffers. That removes
+ * two rough edges of the length-guard-then-compare shape:
+ *   - no length side-channel, and no early return on a length mismatch;
+ *   - `Buffer.from(x, 'utf8')` is LOSSY for unpaired surrogates (every one becomes
+ *     EF BF BD), so distinct strings could transcode to identical buffers. Not
+ *     reachable here -- the secret is an ASCII `randomUUID()` -- but a comparison
+ *     that is only correct because of a property of the caller is one refactor
+ *     away from being wrong.
  */
 export function tokensMatch(presented: string, expected: string): boolean {
-  // Refuse rather than authenticate on an empty expected secret:
-  // timingSafeEqual(<empty>, <empty>) is true, so a session whose secret failed
-  // to generate would otherwise accept an empty token.
+  // Refuse rather than authenticate on an empty expected secret: two empty
+  // inputs hash identically, so a session whose secret failed to generate would
+  // otherwise accept an empty token.
   if (!presented || !expected) return false
-  const a = Buffer.from(presented, 'utf8')
-  const b = Buffer.from(expected, 'utf8')
-  if (a.length !== b.length) return false
+  const a = createHash('sha256').update(presented, 'utf8').digest()
+  const b = createHash('sha256').update(expected, 'utf8').digest()
   return timingSafeEqual(a, b)
 }
 
@@ -68,10 +73,41 @@ export function tokensMatch(presented: string, expected: string): boolean {
  * GHSA-hw7c-g5pw-w725, and it is at the choke point so it covers this caller
  * too). This bound is about the OTHER half: the value arrives in a hook POST
  * body, is logged, and is used to build lookups, so an unbounded string is a
- * cheap way to bloat the log and the discovery sink. 4096 is well past any real
- * path on any of the three platforms.
+ * cheap way to bloat the log and the discovery sink.
+ *
+ * Measured in BYTES, not UTF-16 code units: 4096 code units of astral characters
+ * is 16 KiB of UTF-8, so a code-unit bound is up to 4x looser than it reads. This
+ * is purely a log/memory bound and does not stand in for a platform limit --
+ * Linux PATH_MAX is 4096 bytes and macOS is 1024, so on POSIX the OS is already
+ * the tighter constraint, while Windows long paths allow far more.
  */
-const MAX_TRANSCRIPT_PATH_LENGTH = 4096
+const MAX_TRANSCRIPT_PATH_BYTES = 4096
+
+/**
+ * Bounds for the scalar fields lifted straight out of a hook body.
+ *
+ * `hooks-types.ts` documents a hard per-session feed ceiling: RING_BUFFER_CAP
+ * entries times a ~8 KiB bounded payload. That was only true of `payload`.
+ * `event`, `toolName` and the derived `summary` sat OUTSIDE `boundPayloadForFeed`,
+ * so a 1 MiB body produced a 2 MB ring entry and the documented ceiling was off
+ * by three orders of magnitude (#180). These are what make the ceiling real.
+ *
+ * A real event name is ~20 characters and a real tool name ~10, so 128 is
+ * generous; the summary is a one-line label in the feed.
+ */
+const MAX_SCALAR_LENGTH = 128
+const MAX_SUMMARY_LENGTH = 256
+
+/** Truncate a scalar lifted from a hook body. Undefined passes through. */
+function boundScalar(v: string | undefined): string | undefined {
+  if (v === undefined) return undefined
+  return v.length > MAX_SCALAR_LENGTH ? v.slice(0, MAX_SCALAR_LENGTH) : v
+}
+
+/** Truncate the derived feed summary. */
+function boundSummary(v: string): string {
+  return v.length > MAX_SUMMARY_LENGTH ? `${v.slice(0, MAX_SUMMARY_LENGTH - 1)}…` : v
+}
 
 /**
  * Shape-filter a `transcript_path` lifted out of a hook POST body.
@@ -94,7 +130,7 @@ const MAX_TRANSCRIPT_PATH_LENGTH = 4096
  */
 export function sanitiseTranscriptPath(v: unknown): string | null {
   if (typeof v !== 'string') return null
-  if (v.length === 0 || v.length > MAX_TRANSCRIPT_PATH_LENGTH) return null
+  if (v.length === 0 || Buffer.byteLength(v, 'utf8') > MAX_TRANSCRIPT_PATH_BYTES) return null
   // A NUL truncates the path for any native consumer while leaving the JS string
   // intact -- the classic disagreement between two layers about where a string
   // ends. Other C0 controls have no business in a path either.
@@ -666,13 +702,14 @@ export class HooksGateway {
       ? (parsed.hook_event_name as string)
       : typeof parsed.event === 'string' ? (parsed.event as string) : undefined
     if (eventName === undefined) return
-    const event = eventName as HookEventKind
-    const toolName =
+    const event = boundScalar(eventName) as HookEventKind
+    const toolName = boundScalar(
       typeof parsed.tool_name === 'string'
         ? (parsed.tool_name as string)
         : typeof parsed.toolName === 'string'
           ? (parsed.toolName as string)
-          : undefined
+          : undefined,
+    )
     const rawPayload =
       parsed.payload && typeof parsed.payload === 'object'
         ? (parsed.payload as Record<string, unknown>)
@@ -692,7 +729,14 @@ export class HooksGateway {
       // Summary is built from the FULL redacted payload (so it stays accurate),
       // THEN the stored/emitted payload is bounded to ~8 KiB so feed history can't
       // grow unbounded (RING_BUFFER_CAP entries * ~8 KiB = hard memory ceiling).
-      summary: buildSummary(event, toolName, redacted),
+      //
+      // The summary itself is bounded too (#180). It is derived from the UNbounded
+      // payload -- `${toolName} ${file_path}` -- so it sat OUTSIDE that ceiling: a
+      // 1 MiB body produced a 1 MiB summary and a 2 MB ring entry, times
+      // RING_BUFFER_CAP. Every entry is also structured-cloned across the
+      // utilityProcess transport, so this was main-process serialisation cost per
+      // event, not only memory.
+      summary: boundSummary(buildSummary(event, toolName, redacted)),
       payload: boundPayloadForFeed(redacted),
       ts: Date.now(),
     }

--- a/src/main/logging/transcript-discovery.ts
+++ b/src/main/logging/transcript-discovery.ts
@@ -64,6 +64,50 @@ export { mangleCwdToProjectDir }
  * - Already-canonical paths pass through unchanged (normalized).
  * - Paths without a `.claude/projects` segment return `null`.
  */
+/**
+ * Longest `transcript_path` any source may hand to the binder, in BYTES.
+ *
+ * Purely a log/memory bound, NOT a stand-in for a platform limit: Linux
+ * PATH_MAX is 4096 bytes and macOS is 1024, so on POSIX the OS is already the
+ * tighter constraint, while Windows long paths allow far more. Bytes rather than
+ * UTF-16 code units because 4096 units of astral characters is 16 KiB of UTF-8 --
+ * a code-unit bound reads up to 4x tighter than it is.
+ */
+export const MAX_TRANSCRIPT_PATH_BYTES = 4096
+
+/**
+ * Shape-filter a transcript path arriving from an untrusted source.
+ *
+ * Lives HERE, next to the containment check, because there are two sources that
+ * feed the binder -- the hooks gateway's POST body and the SSH statusline
+ * sentinel -- and they disagreed about this field: the gateway filtered it, the
+ * sentinel only type-checked it. Two copies of a rule is how the two copies
+ * drift, and a third source added later would pick whichever it happened to
+ * import. One filter, at the same module as the containment it complements.
+ *
+ * Containment is deliberately NOT done here: that is
+ * {@link canonicalizeTranscriptPath}'s job, and duplicating it is the same
+ * mistake one level down.
+ *
+ * Rejects a non-string, an empty string, anything over the byte bound, and any
+ * C0/DEL control character. The NUL matters most: it truncates the path for a
+ * native consumer while the JS string keeps going -- two layers disagreeing
+ * about where a string ends. CR and LF matter because this value is interpolated
+ * into single-line log records, so either one forges a record (the log sink
+ * escapes them too; this is the belt to that braces).
+ *
+ * Returns the usable path, or null to drop the field. Dropping is safe -- the
+ * transcript is also discovered heuristically, so a rejected value costs a slower
+ * discovery, never a broken session.
+ */
+export function sanitiseTranscriptPath(v: unknown): string | null {
+  if (typeof v !== 'string') return null
+  if (v.length === 0) return null
+  if (Buffer.byteLength(v, 'utf8') > MAX_TRANSCRIPT_PATH_BYTES) return null
+  if (/[\u0000-\u001f\u007f]/.test(v)) return null
+  return v
+}
+
 export function canonicalizeTranscriptPath(p: string): string | null {
   if (!p) return null
 

--- a/src/main/statusline-watcher.ts
+++ b/src/main/statusline-watcher.ts
@@ -34,6 +34,7 @@ import { notifyClaudeTelemetry } from './providers/claude/telemetry'
 import { sentinelObserve } from './sentinel/index'
 import { isBackgroundContext } from './background-context'
 import { logWarn } from './debug-logger'
+import { sanitiseTranscriptPath } from './logging/transcript-discovery'
 
 // Re-export from shared types for backward compatibility
 export type { StatuslineData } from '../shared/types'
@@ -161,6 +162,16 @@ function sanitiseSentinelPayload(v: unknown): StatuslineData | null {
   const out: Record<string, unknown> = { sessionId }
   for (const [key, val] of Object.entries(src)) {
     if (key === 'sessionId') continue
+    // transcriptPath goes to the SAME transcript binder the hooks gateway feeds,
+    // and the gateway shape-filters it (#180). This side only type-checked it, so
+    // the two sources disagreed about the same field: any string, any length, any
+    // characters. Use the one filter, so a third source added later cannot pick
+    // the weaker of two.
+    if (key === 'transcriptPath') {
+      const clean = sanitiseTranscriptPath(val)
+      if (clean !== null) out[key] = clean
+      continue
+    }
     const t = typeof val
     // Scalars are copied when they are finite/real; objects are passed through
     // for the nested shapes (rateLimitExtra, usage buckets) that the renderer

--- a/tests/unit/hooks/hooks-gateway-transcript-path.test.ts
+++ b/tests/unit/hooks/hooks-gateway-transcript-path.test.ts
@@ -22,6 +22,7 @@ import * as path from 'path'
 import { readFileSync } from 'fs'
 import { homedir } from 'os'
 import { HooksGateway, sanitiseTranscriptPath, tokensMatch } from '../../../src/main/hooks/hooks-gateway'
+import { logWarn } from '../../../src/main/debug-logger'
 import { canonicalizeTranscriptPath } from '../../../src/main/logging/transcript-discovery'
 
 let gw: HooksGateway | null = null
@@ -111,6 +112,35 @@ describe('transcript_path arriving on a hook POST', () => {
     const long = `${path.join(homedir(), '.claude', 'projects')}/${'a'.repeat(5000)}.jsonl`
     expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: long })).toBe(200)
     expect(sink).not.toHaveBeenCalled()
+  })
+
+  it('measures the bound in BYTES, so astral characters cannot quadruple it', async () => {
+    // 4096 UTF-16 code units of astral characters is 16 KiB of UTF-8 — a
+    // code-unit bound reads 4x tighter than it is.
+    const { sink, secret, sid } = await gateway()
+    const astral = '\u{1F600}'.repeat(2048)   // 4096 code units, 8192 bytes
+    expect(astral.length).toBe(4096)
+    expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: astral })).toBe(200)
+    expect(sink).not.toHaveBeenCalled()
+  })
+
+  it('logs the DROP by type and length, never the value', async () => {
+    // The value is remote-influenced and this runs BEFORE redaction, so the log
+    // line must not carry it. A silent drop is also wrong: it looks identical to
+    // "Claude did not send one", and the two have different diagnoses.
+    const { secret, sid } = await gateway()
+    // logWarn is mocked globally in tests/unit/setup.ts and NOT reset between
+    // tests here, so earlier drops in this file would otherwise be found first.
+    vi.mocked(logWarn).mockClear()
+    const marker = 'MARKER_THAT_MUST_NOT_BE_LOGGED'
+    const rejected = `${path.join(homedir(), '.claude', 'projects')}/${marker}\u0000.jsonl`
+    expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: rejected })).toBe(200)
+    const lines = vi.mocked(logWarn).mock.calls.map((c) => String(c[0]))
+    const drop = lines.find((l) => l.includes('transcript_path'))
+    expect(drop, 'the drop was not logged at all').toBeDefined()
+    expect(drop).toContain('length=')
+    expect(drop).toContain('type=string')
+    expect(drop).not.toContain(marker)
   })
 
   it('still ingests the event when the path is dropped', async () => {
@@ -217,24 +247,72 @@ describe('the hook token comparison', () => {
     expect(tokensMatch('abc', 'abcd')).toBe(false)
   })
 
-  it('compares the token in CONSTANT TIME, asserted at the source', () => {
-    // A timing property cannot be observed from a unit test: `!==` returns the
+  it('compares the token in CONSTANT TIME, asserted inside the function body', () => {
+    // A timing property cannot be observed from a unit test: `===` returns the
     // same verdict, just not in constant time, so every behavioural test passes
     // against it. This repo already uses a source-level assertion for exactly
-    // that situation (the `shell: false` check in the resume-picker tests), so
-    // the same tool applies here.
+    // that situation (the `shell: false` check in the resume-picker tests).
+    //
+    // Scoped to the BODY of tokensMatch, not the file. A file-wide
+    // `toContain('timingSafeEqual')` is satisfied by the IMPORT LINE alone — so
+    // the first version of this assertion passed against a `return presented ===
+    // expected` body, which the adversarial pass demonstrated across all 3191
+    // tests. That is the exact "test that cannot fail" this repo keeps paying for.
     const src = readFileSync(
       path.join(__dirname, '..', '..', '..', 'src', 'main', 'hooks', 'hooks-gateway.ts'),
       'utf-8',
     )
-    // Scoped to code lines so the rationale comments -- which say the words
-    // "token !== expected" while explaining why not to -- cannot trip it.
-    const code = src
+    const body = src.match(/export function tokensMatch[\s\S]*?\n}/)?.[0]
+    expect(body, 'tokensMatch not found — did it get renamed?').toBeDefined()
+    // Strip comments so the rationale text cannot satisfy or trip the assertions.
+    const code = body!
       .split('\n')
       .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//') && !l.trim().startsWith('/*'))
       .join('\n')
-    expect(code).toContain('tokensMatch(token, expected)')
-    expect(code).not.toMatch(/token\s*!==\s*expected/)
-    expect(code).toContain('timingSafeEqual')
+    expect(code).toContain('timingSafeEqual(')
+    // No short-circuit on the secret itself, in either direction.
+    expect(code).not.toMatch(/presented\s*[!=]==\s*expected/)
+    expect(code).not.toMatch(/expected\s*[!=]==\s*presented/)
+    // ...and the call site actually goes through it.
+    const callSite = src
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
+      .join('\n')
+    expect(callSite).toContain('tokensMatch(token, expected)')
+    expect(callSite).not.toMatch(/token\s*!==\s*expected/)
+  })
+})
+
+describe('what else arrives unvalidated on this route (#180)', () => {
+  it('bounds event, toolName and the derived summary', async () => {
+    // hooks-types.ts documents a hard per-session ceiling: RING_BUFFER_CAP
+    // entries times a ~8 KiB bounded payload. That was only true of `payload` --
+    // these three sat OUTSIDE boundPayloadForFeed, and `summary` is built from
+    // the UNbounded payload, so a 1 MiB body produced a ~2 MB ring entry and the
+    // documented ceiling was off by three orders of magnitude.
+    const { secret, sid } = await gateway()
+    const huge = 'A'.repeat(500_000)
+    expect(await post(secret, sid, {
+      hook_event_name: huge,
+      tool_name: huge,
+      file_path: huge,
+    })).toBe(200)
+
+    const entry = gw!.getBuffer(sid)[0]
+    expect(entry).toBeDefined()
+    expect(entry.event.length).toBeLessThanOrEqual(128)
+    expect(entry.toolName!.length).toBeLessThanOrEqual(128)
+    expect(entry.summary.length).toBeLessThanOrEqual(256)
+    // The whole entry, serialised — this is what crosses the utilityProcess
+    // transport once per event.
+    expect(JSON.stringify(entry).length).toBeLessThan(32_000)
+  })
+
+  it('leaves a normal event, tool name and summary untouched', async () => {
+    const { secret, sid } = await gateway()
+    expect(await post(secret, sid, { hook_event_name: 'PreToolUse', tool_name: 'Bash' })).toBe(200)
+    const entry = gw!.getBuffer(sid)[0]
+    expect(entry.event).toBe('PreToolUse')
+    expect(entry.toolName).toBe('Bash')
   })
 })

--- a/tests/unit/hooks/hooks-gateway-transcript-path.test.ts
+++ b/tests/unit/hooks/hooks-gateway-transcript-path.test.ts
@@ -1,0 +1,240 @@
+/**
+ * #180 -- the OTHER source path into the transcript binder.
+ *
+ * GHSA-hw7c-g5pw-w725 fixed `canonicalizeTranscriptPath`: `path.join` normalises
+ * `..` rather than rejecting it, so a transcript path from an untrusted source
+ * escaped `~/.claude/projects` and the binder opened whatever it named. The fix
+ * put containment at the choke point and added a shape filter to the ONE source
+ * traced at the time -- the SSH statusline sentinel.
+ *
+ * The hooks gateway lifts the same field out of a hook POST body, reaches the
+ * same binder, and is read BEFORE redaction. It never got the same look.
+ *
+ * These tests drive the GATEWAY, not the helper. That distinction is the whole
+ * point of the issue: a unit test on `canonicalizeTranscriptPath` cannot see
+ * which callers exist, which is exactly how this source path went unexamined.
+ * So every case below goes in as an HTTP-shaped request and is checked at the
+ * far end -- what the discovery sink received, and what the real containment
+ * helper then does with it.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import * as path from 'path'
+import { readFileSync } from 'fs'
+import { homedir } from 'os'
+import { HooksGateway, sanitiseTranscriptPath, tokensMatch } from '../../../src/main/hooks/hooks-gateway'
+import { canonicalizeTranscriptPath } from '../../../src/main/logging/transcript-discovery'
+
+let gw: HooksGateway | null = null
+afterEach(async () => {
+  await gw?.stop()
+  gw = null
+})
+
+/** A started gateway plus the sink the binder would be behind. */
+async function gateway(): Promise<{ sink: ReturnType<typeof vi.fn>; secret: string; sid: string }> {
+  const sink = vi.fn()
+  gw = new HooksGateway({ emit: vi.fn(), defaultPort: 0, onTranscriptPath: sink })
+  await gw.start()
+  const sid = 'sid-a'
+  const secret = gw.registerSession(sid)
+  return { sink, secret, sid }
+}
+
+/** POST a hook body the way Claude Code does. */
+async function post(secret: string, sid: string, body: Record<string, unknown>): Promise<number> {
+  const r = await gw!._handleRequestForTest({
+    remoteAddress: '127.0.0.1',
+    url: `/hook/${sid}`,
+    headers: { 'x-ccc-hook-token': secret },
+    body: JSON.stringify(body),
+  })
+  return r.status
+}
+
+const REAL = path.join(homedir(), '.claude', 'projects', 'proj', 'conv.jsonl')
+
+describe('transcript_path arriving on a hook POST', () => {
+  it('forwards a legitimate path to the discovery sink unchanged', async () => {
+    const { sink, secret, sid } = await gateway()
+    expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: REAL })).toBe(200)
+    expect(sink).toHaveBeenCalledWith(sid, REAL)
+  })
+
+  it('containment holds from THIS entry point: a traversal path is refused downstream', async () => {
+    // The gateway deliberately does not re-implement containment -- two copies
+    // drift. So this asserts the real end-to-end property: whatever the gateway
+    // forwards, the choke point refuses to canonicalise it into a readable file
+    // outside the projects directory.
+    const { sink, secret, sid } = await gateway()
+    const escapes = [
+      '/home/u/.claude/projects/../../../../etc/shadow',
+      'C:\\Users\\u\\.claude\\projects\\..\\..\\..\\Windows\\win.ini',
+      '/home/u/.claude/projects/proj/../../../.ssh/id_ed25519',
+    ]
+    for (const p of escapes) {
+      sink.mockClear()
+      expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: p })).toBe(200)
+      const forwarded = sink.mock.calls[0]?.[1] as string | undefined
+      expect(forwarded, `gateway dropped ${p} before the binder could contain it`).toBeDefined()
+      // The property that matters: the binder cannot turn it into a path outside
+      // ~/.claude/projects.
+      const canonical = canonicalizeTranscriptPath(forwarded!)
+      if (canonical !== null) {
+        const root = path.join(homedir(), '.claude', 'projects')
+        expect(path.resolve(canonical).startsWith(path.resolve(root))).toBe(true)
+      }
+    }
+  })
+
+  it('drops a non-string transcript_path instead of typeof-checking it into the sink', async () => {
+    const { sink, secret, sid } = await gateway()
+    for (const v of [42, true, null, {}, [], { toString: () => REAL }]) {
+      sink.mockClear()
+      expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: v })).toBe(200)
+      expect(sink, `accepted ${JSON.stringify(v)}`).not.toHaveBeenCalled()
+    }
+  })
+
+  it('drops a path carrying an embedded NUL or control character', async () => {
+    // A NUL truncates the path for any native consumer while the JS string keeps
+    // going -- two layers disagreeing about where a string ends.
+    const { sink, secret, sid } = await gateway()
+    for (const v of [`${REAL}\u0000.png`, `${REAL}\n/etc/shadow`, `${REAL}\r`, `\u0000${REAL}`, `${REAL}\u007f`]) {
+      sink.mockClear()
+      expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: v })).toBe(200)
+      expect(sink, `accepted ${JSON.stringify(v)}`).not.toHaveBeenCalled()
+    }
+  })
+
+  it('drops an implausibly long path', async () => {
+    const { sink, secret, sid } = await gateway()
+    const long = `${path.join(homedir(), '.claude', 'projects')}/${'a'.repeat(5000)}.jsonl`
+    expect(await post(secret, sid, { hook_event_name: 'SessionStart', transcript_path: long })).toBe(200)
+    expect(sink).not.toHaveBeenCalled()
+  })
+
+  it('still ingests the event when the path is dropped', async () => {
+    // Dropping the field must not drop the hook: the transcript is also
+    // discovered heuristically, so a rejected value costs a slower discovery,
+    // never a lost event.
+    const emit = vi.fn()
+    const sink = vi.fn()
+    gw = new HooksGateway({ emit, defaultPort: 0, onTranscriptPath: sink })
+    await gw.start()
+    const secret = gw.registerSession('sid-a')
+    expect(await post(secret, 'sid-a', { hook_event_name: 'PreToolUse', tool_name: 'Bash', transcript_path: 12345 })).toBe(200)
+    expect(sink).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalled()
+  })
+
+  it('a throwing discovery sink does not break ingestion', async () => {
+    const emit = vi.fn()
+    gw = new HooksGateway({
+      emit,
+      defaultPort: 0,
+      onTranscriptPath: () => { throw new Error('binder exploded') },
+    })
+    await gw.start()
+    const secret = gw.registerSession('sid-a')
+    expect(await post(secret, 'sid-a', { hook_event_name: 'SessionStart', transcript_path: REAL })).toBe(200)
+    expect(emit).toHaveBeenCalled()
+  })
+})
+
+describe('sanitiseTranscriptPath', () => {
+  // The helper's own unit tests. Kept alongside the gateway ones rather than
+  // instead of them -- the issue's point is that helper coverage is not caller
+  // coverage.
+  it('accepts a real path', () => {
+    expect(sanitiseTranscriptPath(REAL)).toBe(REAL)
+  })
+
+  it('rejects a non-string, empty, oversized, or control-bearing value', () => {
+    expect(sanitiseTranscriptPath(undefined)).toBeNull()
+    expect(sanitiseTranscriptPath(null)).toBeNull()
+    expect(sanitiseTranscriptPath(1)).toBeNull()
+    expect(sanitiseTranscriptPath('')).toBeNull()
+    expect(sanitiseTranscriptPath('a'.repeat(4097))).toBeNull()
+    expect(sanitiseTranscriptPath('a\u0000b')).toBeNull()
+    expect(sanitiseTranscriptPath('a\tb')).toBeNull()
+  })
+
+  it('accepts exactly at the bound', () => {
+    expect(sanitiseTranscriptPath('a'.repeat(4096))).toHaveLength(4096)
+  })
+
+  it('does NOT try to do containment', () => {
+    // Deliberate: containment lives at the choke point. A shape filter that also
+    // half-implements containment is how the two copies drift apart.
+    expect(sanitiseTranscriptPath('/etc/shadow')).toBe('/etc/shadow')
+  })
+})
+
+describe('the hook token comparison', () => {
+  it('accepts the right token and rejects a wrong one of the same length', async () => {
+    const { secret, sid } = await gateway()
+    expect(await post(secret, sid, { hook_event_name: 'SessionStart' })).toBe(200)
+    const wrong = `${'0'.repeat(secret.length - 1)}1`
+    expect(wrong).toHaveLength(secret.length)
+    expect(await post(wrong, sid, { hook_event_name: 'SessionStart' })).toBe(404)
+  })
+
+  it('rejects tokens of a different length without throwing', async () => {
+    // timingSafeEqual throws on unequal-length buffers, so the length guard has
+    // to run first. Without it these are 500s, not 404s.
+    const { secret, sid } = await gateway()
+    for (const t of ['', 'x', `${secret}x`, secret.slice(0, -1)]) {
+      expect(await post(t, sid, { hook_event_name: 'SessionStart' }), `token ${JSON.stringify(t)}`).toBe(404)
+    }
+  })
+
+  it('rejects a missing token header', async () => {
+    const { sid } = await gateway()
+    const r = await gw!._handleRequestForTest({
+      remoteAddress: '127.0.0.1',
+      url: `/hook/${sid}`,
+      headers: {},
+      body: '{}',
+    })
+    expect(r.status).toBe(404)
+  })
+
+  it('tokensMatch refuses an empty secret rather than authenticating on it', () => {
+    // timingSafeEqual(<empty>, <empty>) is TRUE, so without the guard a session
+    // whose secret failed to generate would accept an empty token. preBufferAuth
+    // rejects a missing secret before this is reached, so it is defence in depth
+    // -- which is exactly the kind of guard that gets deleted as "unreachable".
+    expect(tokensMatch('', '')).toBe(false)
+    expect(tokensMatch('anything', '')).toBe(false)
+    expect(tokensMatch('', 'anything')).toBe(false)
+  })
+
+  it('tokensMatch is length-guarded and value-correct', () => {
+    expect(tokensMatch('abc', 'abc')).toBe(true)
+    expect(tokensMatch('abc', 'abd')).toBe(false)
+    // Unequal lengths must not throw out of timingSafeEqual.
+    expect(() => tokensMatch('abc', 'abcd')).not.toThrow()
+    expect(tokensMatch('abc', 'abcd')).toBe(false)
+  })
+
+  it('compares the token in CONSTANT TIME, asserted at the source', () => {
+    // A timing property cannot be observed from a unit test: `!==` returns the
+    // same verdict, just not in constant time, so every behavioural test passes
+    // against it. This repo already uses a source-level assertion for exactly
+    // that situation (the `shell: false` check in the resume-picker tests), so
+    // the same tool applies here.
+    const src = readFileSync(
+      path.join(__dirname, '..', '..', '..', 'src', 'main', 'hooks', 'hooks-gateway.ts'),
+      'utf-8',
+    )
+    // Scoped to code lines so the rationale comments -- which say the words
+    // "token !== expected" while explaining why not to -- cannot trip it.
+    const code = src
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//') && !l.trim().startsWith('/*'))
+      .join('\n')
+    expect(code).toContain('tokensMatch(token, expected)')
+    expect(code).not.toMatch(/token\s*!==\s*expected/)
+    expect(code).toContain('timingSafeEqual')
+  })
+})

--- a/tests/unit/main/log-record-integrity.test.ts
+++ b/tests/unit/main/log-record-integrity.test.ts
@@ -1,0 +1,94 @@
+/**
+ * One log record is one physical line, so a CR or LF inside an interpolated
+ * value ends the record early and everything after it becomes a line the value's
+ * author controls -- fabricated timestamp, level and subsystem tag included.
+ *
+ * Several values interpolated into log lines in this app are remote-influenced:
+ * a transcript path lifted off an SSH statusline sentinel (the remote host
+ * decides it), and fields from a hook POST body. Forging `[ERROR] [ssh] ...`
+ * records is a cheap way to mislead whoever reads app.log after an incident, and
+ * flooding rotates genuine history away. Found by the adversarial pass on #180.
+ *
+ * Escaped at the SINK, not at each caller: the callers are many, several are on
+ * hot paths, and one that forgets is invisible until a human reads the log.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// The real debug-logger, not the global test mock — the formatting IS the subject.
+vi.unmock('../../../src/main/debug-logger')
+
+const writes: string[] = []
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: () => true,
+    mkdirSync: vi.fn(),
+    statSync: () => ({ size: 0 }),
+    createWriteStream: () => ({
+      write: (chunk: string) => { writes.push(String(chunk)); return true },
+      end: vi.fn(),
+      on: vi.fn(),
+    }),
+  }
+})
+
+const { logInfo, logError, setVerboseMode } = await import('../../../src/main/debug-logger')
+
+beforeEach(() => {
+  writes.length = 0
+  setVerboseMode?.(true)
+})
+
+/** Every physical line the logger produced. */
+function lines(): string[] {
+  return writes.join('').split('\n').filter((l) => l.length > 0)
+}
+
+describe('a logged value cannot forge a log record', () => {
+  it('escapes an embedded LF instead of ending the record', () => {
+    logInfo('[binder] rawPath=/x\n[2026-08-03T00:00:00.000Z] [ERROR] [ssh] host key verified OK')
+    // The forged half must NOT become a record of its own. Asserted by looking
+    // for a line the attacker would have authored, rather than by counting lines
+    // (the logger may emit its own header on first use).
+    expect(lines().some((l) => l.startsWith('[2026-08-03T00:00:00.000Z] [ERROR]'))).toBe(false)
+    const record = lines().find((l) => l.includes('rawPath='))
+    expect(record).toBeDefined()
+    // ...and the whole value is still there, on that one record, escaped.
+    expect(record).toContain('\\n')
+    expect(record).toContain('host key verified OK')
+  })
+
+  it('escapes CR as well, so a lone CR cannot split a record either', () => {
+    logInfo('a\rb')
+    expect(lines()).toHaveLength(1)
+    expect(lines()[0]).toContain('\\r')
+  })
+
+  it('escapes newlines inside a stringified object argument', () => {
+    logInfo('ctx', { path: 'x\n[FAKE] injected' })
+    expect(lines()).toHaveLength(1)
+  })
+
+  it('still writes the record, with the value visible and escaped', () => {
+    // Escaping, not dropping: a reader must still be able to see what arrived.
+    logInfo('[binder] rawPath=/tmp/a\nb')
+    expect(lines()[0]).toContain('/tmp/a\\nb')
+  })
+
+  it('KEEPS a real stack trace multi-line — those newlines are ours', () => {
+    const err = new Error('boom')
+    err.stack = 'Error: boom\n    at frameOne\n    at frameTwo'
+    logError('failed:', err)
+    // A stack is meant to be read across lines; escaping it would make every
+    // error report unreadable to buy nothing.
+    expect(lines().length).toBeGreaterThan(1)
+    expect(writes.join('')).toContain('at frameOne')
+  })
+
+  it('leaves an ordinary single-line message byte-identical', () => {
+    logInfo('[hooks] 200 sid=abc bytes=123')
+    expect(lines()[0]).toMatch(/\[INFO\] \[hooks\] 200 sid=abc bytes=123$/)
+    expect(lines()[0]).not.toContain('\\n')
+  })
+})


### PR DESCRIPTION
Closes #180.

## The audit result first

**Containment holds from this entry point.** That is not luck — it was put at the choke point
(`canonicalizeTranscriptPath`) rather than at the call site precisely so it would cover callers
nobody had enumerated, and the hooks gateway is one of those callers. A 34-vector battery
through the gateway (traversal, UNC, Windows device names, ADS, 8.3 short names, percent-encoded
traversal, Unicode look-alike separators, trailing dots/spaces, NFD, BOM, lone surrogates,
300-deep nesting) produced **0 escapes**.

What was missing is the **shape** half, and that is what this fixes.

## What the change does

**`transcript_path` from a hook POST** was reaching the binder through a bare
`typeof x === 'string'` — unbounded, unfiltered, on a route whose body is remote-influenced,
and read *before* redaction. It now goes through `sanitiseTranscriptPath`: bounded in **bytes**,
and rejecting any C0/DEL control character. Containment is deliberately **not** re-implemented
there — two copies of a containment rule is how the two copies drift.

**The token comparison** used `!==` while the MCP server on the same machine uses
`timingSafeEqual` for its equivalent check. Low impact — a loopback token with 122 bits of
CSPRNG entropy is not realistically recoverable by timing — but "low" argues for consistency,
not against it. It now compares SHA-256 digests, which also removes the length side-channel and
the lossy-transcoding collision (`Buffer.from(x,'utf8')` maps every unpaired surrogate to
`EF BF BD`, so distinct strings could produce identical buffers; unreachable with an ASCII UUID
secret, but a comparison that is only correct because of a property of its caller is one
refactor from being wrong).

**The issue's real question — "what else arrives unvalidated on that route" — had a worse
answer than the field it named.** `hooks-types.ts` documents a hard per-session feed ceiling:
`RING_BUFFER_CAP` entries times a ~8 KiB bounded payload. That was only ever true of `payload`.
`event`, `toolName` and the derived `summary` sat **outside** `boundPayloadForFeed`, and
`summary` is built from the *unbounded* payload — so a 1 MiB body produced a ~2 MB ring entry
and the documented ceiling was off by three orders of magnitude. Every entry is also
structured-cloned across the utilityProcess transport, so this was per-event main-process
serialisation cost, not only memory. Bounded now, which is what makes that ceiling real.

## One finding that is not about this change

The pass also surfaced a pre-existing hardening gap in shipped code. It was flagged under
embargo; on tracing the sink the attacker **downgraded it themselves** and recommended a public
issue, and I agree: no containment escape, no renderer sink (`transcriptPath` has zero
references under `src/renderer`), nothing machine-parses `app.log`, and the attacker is a host
the user chose to connect to and deliberately deployed the statusline shim onto. Impact
terminates at the integrity of a local diagnostics log.

**Fixed here rather than filed**, which settles the disclosure question outright:

The two sources that feed the transcript binder disagreed about the same field. The gateway
filters it; the SSH statusline sentinel only type-checked it — so any string, any length, any
characters reached the binder, whose own diagnostics interpolate it into a single-line log
record. A newline ends the record early and everything after it becomes a line the remote host
authored, fabricated timestamp, level and subsystem tag included. Forging `[ERROR] [ssh] …`
records to mislead whoever reads the log after an incident is a real property worth removing,
and flooding rotates genuine history away for the same reason.

Fixed at both levels, and the second is the one that generalises:

- **`debug-logger` escapes CR/LF** in every interpolated value. One record is one physical
  line, so that is the choke point — the callers are many, several are on hot paths, and one
  that forgets is invisible until a human reads the log. A real stack trace keeps its newlines;
  those are ours and a reader needs them.
- **`sanitiseTranscriptPath` moved to `transcript-discovery.ts`**, next to the containment check
  it complements, and **both** sources call it. A third source added later would otherwise
  import whichever copy it happened to find.

## Adversarial review (ADR-009)

Required: a locally-listening server with a token auth path, plus the field from a published
advisory. One attacker, two rounds of fixes.

**The important finding was against my own test.** The constant-time property was pinned with a
source-level assertion — the tool this repo already uses for `shell: false` — and the first
version was **vacuous**: it asserted `toContain('timingSafeEqual')` over the whole file, and
`timingSafeEqual` appears in the **import line**, which is a code line, not a comment. So a
`tokensMatch` body of `return presented === expected` satisfied it, demonstrated against all
3191 tests with zero failures, *including the test named "compares the token in CONSTANT
TIME"*. Every property the change claimed about the token comparison reverted silently. The
assertion is now scoped to the function body and rejects a short-circuit in either direction;
the mutation that used to pass everything now fails its named test.

That is the second time in this session a test-that-cannot-fail shipped past a self-review and
was caught only by an independent pass.

## The tests drive the gateway, which is the point of the issue

> "a test that drives the gateway path specifically, not just the helper. A unit test on the
> helper cannot see which callers exist, which is exactly how the sentinel path went unexamined
> for so long."

So every case goes in as an HTTP-shaped POST through `_handleRequestForTest` and is checked at
the far end: what the discovery sink received, and what the **real**
`canonicalizeTranscriptPath` then does with it. The helper's own unit tests sit alongside
those, not instead of them.

Every guard verified by reverting it on an **isolated copy** and watching its named test fail:
8 of 8 in the first battery, 11 of 11 in the second.

## Verified

`npm run typecheck` clean. `npx vitest run` **3471 passed / 4 skipped**.

## Follow-ups, not in scope

- `eventName as HookEventKind` is a bare cast with no membership check. Currently harmless —
  nothing subscribes to `hooks.onEvent`, and `HookEvent.event` is typed `HookEventKind | string`
  — and it is length-bounded now, so it is a type-hygiene item rather than a security one.
- The `PermissionRequest` responder registry takes an attacker-chosen `tool_use_id` as a Map
  key with no length bound. Growth is bounded by concurrent sockets (entries release on socket
  close or a 120 s timeout), and reaching it needs the per-session token. Worth a separate
  issue; it also needs a test that drives `handleHttp` over a real socket, which
  `_handleRequestForTest` does not reach.
