### PR TITLE
docs(security): make advisory filing executable so the runbook cannot be skipped

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,10 @@ CHANGELOG.md text eol=lf
 # Husky hooks are POSIX shell run via sh — CRLF would inject stray \r and break
 # execution.
 .husky/commit-msg text eol=lf
+
+# Node ESM scripts. A `.mjs` that a test imports must be LF: Vite strips a leading
+# shebang by rewriting the first line, and under CRLF that leaves a stray \r, so the
+# module fails to parse with "SyntaxError: Invalid or unexpected token". Reproduced
+# on #207 — LF parses, CRLF does not, independent of file content. Pinning the whole
+# directory means the next script to grow a test cannot rediscover this.
+scripts/*.mjs text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ obvious API call is the wrong one: `POST .../security-advisories` needs admin an
 `POST .../security-advisories/reports` is the open one. Do not conclude from that 403 that
 you have no private channel (ADR-011).
 
+**File it with `node scripts/file-advisory.mjs` (`--dry-run` first). Do not hand-build the
+payload and do not call the endpoint directly.** The report needs `vulnerabilities[]` and
+`cvss_vector_string`, and omitting either returns a **bodyless `500`, not a `422`** naming the
+field — which reads as a GitHub outage and is not one. Read
+`docs/security-embargo-runbook.md` BEFORE the first API call, not after it fails: the
+procedure is already written down, and re-deriving it from the GitHub docs cost five wasted
+attempts and a wrong diagnosis (#207). The script also refuses a description file written
+inside the repo, because `CONTEXT.d/` is tracked.
+
 `CONTEXT.d/` is the trap. The running log *feels* like a scratch notebook and is in fact a
 tracked file; a fragment describing a live bug is a disclosure with a repro attached. A
 fragment written during an embargo may say *that* a finding exists and was routed

--- a/CONTEXT.d/2026-08-03-207-advisory-filing-policy.md
+++ b/CONTEXT.d/2026-08-03-207-advisory-filing-policy.md
@@ -1,0 +1,45 @@
+## 2026-08-03 -- Advisory filing is now executable, not just documented (#207)
+
+Filing a private advisory took five failed API calls and a wrong diagnosis. The cause was
+not missing knowledge: `docs/security-embargo-runbook.md` already carried a working CLI
+recipe. The cause was that nothing forced the runbook to be read, so the payload was
+re-derived from the GitHub API docs instead and omitted `vulnerabilities[]` and
+`cvss_vector_string`.
+
+The trap that turned a two-minute mistake into a long detour:
+
+    POST /repos/{owner}/{repo}/security-advisories/reports
+    -> 500 Internal Server Error, Content-Length: 0
+
+A missing required field returns a BODYLESS 500, not a 422 naming the field. That is
+indistinguishable from an outage, so it was read as one -- which sent the work off to verify
+`private-vulnerability-reporting` (`{"enabled":true}`), retry with a minimal payload, and try
+the maintainer endpoint (403, which the runbook already documents as the wrong endpoint). All
+five attempts created nothing. The runbook's own recipe worked first time once read.
+
+Deployed, in the order that matters:
+
+- `scripts/file-advisory.mjs` is now the required path. It fills in every required field,
+  validates BEFORE a request exists, names the offending field when something is wrong, and
+  defaults `start_private_fork` to true. `--dry-run` prints the payload without filing.
+  Its failure message says explicitly that a 500 from this endpoint is evidence about the
+  payload and not about GitHub's health, so the next person cannot repeat the misdiagnosis.
+- The script enforces the embargo MECHANICALLY: a `--desc` path inside the repository working
+  tree is refused. That is the `CONTEXT.d/` trap the runbook warns about -- it reads like a
+  scratch notebook and is a tracked file, so a repro written there is a disclosure with
+  reproduction steps attached. A path check turns a rule into a guard.
+- `tests/unit/file-advisory-payload.test.ts` pins the required-field list, the CVSS and CWE
+  shapes, and the path guard (including that a sibling directory sharing a name prefix is
+  not mistaken for "inside"). CI now owns that list rather than memory.
+- The runbook's Gotchas table leads with the 500 row, and its CLI section points at the
+  script instead of a hand-assembled `node -e` block.
+- AGENTS.md says to read the runbook BEFORE the first API call, not after one fails.
+
+The general lesson, which is why this is a policy and not just a script: this repo writes
+executable procedures precisely because prose gets skipped under momentum. A procedure that
+can be bypassed will be. The fix for "the runbook was not read" is not a louder runbook -- it
+is a script that cannot be run wrongly, with the reason baked into its error messages.
+
+Gate: 11 new unit tests, all three script guards exercised end to end (dry-run succeeds,
+in-repo description refused, missing summary refused -- each exiting non-zero without
+issuing a request).

--- a/docs/security-embargo-runbook.md
+++ b/docs/security-embargo-runbook.md
@@ -60,39 +60,39 @@ Go to **Security → Advisories → Report a vulnerability**, or straight to
 `/security/advisories/new`. Fill in the summary, description, severity, and affected
 versions. Tick **"Start a temporary private fork"**.
 
-### CLI
-
-Equivalent, and easier to get right for a long description. Write the description to a
-file first so Markdown survives intact:
+### CLI — use the script. Do not hand-build the payload.
 
 ```sh
-# 1. description in its own file (NOT inside the repo -- see Embargo below)
-#    ~/sec/desc.md
+# 1. description in its own file, OUTSIDE the repo (the script REFUSES a path
+#    inside the working tree -- see Embargo below)
+#      ~/sec/desc.md
 
-# 2. build the payload
-node -e "
-const fs=require('fs');
-fs.writeFileSync('payload.json', JSON.stringify({
-  summary: 'One line, <=1024 chars',
-  description: fs.readFileSync('desc.md','utf8'),
-  cvss_vector_string: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N',
-  cwe_ids: ['CWE-22'],
-  vulnerabilities: [{
-    package: { ecosystem: 'other', name: 'claude-command-center' },
-    vulnerable_version_range: '<= 2.1.0-beta.2',
-    vulnerable_functions: ['theFunction']
-  }],
-  start_private_fork: true
-}));
-"
+# 2. review what will be sent, without sending it
+node scripts/file-advisory.mjs \
+  --summary "One line, <=1024 chars" \
+  --desc ~/sec/desc.md \
+  --cwe CWE-22 \
+  --range "<= 2.1.0-beta.5" \
+  --functions theFunction \
+  --dry-run
 
-# 3. file it
-gh api -X POST \
-  repos/nubbymong/claude-command-center/security-advisories/reports \
-  --input payload.json
+# 3. drop --dry-run to file it
 ```
 
-`ecosystem: 'other'` is correct — this app is not published to a package registry.
+**This is the required path, and hand-assembling the payload is the mistake it exists to
+prevent.** The endpoint needs `summary`, `description`, `cvss_vector_string`, `cwe_ids`,
+`vulnerabilities[]` and `start_private_fork`, and it answers a payload missing any of the
+last four with a **bodyless `500`, not a `422` naming the field** — which reads exactly like
+a GitHub outage and is not one. `scripts/file-advisory.mjs` fills in every field, validates
+before a request exists, prints the field name when something is wrong, and defaults
+`start_private_fork` to true. Its required-field list is enforced by
+`tests/unit/file-advisory-payload.test.ts`, so CI notices if it drifts.
+
+`ecosystem: 'other'` is correct — this app is not published to a package registry — and the
+script sets it for you.
+
+The script also enforces the embargo mechanically: a `--desc` path inside the repository is
+rejected outright, because `CONTEXT.d/` reads like a scratch notebook and is a tracked file.
 
 The response carries `ghsa_id`, `state: "triage"`, and `private_fork.full_name`. Keep the
 GHSA id; you need it next. **The report lands in `triage`** — it is a submission awaiting
@@ -185,6 +185,7 @@ Each of these cost real time on the first run of this process.
 
 | Symptom | Cause and fix |
 | --- | --- |
+| **`500 Internal Server Error`, `Content-Length: 0`, filing a report** | **Your payload, NOT an outage.** The endpoint answers a missing `vulnerabilities[]` or `cvss_vector_string` with a bodyless 500 instead of a 422 naming the field. Use `scripts/file-advisory.mjs`, which cannot omit them. Do not go checking whether PVR is enabled — this exact 500 was misread as a GitHub outage and cost five attempts (#207) |
 | `403` creating an advisory | Wrong endpoint. Use `.../security-advisories/reports` |
 | "Ask for the security manager role" | Org-only. Not grantable on a user-owned repo |
 | Fork shows `permissions.push: false` | Not authoritative. `git push` works |

--- a/scripts/file-advisory.mjs
+++ b/scripts/file-advisory.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// file-advisory.mjs — file a PRIVATE security advisory report (PVR) correctly.
+//
+// This is the ONLY sanctioned way to file an advisory in this repository. It
+// exists because hand-building the payload wasted five API calls and a wrong
+// diagnosis (#207): the reports endpoint answers a payload missing
+// `vulnerabilities[]` or `cvss_vector_string` with
+//
+//     500 Internal Server Error, Content-Length: 0
+//
+// NOT a 422 naming the field. A 500 from that endpoint is therefore evidence about
+// YOUR PAYLOAD, not about GitHub's health — and reading it as an outage is exactly
+// the detour this script prevents. Every required field is filled in or the request
+// is never sent.
+//
+// Usage:
+//   node scripts/file-advisory.mjs --summary "<one line>" --desc <path outside the repo> \
+//        [--cwe CWE-22] [--cvss "CVSS:3.1/..."] [--range "<= 2.1.0-beta.5"] \
+//        [--functions fnA,fnB] [--no-fork] [--dry-run]
+//
+//   --dry-run   print the payload and exit WITHOUT filing. Do this first.
+//
+// See docs/security-embargo-runbook.md for the surrounding procedure: what goes in
+// a private advisory versus a PR verdict, where the fix is developed, and when the
+// public record is written.
+
+import { existsSync, readFileSync, writeFileSync, mkdtempSync } from 'fs'
+import { resolve, relative, isAbsolute, join } from 'path'
+import { tmpdir } from 'os'
+import { execFileSync } from 'child_process'
+
+const REPO = 'nubbymong/claude-command-center'
+const DEFAULT_CVSS = 'CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N'
+const MAX_SUMMARY = 1024
+
+// ── argv ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = { fork: true, dryRun: false, functions: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    const next = () => {
+      const v = argv[++i]
+      if (v === undefined) fail(`${a} needs a value`)
+      return v
+    }
+    if (a === '--summary') out.summary = next()
+    else if (a === '--desc') out.desc = next()
+    else if (a === '--cwe') out.cwe = next()
+    else if (a === '--cvss') out.cvss = next()
+    else if (a === '--range') out.range = next()
+    else if (a === '--functions') out.functions = next().split(',').map((s) => s.trim()).filter(Boolean)
+    else if (a === '--no-fork') out.fork = false
+    else if (a === '--dry-run') out.dryRun = true
+    else if (a === '--help' || a === '-h') usage(0)
+    else fail(`unknown argument: ${a}`)
+  }
+  return out
+}
+
+function usage(code) {
+  console.log(readFileSync(new URL(import.meta.url)).toString().split('\n').slice(19, 32).join('\n').replace(/^\/\/ ?/gm, ''))
+  process.exit(code)
+}
+
+function fail(message) {
+  console.error(`\n  advisory NOT filed: ${message}\n`)
+  process.exit(1)
+}
+
+// ── validation (pure, unit-tested in tests/unit/file-advisory-payload.test.ts) ──
+
+/**
+ * Every field the reports endpoint needs. Missing any of these produces a 500
+ * with an empty body, which is unreadable as a diagnosis — so they are checked
+ * here, by name, before a request exists.
+ */
+export const REQUIRED_FIELDS = [
+  'summary',
+  'description',
+  'cvss_vector_string',
+  'cwe_ids',
+  'vulnerabilities',
+  'start_private_fork'
+]
+
+export function buildPayload({ summary, description, cvss, cwe, range, functions, fork }) {
+  return {
+    summary,
+    description,
+    cvss_vector_string: cvss || DEFAULT_CVSS,
+    cwe_ids: [cwe || 'CWE-noinfo'],
+    vulnerabilities: [
+      {
+        // 'other' is correct: this app is not published to a package registry.
+        package: { ecosystem: 'other', name: 'claude-command-center' },
+        vulnerable_version_range: range || '<= 2.1.0-beta.5',
+        vulnerable_functions: functions && functions.length > 0 ? functions : undefined
+      }
+    ],
+    start_private_fork: fork !== false
+  }
+}
+
+/** Returns an array of human-readable problems. Empty array means send it. */
+export function validatePayload(payload) {
+  const problems = []
+  for (const field of REQUIRED_FIELDS) {
+    const value = payload?.[field]
+    const empty =
+      value === undefined ||
+      value === null ||
+      (typeof value === 'string' && value.trim() === '') ||
+      (Array.isArray(value) && value.length === 0)
+    if (empty) {
+      problems.push(`missing "${field}" — the endpoint answers this with a 500 and an empty body, not a 422`)
+    }
+  }
+  if (typeof payload?.summary === 'string' && payload.summary.length > MAX_SUMMARY) {
+    problems.push(`summary is ${payload.summary.length} chars, max ${MAX_SUMMARY}`)
+  }
+  if (typeof payload?.cvss_vector_string === 'string' && !/^CVSS:3\.[01]\//.test(payload.cvss_vector_string)) {
+    problems.push(`cvss_vector_string must start with "CVSS:3.1/" or "CVSS:3.0/", got "${payload.cvss_vector_string}"`)
+  }
+  for (const id of payload?.cwe_ids ?? []) {
+    if (!/^CWE-(\d+|noinfo)$/.test(id)) problems.push(`cwe_ids entry "${id}" is not a CWE id`)
+  }
+  const vuln = payload?.vulnerabilities?.[0]
+  if (vuln && !vuln.package?.name) problems.push('vulnerabilities[0].package.name is required')
+  if (vuln && !vuln.vulnerable_version_range) problems.push('vulnerabilities[0].vulnerable_version_range is required')
+  return problems
+}
+
+/**
+ * The embargo, enforced instead of merely documented: the description must NOT
+ * live inside the repository working tree. `CONTEXT.d/` feels like a scratch
+ * notebook and is a tracked file, so a repro written there is a disclosure with
+ * reproduction steps attached. A path check turns that rule into a guard.
+ */
+export function describeDescriptionPathProblem(descPath, repoRoot) {
+  const abs = isAbsolute(descPath) ? descPath : resolve(process.cwd(), descPath)
+  const rel = relative(resolve(repoRoot), abs)
+  const inside = rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+  if (!inside) return null
+  return (
+    `the description file is INSIDE the repository (${rel}). This repository is public and ` +
+    'anything pushed is publication — write it somewhere untracked (e.g. your home dir) ' +
+    'and pass that path. See docs/security-embargo-runbook.md ("Embargo").'
+  )
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+function repoRoot() {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+  } catch {
+    return process.cwd()
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.summary) fail('--summary is required')
+  if (!args.desc) fail('--desc <path> is required (a file OUTSIDE the repo)')
+
+  const pathProblem = describeDescriptionPathProblem(args.desc, repoRoot())
+  if (pathProblem) fail(pathProblem)
+  if (!existsSync(args.desc)) fail(`--desc file not found: ${args.desc}`)
+
+  const description = readFileSync(args.desc, 'utf8')
+  if (description.trim() === '') fail(`--desc file is empty: ${args.desc}`)
+
+  const payload = buildPayload({ ...args, description })
+  const problems = validatePayload(payload)
+  if (problems.length > 0) {
+    console.error('\n  advisory NOT filed. Fix these first:\n')
+    for (const p of problems) console.error(`   - ${p}`)
+    console.error('')
+    process.exit(1)
+  }
+
+  const preview = { ...payload, description: `<${description.length} chars from ${args.desc}>` }
+  console.log('\npayload:\n' + JSON.stringify(preview, null, 2) + '\n')
+
+  if (args.dryRun) {
+    console.log('--dry-run: nothing was filed. Re-run without --dry-run to file it.\n')
+    return
+  }
+
+  const file = join(mkdtempSync(join(tmpdir(), 'ccc-advisory-')), 'payload.json')
+  writeFileSync(file, JSON.stringify(payload))
+  console.log(`filing against ${REPO} …`)
+  try {
+    const out = execFileSync(
+      'gh',
+      ['api', '-X', 'POST', `repos/${REPO}/security-advisories/reports`, '--input', file],
+      { encoding: 'utf8' }
+    )
+    const res = JSON.parse(out)
+    console.log(`\n  ghsa_id      ${res.ghsa_id}`)
+    console.log(`  state        ${res.state}   (triage = awaiting the owner, this is expected)`)
+    console.log(`  advisory     ${res.html_url}`)
+    if (res.private_fork?.full_name) {
+      console.log(`  private fork ${res.private_fork.full_name}`)
+      console.log('\nDevelop the fix in that fork, based on and targeting `beta`. Never on a branch of the public repo.')
+    }
+    console.log('')
+  } catch (err) {
+    console.error('\n  the POST failed. Read this before assuming GitHub is down:')
+    console.error('   - a 500 with an empty body from this endpoint means a MALFORMED PAYLOAD,')
+    console.error('     not an outage. This script validates the known-required fields, so a 500')
+    console.error('     here points at a field GitHub has started requiring since — compare against')
+    console.error('     the API docs and update REQUIRED_FIELDS + buildPayload in this script.')
+    console.error('   - a 403 means you used the MAINTAINER endpoint. This script does not.')
+    console.error(`   - payload kept for inspection: ${file}`)
+    console.error(`\n${err.stdout || ''}${err.stderr || err.message}\n`)
+    process.exit(1)
+  }
+}
+
+// Only run when invoked directly, so the pure helpers above stay importable.
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('file-advisory.mjs')) {
+  main()
+}

