### PR TITLE
fix: beta.9 quick wins (win32 ssh ControlMaster, installed-version label, test fixes)

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -15,6 +15,7 @@ import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
 import { buildRemoteSessionCleanupCommand } from './providers/claude/ssh-shim'
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
+import { buildSshArgs } from './ssh-args'
 import { resolveClaudeBinary, resolveHostColorScheme } from './providers/claude/spawn'
 import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
@@ -388,26 +389,15 @@ export function spawnPty(
     // ClaudeProvider's SSH-capable surface (see providers/claude/ssh-shim.ts).
     const claudeProvider = getProvider('claude')
     if (!isSshCapable(claudeProvider)) throw new Error('Claude provider must be SSH-capable')
-    const sshArgs = [
-      `${ssh.username}@${ssh.host}`,
-      '-p', String(ssh.port),
-      '-t', // force TTY allocation
-      '-o', 'StrictHostKeyChecking=accept-new'
-    ]
-
-    // Add reverse tunnel for the Conductor MCP server so remote sessions can reach
-    // both fetch_host_screenshot (always) and vision tools (when browser connected).
-    // Host-side target is 127.0.0.1, NOT `localhost`: the MCP server binds IPv4-only
-    // (conductor-mcp-server.ts listens on '127.0.0.1'), but Windows resolves
-    // `localhost` IPv6-first (::1) — a dead address here — so ssh.exe's forward
-    // connect lands on [::1]:port, gets ECONNREFUSED, and the channel dies
-    // ("socket connection closed unexpectedly" on the remote MCP client). Pinning
-    // the middle field to 127.0.0.1 forwards straight to the address the server
-    // actually binds, with no name resolution and no IPv6-fallback dependency.
-    const mcpPort = getConductorMcpPort()
-    if (mcpPort > 0) {
-      sshArgs.push('-R', `${mcpPort}:127.0.0.1:${mcpPort}`)
-    }
+    // Base ssh argv (target, port, TTY, host-key policy) + a win32-only
+    // ControlMaster/ControlPath override (#241) + the Conductor MCP reverse
+    // tunnel, built in ./ssh-args so the exact flag list is unit-tested. The
+    // tunnel host-side target is 127.0.0.1, not `localhost`: the MCP server binds
+    // IPv4-only (conductor-mcp-server.ts listens on '127.0.0.1'), but Windows
+    // resolves `localhost` IPv6-first (::1) -- a dead address that would
+    // ECONNREFUSED and kill the channel ("socket connection closed unexpectedly"
+    // on the remote MCP client).
+    const sshArgs = buildSshArgs(ssh, getConductorMcpPort(), os.platform())
 
     // HTTP Hooks Gateway: when enabled, tunnel the gateway's loopback port so
     // Claude Code inside the SSH session can reach it via http://localhost:<port>.

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -1,0 +1,46 @@
+// argv builder for spawning `ssh`/`ssh.exe` for an SSH-backed session. Kept in
+// its own module with no electron/node-pty imports so the exact flag list is
+// unit-testable without loading pty-manager's native dependencies.
+
+/** Connection target — the subset of SshConfig the argv needs. */
+export interface SshArgsTarget {
+  username: string
+  host: string
+  port: number
+}
+
+/**
+ * Build the argument list passed to `ssh`/`ssh.exe`.
+ *
+ * @param ssh      connection target (user, host, port)
+ * @param mcpPort  Conductor MCP reverse-tunnel port; when > 0 a `-R` forward is
+ *                 added. The host-side target is 127.0.0.1, not `localhost`: the
+ *                 MCP server binds IPv4-only, but Windows resolves `localhost`
+ *                 IPv6-first (::1) -- a dead address that would ECONNREFUSED and
+ *                 kill the channel.
+ * @param platform host platform (os.platform()). On win32 only, ControlMaster and
+ *                 ControlPath are forced off (#241): Windows OpenSSH has no
+ *                 connection-multiplexing support, so if the user's global
+ *                 ~/.ssh/config enables them ssh.exe errors out before it can
+ *                 connect and every CCC SSH session breaks. POSIX ssh multiplexes
+ *                 fine, so this stays win32-only and leaves other platforms
+ *                 untouched.
+ */
+export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: NodeJS.Platform): string[] {
+  const args = [
+    `${ssh.username}@${ssh.host}`,
+    '-p', String(ssh.port),
+    '-t', // force TTY allocation
+    '-o', 'StrictHostKeyChecking=accept-new',
+  ]
+
+  if (platform === 'win32') {
+    args.push('-o', 'ControlMaster=no', '-o', 'ControlPath=none')
+  }
+
+  if (mcpPort > 0) {
+    args.push('-R', `${mcpPort}:127.0.0.1:${mcpPort}`)
+  }
+
+  return args
+}

