### PR TITLE
fix(insights): survive the Windows rename race when saving the catalogue (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.7] - 2026-08-05
+
+### Fixed
+- Windows: an Insights run could report itself as failed for no visible reason. Security software on Windows briefly holds a file open just after it has been written, and that could make saving the list of runs fail — more often when the machine was busy. Saving now waits a moment and tries again.
+- Insights could get stuck insisting a report was already being generated when nothing was running, leaving restarting the app as the only way out. If saving the list of runs failed at the wrong moment, the app never cleared its "in progress" marker. That marker is now always cleared, however the run ends.
+
 ## [2.1.0-beta.6] - 2026-08-04
 
 > The app is now AI Code Conductor, with a new icon, start-up animation and a rebuilt session setup dialog. Insights can also look at all of your accounts at once: one click generates every account's report and then a combined report that compares them side by side.
@@ -992,6 +998,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.7]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.7
 [2.1.0-beta.6]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.6
 [2.1.0-beta.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.5
 [2.1.0-beta.4]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.4

--- a/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
+++ b/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
@@ -99,9 +99,21 @@ failure mid-fan-out. Verified to fail 3 of 3 against the old ordering. ENOSPC de
 not EPERM: EPERM is now retried, and a guard that the fix above quietly satisfies would not
 be testing this at all.
 
-Follow-up, not done here: the same fixed-`.tmp`-plus-bare-`renameSync` shape appears in
-roughly a dozen other main-process modules (`config-manager.ts`, `session-state.ts`,
-`account-profiles.ts`, `model-registry-service.ts`, `sentinel/sentinel-state.ts`,
-`hooks/per-session-settings.ts`, `channel-storage.ts`, `codex-review-usage.ts` and others).
-Every one of them can lose the same race; `config-manager.ts` losing it means a dropped
-config save. A shared atomic-write helper is the right fix and is out of scope for #213.
+Follow-up, filed as #233 and out of scope here: `insights-runner.ts` is now the ONLY
+atomic-write site in `src/main` that retries. Roughly a dozen others -- `config-manager.ts`,
+`session-state.ts`, `account-profiles.ts`, `model-registry-service.ts`,
+`sentinel/sentinel-state.ts`, `hooks/per-session-settings.ts`, `channel-storage.ts`,
+`codex-review-usage.ts`, `conductor-mcp-server.ts`, `usage/account-usage.ts` -- can lose the
+same race. `config-manager.ts:165` catches it, logs, and returns `false`, so a scanner
+winning a 3ms race silently DROPS a config save: worse than what #213 fixed, because a
+failed insights run is visible and a lost settings write is not. The fix is one shared
+`atomicWriteFileSync` helper, and it wants an adversarial pass because `account-profiles.ts`
+credential writes and their `0600`/`hardenCredentialFile` handling have to survive it.
+
+A correction worth recording, because the first version of this fragment got it wrong: the
+staging-name half of that claim did NOT generalise. Most of those sites already qualify the
+tmp by pid (`${filePath}.tmp.${process.pid}`), and the two GitHub stores use a per-write
+`randomUUID()`. Only `account-profiles.ts`, `channel-storage.ts`, `model-registry-service.ts`
+and `sentinel/sentinel-state.ts` use a bare fixed `.tmp`. The shared gap is the MISSING
+RETRY, not the staging name -- the name is secondary hygiene. Grepping for `+ '.tmp'` found
+one shape and I generalised from it without reading the other construction sites.

--- a/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
+++ b/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
@@ -1,0 +1,66 @@
+## 2026-08-04 -- The flaky insights suite was a Windows rename race, not test ordering (#213)
+
+#213 was filed as "the unit suite is order/timing dependent under load", with a hypothesis
+that `insights-cross-account-run.test.ts` leaked in-flight runs across test boundaries via
+`insights-runner`'s module state, and a suggested fix of awaiting quiescence in `afterEach`
+plus `vi.resetModules()`. The evidence contradicts that hypothesis. None of it was needed.
+
+Reproduced on the first full-suite run, then made repeatable by running the file under eight
+CPU burners: 2 of 6 runs red. A temporary diagnostic `afterEach` that dumped the catalogue
+whenever a test failed produced the same error every time, in whichever test happened to be
+running:
+
+    EPERM: operation not permitted, rename
+      '...\resources\insights\catalogue.json.tmp' -> '...\resources\insights\catalogue.json'
+
+`saveCatalogue` writes a staging file then `renameSync`s it over the target. On Windows that
+rename fails with EPERM/EACCES/EBUSY while ANY other process holds a handle on either path,
+and Defender, the Search indexer and backup agents all open a file briefly right after it is
+written. The window is a few milliseconds, so it is invisible on an idle machine and common
+under load. When it fired, `publish()` threw, `runCrossAccountInsights` caught it, and the
+roll-up was marked failed -- surfacing as whichever assertion that test happened to make.
+That is why a different test failed each run, and why running the file alone always passed.
+
+Cross-test leakage was ruled out rather than assumed: every catalogue path is synchronous
+(`readFileSync`/`writeFileSync`/`renameSync`), so two `upsertRun` calls cannot interleave,
+and each test gets its own `mkdtemp` resources dir, so no catalogue outlives its test.
+
+This is a production bug, not a test bug. On a Defender-managed Windows box a real insights
+run can be reported failed purely because a scanner held `catalogue.json` for a few
+milliseconds. The test suite was the messenger.
+
+Fixed in `saveCatalogue`:
+
+- `renameWithRetry` retries EPERM/EACCES/EBUSY on a 5/10/20/40/80ms backoff (six attempts,
+  ~155ms worst case) and unlinks the staging file before giving up. Any other errno still
+  throws on the first attempt -- a retry cannot fix ENOSPC.
+- The staging file is now `<file>.<pid>.<seq>.tmp` instead of a fixed `<file>.tmp`. A write
+  that dies between `writeFileSync` and the rename leaves its staging file behind, and a
+  fixed name lets the next write adopt those stale bytes. `github/cache/cache-store.ts`
+  already used a unique staging name for the same reason.
+
+The sync backoff uses `Atomics.wait` on a throwaway `SharedArrayBuffer`: `saveCatalogue` is
+synchronous and called from synchronous code, so the wait has to block rather than yield.
+
+Evidence: 2/6 red before the fix under eight burners; 0/8 after, under the same load. Full
+suite 3/3 green idle plus 1/1 green under four burners; 3822 tests (4 new), typecheck clean,
+changelog in sync.
+
+New guard `tests/unit/insights-catalogue-write.test.ts` mocks `fs.renameSync` to fail with
+injected errnos and drives `saveCatalogue` through `cleanupStuckRuns`. It covers: retry then
+land the write, give up after the budget, refuse to retry a non-transient errno, and stage
+each write under a distinct name. Verified to fail against the old code -- 4 of 4 cases red
+when the fixed `.tmp` name and bare `renameSync` are restored.
+
+Worth keeping: the first version of that guard asserted exact rename-attempt counts and
+promptly flaked under load itself, because a REAL Defender EPERM added an attempt the test
+had not injected. It now asserts that the injected failures were consumed and that the set of
+distinct staging paths is right, never the attempt count. Writing a retry-tolerant fix
+deserves a retry-tolerant assertion.
+
+Follow-up, not done here: the same fixed-`.tmp`-plus-bare-`renameSync` shape appears in
+roughly a dozen other main-process modules (`config-manager.ts`, `session-state.ts`,
+`account-profiles.ts`, `model-registry-service.ts`, `sentinel/sentinel-state.ts`,
+`hooks/per-session-settings.ts`, `channel-storage.ts`, `codex-review-usage.ts` and others).
+Every one of them can lose the same race; `config-manager.ts` losing it means a dropped
+config save. A shared atomic-write helper is the right fix and is out of scope for #213.

--- a/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
+++ b/CONTEXT.d/2026-08-04-213-catalogue-rename-race.md
@@ -17,9 +17,23 @@ running:
 rename fails with EPERM/EACCES/EBUSY while ANY other process holds a handle on either path,
 and Defender, the Search indexer and backup agents all open a file briefly right after it is
 written. The window is a few milliseconds, so it is invisible on an idle machine and common
-under load. When it fired, `publish()` threw, `runCrossAccountInsights` caught it, and the
-roll-up was marked failed -- surfacing as whichever assertion that test happened to make.
-That is why a different test failed each run, and why running the file alone always passed.
+under load. That is why a different test failed each run, and why running the file alone
+always passed.
+
+Where the throw lands was measured rather than assumed, by injecting a single EPERM at the
+Nth catalogue write of a two-account roll-up and sweeping N (a throwaway test, since a real
+scanner will not hold still). Three distinct outcomes, and the first guess was the rarest:
+
+- N = 1, the aggregate's opening `publish()`: rejects outright AND strands the lock (below).
+- N = 2..11, any write inside a member's `runInsights`: that member is caught by its own
+  handler and marked failed, so the roll-up legitimately refuses with "Only 1 of 2 accounts
+  produced KPIs". This is the common case and it matches the observed test failures exactly
+  -- `expected 'failed' to be 'complete'`, with the EPERM nowhere in the assertion.
+- N = 12, a write inside the aggregate's own try: caught at the bottom of
+  `runCrossAccountInsights`, roll-up marked failed with the EPERM text as its error.
+
+Only the last of those is "publish() threw and the roll-up caught it", which is what the
+commit message for the first pass claimed. The member path is what actually bit.
 
 Cross-test leakage was ruled out rather than assumed: every catalogue path is synchronous
 (`readFileSync`/`writeFileSync`/`renameSync`), so two `upsertRun` calls cannot interleave,
@@ -57,6 +71,33 @@ promptly flaked under load itself, because a REAL Defender EPERM added an attemp
 had not injected. It now asserts that the injected failures were consumed and that the set of
 distinct staging paths is right, never the attempt count. Writing a retry-tolerant fix
 deserves a retry-tolerant assertion.
+
+## A second, worse bug the sweep exposed: the stranded lock
+
+The N = 1 case is not a variant of the same failure, it is a separate defect. Both run
+entry points take their lock, then do disk work, and only THEN enter the try whose `finally`
+releases it:
+
+    inFlight.add(key)
+    ensureDir(archiveDir)      // can throw: EACCES, ENOSPC
+    upsertRun(run)             // can throw: the rename race above
+    try { ... } finally { inFlight.delete(key) }
+
+Anything that throws in that gap strands the key in `inFlight` for the life of the process.
+The user then gets "Insights already running for this account" -- or "A cross-account report
+is already being generated" -- forever, with nothing running and no way out but restarting
+the app. The retry above makes the rename race far less likely to trigger it, but `ensureDir`
+on a full or locked disk reaches it just as well, so the retry is not a fix for this.
+
+Fixed by moving `ensureDir` and the opening `upsertRun`/`publish()` inside the existing try
+in both `runInsights` and `runCrossAccountInsights`. The lock is still taken immediately
+before the try, so the guard itself is unchanged; only the unprotected gap closes.
+
+`tests/unit/insights-lock-release.test.ts` injects a non-retryable ENOSPC at a chosen write
+and asserts the lock is clear afterwards, for the per-account lock, the aggregate lock, and a
+failure mid-fan-out. Verified to fail 3 of 3 against the old ordering. ENOSPC deliberately,
+not EPERM: EPERM is now retried, and a guard that the fix above quietly satisfies would not
+be testing this at all.
 
 Follow-up, not done here: the same fixed-`.tmp`-plus-bare-`renameSync` shape appears in
 roughly a dozen other main-process modules (`config-manager.ts`, `session-state.ts`,

--- a/src/main/insights-runner.ts
+++ b/src/main/insights-runner.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   writeFileSync,
   renameSync,
+  unlinkSync,
   copyFileSync,
   readdirSync,
   statSync,
@@ -120,15 +121,58 @@ function loadCatalogue(): InsightsCatalogue {
   return { runs: [] }
 }
 
+/**
+ * On Windows a rename over an existing file fails with EPERM/EACCES/EBUSY while
+ * ANY other process holds a handle on either path — and Defender, the Search
+ * indexer and backup agents all open a file briefly right after it is written.
+ * The window is a few milliseconds, so it is invisible on an idle machine and
+ * common under load: on a Defender-managed box, CPU pressure made this throw on
+ * roughly a third of unit-suite runs, aborting whichever run was mid-flight and
+ * reading as an unrelated flaky test (#213).
+ *
+ * Retrying is the whole fix — the handle is transient by definition. A genuine
+ * permission problem still surfaces, just ~155ms later.
+ */
+const RENAME_RETRY_DELAYS_MS = [5, 10, 20, 40, 80]
+
+function sleepSync(ms: number): void {
+  // saveCatalogue is synchronous and called from sync code paths, so the wait
+  // has to block rather than yield.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+function renameWithRetry(from: string, to: string): void {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      renameSync(from, to)
+      return
+    } catch (err: any) {
+      const transient = err?.code === 'EPERM' || err?.code === 'EACCES' || err?.code === 'EBUSY'
+      if (!transient || attempt >= RENAME_RETRY_DELAYS_MS.length) {
+        // Don't leave the staged copy behind for the next writer to trip over.
+        try { unlinkSync(from) } catch { /* ignore */ }
+        throw err
+      }
+      logWarn(`[insights] rename ${from} -> ${to} failed with ${err.code}, retry ${attempt + 1}`)
+      sleepSync(RENAME_RETRY_DELAYS_MS[attempt])
+    }
+  }
+}
+
+let catalogueWriteSeq = 0
+
 function saveCatalogue(catalogue: InsightsCatalogue): void {
   ensureDir(getInsightsDir())
   // Atomic: write a tmp then rename over the target so a crash mid-write can't
   // truncate catalogue.json (which loadCatalogue would then read as an empty
   // catalogue, hiding every run).
   const file = getCatalogueFile()
-  const tmp = file + '.tmp'
+  // Unique per write. A write that dies between writeFileSync and the rename
+  // leaves its staging file behind, and a fixed `.tmp` name would let the next
+  // write adopt those stale bytes if it then failed before its own write landed.
+  const tmp = `${file}.${process.pid}.${++catalogueWriteSeq}.tmp`
   writeFileSync(tmp, JSON.stringify(catalogue, null, 2))
-  renameSync(tmp, file)
+  renameWithRetry(tmp, file)
 }
 
 /** Read-modify-write a single run into the CURRENT on-disk catalogue (replace by

--- a/src/main/insights-runner.ts
+++ b/src/main/insights-runner.ts
@@ -954,14 +954,19 @@ export async function runInsights(getWindow: () => BrowserWindow | null, opts?: 
 
   const id = generateRunId()
   const archiveDir = join(getInsightsDir(), id)
-  ensureDir(archiveDir)
-
   const run: InsightsRun = { id, timestamp: Date.now(), status: 'running', accountEmail: account.accountEmail, profileId: account.profileId }
-  upsertRun(run)
-  notifyRenderer(getWindow, run)
-  logInfo(`[insights] Run ${id} account=${account.accountEmail ?? '(default)'} home=${account.home ?? 'global'}`)
 
+  // Everything that can touch the disk lives inside the try, because only its
+  // `finally` releases the lock. ensureDir and the first upsertRun used to run
+  // above it, so a transient failure there (a scanner losing us the catalogue
+  // rename, a full disk) left `key` in `inFlight` forever and every later run
+  // for that account reported "Insights already running" with nothing running.
   try {
+    ensureDir(archiveDir)
+    upsertRun(run)
+    notifyRenderer(getWindow, run)
+    logInfo(`[insights] Run ${id} account=${account.accountEmail ?? '(default)'} home=${account.home ?? 'global'}`)
+
     // Step 1: Run /insights via interactive PTY
     run.statusMessage = 'Step 1/3: Generating report...'
     upsertRun(run)
@@ -1081,7 +1086,6 @@ export async function runCrossAccountInsights(
 
   const id = generateRunId()
   const archiveDir = join(getInsightsDir(), id)
-  ensureDir(archiveDir)
 
   const run: InsightsRun = {
     id,
@@ -1105,10 +1109,14 @@ export async function runCrossAccountInsights(
     const row = run.members?.find(m => m.profileId === profileId)
     if (row) Object.assign(row, patch)
   }
-  publish()
-  logInfo(`[insights] Cross-account run ${id} over ${targets.length} accounts`)
-
+  // Same reason as runInsights: ensureDir and the opening publish() have to be
+  // inside the try, or a transient disk failure there strands CROSS_ACCOUNT_KEY
+  // in `inFlight` and every later roll-up reports "already being generated".
   try {
+    ensureDir(archiveDir)
+    publish()
+    logInfo(`[insights] Cross-account run ${id} over ${targets.length} accounts`)
+
     // Step 1: fan out one normal per-account run each, bounded so a wide
     // multi-account setup doesn't put N interactive Claude PTYs on the machine.
     let done = 0

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,6 +21,14 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.7',
+    date: '2026-08-05',
+    changes: [
+      { type: 'fix', description: 'Windows: an Insights run could report itself as failed for no visible reason. Security software on Windows briefly holds a file open just after it has been written, and that could make saving the list of runs fail — more often when the machine was busy. Saving now waits a moment and tries again.' },
+      { type: 'fix', description: 'Insights could get stuck insisting a report was already being generated when nothing was running, leaving restarting the app as the only way out. If saving the list of runs failed at the wrong moment, the app never cleared its "in progress" marker. That marker is now always cleared, however the run ends.' }
+    ]
+  },
+  {
     version: '2.1.0-beta.6',
     date: '2026-08-04',
     highlights: 'The app is now AI Code Conductor, with a new icon, start-up animation and a rebuilt session setup dialog. Insights can also look at all of your accounts at once: one click generates every account\'s report and then a combined report that compares them side by side.',

--- a/tests/unit/insights-catalogue-write.test.ts
+++ b/tests/unit/insights-catalogue-write.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// #213: catalogue.json is written tmp-then-rename. On Windows that rename fails
+// with EPERM/EACCES/EBUSY whenever another process (Defender, the Search
+// indexer, a backup agent) holds a momentary handle on either path. It threw
+// often enough under CPU load to abort whichever insights run was mid-flight,
+// which surfaced as an unrelated flaky unit test.
+
+const h = vi.hoisted(() => ({
+  resourcesDir: '',
+  /** Error codes renameSync should throw, one per call, before it succeeds. */
+  failCodes: [] as string[],
+  /** Every `from` path rename was asked to move, in order. */
+  renameFrom: [] as string[]
+}))
+
+vi.mock('../../src/main/ipc/setup-handlers', () => ({
+  getResourcesDirectory: () => h.resourcesDir,
+  registerSetupHandlers: () => {}
+}))
+vi.mock('../../src/main/update-watcher', () => ({ getInstallPath: () => '', getProjectRootPath: () => '' }))
+vi.mock('../../src/main/pty-manager', () => ({ resolveClaudeForPty: () => ({ cmd: 'claude' }), withProfileHome: (e: unknown) => e }))
+vi.mock('../../src/main/claude-headless', () => ({ spawnClaudeHeadless: async () => ({ code: 0, stdout: '', stderr: '' }) }))
+vi.mock('node-pty', () => ({ spawn: () => ({ onData: () => {}, onExit: () => {}, write: () => {}, kill: () => {} }) }))
+
+vi.mock('fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('fs')>()
+  return {
+    ...real,
+    default: real,
+    renameSync: (from: string, to: string) => {
+      h.renameFrom.push(String(from))
+      const code = h.failCodes.shift()
+      if (code) {
+        const err = new Error(`${code}: simulated, rename '${from}' -> '${to}'`) as NodeJS.ErrnoException
+        err.code = code
+        throw err
+      }
+      return real.renameSync(from, to)
+    }
+  }
+})
+
+import { cleanupStuckRuns, getCatalogue } from '../../src/main/insights-runner'
+
+let tmpRoot = ''
+let insightsDir = ''
+
+/** Seed a catalogue holding one run that cleanupStuckRuns will want to rewrite. */
+function seedStuckCatalogue(): void {
+  writeFileSync(
+    join(insightsDir, 'catalogue.json'),
+    JSON.stringify({ runs: [{ id: 'r1', timestamp: 1, status: 'running' }] })
+  )
+}
+
+function stagingFiles(): string[] {
+  return readdirSync(insightsDir).filter((f) => f.endsWith('.tmp'))
+}
+
+describe('catalogue persistence survives a transient Windows rename failure', () => {
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'insights-catwrite-'))
+    h.resourcesDir = join(tmpRoot, 'resources')
+    insightsDir = join(h.resourcesDir, 'insights')
+    mkdirSync(insightsDir, { recursive: true })
+    h.failCodes = []
+    h.renameFrom = []
+  })
+  afterEach(() => {
+    try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  it('retries a rename that loses to a scanner and still lands the write', () => {
+    seedStuckCatalogue()
+    h.failCodes = ['EPERM', 'EACCES', 'EBUSY']
+
+    expect(() => cleanupStuckRuns()).not.toThrow()
+
+    // All three simulated losses were consumed, then a later attempt landed.
+    // Not an exact count: the real filesystem underneath can lose the race too,
+    // and a retry-tolerant fix deserves a retry-tolerant assertion.
+    expect(h.failCodes).toEqual([])
+    expect(h.renameFrom.length).toBeGreaterThanOrEqual(4)
+    // The write is the point — not merely that it stopped throwing.
+    expect(getCatalogue().runs[0].status).toBe('failed')
+    expect(JSON.parse(readFileSync(join(insightsDir, 'catalogue.json'), 'utf-8')).runs[0].error)
+      .toMatch(/Interrupted by app restart/)
+    expect(stagingFiles()).toEqual([])
+  })
+
+  it('gives up on a real permission problem instead of retrying forever', () => {
+    seedStuckCatalogue()
+    // Longer than the retry budget, so the last attempt still fails.
+    h.failCodes = ['EPERM', 'EPERM', 'EPERM', 'EPERM', 'EPERM', 'EPERM', 'EPERM']
+
+    expect(() => cleanupStuckRuns()).toThrow(/EPERM/)
+    // Five delays plus the first try = six attempts, then it stops.
+    expect(h.renameFrom).toHaveLength(6)
+    // A failed write must not leave its staging file for the next writer.
+    expect(stagingFiles()).toEqual([])
+  })
+
+  it('does not retry an error that a retry cannot fix', () => {
+    seedStuckCatalogue()
+    h.failCodes = ['ENOSPC', 'ENOSPC']
+
+    expect(() => cleanupStuckRuns()).toThrow(/ENOSPC/)
+    expect(h.renameFrom).toHaveLength(1)
+    expect(stagingFiles()).toEqual([])
+  })
+
+  it('stages each write under its own name so a stranded tmp is never adopted', () => {
+    seedStuckCatalogue()
+    cleanupStuckRuns()
+    // Re-seed and write again; the two writes must not share a staging path.
+    seedStuckCatalogue()
+    cleanupStuckRuns()
+
+    // Distinct paths, not attempt count: a retry reuses its own staging path, so
+    // a real EPERM underneath adds attempts without adding staging names.
+    const staged = [...new Set(h.renameFrom)]
+    expect(staged).toHaveLength(2)
+    expect(staged.every((p) => !/[/\\]catalogue\.json\.tmp$/.test(p))).toBe(true)
+  })
+})

