### PR TITLE
feat(store): add Microsoft Store (MSIX) packaging as an opt-in target

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "electron-vite preview",
     "package": "electron-vite build && electron-builder --win --dir",
     "package:win": "electron-vite build && electron-builder --win",
+    "package:store": "electron-vite build && electron-builder --win appx",
     "package:mac": "electron-vite build && electron-builder --mac",
     "package:linux": "electron-vite build && electron-builder --linux",
     "verify:package": "node scripts/verify-native-unpack.mjs",
@@ -166,6 +167,16 @@
     "dmg": {
       "sign": false,
       "title": "AI Code Conductor"
+    },
+    "appx": {
+      "identityName": "nicholas-moger.AICodeConductor",
+      "publisher": "CN=219653A3-6C91-474A-9D0D-CC64FC96BD70",
+      "publisherDisplayName": "nicholas-moger",
+      "applicationId": "AICodeConductor",
+      "displayName": "AI Code Conductor",
+      "backgroundColor": "#0b0e15",
+      "showNameOnTiles": true,
+      "artifactName": "AI-Code-Conductor-${version}-store.${ext}"
     },
     "nsis": {
       "oneClick": false,

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -2,7 +2,7 @@ import { ipcMain, app, dialog } from 'electron'
 import { spawn } from 'child_process'
 import * as path from 'path'
 import * as fs from 'fs'
-import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp } from '../update-watcher'
+import { checkForUpdatesOnDemand, markUpdateInstalled, getProjectRootPath, setSourcePathInRegistry, hasSourcePath, isPackagedApp, isStoreBuild } from '../update-watcher'
 import { checkGitHubRelease, downloadGitHubRelease, prepareLinuxAppImageUpdate, isPathOnNoexecMount, InstallerIntegrityError, stillMatchesDigest, createInstallerDir } from '../github-update'
 import { killAllPty } from '../pty-manager'
 import { logInfo, logError } from '../debug-logger'
