### PR TITLE
deps: raise override floors to clear 23 open Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.5",
+  "version": "2.1.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.5",
+      "version": "2.1.0-beta.6",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
@@ -17,7 +17,7 @@
         "@xterm/xterm": "^6.0.0",
         "better-sqlite3": "13.0.1",
         "chrome-remote-interface": "^0.34.0",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "electron-screenshots": "^0.6.2",
         "marked": "^18.0.5",
         "node-pty": "1.2.0-beta.14",
@@ -5802,9 +5802,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -6545,9 +6545,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7334,9 +7334,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7832,9 +7832,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8053,9 +8053,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8856,26 +8856,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -8897,12 +8897,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/mermaid/node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -9073,9 +9073,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -9168,9 +9168,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11257,9 +11257,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "13.0.1",
     "chrome-remote-interface": "^0.34.0",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "electron-screenshots": "^0.6.2",
     "marked": "^18.0.5",
     "node-pty": "1.2.0-beta.14",
@@ -72,10 +72,10 @@
     "esbuild": ">=0.28.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "hono": "^4.12.27",
+    "hono": "^4.12.34",
     "@hono/node-server": "^2.0.5",
     "lodash-es": "^4.18.1",
-    "ip-address": "^10.2.0",
+    "ip-address": "^10.3.1",
     "@xmldom/xmldom": "^0.8.13",
     "minimatch": "^10.2.3",
     "tar": "^7.5.21",
@@ -84,9 +84,9 @@
     "postcss": "^8.5.18",
     "rollup": "^4.59.0",
     "@tootallnate/once": "^3.0.1",
-    "nanoid": "^5.1.11",
-    "fast-uri": "^3.1.4",
-    "mermaid": "^11.15.0",
+    "nanoid": "^5.1.16",
+    "fast-uri": "^3.1.5",
+    "mermaid": "^11.16.1",
     "qs": "^6.15.2",
     "uuid": "^11.1.1",
     "tmp": "^0.2.6",
@@ -96,7 +96,12 @@
     "body-parser": "^2.3.0",
     "immutable": "^4.3.9",
     "js-yaml": "^4.3.0",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.7",
+    "dompurify": "^3.4.13",
+    "undici": "^7.29.0",
+    "node-gyp": {
+      "undici": "^6.28.0"
+    }
   },
   "build": {
     "appId": "com.claudeconductor.app",


### PR DESCRIPTION
## What

Raises the `overrides` floors (plus the direct `dompurify` dep) so every package still inside a vulnerable range on `beta` resolves to a patched version. One PR clears **23 of the 37 open Dependabot alerts** (the other 14 are already fixed on beta and only remain open because alerts track frozen `main`).

| Package | Was | Now resolves | Alerts cleared |
|---|---|---|---|
| nanoid | 5.1.11 | 5.1.16 | #161 (high) |
| fast-uri | 3.1.4 | 3.1.5 | #149 (high) |
| ip-address | 10.2.0 | 10.4.0 | #145 (high), #137, #136 |
| hono | 4.12.32 | 4.13.1 | #160, #158, #144, #159 |
| mermaid | 11.15.0 | 11.16.1 | #156, #155, #154, #153, #152 |
| dompurify | 3.4.12 | 3.4.13 | #157 |
| undici (top-level) | 7.28.0 | 7.29.0 | #143, #142, #141, #140 (high), #139 |
| undici (node-gyp scoped) | 6.27.0 | 6.28.0 | #148, #147, #146 |

## Why

ssbn needs the Security tab cleared for corporate acceptance. These are the alerts that genuinely still applied to `beta`; the rest get dismissed with evidence separately.

## Safety

- All bumps are **patch/minor within existing majors** — no ADR-009 adversarial-review trigger (that applies to *major* runtime bumps).
- `node-gyp` gets a **scoped** override so it stays on its 6.x undici line rather than being force-majored to 7.
- Local verification: `npm run typecheck` clean, **full `npx vitest run`: 3853 passed / 13 skipped** (the baseline).
- The `electron-rebuild` postinstall failure seen locally is the documented host condition (MSB8040 Spectre libs, no local packaging on this machine) — unrelated to these bumps; CI builds on clean runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)