### PR TITLE
build(release): 2.1.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
-## [2.1.0-beta.8] - 2026-08-10
+## [2.1.0-beta.8] - 2026-08-11
 
 ### Added
 - Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session's account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.7",
+  "version": "2.1.0-beta.8",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -22,7 +22,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '2.1.0-beta.8',
-    date: '2026-08-10',
+    date: '2026-08-11',
     changes: [
       { type: 'feature', description: 'Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session\'s account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.' },
       { type: 'improvement', description: 'Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.' }


### PR DESCRIPTION
Version bump to cut **2.1.0-beta.8** — the first **signed** Windows beta.

Rolls up what's already on `beta`:
- **Windows code signing** (#251) — installers Authenticode-signed via SSL.com eSigner CKA; adversarial-review PASS.
- **Accounts active/inactive** (#239) — park an account without removing it.

Bump only: `package.json` → `2.1.0-beta.8`, changelog date synced, `CHANGELOG.md` regenerated (in sync). No code changes. After merge, dispatch `release.yml --ref beta -f channel=beta` for the signed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)