### PR TITLE
fix(dev): keep dev's claude.ai web sessions out of prod's session store (#261)

### DIFF
--- a/CONTEXT.d/2026-08-14-261-dev-session-data.md
+++ b/CONTEXT.d/2026-08-14-261-dev-session-data.md
@@ -1,0 +1,82 @@
+## 2026-08-14 -- 261: dev's claude.ai web sessions no longer land in prod's store
+
+Electron keeps `persist:` partitions under `sessionData`, which defaults to
+`userData`, and nothing here redirected either. So a DEV instance wrote the
+per-account claude.ai web sessions from #216 -- real `sessionKey` cookies -- into
+the same `%APPDATA%\claude-conductor\Partitions` a PROD install uses. Dev and prod
+shared them: signing out in dev revoked prod's session for that account, and
+`ccc --clean` wiped the dev data dir while leaving a live session on disk, because
+the partition was never under it. The startup sweep could not help either -- it
+only walks `<dataDir>/account-web`.
+
+`app.setPath('sessionData', <devRoot>/session)` now runs at module scope in
+index.ts, next to the existing DEV data-dir block, behind a pure
+`devSessionDataDir()` in data-paths.ts.
+
+### Dev only, and that is the whole design
+
+`userData` is Electron's own default for session data and is not wrong for prod.
+Relocating prod would force a re-login for anyone who had already signed in on a
+build that created a partition there. Packaged builds get null and are untouched.
+
+That also retires the urgency this issue was filed with. The ticket argued the fix
+had to land before the next beta release or users would be logged out by a later
+path move -- true only if prod were relocated. It is not, so there is no migration
+cliff and no deadline.
+
+### Verified, not assumed
+
+An attacker sub-agent probed a standalone Electron 43.2.0 rather than trusting the
+premise: `session.fromPartition('persist:...').getStoragePath()` resolves under
+`<sessionData>/Partitions`, and `sessionData` defaults to `userData`. The same
+probe established the ordering hazard is IMPOSSIBLE rather than merely avoided --
+creating a session before app-ready throws ("Session can only be received when app
+is ready"), so no module-scope import can materialise the default session ahead of
+the redirect.
+
+Confirmed live: after launching from this branch, the two partitions appeared under
+`dev\session\Partitions` and the shared location had zero directories touched.
+
+### What the adversarial pass found, and what changed because of it
+
+- A RELATIVE `CCC_DEV_DATA_DIR` half-applied the fix. `mkdirSync` created
+  `<cwd>/<root>/session` -- inside the repo working tree in one observed run --
+  then `app.setPath` threw into a catch and boot continued, leaving dev writing to
+  prod's location exactly as before. `devSessionDataDir` now refuses a
+  non-absolute root, which turns a swallowed throw into a tested branch.
+- The guard was stricter than the data-dir logic it mirrors: `getDataDirectory`
+  honours `CCC_E2E_DATA_DIR` unconditionally, while this returned null whenever
+  packaged. An E2E run against an installed exe would have sent data to a
+  disposable root while leaving the claude.ai partition in prod's `%APPDATA%`,
+  surviving teardown. E2E is now honoured regardless of packaging.
+- The log line used `console.log`, and the comment claimed it made isolation
+  "answerable from the log". It did not: debug-logger neither patches console nor
+  hooks stdout, so it never reached the debug log an operator reads, and was absent
+  entirely under a bare `npm run dev`. Now `logInfo`/`logError`.
+- Partitions created BEFORE this change are orphaned in the shared location and
+  nothing will ever remove them. Dev now logs a one-time warning naming the path.
+  Deliberately a warning and not a deletion: `ccc --seed-accounts` copies prod's
+  account profiles into dev, so a partition named for a dev profile id can BE
+  prod's live session, and tidying up a dev artifact must not sign the user out of
+  their real account. Documented in `docs/dev-alongside-prod.md`.
+
+### Left open, deliberately
+
+- A dev instance that had signed in keeps its session RECORD (under the dev data
+  root) while its cookies stayed behind, so the panel reads "signed in" against an
+  empty partition until the next sign-in. `statusOf` derives status from the stored
+  `expiresAt` alone; the store's own comment says a 401 is what should correct it.
+  Dev-only, self-limiting, one re-sign-in fixes it.
+- `ccc --clean` can now partially delete a live Chromium storage tree, because the
+  wipe happens before the process kill and swallows errors. Narrow -- the launcher
+  refuses a second dev instance on the port check -- but new exposure created by
+  moving session data under the dev root.
+- The `ccc.cmd` header still overstates isolation. `~/.claude` remains shared and
+  `account-profiles.ts` never consults `CCC_DEV_DATA_DIR`, so dev can still contend
+  with prod over OAuth refresh-token rotation. Already a documented caveat, now
+  sharpened with what was actually observed on 2026-08-12, and filed separately.
+
+### State
+
+Gate: typecheck clean, build clean, unit suite 4162 passed across 474 files.
+Verified in the desktop app.

--- a/docs/dev-alongside-prod.md
+++ b/docs/dev-alongside-prod.md
@@ -66,6 +66,7 @@ The dev data dir starts empty. To work with your real configs:
 |---|---|---|
 | Data root | `…\Claude Command Center\` (or registry) | `…\Claude Command Center\dev\` |
 | CONFIG / sessions / transcripts / logs / profiles | under the data root | under the dev data root |
+| Electron session data (cookies, localStorage, caches) and the per-account **claude.ai web session** partitions | `userData` (Electron's default) | `…\dev\session\` (#261) |
 | MCP server port | 19333 | 19433 |
 | Vision CDP port | 9222 | 9322 |
 | Hooks gateway port | 19334 | 19434 |
@@ -84,6 +85,19 @@ The dev switch activates whenever the build is **unpackaged** (`app.isPackaged
 
 - CCC's own state is isolated, but the underlying **Claude CLI global home
   (`~/.claude`) is shared** between dev and prod. Avoid running the *same
-  account's* Claude session in both instances at the same time (OAuth token
-  rotation can contend).
+  account's* Claude session in both instances at the same time — OAuth refresh
+  tokens ROTATE, and this is not theoretical: observed on 2026-08-12, two profile
+  homes had ended up resolving to one account, a refresh in one invalidated the
+  copies in the others, and two of four accounts were left with blank
+  `accessToken`/`refreshToken` values reporting `loggedIn=False`. Recovering meant
+  copying prod's credentials back in (`ccc --seed-accounts`).
 - First isolated dev launch is empty unless you `--seed`.
+- **claude.ai web session partitions created before #261** live in the SHARED
+  location (`<userData>\Partitions\claude-web-*`) and are no longer used by dev
+  after the redirect. They hold live session cookies, and nothing will ever remove
+  them — `ccc --clean` cannot reach them (wrong root) and the startup sweep only
+  walks `<dataDir>\account-web`. Dev logs a one-time warning naming the path at
+  boot. **Delete them by hand only if you are sure they are not your production
+  install's**: `ccc --seed-accounts` copies prod's account profiles into dev, so a
+  partition named for a dev profile id can be prod's live session. That is why the
+  app warns instead of tidying up for you.

--- a/src/main/data-paths.ts
+++ b/src/main/data-paths.ts
@@ -100,6 +100,51 @@ export function getDataDirectory(): string {
   return cachedDataDir
 }
 
+/**
+ * Where a DEV instance should keep Electron's `sessionData`, or null for prod.
+ *
+ * PURE, so the decision is testable without booting Electron. Called from
+ * index.ts at module scope, because `app.setPath` only has any effect before the
+ * first session is created.
+ *
+ * WHY THIS EXISTS. Electron stores `persist:` partitions under `sessionData`,
+ * which defaults to `userData` — and nothing redirected either, so the
+ * per-account claude.ai web sessions (#216) went to
+ * `%APPDATA%\claude-conductor\Partitions` no matter which data dir the instance
+ * was using. Dev and prod therefore SHARED them: signing out in dev revoked
+ * prod's session for that account, and `ccc --clean` wiped the dev data dir while
+ * leaving a live `sessionKey` on disk, because the partition was never under it.
+ * `sweepAbandonedProfiles` could not help either — it only walks
+ * `<dataDir>/account-web` (#261).
+ *
+ * DEV ONLY, DELIBERATELY. `userData` is Electron's own default for session data
+ * and is not wrong for prod; relocating prod would force a re-login for anyone who
+ * had already signed in on a build that created a partition there, which is a real
+ * cost with no matching benefit. Packaged builds get null and are untouched.
+ *
+ * Returns null when there is no dev override, so the caller does nothing at all
+ * rather than setting a path it computed from a guess.
+ */
+export function devSessionDataDir(
+  env: NodeJS.ProcessEnv = process.env,
+  isPackaged = true,
+): string | null {
+  // E2E FIRST AND UNCONDITIONALLY, matching getDataDirectory's own ordering
+  // above. Its whole point is a disposable data root, and a partition outside it
+  // would survive the teardown that is supposed to remove it. An explicit E2E
+  // override is never a real user's install, so `isPackaged` is not the question.
+  const root = env.CCC_E2E_DATA_DIR || (isPackaged ? undefined : env.CCC_DEV_DATA_DIR)
+  if (!root) return null
+  // ABSOLUTE ONLY. `app.setPath` rejects a relative path, and the caller creates
+  // the directory BEFORE calling it — so a relative root meant `mkdirSync` quietly
+  // made `<cwd>/<root>/session` (inside the repo, in one observed run) and then
+  // `setPath` threw into a catch, leaving dev writing claude.ai sessionKeys to
+  // prod's location exactly as before. Refusing here turns a swallowed throw into
+  // a decision with a test.
+  if (!path.isAbsolute(root)) return null
+  return path.join(root, 'session')
+}
+
 // Read resources directory from registry (cached after first call)
 export function getResourcesDirectory(): string {
   if (cachedResourcesDir) return cachedResourcesDir

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell } from 'electron'
 import { join } from 'path'
 import { homedir } from 'os'
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { registerPtyHandlers } from './ipc/pty-handlers'
 import { registerUsageHandlers } from './ipc/usage-handlers'
@@ -24,6 +24,10 @@ import { registerDebugHandlers } from './ipc/debug-handlers'
 import { disableDebugMode } from './debug-capture'
 import { registerUpdateHandlers } from './ipc/update-handlers'
 import { registerSetupHandlers, getResourcesDirectory, getDataDirectory } from './ipc/setup-handlers'
+// Direct from data-paths, not the handlers barrel: this runs at module scope
+// before app-ready, so it must not pull the IPC registration side of that module
+// in ahead of time.
+import { devSessionDataDir } from './data-paths'
 import { ensureHelpWorkspace } from './help-workspace'
 import { registerScreenshotHandlers } from './ipc/screenshot-handlers'
 import { registerWebviewHandlers } from './ipc/webview-handlers'
@@ -105,6 +109,65 @@ if (!app.isPackaged && !process.env.CCC_DEV_DATA_DIR) {
         ? join(homedir(), '.claude-conductor', 'data')
         : join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'Claude Command Center')
   process.env.CCC_DEV_DATA_DIR = join(base, 'dev')
+}
+
+// ...and point Electron's SESSION data at the dev root too (#261). `persist:`
+// partitions live under `sessionData`, which defaults to `userData`, so without
+// this a dev instance wrote the per-account claude.ai web sessions (#216) into the
+// very same %APPDATA%\claude-conductor\Partitions a PROD install uses — dev and
+// prod shared them, signing out in one revoked the other, and `ccc --clean` left a
+// live sessionKey on disk because the partition was never under the dev data dir.
+//
+// MUST be before app-ready and before any session exists, which is why it sits at
+// module scope next to the block above. Dev/E2E only: `devSessionDataDir` returns
+// null for a packaged build, so production keeps Electron's default and nobody
+// gets logged out by a path move.
+const devSessionDir = devSessionDataDir(process.env, app.isPackaged)
+if (devSessionDir) {
+  try {
+    mkdirSync(devSessionDir, { recursive: true })
+    app.setPath('sessionData', devSessionDir)
+    // Logged via logInfo, NOT console.log: debug-logger does not patch console or
+    // hook stdout, so a console line reaches the terminal and the `ccc` tee but
+    // never the debug log an operator actually reads — and it is absent entirely
+    // under a bare `npm run dev`. The failure mode here is invisible otherwise:
+    // partitions just appear in the shared location and nothing says they did.
+    logInfo(`[setup] Dev session data redirected to: ${devSessionDir}`)
+    warnAboutOrphanedSharedPartitions(devSessionDir)
+  } catch (err) {
+    // Not fatal: worst case partitions land in the default location, which is
+    // exactly the pre-#261 behaviour. Say so rather than failing to boot.
+    logError(`[setup] could not redirect dev sessionData to ${devSessionDir}: ${(err as Error)?.message ?? err}`)
+  }
+}
+
+/**
+ * Point out claude.ai partitions this dev instance left in the SHARED location
+ * before the redirect existed (#261).
+ *
+ * WARN, NEVER DELETE. Those directories hold live `sessionKey` cookies and after
+ * the redirect nothing references them: `ccc --clean` cannot reach them (wrong
+ * root) and `sweepAbandonedProfiles` only walks `<dataDir>/account-web`. So they
+ * would sit there forever, which is the very complaint the redirect is meant to
+ * fix. But automatic removal is NOT safe: `ccc --seed-accounts` copies prod's
+ * account profiles into dev, so a partition named for a dev profile id can be
+ * the PROD install's live session. Deleting it would sign the user out of their
+ * real account to tidy up a dev artifact. Naming the path and leaving the choice
+ * to a human is the correct trade here.
+ */
+function warnAboutOrphanedSharedPartitions(newLocation: string): void {
+  try {
+    const shared = join(app.getPath('userData'), 'Partitions')
+    if (shared === join(newLocation, 'Partitions') || !existsSync(shared)) return
+    const orphans = readdirSync(shared).filter((n) => n.startsWith('claude-web-'))
+    if (!orphans.length) return
+    logInfo(
+      `[setup] ${orphans.length} claude.ai web session partition(s) remain in the SHARED location `
+      + `and are no longer used by this dev instance: ${shared}. They hold live session cookies. `
+      + `Remove them by hand ONLY if you are sure they are not your production install's `
+      + `(see docs/dev-alongside-prod.md).`,
+    )
+  } catch { /* advisory only — never let a warning break boot */ }
 }
 
 // Migrate registry keys from old "Claude Conductor" → new "Claude Command Center"

