### PR TITLE
feat(sessions): terminal-only session UX — Restart control + hide context meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.
 - The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.
+- Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.
 
 ## [2.1.0-beta.7] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.
 - Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.
 
+### Fixed
+- Terminal-only sessions no longer show a context-usage percentage on their sidebar card. A shell session has no reliable context signal, so the number could be stale or borrowed from another session; it is hidden until terminal integration improves. The model and mode still show.
+
 ## [2.1.0-beta.7] - 2026-08-10
 
 > A security release. Two high-severity local-attacker vulnerabilities are fixed — their advisories publish alongside this release — and every open dependency security alert on the project is cleared.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -915,9 +915,10 @@ export default function App() {
             terminal/GitHub-panel row so they span the full content-column
             width and the GitHub panel ends above them. Rendered once for the
             ACTIVE session only -- switching tabs re-resolves these against
-            `activeSession`. The telemetry strip is hidden for shell-only
-            sessions (matches the old per-TerminalView gate). */}
-        {activeSession && !activeSession.shellOnly && (
+            `activeSession`. Shell-only sessions render a minimal variant of the
+            strip — just a Restart control, no telemetry (the strip handles that
+            internally). */}
+        {activeSession && (
           <SessionStatusStrip sessionId={activeSession.id} />
         )}
         {activeSession && (

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -26,7 +26,8 @@ export const changelog: ChangelogEntry[] = [
     changes: [
       { type: 'feature', description: 'Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session\'s account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.' },
       { type: 'improvement', description: 'Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.' },
-      { type: 'improvement', description: 'The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.' }
+      { type: 'improvement', description: 'The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.' },
+      { type: 'improvement', description: 'Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.' }
     ]
   },
   {

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -27,7 +27,8 @@ export const changelog: ChangelogEntry[] = [
       { type: 'feature', description: 'Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session\'s account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.' },
       { type: 'improvement', description: 'Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.' },
       { type: 'improvement', description: 'The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.' },
-      { type: 'improvement', description: 'Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.' }
+      { type: 'improvement', description: 'Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.' },
+      { type: 'fix', description: 'Terminal-only sessions no longer show a context-usage percentage on their sidebar card. A shell session has no reliable context signal, so the number could be stale or borrowed from another session; it is hidden until terminal integration improves. The model and mode still show.' }
     ]
   },
   {

--- a/src/renderer/components/SessionStatusStrip.tsx
+++ b/src/renderer/components/SessionStatusStrip.tsx
@@ -114,6 +114,34 @@ export default function SessionStatusStrip({ sessionId }: SessionStatusStripProp
   }
 
   if (!session) return null
+
+  // Terminal-only (shell) sessions get just a Restart control, in the same
+  // bottom-right position and styling as a Claude session — no telemetry and no
+  // Claude-only Model/Compact/account controls (those write slash-commands a raw
+  // shell would not understand). restart() already handles a shell session (kill
+  // PTY + remount → generic respawn, skipping the resume picker). Placed before
+  // the status-line guard so Restart shows regardless of the status-line toggle.
+  if (session.shellOnly) {
+    return (
+      <div
+        className="min-h-7 shrink-0 flex items-center gap-3 px-3 text-xs border-t border-b"
+        style={{ background: 'var(--surface-raised)', color: 'var(--text-on-chrome)', borderColor: 'var(--border-subtle)' }}
+      >
+        <div className="flex-1" aria-hidden />
+        <button
+          onClick={() => restart()}
+          className={CONTROL_PILL}
+          style={{ background: 'transparent', border: '1px solid transparent', color: 'var(--text-muted)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--status-danger) 14%, transparent)'; e.currentTarget.style.color = 'var(--status-danger)' }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)' }}
+          title="Restart session"
+        >
+          Restart
+        </button>
+      </div>
+    )
+  }
+
   // A Codex strip is telemetry-only (no controls cluster), so with the master
   // off there is nothing left to show — collapse the band entirely.
   if (!statusLineEnabled && !isClaude) return null

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -164,12 +164,21 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
           column 1. */}
       <div className="relative z-10 row-start-2 flex items-center gap-2" style={{ gridColumn: '1 / 3' }} data-testid="card-line2">
         <span className="meta truncate">{metaLine}</span>
-        <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
-          <div className={`meter-fill ${meterClass(pct)}`} style={{ width: `${pct}%` }} />
-        </div>
-        <span className="meta w-9 text-right tabular-nums shrink-0">
-          {session.contextPercent != null ? `${Math.round(pct)}%` : ''}
-        </span>
+        {/* Context meter is Claude-session telemetry. Terminal-only (shell)
+            sessions don't have a reliable context signal — the statusline bridge
+            can leak a stale/foreign percentage onto them — so hide the meter and
+            the % for shell sessions until there's proper integration. The model ·
+            mode meta stays. */}
+        {!session.shellOnly && (
+          <>
+            <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: 'var(--surface-sunken)' }}>
+              <div className={`meter-fill ${meterClass(pct)}`} style={{ width: `${pct}%` }} />
+            </div>
+            <span className="meta w-9 text-right tabular-nums shrink-0">
+              {session.contextPercent != null ? `${Math.round(pct)}%` : ''}
+            </span>
+          </>
+        )}
       </div>
 
       {/* Line 3: account on its own row, under the model (spans 1 / 3 so it aligns

--- a/tests/unit/renderer/SessionRow.effort.test.tsx
+++ b/tests/unit/renderer/SessionRow.effort.test.tsx
@@ -94,3 +94,23 @@ describe('SessionRow fast-mode bolt', () => {
     expect(container.querySelector('[data-testid="fast-bolt"]')).toBeNull()
   })
 })
+
+describe('SessionRow context meter', () => {
+  it('hides the context meter and % for a terminal-only (shell) session, keeping the model · mode meta', () => {
+    // The statusline bridge can leak a stale/foreign context % onto a shell
+    // session; until proper integration we do not show context for shells.
+    act(() => { root.render(createElement(SessionRow, { session: makeSession({ shellOnly: true, model: 'opus', contextPercent: 98 }), ...baseProps })) })
+    const line2 = container.querySelector('[data-testid="card-line2"]') as HTMLElement
+    expect(line2).not.toBeNull()
+    expect(line2.querySelector('.meter-fill')).toBeNull()
+    expect(line2.textContent).not.toContain('98%')
+    expect(line2.textContent).toContain('opus · shell')
+  })
+
+  it('still shows the context meter and % for a normal (non-shell) session', () => {
+    act(() => { root.render(createElement(SessionRow, { session: makeSession({ contextPercent: 42 }), ...baseProps })) })
+    const line2 = container.querySelector('[data-testid="card-line2"]') as HTMLElement
+    expect(line2.querySelector('.meter-fill')).not.toBeNull()
+    expect(line2.textContent).toContain('42%')
+  })
+})

--- a/tests/unit/renderer/session-status-strip-surface.test.tsx
+++ b/tests/unit/renderer/session-status-strip-surface.test.tsx
@@ -10,6 +10,7 @@ import { act } from 'react'
 const sessionState: any = { sessions: [{ id: 's1', provider: 'claude', contextPercent: 10 }] }
 const settingsState: any = { settings: { statusLine: { font: 'sans', fontSize: 11 }, theme: 'dark', accountAliases: {}, accountColourOverrides: {} } }
 const profilesState: any = { profiles: [] }
+const restartState = vi.hoisted(() => ({ restart: vi.fn() }))
 
 vi.mock('../../../src/renderer/stores/sessionStore', () => ({
   useSessionStore: (sel: any) => sel(sessionState),
@@ -23,7 +24,7 @@ vi.mock('../../../src/renderer/stores/accountProfilesStore', () => ({
   useAccountProfilesStore: (sel: any) => sel(profilesState),
 }))
 vi.mock('../../../src/renderer/hooks/useCodexReviewUsage', () => ({ useCodexReviewUsage: () => null }))
-vi.mock('../../../src/renderer/hooks/useRestartSession', () => ({ useRestartSession: () => ({ restart: () => {} }) }))
+vi.mock('../../../src/renderer/hooks/useRestartSession', () => ({ useRestartSession: () => ({ restart: restartState.restart }) }))
 vi.mock('../../../src/renderer/hooks/useSwitchAccount', () => ({ useSwitchAccount: () => () => {} }))
 vi.mock('../../../src/renderer/hooks/useThemeController', () => ({ useResolvedTheme: () => 'dark' }))
 
@@ -41,6 +42,7 @@ beforeEach(() => {
   sessionState.sessions = [{ id: 's1', provider: 'claude', contextPercent: 10 }]
   settingsState.settings = { statusLine: { font: 'sans', fontSize: 11 }, theme: 'dark', accountAliases: {}, accountColourOverrides: {} }
   profilesState.profiles = []
+  restartState.restart.mockClear()
 })
 
 afterEach(() => {
@@ -119,5 +121,46 @@ describe('SessionStatusStrip master switch (onboarding p4)', () => {
     act(() => { root.render(createElement(SessionStatusStrip, { sessionId: 's1' })) })
 
     expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('SessionStatusStrip terminal-only (shell) sessions', () => {
+  it('shows a Restart control, but none of the Claude telemetry or Model/account controls', () => {
+    sessionState.sessions = [{ id: 's1', shellOnly: true, contextPercent: 10, accountEmail: 'a@x.com', profileId: 'p1' }]
+    settingsState.settings.statusLine = { font: 'sans', fontSize: 11, showContextBar: true, showAccount: true, showModel: true }
+    profilesState.profiles = [
+      { id: 'p1', name: '', accountEmail: 'a@x.com', createdAt: 1 },
+      { id: 'p2', name: '', accountEmail: 'b@x.com', createdAt: 2 },
+    ]
+
+    act(() => { root.render(createElement(SessionStatusStrip, { sessionId: 's1' })) })
+
+    // The Restart pill is present (same title/affordance as a Claude session).
+    expect(container.querySelector('[title="Restart session"]')).not.toBeNull()
+    // No telemetry (context %) and no Claude-only controls leak onto a raw shell.
+    expect(container.textContent).not.toContain('10%')
+    expect(container.querySelector('[title^="Switch account"]')).toBeNull()
+    expect(container.textContent).not.toContain('a@x.com')
+  })
+
+  it('clicking Restart calls restart()', () => {
+    sessionState.sessions = [{ id: 's1', shellOnly: true }]
+    act(() => { root.render(createElement(SessionStatusStrip, { sessionId: 's1' })) })
+
+    const btn = container.querySelector('[title="Restart session"]') as HTMLButtonElement
+    expect(btn).not.toBeNull()
+    act(() => { btn.click() })
+    expect(restartState.restart).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows Restart even when the status line is turned off', () => {
+    // The shell Restart is gated before the status-line collapse, unlike the
+    // telemetry band — turning the status line off must not remove it.
+    sessionState.sessions = [{ id: 's1', shellOnly: true }]
+    settingsState.settings.statusLineEnabled = false
+
+    act(() => { root.render(createElement(SessionStatusStrip, { sessionId: 's1' })) })
+
+    expect(container.querySelector('[title="Restart session"]')).not.toBeNull()
   })
 })


### PR DESCRIPTION
Two small, related fixes for terminal-only ("no AI" / `shellOnly`) sessions, both riding 2.1.0-beta.8.

### 1. Restart control (feature)
Shell sessions had no per-session controls — the status strip was gated out. They now show a **Restart** pill in the same bottom-right spot and styling as a Claude session. Render-condition change only: `restart()` already handles a shell (kill PTY + remount → generic respawn); `App.tsx` renders the strip for `shellOnly` and `SessionStatusStrip` early-returns a minimal Restart-only variant, so no Claude-only Model/Compact/account controls or telemetry leak onto a raw shell.

### 2. Hide the context meter on shell cards (bug fix)
A shell session has no reliable context signal, but the statusline bridge could leak a stale/foreign context % onto its **sidebar card** (`SessionRow` line 2) — e.g. an OpenClaw shell showing 98%. The context meter and % are now hidden for `shellOnly` sessions; the model · mode meta ("opus · shell") still shows.

**Tests:** both behaviours covered (Restart shows incl. status-line off, no Claude controls on a shell, click calls `restart()`; context meter hidden for shell / shown for normal), each verified to fail when the guard is removed.

Not security-sensitive (renderer render-gates; reuses the existing restart path — no new IPC/argv/spawn), so no adversarial review required per the ADR-009 path table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)