--- a/src/renderer/components/BottomBar.tsx
+++ b/src/renderer/components/BottomBar.tsx
@@ -5,6 +5,7 @@ import { retryFailedConfigSaves } from '../utils/config-saver'
 import { ViewType } from '../types/views'
 import MultiAccountStatusline from './MultiAccountStatusline'
 import { useRegionTypography } from '../hooks/useTypography'
+import { formatInstalledVersion } from '../utils/versionLabel'
 
 declare const __BUILD_TIME__: string
 declare const __APP_VERSION__: string
@@ -110,7 +111,7 @@ export default function BottomBar({ currentView, onViewChange, onUpdateRequested
             onClick={() => { if (onUpdateRequested) onUpdateRequested(); else void Promise.resolve(window.electronAPI.update.installAndRestart()).catch((e: unknown) => console.error('[update] install failed:', e)) }}
             className="footer-update-pulse px-1.5 py-px rounded-full text-[10px] font-medium focus-ring"
             style={{ color: 'var(--status-success)', background: 'color-mix(in srgb, var(--status-success) 15%, transparent)' }}
-            title="Update available -- click to install and restart"
+            title={`Update available -- you're on ${formatInstalledVersion(__APP_VERSION__, channel)} -- click to install and restart`}
           >
             Update
           </button>

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import { useAppMetaStore } from '../stores/appMetaStore'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { eventToShortcutString, DEFAULT_SHORTCUTS, SHORTCUT_LABELS } from '../utils/shortcuts'
+import { formatInstalledVersion } from '../utils/versionLabel'
 import GitHubConfigTab from './github/config/GitHubConfigTab'
 import CopilotMeterSettings from './settings/CopilotMeterSettings'
 import { isSentinelEnabled } from '../../shared/sentinel-enabled'
@@ -868,6 +869,11 @@ export function CheckForUpdatesField({ onUpdateRequested }: { onUpdateRequested?
   const [status, setStatus] = useState<UpdateCheckStatus>('idle')
   const [foundVersion, setFoundVersion] = useState<string | null>(null)
   const [installing, setInstalling] = useState(false)
+  // #250: surface the running build (full tag) + release channel in the
+  // up-to-date and update-available states. Channel comes from the store so it
+  // stays in sync with the channel selector and the BottomBar Beta pill; version
+  // is the build-time define already shown in the footer.
+  const channel = useSettingsStore((s) => s.settings.updateChannel)
 
   // Route through App's handler so an install with sessions open goes via the
   // 'update' close dialog (session state saved first). The direct call is only
@@ -942,6 +948,11 @@ export function CheckForUpdatesField({ onUpdateRequested }: { onUpdateRequested?
         )}
         {statusText && status !== 'checking' && (
           <span className={`text-xs ${statusColor}`}>{statusText}</span>
+        )}
+        {(status === 'up-to-date' || status === 'available') && (
+          <span className="text-[10px] text-overlay0" title="Installed version and release channel">
+            Installed: {formatInstalledVersion(__APP_VERSION__, channel)}
+          </span>
         )}
         {updateFound && !installing && (
           <span className="text-[10px] text-overlay0">Restarts the app; open sessions are saved.</span>

--- a/src/renderer/utils/versionLabel.ts
+++ b/src/renderer/utils/versionLabel.ts
@@ -1,0 +1,10 @@
+import type { UpdateChannel } from '../stores/settingsStore'
+
+// "current installed version + channel" label for the update UI -- the Settings
+// Check-for-Updates field and the BottomBar update-pill tooltip (#250). Pure so
+// it can be unit-tested without a renderer; callers pass the build-time
+// __APP_VERSION__ (full tag, incl. any prerelease suffix) and the reactive
+// settings.updateChannel.
+export function formatInstalledVersion(version: string, channel: UpdateChannel): string {
+  return `v${version} (${channel})`
+}

--- a/tests/unit/config-manager-atomic.test.ts
+++ b/tests/unit/config-manager-atomic.test.ts
@@ -113,7 +113,13 @@ describe('writeConfig atomicity (real fs)', () => {
   it('repeated overwrites leave exactly the final content and no debris', () => {
     for (let i = 1; i <= 5; i++) expect(writeConfig('settings', { v: i })).toBe(true)
     expect(readConfig('settings')).toEqual({ v: 5 })
+    // Don't exact-match the raw dir listing: an atomic-write `.tmp` staging file
+    // occasionally lingers when the assertion runs, which flaked this ~1 in 3
+    // (#183). Assert what actually matters instead, mirroring tmpLeftovers() used
+    // by the sibling tests: the real file exists and no staging debris is left.
     const entries = realFs.readdirSync(getConfigDir())
-    expect(entries).toEqual(['settings.json'])
+    expect(entries, `expected settings.json present, got: [${entries.join(', ')}]`).toContain('settings.json')
+    const leftovers = tmpLeftovers()
+    expect(leftovers, `atomic-write staging debris left behind: [${leftovers.join(', ')}]`).toEqual([])
   })
 })

--- a/tests/unit/credential-file-mode-hardening.test.ts
+++ b/tests/unit/credential-file-mode-hardening.test.ts
@@ -97,18 +97,20 @@ describe('(C) ssh-shim remote setup script', () => {
     expect(script()).toContain('mkdirSync(claudeDir,{recursive:true,mode:0o700})')
   })
 
-  it('writes the remote mcp token file owner-only with a fresh create', () => {
+  it('writes the remote mcp token file owner-only with a fresh exclusive create', () => {
     const s = script()
     expect(s).toContain('rmSync(mcpPath,{force:true})')
-    expect(s).toMatch(/writeFileSync\(mcpPath,[^)]*,\{mode:0o600\}\)/)
+    // rm + flag:'wx' (exclusive create): never reuses or follows a pre-existing
+    // path, and the file is born 0600 — both halves are load-bearing.
+    expect(s).toMatch(/writeFileSync\(mcpPath,[^)]*,\{mode:0o600,flag:'wx'\}\)/)
     // The unfixed shape — a bare writeFileSync(mcpPath, literal) with no mode — is gone.
     expect(s).not.toMatch(/writeFileSync\(mcpPath,\$\{[^}]*\}\)\}catch/)
   })
 
-  it('writes the remote per-session settings (hook token) owner-only', () => {
+  it('writes the remote per-session settings (hook token) owner-only with a fresh exclusive create', () => {
     const s = script()
     expect(s).toContain('rmSync(sesPath,{force:true})')
-    expect(s).toContain('writeFileSync(sesPath,JSON.stringify(sesCfg,null,2),{mode:0o600})')
+    expect(s).toContain("writeFileSync(sesPath,JSON.stringify(sesCfg,null,2),{mode:0o600,flag:'wx'})")
   })
 })
 

--- a/tests/unit/renderer/settings-check-for-updates.test.tsx
+++ b/tests/unit/renderer/settings-check-for-updates.test.tsx
@@ -16,6 +16,11 @@ import { act } from 'react'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
+// __APP_VERSION__ is an esbuild `define` global at build time; stub it for the
+// jsdom render (CheckForUpdatesField now shows the installed version + channel,
+// #250), mirroring bottom-bar.test.ts.
+;(globalThis as any).__APP_VERSION__ = '9.9.9-test'
+
 const { CheckForUpdatesField } = await import('../../../src/renderer/components/SettingsPage')
 
 function renderComponent(ui: React.ReactElement): { container: HTMLElement; unmount: () => void } {
@@ -80,6 +85,8 @@ describe('Settings > Check for Updates (#142)', () => {
     expect(buttonByText(container, 'Install now')).toBeTruthy()
     expect(buttonByText(container, 'Check now')).toBeUndefined()
     expect(container.textContent).toContain('2.1.0-beta.2')
+    // #250: update-available state also surfaces the installed version + channel.
+    expect(container.textContent).toContain('v9.9.9-test (stable)')
   })
 
   it('stays on "Check now" and reports up to date when there is no update', async () => {
@@ -91,6 +98,8 @@ describe('Settings > Check for Updates (#142)', () => {
 
     expect(buttonByText(container, 'Install now')).toBeUndefined()
     expect(container.textContent).toContain('Up to date')
+    // #250: up-to-date state also surfaces the installed version + channel.
+    expect(container.textContent).toContain('v9.9.9-test (stable)')
   })
 
   it('Install now calls onUpdateRequested (App saves sessions) and NOT installAndRestart', async () => {

--- a/tests/unit/renderer/version-label.test.ts
+++ b/tests/unit/renderer/version-label.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { formatInstalledVersion } from '../../../src/renderer/utils/versionLabel'
+
+describe('formatInstalledVersion', () => {
+  it('renders the full version tag + beta channel', () => {
+    expect(formatInstalledVersion('2.1.0-beta.8', 'beta')).toBe('v2.1.0-beta.8 (beta)')
+  })
+
+  it('renders the full version tag + stable channel', () => {
+    expect(formatInstalledVersion('2.0.0', 'stable')).toBe('v2.0.0 (stable)')
+  })
+
+  it('preserves rc-style prerelease suffixes verbatim', () => {
+    expect(formatInstalledVersion('2.2.0-rc.1', 'beta')).toBe('v2.2.0-rc.1 (beta)')
+  })
+})

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { buildSshArgs } from '../../src/main/ssh-args'
+
+// pty-manager builds the ssh argv from this helper; these pin exactly which
+// flags reach ssh/ssh.exe per platform.
+const target = { username: 'me', host: 'example.com', port: 22 }
+
+describe('buildSshArgs', () => {
+  it('forces ControlMaster/ControlPath off on win32 (Windows OpenSSH has no multiplexing) -- #241', () => {
+    const args = buildSshArgs(target, 0, 'win32')
+    expect(args).toContain('ControlMaster=no')
+    expect(args).toContain('ControlPath=none')
+    // Each must be paired with its own -o so ssh actually parses it.
+    expect(args).toEqual(expect.arrayContaining(['-o', 'ControlMaster=no', '-o', 'ControlPath=none']))
+  })
+
+  it('does NOT disable ControlMaster/ControlPath on non-win32 platforms', () => {
+    for (const platform of ['linux', 'darwin'] as const) {
+      const args = buildSshArgs(target, 0, platform)
+      expect(args).not.toContain('ControlMaster=no')
+      expect(args).not.toContain('ControlPath=none')
+    }
+  })
+
+  it('keeps the base flags (target, port, TTY, host-key policy) on every platform', () => {
+    const args = buildSshArgs(target, 0, 'linux')
+    expect(args.slice(0, 6)).toEqual(['me@example.com', '-p', '22', '-t', '-o', 'StrictHostKeyChecking=accept-new'])
+  })
+
+  it('adds the Conductor MCP reverse tunnel to 127.0.0.1 only when mcpPort > 0', () => {
+    expect(buildSshArgs(target, 5111, 'linux')).toEqual(expect.arrayContaining(['-R', '5111:127.0.0.1:5111']))
+    expect(buildSshArgs(target, 0, 'linux').some((a) => a.startsWith('-R'))).toBe(false)
+    // The IPv6 footgun: never tunnel to `localhost`.
+    expect(buildSshArgs(target, 5111, 'win32')).not.toContain('5111:localhost:5111')
+  })
+})

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -1,17 +1,33 @@
 import { describe, it, expect } from 'vitest'
 import { buildSshArgs } from '../../src/main/ssh-args'
 
-// pty-manager builds the ssh argv from this helper; these pin exactly which
-// flags reach ssh/ssh.exe per platform.
+// pty-manager builds the ssh argv from this helper; these pin the EXACT argv
+// (order, pairing, and length) reaching ssh/ssh.exe per platform. Whole-array
+// toEqual is deliberate: a membership check (arrayContaining) can't catch a
+// dropped `-o`, and an orphaned `ControlPath=none` would become a positional
+// argument -- i.e. the remote command -- breaking every win32 SSH session.
 const target = { username: 'me', host: 'example.com', port: 22 }
+const BASE = ['me@example.com', '-p', '22', '-t', '-o', 'StrictHostKeyChecking=accept-new']
+const WIN_MUX = ['-o', 'ControlMaster=no', '-o', 'ControlPath=none']
+const TUNNEL = ['-R', '5111:127.0.0.1:5111']
 
 describe('buildSshArgs', () => {
-  it('forces ControlMaster/ControlPath off on win32 (Windows OpenSSH has no multiplexing) -- #241', () => {
-    const args = buildSshArgs(target, 0, 'win32')
-    expect(args).toContain('ControlMaster=no')
-    expect(args).toContain('ControlPath=none')
-    // Each must be paired with its own -o so ssh actually parses it.
-    expect(args).toEqual(expect.arrayContaining(['-o', 'ControlMaster=no', '-o', 'ControlPath=none']))
+  it('linux/darwin, no tunnel: base flags only, user config untouched', () => {
+    expect(buildSshArgs(target, 0, 'linux')).toEqual([...BASE])
+    expect(buildSshArgs(target, 0, 'darwin')).toEqual([...BASE])
+  })
+
+  it('linux/darwin, tunnel: base flags + the 127.0.0.1 reverse tunnel', () => {
+    expect(buildSshArgs(target, 5111, 'linux')).toEqual([...BASE, ...TUNNEL])
+  })
+
+  it('win32, no tunnel: base flags + BOTH ControlMaster=no and ControlPath=none, each with its own -o (#241)', () => {
+    // Exact array: a single-`-o` mutant (orphaned ControlPath=none) fails here.
+    expect(buildSshArgs(target, 0, 'win32')).toEqual([...BASE, ...WIN_MUX])
+  })
+
+  it('win32, tunnel: the mux override precedes the reverse tunnel, both present (#241)', () => {
+    expect(buildSshArgs(target, 5111, 'win32')).toEqual([...BASE, ...WIN_MUX, ...TUNNEL])
   })
 
   it('does NOT disable ControlMaster/ControlPath on non-win32 platforms', () => {
@@ -22,15 +38,9 @@ describe('buildSshArgs', () => {
     }
   })
 
-  it('keeps the base flags (target, port, TTY, host-key policy) on every platform', () => {
-    const args = buildSshArgs(target, 0, 'linux')
-    expect(args.slice(0, 6)).toEqual(['me@example.com', '-p', '22', '-t', '-o', 'StrictHostKeyChecking=accept-new'])
-  })
-
-  it('adds the Conductor MCP reverse tunnel to 127.0.0.1 only when mcpPort > 0', () => {
-    expect(buildSshArgs(target, 5111, 'linux')).toEqual(expect.arrayContaining(['-R', '5111:127.0.0.1:5111']))
+  it('adds the reverse tunnel only when mcpPort > 0, and never to `localhost` (the IPv6 footgun)', () => {
     expect(buildSshArgs(target, 0, 'linux').some((a) => a.startsWith('-R'))).toBe(false)
-    // The IPv6 footgun: never tunnel to `localhost`.
+    expect(buildSshArgs(target, 0, 'win32').some((a) => a.startsWith('-R'))).toBe(false)
     expect(buildSshArgs(target, 5111, 'win32')).not.toContain('5111:localhost:5111')
   })
 })


### PR DESCRIPTION
Three small fixes queued for beta.9, plus a suite-green repair found on the way.

## Changes

- **#241 — win32 ssh sessions break when the user's `~/.ssh/config` enables ControlMaster.** Windows OpenSSH has no connection-multiplexing support, so ssh.exe errors out before connecting. The ssh argv now comes from a new pure `src/main/ssh-args.ts` (`buildSshArgs`), which appends `-o ControlMaster=no -o ControlPath=none` on win32 only. POSIX platforms keep the user's multiplexing. The exact per-platform flag list is pinned by `tests/unit/ssh-args.test.ts`.
- **#183 — flaky `config-manager-atomic` test.** The 'repeated overwrites' case exact-matched the raw dir listing; an atomic-write `.tmp` staging file occasionally lingers when the assertion runs (~1 in 3). It now asserts the outcome (settings.json present, no staging debris via `tmpLeftovers()`), mirroring its sibling tests. Verified 25/25 in a stress loop.
- **#250 — update UX: show what's installed.** Settings → Check for Updates shows `Installed: v<version> (<channel>)` in the up-to-date and update-available states, and the BottomBar update-pill tooltip carries the same label. Version is the build-time `__APP_VERSION__`; channel tracks `settings.updateChannel`.
- **Suite-green repair:** two tests in `credential-file-mode-hardening.test.ts` still expected the ssh-shim token writes' older `{mode:0o600}` shape and have been red on `beta` since those writes gained `flag:'wx'`. The expectations now pin the full `{mode:0o600,flag:'wx'}` exclusive-create shape — strictly stronger assertions, no source change.

## Verification

- `npm run typecheck` clean; full `npx vitest run`: **4152 passed, 0 failed** (was 2 failed on the `beta` tip before the alignment commit).
- ADR-009: `buildSshArgs` touches PTY argv construction → adversarial review running; verdict will be recorded here before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)