--- a/tests/unit/dev-session-data-dir.test.ts
+++ b/tests/unit/dev-session-data-dir.test.ts
@@ -16,16 +16,26 @@ vi.mock('electron', () => ({ app: { getPath: () => 'C:/fake/userData', isPackage
 
 const { devSessionDataDir } = await import('../../src/main/data-paths')
 
+/**
+ * A platform-ABSOLUTE path.
+ *
+ * `devSessionDataDir` refuses a relative root, and `path.isAbsolute` is
+ * platform-dependent: `C:/data/dev` is absolute on Windows and RELATIVE on
+ * POSIX. Hardcoding Windows literals made these tests pass on Windows and fail on
+ * macOS, which is what the CI matrix exists to catch.
+ */
+const abs = (...seg: string[]): string => join(process.platform === 'win32' ? 'C:\\' : '/', ...seg)
+
 describe('devSessionDataDir', () => {
   it('returns null for a packaged build, so prod keeps Electron’s default', () => {
     // The whole point of scoping this to dev: moving prod's partitions would log
     // out everyone who already signed in on a build that created one there.
-    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, true)).toBeNull()
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: abs('data', 'dev') }, true)).toBeNull()
   })
 
   it('puts dev session data under the dev data root', () => {
-    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, false))
-      .toBe(join('C:/data/dev', 'session'))
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: abs('data', 'dev') }, false))
+      .toBe(join(abs('data', 'dev'), 'session'))
   })
 
   it('returns null when there is no dev override rather than guessing a path', () => {
@@ -35,14 +45,14 @@ describe('devSessionDataDir', () => {
   it('covers E2E too, and prefers it over the dev dir', () => {
     // An E2E run's data root is disposable; a partition outside it would survive
     // the teardown that is supposed to remove it.
-    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: 'C:/tmp/e2e', CCC_DEV_DATA_DIR: 'C:/data/dev' }, false))
-      .toBe(join('C:/tmp/e2e', 'session'))
+    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: abs('tmp', 'e2e'), CCC_DEV_DATA_DIR: abs('data', 'dev') }, false))
+      .toBe(join(abs('tmp', 'e2e'), 'session'))
   })
 
   it('is a SUBDIRECTORY of the data root, so --clean removes it', () => {
     // `ccc --clean` deletes the dev data dir wholesale. The session dir has to be
     // inside it for that to clear the web sessions, which is the bug being fixed.
-    const root = 'C:/data/dev'
+    const root = abs('data', 'dev')
     const got = devSessionDataDir({ CCC_DEV_DATA_DIR: root }, false)!
     // Separator-normalised: `join` yields backslashes on Windows and forward
     // slashes elsewhere, and the containment claim is about the path, not its
@@ -72,9 +82,9 @@ describe('devSessionDataDir', () => {
     // so `isPackaged` is not the question — and without this, an E2E run against a
     // packaged exe would send its data to a disposable root while leaving the
     // claude.ai partition in prod's %APPDATA%, surviving teardown.
-    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: 'C:/tmp/e2e' }, true))
-      .toBe(join('C:/tmp/e2e', 'session'))
+    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: abs('tmp', 'e2e') }, true))
+      .toBe(join(abs('tmp', 'e2e'), 'session'))
     // A packaged build with only the DEV var set is still left alone.