--- a/tests/unit/insights-lock-release.test.ts
+++ b/tests/unit/insights-lock-release.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// #213: an insights run takes its lock, then does disk work, then enters the
+// try whose `finally` releases that lock. Anything that threw in between —
+// ensureDir, or the opening catalogue write losing a rename race to a virus
+// scanner — stranded the key in `inFlight` for the life of the process, and
+// every later run reported "already running" with nothing running. A restart
+// was the only way out.
+
+const h = vi.hoisted(() => ({
+  resourcesDir: '',
+  profileDir: {} as Record<string, string>,
+  profiles: [] as Array<{ id: string; name?: string; accountEmail: string; isPrimary?: boolean }>,
+  /** renameSync call number that should fail, 1-based. -1 disables. */
+  failOnCall: -1,
+  callCount: 0
+}))
+
+vi.mock('../../src/main/ipc/setup-handlers', () => ({
+  getResourcesDirectory: () => h.resourcesDir,
+  registerSetupHandlers: () => {}
+}))
+vi.mock('../../src/main/account-profiles', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/main/account-profiles')>()),
+  getProfileConfigDir: (id: string) => h.profileDir[id] ?? '',
+  getPrimaryProfileId: () => h.profiles.find((p) => p.isPrimary)?.id ?? h.profiles[0]?.id ?? null,
+  setupProfileLinks: () => {},
+  listProfiles: () => h.profiles
+}))
+vi.mock('../../src/main/update-watcher', () => ({ getInstallPath: () => '', getProjectRootPath: () => '' }))
+vi.mock('../../src/main/pty-manager', () => ({
+  resolveClaudeForPty: () => ({ cmd: 'claude' }),
+  withProfileHome: (e: unknown) => e
+}))
+vi.mock('node-pty', () => ({
+  spawn: () => ({
+    onData: () => {},
+    onExit: (cb: (e: { exitCode: number }) => void) => cb({ exitCode: 0 }),
+    write: () => {},
+    kill: () => {}
+  })
+}))
+vi.mock('../../src/main/claude-headless', () => ({
+  spawnClaudeHeadless: async () => ({ code: 0, stdout: JSON.stringify(KPIS), stderr: '' })
+}))
+
+// ENOSPC, deliberately: it is NOT one of the transient codes saveCatalogue
+// retries, so it models "the write really did fail" rather than the scanner
+// race. The lock must be released either way.
+vi.mock('fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('fs')>()
+  return {
+    ...real,
+    default: real,
+    renameSync: (from: string, to: string) => {
+      h.callCount++
+      if (h.callCount === h.failOnCall) {
+        const e = new Error(`ENOSPC: no space left on device, rename '${from}' -> '${to}'`) as NodeJS.ErrnoException
+        e.code = 'ENOSPC'
+        throw e
+      }
+      return real.renameSync(from, to)
+    }
+  }
+})
+
+const KPIS = {
+  period: { start: '2026-07-01', end: '2026-07-31', days: 31 },
+  kpis: { Volume: { sessions: { value: 10, label: 'Sessions', format: 'number', goodDirection: 'up' } } }
+}
+
+import { runInsights, runCrossAccountInsights, isRunning, isCrossAccountRunning } from '../../src/main/insights-runner'
+
+let tmpRoot = ''
+const getWin = () => null
+
+function seed(id: string, email: string, isPrimary = false): void {
+  const dir = join(tmpRoot, 'profiles', id)
+  mkdirSync(join(dir, '.claude', 'usage-data'), { recursive: true })
+  writeFileSync(join(dir, '.claude', 'usage-data', 'report.html'), '<html><body>r</body></html>')
+  h.profileDir[id] = dir
+  h.profiles.push({ id, name: `Acct ${id.toUpperCase()}`, accountEmail: email, isPrimary })
+}
+
+/** Swallow whatever the run does with the failure; the lock is what is on trial. */
+async function attempt(fn: () => Promise<unknown>): Promise<void> {
+  try { await fn() } catch { /* the run is allowed to fail */ }
+}
+
+describe('a failed catalogue write never strands an insights lock', () => {
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'insights-lock-'))
+    h.resourcesDir = join(tmpRoot, 'resources')
+    mkdirSync(h.resourcesDir, { recursive: true })
+    h.profileDir = {}
+    h.profiles = []
+    h.failOnCall = -1
+    h.callCount = 0
+  })
+  afterEach(() => {
+    try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  it('releases the per-account lock when the opening write fails', async () => {
+    seed('a', 'a@example.com', true)
+    h.failOnCall = 1 // the very first upsertRun, before any awaited work
+
+    await attempt(() => runInsights(getWin, { profileId: 'a' }))
+
+    expect(isRunning('a')).toBe(false)
+    // The real symptom was the NEXT run being refused, so prove that directly.
+    await expect(runInsights(getWin, { profileId: 'a' })).resolves.toBeTruthy()
+  })
+
+  it('releases the aggregate lock when the opening write fails', async () => {
+    seed('a', 'a@example.com', true)
+    seed('b', 'b@example.com')
+    h.failOnCall = 1 // the aggregate's own opening publish()
+
+    await attempt(() => runCrossAccountInsights(getWin))
+
+    expect(isCrossAccountRunning()).toBe(false)
+    // Pre-fix this threw "A cross-account report is already being generated"
+    // forever, with no run in flight.
+    await attempt(() => runCrossAccountInsights(getWin))
+    expect(isCrossAccountRunning()).toBe(false)
+  })
+
+  it('leaves no lock behind when a member run fails mid-fan-out', async () => {
+    seed('a', 'a@example.com', true)
+    seed('b', 'b@example.com')
+    h.failOnCall = 3 // inside the fan-out, once members are already writing
+
+    await attempt(() => runCrossAccountInsights(getWin))
+
+    expect(isCrossAccountRunning()).toBe(false)
+    expect(isRunning('a')).toBe(false)
+    expect(isRunning('b')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #213 — but not as filed. The issue described an order/timing-dependent unit
suite and proposed awaiting quiescence in `afterEach` plus `vi.resetModules()`.
Neither was needed, and **`tests/unit/insights-cross-account-run.test.ts` is
untouched by this PR.** The suite was reporting a real Windows defect in the app.

## The actual cause

`saveCatalogue` stages `catalogue.json.tmp` then `renameSync`s it over the target.
On Windows that rename fails with `EPERM`/`EACCES`/`EBUSY` while any other process
holds a handle on either path, and Defender's real-time protection opens a file the
instant its write handle closes — precisely the gap between `writeFileSync` and
`renameSync`. A few milliseconds, so it never fires on an idle machine.

Cross-test leakage was ruled out rather than assumed: every catalogue path is
synchronous, so two `upsertRun` calls cannot interleave, and each test gets its own
`mkdtemp` resources dir, so no catalogue outlives its test.

## Why it read as an unrelated flaky test

Measured by injecting a single `EPERM` at the Nth catalogue write of a two-account
roll-up and sweeping N:

| N | lands in | what a test sees |
| --- | --- | --- |
| 1 | the aggregate's opening `publish()` | rejects, **and strands the lock** |
| 2–11 | a member's `runInsights` | member failed → "Only 1 of 2 accounts produced KPIs" |
| 12 | the aggregate's own `try` | roll-up failed, `EPERM` as its error text |

The middle band is the common case and the deceptive one: a member run catches the
`EPERM`, marks itself failed, and the roll-up then legitimately refuses. By the time
an assertion runs, a disk error has been digested into a plausible business outcome
— `expected 'failed' to be 'complete'`, with `EPERM` nowhere in sight.

## Two commits, two defects

**`3649cc9` — the race.** Retry `EPERM`/`EACCES`/`EBUSY` on a 5/10/20/40/80ms
backoff, six attempts, ~155ms worst case. Every other errno throws on the first
attempt, because a retry cannot fix `ENOSPC`. Staging file is now
`<file>.<pid>.<seq>.tmp`. The backoff blocks via `Atomics.wait` rather than yielding,
because `saveCatalogue` is synchronous and called from synchronous code.

**`24c38cd` — the stranded lock, which is worse.** Both entry points took their lock,
then ran `ensureDir` and the first catalogue write, and only then entered the `try`
whose `finally` releases it:

```
inFlight.add(key)
ensureDir(archiveDir)   // can throw: EACCES, ENOSPC
upsertRun(run)          // can throw: the rename race
try { … } finally { inFlight.delete(key) }
```

Anything throwing in that gap stranded the key for the life of the process. The user
then gets "Insights already running for this account", or "A cross-account report is
already being generated", forever, with nothing running and no way out but restarting
the app. The retry does not cover this — `ensureDir` on a full or locked disk reaches
it just as well. Fixed by moving both calls inside the existing `try`; the lock is
still taken immediately before it, so the guard itself is unchanged.

## Evidence

| | before | after |
| --- | --- | --- |
| flaky file, 8 CPU burners | 2/6 red | 0/8 green |
| both insights files, 8 burners | — | 0/10 red |
| full suite, idle | failed on run 1 | 3/3 green |
| full suite, 4 burners | — | 1/1 green |

3825 tests (7 new), typecheck clean, `CHANGELOG.md` in sync.

Both guards were verified against the old code rather than assumed to work:
`insights-catalogue-write.test.ts` 4/4 red with the retry reverted,
`insights-lock-release.test.ts` 3/3 red with the `try` boundary moved back.

The lock guard injects a non-retryable `ENOSPC` deliberately: `EPERM` is now retried,
so a guard using it would pass without testing the lock at all.

One thing worth carrying forward: the first version of the rename guard asserted
exact rename-attempt counts and promptly flaked under load itself, because a *real*
Defender `EPERM` added an attempt the test had not injected. It now asserts that the
injected failures were consumed and that the set of distinct staging paths is right,
never the attempt count. A retry-tolerant fix needs retry-tolerant assertions.

## Follow-up

`insights-runner.ts` is now the only atomic-write site in `src/main` that retries.
Filed as #233 — roughly a dozen others can lose the same race, and
`config-manager.ts:165` catches it, logs, and returns `false`, so a scanner winning a
3ms race silently drops a config save. That is a worse outcome than this PR fixes,
because a failed insights run is visible and a lost settings write is not.

## Review scope

Not on the ADR-009 path table, in my reading: no IPC/preload, PTY argv, credential,
updater or `webPreferences` surface. It does build a filename inside the
user-selected resources dir, but only by appending a numeric pid and an in-process
counter to an already-resolved path, with no renderer input reaching it — so no
path-resolution change to attack. Flagging the judgement rather than burying it;
say so and I will dispatch the pass.

Desktop-checked on Windows before this PR was opened: single-account run, status
stepping through all three phases, cross-account roll-up over 4 profiles, and a
second consecutive run on the same account to confirm the lock releases.

Changelog opens a `2.1.0-beta.7` entry — `v2.1.0-beta.6` shipped 2026-08-04, so the
previous top entry was spent. No `highlights` line: that is a release-level summary
and the entry will collect more changes before one is written (three existing entries
omit it, so the generator copes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