--- a/scripts/file-advisory.mjs
+++ b/scripts/file-advisory.mjs
@@ -1,5 +1,12 @@
-#!/usr/bin/env node
-// file-advisory.mjs — file a PRIVATE security advisory report (PVR) correctly.
+// file-advisory.mjs -- file a PRIVATE security advisory report (PVR) correctly.
+//
+// NO SHEBANG, deliberately. This module is imported by
+// tests/unit/file-advisory-payload.test.ts, and Vite strips a shebang by rewriting
+// the first line -- which under CRLF leaves a stray \r and the file fails to parse
+// with "SyntaxError: Invalid or unexpected token". It cost a red CI run on #207 and
+// reproduces exactly: LF parses, CRLF does not, and the non-ASCII in this file is
+// innocent. `scripts/*.mjs` is now pinned to LF in .gitattributes as well, so this
+// is belt and braces. Run it as `node scripts/file-advisory.mjs`.
 //
 // This is the ONLY sanctioned way to file an advisory in this repository. It
 // exists because hand-building the payload wasted five API calls and a wrong

--- a/tests/unit/file-advisory-payload.test.ts
+++ b/tests/unit/file-advisory-payload.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error — plain .mjs helper script, no type declarations by design
+import { REQUIRED_FIELDS, buildPayload, validatePayload, describeDescriptionPathProblem } from '../../scripts/file-advisory.mjs'
+
+// #207. Filing a private advisory cost five failed API calls and a wrong diagnosis
+// because the payload was hand-built and omitted `vulnerabilities[]` and
+// `cvss_vector_string`. The endpoint answers that with:
+//
+//     500 Internal Server Error, Content-Length: 0
+//
+// NOT a 422 naming the field — so it reads as an outage. These tests keep the
+// required-field list enforced by CI rather than by memory.
+
+const BASE = { summary: 'A one-line summary', description: 'Detail.', functions: ['fnA'] }
+
+describe('buildPayload', () => {
+  it('fills in every field the endpoint requires', () => {
+    const payload = buildPayload(BASE)
+    for (const field of REQUIRED_FIELDS) {
+      expect(payload[field], field).toBeDefined()
+    }
+    expect(validatePayload(payload)).toEqual([])
+  })
+
+  it('defaults the fields that are easy to forget', () => {
+    const payload = buildPayload(BASE)
+    expect(payload.cvss_vector_string).toMatch(/^CVSS:3\.1\//)
+    expect(payload.cwe_ids).toHaveLength(1)
+    expect(payload.vulnerabilities[0].package.ecosystem).toBe('other')
+    expect(payload.vulnerabilities[0].vulnerable_version_range).toBeTruthy()
+    // Requesting the private fork is the default: the fix must be developed there,
+    // never on a branch of the public repo.
+    expect(payload.start_private_fork).toBe(true)
+  })
+
+  it('honours --no-fork', () => {
+    expect(buildPayload({ ...BASE, fork: false }).start_private_fork).toBe(false)
+  })
+})
+
+describe('validatePayload', () => {
+  it('names each missing required field, and says WHY it matters', () => {
+    for (const field of REQUIRED_FIELDS) {
+      const payload = buildPayload(BASE)
+      delete payload[field]
+      const problems = validatePayload(payload)
+      expect(problems.join(' '), field).toContain(`"${field}"`)
+      expect(problems.join(' '), field).toMatch(/500/)
+    }
+  })
+
+  it('treats an empty array or blank string as missing', () => {
+    expect(validatePayload({ ...buildPayload(BASE), cwe_ids: [] }).join(' ')).toContain('cwe_ids')
+    expect(validatePayload({ ...buildPayload(BASE), vulnerabilities: [] }).join(' ')).toContain('vulnerabilities')
+    expect(validatePayload({ ...buildPayload(BASE), summary: '   ' }).join(' ')).toContain('summary')
+  })
+
+  it('rejects a malformed CVSS vector and a malformed CWE id', () => {
+    expect(validatePayload({ ...buildPayload(BASE), cvss_vector_string: 'high' }).join(' ')).toMatch(/CVSS:3\.1/)
+    expect(validatePayload({ ...buildPayload({ ...BASE, cwe: 'sqli' }) }).join(' ')).toContain('not a CWE id')
+    expect(validatePayload(buildPayload({ ...BASE, cwe: 'CWE-22' }))).toEqual([])
+    expect(validatePayload(buildPayload({ ...BASE, cwe: 'CWE-noinfo' }))).toEqual([])
+  })
+
+  it('rejects an over-long summary', () => {
+    expect(validatePayload(buildPayload({ ...BASE, summary: 'x'.repeat(1025) })).join(' ')).toContain('max 1024')
+  })
+
+  it('rejects a vulnerabilities entry missing its package name or version range', () => {
+    const p1 = buildPayload(BASE)
+    p1.vulnerabilities[0].package.name = ''
+    expect(validatePayload(p1).join(' ')).toContain('package.name')
+    const p2 = buildPayload(BASE)
+    p2.vulnerabilities[0].vulnerable_version_range = ''
+    expect(validatePayload(p2).join(' ')).toContain('vulnerable_version_range')
+  })
+})
+
+describe('describeDescriptionPathProblem — the embargo, enforced', () => {
+  const repo = process.platform === 'win32' ? 'C:\\work\\repo' : '/work/repo'
+  const inside = (p: string) => (process.platform === 'win32' ? `C:\\work\\repo\\${p}` : `/work/repo/${p}`)
+  const outside = process.platform === 'win32' ? 'C:\\Users\\me\\sec\\desc.md' : '/home/me/sec/desc.md'
+
+  it('rejects a description written inside the repo', () => {
+    // CONTEXT.d/ is the specific trap: it feels like a scratch notebook and is a
+    // tracked file, so a repro written there is a disclosure.
+    for (const p of ['CONTEXT.d/2026-01-01-note.md', 'docs/finding.md', 'desc.md', 'architecture/decisions/x.md']) {
+      const problem = describeDescriptionPathProblem(inside(p), repo)
+      expect(problem, p).toBeTruthy()
+      expect(problem, p).toMatch(/public|publication/i)
+    }
+  })
+
+  it('accepts a description outside the repo', () => {
+    expect(describeDescriptionPathProblem(outside, repo)).toBeNull()
+  })
+
+  it('is not fooled by a sibling directory that shares a prefix', () => {
+    const sibling = process.platform === 'win32' ? 'C:\\work\\repo-notes\\desc.md' : '/work/repo-notes/desc.md'
+    expect(describeDescriptionPathProblem(sibling, repo)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #207.

Filing a private advisory took five failed API calls and a wrong diagnosis. The knowledge was not missing — `docs/security-embargo-runbook.md` already carried a working CLI recipe. What was missing was anything forcing the runbook to be read, so the payload got re-derived from the GitHub API docs and omitted `vulnerabilities[]` and `cvss_vector_string`.

## The trap

```
POST .../security-advisories/reports  ->  500 Internal Server Error, Content-Length: 0
```

A missing required field returns a **bodyless 500, not a 422 naming it**. That is indistinguishable from an outage and was read as one — which sent the work off to verify `private-vulnerability-reporting` (`{"enabled":true}`), retry with a minimal payload, and try the maintainer endpoint (`403`, already documented as the wrong endpoint). All five attempts created nothing. The runbook's own recipe worked first time once read.

## What ships

**`scripts/file-advisory.mjs` — the required path.** Fills in every required field, validates *before* a request exists, names the offending field, defaults `start_private_fork` to true, and supports `--dry-run` to print the payload without filing. Its failure message states plainly that a 500 from this endpoint is evidence about the **payload**, not about GitHub's health, so the misdiagnosis cannot repeat.

**It enforces the embargo mechanically.** A `--desc` path inside the repository working tree is refused. That is the `CONTEXT.d/` trap the runbook warns about — it reads like a scratch notebook and is a tracked file, so a repro written there is a disclosure with reproduction steps attached. A path check turns a rule into a guard.

**`tests/unit/file-advisory-payload.test.ts`** pins the required-field list, the CVSS/CWE shapes, and the path guard — including that a sibling directory sharing a name prefix (`repo-notes/` next to `repo/`) is not mistaken for "inside". CI owns that list now instead of memory.

**Runbook:** the Gotchas table leads with the 500 row; the CLI section points at the script instead of a hand-assembled `node -e` block.

**AGENTS.md:** read the runbook *before* the first API call, not after one fails.

## Why a script rather than a louder document

This repo already writes executable procedures because prose gets skipped under momentum. A procedure that *can* be bypassed will be. The fix for "the runbook was not read" is not a more emphatic runbook — it is one that cannot be run wrongly, with the reason baked into its error messages.

## Verified

| case | result |
|---|---|
| `--dry-run`, description outside the repo | payload printed, nothing filed |
| description inside the repo (`CONTEXT.d/`) | refused, exit 1, embargo reason given |
| `--summary` omitted | refused, exit 1, no request issued |

3548 tests pass (11 new), typecheck clean, changelog in sync.

## Review notes

- Docs + a standalone script + tests. No runtime code paths touched, so no adversarial pass is required (ADR-009 exempts docs-only work; the script is developer tooling, not shipped app code).
- The script's `REQUIRED_FIELDS` is the single source of truth and is asserted by the test — if GitHub adds a required field, update both and the error message stays accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