-    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, true)).toBeNull()
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: abs('data', 'dev') }, true)).toBeNull()
   })
 })

--- a/tests/unit/dev-session-data-dir.test.ts
+++ b/tests/unit/dev-session-data-dir.test.ts
@@ -1,0 +1,80 @@
+// #261 — where a dev instance keeps Electron's sessionData.
+//
+// `persist:` partitions live under `sessionData`, which defaults to `userData`.
+// Nothing redirected either, so a DEV instance wrote the per-account claude.ai web
+// sessions (#216) into the same `%APPDATA%\claude-conductor\Partitions` a PROD
+// install uses. Consequences observed on a real machine: dev and prod shared the
+// session, signing out in dev revoked prod's, and `ccc --clean` wiped the dev data
+// dir while leaving a live sessionKey on disk because the partition was never
+// under it.
+import { describe, it, expect, vi } from 'vitest'
+import { join } from 'node:path'
+
+vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+vi.mock('../../src/main/registry', () => ({ readRegistry: () => null, writeRegistry: vi.fn() }))
+vi.mock('electron', () => ({ app: { getPath: () => 'C:/fake/userData', isPackaged: true } }))
+
+const { devSessionDataDir } = await import('../../src/main/data-paths')
+
+describe('devSessionDataDir', () => {
+  it('returns null for a packaged build, so prod keeps Electron’s default', () => {
+    // The whole point of scoping this to dev: moving prod's partitions would log
+    // out everyone who already signed in on a build that created one there.
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, true)).toBeNull()
+  })
+
+  it('puts dev session data under the dev data root', () => {
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, false))
+      .toBe(join('C:/data/dev', 'session'))
+  })
+
+  it('returns null when there is no dev override rather than guessing a path', () => {
+    expect(devSessionDataDir({}, false)).toBeNull()
+  })
+
+  it('covers E2E too, and prefers it over the dev dir', () => {
+    // An E2E run's data root is disposable; a partition outside it would survive
+    // the teardown that is supposed to remove it.
+    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: 'C:/tmp/e2e', CCC_DEV_DATA_DIR: 'C:/data/dev' }, false))
+      .toBe(join('C:/tmp/e2e', 'session'))
+  })
+
+  it('is a SUBDIRECTORY of the data root, so --clean removes it', () => {
+    // `ccc --clean` deletes the dev data dir wholesale. The session dir has to be
+    // inside it for that to clear the web sessions, which is the bug being fixed.
+    const root = 'C:/data/dev'
+    const got = devSessionDataDir({ CCC_DEV_DATA_DIR: root }, false)!
+    // Separator-normalised: `join` yields backslashes on Windows and forward
+    // slashes elsewhere, and the containment claim is about the path, not its
+    // spelling.
+    const norm = (s: string): string => s.replace(/\\/g, '/')
+    expect(norm(got).startsWith(norm(root) + '/')).toBe(true)
+    expect(norm(got)).not.toBe(norm(root))   // not the root itself: Electron writes into it
+  })
+
+  it('ignores an empty override rather than treating it as a root', () => {
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: '' }, false)).toBeNull()
+  })
+
+  it('REFUSES a relative root instead of half-applying the redirect', () => {
+    // `app.setPath` rejects a relative path, but the caller mkdirSync's first — so
+    // a relative root quietly created `<cwd>/<root>/session` (inside the repo, in
+    // one observed run) and then setPath threw into a catch, leaving dev writing
+    // claude.ai sessionKeys to prod's location exactly as before the fix.
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'relative/dev' }, false)).toBeNull()
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: './dev' }, false)).toBeNull()
+    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: 'tmp/e2e' }, false)).toBeNull()
+  })
+
+  it('honours an explicit E2E root even on a packaged build', () => {
+    // Matches getDataDirectory's own ordering, which checks CCC_E2E_DATA_DIR
+    // unconditionally. An explicit E2E override is never a real user's install,
+    // so `isPackaged` is not the question — and without this, an E2E run against a
+    // packaged exe would send its data to a disposable root while leaving the
+    // claude.ai partition in prod's %APPDATA%, surviving teardown.
+    expect(devSessionDataDir({ CCC_E2E_DATA_DIR: 'C:/tmp/e2e' }, true))
+      .toBe(join('C:/tmp/e2e', 'session'))
+    // A packaged build with only the DEV var set is still left alone.
+    expect(devSessionDataDir({ CCC_DEV_DATA_DIR: 'C:/data/dev' }, true)).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #261.

## The bug

Electron keeps `persist:` partitions under `sessionData`, which defaults to
`userData`, and nothing redirected either. So a **dev** instance wrote the
per-account claude.ai web sessions from #216 — real `sessionKey` cookies — into the
same `%APPDATA%\claude-conductor\Partitions` a **prod** install uses:

- dev and prod shared the session for a given account
- signing out in dev revoked prod's session, and vice versa
- `ccc --clean` wiped the dev data dir while leaving a live session on disk,
  because the partition was never under it
- `sweepAbandonedProfiles` could not reach it either — it only walks
  `<dataDir>/account-web`

## The fix

`app.setPath('sessionData', <devRoot>/session)` at module scope in `index.ts`,
beside the existing DEV data-dir block, behind a pure `devSessionDataDir()` in
`data-paths.ts`.

**Dev/E2E only, deliberately.** `userData` is Electron's own default for session
data and is not wrong for prod; relocating prod would force a re-login for anyone
who already signed in on a build that created a partition there. Packaged builds
get `null` and are untouched.

That also **retires the deadline #261 was filed with.** The issue argued this had
to land before the next beta release or a later path move would log users out —
true only if prod were relocated. It isn't, so there's no migration cliff.

## Verified, not assumed

An attacker sub-agent probed a standalone Electron 43.2.0 rather than trusting the
premise:

```
getStoragePath() = <ROOT>\session\Partitions\claude-web-test
early fromPartition threw: Session can only be received when app is ready
```

The first line confirms partitions really do follow `sessionData`. The second is
better than the ordering check I asked for: creating a session before app-ready
*throws* in Electron 43, so no module-scope import can materialise the default
session ahead of the redirect — the hazard is impossible, not merely avoided.

Confirmed live in the app: after launching this branch, both partitions appeared
under `dev\session\Partitions` and the shared location had **zero** directories
touched.

## What the adversarial pass changed, including two of my own errors

- **A relative `CCC_DEV_DATA_DIR` half-applied the fix.** `mkdirSync` created
  `<cwd>/<root>/session` — inside the repo working tree in one observed run — then
  `setPath` threw into a `catch` and boot continued with dev still writing to
  prod's location. `devSessionDataDir` now refuses a non-absolute root: a tested
  branch instead of a swallowed throw.
- **The guard was stricter than the logic it mirrors.** `getDataDirectory` honours
  `CCC_E2E_DATA_DIR` unconditionally; this returned `null` whenever packaged, so an
  E2E run against an installed exe would leave its claude.ai partition in prod's
  `%APPDATA%` to survive teardown. E2E is now honoured regardless of packaging.
- **The log line lied.** It used `console.log` while its comment claimed it made
  isolation "answerable from the log" — but debug-logger neither patches `console`
  nor hooks stdout, so it reached neither the debug log nor a bare `npm run dev`.
  Now `logInfo`/`logError`.
- **Partitions created before this change are orphaned** in the shared location and
  nothing will ever remove them. Dev now logs a one-time warning naming the path.
  A warning and **not** a deletion on purpose: `ccc --seed-accounts` copies prod's
  account profiles into dev, so a partition named for a dev profile id can *be*
  prod's live session — tidying a dev artifact must not sign someone out of their
  real account.

## Known, left open on purpose

- A dev instance that had signed in keeps its session **record** (dev data root)
  while its **cookies** stayed behind, so the panel reads "signed in" against an
  empty partition until the next sign-in. `statusOf` derives status from the stored
  `expiresAt` alone, and the store's own comment says a 401 is what should correct
  it. Dev-only, self-limiting — **so the first dev boot after this merges is not a
  sign-in bug.**
- `ccc --clean` can now partially delete a live Chromium storage tree: the wipe runs
  before the process kill and swallows errors. Narrow (the launcher refuses a second
  dev instance on the port check) but new exposure from moving session data under
  the dev root.
- The `ccc.cmd` header still overstates isolation — `~/.claude` remains shared and
  `account-profiles.ts` never consults `CCC_DEV_DATA_DIR`, so dev can still contend
  with prod over OAuth refresh-token rotation. Already a documented caveat, now
  sharpened with what was actually observed on 2026-08-12, and filed separately.

## Gate

Typecheck clean. Build clean. Unit suite **4162 passed** across 474 files. Verified
in the desktop app. ADR-009 pass run (two lenses, scoped to this diff); every
finding above is either fixed here or listed as knowingly deferred.
