### PR TITLE
fix(usage): clear stale usageBuckets on session respawn

### DIFF
--- a/src/renderer/hooks/useRestartSession.ts
+++ b/src/renderer/hooks/useRestartSession.ts
@@ -49,6 +49,12 @@ export function useRestartSession(
         rateLimitWeekly: undefined,
         rateLimitWeeklyResets: undefined,
         rateLimitExtra: undefined,
+        // Per-model usage buckets (statusline limits[], incl. the weekly Fable
+        // bucket) are live indicators too -- omitting them left the previous
+        // account's hit limit painted on the card after a mid-session switch
+        // (which routes through this same remount) until a later tick overwrote
+        // it. Clear them like the rateLimit* siblings.
+        usageBuckets: undefined,
       })
     },
     [session],

--- a/tests/unit/renderer/use-restart-session.test.ts
+++ b/tests/unit/renderer/use-restart-session.test.ts
@@ -151,6 +151,27 @@ describe('useRestartSession (P4 Task A)', () => {
     expect(stored!.rateLimitWeekly).toBeUndefined()
     expect(stored!.rateLimitWeeklyResets).toBeUndefined()
     expect(stored!.rateLimitExtra).toBeUndefined()
+    expect(stored!.usageBuckets).toBeUndefined()
+  })
+
+  // 1b. Regression (Fable usage): a hit per-model limit must not linger across
+  //     the remount that a mid-session account switch also routes through.
+  it("restart() clears usageBuckets so a prior account's hit limit does not linger", () => {
+    const session = makeSession({
+      sessionType: 'local',
+      shellOnly: false,
+      usageBuckets: [
+        { key: 'weekly:Fable', label: 'Fable', group: 'weekly', percent: 100, resetsAt: '', severity: 'critical' },
+      ],
+    })
+    useSessionStore.getState().addSession(session)
+
+    renderHarness(session)
+    act(() => { capturedActions!.restart() })
+
+    const stored = useSessionStore.getState().sessions.find((s) => s.id === session.id)
+    expect(stored).toBeDefined()
+    expect(stored!.usageBuckets).toBeUndefined()
   })
 
   it('restart() does NOT call markSessionForResumePicker for shell sessions', () => {


### PR DESCRIPTION
## Problem

In a session on account A, when A hits its Fable weekly limit the session shows the usage-limit state. Right-click → **change account** to an account (B) that still has Fable usage, and the session **still reports "Fable needs usage credits."** Only a manual **Restart** clears it.

## Root cause

A mid-session account switch is *respawn + resume* — `useSwitchAccount` routes through the **same** `forceRemount` path as the Restart button (`useRestartSession.ts`). That path clears the previous run's live indicators (context, cost, tokens, and the aggregate `rateLimit*` fields) so they don't linger on the restarted card — but it was **missing `usageBuckets`**, the dynamic per-model buckets from the statusline `limits[]` discovery, which include the **weekly Fable** limit (`SessionStatusStrip.tsx` renders the usage strip straight from `session.usageBuckets`).

So the outgoing account's exhausted Fable bucket stayed painted across the respawn until a later statusline tick happened to overwrite it. Restart only *appeared* to fix it because, by the time the user clicked it, a fresh tick had arrived with the new account's data — both paths use the identical `forceRemount`, so neither cleared the bucket.

## Fix

Clear `usageBuckets` in `forceRemount` alongside the `rateLimit*` siblings — one line. The next statusline tick repopulates it with the live account's usage. Covers switch, Restart, and Recover (all route through `forceRemount`).

## Test

Adds a regression test that seeds an exhausted Fable bucket on a session and asserts it is cleared on `restart()`. **Verify-by-revert done:** with the fix line removed the seeded bucket survives the `...session` spread and the test fails at the `usageBuckets` assertion.

- `npx vitest run tests/unit/renderer/use-restart-session.test.ts tests/unit/renderer/use-switch-account.test.ts` → 15 passed
- `npm run typecheck` → clean

## Notes

- Renderer-only, behavior of the session card; no main-process / IPC / security-surface changes (no adversarial review required per the ADR-009 path table).
- Tagged `release-2.1`; **not** `ci-run` yet (per the beta-triage flow) — add `ci-run` when you want the matrix before merge. No release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