@@ -15,6 +15,14 @@ let updateInProgress = false
 
 export function registerUpdateHandlers(): void {
   ipcMain.handle('update:check', async () => {
+    // Store builds are updated by the Store. Report "no update" so the UI never
+    // offers one — the download path could not run the installer from inside the
+    // package container, and a self-updating Store app fails certification.
+    if (isStoreBuild()) {
+      logInfo('[update] Store build — updates are handled by the Microsoft Store')
+      return false
+    }
+
     // In dev mode, check the local source watcher first (live-reload workflow).
     // In production, always go straight to GitHub.
     if (!isPackagedApp()) {
@@ -70,6 +78,15 @@ export function registerUpdateHandlers(): void {
   })
 
   ipcMain.handle('update:installAndRestart', async () => {
+    // Belt and braces with the update:check gate above: nothing should be able to
+    // reach here in a Store build, but a scripted invoke bypasses the UI, and
+    // running an NSIS installer from inside the package container would fail in a
+    // confusing way rather than a clear one.
+    if (isStoreBuild()) {
+      logInfo('[update] Refusing self-install — this copy is managed by the Microsoft Store')
+      throw new Error('This copy is installed from the Microsoft Store, which manages its own updates.')
+    }
+
     // ipcMain.handle serialises nothing. Two concurrent runs each prune the
     // staging root keeping only THEIR OWN directory, so each deletes the other's
     // in-flight installer. The renderer latches on `isUpdating`, but that is one

--- a/src/main/update-watcher.ts
+++ b/src/main/update-watcher.ts
@@ -71,6 +71,23 @@ export function isPackagedApp(): boolean {
   return IS_PACKAGED
 }
 
+/**
+ * True when this copy is running from a Microsoft Store (MSIX) package.
+ *
+ * Electron sets `process.windowsStore` for Store builds. The Store owns updates
+ * for those installs: downloading and running our own NSIS installer would fail
+ * inside the package container anyway, and shipping a self-updater in a Store
+ * app is grounds for certification rejection. Every self-update path checks this
+ * and declines.
+ *
+ * Deliberately a runtime check rather than a build-time flag — the Store package
+ * and the direct-download build come from the same compiled output, and one
+ * binary that behaves correctly in both places is easier to trust than two.
+ */
+export function isStoreBuild(): boolean {
+  return (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true
+}
+
 export function hasSourcePath(): boolean {
   const projectRoot = getProjectRootPath()
   if (!projectRoot) return false

--- a/tests/unit/github-update.test.ts
+++ b/tests/unit/github-update.test.ts
@@ -665,6 +665,45 @@ describe('github-update', () => {
       expect(result!.installerUrl).toBe(expected.url)
     })
 
+    it('never confuses the Store (.appx) package with a direct-download installer', async () => {
+      // The Store artifact is AI-Code-Conductor-<v>-store.appx — it starts with an
+      // ACCEPTED prefix (AI-Code-Conductor-), so only the extension keeps the
+      // updater from serving it. Prove the real matcher rejects it on every
+      // platform, and still picks the genuine installer when both are present.
+      const platformInstaller: Record<string, { name: string; url: string }> = {
+        darwin: { name: 'ClaudeCommandCenter-Beta-1.2.125-mac.dmg', url: 'https://x/mac.dmg' },
+        linux: { name: 'ClaudeCommandCenter-Beta-1.2.125-linux-x86_64.AppImage', url: 'https://x/linux.AppImage' },
+        win32: { name: 'ClaudeCommandCenter-Beta-1.2.125.exe', url: 'https://x/win.exe' },
+      }
+      const good = platformInstaller[process.platform] ?? platformInstaller.win32
+
+      // appx alone → not installable on any platform → null (never offered)
+      httpsState.nextResponse = {
+        statusCode: 200,
+        body: [
+          { tag_name: 'v1.2.125', draft: false, prerelease: false, assets: [
+            { name: 'CHECKSUMS.txt', browser_download_url: 'https://x/c.txt' },
+            { name: 'AI-Code-Conductor-1.2.125-store.appx', browser_download_url: 'https://x/store.appx' },
+          ] },
+        ],
+      }
+      expect(await checkGitHubRelease()).toBeNull()
+
+      // appx alongside the real installer → the real installer wins, never the appx
+      httpsState.nextResponse = {
+        statusCode: 200,
+        body: [
+          { tag_name: 'v1.2.125', draft: false, prerelease: false, assets: [
+            { name: 'CHECKSUMS.txt', browser_download_url: 'https://x/c.txt' },
+            { name: 'AI-Code-Conductor-1.2.125-store.appx', browser_download_url: 'https://x/store.appx' },
+            { name: good.name, browser_download_url: good.url },
+          ] },
+        ],
+      }
+      const both = await checkGitHubRelease()
+      expect(both!.installerName).toBe(good.name)
+    })
+
     it('returns null entirely when no installer asset exists for this platform', async () => {
       // No matching asset — we must not offer an update the user cannot install
       httpsState.nextResponse = {

--- a/tests/unit/main/store-package-guard.test.ts
+++ b/tests/unit/main/store-package-guard.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Guards for the Microsoft Store (MSIX) package.
+ *
+ * The load-bearing one is the first: `.github/workflows/release.yml` runs
+ * `electron-builder --win`, which builds EVERY target listed in build.win.target.
+ * If `appx` were added there, a Store-packaging problem — a wrong identity
+ * string, missing tooling — would fail the whole Windows job and ship NO
+ * installer at all. The Store package is therefore built only on demand, via
+ * `npm run package:store`.
+ *
+ * The identity values are copied verbatim from Partner Center (Product identity).
+ * The Store rejects an upload whose identity does not match the reservation
+ * exactly, so they are pinned here rather than left to be retyped.
+ */
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../../package.json'), 'utf-8'))
+
+describe('Store package guard', () => {
+  it('the release build never builds the Store package', () => {
+    const winTargets = pkg.build.win.target.map((t: { target: string }) => t.target)
+    expect(winTargets).toEqual(['nsis'])
+    expect(winTargets).not.toContain('appx')
+  })
+
+  it('the Store package is buildable on demand', () => {
+    expect(pkg.scripts['package:store']).toMatch(/electron-builder --win appx/)
+  })
+
+  it('identity matches the Partner Center reservation exactly', () => {
+    expect(pkg.build.appx.identityName).toBe('nicholas-moger.AICodeConductor')
+    expect(pkg.build.appx.publisher).toBe('CN=219653A3-6C91-474A-9D0D-CC64FC96BD70')
+    expect(pkg.build.appx.publisherDisplayName).toBe('nicholas-moger')
+  })
+
+  it('the Store artifact cannot be confused with the direct-download installer', () => {
+    // The updater matches release assets by prefix and extension. A Store package
+    // must never be mistaken for something it could hand to a self-updating
+    // client, so it carries its own suffix and a different extension (.appx).
+    expect(pkg.build.appx.artifactName).toMatch(/-store\./)
+    expect(pkg.build.appx.artifactName).not.toMatch(/ClaudeCommandCenter-/)
+  })
+})

--- a/tests/unit/main/store-package-guard.test.ts
+++ b/tests/unit/main/store-package-guard.test.ts
@@ -35,11 +35,16 @@ describe('Store package guard', () => {
     expect(pkg.build.appx.publisherDisplayName).toBe('nicholas-moger')
   })
 
-  it('the Store artifact cannot be confused with the direct-download installer', () => {
-    // The updater matches release assets by prefix and extension. A Store package
-    // must never be mistaken for something it could hand to a self-updating
-    // client, so it carries its own suffix and a different extension (.appx).
-    expect(pkg.build.appx.artifactName).toMatch(/-store\./)
-    expect(pkg.build.appx.artifactName).not.toMatch(/ClaudeCommandCenter-/)
+  it('the Store artifact carries the non-installer extension the updater filters on', () => {
+    // The updater matches release assets by prefix AND extension
+    // (github-update.ts: INSTALLER_PREFIXES + endsWith(INSTALLER_EXT)). The Store
+    // artifact name starts with the accepted `AI-Code-Conductor-` prefix, so the
+    // ONLY thing stopping the updater from serving it is the `.appx` extension —
+    // pin that, not the prefix (a prefix assertion passes even for a dangerous
+    // `-store.exe`). The behavioural proof that the matcher rejects `.appx` lives
+    // in tests/unit/github-update.test.ts ('never confuses the Store package…').
+    expect(pkg.build.appx.artifactName).toMatch(/-store\.\$\{ext\}$/)
+    // The appx target resolves ${ext} to `appx`, never an installer extension.
+    expect(pkg.build.win.target.map((t: { target: string }) => t.target)).not.toContain('appx')
   })
 })

--- a/tests/unit/main/update-handlers.test.ts
+++ b/tests/unit/main/update-handlers.test.ts
@@ -89,6 +89,7 @@ vi.mock('../../../src/main/github-update', () => ({
 
 // ── everything else the module pulls in ────────────────────────────────
 const fsState = vi.hoisted(() => ({ accessThrows: false }))
+const storeState = vi.hoisted(() => ({ isStoreBuild: false }))
 vi.mock('fs', () => ({
   existsSync: () => true,
   readFileSync: () => '{"version":"2.1.1"}',
@@ -111,6 +112,10 @@ vi.mock('../../../src/main/update-watcher', () => ({
   // `gh.verified = null`, which is why nothing covered that path.
   isPackagedApp: () => true,
   hasSourcePath: () => false,
+  // Same reason as the two above: the handlers call this on every update path,
+  // so omitting it fails every test in the file rather than just the Store one.
+  // Defaults to the direct-download build; the Store gate has its own suite.
+  isStoreBuild: () => storeState.isStoreBuild,
 }))
 vi.mock('../../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
 vi.mock('../../../src/main/pty-manager', () => ({ killAllPty: vi.fn() }))
@@ -142,7 +147,31 @@ beforeEach(() => {
   gh.noexec = false
   gh.appImageVerifiers = []
   fsState.accessThrows = false
+  storeState.isStoreBuild = false
   registerUpdateHandlers()
+})
+
+describe('Microsoft Store builds do not self-update', () => {
+  // The Store owns updates for an MSIX install. Offering one would download an
+  // NSIS installer the package container cannot run, and shipping a
+  // self-updater in a Store app fails certification.
+  it('reports no update available, so the UI never offers one', async () => {
+    storeState.isStoreBuild = true
+    const check = handlers.get('update:check')!
+    await expect(Promise.resolve(check())).resolves.toBe(false)
+  })
+
+  it('refuses to install even when invoked directly, bypassing the UI', async () => {
+    storeState.isStoreBuild = true
+    await expect(invoke()).rejects.toThrow(/Microsoft Store/i)
+    // Nothing was launched: the refusal happens before any spawn.
+    expect(spawnState.calls).toHaveLength(0)
+  })
+
+  it('still updates normally in the direct-download build', async () => {
+    storeState.isStoreBuild = false
+    await expect(invoke()).resolves.toBe(true)
+  })
 })
 
 describe('update:installAndRestart — launch handshake', () => {

--- a/tests/unit/update-watcher.test.ts
+++ b/tests/unit/update-watcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Track mock filesystem state
 const { mockExistsSync, mockReaddir, mockReadFile } = vi.hoisted(() => ({
@@ -56,12 +56,52 @@ import {
   hasSourcePath,
   getProjectRootPath,
   stopUpdateWatcher,
+  isStoreBuild,
 } from '../../src/main/update-watcher'
 
 describe('update-watcher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     stopUpdateWatcher()
+  })
+
+  // isStoreBuild is the single runtime primitive the whole Store self-update
+  // gate rests on. update-handlers.test.ts mocks it, so this is the ONLY place
+  // its real implementation is exercised — a regression here (a typo'd property,
+  // a loosened `=== true`) must go red. See PR #225 adversarial review.
+  describe('isStoreBuild', () => {
+    const proc = process as NodeJS.Process & { windowsStore?: boolean }
+    let original: boolean | undefined
+    beforeEach(() => { original = proc.windowsStore })
+    afterEach(() => {
+      if (original === undefined) delete proc.windowsStore
+      else proc.windowsStore = original
+    })
+
+    it('is false for a direct-download build (property absent)', () => {
+      delete proc.windowsStore
+      expect(isStoreBuild()).toBe(false)
+    })
+
+    it('is true when Electron marks the process a Store build', () => {
+      proc.windowsStore = true
+      expect(isStoreBuild()).toBe(true)
+    })
+
+    it('is false when explicitly not a Store build', () => {
+      proc.windowsStore = false
+      expect(isStoreBuild()).toBe(false)
+    })
+
+    it('does not treat a truthy non-boolean as a Store build (strict === true)', () => {
+      // A future regression from `=== true` to a truthy check would wrongly
+      // disable updates for the whole direct-download base if the property were
+      // ever a string/number. Pin the strictness.
+      ;(proc as unknown as { windowsStore: unknown }).windowsStore = 'true'
+      expect(isStoreBuild()).toBe(false)
+      ;(proc as unknown as { windowsStore: unknown }).windowsStore = 1
+      expect(isStoreBuild()).toBe(false)
+    })
   })
 
   describe('getProjectRootPath', () => {


### PR DESCRIPTION
Adds the Microsoft Store package as a **second** distribution channel alongside the SSL.com-signed NSIS installer. The direct-download path is untouched.

## Verified end-to-end on the Windows VM

Built the package, self-signed it, sideloaded it, and ran it:

| Check | Result |
|---|---|
| Builds | ✅ 235 MB `.appx` — `"not signed — Windows Store only build"` (correct; the Store signs on upload) |
| Identity | ✅ Package Family Name matches Partner Center exactly: `nicholas-moger.AICodeConductor_j5s64xrg70x9r` |
| Package identity at runtime | ✅ Confirmed via `GetPackageFamilyName` → `process.windowsStore` is true, so the updater gate fires |
| `better-sqlite3` | ✅ databases created and written |
| **ConPTY terminal** | ✅ **live PowerShell session running inside the container** |
| Spawning external programs | ✅ launched Chrome as a child process and connected over CDP |
| Localhost server | ✅ MCP listening on `127.0.0.1:19333` |

## Why `appx` and not a `msix` target

Same format — MSIX is the 2018 rename of AppX (same OPC container, same `AppxManifest.xml`). electron-builder's target is still called `appx`, and Partner Center accepts `.appx` alongside `.msix`.

## The release pipeline cannot break

`appx` is deliberately **NOT** in `build.win.target`. `release.yml` runs `electron-builder --win`, which builds every target listed there — so a Store-packaging problem (bad identity string, missing tooling) would fail the whole Windows job and ship **no installer at all**. The Store package is built on demand with `npm run package:store`, and a guard test pins `win.target` to `nsis` only.

## Updater

Declines in a Store build (`process.windowsStore`) at both `update:check` — so the UI never offers one — and `update:installAndRestart`, which a scripted invoke could otherwise reach. The Store owns updates for MSIX installs; running our NSIS installer from inside the container would fail anyway, and a self-updating Store app fails certification. It's a runtime check, not a build flag, so both channels ship the same binary. Covered by tests.

## Two findings worth knowing

1. **Store and EXE installs share data.** With `runFullTrust` there's no `%LOCALAPPDATA%` redirection — the packaged app wrote to the real `…\Local\AI Code Conductor`. (I'd previously assumed the container would isolate it; it doesn't.)
2. **A Store install opens on the storage-directory setup dialog**, because there's no NSIS installer to pre-seed the registry. Defaults are already correct, so it's one click, but Store users see a step EXE users don't. Worth a follow-up decision on whether to auto-accept defaults when `process.windowsStore` is true.

Typecheck clean; full suite green (3811).

🤖 Generated with [Claude Code](https://claude.com/claude-code)