### PR TITLE
build(release): 2.1.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
-## [2.1.0-beta.8] - 2026-08-10
+## [2.1.0-beta.8] - 2026-08-11
 
 ### Added
 - Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session's account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.
 - The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.
 - Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.
+- The per-session Draw button is now labelled Canvas and opens the same freehand sketchpad as before. This is the groundwork for an upcoming agent-assisted review surface; there is no change to how you sketch today.
 
 ### Fixed
 - Terminal-only sessions no longer show a context-usage percentage on their sidebar card. A shell session has no reliable context signal, so the number could be stale or borrowed from another session; it is hidden until terminal integration improves. The model and mode still show.
+- Switching a session's account no longer leaves a usage limit from the previous account showing. Changing accounts mid-session could keep the old account's exhausted-usage state painted on the meter until you restarted; the session now clears it on switch.
 
 ## [2.1.0-beta.7] - 2026-08-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.7",
+  "version": "2.1.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.7",
+      "version": "2.1.0-beta.8",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.7",
+  "version": "2.1.0-beta.8",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -22,13 +22,15 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '2.1.0-beta.8',
-    date: '2026-08-10',
+    date: '2026-08-11',
     changes: [
       { type: 'feature', description: 'Accounts can now be marked inactive. An inactive account still appears in the accounts list but cannot be chosen when you switch a session\'s account — it shows up greyed and labelled "inactive" in the switch menus. Toggle it from Settings › Accounts; every existing account stays active, and the primary account is always active. Handy for parking an account you are not using without removing it.' },
       { type: 'improvement', description: 'Windows releases are now digitally code-signed. The installer and the app carry a verified publisher, so Windows no longer shows an "unknown publisher" warning when you download or install them. SmartScreen may still show a reputation prompt for a little while — trust accrues to the new certificate with each install. Update downloads continue to be verified by SHA-256 checksum, as before.' },
       { type: 'improvement', description: 'The product mark now appears in the title bar, and in the empty window before you start a session in place of the old terminal-prompt placeholder — so the app carries the same mark as its icon and start-up screen throughout.' },
       { type: 'improvement', description: 'Terminal-only ("no AI") sessions now have a Restart control in the bottom-right, the same as Claude sessions — restart re-runs the shell without disturbing your other tabs.' },
-      { type: 'fix', description: 'Terminal-only sessions no longer show a context-usage percentage on their sidebar card. A shell session has no reliable context signal, so the number could be stale or borrowed from another session; it is hidden until terminal integration improves. The model and mode still show.' }
+      { type: 'improvement', description: 'The per-session Draw button is now labelled Canvas and opens the same freehand sketchpad as before. This is the groundwork for an upcoming agent-assisted review surface; there is no change to how you sketch today.' },
+      { type: 'fix', description: 'Terminal-only sessions no longer show a context-usage percentage on their sidebar card. A shell session has no reliable context signal, so the number could be stale or borrowed from another session; it is hidden until terminal integration improves. The model and mode still show.' },
+      { type: 'fix', description: 'Switching a session\'s account no longer leaves a usage limit from the previous account showing. Changing accounts mid-session could keep the old account\'s exhausted-usage state painted on the meter until you restarted; the session now clears it on switch.' }
     ]
   },
   {


### PR DESCRIPTION
Version bump + changelog for **2.1.0-beta.8** — the first *signed* beta.

Rolls up what merged to `beta` since beta.7:
- Accounts can be marked inactive (#239)
- Windows code-signing via SSL.com eSigner (#251)
- Product mark in the title bar + empty stage (#236)
- Terminal-only session Restart control + hidden context meter (#253)
- Atomic file-write consolidation carrying the rename-race + staging-path fixes (#244 / #233)
- GHSA-pwfw public record (#240)
- Agent Canvas P1 groundwork — the Draw button is now "Canvas" (#254; adversarial-review PASS)
- Fix: a usage limit from the previous account could linger after an account switch (#245)

package.json + package-lock bumped to 2.1.0-beta.8; changelog.ts dated 2026-08-11; CHANGELOG.md regenerated (`Changelog in sync` covers this).

After merge: `gh workflow run release.yml --ref beta -f channel=beta -f skip_vt=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)