### PR TITLE
fix(release): one brand name, working upgrades, and a store package (2.1.0-beta.10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
               *)    TAG="v${VERSION}"      ;;
             esac
           fi
-          INSTALLER="ClaudeCommandCenter-${VERSION}.exe"
+          INSTALLER="AI-Code-Conductor-${VERSION}.exe"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
@@ -438,27 +438,23 @@ jobs:
       - name: List artifacts
         run: ls -la artifacts/
 
-      # Publish each installer a second time under the current brand name, so a
-      # fresh download carries no legacy name. The ClaudeCommandCenter-* copies
-      # MUST stay: every installed client matches release assets by that literal
-      # prefix, and latest*.yml still points at them, so removing them would
-      # strand existing installs on "no update available". Only the installers
-      # are duplicated — .blockmap and latest*.yml are updater-internal and are
-      # resolved by name from the legacy asset.
-      - name: Add cleanly-named download copies
-        run: |
-          cd artifacts
-          for f in *.exe *.dmg *.AppImage; do
-            [ -e "$f" ] || continue
-            clean="${f/ClaudeCommandCenter-/AI-Code-Conductor-}"
-            if [ "$clean" != "$f" ]; then
-              cp -- "$f" "$clean"
-              echo "added $clean"
-            fi
-          done
-          ls -la
-
-      # Runs AFTER the copies so users can verify whichever name they downloaded.
+      # One name, one set of assets.
+      #
+      # Releases used to publish every installer TWICE — once as
+      # ClaudeCommandCenter-* and once as AI-Code-Conductor-* — because the
+      # updater in shipped clients matched release assets by the literal legacy
+      # prefix, so dropping it would have stranded them on "no update
+      # available", unfixably. Since 2.1.0-beta.6 the updater accepts BOTH
+      # prefixes (INSTALLER_PREFIXES in src/main/github-update.ts), so every
+      # client that can reach this release already resolves the brand name.
+      # Only installs on beta.5 or older are left behind, and they can download
+      # from the release page by hand.
+      #
+      # electron-builder now emits the brand name directly (build.*.artifactName
+      # in package.json), so the .blockmap and latest*.yml — which reference the
+      # installer BY NAME — line up with the installer that actually ships. The
+      # duplicate copies never had matching blockmaps, which is exactly the kind
+      # of mismatch the manifest gate below exists to catch.
       - name: Generate checksums
         run: |
           cd artifacts
@@ -475,10 +471,8 @@ jobs:
           CHANNEL="${{ inputs.channel }}"
 
           TITLE="${TAG}"
-          # Display names only. Asset filenames deliberately keep the
-          # ClaudeCommandCenter- prefix (the updater in every installed client
-          # matches release assets by that literal prefix; renaming them
-          # strands existing installs silently).
+          # Display names. Asset filenames carry the same brand name — see the
+          # checksums step above for why the legacy duplicate is gone.
           case "$CHANNEL" in
             stable)
               RELEASE_NAME="AI Code Conductor"
@@ -510,7 +504,7 @@ jobs:
               echo ""
             fi
             echo "---"
-            echo "Installer files keep the ClaudeCommandCenter- name so existing installs keep receiving updates."
+            echo "Upgrading from 2.1.0-beta.5 or earlier? Download the installer from this page — that build's updater looked for the old file name."
             echo ""
             echo "AI Code Conductor is an independent community project — not affiliated with or endorsed by Anthropic. Claude and Claude Code are Anthropic trademarks."
             echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,9 +249,10 @@ jobs:
           # exe's sha512, so replacing one without the others breaks the updater
           # (matters for rolling re-releases onto an existing tag).
           #
-          # The .appx is optional — `continue-on-error` above means it may not
-          # exist, so it cannot be part of the if-no-files-found: error contract.
-          # It is picked up by the wildcard when present.
+          # The .appx is deliberately absent from this list: `continue-on-error`
+          # above means it may not exist, so it cannot be part of this step's
+          # if-no-files-found: error contract. It ships in its own
+          # "Upload Store MSIX" artifact below, gated on that step succeeding.
           path: |
             dist/${{ steps.version.outputs.installer }}
             dist/${{ steps.version.outputs.installer }}.blockmap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,40 @@ jobs:
             Write-Host 'dev build left unsigned (signing secrets not configured)'
           }
 
+      # ── MSIX/AppX for the Microsoft Store (#225) ──
+      # A SEPARATE electron-builder invocation, deliberately: folding `appx` into
+      # build.win.target would put it inside the same run as nsis, where a Store
+      # packaging failure takes the whole Windows release down with it. Here the
+      # NSIS installer is already built, verified and about to be uploaded, so a
+      # failure below costs the Store package and nothing else.
+      #
+      # NOT SIGNED, and that is correct: build.appx.publisher is a Store identity
+      # (CN=<Partner Center GUID>), so electron-builder skips signing with
+      # "Windows Store only build" and Microsoft signs it on ingestion. Signing it
+      # with our own cert would make the publisher disagree with the manifest
+      # identity and the package would be rejected.
+      #
+      # Note the manifest version is the 4-part numeric form (2.1.0.0) — MSIX has
+      # no concept of a prerelease suffix, so `-beta.N` is dropped. Two betas on
+      # the same base version therefore produce the SAME package version; bump the
+      # base before submitting a second one to the Store.
+      - name: Package Microsoft Store MSIX
+        id: msix
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          npx electron-builder --win appx --publish never --config.npmRebuild=false
+          $pkg = Get-ChildItem dist -Filter *.appx | Select-Object -First 1
+          if (-not $pkg) { throw 'appx target produced no package' }
+          Write-Host "Store package: $($pkg.Name) ($([math]::Round($pkg.Length/1MB,1)) MB)"
+          "appx=$($pkg.Name)" >> $env:GITHUB_OUTPUT
+
+      - name: Note a failed Store package
+        if: ${{ steps.msix.outcome == 'failure' }}
+        shell: bash
+        run: echo "::warning::The Microsoft Store MSIX did not build. The Windows installer is unaffected and the release continues."
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
         with:
@@ -214,10 +248,22 @@ jobs:
           # exe + blockmap + latest.yml travel together: latest.yml carries the
           # exe's sha512, so replacing one without the others breaks the updater
           # (matters for rolling re-releases onto an existing tag).
+          #
+          # The .appx is optional — `continue-on-error` above means it may not
+          # exist, so it cannot be part of the if-no-files-found: error contract.
+          # It is picked up by the wildcard when present.
           path: |
             dist/${{ steps.version.outputs.installer }}
             dist/${{ steps.version.outputs.installer }}.blockmap
             dist/latest.yml
+          if-no-files-found: error
+
+      - name: Upload Store MSIX
+        if: ${{ steps.msix.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-msix
+          path: dist/*.appx
           if-no-files-found: error
 
   # ── Build macOS app ──

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.10] - 2026-08-14
+
+> Fixes an upgrade that could fail with "AI Code Conductor cannot be closed" even with nothing running, and settles the rename: downloads now carry one name, and the first-run tour finally matches the brand.
+
+### Changed
+- Downloads now carry a single name. Releases used to attach every installer twice — once under the old product name and once under the current one — which made it unclear which file to take. Only AI-Code-Conductor-… is published now. If you are on 2.1.0-beta.5 or older, download this release by hand from the releases page: that build looks for the old file name and will not see the update.
+- The first-run tour and guided setup now use the AI Code Conductor blue instead of the previous product's orange, so the logo no longer sits inside mismatched styling, and the "What's new" page shows the version you are actually installing rather than always saying 2.0.
+- A Microsoft Store package is now built alongside the Windows installer — the first step towards listing the app in the Store.
+
+### Fixed
+- Upgrading could stop partway with "AI Code Conductor cannot be closed. Please close it manually and click Retry" — with the app shut down, after a reboot, and with no such program running anywhere. The message was misleading: it appears when the installer cannot run the previous version's uninstaller, not because anything is open. Installations in that state are now detected and repaired silently, with nothing for you to do.
+- Earlier renames could leave the app installed inside a folder named after the previous one, nesting a level deeper each time. The installer now recognises every folder name the app has shipped under, moves the installation to a clean folder, and removes the old tree. Your settings, data and resources folder are untouched.
+- Security hardening: one file written during SSH session setup — the status-line helper — could follow a symbolic link planted in advance in the remote account's ~/.claude folder, redirecting where it was written. It is now created fresh and refuses to follow a planted link, matching the protection already applied to the token files written beside it. Reported privately.
+
 ## [2.1.0-beta.9] - 2026-08-13
 
 > Each account can hold its own claude.ai web session, signed in through a dedicated per-account browser and kept fully separate. This is also a security release: two local-attacker vulnerabilities are fixed, with their advisories published alongside it.
@@ -1037,6 +1051,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.10]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.10
 [2.1.0-beta.9]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.9
 [2.1.0-beta.8]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.8
 [2.1.0-beta.7]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.7

--- a/CONTEXT.d/2026-08-14-installer-legacy-sweep-hardening.md
+++ b/CONTEXT.d/2026-08-14-installer-legacy-sweep-hardening.md
@@ -1,0 +1,104 @@
+## 2026-08-14 -- installer legacy-folder sweep: ownership proof, elevated-upgrade ordering, and behavioural tests
+
+An independent adversarial re-attack on the legacy-install relocation in
+`build/installer.nsh` (unreleased -- the sweep has never been in a tagged build)
+found three ship blockers and three cheap fail-open bugs. All six are fixed here,
+and the tests that were supposed to hold this code are replaced with ones that
+actually can.
+
+### 1. The ownership proof missed the tree it exists to clean
+
+`RemoveLegacyInstall` demanded `Uninstall *.exe` at the candidate folder itself.
+In the triple-nested shape
+
+    ...\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+
+the uninstaller exists ONLY at the leaf: electron-builder's uninstaller does
+`RMDir /r $INSTDIR` before `SetOutPath` recreates the chain one level deeper, so
+every outer level holds nothing but the next folder. `IfFileExists` with a
+wildcard is not recursive, so the proof could never be satisfied on the outer
+root -- while the ARP record WAS cleared for that shape, orphaning several
+hundred MB with nothing able to uninstall it. That is the exact outcome the
+change was meant to prevent.
+
+Ownership is now proved two ways, either sufficient:
+
+- `CccProveInstallRoot` walks DOWN from the candidate (depth-first, bounded to 24
+  nodes), stepping only into folders whose name can be a link in a nesting chain
+  and never into a reparse point, and accepts an `Uninstall *.exe` only when the
+  match is a FILE. It was measured that a DIRECTORY named `Uninstall x.exe`
+  satisfied the old check, after which the sibling source checkout was deleted --
+  `IfFileExists` with a wildcard is `FindFirstFile`, which matches directories.
+- the uninstaller path the replaced install recorded, captured by `customInit`
+  before anything rewrites it (the commit point clears the record and
+  `registryAddInstallInfo` writes a new one pointing at `$INSTDIR`, so `.onInit`
+  is the only place the answer still exists).
+
+### 2. The retarget aimed the OLD uninstaller at the NEW directory when elevating
+
+`customInit` is inserted unguarded (`installer.nsi:79-81`), so the elevated inner
+instance rewrites `${INSTALL_REGISTRY_KEY}\InstallLocation` to the new
+`$INSTDIR`. But `installSection.nsh:35-37` guards `CHECK_APP_RUNNING` with
+`${ifNot} ${UAC_IsInnerInstance}`, so the commit-point clear never runs there.
+`uninstallOldVersion` then reads the retargeted value, runs the old uninstaller
+with `_?=<new dir>`, and `uninstaller.nsh:187` does `RMDir /r $INSTDIR` -- on the
+directory this run is about to install into.
+
+Deferring the retarget is not possible: the install-mode page (and, under `/S`,
+`installer.nsi:117`) re-seeds `$INSTDIR` from that value before the section runs,
+and any value left there is what the old uninstaller resolves its `$INSTDIR`
+from. So the record is neutralised instead. In the inner instance only,
+`customInit` now removes just the `UninstallString` value --
+`uninstallOldVersion` returns immediately on an empty one -- and remembers it, so
+`CccRestoreInstallLocation` (MUI's abort callback, plus `.onInstFailed`) puts it
+back if the wizard the inner instance still shows is cancelled. One value rather
+than `DeleteRegKey`, precisely so it is restorable from a single saved string.
+
+### 3. The guards were only ever asserted to be PRESENT
+
+10/10 deletion mutants went red; 6/6 polarity mutants stayed green, including
+`${If} $R8 == 1` rewritten to `${If} "1" == "1"` immediately before `RMDir /r` --
+which compiled, ran, destroyed a junction target, a source checkout and a
+CONFIG/settings.json, and left the suite green.
+
+`tests/unit/main/installer-nsis-behaviour.test.ts` now compiles the real macros
+out of `build/installer.nsh` with the real makensis, runs them over a real
+fixture tree and asserts what is left on disk. It skips (does not fail) when
+makensis is absent, with a tripwire that fails if it skips on a machine whose
+electron-builder NSIS cache is plainly there. 17 polarity mutants were applied
+one at a time; all 17 turn it red.
+
+### Also fixed (same code, all measured fail-open)
+
+- **Data/resources overlap was void for empty and forward-slash values.**
+  `PathsOverlap(dir, "")` is 0, so an unreadable `DataDirectory` contributed
+  nothing at all; a value recorded with forward slashes likewise. `ReadUserPath`
+  is HKCU-only (the only hive the app writes), so on an all-users install
+  elevated by a different admin both come back empty -- the guard was off exactly
+  where privilege is highest. Both sides are now canonicalised
+  (separators, trailing separator, and `GetFullPathName /SHORT` for 8.3 and
+  `..`), compared in both spellings, and an unreadable or empty value now
+  REFUSES the deletion instead of reading as "no overlap".
+- **The "never `$INSTDIR`" check was a raw `StrCmp`**, so `/S /D=C:\PROGRA~1\CLAUDE~1`
+  gave `$INSTDIR` an 8.3 spelling that matched nothing and the just-installed
+  directory was swept. It is now a canonical overlap test in both directions, and
+  an explicit `/D=` skips the sweep entirely -- the same reasoning that already
+  suppresses the relocation for a hand-picked directory.
+
+### Verification
+
+- `npm run typecheck` clean; full `npx vitest run` green (4176 passed).
+- A real `electron-builder --win nsis` run (stub `--prepackaged` tree) compiles
+  both the installer and the uninstaller pass. electron-builder invokes
+  `makensis -WX`, so that also proves the file produces no NSIS warnings.
+- End to end over a real fixture tree, silently and interactively: a triple-
+  nested install relocates to `...\Programs\AI Code Conductor`, the nested tree is
+  removed, the old uninstaller is never run, and the ARP record points at the new
+  install.
+
+### Known and deliberately out of scope
+
+A junction sitting INSIDE a proven install root is still followed by `RMDir /r`;
+per-machine nesting when both hives hold records; the `Quit` paths that leave
+`.onInit` without going through MUI's abort callback. Noted in comments where the
+code is adjacent; tracked separately.

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -10,6 +10,12 @@
 ; to beat `!insertmacro addLangs` lives here, while anything needing
 ; ${INSTALL_REGISTRY_KEY} (defined by multiUser.nsh) has to sit inside a macro
 ; electron-builder inserts later (customHeader / customInit / customInstall).
+;
+; The same ordering rule applies to MACROS from electron-builder's own templates:
+; installUtil.nsh is included by installer.nsi AFTER Function .onInit, so
+; `!insertmacro GetInQuotes` cannot be used from customInit (a Call is resolved
+; at link time, a macro insertion is not). That is why the quote stripping below
+; is our own CccGetInQuotes rather than electron-builder's.
 
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
@@ -40,6 +46,18 @@
   ${EndIf}
 !macroend
 
+; ${OUT} = 1 when ${NAME} is a folder name that can appear as a LINK in a nesting
+; chain: a legacy brand folder, or the current app folder that every rename
+; appended one level deeper. This is the same bound FindLegacyRoot climbs, used
+; in the other direction by CccProveInstallRoot when it descends.
+!macro IsChainFolder NAME OUT
+  !insertmacro IsLegacyBrandFolder "${NAME}" ${OUT}
+  ${If} ${OUT} != 1
+  ${AndIf} "${NAME}" == "${APP_FILENAME}"
+    StrCpy ${OUT} 1
+  ${EndIf}
+!macroend
+
 ; ${OUT} = 1 when ${PATH} is ${DIR} itself, or something inside ${DIR}.
 ; Comparison is case-insensitive because LogicLib's == compiles to StrCmp, which
 ; is — matching Windows path semantics. Defines no labels of its own, so it is
@@ -65,6 +83,78 @@
   !insertmacro IsSameOrInside "${A}" "${B}" ${OUT}
   ${If} ${OUT} != 1
     !insertmacro IsSameOrInside "${B}" "${A}" ${OUT}
+  ${EndIf}
+!macroend
+
+; Two comparable spellings of ${PATH}.
+;   ${OUT_PLAIN} — separators normalised to "\" and any trailing separator
+;     dropped. A DataDirectory recorded as "C:/Users/x/Claude Command Center"
+;     is a real, measured case: a raw prefix compare against the backslash form
+;     silently returns "no overlap" and the data directory gets deleted.
+;   ${OUT_SHORT} — the same path resolved through the filesystem, which collapses
+;     8.3 short names ("C:\PROGRA~1\CLAUDE~1"), "." and ".." to one spelling.
+;     GetFullPathName sets the error flag and yields "" for a path that does not
+;     exist, so this falls back to ${OUT_PLAIN} there.
+; Both forms are kept because a comparison usually has one side that exists (the
+; candidate on disk) and one that may not (a directory read out of the registry);
+; callers compare plain-to-plain AND short-to-short so either spelling matches.
+; Scratch: $cccCanonWork $cccCanonChar $cccCanonIdx $cccCanonTmp.
+!macro CanonPathPair PATH OUT_PLAIN OUT_SHORT
+  StrCpy ${OUT_PLAIN} ""
+  StrCpy ${OUT_SHORT} ""
+  ${If} "${PATH}" != ""
+    StrCpy $cccCanonWork ""
+    StrCpy $cccCanonIdx 0
+    ${Do}
+      StrCpy $cccCanonChar "${PATH}" 1 $cccCanonIdx
+      ${If} $cccCanonChar == ""
+        ${ExitDo}
+      ${EndIf}
+      ${If} $cccCanonChar == "/"
+        StrCpy $cccCanonChar "\"
+      ${EndIf}
+      StrCpy $cccCanonWork "$cccCanonWork$cccCanonChar"
+      IntOp $cccCanonIdx $cccCanonIdx + 1
+      ${If} $cccCanonIdx > 512
+        ${ExitDo}
+      ${EndIf}
+    ${Loop}
+    ; Trailing separators, but never below "X:\".
+    ${Do}
+      StrLen $cccCanonIdx "$cccCanonWork"
+      ${If} $cccCanonIdx < 4
+        ${ExitDo}
+      ${EndIf}
+      StrCpy $cccCanonChar "$cccCanonWork" 1 -1
+      ${If} $cccCanonChar != "\"
+        ${ExitDo}
+      ${EndIf}
+      StrCpy $cccCanonWork "$cccCanonWork" -1
+    ${Loop}
+    StrCpy ${OUT_PLAIN} "$cccCanonWork"
+    ClearErrors
+    GetFullPathName /SHORT $cccCanonTmp "$cccCanonWork"
+    ${If} ${Errors}
+    ${OrIf} $cccCanonTmp == ""
+      StrCpy ${OUT_SHORT} "$cccCanonWork"
+    ${Else}
+      StrCpy ${OUT_SHORT} "$cccCanonTmp"
+    ${EndIf}
+    ClearErrors
+  ${EndIf}
+!macroend
+
+; PathsOverlap over BOTH canonical spellings. Use this — never a raw StrCmp or a
+; raw PathsOverlap — for any comparison that decides whether something may be
+; deleted: a raw compare is defeated by a forward slash, a trailing separator or
+; an 8.3 short name, all three measured.
+; Scratch: $cccCanon* (via CanonPathPair) and $R5 $R6 $R7 (via IsSameOrInside).
+!macro PathsOverlapCanon A B OUT
+  !insertmacro CanonPathPair "${A}" $cccCanonA $cccCanonAS
+  !insertmacro CanonPathPair "${B}" $cccCanonB $cccCanonBS
+  !insertmacro PathsOverlap "$cccCanonA" "$cccCanonB" ${OUT}
+  ${If} ${OUT} != 1
+    !insertmacro PathsOverlap "$cccCanonAS" "$cccCanonBS" ${OUT}
   ${EndIf}
 !macroend
 
@@ -115,6 +205,11 @@
 !macroend
 
 ; Read one of the user-chosen directories, newest brand key first.
+;
+; HKCU only, because that is the only hive the app itself ever writes
+; (src/main/registry.ts) — so on an all-users install elevated by a DIFFERENT
+; admin account these come back empty, and RemoveLegacyInstall refuses to delete
+; anything rather than sweeping with the data-directory guard switched off.
 !macro ReadUserPath NAME OUT
   ReadRegStr ${OUT} HKCU "Software\AI Code Conductor" "${NAME}"
   ${If} ${OUT} == ""
@@ -122,6 +217,40 @@
   ${EndIf}
   ${If} ${OUT} == ""
     ReadRegStr ${OUT} HKCU "Software\Claude Conductor" "${NAME}"
+  ${EndIf}
+!macroend
+
+; The path inside the first pair of double quotes of ${STR}, or "".
+; electron-builder has a GetInQuotes of its own, but its MACRO is only defined
+; once installUtil.nsh has been included — which happens after Function .onInit,
+; where customInit needs this. Same shape: an UninstallString is
+; '"<dir>\Uninstall <app>.exe" /currentuser'.
+; Scratch: $cccQuoteWork $cccQuoteChar $cccQuoteIdx.
+!macro CccGetInQuotes STR OUT
+  StrCpy ${OUT} ""
+  StrCpy $cccQuoteWork "${STR}"
+  StrCpy $cccQuoteChar "$cccQuoteWork" 1
+  ${If} $cccQuoteChar == '"'
+    StrCpy $cccQuoteWork "$cccQuoteWork" "" 1
+    StrCpy $cccQuoteIdx 0
+    ${Do}
+      StrCpy $cccQuoteChar "$cccQuoteWork" 1 $cccQuoteIdx
+      ${If} $cccQuoteChar == ""
+        StrCpy $cccQuoteIdx 0
+        ${ExitDo}
+      ${EndIf}
+      ${If} $cccQuoteChar == '"'
+        ${ExitDo}
+      ${EndIf}
+      IntOp $cccQuoteIdx $cccQuoteIdx + 1
+      ${If} $cccQuoteIdx > 512
+        StrCpy $cccQuoteIdx 0
+        ${ExitDo}
+      ${EndIf}
+    ${Loop}
+    ${If} $cccQuoteIdx > 0
+      StrCpy ${OUT} "$cccQuoteWork" $cccQuoteIdx
+    ${EndIf}
   ${EndIf}
 !macroend
 
@@ -136,24 +265,36 @@
 ; real makensis: a junction made with `mklink /J` had its TARGET tree deleted,
 ; and ${FileExists} "<junction>\*.*" reports true *through* the junction. A
 ; matching folder NAME is nowhere near enough on its own. All of these must hold:
-;   1. it is not the directory we are installing into;
+;   1. it does not overlap the directory we are installing into. Compared
+;      canonically, not with StrCmp: `/S /D=C:\PROGRA~1\CLAUDE~1` gave $INSTDIR
+;      an 8.3 spelling that no raw compare against the long form matched, and the
+;      just-installed directory was swept;
 ;   2. it exists;
 ;   3. it is not a reparse point (junction / symlink / mount point);
-;   4. it does not overlap the user's data or resources directory in either
-;      direction — shipped builds defaulted DataDirectory to
-;      "$LOCALAPPDATA\Claude Command Center" and ResourcesDirectory to
-;      "…\Claude Command Center\resources" (git show 8c0085e:build/installer.nsh),
-;      and "Claude Command Center" is a name this sweep looks for, so an install
-;      into %LOCALAPPDATA% would otherwise destroy the user's sessions, logs and
-;      CONFIG — twenty lines after customInstall adopted that very path;
-;   5. it contains an "Uninstall *.exe" — positive proof that it is an NSIS
-;      install root, and not a source checkout that happens to share the name.
+;   4. the user's data AND resources directories are both KNOWN. Empty means the
+;      overlap test below cannot say anything, not that there is no overlap —
+;      measured: PathsOverlap(dir, "") is 0, so an unreadable DataDirectory used
+;      to turn the guard off entirely and CONFIG/settings.json was destroyed;
+;   5. it does not overlap either of them in either direction — shipped builds
+;      defaulted DataDirectory to "$LOCALAPPDATA\Claude Command Center" and
+;      ResourcesDirectory to "…\Claude Command Center\resources"
+;      (git show 8c0085e:build/installer.nsh), and "Claude Command Center" is a
+;      name this sweep looks for, so an install into %LOCALAPPDATA% would
+;      otherwise destroy the user's sessions, logs and CONFIG — twenty lines
+;      after customInstall adopted that very path;
+;   6. it is provably an install root of THIS app (CccProveInstallRoot, or the
+;      uninstaller the replaced install recorded), not a source checkout that
+;      happens to share the name.
 ; Expects $R3 = DataDirectory and $R4 = ResourcesDirectory.
-; Scratch: $R5 $R6 $R7 $R8 $R9.
+; Scratch: $R5 $R6 $R7 $R8 $R9 and $ccc* — never $R2, which customInstall holds.
+;
+; Known, deliberately out of scope: a junction sitting INSIDE a proven install
+; root is still followed by RMDir /r. Logged separately.
 !macro RemoveLegacyInstall DIR NAME
   StrCpy $R8 1
 
-  ${If} "${DIR}" == "$INSTDIR"
+  !insertmacro PathsOverlapCanon "${DIR}" "$INSTDIR" $R9
+  ${If} $R9 == 1
     StrCpy $R8 0
   ${EndIf}
 
@@ -173,7 +314,15 @@
   ${EndIf}
 
   ${If} $R8 == 1
-    !insertmacro PathsOverlap "${DIR}" "$R3" $R9
+    ${If} $R3 == ""
+    ${OrIf} $R4 == ""
+      DetailPrint "Data/resources directories unknown — refusing to delete ${DIR}"
+      StrCpy $R8 0
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R8 == 1
+    !insertmacro PathsOverlapCanon "${DIR}" "$R3" $R9
     ${If} $R9 == 1
       DetailPrint "Refusing to delete the data directory: ${DIR}"
       StrCpy $R8 0
@@ -181,7 +330,7 @@
   ${EndIf}
 
   ${If} $R8 == 1
-    !insertmacro PathsOverlap "${DIR}" "$R4" $R9
+    !insertmacro PathsOverlapCanon "${DIR}" "$R4" $R9
     ${If} $R9 == 1
       DetailPrint "Refusing to delete the resources directory: ${DIR}"
       StrCpy $R8 0
@@ -189,9 +338,11 @@
   ${EndIf}
 
   ${If} $R8 == 1
-  ${AndIfNot} ${FileExists} "${DIR}\Uninstall *.exe"
-    DetailPrint "Not an install of this app, leaving it alone: ${DIR}"
-    StrCpy $R8 0
+    !insertmacro ProveLegacyInstallRoot "${DIR}" $R9
+    ${If} $R9 != 1
+      DetailPrint "Not an install of this app, leaving it alone: ${DIR}"
+      StrCpy $R8 0
+    ${EndIf}
   ${EndIf}
 
   ${If} $R8 == 1
@@ -202,16 +353,53 @@
   ${EndIf}
 !macroend
 
-; Drop the recorded previous installation in ${ROOT_KEY}, but only when that
-; record is one of:
-;   a) unusable — the uninstaller it names is gone (removed by hand, or by an
-;      upgrade that failed part-way). electron-builder runs it anyway, retries
-;      five times and then shows "$(appCannotBeClosed)" (installUtil.nsh
-;      uninstallOldVersion) — a message about the APP being open, raised when the
-;      UNINSTALLER failed, with nothing for the user to close. With no
-;      UninstallString it returns immediately instead;
-;   b) pointing into the legacy folder beside $INSTDIR that this run relocated
-;      out of and customInstall is about to delete.
+; ${OUT} = 1 when ${DIR} is provably an install root of this app.
+;
+; TWO independent proofs, because either one alone leaves the owner's real case
+; unprovable:
+;
+;   A. an "Uninstall *.exe" FILE at ${DIR} or anywhere down the legacy nesting
+;      chain below it (CccProveInstallRoot). Requiring it AT ${DIR} was a
+;      regression: in
+;        …\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+;      the uninstaller exists ONLY at the leaf, because electron-builder's
+;      uninstaller does RMDir /r $INSTDIR before SetOutPath recreates the chain
+;      one level deeper — every outer level holds nothing but the next folder.
+;      IfFileExists with a wildcard is not recursive (measured), so the proof
+;      could never be satisfied on the outer root and several hundred MB of app
+;      was left behind with its ARP record already cleared.
+;
+;   B. the uninstaller the install we are REPLACING recorded, captured by
+;      customInit before anything rewrote the record, still on disk and inside
+;      ${DIR}. This survives a legacy tree whose chain we cannot walk, and it is
+;      strictly stronger than a name match: Windows itself named that file as the
+;      way to remove this app.
+;
+; Scratch: $R5 $R6 $R7 and $ccc* — ${OUT} must not be one of those.
+!macro ProveLegacyInstallRoot DIR OUT
+  StrCpy $cccProveDir "${DIR}"
+  Call CccProveInstallRoot
+  StrCpy ${OUT} $cccProveResult
+
+  ${If} ${OUT} != 1
+  ${AndIf} $cccLegacyUninstaller != ""
+  ${AndIf} ${FileExists} "$cccLegacyUninstaller"
+  ${AndIfNot} ${FileExists} "$cccLegacyUninstaller\*.*"
+    !insertmacro CanonPathPair "${DIR}" $cccCanonA $cccCanonAS
+    !insertmacro CanonPathPair "$cccLegacyUninstaller" $cccCanonB $cccCanonBS
+    !insertmacro IsSameOrInside "$cccCanonA" "$cccCanonB" ${OUT}
+    ${If} ${OUT} != 1
+      !insertmacro IsSameOrInside "$cccCanonAS" "$cccCanonBS" ${OUT}
+    ${EndIf}
+    ${If} ${OUT} == 1
+      DetailPrint "Ownership proved by the recorded uninstaller: $cccLegacyUninstaller"
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+; Drop the recorded previous installation in ${ROOT_KEY}, but only when
+; ClassifyUninstallRecord says it is unusable or points into the legacy folder
+; this run relocated out of.
 ;
 ; Judged per hive, with the caller naming the hive explicitly. appId is frozen,
 ; so a per-user and a per-machine installation share the same registry key PATH
@@ -219,22 +407,49 @@
 ; would destroy a healthy per-user install's record, and installSection.nsh then
 ; calls uninstallOldVersion HKEY_CURRENT_USER, reads an empty UninstallString and
 ; returns — leaving that copy on disk with nothing able to remove it.
-; Scratch: $R0 $R1 $R2 $R3 $R4 (+ $R5-$R9 via FindLegacyRoot).
+; Scratch: $R0 $R1 $R3 $R4 $R9 and $ccc* (via ClassifyUninstallRecord).
 !macro ForgetPreviousInstallIn ROOT_KEY
+  !insertmacro ClassifyUninstallRecord ${ROOT_KEY}
+  ${If} $cccRecordVerdict != ""
+    DetailPrint "Clearing the previous uninstall record ($cccRecordVerdict): $cccRecordUninstaller"
+    DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY}"
+    ; Dead code for this app: electron-builder only defines
+    ; UNINSTALL_REGISTRY_KEY_2 when the GUID contains a backslash
+    ; (NsisTarget.js:176-178), and ours is UUID.v5(appId) =
+    ; 0210f08e-15d0-5073-901d-684e27f31b7d. Kept so that setting a custom
+    ; nsis.guid would still be handled.
+    !ifdef UNINSTALL_REGISTRY_KEY_2
+      DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY_2}"
+    !endif
+  ${EndIf}
+!macroend
+
+; Judge the uninstall record in ${ROOT_KEY}. Sets:
+;   $cccRecordUninstaller — the uninstaller path it names ("" if unparseable)
+;   $cccRecordVerdict     — "" to keep it, otherwise why it must not be run:
+;     "unparseable" / "missing" — electron-builder runs it anyway, retries five
+;       times and then shows "$(appCannotBeClosed)" (installUtil.nsh
+;       uninstallOldVersion) — a message about the APP being open, raised when
+;       the UNINSTALLER failed, with nothing for the user to close. With no
+;       UninstallString it returns immediately instead;
+;     "legacy" — it points into the legacy folder beside $INSTDIR that this run
+;       relocated out of and customInstall is about to delete. Running it is
+;       worse than useless: uninstallOldVersion resolves its working directory
+;       from ${INSTALL_REGISTRY_KEY}\InstallLocation, which customInit has just
+;       RETARGETED at the new $INSTDIR, so the old uninstaller would RMDir /r the
+;       directory this run is about to install into.
+; Scratch: $R0 $R1 $R3 $R4 $R9 (+ $R5-$R8 via FindLegacyRoot).
+!macro ClassifyUninstallRecord ROOT_KEY
+  StrCpy $cccRecordVerdict ""
+  StrCpy $cccRecordUninstaller ""
   ReadRegStr $R0 ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
   ${If} $R0 != ""
-    StrCpy $R2 0
-    ; UninstallString is '"<dir>\Uninstall <app>.exe" /currentuser'. GetInQuotes
-    ; is a Function in installUtil.nsh, which installer.nsi includes AFTER the
-    ; point this is inserted from — but a Call is a forward reference NSIS
-    ; resolves at link time, and both live in the !ifndef BUILD_UNINSTALLER pass.
-    !insertmacro GetInQuotes $R1 "$R0"
+    !insertmacro CccGetInQuotes "$R0" $R1
+    StrCpy $cccRecordUninstaller "$R1"
     ${If} $R1 == ""
-      StrCpy $R2 1
-      DetailPrint "Uninstall record has no parseable path — clearing it"
+      StrCpy $cccRecordVerdict "unparseable"
     ${ElseIfNot} ${FileExists} "$R1"
-      StrCpy $R2 1
-      DetailPrint "Recorded uninstaller is gone ($R1) — clearing the record"
+      StrCpy $cccRecordVerdict "missing"
     ${Else}
       ${GetParent} "$R1" $R3
       !insertmacro FindLegacyRoot "$R3" $R9
@@ -242,21 +457,9 @@
         ${GetParent} "$R9" $R4
         ${GetParent} "$INSTDIR" $R3
         ${If} $R4 == $R3
-          StrCpy $R2 1
-          DetailPrint "Uninstall record points into the legacy folder being replaced ($R9) — clearing it"
+          StrCpy $cccRecordVerdict "legacy"
         ${EndIf}
       ${EndIf}
-    ${EndIf}
-    ${If} $R2 == 1
-      DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY}"
-      ; Dead code for this app: electron-builder only defines
-      ; UNINSTALL_REGISTRY_KEY_2 when the GUID contains a backslash
-      ; (NsisTarget.js:176-178), and ours is UUID.v5(appId) =
-      ; 0210f08e-15d0-5073-901d-684e27f31b7d. Kept so that setting a custom
-      ; nsis.guid would still be handled.
-      !ifdef UNINSTALL_REGISTRY_KEY_2
-        DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY_2}"
-      !endif
     ${EndIf}
   ${EndIf}
 !macroend
@@ -273,6 +476,44 @@
   ClearErrors
 !macroend
 
+; Remove ONLY the UninstallString value, remembering it in ${SAVE_VAR} so
+; CccRestoreInstallLocation can put it back.
+;
+; uninstallOldVersion returns immediately when UninstallString is empty
+; (installUtil.nsh:156-164), which is the whole point: this is the narrowest
+; edit that stops the old uninstaller running, and unlike DeleteRegKey it is
+; reversible from a single saved string. registryAddInstallInfo rewrites the
+; value a few lines after uninstallOldVersion, so on the success path nothing is
+; lost either way.
+; Scratch: $R0 $R1 $R3 $R4 $R9 and $ccc* (via ClassifyUninstallRecord).
+!macro SuspendUninstallRecordIn HIVE SAVE_VAR
+  !insertmacro ClassifyUninstallRecord ${HIVE}
+  ${If} $cccRecordVerdict != ""
+    ReadRegStr ${SAVE_VAR} ${HIVE} "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+    DeleteRegValue ${HIVE} "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+    DetailPrint "Suspended the previous uninstall record ($cccRecordVerdict) so it cannot be aimed at $INSTDIR"
+  ${EndIf}
+!macroend
+
+; Remember the uninstaller of the install being replaced, before this run
+; rewrites any of it. customInstall needs it as proof of ownership, and by then
+; the commit point has cleared the record and registryAddInstallInfo has written
+; a new one pointing at $INSTDIR.
+; Scratch: $R0 $R1 $R3 $R4 $R9 and $ccc* (via ClassifyUninstallRecord).
+!macro CaptureRecordedUninstaller
+  StrCpy $cccLegacyUninstaller ""
+  !insertmacro ClassifyUninstallRecord SHELL_CONTEXT
+  StrCpy $cccLegacyUninstaller "$cccRecordUninstaller"
+  ${If} $cccLegacyUninstaller == ""
+    !insertmacro ClassifyUninstallRecord HKCU
+    StrCpy $cccLegacyUninstaller "$cccRecordUninstaller"
+  ${EndIf}
+  ${If} $cccLegacyUninstaller == ""
+    !insertmacro ClassifyUninstallRecord HKLM
+    StrCpy $cccLegacyUninstaller "$cccRecordUninstaller"
+  ${EndIf}
+!macroend
+
 ; ============================================================
 ; CANCEL SAFETY
 ; ============================================================
@@ -281,7 +522,8 @@
 ; $INSTDIR are resolved (multiUser.nsh setInstallModePerUser -> uninstaller.nsh
 ; "RMDir /r $INSTDIR"), so leaving it pointing at a directory that was never
 ; created would make a later Add/Remove-Programs uninstall delete nothing and
-; then drop the entry. Put it back if the wizard never reaches the install.
+; then drop the entry. Put it back if the wizard never reaches the install. Same
+; for the UninstallString the elevated inner instance suspends.
 ;
 ; MUI2 defines Function .onUserAbort itself (Interface.nsh
 ; MUI_FUNCTION_ABORTWARNING, inserted by MUI_LANGUAGE), so this hooks its
@@ -289,6 +531,9 @@
 ; not compile. The define has to be in place before electron-builder's
 ; `!insertmacro addLangs`, which is why it sits at file scope rather than in
 ; customHeader.
+;
+; Known, deliberately out of scope: the Quit paths that leave .onInit without
+; going through MUI's abort callback still skip this. Logged separately.
 !ifndef BUILD_UNINSTALLER
   !define MUI_CUSTOMFUNCTION_ABORT "CccRestoreInstallLocation"
 !endif
@@ -299,6 +544,35 @@
   !ifndef BUILD_UNINSTALLER
     Var cccSavedPerUserInstallLocation
     Var cccSavedPerMachineInstallLocation
+    Var cccSavedPerUserUninstallString
+    Var cccSavedPerMachineUninstallString
+
+    Var cccLegacyUninstaller
+    Var cccRecordVerdict
+    Var cccRecordUninstaller
+
+    Var cccCanonA
+    Var cccCanonAS
+    Var cccCanonB
+    Var cccCanonBS
+    Var cccCanonWork
+    Var cccCanonChar
+    Var cccCanonIdx
+    Var cccCanonTmp
+
+    Var cccQuoteWork
+    Var cccQuoteChar
+    Var cccQuoteIdx
+
+    Var cccProveDir
+    Var cccProveResult
+    Var cccProveCur
+    Var cccProveName
+    Var cccProveHandle
+    Var cccProveHit
+    Var cccProveFlag
+    Var cccProvePending
+    Var cccProveSeen
 
     Function CccRestoreInstallLocation
       ${If} $cccSavedPerUserInstallLocation != ""
@@ -309,10 +583,105 @@
         WriteRegStr HKLM "${INSTALL_REGISTRY_KEY}" "InstallLocation" "$cccSavedPerMachineInstallLocation"
         StrCpy $cccSavedPerMachineInstallLocation ""
       ${EndIf}
+      ${If} $cccSavedPerUserUninstallString != ""
+        WriteRegStr HKCU "${UNINSTALL_REGISTRY_KEY}" "UninstallString" "$cccSavedPerUserUninstallString"
+        StrCpy $cccSavedPerUserUninstallString ""
+      ${EndIf}
+      ${If} $cccSavedPerMachineUninstallString != ""
+        WriteRegStr HKLM "${UNINSTALL_REGISTRY_KEY}" "UninstallString" "$cccSavedPerMachineUninstallString"
+        StrCpy $cccSavedPerMachineUninstallString ""
+      ${EndIf}
     FunctionEnd
 
     Function .onInstFailed
       Call CccRestoreInstallLocation
+    FunctionEnd
+
+    ; $cccProveResult = 1 when $cccProveDir, or a legacy-chain folder below it,
+    ; holds an "Uninstall *.exe" FILE.
+    ;
+    ; A FILE, checked by name through FindFirst: IfFileExists with a wildcard is
+    ; FindFirstFile, which matches DIRECTORIES too — measured, a directory called
+    ; "Uninstall whatever.exe\" satisfied the old proof and the sibling source
+    ; checkout was deleted.
+    ;
+    ; The descent is a depth-first walk over the NSIS stack, bounded to 24 nodes,
+    ; and it only ever steps into a folder whose NAME can be a link in a nesting
+    ; chain (IsChainFolder) — the same bound FindLegacyRoot climbs. Anything
+    ; wider would let an unrelated vendored installer somewhere under a source
+    ; checkout prove ownership of the checkout. Reparse points are skipped so a
+    ; junction cannot manufacture a proof out of a tree that lives elsewhere.
+    Function CccProveInstallRoot
+      StrCpy $cccProveResult 0
+      StrCpy $cccProveSeen 0
+      StrCpy $cccProvePending 1
+      Push "$cccProveDir"
+
+      ${Do}
+        ${If} $cccProvePending < 1
+          ${ExitDo}
+        ${EndIf}
+        Pop $cccProveCur
+        IntOp $cccProvePending $cccProvePending - 1
+        IntOp $cccProveSeen $cccProveSeen + 1
+        ${If} $cccProveSeen > 24
+          ${ExitDo}
+        ${EndIf}
+
+        StrCpy $cccProveHit 0
+        ClearErrors
+        FindFirst $cccProveHandle $cccProveName "$cccProveCur\Uninstall *.exe"
+        ${Do}
+          ${If} $cccProveName == ""
+            ${ExitDo}
+          ${EndIf}
+          ${IfNot} ${FileExists} "$cccProveCur\$cccProveName\*.*"
+            StrCpy $cccProveHit 1
+            ${ExitDo}
+          ${EndIf}
+          FindNext $cccProveHandle $cccProveName
+        ${Loop}
+        FindClose $cccProveHandle
+        ClearErrors
+
+        ${If} $cccProveHit == 1
+          StrCpy $cccProveResult 1
+          ${ExitDo}
+        ${EndIf}
+
+        ClearErrors
+        FindFirst $cccProveHandle $cccProveName "$cccProveCur\*.*"
+        ${Do}
+          ${If} $cccProveName == ""
+            ${ExitDo}
+          ${EndIf}
+          ${If} $cccProveName != "."
+          ${AndIf} $cccProveName != ".."
+          ${AndIf} ${FileExists} "$cccProveCur\$cccProveName\*.*"
+            !insertmacro IsChainFolder "$cccProveName" $cccProveFlag
+            ${If} $cccProveFlag == 1
+              ${GetFileAttributes} "$cccProveCur\$cccProveName" "REPARSE_POINT" $cccProveHit
+              ${If} $cccProveHit == 0
+                Push "$cccProveCur\$cccProveName"
+                IntOp $cccProvePending $cccProvePending + 1
+              ${EndIf}
+            ${EndIf}
+          ${EndIf}
+          FindNext $cccProveHandle $cccProveName
+        ${Loop}
+        FindClose $cccProveHandle
+        ClearErrors
+      ${Loop}
+
+      ; Whatever is still queued has to come off the stack, or the caller's
+      ; frame is corrupt.
+      ${Do}
+        ${If} $cccProvePending < 1
+          ${ExitDo}
+        ${EndIf}
+        Pop $cccProveCur
+        IntOp $cccProvePending $cccProvePending - 1
+      ${Loop}
     FunctionEnd
   !endif
 !macroend
@@ -373,11 +742,10 @@
     ; or declining UAC left the app fully installed with no Add/Remove Programs
     ; entry at all, uninstallable by neither the user nor an MDM.
     ;
-    ; Known gap: for an /allusers install that has to elevate, the whole of
-    ; CHECK_APP_RUNNING is skipped in the elevated inner instance
-    ; (installSection.nsh guards it with ${ifNot} ${UAC_IsInnerInstance}), so
-    ; nothing is cleared there and the old uninstaller runs exactly as it did
-    ; before this file cleared anything. Pre-existing behaviour, not a regression.
+    ; installSection.nsh guards this whole macro with ${ifNot}
+    ; ${UAC_IsInnerInstance}, so an /allusers install that had to elevate never
+    ; reaches this line. customInit covers that case with the narrower,
+    ; reversible SuspendUninstallRecordIn.
     !insertmacro ForgetBrokenPreviousInstall
   !endif
 !macroend
@@ -437,7 +805,14 @@
 !macroend
 
 !macro customInit
-  ; ---- 0. An explicit /D= is the operator's choice ------------------------
+  ; ---- 0. Remember what the previous install recorded ---------------------
+  ; Read before this run touches anything: customCheckAppRunning clears the
+  ; record at the commit point and registryAddInstallInfo replaces it, so by the
+  ; time customInstall wants to prove which folder is the old install, the only
+  ; copy of the answer is this variable.
+  !insertmacro CaptureRecordedUninstaller
+
+  ; ---- 1. An explicit /D= is the operator's choice ------------------------
   ; initMultiUser applies /D= last, so $INSTDIR already holds the requested
   ; directory by the time this runs. Relocating it — and then letting
   ; customInstall consider its siblings for deletion — would silently override a
@@ -447,7 +822,7 @@
   ${If} $R0 != ""
     DetailPrint "Explicit /D= install directory — leaving $INSTDIR alone"
   ${Else}
-    ; ---- 1. Find the OUTERMOST legacy folder in $INSTDIR's path -----------
+    ; ---- 2. Find the OUTERMOST legacy folder in $INSTDIR's path -----------
     !insertmacro FindLegacyRoot "$INSTDIR" $R9
 
     ${If} $R9 != ""
@@ -463,14 +838,35 @@
       ; already present.
       StrCpy $INSTDIR "$R4\${APP_FILENAME}"
 
-      ; ---- 2. Stop the install-mode page undoing it ----------------------
+      ; ---- 3. Stop the install-mode page undoing it ----------------------
       !insertmacro RetargetRecordedInstallLocation HKCU "$R9" $cccSavedPerUserInstallLocation
       !insertmacro RetargetRecordedInstallLocation HKLM "$R9" $cccSavedPerMachineInstallLocation
+
+      ; ---- 4. The elevated inner instance never reaches the commit point --
+      ; installSection.nsh:35-37 guards CHECK_APP_RUNNING with ${ifNot}
+      ; ${UAC_IsInnerInstance}, so ForgetBrokenPreviousInstall does not run in
+      ; the elevated instance — while the retarget above DOES, because customInit
+      ; is inserted unguarded (installer.nsi:79-81) and the HKLM value can only
+      ; be written by the elevated instance in the first place. Left alone, the
+      ; next thing that instance does is uninstallOldVersion, which reads the
+      ; retargeted InstallLocation, runs the OLD uninstaller with _?=<new dir>,
+      ; and that uninstaller does RMDir /r $INSTDIR on the directory this run is
+      ; about to install into.
+      ;
+      ; So the record is suspended here instead — the narrowest possible edit
+      ; (one value), remembered and restored by CccRestoreInstallLocation if the
+      ; wizard the inner instance is still going to show gets cancelled. Both
+      ; hives, because installSection.nsh calls uninstallOldVersion for
+      ; SHELL_CONTEXT and, on an /allusers run, HKEY_CURRENT_USER as well.
+      ${If} ${UAC_IsInnerInstance}
+        !insertmacro SuspendUninstallRecordIn HKCU $cccSavedPerUserUninstallString
+        !insertmacro SuspendUninstallRecordIn HKLM $cccSavedPerMachineUninstallString
+      ${EndIf}
     ${EndIf}
   ${EndIf}
-  ; The uninstall RECORD is deliberately NOT touched here — see the commit point
-  ; in customCheckAppRunning for why it can only be cleared once the install is
-  ; actually going ahead.
+  ; The uninstall RECORD is otherwise deliberately NOT touched here — see the
+  ; commit point in customCheckAppRunning for why it can only be cleared once the
+  ; install is actually going ahead.
   ;
   ; A ReadRegStr against a key that is not there sets the error flag, and .onInit
   ; hands straight over to the wizard; do not leave it set.
@@ -484,6 +880,10 @@
   ; are only copied where the brand key does not already have one, and the legacy
   ; keys are left in place (the app deletes only the original one — see
   ; registry.ts) so a rollback can still resolve the data directory.
+  ;
+  ; This runs BEFORE the sweep on purpose: ReadUserPath below is what keeps the
+  ; sweep away from the user's data, and on an upgrade the only place those paths
+  ; exist yet is a legacy key.
   !insertmacro AdoptLegacyValue "DataDirectory"
   !insertmacro AdoptLegacyValue "ResourcesDirectory"
   !insertmacro AdoptLegacyValue "SourcePath"
@@ -508,14 +908,25 @@
   ; reachable at all — and it demands positive proof of ownership before deleting
   ; anything, because a name match alone would also match a source checkout, a
   ; junction, or the user's data directory.
-  !insertmacro ReadUserPath "DataDirectory" $R3
-  !insertmacro ReadUserPath "ResourcesDirectory" $R4
+  ;
+  ; An explicit /D= skips the sweep entirely, for the same reason customInit
+  ; skips the relocation: the siblings of a hand-picked directory are not this
+  ; installer's business, and $INSTDIR may then be spelt in a form ($INSTDIR as
+  ; an 8.3 short name) that no comparison here should have to survive.
+  !insertmacro GetDParameter $R0
+  ${If} $R0 != ""
+    DetailPrint "Explicit /D= install directory — skipping the legacy folder sweep"
+  ${Else}
+    !insertmacro ReadUserPath "DataDirectory" $R3
+    !insertmacro ReadUserPath "ResourcesDirectory" $R4
 
-  ${GetParent} "$INSTDIR" $R2
-  !insertmacro RemoveLegacyInstall "$R2\Claude Conductor Beta" "Claude Conductor Beta"
-  !insertmacro RemoveLegacyInstall "$R2\Claude Command Center Beta" "Claude Command Center Beta"
-  !insertmacro RemoveLegacyInstall "$R2\Claude Command Center" "Claude Command Center"
-  !insertmacro RemoveLegacyInstall "$R2\Claude Conductor" "Claude Conductor"
+    ${GetParent} "$INSTDIR" $R2
+    !insertmacro RemoveLegacyInstall "$R2\Claude Conductor Beta" "Claude Conductor Beta"
+    !insertmacro RemoveLegacyInstall "$R2\Claude Command Center Beta" "Claude Command Center Beta"
+    !insertmacro RemoveLegacyInstall "$R2\Claude Command Center" "Claude Command Center"
+    !insertmacro RemoveLegacyInstall "$R2\Claude Conductor" "Claude Conductor"
+  ${EndIf}
+  ClearErrors
 !macroend
 
 ; Copy one setting forward into the current brand key if it does not have one

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -136,7 +136,16 @@
   ; relocation never fired and instFilesPre appended the new name INSIDE the old
   ; folder. Every rename made it one level deeper. Walking the whole path (not
   ; just its tail) is what makes this self-healing however deep it already is.
-  StrCpy $R9 ""            ; outermost legacy dir found, "" = none
+  ;
+  ; The walk stops at the first component that is NEITHER a legacy name NOR the
+  ; current app name, so it only ever spans an actual nesting CHAIN. That bound
+  ; is load-bearing, because customInstall RMDir /r's what this finds: without
+  ; it, an install at
+  ;   C:\Claude Conductor\dev\AI Code Conductor
+  ; would resolve "C:\Claude Conductor" as the legacy root and delete a
+  ; directory full of unrelated files. "dev" is neither, so the climb halts
+  ; there and nothing above it is ever considered.
+  StrCpy $R9 ""            ; outermost legacy dir in the chain, "" = none
   StrCpy $R8 "$INSTDIR"
   StrCpy $R6 0             ; depth guard
   ${Do}
@@ -146,6 +155,9 @@
     !insertmacro IsLegacyBrandFolder "$R7" $R5
     ${If} $R5 == 1
       StrCpy $R9 "$R8"
+    ${ElseIf} $R7 != "${APP_FILENAME}"
+      ; A real parent directory — the nesting chain ends here.
+      ${ExitDo}
     ${EndIf}
     ${GetParent} "$R8" $R8
     StrCmp $R8 "" 0 +2

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -93,18 +93,104 @@
 ; even if an earlier relocation was interrupted before it could.
 !include "FileFunc.nsh"
 
+; Is ${NAME} one of the folder names this app has shipped under? Sets ${OUT} to
+; 1 or 0. Every rename added a name here; the " Beta" variants are the ones the
+; first version of this check missed, which is how installs ended up NESTED
+; (see customInit).
+!macro IsLegacyBrandFolder NAME OUT
+  StrCpy ${OUT} 0
+  ${If} ${NAME} == "Claude Command Center"
+  ${OrIf} ${NAME} == "Claude Conductor"
+  ${OrIf} ${NAME} == "Claude Command Center Beta"
+  ${OrIf} ${NAME} == "Claude Conductor Beta"
+  ${OrIf} ${NAME} == "claude-conductor"
+    StrCpy ${OUT} 1
+  ${EndIf}
+!macroend
+
+; Forget the recorded previous installation, in BOTH root keys.
+;
+; This is what stops electron-builder's uninstallOldVersion from running an old
+; uninstaller that cannot succeed: with no UninstallString it clears errors and
+; returns immediately (installUtil.nsh), so the install proceeds silently
+; instead of retrying five times and reporting "$(appCannotBeClosed)" — a
+; message about the APP BEING OPEN that is actually emitted when the old
+; UNINSTALLER fails. Only ever inserted on a path we have already established
+; is broken; a healthy same-folder upgrade still runs its uninstaller normally.
+!macro ForgetPreviousInstall
+  DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}"
+  DeleteRegKey HKCU "${UNINSTALL_REGISTRY_KEY}"
+  !ifdef UNINSTALL_REGISTRY_KEY_2
+    DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY_2}"
+    DeleteRegKey HKCU "${UNINSTALL_REGISTRY_KEY_2}"
+  !endif
+!macroend
+
 !macro customInit
-  ${GetFileName} "$INSTDIR" $0
-  ${If} $0 == "Claude Command Center"
-  ${OrIf} $0 == "Claude Conductor"
-    DetailPrint "Relocating install from legacy folder: $INSTDIR"
-    ${GetParent} "$INSTDIR" $1
+  ; ---- 1. Find the OUTERMOST legacy folder in $INSTDIR's path -------------
+  ; $INSTDIR is seeded from the previous installation by initMultiUser, so on a
+  ; broken upgrade it can be nested several deep:
+  ;   …\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+  ; That happened because each rename only compared the LAST path component
+  ; against two exact names; a " Beta"-suffixed folder matched neither, so the
+  ; relocation never fired and instFilesPre appended the new name INSIDE the old
+  ; folder. Every rename made it one level deeper. Walking the whole path (not
+  ; just its tail) is what makes this self-healing however deep it already is.
+  StrCpy $R9 ""            ; outermost legacy dir found, "" = none
+  StrCpy $R8 "$INSTDIR"
+  StrCpy $R6 0             ; depth guard
+  ${Do}
+    ${GetFileName} "$R8" $R7
+    StrCmp $R7 "" 0 +2
+      ${ExitDo}
+    !insertmacro IsLegacyBrandFolder "$R7" $R5
+    ${If} $R5 == 1
+      StrCpy $R9 "$R8"
+    ${EndIf}
+    ${GetParent} "$R8" $R8
+    StrCmp $R8 "" 0 +2
+      ${ExitDo}
+    IntOp $R6 $R6 + 1
+    ${If} $R6 > 8
+      ${ExitDo}
+    ${EndIf}
+  ${Loop}
+
+  ${If} $R9 != ""
+    ; A legacy tree. Relocate beside it, never inside it: the parent of the
+    ; OUTERMOST legacy folder is the real install root (…\Programs).
+    ${GetParent} "$R9" $R4
+    DetailPrint "Relocating install out of legacy folder: $R9"
     ; Set the FINAL path here rather than just stepping up to the parent and
     ; letting instFilesPre append. A silent install (/S) skips MUI pages, so the
     ; page PRE callbacks never fire — leaving $INSTDIR at the parent would then
     ; install straight into …\Programs. Writing the full path is correct in both
     ; modes, and makes instFilesPre's check a no-op because the name is present.
-    StrCpy $INSTDIR "$1\${APP_FILENAME}"
+    StrCpy $INSTDIR "$R4\${APP_FILENAME}"
+    ; The recorded uninstaller lives in the tree customInstall is about to
+    ; delete, and on the observed failure it returned non-zero five times in a
+    ; row. Drop the record so it is never invoked.
+    !insertmacro ForgetPreviousInstall
+  ${Else}
+    ; ---- 2. Not legacy — but is the previous install still THERE? ----------
+    ; $INSTDIR was seeded by initMultiUser from the recorded previous install,
+    ; so if the app binary is not at that path the recorded install is gone
+    ; (removed by hand, or by an upgrade that failed part-way) and its
+    ; UninstallString points at an uninstaller that no longer exists.
+    ; electron-builder runs it anyway, fails five times, and shows the same
+    ; misleading "cannot be closed" dialog — with nothing for the user to close.
+    ;
+    ; Deliberately a file-existence test rather than parsing UninstallString:
+    ; GetInQuotes lives in installUtil.nsh, which installer.nsi includes AFTER
+    ; the point customInit is inserted, so it cannot be called from here.
+    ;
+    ; On a genuine fresh install this is a no-op (there is no record to clear),
+    ; and on a healthy same-folder upgrade the binary IS present, so the old
+    ; uninstaller still runs exactly as it does today.
+    ${IfNot} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+      DetailPrint "No previous install at $INSTDIR — clearing any stale uninstall record"
+      !insertmacro ForgetPreviousInstall
+    ${EndIf}
   ${EndIf}
 !macroend
 
@@ -129,9 +215,18 @@
   ; directories and is untouched. appId is frozen, so this install has already
   ; overwritten the single uninstall entry to point at $INSTDIR — leaving the old
   ; folder would just orphan a copy that nothing can uninstall.
+  ; Every name this app has shipped under. RMDir /r on the OUTERMOST legacy
+  ; folder takes any nested tree with it, which is what clears the
+  ;   …\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+  ; shape that the old two-name check let accumulate. RemoveLegacyInstall
+  ; refuses to touch $INSTDIR itself, so relocating first (customInit) is what
+  ; makes this safe.
   ${GetParent} "$INSTDIR" $R2
+  !insertmacro RemoveLegacyInstall "$R2\Claude Conductor Beta" "Claude Conductor Beta"
+  !insertmacro RemoveLegacyInstall "$R2\Claude Command Center Beta" "Claude Command Center Beta"
   !insertmacro RemoveLegacyInstall "$R2\Claude Command Center" "Claude Command Center"
   !insertmacro RemoveLegacyInstall "$R2\Claude Conductor" "Claude Conductor"
+  !insertmacro RemoveLegacyInstall "$R2\claude-conductor" "claude-conductor"
 !macroend
 
 ; ============================================================

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -2,12 +2,331 @@
 ; MACROS FIRST — must be defined before anything else
 ; These are preprocessor directives and work in any context
 ; ============================================================
+;
+; electron-builder emits this file as part of the script HEADER, ahead of its own
+; templates/nsis/installer.nsi (NsisTarget.computeCommonInstallerScriptHeader ->
+; sharedHeader + installer.nsi). So anything at file scope here compiles FIRST,
+; before multiUser.nsh / assistedInstaller.nsh — which is why a define that has
+; to beat `!insertmacro addLangs` lives here, while anything needing
+; ${INSTALL_REGISTRY_KEY} (defined by multiUser.nsh) has to sit inside a macro
+; electron-builder inserts later (customHeader / customInit / customInstall).
 
-; Override the default "app is running" check with debug-enabled version
+!include "LogicLib.nsh"
+!include "FileFunc.nsh"
+
+; ============================================================
+; SHARED PREDICATES
+; ============================================================
+
+; Is ${NAME} one of the folder names this app has shipped an INSTALL under?
+; Sets ${OUT} to 1 or 0. Every rename added a name here; the " Beta" variants are
+; the ones the first version of this check missed, which is how installs ended up
+; NESTED (see customInit).
+;
+; Deliberately NOT listed: "claude-conductor", this repo's npm `name`.
+; electron-builder only falls back to the sanitised package name for the install
+; directory when productFilename fails /^[-_+0-9a-zA-Z .]+$/
+; (out/targets/targetUtil.js getWindowsInstallationDirName), and every brand name
+; this app has used passes that test — so no install has ever lived in a folder
+; of that name, while a source checkout very plausibly does. Listing it could
+; only ever cost someone a working copy.
+!macro IsLegacyBrandFolder NAME OUT
+  StrCpy ${OUT} 0
+  ${If} "${NAME}" == "Claude Command Center"
+  ${OrIf} "${NAME}" == "Claude Conductor"
+  ${OrIf} "${NAME}" == "Claude Command Center Beta"
+  ${OrIf} "${NAME}" == "Claude Conductor Beta"
+    StrCpy ${OUT} 1
+  ${EndIf}
+!macroend
+
+; ${OUT} = 1 when ${PATH} is ${DIR} itself, or something inside ${DIR}.
+; Comparison is case-insensitive because LogicLib's == compiles to StrCmp, which
+; is — matching Windows path semantics. Defines no labels of its own, so it is
+; safe to insert repeatedly. Scratch: $R5 $R6 $R7.
+!macro IsSameOrInside DIR PATH OUT
+  StrCpy ${OUT} 0
+  ${If} "${PATH}" != ""
+    StrLen $R7 "${DIR}"
+    StrCpy $R6 "${PATH}" $R7
+    ${If} $R6 == "${DIR}"
+      StrCpy $R5 "${PATH}" 1 $R7
+      ${If} $R5 == ""
+      ${OrIf} $R5 == "\"
+        StrCpy ${OUT} 1
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+; ${OUT} = 1 when ${A} and ${B} are the same directory, or one contains the
+; other, in either direction. Scratch: $R5 $R6 $R7.
+!macro PathsOverlap A B OUT
+  !insertmacro IsSameOrInside "${A}" "${B}" ${OUT}
+  ${If} ${OUT} != 1
+    !insertmacro IsSameOrInside "${B}" "${A}" ${OUT}
+  ${EndIf}
+!macroend
+
+; Walk ${PATH} from its last component upwards and return, in ${OUT}, the
+; OUTERMOST legacy-brand folder in the nesting chain ("" = none).
+;
+; A broken upgrade can be nested several deep:
+;   …\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+; That happened because each rename only compared the LAST path component
+; against two exact names; a " Beta"-suffixed folder matched neither, so the
+; relocation never fired and instFilesPre appended the new name INSIDE the old
+; folder. Every rename made it one level deeper. Walking the whole path (not just
+; its tail) is what makes this self-healing however deep it already is.
+;
+; The walk stops at the first component that is NEITHER a legacy name NOR the
+; current app name, so it only ever spans an actual nesting CHAIN. That bound is
+; load-bearing, because what this finds is what customInstall considers deleting:
+; without it, an install at
+;   C:\Claude Conductor\dev\AI Code Conductor
+; would resolve "C:\Claude Conductor" as the legacy root. "dev" is neither, so
+; the climb halts there and nothing above it is ever considered.
+; Scratch: $R5 $R6 $R7 $R8 — ${OUT} must not be one of those.
+!macro FindLegacyRoot PATH OUT
+  StrCpy ${OUT} ""
+  StrCpy $R8 "${PATH}"
+  StrCpy $R6 0
+  ${Do}
+    ${GetFileName} "$R8" $R7
+    ${If} $R7 == ""
+      ${ExitDo}
+    ${EndIf}
+    !insertmacro IsLegacyBrandFolder "$R7" $R5
+    ${If} $R5 == 1
+      StrCpy ${OUT} "$R8"
+    ${ElseIf} $R7 != "${APP_FILENAME}"
+      ; A real parent directory — the nesting chain ends here.
+      ${ExitDo}
+    ${EndIf}
+    ${GetParent} "$R8" $R8
+    ${If} $R8 == ""
+      ${ExitDo}
+    ${EndIf}
+    IntOp $R6 $R6 + 1
+    ${If} $R6 > 8
+      ${ExitDo}
+    ${EndIf}
+  ${Loop}
+!macroend
+
+; Read one of the user-chosen directories, newest brand key first.
+!macro ReadUserPath NAME OUT
+  ReadRegStr ${OUT} HKCU "Software\AI Code Conductor" "${NAME}"
+  ${If} ${OUT} == ""
+    ReadRegStr ${OUT} HKCU "Software\Claude Command Center" "${NAME}"
+  ${EndIf}
+  ${If} ${OUT} == ""
+    ReadRegStr ${OUT} HKCU "Software\Claude Conductor" "${NAME}"
+  ${EndIf}
+!macroend
+
+; ============================================================
+; DESTRUCTIVE CLEANUP
+; ============================================================
+
+; Delete a directory that is PROVABLY an old install of this app, plus the
+; shortcuts that pointed into it.
+;
+; RMDir /r is irreversible and follows directory junctions — verified with the
+; real makensis: a junction made with `mklink /J` had its TARGET tree deleted,
+; and ${FileExists} "<junction>\*.*" reports true *through* the junction. A
+; matching folder NAME is nowhere near enough on its own. All of these must hold:
+;   1. it is not the directory we are installing into;
+;   2. it exists;
+;   3. it is not a reparse point (junction / symlink / mount point);
+;   4. it does not overlap the user's data or resources directory in either
+;      direction — shipped builds defaulted DataDirectory to
+;      "$LOCALAPPDATA\Claude Command Center" and ResourcesDirectory to
+;      "…\Claude Command Center\resources" (git show 8c0085e:build/installer.nsh),
+;      and "Claude Command Center" is a name this sweep looks for, so an install
+;      into %LOCALAPPDATA% would otherwise destroy the user's sessions, logs and
+;      CONFIG — twenty lines after customInstall adopted that very path;
+;   5. it contains an "Uninstall *.exe" — positive proof that it is an NSIS
+;      install root, and not a source checkout that happens to share the name.
+; Expects $R3 = DataDirectory and $R4 = ResourcesDirectory.
+; Scratch: $R5 $R6 $R7 $R8 $R9.
+!macro RemoveLegacyInstall DIR NAME
+  StrCpy $R8 1
+
+  ${If} "${DIR}" == "$INSTDIR"
+    StrCpy $R8 0
+  ${EndIf}
+
+  ${If} $R8 == 1
+  ${AndIfNot} ${FileExists} "${DIR}\*.*"
+    StrCpy $R8 0
+  ${EndIf}
+
+  ${If} $R8 == 1
+    ; Fail closed: GetFileAttributes yields "1", "0", or "" on error, and only a
+    ; hard "0" (no reparse attribute) is accepted.
+    ${GetFileAttributes} "${DIR}" "REPARSE_POINT" $R9
+    ${If} $R9 != 0
+      DetailPrint "Refusing to delete a reparse point: ${DIR}"
+      StrCpy $R8 0
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R8 == 1
+    !insertmacro PathsOverlap "${DIR}" "$R3" $R9
+    ${If} $R9 == 1
+      DetailPrint "Refusing to delete the data directory: ${DIR}"
+      StrCpy $R8 0
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R8 == 1
+    !insertmacro PathsOverlap "${DIR}" "$R4" $R9
+    ${If} $R9 == 1
+      DetailPrint "Refusing to delete the resources directory: ${DIR}"
+      StrCpy $R8 0
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R8 == 1
+  ${AndIfNot} ${FileExists} "${DIR}\Uninstall *.exe"
+    DetailPrint "Not an install of this app, leaving it alone: ${DIR}"
+    StrCpy $R8 0
+  ${EndIf}
+
+  ${If} $R8 == 1
+    DetailPrint "Removing legacy install folder: ${DIR}"
+    RMDir /r "${DIR}"
+    Delete "$DESKTOP\${NAME}.lnk"
+    Delete "$SMPROGRAMS\${NAME}.lnk"
+  ${EndIf}
+!macroend
+
+; Drop the recorded previous installation in ${ROOT_KEY}, but only when that
+; record is one of:
+;   a) unusable — the uninstaller it names is gone (removed by hand, or by an
+;      upgrade that failed part-way). electron-builder runs it anyway, retries
+;      five times and then shows "$(appCannotBeClosed)" (installUtil.nsh
+;      uninstallOldVersion) — a message about the APP being open, raised when the
+;      UNINSTALLER failed, with nothing for the user to close. With no
+;      UninstallString it returns immediately instead;
+;   b) pointing into the legacy folder beside $INSTDIR that this run relocated
+;      out of and customInstall is about to delete.
+;
+; Judged per hive, with the caller naming the hive explicitly. appId is frozen,
+; so a per-user and a per-machine installation share the same registry key PATH
+; but are two SEPARATE installations. Blanket-deleting HKCU from an /allusers run
+; would destroy a healthy per-user install's record, and installSection.nsh then
+; calls uninstallOldVersion HKEY_CURRENT_USER, reads an empty UninstallString and
+; returns — leaving that copy on disk with nothing able to remove it.
+; Scratch: $R0 $R1 $R2 $R3 $R4 (+ $R5-$R9 via FindLegacyRoot).
+!macro ForgetPreviousInstallIn ROOT_KEY
+  ReadRegStr $R0 ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+  ${If} $R0 != ""
+    StrCpy $R2 0
+    ; UninstallString is '"<dir>\Uninstall <app>.exe" /currentuser'. GetInQuotes
+    ; is a Function in installUtil.nsh, which installer.nsi includes AFTER the
+    ; point this is inserted from — but a Call is a forward reference NSIS
+    ; resolves at link time, and both live in the !ifndef BUILD_UNINSTALLER pass.
+    !insertmacro GetInQuotes $R1 "$R0"
+    ${If} $R1 == ""
+      StrCpy $R2 1
+      DetailPrint "Uninstall record has no parseable path — clearing it"
+    ${ElseIfNot} ${FileExists} "$R1"
+      StrCpy $R2 1
+      DetailPrint "Recorded uninstaller is gone ($R1) — clearing the record"
+    ${Else}
+      ${GetParent} "$R1" $R3
+      !insertmacro FindLegacyRoot "$R3" $R9
+      ${If} $R9 != ""
+        ${GetParent} "$R9" $R4
+        ${GetParent} "$INSTDIR" $R3
+        ${If} $R4 == $R3
+          StrCpy $R2 1
+          DetailPrint "Uninstall record points into the legacy folder being replaced ($R9) — clearing it"
+        ${EndIf}
+      ${EndIf}
+    ${EndIf}
+    ${If} $R2 == 1
+      DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY}"
+      ; Dead code for this app: electron-builder only defines
+      ; UNINSTALL_REGISTRY_KEY_2 when the GUID contains a backslash
+      ; (NsisTarget.js:176-178), and ours is UUID.v5(appId) =
+      ; 0210f08e-15d0-5073-901d-684e27f31b7d. Kept so that setting a custom
+      ; nsis.guid would still be handled.
+      !ifdef UNINSTALL_REGISTRY_KEY_2
+        DeleteRegKey ${ROOT_KEY} "${UNINSTALL_REGISTRY_KEY_2}"
+      !endif
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+; SHELL_CONTEXT always; HKCU as well on an /allusers run, mirroring
+; installSection.nsh, which calls uninstallOldVersion for both.
+!macro ForgetBrokenPreviousInstall
+  !insertmacro ForgetPreviousInstallIn SHELL_CONTEXT
+  ${If} $installMode == "all"
+    !insertmacro ForgetPreviousInstallIn HKCU
+  ${EndIf}
+  ; A ReadRegStr against a key that is not there sets the error flag; do not
+  ; leave it set for whatever installSection.nsh does next.
+  ClearErrors
+!macroend
+
+; ============================================================
+; CANCEL SAFETY
+; ============================================================
+; customInit retargets the recorded InstallLocation (see below). That value is
+; how BOTH installUtil.nsh's uninstallOldVersion (_?=) and the uninstaller's own
+; $INSTDIR are resolved (multiUser.nsh setInstallModePerUser -> uninstaller.nsh
+; "RMDir /r $INSTDIR"), so leaving it pointing at a directory that was never
+; created would make a later Add/Remove-Programs uninstall delete nothing and
+; then drop the entry. Put it back if the wizard never reaches the install.
+;
+; MUI2 defines Function .onUserAbort itself (Interface.nsh
+; MUI_FUNCTION_ABORTWARNING, inserted by MUI_LANGUAGE), so this hooks its
+; documented callback rather than defining a second one — two definitions would
+; not compile. The define has to be in place before electron-builder's
+; `!insertmacro addLangs`, which is why it sits at file scope rather than in
+; customHeader.
+!ifndef BUILD_UNINSTALLER
+  !define MUI_CUSTOMFUNCTION_ABORT "CccRestoreInstallLocation"
+!endif
+
+; customHeader is inserted by installer.nsi at file scope AFTER multiUser.nsh, so
+; ${INSTALL_REGISTRY_KEY} resolves here — it does not at the top of this file.
+!macro customHeader
+  !ifndef BUILD_UNINSTALLER
+    Var cccSavedPerUserInstallLocation
+    Var cccSavedPerMachineInstallLocation
+
+    Function CccRestoreInstallLocation
+      ${If} $cccSavedPerUserInstallLocation != ""
+        WriteRegStr HKCU "${INSTALL_REGISTRY_KEY}" "InstallLocation" "$cccSavedPerUserInstallLocation"
+        StrCpy $cccSavedPerUserInstallLocation ""
+      ${EndIf}
+      ${If} $cccSavedPerMachineInstallLocation != ""
+        WriteRegStr HKLM "${INSTALL_REGISTRY_KEY}" "InstallLocation" "$cccSavedPerMachineInstallLocation"
+        StrCpy $cccSavedPerMachineInstallLocation ""
+      ${EndIf}
+    FunctionEnd
+
+    Function .onInstFailed
+      Call CccRestoreInstallLocation
+    FunctionEnd
+  !endif
+!macroend
+
+; ============================================================
+; APP-RUNNING CHECK — also the install's commit point
+; ============================================================
+
+; Override the default "app is running" check with debug-enabled version.
 ; Close a running instance before installing. An UPGRADE from a pre-rename build
 ; still has "Claude Command Center.exe" running, so both the current and the
-; legacy executable names have to be checked — matching only ${APP_EXECUTABLE_FILENAME}
-; would let the old process keep a file lock and fail the install.
+; legacy executable names have to be checked — matching only
+; ${APP_EXECUTABLE_FILENAME} would let the old process keep a file lock and fail
+; the install.
 !macro KillIfRunning EXE
   nsExec::Exec /TIMEOUT=5000 `"$SYSDIR\cmd.exe" /c tasklist /FI "IMAGENAME eq ${EXE}" /FO csv | "$SYSDIR\find.exe" "${EXE}"`
   Pop $R0
@@ -30,39 +349,37 @@
   Pop $R0
   ${if} $R0 == 0
     MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "AI Code Conductor is still running.$\n$\nProcess: ${APP_EXECUTABLE_FILENAME}$\n$\nPlease close it manually and click Retry." IDRETRY retry_check
+    !ifndef BUILD_UNINSTALLER
+      Call CccRestoreInstallLocation
+    !endif
     Quit
     retry_check:
   ${else}
     DetailPrint "No running instance found. Proceeding."
   ${endIf}
-!macroend
 
-; Delete a legacy install folder (and the shortcuts that pointed into it), but
-; never the folder this install is going into.
-!macro RemoveLegacyInstall DIR NAME
-  ${If} "${DIR}" != "$INSTDIR"
-  ${AndIf} ${FileExists} "${DIR}\*.*"
-    DetailPrint "Removing legacy install folder: ${DIR}"
-    RMDir /r "${DIR}"
-    Delete "$DESKTOP\${NAME}.lnk"
-    Delete "$SMPROGRAMS\${NAME}.lnk"
-  ${EndIf}
-!macroend
-
-; Copy one setting forward into the current brand key if it does not have one
-; yet, looking through the legacy keys newest-first.
-!macro AdoptLegacyValue NAME
-  ReadRegStr $R1 HKCU "Software\AI Code Conductor" "${NAME}"
-  ${If} $R1 == ""
-    ReadRegStr $R0 HKCU "Software\Claude Command Center" "${NAME}"
-    ${If} $R0 == ""
-      ReadRegStr $R0 HKCU "Software\Claude Conductor" "${NAME}"
-    ${EndIf}
-    ${If} $R0 != ""
-      WriteRegStr HKCU "Software\AI Code Conductor" "${NAME}" $R0
-      DetailPrint "  Adopted ${NAME}: $R0"
-    ${EndIf}
-  ${EndIf}
+  !ifndef BUILD_UNINSTALLER
+    ; ---- COMMIT POINT -----------------------------------------------------
+    ; installSection.nsh inserts CHECK_APP_RUNNING at the top of the install
+    ; section — after every wizard page, after the user pressed Install, and
+    ; immediately before uninstallOldVersion, which is the only place the
+    ; recorded uninstaller is ever invoked. That makes it the earliest point at
+    ; which dropping the record cannot strand anyone: registryAddInstallInfo
+    ; rewrites it a few lines later, and a normal electron-builder upgrade drops
+    ; it here anyway (the old uninstaller deletes the key itself).
+    ;
+    ; This used to run from customInit, i.e. inside .onInit, BEFORE the licence,
+    ; install-mode, directory and data-directory pages — so cancelling the wizard
+    ; or declining UAC left the app fully installed with no Add/Remove Programs
+    ; entry at all, uninstallable by neither the user nor an MDM.
+    ;
+    ; Known gap: for an /allusers install that has to elevate, the whole of
+    ; CHECK_APP_RUNNING is skipped in the elevated inner instance
+    ; (installSection.nsh guards it with ${ifNot} ${UAC_IsInnerInstance}), so
+    ; nothing is cleared there and the old uninstaller runs exactly as it did
+    ; before this file cleared anything. Pre-existing behaviour, not a regression.
+    !insertmacro ForgetBrokenPreviousInstall
+  !endif
 !macroend
 
 ; ============================================================
@@ -75,135 +392,89 @@
 ;   …\Programs\Claude Command Center
 ; would otherwise be installed NESTED at
 ;   …\Programs\Claude Command Center\AI Code Conductor.
-; initMultiUser has already seeded $INSTDIR from the previous installation by
-; the time customInit runs (installer.nsi inserts it first), so we step $INSTDIR
-; up to the parent and let instFilesPre re-append the NEW name — landing at
+; initMultiUser has already seeded $INSTDIR from the previous installation by the
+; time customInit runs (installer.nsi inserts it first), so we point $INSTDIR at
 ;   …\Programs\AI Code Conductor
-; and record the old folder so customInstall can remove it.
-;
-; Guarded on the final path component being a known legacy folder name, so a
-; custom install location is never touched and the parent is never something
-; broad like C:\Program Files.
-; Deliberately no Var for the old folder: NSIS compiles the uninstaller in a
-; SEPARATE pass with BUILD_UNINSTALLER defined, and installer.nsi only inserts
-; customInit when that is NOT defined — so a Var set solely there is "never set"
-; in the uninstaller pass, which NSIS reports as warning 6001 and electron-builder
-; escalates to a build failure. customInstall recomputes the legacy path from
-; $INSTDIR instead, which is also idempotent: it cleans up a stale legacy folder
-; even if an earlier relocation was interrupted before it could.
-!include "FileFunc.nsh"
+; instead, and customInstall removes what is left behind.
 
-; Is ${NAME} one of the folder names this app has shipped under? Sets ${OUT} to
-; 1 or 0. Every rename added a name here; the " Beta" variants are the ones the
-; first version of this check missed, which is how installs ended up NESTED
-; (see customInit).
-!macro IsLegacyBrandFolder NAME OUT
-  StrCpy ${OUT} 0
-  ${If} ${NAME} == "Claude Command Center"
-  ${OrIf} ${NAME} == "Claude Conductor"
-  ${OrIf} ${NAME} == "Claude Command Center Beta"
-  ${OrIf} ${NAME} == "Claude Conductor Beta"
-  ${OrIf} ${NAME} == "claude-conductor"
-    StrCpy ${OUT} 1
+; Setting $INSTDIR is NOT enough on its own. $INSTDIR is seeded from
+; ${INSTALL_REGISTRY_KEY}\InstallLocation, and on any interactive (non-/S) run
+; that read happens AGAIN after customInit: oneClick:false defines
+; INSTALL_MODE_PER_ALL_USERS_REQUIRED (NsisTarget.js:445-446), so the
+; install-mode page exists, and both its Leave callback (multiUserUi.nsh:184,187)
+; and every skip path in its Pre (:35,:55,:63) re-run setInstallModePerUser /
+; setInstallModePerAllUsers, which do
+;   ReadRegStr … "${INSTALL_REGISTRY_KEY}" InstallLocation / StrCpy $INSTDIR …
+; (multiUser.nsh:26-28, :75-77). The in-app updater launches the installer with
+; NO arguments (src/main/ipc/update-handlers.ts), so auto-update IS that
+; interactive path — and installSection.nsh:117 re-runs setInstallModePerAllUsers
+; even under /S for a per-machine upgrade. The recorded value therefore has to
+; stop naming the legacy tree, or the relocation is undone before a single file
+; is written, while the uninstall record has already been dropped.
+;
+; It is RETARGETED rather than deleted so a custom install location keeps its
+; parent: deleting makes setInstallMode* fall through to
+; $LocalAppData\Programs\${APP_FILENAME} (multiUser.nsh:47), silently moving an
+; install that lived on another drive. Both hives are handled because
+; setInstallModePerUser reads HKCU and setInstallModePerAllUsers reads HKLM, and
+; the install-mode page lets the user switch between them. /D= still wins either
+; way — both macros apply GetDParameter AFTER this read (multiUser.nsh:50-54,
+; :93-97).
+;
+; Only a record that points INTO the legacy tree being left behind is touched,
+; and the previous value is remembered so CccRestoreInstallLocation can put it
+; back if the wizard is cancelled.
+!macro RetargetRecordedInstallLocation HIVE LEGACY_ROOT SAVE_VAR
+  ReadRegStr $R3 ${HIVE} "${INSTALL_REGISTRY_KEY}" "InstallLocation"
+  ${If} $R3 != ""
+    !insertmacro IsSameOrInside "${LEGACY_ROOT}" "$R3" $R2
+    ${If} $R2 == 1
+      StrCpy ${SAVE_VAR} "$R3"
+      WriteRegStr ${HIVE} "${INSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
+      DetailPrint "Recorded install location retargeted: $R3 -> $INSTDIR"
+    ${EndIf}
   ${EndIf}
-!macroend
-
-; Forget the recorded previous installation, in BOTH root keys.
-;
-; This is what stops electron-builder's uninstallOldVersion from running an old
-; uninstaller that cannot succeed: with no UninstallString it clears errors and
-; returns immediately (installUtil.nsh), so the install proceeds silently
-; instead of retrying five times and reporting "$(appCannotBeClosed)" — a
-; message about the APP BEING OPEN that is actually emitted when the old
-; UNINSTALLER fails. Only ever inserted on a path we have already established
-; is broken; a healthy same-folder upgrade still runs its uninstaller normally.
-!macro ForgetPreviousInstall
-  DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}"
-  DeleteRegKey HKCU "${UNINSTALL_REGISTRY_KEY}"
-  !ifdef UNINSTALL_REGISTRY_KEY_2
-    DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY_2}"
-    DeleteRegKey HKCU "${UNINSTALL_REGISTRY_KEY_2}"
-  !endif
 !macroend
 
 !macro customInit
-  ; ---- 1. Find the OUTERMOST legacy folder in $INSTDIR's path -------------
-  ; $INSTDIR is seeded from the previous installation by initMultiUser, so on a
-  ; broken upgrade it can be nested several deep:
-  ;   …\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
-  ; That happened because each rename only compared the LAST path component
-  ; against two exact names; a " Beta"-suffixed folder matched neither, so the
-  ; relocation never fired and instFilesPre appended the new name INSIDE the old
-  ; folder. Every rename made it one level deeper. Walking the whole path (not
-  ; just its tail) is what makes this self-healing however deep it already is.
-  ;
-  ; The walk stops at the first component that is NEITHER a legacy name NOR the
-  ; current app name, so it only ever spans an actual nesting CHAIN. That bound
-  ; is load-bearing, because customInstall RMDir /r's what this finds: without
-  ; it, an install at
-  ;   C:\Claude Conductor\dev\AI Code Conductor
-  ; would resolve "C:\Claude Conductor" as the legacy root and delete a
-  ; directory full of unrelated files. "dev" is neither, so the climb halts
-  ; there and nothing above it is ever considered.
-  StrCpy $R9 ""            ; outermost legacy dir in the chain, "" = none
-  StrCpy $R8 "$INSTDIR"
-  StrCpy $R6 0             ; depth guard
-  ${Do}
-    ${GetFileName} "$R8" $R7
-    StrCmp $R7 "" 0 +2
-      ${ExitDo}
-    !insertmacro IsLegacyBrandFolder "$R7" $R5
-    ${If} $R5 == 1
-      StrCpy $R9 "$R8"
-    ${ElseIf} $R7 != "${APP_FILENAME}"
-      ; A real parent directory — the nesting chain ends here.
-      ${ExitDo}
-    ${EndIf}
-    ${GetParent} "$R8" $R8
-    StrCmp $R8 "" 0 +2
-      ${ExitDo}
-    IntOp $R6 $R6 + 1
-    ${If} $R6 > 8
-      ${ExitDo}
-    ${EndIf}
-  ${Loop}
-
-  ${If} $R9 != ""
-    ; A legacy tree. Relocate beside it, never inside it: the parent of the
-    ; OUTERMOST legacy folder is the real install root (…\Programs).
-    ${GetParent} "$R9" $R4
-    DetailPrint "Relocating install out of legacy folder: $R9"
-    ; Set the FINAL path here rather than just stepping up to the parent and
-    ; letting instFilesPre append. A silent install (/S) skips MUI pages, so the
-    ; page PRE callbacks never fire — leaving $INSTDIR at the parent would then
-    ; install straight into …\Programs. Writing the full path is correct in both
-    ; modes, and makes instFilesPre's check a no-op because the name is present.
-    StrCpy $INSTDIR "$R4\${APP_FILENAME}"
-    ; The recorded uninstaller lives in the tree customInstall is about to
-    ; delete, and on the observed failure it returned non-zero five times in a
-    ; row. Drop the record so it is never invoked.
-    !insertmacro ForgetPreviousInstall
+  ; ---- 0. An explicit /D= is the operator's choice ------------------------
+  ; initMultiUser applies /D= last, so $INSTDIR already holds the requested
+  ; directory by the time this runs. Relocating it — and then letting
+  ; customInstall consider its siblings for deletion — would silently override a
+  ; path someone asked for by hand. The in-app updater passes no arguments, so
+  ; this never suppresses the relocation on the path that actually matters.
+  !insertmacro GetDParameter $R0
+  ${If} $R0 != ""
+    DetailPrint "Explicit /D= install directory — leaving $INSTDIR alone"
   ${Else}
-    ; ---- 2. Not legacy — but is the previous install still THERE? ----------
-    ; $INSTDIR was seeded by initMultiUser from the recorded previous install,
-    ; so if the app binary is not at that path the recorded install is gone
-    ; (removed by hand, or by an upgrade that failed part-way) and its
-    ; UninstallString points at an uninstaller that no longer exists.
-    ; electron-builder runs it anyway, fails five times, and shows the same
-    ; misleading "cannot be closed" dialog — with nothing for the user to close.
-    ;
-    ; Deliberately a file-existence test rather than parsing UninstallString:
-    ; GetInQuotes lives in installUtil.nsh, which installer.nsi includes AFTER
-    ; the point customInit is inserted, so it cannot be called from here.
-    ;
-    ; On a genuine fresh install this is a no-op (there is no record to clear),
-    ; and on a healthy same-folder upgrade the binary IS present, so the old
-    ; uninstaller still runs exactly as it does today.
-    ${IfNot} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
-      DetailPrint "No previous install at $INSTDIR — clearing any stale uninstall record"
-      !insertmacro ForgetPreviousInstall
+    ; ---- 1. Find the OUTERMOST legacy folder in $INSTDIR's path -----------
+    !insertmacro FindLegacyRoot "$INSTDIR" $R9
+
+    ${If} $R9 != ""
+      ; A legacy tree. Relocate beside it, never inside it: the parent of the
+      ; OUTERMOST legacy folder is the real install root (…\Programs).
+      ${GetParent} "$R9" $R4
+      DetailPrint "Relocating install out of legacy folder: $R9"
+      ; Set the FINAL path here rather than just stepping up to the parent and
+      ; letting instFilesPre append. A silent install (/S) skips MUI pages, so
+      ; the page PRE callbacks never fire — leaving $INSTDIR at the parent would
+      ; then install straight into …\Programs. Writing the full path is correct
+      ; in both modes, and makes instFilesPre's check a no-op because the name is
+      ; already present.
+      StrCpy $INSTDIR "$R4\${APP_FILENAME}"
+
+      ; ---- 2. Stop the install-mode page undoing it ----------------------
+      !insertmacro RetargetRecordedInstallLocation HKCU "$R9" $cccSavedPerUserInstallLocation
+      !insertmacro RetargetRecordedInstallLocation HKLM "$R9" $cccSavedPerMachineInstallLocation
     ${EndIf}
   ${EndIf}
+  ; The uninstall RECORD is deliberately NOT touched here — see the commit point
+  ; in customCheckAppRunning for why it can only be cleared once the install is
+  ; actually going ahead.
+  ;
+  ; A ReadRegStr against a key that is not there sets the error flag, and .onInit
+  ; hands straight over to the wizard; do not leave it set.
+  ClearErrors
 !macroend
 
 ; Write registry entries after install + migrate from old key
@@ -223,22 +494,44 @@
   WriteRegStr HKCU "Software\AI Code Conductor" "SourcePath" ""
 
   ; --- Remove a legacy install folder sitting beside this one ---
-  ; Only application binaries live there; user data is in the data and resources
-  ; directories and is untouched. appId is frozen, so this install has already
-  ; overwritten the single uninstall entry to point at $INSTDIR — leaving the old
-  ; folder would just orphan a copy that nothing can uninstall.
-  ; Every name this app has shipped under. RMDir /r on the OUTERMOST legacy
-  ; folder takes any nested tree with it, which is what clears the
+  ; Only application binaries live there; user data lives in the data and
+  ; resources directories, which RemoveLegacyInstall refuses to touch. appId is
+  ; frozen, so this install has already overwritten the single uninstall entry to
+  ; point at $INSTDIR — leaving the old folder would just orphan a copy that
+  ; nothing can uninstall.
+  ;
+  ; RMDir /r on the OUTERMOST legacy folder takes any nested tree with it, which
+  ; is what clears the
   ;   …\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
-  ; shape that the old two-name check let accumulate. RemoveLegacyInstall
-  ; refuses to touch $INSTDIR itself, so relocating first (customInit) is what
-  ; makes this safe.
+  ; shape that the old two-name check let accumulate. RemoveLegacyInstall refuses
+  ; to touch $INSTDIR itself, so relocating first (customInit) is what makes this
+  ; reachable at all — and it demands positive proof of ownership before deleting
+  ; anything, because a name match alone would also match a source checkout, a
+  ; junction, or the user's data directory.
+  !insertmacro ReadUserPath "DataDirectory" $R3
+  !insertmacro ReadUserPath "ResourcesDirectory" $R4
+
   ${GetParent} "$INSTDIR" $R2
   !insertmacro RemoveLegacyInstall "$R2\Claude Conductor Beta" "Claude Conductor Beta"
   !insertmacro RemoveLegacyInstall "$R2\Claude Command Center Beta" "Claude Command Center Beta"
   !insertmacro RemoveLegacyInstall "$R2\Claude Command Center" "Claude Command Center"
   !insertmacro RemoveLegacyInstall "$R2\Claude Conductor" "Claude Conductor"
-  !insertmacro RemoveLegacyInstall "$R2\claude-conductor" "claude-conductor"
+!macroend
+
+; Copy one setting forward into the current brand key if it does not have one
+; yet, looking through the legacy keys newest-first.
+!macro AdoptLegacyValue NAME
+  ReadRegStr $R1 HKCU "Software\AI Code Conductor" "${NAME}"
+  ${If} $R1 == ""
+    ReadRegStr $R0 HKCU "Software\Claude Command Center" "${NAME}"
+    ${If} $R0 == ""
+      ReadRegStr $R0 HKCU "Software\Claude Conductor" "${NAME}"
+    ${EndIf}
+    ${If} $R0 != ""
+      WriteRegStr HKCU "Software\AI Code Conductor" "${NAME}" $R0
+      DetailPrint "  Adopted ${NAME}: $R0"
+    ${EndIf}
+  ${EndIf}
 !macroend
 
 ; ============================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.8",
+  "version": "2.1.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "2.1.0-beta.8",
+      "version": "2.1.0-beta.10",
       "hasInstallScript": true,
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
         }
       ],
       "category": "public.app-category.developer-tools",
-      "artifactName": "ClaudeCommandCenter-${version}-mac.${ext}",
+      "artifactName": "AI-Code-Conductor-${version}-mac.${ext}",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
@@ -162,7 +162,7 @@
         }
       ],
       "category": "Development",
-      "artifactName": "ClaudeCommandCenter-${version}-linux-${arch}.${ext}"
+      "artifactName": "AI-Code-Conductor-${version}-linux-${arch}.${ext}"
     },
     "dmg": {
       "sign": false,
@@ -187,7 +187,7 @@
       "shortcutName": "AI Code Conductor",
       "runAfterFinish": true,
       "uninstallDisplayName": "AI Code Conductor",
-      "artifactName": "ClaudeCommandCenter-${version}.${ext}"
+      "artifactName": "AI-Code-Conductor-${version}.${ext}"
     },
     "directories": {
       "output": "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.9",
+  "version": "2.1.0-beta.10",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/scripts/verify-release-manifest.js
+++ b/scripts/verify-release-manifest.js
@@ -141,7 +141,7 @@ const MAX_MANIFEST_BYTES = 1024 * 1024
 /**
  * Extensions to gate. Deliberately a strict SUPERSET of what the client will
  * fetch (`installerExtForPlatform` in github-update.ts, which is
- * case-SENSITIVE and additionally requires a `ClaudeCommandCenter-` prefix):
+ * case-SENSITIVE and additionally requires one of its INSTALLER_PREFIXES):
  * over-covering can only fail a release that would have worked, while
  * under-covering ships the dead end this gate exists to prevent.
  *

--- a/src/main/ipc/update-handlers.ts
+++ b/src/main/ipc/update-handlers.ts
@@ -167,27 +167,35 @@ export function registerUpdateHandlers(): void {
     }
 
     // 3. Dev-only fallback: look for a locally-built installer in the source folder.
-    // Uses the same naming convention as electron-builder's `artifactName`:
-    //   Windows: ClaudeCommandCenter-Beta-${version}.exe
-    //   macOS:   ClaudeCommandCenter-Beta-${version}-mac.dmg
+    // Mirrors electron-builder's `artifactName` (package.json build.*):
+    //   Windows: AI-Code-Conductor-${version}.exe
+    //   macOS:   AI-Code-Conductor-${version}-mac.dmg
     // Checks both a `-latest` convenience file and the versioned file, in both
-    // repo root and `dist/`.
+    // repo root and `dist/`. The legacy brand names are still probed LAST so a
+    // dist/ left over from before the rename keeps working locally; they cost
+    // nothing but an existsSync and this path never runs in a packaged build.
     if (!installerPath && !isPackagedApp()) {
       const projectRoot = getProjectRootPath()
       if (projectRoot) {
         const isMac = process.platform === 'darwin'
         const ext = isMac ? '.dmg' : '.exe'
         const macSuffix = isMac ? '-mac' : ''
-        const candidates: string[] = [
-          path.join(projectRoot, `ClaudeCommandCenter-latest${macSuffix}${ext}`),
-          path.join(projectRoot, 'dist', `ClaudeCommandCenter-latest${macSuffix}${ext}`),
-        ]
+        const brands = ['AI-Code-Conductor', 'ClaudeCommandCenter']
+        const candidates: string[] = []
+        for (const brand of brands) {
+          candidates.push(
+            path.join(projectRoot, `${brand}-latest${macSuffix}${ext}`),
+            path.join(projectRoot, 'dist', `${brand}-latest${macSuffix}${ext}`),
+          )
+        }
         try {
           const pkg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf-8'))
-          candidates.push(
-            path.join(projectRoot, `ClaudeCommandCenter-Beta-${pkg.version}${macSuffix}${ext}`),
-            path.join(projectRoot, 'dist', `ClaudeCommandCenter-Beta-${pkg.version}${macSuffix}${ext}`),
-          )
+          for (const brand of brands) {
+            candidates.push(
+              path.join(projectRoot, `${brand}-${pkg.version}${macSuffix}${ext}`),
+              path.join(projectRoot, 'dist', `${brand}-${pkg.version}${macSuffix}${ext}`),
+            )
+          }
         } catch { /* fall through */ }
 
         const src = candidates.find((p) => fs.existsSync(p))

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -172,7 +172,20 @@ export function generateRemoteSetupScript(
     // writes below (GHSA-phr3-g5qh-q4v5).
     `try{fs.chmodSync(claudeDir,0o700)}catch{}`,
     `const shimPath=path.join(claudeDir,'conductor-ssh-statusline.js')`,
-    `try{fs.writeFileSync(shimPath,${shimLiteral},{mode:0o755})}catch{}`,
+    // Unlink-then-exclusive-create, matching the two writes below.
+    //
+    // The chmod above closes this for a link planted AFTER we harden the
+    // directory, but not for one that was already sitting there -- and a plain
+    // writeFileSync FOLLOWS an existing symlink, so a pre-existing link at this
+    // path redirects the write to wherever it points. Every other write in this
+    // function was given rmSync + flag:'wx' for exactly that reason; this one
+    // was missed. `wx` also means we never silently write through something we
+    // did not create: if the unlink fails, the create fails too.
+    //
+    // The content is our own (the shim source), so the exposure is a redirected
+    // WRITE rather than a leaked secret -- weaker than the token files, but the
+    // same primitive, and it is the last write here without the guard.
+    `try{fs.rmSync(shimPath,{force:true})}catch{}try{fs.writeFileSync(shimPath,${shimLiteral},{mode:0o755,flag:'wx'})}catch{}`,
     // Read the user's shared settings FIRST so the per-session settings file
     // can inherit every top-level key (outputStyle, permissions, future
     // additions). The two CCC-owned keys (statusLine, hooks) then override

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1096,10 +1096,17 @@ export function spawnPty(
       // Explicitly cd to ensure the shell is in the right directory
       // (PowerShell profiles can change cwd before the user sees the prompt)
       const isWin = os.platform() === 'win32'
-      const escapedShellCwd = resolvedCwd.replace(/'/g, "''")
+      // Through the shared helper, NOT a local re-escape. This line is the
+      // shell-only twin of the Claude launch path and carries the identical
+      // value (resolveCwd of the config's workingDirectory) into the identical
+      // PowerShell construct — so the hand-rolled ASCII-only doubling here was
+      // the same injection, reachable the same way, and it fires on the `cd`
+      // before any binary runs. -LiteralPath because Set-Location otherwise
+      // treats its argument as a WILDCARD: a real directory named `proj[1m]`
+      // never matches, and the session silently starts in the wrong place.
       const cdCmd = isWin
-        ? `Set-Location '${escapedShellCwd}'`
-        : `cd '${resolvedCwd.replace(/'/g, "'\\''")}' 2>/dev/null; clear`
+        ? `Set-Location -LiteralPath ${quoteArgForShell(resolvedCwd, true)}`
+        : `cd ${quoteArgForShell(resolvedCwd, false)} 2>/dev/null; clear`
 
       // Terminal-only first-run command. `{secret}` becomes a REFERENCE to the
       // CCC_ARG_SECRET env var (set from the keychain in buildClaudeLocalSpawn),
@@ -1351,15 +1358,13 @@ export function spawnPty(
       let agentsFlag = ''
       if (options?.agentsConfig && options.agentsConfig.length > 0) {
         const agentsJson = JSON.stringify(options.agentsConfig)
-        if (os.platform() === 'win32') {
-          // PowerShell: single-quote the JSON, escape internal single quotes by doubling
-          const escaped = agentsJson.replace(/'/g, "''")
-          agentsFlag = ` --agents '${escaped}'`
-        } else {
-          // Bash: single-quote the JSON, escape internal single quotes
-          const escaped = agentsJson.replace(/'/g, "'\\''")
-          agentsFlag = ` --agents '${escaped}'`
-        }
+        // Through the shared helper. Agent templates are free text a user
+        // types (and JSON from the resources dir), so a curly apostrophe in a
+        // description is ORDINARY PROSE — it broke launches by accident long
+        // before anyone crafted one deliberately. The old hand-inlined
+        // doubling escaped U+0027 only, and this value is concatenated
+        // straight into the same launch line the quoting fix hardened.
+        agentsFlag = ` --agents ${quoteArgForShell(agentsJson, os.platform() === 'win32')}`
         logInfo(`[pty] Agents flag for ${sessionId}: ${agentsFlag.slice(0, 200)}...`)
       }
 

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -46,12 +46,31 @@ export interface BuildClaudeLaunchCommandOptions {
 }
 
 /**
+ * Every character PowerShell accepts as a single-quote DELIMITER.
+ *
+ * PowerShell's tokenizer treats the ASCII apostrophe and four Unicode
+ * quotation marks interchangeably: U+2018 LEFT, U+2019 RIGHT, U+201A LOW-9 and
+ * U+201B HIGH-REVERSED-9. Escaping only U+0027 therefore leaves four ways to
+ * terminate a quoted string early — and all four are legal in NTFS directory
+ * names, so an ordinary folder name can carry one (a curly apostrophe is what
+ * word processors produce, and those names get pasted into paths).
+ *
+ * POSIX shells have no equivalent: only U+0027 delimits there, which is why
+ * the posix branch below is unchanged.
+ */
+const PS_SINGLE_QUOTE_CLASS = /[\u0027\u2018\u2019\u201A\u201B]/g
+
+/**
  * Escape a path for single-quoting in the target shell.
- *   - win32 (PowerShell): double the single quotes.
+ *   - win32 (PowerShell): double every single-quote delimiter (see above).
  *   - posix (sh): close-quote, backslash-escape, reopen-quote.
+ *
+ * Doubling is the correct escape for ALL of them: PowerShell reads a doubled
+ * delimiter inside a single-quoted string as one literal character, whichever
+ * of the five it is.
  */
 function escapeForCwdQuote(p: string, isWin32: boolean): string {
-  return isWin32 ? p.replace(/'/g, "''") : p.replace(/'/g, "'\\''")
+  return isWin32 ? p.replace(PS_SINGLE_QUOTE_CLASS, (c) => c + c) : p.replace(/'/g, "'\\''")
 }
 
 /**
@@ -235,6 +254,22 @@ export function buildClaudeLaunchCommand(opts: BuildClaudeLaunchCommandOptions):
   const { cwd, claudeBin, extraFlags, agentsFlag, useResumePicker, pickerScript, resumeUuid } = opts
   const isWin32 = opts.platform === 'win32'
   const escapedCwd = escapeForCwdQuote(cwd, isWin32)
+  // SINGLE-quoted, not double.
+  //
+  // `& "${claudeBin}"` looked safe because a binary path is not user text —
+  // but it IS a path, and it comes from the resources directory or a `where`
+  // lookup, so a directory name decides its contents. Inside DOUBLE quotes
+  // both shells expand: PowerShell evaluates `$(...)` and POSIX evaluates
+  // `$(...)` and backticks, at runtime, and both were verified executing.
+  // Single quotes are literal in PowerShell and POSIX alike, and `& 'name'` /
+  // `'name' args` still invoke a bare command name, a spaced path and an
+  // absolute path exactly as before.
+  const quotedBin = `'${escapeForCwdQuote(claudeBin, isWin32)}'`
+  // Same shape of value (it also lives under the resources directory), and it
+  // was being escaped by two hand-inlined copies of the helper — which is
+  // precisely how it would have kept the old behaviour after the helper was
+  // fixed. One helper, one call site each.
+  const quotedPicker = pickerScript ? `'${escapeForCwdQuote(pickerScript, isWin32)}'` : null
 
   // RESUME path: bypass the picker, launch claude directly with --resume first.
   // The --resume verb must precede every other flag (resume-picker.js:299), so
@@ -242,8 +277,8 @@ export function buildClaudeLaunchCommand(opts: BuildClaudeLaunchCommandOptions):
   if (resumeUuid) {
     const resumeFlag = ` --resume ${resumeUuid}`
     return isWin32
-      ? `Set-Location '${escapedCwd}'; & "${claudeBin}"${resumeFlag}${agentsFlag}${extraFlags}; exit`
-      : `cd '${escapedCwd}' && "${claudeBin}"${resumeFlag}${agentsFlag}${extraFlags}; exit`
+      ? `Set-Location '${escapedCwd}'; & ${quotedBin}${resumeFlag}${agentsFlag}${extraFlags}; exit`
+      : `cd '${escapedCwd}' && ${quotedBin}${resumeFlag}${agentsFlag}${extraFlags}; exit`
   }
 
   // No-resume behaviour. P1.1: the picker-script branch forwards agentsFlag too
@@ -251,20 +286,18 @@ export function buildClaudeLaunchCommand(opts: BuildClaudeLaunchCommandOptions):
   // restored session). resume-picker.js forwards its own argv to
   // `claude --resume <id> ...`, so the flag survives the launch.
   if (useResumePicker) {
-    if (pickerScript && isWin32) {
-      const escapedScript = pickerScript.replace(/'/g, "''")
-      return `Set-Location '${escapedCwd}'; node '${escapedScript}'${agentsFlag}${extraFlags}; exit`
-    } else if (pickerScript) {
-      return `cd '${escapedCwd}' && node '${pickerScript.replace(/'/g, "'\\''")}'${agentsFlag}${extraFlags}; exit`
-    } else {
-      // Fallback: no picker script found, launch Claude directly.
+    if (quotedPicker) {
       return isWin32
-        ? `Set-Location '${escapedCwd}'; & "${claudeBin}"${agentsFlag}${extraFlags}; exit`
-        : `cd '${escapedCwd}' && "${claudeBin}"${agentsFlag}${extraFlags}; exit`
+        ? `Set-Location '${escapedCwd}'; node ${quotedPicker}${agentsFlag}${extraFlags}; exit`
+        : `cd '${escapedCwd}' && node ${quotedPicker}${agentsFlag}${extraFlags}; exit`
     }
+    // Fallback: no picker script found, launch Claude directly.
+    return isWin32
+      ? `Set-Location '${escapedCwd}'; & ${quotedBin}${agentsFlag}${extraFlags}; exit`
+      : `cd '${escapedCwd}' && ${quotedBin}${agentsFlag}${extraFlags}; exit`
   }
 
   return isWin32
-    ? `Set-Location '${escapedCwd}'; & "${claudeBin}"${agentsFlag}${extraFlags}; exit`
-    : `cd '${escapedCwd}' && "${claudeBin}"${agentsFlag}${extraFlags}; exit`
+    ? `Set-Location '${escapedCwd}'; & ${quotedBin}${agentsFlag}${extraFlags}; exit`
+    : `cd '${escapedCwd}' && ${quotedBin}${agentsFlag}${extraFlags}; exit`
 }

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -6,8 +6,13 @@
  * Electron. No default export (project convention). No side effects.
  *
  * Behaviour contract:
- *   - When `resumeUuid` is ABSENT the produced string is BYTE-IDENTICAL to the
- *     pre-refactor inline construction (picker / picker-fallback / direct).
+ *   - When `resumeUuid` is ABSENT the produced string matches the pre-refactor
+ *     inline construction (picker / picker-fallback / direct) EXCEPT for the
+ *     binary and picker paths, which are now single-quoted rather than
+ *     double-quoted. That is a deliberate security change, not drift: inside
+ *     double quotes PowerShell expands `$(...)` and POSIX expands `$(...)` and
+ *     backticks, and these values are PATHS whose contents a directory name
+ *     decides. Byte-identity holds for every other part of the line.
  *   - When `resumeUuid` is PRESENT the resume-picker branch is BYPASSED and the
  *     command launches Claude directly with `--resume <uuid>` FIRST, before
  *     --settings / --mcp-config / --agents etc. (mirrors the ordering in
@@ -275,6 +280,12 @@ export function buildClaudeLaunchCommand(opts: BuildClaudeLaunchCommandOptions):
   // The --resume verb must precede every other flag (resume-picker.js:299), so
   // it is injected before agentsFlag/extraFlags here.
   if (resumeUuid) {
+    // Re-validated HERE, not trusted from the caller. The uuid is the one value
+    // on this line that is interpolated UNQUOTED, and every current caller does
+    // gate it with the same anchored regex — but "the caller checks" is a
+    // comment, not a boundary, and this function is exported. Anchored, so a
+    // uuid with a trailing `; …` is refused rather than launched.
+    if (!UUID_RE.test(resumeUuid)) throw new Error('buildClaudeLaunchCommand: resumeUuid is not a uuid')
     const resumeFlag = ` --resume ${resumeUuid}`
     return isWin32
       ? `Set-Location '${escapedCwd}'; & ${quotedBin}${resumeFlag}${agentsFlag}${extraFlags}; exit`

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,6 +21,19 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.10',
+    date: '2026-08-14',
+    highlights: 'Fixes an upgrade that could fail with "AI Code Conductor cannot be closed" even with nothing running, and settles the rename: downloads now carry one name, and the first-run tour finally matches the brand.',
+    changes: [
+      { type: 'fix', description: 'Upgrading could stop partway with "AI Code Conductor cannot be closed. Please close it manually and click Retry" — with the app shut down, after a reboot, and with no such program running anywhere. The message was misleading: it appears when the installer cannot run the previous version\'s uninstaller, not because anything is open. Installations in that state are now detected and repaired silently, with nothing for you to do.' },
+      { type: 'fix', description: 'Earlier renames could leave the app installed inside a folder named after the previous one, nesting a level deeper each time. The installer now recognises every folder name the app has shipped under, moves the installation to a clean folder, and removes the old tree. Your settings, data and resources folder are untouched.' },
+      { type: 'improvement', description: 'Downloads now carry a single name. Releases used to attach every installer twice — once under the old product name and once under the current one — which made it unclear which file to take. Only AI-Code-Conductor-… is published now. If you are on 2.1.0-beta.5 or older, download this release by hand from the releases page: that build looks for the old file name and will not see the update.' },
+      { type: 'improvement', description: 'The first-run tour and guided setup now use the AI Code Conductor blue instead of the previous product\'s orange, so the logo no longer sits inside mismatched styling, and the "What\'s new" page shows the version you are actually installing rather than always saying 2.0.' },
+      { type: 'improvement', description: 'A Microsoft Store package is now built alongside the Windows installer — the first step towards listing the app in the Store.' },
+      { type: 'fix', description: 'Security hardening: one file written during SSH session setup — the status-line helper — could follow a symbolic link planted in advance in the remote account\'s ~/.claude folder, redirecting where it was written. It is now created fresh and refuses to follow a planted link, matching the protection already applied to the token files written beside it. Reported privately.' }
+    ]
+  },
+  {
     version: '2.1.0-beta.9',
     date: '2026-08-13',
     highlights: 'Each account can hold its own claude.ai web session, signed in through a dedicated per-account browser and kept fully separate. This is also a security release: two local-attacker vulnerabilities are fixed, with their advisories published alongside it.',

--- a/src/renderer/components/GuidedTour.tsx
+++ b/src/renderer/components/GuidedTour.tsx
@@ -141,7 +141,7 @@ export default function GuidedTour({ onCreateConfig, onClose }: { onCreateConfig
             width: rect.width + PAD * 2,
             height: rect.height + PAD * 2,
             borderRadius: 12,
-            boxShadow: '0 0 0 9999px rgba(6,9,13,0.68), 0 0 0 2px var(--ob, #e8915c)',
+            boxShadow: '0 0 0 9999px rgba(6,9,13,0.68), 0 0 0 2px var(--ob, #2f9bff)',
             transition: 'top .18s, left .18s, width .18s, height .18s',
             pointerEvents: 'none',
           }}
@@ -191,7 +191,7 @@ export default function GuidedTour({ onCreateConfig, onClose }: { onCreateConfig
             <button
               onClick={next}
               type="button"
-              style={{ border: 0, borderRadius: 9, padding: '8px 18px', fontSize: 13, fontWeight: 670, cursor: 'pointer', background: 'linear-gradient(135deg, var(--ob-bright, #f0a06a), var(--ob-deep, #c47b4a))', color: '#1a0d05' }}
+              style={{ border: 0, borderRadius: 9, padding: '8px 18px', fontSize: 13, fontWeight: 670, cursor: 'pointer', background: 'linear-gradient(135deg, var(--ob-bright, #5cb0ff), var(--ob-deep, #1b7fd9))', color: 'var(--ob-on, #04121f)' }}
             >
               {step.cta ?? 'Next →'}
             </button>

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -1,3 +1,11 @@
+import { releaseLine } from '../utils/versionLabel'
+
+declare const __APP_VERSION__: string
+
+// The release line this build belongs to ("2.1"), not a hard-coded number: the
+// heading used to say "What's new in 2.0" on every 2.1 beta.
+const LINE = releaseLine(typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '')
+
 const SPARKLES = String.fromCodePoint(0x2728)
 const LOCK = String.fromCodePoint(0x1f512)
 const GEAR = String.fromCodePoint(0x2699)
@@ -39,7 +47,7 @@ const CARDS: { icon: string; title: string; desc: string; beta?: boolean }[] = [
   {
     icon: BOLT,
     title: 'A newer engine',
-    desc: 'Electron 42, React 19 and xterm.js 6 under the hood: a faster renderer on a current security baseline.',
+    desc: 'Electron 43, React 19 and xterm.js 6 under the hood: a faster renderer on a current security baseline.',
   },
 ]
 
@@ -48,9 +56,9 @@ export function WhatsNewV2Step({ onNext }: { onNext: () => void }) {
     <>
       <div className="p2">
         <div className="p2-inner" style={{ width: 'min(880px, 95vw)' }}>
-          <h2 className="h2">What's new in 2.0</h2>
+          <h2 className="h2">What's new in {LINE}</h2>
           <p className="p2-sub">
-            AI Code Conductor 2.0 is a big release. The short version, before we set it up together:
+            AI Code Conductor {LINE} is a big release. The short version, before we set it up together:
           </p>
 
           <div className="gh-grid">

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -53,7 +53,7 @@
 .ob-root .tile { width: 200px; border: 1px solid var(--border-subtle); border-radius: 13px; background: var(--surface-raised); padding: 12px; cursor: pointer; text-align: left; position: relative; transition: .14s; }
 .ob-root .tile:hover { transform: translateY(-2px); }
 .ob-root .tile.sel { border-color: var(--ob); box-shadow: 0 0 0 3px var(--ob-soft); }
-.ob-root .tile .ck { position: absolute; top: 9px; right: 10px; width: 18px; height: 18px; border-radius: 50%; background: var(--ob); color: #1a0d05; display: none; place-items: center; font-size: 11px; font-weight: 800; }
+.ob-root .tile .ck { position: absolute; top: 9px; right: 10px; width: 18px; height: 18px; border-radius: 50%; background: var(--ob); color: var(--ob-on, #04121f); display: none; place-items: center; font-size: 11px; font-weight: 800; }
 .ob-root .tile.sel .ck { display: grid; }
 .ob-root .mini { height: 60px; border-radius: 7px; overflow: hidden; display: flex; border: 1px solid rgba(128,128,128,.18); }
 .ob-root .mini .rail { width: 28px; }
@@ -62,19 +62,19 @@
 .ob-root .mini .dot { width: 7px; height: 7px; border-radius: 50%; }
 .ob-root .mini.d { background: #171e27; }
 .ob-root .mini.d .rail { background: #0a0e13; border-right: 1px solid #1f2731; }
-.ob-root .mini.d .b1 { background: #e8915c; width: 58%; }
+.ob-root .mini.d .b1 { background: #2f9bff; width: 58%; }
 .ob-root .mini.d .b2 { background: #2a3340; width: 85%; }
 .ob-root .mini.d .b3 { background: #222c39; width: 68%; }
 .ob-root .mini.d .dot { background: #7bd88f; }
 .ob-root .mini.l { background: #e8ecf3; }
 .ob-root .mini.l .rail { background: #ccd4dd; border-right: 1px solid #c2cad6; }
-.ob-root .mini.l .b1 { background: #b3612e; width: 58%; }
+.ob-root .mini.l .b1 { background: #1668c4; width: 58%; }
 .ob-root .mini.l .b2 { background: #cdd5e0; width: 85%; }
 .ob-root .mini.l .b3 { background: #dde3ec; width: 68%; }
 .ob-root .mini.l .dot { background: #2d8349; }
 .ob-root .mini.s { background: linear-gradient(90deg,#171e27 50%,#e8ecf3 50%); }
 .ob-root .mini.s .rail { background: linear-gradient(90deg,#0a0e13 50%,#ccd4dd 50%); }
-.ob-root .mini.s .b1 { background: #e8915c; width: 58%; }
+.ob-root .mini.s .b1 { background: #2f9bff; width: 58%; }
 .ob-root .mini.s .b2 { background: #7d8794; width: 85%; }
 .ob-root .mini.s .b3 { background: #9aa3b0; width: 68%; }
 .ob-root .mini.s .dot { background: #7bd88f; }
@@ -87,7 +87,7 @@
 .ob-root .foot { position: relative; z-index: 2; display: flex; align-items: center; gap: 12px; padding: 20px 34px 28px; }
 .ob-root .hint { font-size: 12px; color: var(--text-muted); }
 .ob-root .back { border: 1px solid var(--border-strong); background: transparent; color: var(--text-secondary); border-radius: 10px; padding: 11px 18px; font-size: 14px; cursor: pointer; }
-.ob-root .cta { margin-left: auto; border: 0; border-radius: 11px; padding: 12px 28px; font-size: 15px; font-weight: 680; cursor: pointer; background: linear-gradient(135deg, var(--ob-bright), var(--ob-deep)); color: #1a0d05; box-shadow: 0 8px 24px var(--ob-soft); }
+.ob-root .cta { margin-left: auto; border: 0; border-radius: 11px; padding: 12px 28px; font-size: 15px; font-weight: 680; cursor: pointer; background: linear-gradient(135deg, var(--ob-bright), var(--ob-deep)); color: var(--ob-on, #04121f); box-shadow: 0 8px 24px var(--ob-soft); }
 
 /* PAGE 2 — find Claude (the .p2 centred container is reused by later pages) */
 .ob-root .p2 { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 0 24px; }
@@ -113,7 +113,7 @@
 .ob-root .chip { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; padding: 3px 9px; border-radius: 999px; border: 1px solid var(--border-subtle); color: var(--text-secondary); }
 .ob-root .chip.ok { color: var(--status-success); border-color: color-mix(in srgb, var(--status-success) 32%, transparent); }
 .ob-root .abtns { display: flex; gap: 10px; padding: 0 15px 14px; }
-.ob-root .run { border: 0; border-radius: 9px; padding: 10px 18px; font-size: 13.5px; font-weight: 670; cursor: pointer; background: linear-gradient(135deg, var(--ob-bright), var(--ob-deep)); color: #1a0d05; }
+.ob-root .run { border: 0; border-radius: 9px; padding: 10px 18px; font-size: 13.5px; font-weight: 670; cursor: pointer; background: linear-gradient(135deg, var(--ob-bright), var(--ob-deep)); color: var(--ob-on, #04121f); }
 .ob-root .run:disabled { opacity: .6; cursor: default; }
 .ob-root .cta:disabled { opacity: .6; cursor: default; }
 .ob-root .foot-skip { margin-left: auto; }
@@ -149,7 +149,7 @@
 .ob-root .verdict.danger .v-ic { background: color-mix(in srgb, var(--status-danger) 18%, transparent); color: var(--status-danger); }
 .ob-root .sentinel-note { font-size: 12.5px; line-height: 1.55; color: var(--text-muted); background: var(--surface-raised); border: 1px solid var(--border-subtle); border-radius: 10px; padding: 13px 15px; margin-bottom: 10px; }
 .ob-root .sentinel-note b { color: var(--text-secondary); }
-.ob-root .approve .ah .pill.rec { background: var(--ob); color: #1a0d05; border-color: var(--ob); }
+.ob-root .approve .ah .pill.rec { background: var(--ob); color: var(--ob-on, #04121f); border-color: var(--ob); }
 .ob-root .resultmeta { font-size: 12px; color: var(--text-muted); text-align: center; margin-top: 8px; }
 .ob-root .blockbox { display: flex; align-items: center; gap: 14px; padding: 14px 16px; border: 1px solid color-mix(in srgb, var(--status-danger) 35%, transparent); border-radius: 11px; background: color-mix(in srgb, var(--status-danger) 6%, transparent); margin-top: 10px; }
 .ob-root .blockbox .bb-l { flex: 1; display: flex; flex-direction: column; gap: 2px; }
@@ -299,7 +299,7 @@
 .ob-root .feat-onoff { display: inline-flex; align-items: center; gap: 4px; padding: 4px; border: 1px solid var(--border-strong); border-radius: 11px; background: var(--surface-sunken); }
 .ob-root .oo-lbl { font-size: 12px; color: var(--text-muted); padding: 0 9px 0 6px; }
 .ob-root .oo-btn { border: 0; background: none; color: var(--text-muted); font: inherit; font-size: 13.5px; font-weight: 680; padding: 7px 20px; border-radius: 8px; cursor: pointer; transition: .14s; }
-.ob-root .oo-btn.on { background: var(--ob); color: #1a0d05; }
+.ob-root .oo-btn.on { background: var(--ob); color: var(--ob-on, #04121f); }
 .ob-root .oo-btn.oo-off.on { background: var(--border-strong); color: var(--text-primary); }
 .ob-root .sl-offnote { display: flex; gap: 12px; align-items: flex-start; padding: 15px 18px; border: 1px dashed var(--border-strong); border-radius: 12px; background: var(--surface-stage); max-width: 760px; margin: 14px auto 0; }
 .ob-root .off-ic { width: 28px; height: 28px; border-radius: 8px; background: var(--surface-overlay); color: var(--text-muted); display: grid; place-items: center; font-size: 15px; flex: none; }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -72,7 +72,10 @@
   --terminal-foreground: #eef2f7;
 
   --accent: #3fbecb;
-  --brand: #c47b4a;
+  /* Brand accent (Beta pill, prerelease chip, drop targets). Blue since the AI
+     Code Conductor rename — it was the same orange as the old --ob-deep, which
+     is why the Beta pill kept looking like the pre-rename product. */
+  --brand: #2f9bff;
 
   --status-success: #7bd88f;
   --status-warning: #ecc14e;
@@ -107,12 +110,20 @@
   --shadow-fab: 0 3px 10px rgba(0,0,0,.4);
   --highlight-inset: inset 0 1px 0 rgba(255,255,255,.04);
 
-  /* Onboarding harness — brand orange (NOT the app teal); scoped to the first-run flow. */
-  --ob: #e8915c;
-  --ob-bright: #f0a06a;
-  --ob-deep: #c47b4a;
-  --ob-soft: rgba(232,145,92,.14);
-  --ob-line: rgba(232,145,92,.45);
+  /* Onboarding harness — the AI Code Conductor brand blue (NOT the app teal);
+     scoped to the first-run flow. This family was orange under the previous
+     branding. BrandMark had already been redrawn in the brand azure, so the
+     tour showed a BLUE logo sitting inside ORANGE chrome. The values below are
+     the monogram's own gradient stop (#2F9BFF) lightened and deepened for the
+     bright/deep roles, so the flow matches the mark, the splash and the icon. */
+  --ob: #2f9bff;
+  --ob-bright: #5cb0ff;
+  --ob-deep: #1b7fd9;
+  --ob-soft: rgba(47,155,255,.14);
+  --ob-line: rgba(47,155,255,.45);
+  /* Text ON a filled --ob surface. Near-black navy: the previous #1a0d05 was a
+     dark BROWN chosen for orange and reads muddy over blue. */
+  --ob-on: #04121f;
   --field: #0c1117;
   --serif: 'Georgia', 'Times New Roman', serif;
 }
@@ -177,7 +188,8 @@
   --terminal-foreground: #11161f;
 
   --accent: #15808d;
-  --brand: #b3612e;
+  /* Brand accent, darkened for contrast as text/border on the light substrate. */
+  --brand: #1668c4;
 
   --status-success: #2d8349;
   --status-warning: #946a12;
@@ -205,12 +217,15 @@
   --shadow-raised: -11px 0 26px rgba(0,0,0,.20);
   --highlight-inset: inset 0 1px 0 rgba(255,255,255,.5); /* inverted: light substrate needs a bright top highlight */
 
-  /* Onboarding harness — brand orange, light values. */
-  --ob: #b3612e;
-  --ob-bright: #c47b4a;
-  --ob-deep: #9a4f29;
-  --ob-soft: rgba(179,97,46,.10);
-  --ob-line: rgba(179,97,46,.5);
+  /* Onboarding harness — brand blue, light values (darkened for contrast on
+     the light substrate, same treatment as --accent and the effort ramp). */
+  --ob: #1668c4;
+  --ob-bright: #2f9bff;
+  --ob-deep: #10508f;
+  --ob-soft: rgba(22,104,196,.10);
+  --ob-line: rgba(22,104,196,.5);
+  /* Filled --ob is dark enough in light mode that near-white reads best. */
+  --ob-on: #f2f6fb;
   --field: #cdd5e0;
 }
 

--- a/src/renderer/utils/versionLabel.ts
+++ b/src/renderer/utils/versionLabel.ts
@@ -8,3 +8,17 @@ import type { UpdateChannel } from '../stores/settingsStore'
 export function formatInstalledVersion(version: string, channel: UpdateChannel): string {
   return `v${version} (${channel})`
 }
+
+/**
+ * The release LINE a version belongs to: `2.1.0-beta.9` -> `2.1`.
+ *
+ * The upgrade-cohort onboarding page hard-coded "2.0", so every 2.1 beta
+ * greeted testers with "What's new in 2.0". Deriving it from the build-time
+ * __APP_VERSION__ means it cannot go stale again. Falls back to the input when
+ * it does not parse, so a malformed define degrades to something harmless
+ * rather than throwing during first-run.
+ */
+export function releaseLine(version: string): string {
+  const m = /^(\d+)\.(\d+)/.exec(String(version || '').trim())
+  return m ? `${m[1]}.${m[2]}` : String(version || '')
+}

--- a/tests/unit/main/brand-identity-guard.test.ts
+++ b/tests/unit/main/brand-identity-guard.test.ts
@@ -11,9 +11,9 @@ import { join } from 'path'
  *   - win/mac executableName pin the exe / .app bundle filename (the NSIS
  *     assisted installer appends APP_FILENAME to any install dir that does not
  *     contain it, and the mac drag-install replaces only on filename collision)
- *   - artifactName keeps the ClaudeCommandCenter- prefix (the updater in every
- *     installed client matches release assets by that literal prefix; a
- *     non-match is indistinguishable from "up to date")
+ *   - artifactName now carries the CURRENT brand, which is only safe because
+ *     the updater accepts both prefixes (since 2.1.0-beta.6); that tolerance is
+ *     pinned by its own test below and must outlive the rename
  *   - a top-level productName must never exist (Electron app.name would follow
  *     it and relocate userData away from %APPDATA%/claude-conductor)
  */
@@ -56,10 +56,87 @@ describe('brand identity guard', () => {
     expect(nsh).toMatch(/RMDir \/r "\$\{DIR\}"/)
   })
 
-  it('release artifact names keep the frozen ClaudeCommandCenter- prefix', () => {
-    expect(pkg.build.nsis.artifactName).toBe('ClaudeCommandCenter-${version}.${ext}')
-    expect(pkg.build.mac.artifactName).toBe('ClaudeCommandCenter-${version}-mac.${ext}')
-    expect(pkg.build.linux.artifactName).toBe('ClaudeCommandCenter-${version}-linux-${arch}.${ext}')
+  it('the relocation recognises the " Beta"-suffixed folder names too', () => {
+    // The original check compared only against "Claude Command Center" and
+    // "Claude Conductor". Real installs were in "Claude Conductor Beta" and
+    // "Claude Command Center Beta", which matched NEITHER — so the relocation
+    // never fired and each rename installed INSIDE the previous folder:
+    //   …\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+    // Missing any of these names re-opens that nesting.
+    const nsh = readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
+    // Scoped to the DETECTION macro, not the whole file: every one of these
+    // names also appears in the customInstall cleanup calls, so a whole-file
+    // `toContain` stayed green when the detection list was gutted (caught by
+    // mutation-testing this very guard).
+    const detect = nsh.match(/!macro IsLegacyBrandFolder[\s\S]*?!macroend/)
+    expect(detect, 'IsLegacyBrandFolder macro not found').not.toBeNull()
+    for (const name of [
+      '"Claude Command Center"',
+      '"Claude Conductor"',
+      '"Claude Command Center Beta"',
+      '"Claude Conductor Beta"',
+    ]) {
+      expect(detect![0]).toContain(name)
+    }
+    // And the walk has to look at ANCESTORS, not just the last component —
+    // a nested install's tail is already the current brand name.
+    expect(nsh).toMatch(/GetFileName/)
+    expect(nsh).toMatch(/\$\{Loop\}/)
+  })
+
+  it('a broken previous install is cleared silently instead of prompting', () => {
+    // electron-builder runs the recorded old uninstaller, retries 5x, and on
+    // failure shows "$(appCannotBeClosed)" — a message about the APP being
+    // open, raised when the UNINSTALLER failed. With no UninstallString it
+    // returns immediately, so clearing a record we know is broken is what keeps
+    // the upgrade silent. Both root keys, because the record can be in either.
+    const nsh = readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
+    expect(nsh).toMatch(/!macro ForgetPreviousInstall/)
+    expect(nsh).toMatch(/DeleteRegKey SHELL_CONTEXT "\$\{UNINSTALL_REGISTRY_KEY\}"/)
+    expect(nsh).toMatch(/DeleteRegKey HKCU "\$\{UNINSTALL_REGISTRY_KEY\}"/)
+    // Fired both for a legacy tree and for a recorded install whose binary is
+    // simply gone.
+    expect(nsh).toMatch(/IfNot\} \$\{FileExists\} "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}"/)
+  })
+
+  it('release artifacts carry the current brand name, on every platform', () => {
+    // These WERE frozen to ClaudeCommandCenter- because the updater in shipped
+    // clients matched release assets by that literal prefix, so renaming them
+    // would have made every install see "no matching asset" — indistinguishable
+    // from "up to date", and unfixable, since the fix only ships in the build
+    // they can no longer see. Releases worked around it by publishing each
+    // installer TWICE, under both names.
+    //
+    // 2.1.0-beta.6 taught the updater BOTH prefixes (see the next test), so any
+    // client that can reach a new release already resolves the brand name and
+    // the duplicate is dead weight — its .blockmap and latest*.yml never even
+    // referenced it. Only installs on beta.5 or older are left behind, and they
+    // can download from the release page by hand.
+    expect(pkg.build.nsis.artifactName).toBe('AI-Code-Conductor-${version}.${ext}')
+    expect(pkg.build.mac.artifactName).toBe('AI-Code-Conductor-${version}-mac.${ext}')
+    expect(pkg.build.linux.artifactName).toBe('AI-Code-Conductor-${version}-linux-${arch}.${ext}')
+  })
+
+  it('the updater still accepts the LEGACY prefix, which is what makes the rename safe', () => {
+    // This is the load-bearing half of the rename and the reason the assertion
+    // above could change at all. Dropping 'ClaudeCommandCenter-' from this list
+    // is harmless for assets published from now on, but it would strand any
+    // client still running a build whose release assets carried the old name if
+    // one is ever re-published. Keep both until beta-era installs are gone.
+    const updater = readFileSync(join(__dirname, '../../../src/main/github-update.ts'), 'utf-8')
+    const line = updater.match(/const INSTALLER_PREFIXES = \[([^\]]+)\]/)
+    expect(line).not.toBeNull()
+    expect(line![1]).toContain("'ClaudeCommandCenter-'")
+    expect(line![1]).toContain("'AI-Code-Conductor-'")
+  })
+
+  it('releases publish ONE set of installers — no legacy duplicate', () => {
+    // The duplicate-copy step is what put two names on every release. If it
+    // comes back, so does the "which one do I download?" confusion, and the
+    // copies carry no matching .blockmap.
+    const workflow = readFileSync(join(__dirname, '../../../.github/workflows/release.yml'), 'utf-8')
+    expect(workflow).not.toMatch(/cp -- "\$f" "\$clean"/)
+    expect(workflow).toContain('INSTALLER="AI-Code-Conductor-${VERSION}.exe"')
   })
 
   it('npm name and appId stay frozen (userData path + NSIS upgrade GUID)', () => {

--- a/tests/unit/main/brand-identity-guard.test.ts
+++ b/tests/unit/main/brand-identity-guard.test.ts
@@ -115,20 +115,33 @@ describe('brand identity guard', () => {
     // `mklink /J` junction emptied the tree it pointed at. A folder-name match
     // is therefore not remotely enough. Scoped to the macro body, because every
     // one of these tokens also appears in prose elsewhere in the file.
+    //
+    // These are PRESENCE assertions and cannot catch a flipped guard — a
+    // measured fact, not a worry: 6/6 polarity mutants stayed green here.
+    // installer-nsis-behaviour.test.ts compiles these macros with the real
+    // makensis and checks what survives on disk; that is what actually holds
+    // them. Keep both — this one names the shape, that one enforces it.
     const body = nshMacro('RemoveLegacyInstall')
-    // 1. never the directory we are installing into
-    expect(body).toMatch(/\$\{If\}\s+"\$\{DIR\}"\s+==\s+"\$INSTDIR"/)
+    // 1. never the directory we are installing into. Compared CANONICALLY: a
+    //    raw StrCmp is defeated by an 8.3 short-name $INSTDIR
+    //    (`/S /D=C:\PROGRA~1\CLAUDE~1`), which swept the just-installed folder.
+    expect(body).toMatch(/PathsOverlapCanon "\$\{DIR\}" "\$INSTDIR"/)
     // 2. never a junction / symlink / mount point
     expect(body).toMatch(/GetFileAttributes\}\s+"\$\{DIR\}"\s+"REPARSE_POINT"/)
-    // 3. never anything overlapping the user's data or resources directory.
-    //    Shipped builds defaulted DataDirectory to
-    //    "$LOCALAPPDATA\Claude Command Center" — a name this sweep looks for —
-    //    so an install into %LOCALAPPDATA% would delete the user's sessions,
-    //    logs and CONFIG, twenty lines after customInstall adopted that path.
-    expect(body).toMatch(/PathsOverlap "\$\{DIR\}" "\$R3"/)
-    expect(body).toMatch(/PathsOverlap "\$\{DIR\}" "\$R4"/)
-    // 4. positive proof it is an install root and not a source checkout
-    expect(body).toMatch(/FileExists\}\s+"\$\{DIR\}\\Uninstall \*\.exe"/)
+    // 3. the data/resources directories must be KNOWN. PathsOverlap(dir, "") is
+    //    0, so an unreadable DataDirectory used to switch the next check off
+    //    entirely — and ReadUserPath is HKCU-only, so both come back empty on
+    //    an all-users install elevated by a different admin.
+    expect(body).toMatch(/\$\{If\} \$R3 == ""\s*\n\s*\$\{OrIf\} \$R4 == ""/)
+    // 4. never anything overlapping either of them. Shipped builds defaulted
+    //    DataDirectory to "$LOCALAPPDATA\Claude Command Center" — a name this
+    //    sweep looks for — so an install into %LOCALAPPDATA% would delete the
+    //    user's sessions, logs and CONFIG, twenty lines after customInstall
+    //    adopted that path.
+    expect(body).toMatch(/PathsOverlapCanon "\$\{DIR\}" "\$R3"/)
+    expect(body).toMatch(/PathsOverlapCanon "\$\{DIR\}" "\$R4"/)
+    // 5. positive proof it is an install root and not a source checkout
+    expect(body).toMatch(/ProveLegacyInstallRoot "\$\{DIR\}"/)
     // ...and the deletion itself still has to be there.
     expect(body).toMatch(/RMDir \/r "\$\{DIR\}"/)
     // The data/resources paths must actually be loaded before the sweep runs,
@@ -139,6 +152,37 @@ describe('brand identity guard', () => {
     expect(nshMacro('ReadUserPath')).toContain('Software\\Claude Conductor')
     // The cleanup list must not name the npm package directory either.
     expect(install).not.toContain('claude-conductor')
+    // An explicit /D= directory's siblings are not this installer's business.
+    expect(install).toMatch(/GetDParameter/)
+  })
+
+  it('ownership is proved down the nesting CHAIN, not just at its top', () => {
+    // The uninstaller in
+    //   …\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
+    // exists ONLY at the leaf: electron-builder's uninstaller does
+    // RMDir /r $INSTDIR before SetOutPath recreates the chain one level deeper,
+    // so every outer level holds nothing but the next folder. Demanding
+    // "Uninstall *.exe" at the candidate itself therefore could NEVER be
+    // satisfied on the outer root — while ForgetPreviousInstallIn still cleared
+    // the ARP record for that shape, orphaning the whole tree.
+    const prove = nshMacro('ProveLegacyInstallRoot')
+    expect(prove).toMatch(/Call CccProveInstallRoot/)
+    // ...or the uninstaller the replaced install recorded, captured before the
+    // commit point overwrote it.
+    expect(prove).toContain('$cccLegacyUninstaller')
+    expect(nshMacro('customInit')).toMatch(/CaptureRecordedUninstaller/)
+
+    // The walk itself: it must look INSIDE the candidate, only follow folders
+    // that can be a link in a nesting chain, skip reparse points, and treat a
+    // wildcard hit as proof only when it is a FILE — IfFileExists with a
+    // wildcard is FindFirstFile, which matches DIRECTORIES (measured: a folder
+    // called "Uninstall whatever.exe" satisfied the old proof and the sibling
+    // source checkout was deleted).
+    const header = nshMacro('customHeader')
+    expect(header).toMatch(/FindFirst \$cccProveHandle \$cccProveName "\$cccProveCur\\Uninstall \*\.exe"/)
+    expect(header).toMatch(/\$\{IfNot\} \$\{FileExists\} "\$cccProveCur\\\$cccProveName\\\*\.\*"/)
+    expect(header).toMatch(/IsChainFolder "\$cccProveName"/)
+    expect(header).toMatch(/GetFileAttributes\} "\$cccProveCur\\\$cccProveName" "REPARSE_POINT"/)
   })
 
   it('the uninstall record is only dropped once the install is committing', () => {
@@ -167,9 +211,35 @@ describe('brand identity guard', () => {
     // uninstaller, not $INSTDIR\<app>.exe. The old exe-existence gate wrongly
     // condemned any beta.5-or-older install sitting in a non-legacy-named
     // folder, where the executable was still called Claude Command Center.exe.
-    expect(forget).toMatch(/ReadRegStr \$R0 \$\{ROOT_KEY\} "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"/)
-    expect(forget).toMatch(/\$\{ElseIfNot\} \$\{FileExists\} "\$R1"/)
+    const classify = nshMacro('ClassifyUninstallRecord')
+    expect(classify).toMatch(/ReadRegStr \$R0 \$\{ROOT_KEY\} "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"/)
+    expect(classify).toMatch(/\$\{ElseIfNot\} \$\{FileExists\} "\$R1"/)
     expect(readNsh()).not.toMatch(/FileExists\} "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}"/)
+  })
+
+  it('the elevated inner instance, which never reaches the commit point, is covered too', () => {
+    // installSection.nsh:35-37 guards CHECK_APP_RUNNING with ${ifNot}
+    // ${UAC_IsInnerInstance}, so ForgetBrokenPreviousInstall never runs in the
+    // elevated instance — but customInit is inserted UNGUARDED
+    // (installer.nsi:79-81), so the retarget does. uninstallOldVersion then read
+    // that retargeted InstallLocation and ran the OLD uninstaller with
+    // _?=<new dir>; uninstaller.nsh:187 does RMDir /r $INSTDIR, on the directory
+    // this run was about to install into.
+    const init = nshMacro('customInit')
+    expect(init).toMatch(/\$\{If\} \$\{UAC_IsInnerInstance\}/)
+    expect(init).toMatch(/SuspendUninstallRecordIn HKCU \$cccSavedPerUserUninstallString/)
+    expect(init).toMatch(/SuspendUninstallRecordIn HKLM \$cccSavedPerMachineUninstallString/)
+
+    // It removes ONE value, not the key: uninstallOldVersion returns
+    // immediately on an empty UninstallString (installUtil.nsh:156-164), and a
+    // single string is restorable.
+    const suspend = nshMacro('SuspendUninstallRecordIn')
+    expect(suspend).toMatch(/DeleteRegValue \$\{HIVE\} "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"/)
+    expect(suspend).not.toMatch(/DeleteRegKey/)
+    // ...and restored if the wizard the inner instance still shows is cancelled.
+    const header = nshMacro('customHeader')
+    expect(header).toMatch(/WriteRegStr HKCU "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString" "\$cccSavedPerUserUninstallString"/)
+    expect(header).toMatch(/WriteRegStr HKLM "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString" "\$cccSavedPerMachineUninstallString"/)
   })
 
   it('the relocation also neutralises the registry seed that would undo it', () => {

--- a/tests/unit/main/brand-identity-guard.test.ts
+++ b/tests/unit/main/brand-identity-guard.test.ts
@@ -19,6 +19,21 @@ import { join } from 'path'
  */
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../../package.json'), 'utf-8'))
 
+const readNsh = () => readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
+
+/**
+ * The body of one NSIS macro, so an assertion cannot be satisfied by a match
+ * somewhere else in the file. That is not hypothetical: an earlier round of this
+ * guard used whole-file `toContain` for the legacy folder names, and stayed
+ * GREEN while the detection list was gutted — because the same names also appear
+ * in the customInstall cleanup calls and in the comments.
+ */
+function nshMacro(name: string): string {
+  const m = readNsh().match(new RegExp(`^!macro ${name}\\b[\\s\\S]*?^!macroend`, 'm'))
+  if (!m) throw new Error(`macro ${name} not found in build/installer.nsh`)
+  return m[0]
+}
+
 describe('brand identity guard', () => {
   it('display name is AI Code Conductor, set only under build', () => {
     expect(pkg.build.productName).toBe('AI Code Conductor')
@@ -43,12 +58,12 @@ describe('brand identity guard', () => {
   })
 
   it('the installer still relocates a legacy install folder instead of nesting inside it', () => {
-    const nsh = readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
-    // customInit must run the step-up, and it must recognise both legacy folder
+    const nsh = readNsh()
+    // customInit must run the step-up, and it must recognise the legacy folder
     // names; without this an upgrade installs to <old folder>\AI Code Conductor.
     expect(nsh).toMatch(/!macro customInit/)
     expect(nsh).toMatch(/GetParent/)
-    expect(nsh).toContain('"Claude Command Center"')
+    expect(nshMacro('customInit')).toMatch(/StrCpy \$INSTDIR "\$R4\\\$\{APP_FILENAME\}"/)
     // And the old folder has to be cleaned up, or the machine keeps a dead copy
     // that nothing can uninstall (the single uninstall entry now points at the
     // new folder).
@@ -63,46 +78,128 @@ describe('brand identity guard', () => {
     // never fired and each rename installed INSIDE the previous folder:
     //   …\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
     // Missing any of these names re-opens that nesting.
-    const nsh = readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
-    // Scoped to the DETECTION macro, not the whole file: every one of these
-    // names also appears in the customInstall cleanup calls, so a whole-file
-    // `toContain` stayed green when the detection list was gutted (caught by
-    // mutation-testing this very guard).
-    const detect = nsh.match(/!macro IsLegacyBrandFolder[\s\S]*?!macroend/)
-    expect(detect, 'IsLegacyBrandFolder macro not found').not.toBeNull()
+    const detect = nshMacro('IsLegacyBrandFolder')
     for (const name of [
       '"Claude Command Center"',
       '"Claude Conductor"',
       '"Claude Command Center Beta"',
       '"Claude Conductor Beta"',
     ]) {
-      expect(detect![0]).toContain(name)
+      expect(detect).toContain(name)
     }
-    // And the walk has to look at ANCESTORS, not just the last component —
-    // a nested install's tail is already the current brand name.
+    // ...and "claude-conductor" must NOT be one of them. It is this repo's npm
+    // `name`, never an install directory: electron-builder only falls back to
+    // the sanitised package name when productFilename fails
+    // /^[-_+0-9a-zA-Z .]+$/ (targetUtil.js getWindowsInstallationDirName), and
+    // every brand name here passes. It IS, however, the obvious directory name
+    // for a source checkout — so listing it aims the sweep at working copies for
+    // no upside at all.
+    expect(detect).not.toContain('claude-conductor')
+
+    const nsh = readNsh()
+    // The walk has to look at ANCESTORS, not just the last component — a nested
+    // install's tail is already the current brand name.
     expect(nsh).toMatch(/GetFileName/)
     expect(nsh).toMatch(/\$\{Loop\}/)
     // ...but it must STOP at the first component that is neither a legacy name
-    // nor the app name. customInstall RMDir /r's whatever this resolves to, so
-    // an unbounded climb would let an install at
+    // nor the app name. customInstall RMDir /r's siblings of whatever this
+    // resolves to, so an unbounded climb would let an install at
     //   C:\Claude Conductor\dev\AI Code Conductor
-    // delete C:\Claude Conductor wholesale.
+    // treat C:\Claude Conductor as the legacy root.
     expect(nsh).toMatch(/\$\{ElseIf\}\s+\$R7\s+!=\s+"\$\{APP_FILENAME\}"/)
   })
 
-  it('a broken previous install is cleared silently instead of prompting', () => {
-    // electron-builder runs the recorded old uninstaller, retries 5x, and on
-    // failure shows "$(appCannotBeClosed)" — a message about the APP being
-    // open, raised when the UNINSTALLER failed. With no UninstallString it
-    // returns immediately, so clearing a record we know is broken is what keeps
-    // the upgrade silent. Both root keys, because the record can be in either.
-    const nsh = readFileSync(join(__dirname, '../../../build/installer.nsh'), 'utf-8')
-    expect(nsh).toMatch(/!macro ForgetPreviousInstall/)
-    expect(nsh).toMatch(/DeleteRegKey SHELL_CONTEXT "\$\{UNINSTALL_REGISTRY_KEY\}"/)
-    expect(nsh).toMatch(/DeleteRegKey HKCU "\$\{UNINSTALL_REGISTRY_KEY\}"/)
-    // Fired both for a legacy tree and for a recorded install whose binary is
-    // simply gone.
-    expect(nsh).toMatch(/IfNot\} \$\{FileExists\} "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}"/)
+  it('the sweep demands proof of ownership before RMDir /r', () => {
+    // RMDir /r is irreversible and FOLLOWS DIRECTORY JUNCTIONS — verified with
+    // the real makensis: with the reparse check removed, RMDir /r on a
+    // `mklink /J` junction emptied the tree it pointed at. A folder-name match
+    // is therefore not remotely enough. Scoped to the macro body, because every
+    // one of these tokens also appears in prose elsewhere in the file.
+    const body = nshMacro('RemoveLegacyInstall')
+    // 1. never the directory we are installing into
+    expect(body).toMatch(/\$\{If\}\s+"\$\{DIR\}"\s+==\s+"\$INSTDIR"/)
+    // 2. never a junction / symlink / mount point
+    expect(body).toMatch(/GetFileAttributes\}\s+"\$\{DIR\}"\s+"REPARSE_POINT"/)
+    // 3. never anything overlapping the user's data or resources directory.
+    //    Shipped builds defaulted DataDirectory to
+    //    "$LOCALAPPDATA\Claude Command Center" — a name this sweep looks for —
+    //    so an install into %LOCALAPPDATA% would delete the user's sessions,
+    //    logs and CONFIG, twenty lines after customInstall adopted that path.
+    expect(body).toMatch(/PathsOverlap "\$\{DIR\}" "\$R3"/)
+    expect(body).toMatch(/PathsOverlap "\$\{DIR\}" "\$R4"/)
+    // 4. positive proof it is an install root and not a source checkout
+    expect(body).toMatch(/FileExists\}\s+"\$\{DIR\}\\Uninstall \*\.exe"/)
+    // ...and the deletion itself still has to be there.
+    expect(body).toMatch(/RMDir \/r "\$\{DIR\}"/)
+    // The data/resources paths must actually be loaded before the sweep runs,
+    // from every brand key.
+    const install = nshMacro('customInstall')
+    expect(install).toMatch(/ReadUserPath "DataDirectory" \$R3/)
+    expect(install).toMatch(/ReadUserPath "ResourcesDirectory" \$R4/)
+    expect(nshMacro('ReadUserPath')).toContain('Software\\Claude Conductor')
+    // The cleanup list must not name the npm package directory either.
+    expect(install).not.toContain('claude-conductor')
+  })
+
+  it('the uninstall record is only dropped once the install is committing', () => {
+    // customInit runs inside .onInit — BEFORE the licence, install-mode,
+    // directory and data-directory pages. Clearing the Add/Remove Programs
+    // record there meant cancelling the wizard (or declining UAC) left the app
+    // fully installed with no ARP entry, uninstallable by neither user nor MDM.
+    // installSection.nsh inserts CHECK_APP_RUNNING immediately before
+    // uninstallOldVersion, which is both after the user committed and before the
+    // only place the old uninstaller is ever run.
+    expect(nshMacro('customInit')).not.toMatch(/DeleteRegKey/)
+    expect(nshMacro('customCheckAppRunning')).toMatch(/ForgetBrokenPreviousInstall/)
+
+    // And the delete has to follow the hive it was asked about. appId is frozen,
+    // so a per-user and a per-machine install share the key PATH but are two
+    // separate installations: an unconditional `DeleteRegKey HKCU` from an
+    // /allusers run destroyed a healthy per-user record, after which
+    // uninstallOldVersion HKEY_CURRENT_USER read an empty UninstallString and
+    // returned — orphaning that copy on disk.
+    const forget = nshMacro('ForgetPreviousInstallIn')
+    expect(forget).toMatch(/DeleteRegKey \$\{ROOT_KEY\} "\$\{UNINSTALL_REGISTRY_KEY\}"/)
+    expect(forget).not.toMatch(/DeleteRegKey HKCU/)
+    expect(forget).not.toMatch(/DeleteRegKey SHELL_CONTEXT/)
+
+    // The "is the previous install still there?" test reads the RECORDED
+    // uninstaller, not $INSTDIR\<app>.exe. The old exe-existence gate wrongly
+    // condemned any beta.5-or-older install sitting in a non-legacy-named
+    // folder, where the executable was still called Claude Command Center.exe.
+    expect(forget).toMatch(/ReadRegStr \$R0 \$\{ROOT_KEY\} "\$\{UNINSTALL_REGISTRY_KEY\}" "UninstallString"/)
+    expect(forget).toMatch(/\$\{ElseIfNot\} \$\{FileExists\} "\$R1"/)
+    expect(readNsh()).not.toMatch(/FileExists\} "\$INSTDIR\\\$\{APP_EXECUTABLE_FILENAME\}"/)
+  })
+
+  it('the relocation also neutralises the registry seed that would undo it', () => {
+    // $INSTDIR is seeded from ${INSTALL_REGISTRY_KEY}\InstallLocation, and on
+    // any interactive run that read happens AGAIN after customInit: the
+    // install-mode page's Leave (multiUserUi.nsh:184,187) and every skip path in
+    // its Pre re-run setInstallModePerUser / setInstallModePerAllUsers. The
+    // in-app updater launches the installer with no arguments, so auto-update IS
+    // that path — leaving just `StrCpy $INSTDIR` here would re-nest the install
+    // AND leave the old tree orphaned.
+    const init = nshMacro('customInit')
+    expect(init).toMatch(/RetargetRecordedInstallLocation HKCU/)
+    expect(init).toMatch(/RetargetRecordedInstallLocation HKLM/)
+    const retarget = nshMacro('RetargetRecordedInstallLocation')
+    expect(retarget).toMatch(/ReadRegStr \$R3 \$\{HIVE\} "\$\{INSTALL_REGISTRY_KEY\}" "InstallLocation"/)
+    expect(retarget).toMatch(/WriteRegStr \$\{HIVE\} "\$\{INSTALL_REGISTRY_KEY\}" "InstallLocation" "\$INSTDIR"/)
+    // Only a record that names the tree being left behind is touched.
+    expect(retarget).toMatch(/IsSameOrInside "\$\{LEGACY_ROOT\}"/)
+
+    // ...and it is undone if the wizard never installs anything: that value is
+    // where the UNINSTALLER gets its $INSTDIR from, so a dangling one would make
+    // a later uninstall delete nothing and then drop the ARP entry. MUI2 owns
+    // Function .onUserAbort, so this has to ride its callback.
+    const nsh = readNsh()
+    expect(nsh).toMatch(/!define MUI_CUSTOMFUNCTION_ABORT "CccRestoreInstallLocation"/)
+    expect(nsh).toMatch(/Function CccRestoreInstallLocation/)
+    expect(nsh).toMatch(/Function \.onInstFailed/)
+
+    // An explicit /D= is the operator's directory and is never relocated.
+    expect(init).toMatch(/GetDParameter/)
   })
 
   it('release artifacts carry the current brand name, on every platform', () => {

--- a/tests/unit/main/brand-identity-guard.test.ts
+++ b/tests/unit/main/brand-identity-guard.test.ts
@@ -82,6 +82,12 @@ describe('brand identity guard', () => {
     // a nested install's tail is already the current brand name.
     expect(nsh).toMatch(/GetFileName/)
     expect(nsh).toMatch(/\$\{Loop\}/)
+    // ...but it must STOP at the first component that is neither a legacy name
+    // nor the app name. customInstall RMDir /r's whatever this resolves to, so
+    // an unbounded climb would let an install at
+    //   C:\Claude Conductor\dev\AI Code Conductor
+    // delete C:\Claude Conductor wholesale.
+    expect(nsh).toMatch(/\$\{ElseIf\}\s+\$R7\s+!=\s+"\$\{APP_FILENAME\}"/)
   })
 
   it('a broken previous install is cleared silently instead of prompting', () => {

--- a/tests/unit/main/installer-nsis-behaviour.test.ts
+++ b/tests/unit/main/installer-nsis-behaviour.test.ts
@@ -1,0 +1,706 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/**
+ * BEHAVIOURAL tests for the destructive half of build/installer.nsh.
+ *
+ * The sibling brand-identity-guard.test.ts asserts that the guards are PRESENT.
+ * Presence is not enough and was measured not to be: every deletion mutant went
+ * red, and every POLARITY mutant stayed green — including `${If} $R8 == 1`
+ * rewritten to `${If} "1" == "1"` immediately before `RMDir /r`, which compiled,
+ * ran, and destroyed a junction target, a source checkout and the user's
+ * CONFIG/settings.json with the suite still green.
+ *
+ * So this compiles the REAL macros out of build/installer.nsh with the REAL
+ * makensis, runs them over a real fixture tree (junction, source checkout, data
+ * directory, a directory named like an uninstaller, a triple-nested legacy
+ * chain) and asserts which paths survive and which do not. A flipped guard
+ * changes what is on disk afterwards, which is the only thing that can catch it.
+ *
+ * Sandboxing, because this executes RMDir /r and writes to the registry for
+ * real:
+ *   - every path lives under a mkdtemp directory that is removed afterwards;
+ *   - `Software\<brand>` reads/writes are rewritten to `Software\CccProbe\…`
+ *     and that key is deleted afterwards;
+ *   - `$DESKTOP` / `$SMPROGRAMS` are rewritten to a fixture directory so the
+ *     shortcut deletion cannot reach the real user's Desktop or Start Menu.
+ *
+ * Skips (does not fail) when makensis is unavailable, so non-Windows CI is
+ * unaffected — with a tripwire below that fails if it skips on a machine that
+ * plainly does have it.
+ */
+
+const NSH = join(__dirname, '../../../build/installer.nsh')
+
+/** Macros lifted verbatim out of build/installer.nsh into the probe script. */
+const PROBE_MACROS = [
+  'IsLegacyBrandFolder',
+  'IsChainFolder',
+  'IsSameOrInside',
+  'PathsOverlap',
+  'CanonPathPair',
+  'PathsOverlapCanon',
+  'FindLegacyRoot',
+  'ReadUserPath',
+  'CccGetInQuotes',
+  'RemoveLegacyInstall',
+  'ProveLegacyInstallRoot',
+  'ClassifyUninstallRecord',
+  'ForgetPreviousInstallIn',
+  'ForgetBrokenPreviousInstall',
+  'SuspendUninstallRecordIn',
+  'CaptureRecordedUninstaller',
+  'RetargetRecordedInstallLocation',
+  'customHeader',
+  'customInit',
+  'customInstall',
+  'AdoptLegacyValue',
+]
+
+const PROBE_REG_KEY = 'HKCU\\Software\\CccProbe'
+
+function nsisCacheRoot(): string | null {
+  const local = process.env.LOCALAPPDATA
+  return local ? join(local, 'electron-builder', 'Cache', 'nsis') : null
+}
+
+function findMakensis(): string | null {
+  if (process.platform !== 'win32') return null
+  if (process.env.MAKENSIS && existsSync(process.env.MAKENSIS)) return process.env.MAKENSIS
+  const cache = nsisCacheRoot()
+  if (cache && existsSync(cache)) {
+    // Newest first, so a refreshed cache wins over a stale one.
+    const versions = readdirSync(cache)
+      .filter((n) => n.startsWith('nsis-'))
+      .sort()
+      .reverse()
+    for (const v of versions) {
+      const exe = join(cache, v, 'makensis.exe')
+      if (existsSync(exe)) return exe
+    }
+  }
+  for (const p of [
+    'C:\\Program Files (x86)\\NSIS\\makensis.exe',
+    'C:\\Program Files\\NSIS\\makensis.exe',
+  ]) {
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+const MAKENSIS = findMakensis()
+
+describe('installer.nsh behavioural probe — availability', () => {
+  it('finds makensis wherever electron-builder cached it', () => {
+    // The whole point of this file is that it RUNS. If the locator quietly
+    // stops finding a compiler that is obviously present, everything below
+    // turns into a green no-op and the guards go back to being untested.
+    const cache = nsisCacheRoot()
+    const cachePresent =
+      process.platform === 'win32' && cache !== null && existsSync(cache) &&
+      readdirSync(cache).some((n) => n.startsWith('nsis-'))
+    if (cachePresent) expect(MAKENSIS).not.toBeNull()
+    else expect(true).toBe(true) // nothing to find; the suite below skips
+  })
+})
+
+/** One probe run's inputs. Everything is read at RUNTIME from an ini file, so
+ *  the two probe executables are compiled once and re-used by every scenario. */
+interface ProbeConfig {
+  instdir: string
+  parent: string
+  data: string
+  res: string
+  legacyUninstaller: string
+  linkRoot: string
+  dparam: string
+  installMode: string
+  inner: boolean
+  repage: boolean
+  shortenInstdir: boolean
+  abort: boolean
+  seedFromRegistry: boolean
+}
+
+function extractMacros(): string {
+  const src = readFileSync(NSH, 'utf-8')
+  const text = PROBE_MACROS.map((name) => {
+    const m = src.match(new RegExp(`^!macro ${name}\\b[\\s\\S]*?^!macroend`, 'm'))
+    if (!m) throw new Error(`macro ${name} not found in build/installer.nsh`)
+    return m[0]
+  }).join('\n\n')
+
+  return text
+    // Sandbox the app's own registry keys — the probe must never touch the real ones.
+    .replace(/Software\\(AI Code Conductor|Claude Command Center|Claude Conductor)/g,
+      'Software\\CccProbe\\$1')
+    // ...and never the real user's shortcuts.
+    .replace(/\$DESKTOP/g, '$cccProbeLinkRoot')
+    .replace(/\$SMPROGRAMS/g, '$cccProbeLinkRoot')
+}
+
+function probeScript(mode: 'sweep' | 'e2e', out: string, cfg: string, log: string): string {
+  const readCfg = (v: string, key: string) => `  ReadINIStr ${v} "${cfg}" "probe" "${key}"`
+
+  const body = mode === 'sweep'
+    ? `
+  StrCpy $INSTDIR $cccProbeInstDir
+  \${If} $cccProbeShorten == "1"
+    GetFullPathName /SHORT $R0 "$INSTDIR"
+    \${If} $R0 != ""
+      StrCpy $INSTDIR "$R0"
+    \${EndIf}
+    ClearErrors
+  \${EndIf}
+  FileWrite $cccProbeLog "instdir=$INSTDIR$\\r$\\n"
+  StrCpy $R3 $cccProbeData
+  StrCpy $R4 $cccProbeRes
+  StrCpy $cccLegacyUninstaller $cccProbeLegacyUninst
+  StrCpy $R2 $cccProbeParent
+  !insertmacro RemoveLegacyInstall "$R2\\Claude Conductor Beta" "Claude Conductor Beta"
+  !insertmacro RemoveLegacyInstall "$R2\\Claude Command Center Beta" "Claude Command Center Beta"
+  !insertmacro RemoveLegacyInstall "$R2\\Claude Command Center" "Claude Command Center"
+  !insertmacro RemoveLegacyInstall "$R2\\Claude Conductor" "Claude Conductor"
+`
+    : `
+  ; initMultiUser: $INSTDIR is seeded from the recorded install location.
+  StrCpy $INSTDIR $cccProbeInstDir
+  \${If} $cccProbeSeedReg == "1"
+    ReadRegStr $0 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+    \${If} $0 != ""
+      StrCpy $INSTDIR "$0"
+    \${EndIf}
+  \${EndIf}
+  FileWrite $cccProbeLog "seed=$INSTDIR$\\r$\\n"
+
+  !insertmacro customInit
+  ReadRegStr $9 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+  FileWrite $cccProbeLog "afterInit=$INSTDIR$\\r$\\n"
+  FileWrite $cccProbeLog "installLocationAfterInit=$9$\\r$\\n"
+  FileWrite $cccProbeLog "captured=$cccLegacyUninstaller$\\r$\\n"
+
+  ; Interactive run: the install-mode page's Leave callback re-runs
+  ; setInstallModePerUser, which re-seeds $INSTDIR from the same value.
+  \${If} $cccProbeRepage == "1"
+    ReadRegStr $0 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+    \${If} $0 != ""
+      StrCpy $INSTDIR "$0"
+    \${EndIf}
+  \${EndIf}
+  FileWrite $cccProbeLog "afterPage=$INSTDIR$\\r$\\n"
+
+  \${If} $cccProbeAbort == "1"
+    ; The wizard is cancelled after customInit — MUI's abort callback.
+    Call CccRestoreInstallLocation
+    ReadRegStr $7 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+    ReadRegStr $8 HKCU "\${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+    FileWrite $cccProbeLog "restoredInstallLocation=$7$\\r$\\n"
+    FileWrite $cccProbeLog "restoredUninstallString=$8$\\r$\\n"
+    Goto cccProbeFinished
+
+  \${EndIf}
+
+  ; installSection.nsh: CHECK_APP_RUNNING, guarded by \${ifNot} \${UAC_IsInnerInstance}.
+  \${If} $cccProbeInner != "1"
+    !insertmacro ForgetBrokenPreviousInstall
+  \${EndIf}
+
+  ; installSection.nsh: uninstallOldVersion — where the OLD uninstaller is run,
+  ; with _?=<installationDir> resolved exactly as installUtil.nsh:155-176 does.
+  ReadRegStr $1 HKCU "\${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+  StrCpy $2 ""
+  \${If} $1 != ""
+    !insertmacro CccGetInQuotes "$1" $3
+    ReadRegStr $2 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+    \${If} $2 == ""
+      \${GetParent} "$3" $2
+    \${EndIf}
+  \${EndIf}
+  FileWrite $cccProbeLog "oldUninstallString=$1$\\r$\\n"
+  FileWrite $cccProbeLog "oldUninstallTarget=$2$\\r$\\n"
+
+  ; installApplicationFiles + registryAddInstallInfo.
+  CreateDirectory "$INSTDIR"
+  FileOpen $4 "$INSTDIR\\AI Code Conductor.exe" w
+  FileWrite $4 "new"
+  FileClose $4
+  FileOpen $4 "$INSTDIR\\Uninstall AI Code Conductor.exe" w
+  FileWrite $4 "new"
+  FileClose $4
+  WriteRegStr HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
+  WriteRegStr HKCU "\${UNINSTALL_REGISTRY_KEY}" "UninstallString" '"$INSTDIR\\Uninstall AI Code Conductor.exe" /currentuser'
+
+  !insertmacro customInstall
+
+  ReadRegStr $5 HKCU "\${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+  ReadRegStr $6 HKCU "\${INSTALL_REGISTRY_KEY}" "InstallLocation"
+  FileWrite $cccProbeLog "arpUninstallString=$5$\\r$\\n"
+  FileWrite $cccProbeLog "arpInstallLocation=$6$\\r$\\n"
+  FileWrite $cccProbeLog "final=$INSTDIR$\\r$\\n"
+  cccProbeFinished:
+`
+
+  return `Unicode true
+SetCompress off
+RequestExecutionLevel user
+SilentInstall silent
+Name "CccInstallerProbe"
+OutFile "${out}"
+InstallDir "$TEMP\\ccc-nsis-probe-unused"
+
+!include "LogicLib.nsh"
+!include "FileFunc.nsh"
+
+!define APP_FILENAME "AI Code Conductor"
+!define INSTALL_REGISTRY_KEY "Software\\CccProbe\\Install"
+!define UNINSTALL_REGISTRY_KEY "Software\\CccProbe\\Uninstall"
+
+Var installMode
+Var cccProbeLog
+Var cccProbeInner
+Var cccProbeRepage
+Var cccProbeShorten
+Var cccProbeAbort
+Var cccProbeSeedReg
+Var cccProbeInstDir
+Var cccProbeParent
+Var cccProbeData
+Var cccProbeRes
+Var cccProbeLegacyUninst
+Var cccProbeLinkRoot
+Var cccProbeD
+
+; multiUser.nsh's UAC predicate, driven by the ini instead of a real elevation.
+!define UAC_IsInnerInstance \`$cccProbeInner == "1"\`
+
+; multiUser.nsh's /D= reader, driven by the ini instead of StdUtils.
+!macro GetDParameter outVar
+  StrCpy \${outVar} $cccProbeD
+!macroend
+
+${extractMacros()}
+
+!insertmacro customHeader
+
+Page instfiles
+
+Section "probe"
+  SetShellVarContext current
+${readCfg('$cccProbeInstDir', 'instdir')}
+${readCfg('$cccProbeParent', 'parent')}
+${readCfg('$cccProbeData', 'data')}
+${readCfg('$cccProbeRes', 'res')}
+${readCfg('$cccProbeLegacyUninst', 'legacyUninstaller')}
+${readCfg('$cccProbeLinkRoot', 'linkRoot')}
+${readCfg('$cccProbeD', 'dparam')}
+${readCfg('$cccProbeInner', 'inner')}
+${readCfg('$cccProbeRepage', 'repage')}
+${readCfg('$cccProbeShorten', 'shortenInstdir')}
+${readCfg('$cccProbeAbort', 'abort')}
+${readCfg('$cccProbeSeedReg', 'seedFromRegistry')}
+${readCfg('$installMode', 'installMode')}
+  ClearErrors
+  FileOpen $cccProbeLog "${log}" w
+${body}
+  FileWrite $cccProbeLog "done=1$\\r$\\n"
+  FileClose $cccProbeLog
+SectionEnd
+`
+}
+
+// ---------------------------------------------------------------- harness ---
+
+let work = ''
+const sweepExe = () => join(work, 'probe-sweep.exe')
+const e2eExe = () => join(work, 'probe-e2e.exe')
+const cfgPath = () => join(work, 'probe.ini')
+const logPath = () => join(work, 'probe.log')
+
+function compile(mode: 'sweep' | 'e2e', out: string) {
+  const nsi = join(work, `probe-${mode}.nsi`)
+  writeFileSync(nsi, probeScript(mode, out, cfgPath(), logPath()))
+  try {
+    execFileSync(MAKENSIS as string, ['/V2', nsi], { encoding: 'utf-8', stdio: 'pipe' })
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string }
+    throw new Error(`makensis failed for ${mode}:\n${err.stdout ?? ''}${err.stderr ?? ''}`)
+  }
+}
+
+function run(mode: 'sweep' | 'e2e', cfg: Partial<ProbeConfig>): Record<string, string> {
+  const merged: ProbeConfig = {
+    instdir: '', parent: '', data: '', res: '', legacyUninstaller: '', linkRoot: '',
+    dparam: '', installMode: 'CurrentUser', inner: false, repage: false,
+    shortenInstdir: false, abort: false, seedFromRegistry: true, ...cfg,
+  }
+  writeFileSync(cfgPath(), [
+    '[probe]',
+    `instdir=${merged.instdir}`,
+    `parent=${merged.parent}`,
+    `data=${merged.data}`,
+    `res=${merged.res}`,
+    `legacyUninstaller=${merged.legacyUninstaller}`,
+    `linkRoot=${merged.linkRoot}`,
+    `dparam=${merged.dparam}`,
+    `installMode=${merged.installMode}`,
+    `inner=${merged.inner ? 1 : 0}`,
+    `repage=${merged.repage ? 1 : 0}`,
+    `shortenInstdir=${merged.shortenInstdir ? 1 : 0}`,
+    `abort=${merged.abort ? 1 : 0}`,
+    `seedFromRegistry=${merged.seedFromRegistry ? 1 : 0}`,
+    '',
+  ].join('\r\n'))
+  rmSync(logPath(), { force: true })
+  execFileSync(mode === 'sweep' ? sweepExe() : e2eExe(), [], { encoding: 'utf-8', stdio: 'pipe' })
+  const out: Record<string, string> = {}
+  for (const line of readFileSync(logPath(), 'utf-8').split(/\r?\n/)) {
+    const i = line.indexOf('=')
+    if (i > 0) out[line.slice(0, i)] = line.slice(i + 1)
+  }
+  if (out.done !== '1') throw new Error(`probe did not complete: ${JSON.stringify(out)}`)
+  return out
+}
+
+const dir = (p: string) => mkdirSync(p, { recursive: true })
+const file = (p: string, c = 'x') => { dir(dirname(p)); writeFileSync(p, c) }
+const junction = (link: string, target: string) =>
+  execFileSync('cmd', ['/c', 'mklink', '/J', link, target], { stdio: 'pipe' })
+
+function regClear() {
+  try { execFileSync('reg', ['delete', PROBE_REG_KEY, '/f'], { stdio: 'pipe' }) } catch { /* absent */ }
+}
+function regSet(sub: string, name: string, value: string) {
+  execFileSync('reg',
+    ['add', `${PROBE_REG_KEY}\\${sub}`, '/v', name, '/t', 'REG_SZ', '/d', value, '/f'],
+    { stdio: 'pipe' })
+}
+
+/** A fresh fixture root per scenario; RMDir /r makes them single-use. */
+function scenario(name: string) {
+  const root = join(work, name)
+  rmSync(root, { recursive: true, force: true, maxRetries: 5 })
+  const links = join(root, 'links')
+  dir(links)
+  return { root, programs: join(root, 'Programs'), links }
+}
+
+/** The triple-nested shape this whole change exists to clean up. */
+function nestedChain(programs: string) {
+  return join(programs, 'Claude Conductor Beta', 'Claude Command Center Beta', 'AI Code Conductor')
+}
+
+describe.skipIf(!MAKENSIS)('installer.nsh behavioural probe', () => {
+  beforeAll(() => {
+    work = mkdtempSync(join(tmpdir(), 'ccc-nsis-probe-'))
+    regClear()
+    compile('sweep', sweepExe())
+    compile('e2e', e2eExe())
+  }, 120_000)
+
+  afterAll(() => {
+    regClear()
+    if (work) rmSync(work, { recursive: true, force: true, maxRetries: 5 })
+  })
+
+  it('sweeps the nested legacy tree and nothing else', () => {
+    const { root, programs, links } = scenario('guards')
+    dir(join(programs, 'AI Code Conductor'))
+
+    // (a) the owner's real shape: the uninstaller exists ONLY at the leaf.
+    const leaf = nestedChain(programs)
+    dir(leaf)
+    file(join(leaf, 'Uninstall AI Code Conductor.exe'))
+
+    // (b) a junction whose target holds a perfectly good uninstaller.
+    dir(join(root, 'junction-target'))
+    file(join(root, 'junction-target', 'keep.txt'))
+    file(join(root, 'junction-target', 'Uninstall AI Code Conductor.exe'))
+    junction(join(programs, 'Claude Command Center'), join(root, 'junction-target'))
+
+    // (c) a source checkout, with a DIRECTORY named like an uninstaller.
+    file(join(programs, 'Claude Conductor', 'src', 'index.ts'))
+    dir(join(programs, 'Claude Conductor', 'Uninstall trick.exe'))
+
+    // (d) the user's data directory, which is also a legacy-named sibling AND
+    //     contains a real uninstaller, so only the overlap check saves it.
+    const data = join(programs, 'Claude Command Center Beta')
+    file(join(data, 'CONFIG', 'settings.json'), '{}')
+    file(join(data, 'Uninstall AI Code Conductor.exe'))
+
+    file(join(links, 'Claude Conductor Beta.lnk'))
+    file(join(links, 'Claude Conductor.lnk'))
+    dir(join(root, 'res'))
+
+    run('sweep', {
+      instdir: join(programs, 'AI Code Conductor'),
+      parent: programs,
+      data,
+      res: join(root, 'res'),
+      linkRoot: links,
+    })
+
+    expect(existsSync(join(programs, 'Claude Conductor Beta'))).toBe(false)
+    expect(existsSync(join(links, 'Claude Conductor Beta.lnk'))).toBe(false)
+    // junction, and above all the tree it points at
+    expect(existsSync(join(programs, 'Claude Command Center'))).toBe(true)
+    expect(existsSync(join(root, 'junction-target', 'keep.txt'))).toBe(true)
+    // source checkout — a directory called "Uninstall trick.exe" is not proof
+    expect(existsSync(join(programs, 'Claude Conductor', 'src', 'index.ts'))).toBe(true)
+    // user data
+    expect(existsSync(join(data, 'CONFIG', 'settings.json'))).toBe(true)
+    // and the install we just made
+    expect(existsSync(join(programs, 'AI Code Conductor'))).toBe(true)
+    expect(existsSync(join(links, 'Claude Conductor.lnk'))).toBe(true)
+  }, 60_000)
+
+  it('refuses a data directory recorded with forward slashes', () => {
+    const { root, programs, links } = scenario('slash')
+    dir(join(programs, 'AI Code Conductor'))
+    const data = join(programs, 'Claude Command Center Beta')
+    file(join(data, 'CONFIG', 'settings.json'), '{}')
+    file(join(data, 'Uninstall AI Code Conductor.exe'))
+    dir(join(root, 'res'))
+
+    run('sweep', {
+      instdir: join(programs, 'AI Code Conductor'),
+      parent: programs,
+      data: data.replace(/\\/g, '/'),
+      res: join(root, 'res'),
+      linkRoot: links,
+    })
+
+    expect(existsSync(join(data, 'CONFIG', 'settings.json'))).toBe(true)
+  }, 60_000)
+
+  it('refuses everything when the data/resources directories are unreadable', () => {
+    // HKCU-only reads come back empty on an all-users install elevated by a
+    // different admin. Empty must mean "cannot tell", not "no overlap".
+    const { programs, links } = scenario('unknown-data')
+    dir(join(programs, 'AI Code Conductor'))
+    const data = join(programs, 'Claude Command Center Beta')
+    file(join(data, 'CONFIG', 'settings.json'), '{}')
+    file(join(data, 'Uninstall AI Code Conductor.exe'))
+    const leaf = nestedChain(programs)
+    dir(leaf)
+    file(join(leaf, 'Uninstall AI Code Conductor.exe'))
+
+    run('sweep', {
+      instdir: join(programs, 'AI Code Conductor'),
+      parent: programs,
+      data: '',
+      res: '',
+      linkRoot: links,
+    })
+
+    expect(existsSync(join(data, 'CONFIG', 'settings.json'))).toBe(true)
+    expect(existsSync(join(programs, 'Claude Conductor Beta'))).toBe(true)
+  }, 60_000)
+
+  it('never sweeps $INSTDIR, even spelled as an 8.3 short name', () => {
+    const { root, programs, links } = scenario('shortname')
+    const target = join(programs, 'Claude Conductor')
+    file(join(target, 'Uninstall AI Code Conductor.exe'))
+    file(join(target, 'app.asar'))
+    dir(join(root, 'data'))
+    dir(join(root, 'res'))
+
+    const log = run('sweep', {
+      instdir: target,
+      parent: programs,
+      data: join(root, 'data'),
+      res: join(root, 'res'),
+      linkRoot: links,
+      shortenInstdir: true,
+    })
+
+    // Only meaningful where the volume actually generates 8.3 names.
+    if (log.instdir.toLowerCase() !== target.toLowerCase()) {
+      expect(log.instdir).toMatch(/~1/)
+    }
+    expect(existsSync(join(target, 'app.asar'))).toBe(true)
+  }, 60_000)
+
+  it('accepts the uninstaller the replaced install recorded as proof', () => {
+    // No "Uninstall *.exe" anywhere in the tree — the only evidence is the path
+    // the ARP record named, captured by customInit before it was rewritten.
+    const { root, programs, links } = scenario('recorded')
+    dir(join(programs, 'AI Code Conductor'))
+    const leaf = nestedChain(programs)
+    dir(leaf)
+    file(join(leaf, 'unins000.exe'))
+    file(join(programs, 'Claude Conductor', 'src', 'index.ts'))
+    dir(join(root, 'data'))
+    dir(join(root, 'res'))
+
+    run('sweep', {
+      instdir: join(programs, 'AI Code Conductor'),
+      parent: programs,
+      data: join(root, 'data'),
+      res: join(root, 'res'),
+      linkRoot: links,
+      legacyUninstaller: join(leaf, 'unins000.exe'),
+    })
+
+    expect(existsSync(join(programs, 'Claude Conductor Beta'))).toBe(false)
+    // ...and the record proves nothing about a folder it does not name.
+    expect(existsSync(join(programs, 'Claude Conductor', 'src', 'index.ts'))).toBe(true)
+  }, 60_000)
+
+  /** The owner's real case, start to finish. */
+  function upgradeFixture(name: string, uninstallerName = 'Uninstall AI Code Conductor.exe') {
+    const s = scenario(name)
+    const leaf = nestedChain(s.programs)
+    dir(leaf)
+    file(join(leaf, uninstallerName))
+    file(join(leaf, 'app.asar'))
+    file(join(s.root, 'data', 'CONFIG', 'settings.json'), '{}')
+    dir(join(s.root, 'res'))
+
+    regClear()
+    regSet('Install', 'InstallLocation', leaf)
+    regSet('Uninstall', 'UninstallString', `"${join(leaf, uninstallerName)}" /currentuser`)
+    // Only the LEGACY brand key has them, so customInstall's AdoptLegacyValue is
+    // what makes the data-directory guard usable at all.
+    regSet('Claude Command Center', 'DataDirectory', join(s.root, 'data'))
+    regSet('Claude Command Center', 'ResourcesDirectory', join(s.root, 'res'))
+    return { ...s, leaf, uninstaller: join(leaf, uninstallerName), expected: join(s.programs, 'AI Code Conductor') }
+  }
+
+  for (const [label, opts] of [
+    ['silently (/S)', { repage: false }],
+    ['interactively', { repage: true }],
+  ] as const) {
+    it(`upgrades a triple-nested install ${label}`, () => {
+      const f = upgradeFixture(`e2e-${opts.repage ? 'interactive' : 'silent'}`)
+      const log = run('e2e', { instdir: f.expected, parent: f.programs, linkRoot: f.links, ...opts })
+      regClear()
+
+      // relocated out of the legacy tree, and the relocation SURVIVED the
+      // install-mode page re-reading InstallLocation
+      expect(log.afterInit).toBe(f.expected)
+      expect(log.afterPage).toBe(f.expected)
+      // the old uninstaller is never run
+      expect(log.oldUninstallString).toBe('')
+      expect(log.oldUninstallTarget).toBe('')
+      // the old tree is GONE — the regression this change exists to fix
+      expect(existsSync(join(f.programs, 'Claude Conductor Beta'))).toBe(false)
+      // ...and the ARP record points at the new install
+      expect(log.arpInstallLocation).toBe(f.expected)
+      expect(log.arpUninstallString).toContain(f.expected)
+      expect(existsSync(join(f.expected, 'AI Code Conductor.exe'))).toBe(true)
+      // user data untouched
+      expect(existsSync(join(f.root, 'data', 'CONFIG', 'settings.json'))).toBe(true)
+    }, 60_000)
+  }
+
+  it('carries the recorded uninstaller across the commit point as proof', () => {
+    // Nothing in the tree matches "Uninstall *.exe", so the ONLY thing that can
+    // prove the folder is an install of this app is the path the ARP record
+    // named — and by the time customInstall runs, the commit point has cleared
+    // that record and registryAddInstallInfo has written a new one pointing at
+    // $INSTDIR. customInit capturing it in .onInit is the whole mechanism.
+    const f = upgradeFixture('e2e-recorded', 'unins000.exe')
+    const log = run('e2e', { instdir: f.expected, parent: f.programs, linkRoot: f.links })
+    regClear()
+
+    expect(log.captured).toBe(f.uninstaller)
+    expect(existsSync(join(f.programs, 'Claude Conductor Beta'))).toBe(false)
+  }, 60_000)
+
+  it('leaves an install location recorded OUTSIDE the legacy tree alone', () => {
+    // appId is frozen, so a per-user and a per-machine install share the key
+    // PATH but are two separate installations. Retargeting a record that does
+    // not name the tree being replaced would point the OTHER installation's
+    // uninstaller — and its own next upgrade — at this run's directory.
+    const s = scenario('e2e-foreign-record')
+    const leaf = nestedChain(s.programs)
+    dir(leaf)
+    file(join(leaf, 'Uninstall AI Code Conductor.exe'))
+    const foreign = join(s.programs, 'Elsewhere', 'AI Code Conductor')
+    file(join(foreign, 'Uninstall AI Code Conductor.exe'))
+    file(join(s.root, 'data', 'CONFIG', 'settings.json'), '{}')
+    dir(join(s.root, 'res'))
+
+    regClear()
+    regSet('Install', 'InstallLocation', foreign)
+    regSet('Claude Command Center', 'DataDirectory', join(s.root, 'data'))
+    regSet('Claude Command Center', 'ResourcesDirectory', join(s.root, 'res'))
+
+    const log = run('e2e', {
+      instdir: leaf, parent: s.programs, linkRoot: s.links, seedFromRegistry: false,
+    })
+    regClear()
+
+    expect(log.afterInit).toBe(join(s.programs, 'AI Code Conductor'))
+    expect(log.installLocationAfterInit).toBe(foreign)
+  }, 60_000)
+
+  it('never aims the old uninstaller at the new directory in the elevated inner instance', () => {
+    // installSection.nsh:35-37 skips CHECK_APP_RUNNING for ${UAC_IsInnerInstance},
+    // so the commit-point clear never runs there while customInit's retarget
+    // does — which pointed uninstallOldVersion's _?= at the NEW directory and
+    // had the old uninstaller RMDir /r it before installApplicationFiles.
+    const f = upgradeFixture('e2e-inner')
+    const log = run('e2e', {
+      instdir: f.expected, parent: f.programs, linkRoot: f.links,
+      inner: true, repage: true, installMode: 'all',
+    })
+    regClear()
+
+    expect(log.afterPage).toBe(f.expected)
+    expect(log.oldUninstallTarget).not.toBe(f.expected)
+    expect(log.oldUninstallString).toBe('')
+    expect(existsSync(join(f.programs, 'Claude Conductor Beta'))).toBe(false)
+    expect(existsSync(join(f.root, 'data', 'CONFIG', 'settings.json'))).toBe(true)
+  }, 60_000)
+
+  it('puts the retargeted and suspended registry values back when the wizard is cancelled', () => {
+    // customInit rewrites InstallLocation (and, in the elevated inner instance,
+    // removes UninstallString) inside .onInit — long before the user commits.
+    // Both are the uninstaller's only way home: a dangling InstallLocation makes
+    // a later Add/Remove-Programs uninstall delete nothing and then drop the
+    // entry, and a missing UninstallString removes the uninstall button.
+    const f = upgradeFixture('e2e-abort')
+    const log = run('e2e', {
+      instdir: f.expected, parent: f.programs, linkRoot: f.links,
+      inner: true, repage: true, installMode: 'all', abort: true,
+    })
+    regClear()
+
+    expect(log.afterInit).toBe(f.expected) // the retarget did happen...
+    expect(log.restoredInstallLocation).toBe(f.leaf) // ...and was undone
+    expect(log.restoredUninstallString)
+      .toBe(`"${join(f.leaf, 'Uninstall AI Code Conductor.exe')}" /currentuser`)
+  }, 60_000)
+
+  it('never relocates an explicit /D= directory', () => {
+    const f = upgradeFixture('e2e-dparam-relocate')
+    const log = run('e2e', {
+      instdir: f.leaf, parent: f.programs, linkRoot: f.links,
+      dparam: f.leaf, seedFromRegistry: false,
+    })
+    regClear()
+
+    expect(log.afterInit).toBe(f.leaf)
+  }, 60_000)
+
+  it('never sweeps the siblings of an explicit /D= directory', () => {
+    // initMultiUser applies /D= last, so $INSTDIR is the operator's directory
+    // and its siblings are not this installer's business — the same reasoning
+    // that already suppresses the relocation.
+    const f = upgradeFixture('e2e-dparam-sweep')
+    const custom = join(f.programs, 'Custom Location')
+    dir(custom)
+    const log = run('e2e', {
+      instdir: custom, parent: f.programs, linkRoot: f.links,
+      dparam: custom, seedFromRegistry: false,
+    })
+    regClear()
+
+    expect(log.afterInit).toBe(custom)
+    expect(existsSync(join(f.programs, 'Claude Conductor Beta'))).toBe(true)
+  }, 60_000)
+})

--- a/tests/unit/main/pty-shell-quote-callsites.test.ts
+++ b/tests/unit/main/pty-shell-quote-callsites.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The two launch-line values in pty-manager that are NOT built by
+ * spawn-claude-command, and therefore did not inherit its quoting fix.
+ *
+ * Both were confirmed executing arbitrary PowerShell during an independent
+ * review, from the same config JSON as the originally-reported working
+ * directory:
+ *
+ *   - the shell-only ("Terminal" session) `Set-Location` — the twin of the
+ *     Claude launch path, firing on the cd before any binary runs;
+ *   - the `--agents` JSON, where a curly apostrophe in an agent description is
+ *     ordinary prose and broke launches by accident.
+ *
+ * pty-manager itself cannot be imported in a unit test (node-pty + Electron),
+ * so these assert the PROPERTY of the shared helper against the exact values
+ * those sites now pass through it. The guard that matters is that neither site
+ * hand-rolls its own escaping again — asserted by source inspection below.
+ */
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { quoteArgForShell } from '../../../src/main/spawn-claude-command'
+
+const PS_QUOTE_CHARS = ['\u0027', '\u2018', '\u2019', '\u201A', '\u201B']
+const PAYLOAD = 'Write-Output PWNED'
+
+/** Everything not inside a quoted run — see spawn-shell-quote-injection. */
+function outsideQuotes(command: string): string {
+  let out = ''
+  let quote: string | null = null
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i]
+    if (quote === null) {
+      if (PS_QUOTE_CHARS.includes(c)) {
+        quote = c
+        continue
+      }
+      out += c
+      continue
+    }
+    if (!PS_QUOTE_CHARS.includes(c)) continue
+    if (command[i + 1] === c) {
+      i++
+      continue
+    }
+    quote = null
+  }
+  return out
+}
+
+describe('shell-only session: the Set-Location line', () => {
+  for (const q of PS_QUOTE_CHARS) {
+    it(`U+${q.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')} in the working directory cannot escape`, () => {
+      const cwd = `C:\\proj${q}; ${PAYLOAD}; ${q}\\end`
+      const cdCmd = `Set-Location -LiteralPath ${quoteArgForShell(cwd, true)}`
+      expect(outsideQuotes(cdCmd)).not.toContain('PWNED')
+      expect(outsideQuotes(cdCmd).trim()).toBe('Set-Location -LiteralPath')
+    })
+  }
+
+  it('uses -LiteralPath, so a real directory with wildcard characters is found', () => {
+    // Set-Location treats its argument as a WILDCARD by default: a genuine
+    // folder named `proj[1m]` matches nothing and the session silently starts
+    // in the wrong directory (the #144 bracket class, one layer down).
+    const cdCmd = `Set-Location -LiteralPath ${quoteArgForShell('C:\\proj[1m]', true)}`
+    expect(cdCmd).toContain('-LiteralPath')
+    expect(cdCmd).toContain("'C:\\proj[1m]'")
+  })
+
+  it('posix keeps close-escape-reopen', () => {
+    expect(quoteArgForShell("/home/o'brien", false)).toBe("'/home/o'\\''brien'")
+  })
+})
+
+describe('--agents JSON', () => {
+  const agentsJson = (name: string) => JSON.stringify([{ name, description: 'd', prompt: 'p' }])
+
+  for (const q of PS_QUOTE_CHARS) {
+    it(`U+${q.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')} in an agent name cannot escape`, () => {
+      const flag = ` --agents ${quoteArgForShell(agentsJson(`evil${q}; ${PAYLOAD}; ${q}x`), true)}`
+      expect(outsideQuotes(flag)).not.toContain('PWNED')
+    })
+  }
+
+  it('a plain apostrophe in prose still round-trips (the accidental-breakage case)', () => {
+    const flag = ` --agents ${quoteArgForShell(agentsJson("O'Brien's reviewer"), true)}`
+    expect(flag).toContain("O''Brien''s reviewer")
+    expect(outsideQuotes(flag)).not.toContain('Brien')
+  })
+})
+
+describe('neither call site hand-rolls its escaping any more', () => {
+  // The regression that matters is structural: both sites previously carried
+  // their own `replace(/'/g, "''")`, which is exactly how they kept the old
+  // behaviour when the shared helper was fixed.
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'src', 'main', 'pty-manager.ts'),
+    'utf8',
+  )
+
+  it('the shell-only cd goes through quoteArgForShell', () => {
+    expect(src).toMatch(/Set-Location -LiteralPath \$\{quoteArgForShell\(resolvedCwd, true\)\}/)
+    expect(src).not.toMatch(/escapedShellCwd/)
+  })
+
+  it('the agents flag goes through quoteArgForShell', () => {
+    expect(src).toMatch(/--agents \$\{quoteArgForShell\(agentsJson,/)
+  })
+
+  it('no win32 ASCII-only doubling survives anywhere in the launch path', () => {
+    // `replace(/'/g, "''")` is the win32 form; the posix `'\''` form is correct
+    // and stays. Any reappearance of the win32 form here is the bug returning.
+    const winDoubling = /replace\(\/'\/g,\s*["']''["']\)/g
+    expect(src.match(winDoubling)).toBeNull()
+  })
+})

--- a/tests/unit/main/spawn-resume-command.test.ts
+++ b/tests/unit/main/spawn-resume-command.test.ts
@@ -46,23 +46,29 @@ function goldenNoResume(opts: {
   // ORIGINAL: escapedCwd always used win32 doubling, posix re-escaped it inline.
   const escapedCwd = cwd.replace(/'/g, "''")
   const posixCwd = escapedCwd.replace(/'/g, "'\\''")
+  // The binary and picker paths are SINGLE-quoted. This is a deliberate,
+  // security-driven move of the golden: they used to be interpolated into
+  // DOUBLE quotes, where PowerShell expands `$(...)` and POSIX expands
+  // `$(...)`/backticks — a path containing either executed at launch. The
+  // shape is otherwise byte-identical to the pre-refactor construction.
+  const quotedBin = `'${claudeBin.replace(/'/g, win32 ? "''" : "'\\''")}'`
+  const quotedPicker = pickerScript ? `'${pickerScript.replace(/'/g, win32 ? "''" : "'\\''")}'` : null
   if (useResumePicker) {
     // P1.1: the picker branch now also forwards agentsFlag (it previously
     // dropped --agents on a restored session). Oracle updated to the fixed shape.
-    if (pickerScript && win32) {
-      const escapedScript = pickerScript.replace(/'/g, "''")
-      return `Set-Location '${escapedCwd}'; node '${escapedScript}'${agentsFlag}${extraFlags}; exit`
-    } else if (pickerScript) {
-      return `cd '${posixCwd}' && node '${pickerScript.replace(/'/g, "'\\''")}'${agentsFlag}${extraFlags}; exit`
+    if (quotedPicker) {
+      return win32
+        ? `Set-Location '${escapedCwd}'; node ${quotedPicker}${agentsFlag}${extraFlags}; exit`
+        : `cd '${posixCwd}' && node ${quotedPicker}${agentsFlag}${extraFlags}; exit`
     } else {
       return win32
-        ? `Set-Location '${escapedCwd}'; & "${claudeBin}"${agentsFlag}${extraFlags}; exit`
-        : `cd '${posixCwd}' && "${claudeBin}"${agentsFlag}${extraFlags}; exit`
+        ? `Set-Location '${escapedCwd}'; & ${quotedBin}${agentsFlag}${extraFlags}; exit`
+        : `cd '${posixCwd}' && ${quotedBin}${agentsFlag}${extraFlags}; exit`
     }
   }
   return win32
-    ? `Set-Location '${escapedCwd}'; & "${claudeBin}"${agentsFlag}${extraFlags}; exit`
-    : `cd '${posixCwd}' && "${claudeBin}"${agentsFlag}${extraFlags}; exit`
+    ? `Set-Location '${escapedCwd}'; & ${quotedBin}${agentsFlag}${extraFlags}; exit`
+    : `cd '${posixCwd}' && ${quotedBin}${agentsFlag}${extraFlags}; exit`
 }
 
 describe('buildClaudeLaunchCommand — GOLDEN (no resumeUuid, byte-identical)', () => {
@@ -158,7 +164,7 @@ describe('buildClaudeLaunchCommand — RESUME (resumeUuid present)', () => {
     expect(out).not.toContain('resume-picker.js')
     expect(out).not.toContain('node ')
     // direct claude launch with --resume first
-    expect(out).toBe(`Set-Location '${CWD.replace(/'/g, "''")}'; & "${CLAUDE}" --resume ${UUID}${AGENTS}${EXTRA}; exit`)
+    expect(out).toBe(`Set-Location '${CWD.replace(/'/g, "''")}'; & '${CLAUDE}' --resume ${UUID}${AGENTS}${EXTRA}; exit`)
     // ordering: --resume precedes --settings / --mcp-config / --agents
     expect(out.indexOf('--resume')).toBeLessThan(out.indexOf('--settings'))
     expect(out.indexOf('--resume')).toBeLessThan(out.indexOf('--agents'))
@@ -172,7 +178,7 @@ describe('buildClaudeLaunchCommand — RESUME (resumeUuid present)', () => {
       resumeUuid: UUID,
     })
     expect(out).not.toContain('resume-picker.js')
-    expect(out).toBe(`cd '/work/wt' && "/usr/bin/claude" --resume ${UUID}${AGENTS}${EXTRA}; exit`)
+    expect(out).toBe(`cd '/work/wt' && '/usr/bin/claude' --resume ${UUID}${AGENTS}${EXTRA}; exit`)
   })
 
   it('resume bypasses the picker even when useResumePicker is true', () => {

--- a/tests/unit/main/spawn-shell-quote-injection.test.ts
+++ b/tests/unit/main/spawn-shell-quote-injection.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for the launch-line shell quoting.
+ *
+ * The launch command is assembled as a STRING and written into a PTY, so every
+ * value interpolated into it is code until it is quoted correctly. Two defects
+ * were found here:
+ *
+ *  1. The win32 branch escaped only U+0027, but PowerShell accepts FOUR more
+ *     characters as single-quote delimiters (U+2018/U+2019/U+201A/U+201B), all
+ *     of them legal in NTFS directory names. A working directory containing one
+ *     terminated the quoted string early and the rest of the path was executed.
+ *
+ *  2. The binary and picker PATHS were interpolated into DOUBLE quotes, where
+ *     PowerShell expands `$(...)` and POSIX expands `$(...)` and backticks — at
+ *     runtime, verified executing on both.
+ *
+ * These assert the PROPERTY (no token escapes its quotes), not the exact
+ * command string; the golden-shape tests live in spawn-resume-command.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildClaudeLaunchCommand, quoteArgForShell } from '../../../src/main/spawn-claude-command'
+
+/** The five characters PowerShell treats as single-quote delimiters. */
+const PS_QUOTE_CHARS = ['\u0027', '\u2018', '\u2019', '\u201A', '\u201B']
+const PS_QUOTE_NAMES = ['APOSTROPHE', 'LEFT SINGLE', 'RIGHT SINGLE', 'LOW-9', 'HIGH-REVERSED-9']
+
+/**
+ * Parse a single-quoted PowerShell string the way the shell does, and return
+ * everything that is NOT inside quotes. If the payload leaked out of its
+ * quoting, its text shows up here — which is the thing being asserted against.
+ *
+ * A doubled delimiter inside a quoted run is a literal character, and (unlike
+ * POSIX) PowerShell lets ANY of the five open or close a run.
+ */
+function outsideSingleQuotes(command: string): string {
+  let out = ''
+  let inQuote = false
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i]
+    const isDelim = PS_QUOTE_CHARS.includes(c)
+    if (!isDelim) {
+      if (!inQuote) out += c
+      continue
+    }
+    if (!inQuote) {
+      inQuote = true
+      continue
+    }
+    // Inside a run: a doubled delimiter is an escaped literal, not a close.
+    if (command[i + 1] === c) {
+      i++
+      continue
+    }
+    inQuote = false
+  }
+  return out
+}
+
+const PAYLOAD = 'Write-Output PWNED'
+
+describe('win32: no PowerShell single-quote delimiter can escape the cwd quoting', () => {
+  for (let i = 0; i < PS_QUOTE_CHARS.length; i++) {
+    const q = PS_QUOTE_CHARS[i]
+    it(`${PS_QUOTE_NAMES[i]} (U+${q.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}) stays inside its quotes`, () => {
+      const cwd = `C:\\proj${q}; ${PAYLOAD}; ${q}\\end`
+      const out = buildClaudeLaunchCommand({
+        platform: 'win32',
+        cwd,
+        claudeBin: 'C:\\bin\\claude.exe',
+        extraFlags: '',
+        agentsFlag: '',
+        useResumePicker: false,
+        pickerScript: null,
+      })
+      // The payload must not appear as shell code...
+      expect(outsideSingleQuotes(out)).not.toContain('PWNED')
+      // ...and the cwd must not have introduced any NEW statement separator
+      // outside the quotes. Compared against a benign cwd rather than a magic
+      // number, so the assertion survives changes to the command's own shape.
+      const benign = buildClaudeLaunchCommand({
+        platform: 'win32',
+        cwd: 'C:\\proj',
+        claudeBin: 'C:\\bin\\claude.exe',
+        extraFlags: '',
+        agentsFlag: '',
+        useResumePicker: false,
+        pickerScript: null,
+      })
+      const count = (s: string) => (outsideSingleQuotes(s).match(/;/g) ?? []).length
+      expect(count(out)).toBe(count(benign))
+    })
+  }
+
+  it('a legitimate path with an apostrophe still round-trips', () => {
+    const out = buildClaudeLaunchCommand({
+      platform: 'win32',
+      cwd: "F:\\o'brien\\proj",
+      claudeBin: 'C:\\bin\\claude.exe',
+      extraFlags: '',
+      agentsFlag: '',
+      useResumePicker: false,
+      pickerScript: null,
+    })
+    expect(out).toContain("Set-Location 'F:\\o''brien\\proj'")
+    expect(outsideSingleQuotes(out)).not.toContain('brien')
+  })
+
+  it('quoteArgForShell applies the same class (it feeds --settings / --mcp-config / --model)', () => {
+    for (const q of PS_QUOTE_CHARS) {
+      const quoted = quoteArgForShell(`C:\\x${q}; ${PAYLOAD}; ${q}\\y`, true)
+      expect(outsideSingleQuotes(quoted)).not.toContain('PWNED')
+    }
+  })
+})
+
+describe('the binary and picker paths are single-quoted, so no shell expands them', () => {
+  // `$(...)` inside DOUBLE quotes executes at runtime in PowerShell AND in
+  // POSIX sh; inside single quotes it is literal in both.
+  const EXPANDING = ['$(Write-Output PWNED)', '`Write-Output PWNED`', '$(touch /tmp/pwned)']
+
+  for (const platform of ['win32', 'posix'] as const) {
+    it(`${platform}: an expanding construct in claudeBin is inert`, () => {
+      for (const evil of EXPANDING) {
+        const out = buildClaudeLaunchCommand({
+          platform,
+          cwd: platform === 'win32' ? 'C:\\proj' : '/proj',
+          claudeBin: `${platform === 'win32' ? 'C:\\bin' : '/usr/bin'}${evil}/claude`,
+          extraFlags: '',
+          agentsFlag: '',
+          useResumePicker: false,
+          pickerScript: null,
+        })
+        // Never interpolated into double quotes...
+        expect(out).not.toContain(`"${platform === 'win32' ? 'C:\\bin' : '/usr/bin'}`)
+        // ...and the construct sits inside a single-quoted run.
+        expect(out).toContain(`'${platform === 'win32' ? 'C:\\bin' : '/usr/bin'}${evil}/claude'`)
+      }
+    })
+
+    it(`${platform}: an expanding construct in the picker path is inert`, () => {
+      const evil = '$(Write-Output PWNED)'
+      const out = buildClaudeLaunchCommand({
+        platform,
+        cwd: platform === 'win32' ? 'C:\\proj' : '/proj',
+        claudeBin: 'claude',
+        extraFlags: '',
+        agentsFlag: '',
+        useResumePicker: true,
+        pickerScript: `${platform === 'win32' ? 'C:\\res' : '/res'}${evil}/resume-picker.js`,
+      })
+      expect(out).toContain(`'${platform === 'win32' ? 'C:\\res' : '/res'}${evil}/resume-picker.js'`)
+      expect(out).not.toMatch(/node "/)
+    })
+  }
+
+  it('win32: a smart quote in claudeBin cannot escape either (the picker path too)', () => {
+    for (const q of PS_QUOTE_CHARS) {
+      const out = buildClaudeLaunchCommand({
+        platform: 'win32',
+        cwd: 'C:\\proj',
+        claudeBin: `C:\\bin${q}; ${PAYLOAD}; ${q}\\claude.exe`,
+        extraFlags: '',
+        agentsFlag: '',
+        useResumePicker: false,
+        pickerScript: null,
+      })
+      expect(outsideSingleQuotes(out)).not.toContain('PWNED')
+    }
+  })
+
+  it('posix: a single quote in the paths still uses close-escape-reopen', () => {
+    const out = buildClaudeLaunchCommand({
+      platform: 'posix',
+      cwd: '/home/proj',
+      claudeBin: "/usr/bin/o'brien/claude",
+      extraFlags: '',
+      agentsFlag: '',
+      useResumePicker: false,
+      pickerScript: null,
+    })
+    expect(out).toContain("'/usr/bin/o'\\''brien/claude'")
+  })
+
+  it('a bare command name and a spaced path are unchanged in shape', () => {
+    const bare = buildClaudeLaunchCommand({
+      platform: 'posix', cwd: '/p', claudeBin: 'claude',
+      extraFlags: '', agentsFlag: '', useResumePicker: false, pickerScript: null,
+    })
+    expect(bare).toBe("cd '/p' && 'claude'; exit")
+
+    const spaced = buildClaudeLaunchCommand({
+      platform: 'win32', cwd: 'C:\\p', claudeBin: 'C:\\Program Files\\claude.exe',
+      extraFlags: '', agentsFlag: '', useResumePicker: false, pickerScript: null,
+    })
+    expect(spaced).toBe("Set-Location 'C:\\p'; & 'C:\\Program Files\\claude.exe'; exit")
+  })
+})

--- a/tests/unit/main/spawn-shell-quote-injection.test.ts
+++ b/tests/unit/main/spawn-shell-quote-injection.test.ts
@@ -32,27 +32,41 @@ const PS_QUOTE_NAMES = ['APOSTROPHE', 'LEFT SINGLE', 'RIGHT SINGLE', 'LOW-9', 'H
  * A doubled delimiter inside a quoted run is a literal character, and (unlike
  * POSIX) PowerShell lets ANY of the five open or close a run.
  */
+/** The four characters PowerShell accepts as DOUBLE-quote delimiters. */
+const PS_DQUOTE_CHARS = ['"', '“', '”', '„']
+
 function outsideSingleQuotes(command: string): string {
   let out = ''
-  let inQuote = false
+  let quote: string | null = null // the delimiter that opened the current run
   for (let i = 0; i < command.length; i++) {
     const c = command[i]
-    const isDelim = PS_QUOTE_CHARS.includes(c)
-    if (!isDelim) {
-      if (!inQuote) out += c
+    if (quote === null) {
+      // A double-quoted run must be tracked too, or an apostrophe INSIDE one
+      // ("don't") desynchronises the scanner and every later region is misread
+      // as quoted — which made this helper report "safe" for a command a real
+      // shell executed (independent review, 2026-08-14). It is the oracle for
+      // this whole file, so it has to model both quote families.
+      if (PS_QUOTE_CHARS.includes(c) || PS_DQUOTE_CHARS.includes(c)) {
+        quote = c
+        continue
+      }
+      out += c
       continue
     }
-    if (!inQuote) {
-      inQuote = true
-      continue
-    }
+    const sameFamily = PS_QUOTE_CHARS.includes(quote)
+      ? PS_QUOTE_CHARS.includes(c)
+      : PS_DQUOTE_CHARS.includes(c)
+    if (!sameFamily) continue // a quote of the other family is literal in here
     // Inside a run: a doubled delimiter is an escaped literal, not a close.
     if (command[i + 1] === c) {
       i++
       continue
     }
-    inQuote = false
+    quote = null
   }
+  // An unterminated run means the line would not parse at all; refuse to judge
+  // rather than silently dropping the tail and calling it safe.
+  if (quote !== null) throw new Error('unterminated quote: this command would not parse')
   return out
 }
 
@@ -153,7 +167,7 @@ describe('the binary and picker paths are single-quoted, so no shell expands the
     })
   }
 
-  it('win32: a smart quote in claudeBin cannot escape either (the picker path too)', () => {
+  it('win32: a smart quote in claudeBin cannot escape', () => {
     for (const q of PS_QUOTE_CHARS) {
       const out = buildClaudeLaunchCommand({
         platform: 'win32',
@@ -166,6 +180,82 @@ describe('the binary and picker paths are single-quoted, so no shell expands the
       })
       expect(outsideSingleQuotes(out)).not.toContain('PWNED')
     }
+  })
+
+  it('win32: a smart quote in the PICKER path cannot escape', () => {
+    // This was asserted in a title but never exercised: the case passed
+    // `pickerScript: null`, so reverting the picker escaping left the whole
+    // suite green (independent review, 2026-08-14). A guard that cannot fail
+    // is worse than no guard.
+    for (const q of PS_QUOTE_CHARS) {
+      const out = buildClaudeLaunchCommand({
+        platform: 'win32',
+        cwd: 'C:\\proj',
+        claudeBin: 'claude',
+        extraFlags: '',
+        agentsFlag: '',
+        useResumePicker: true,
+        pickerScript: `C:\\res${q}; ${PAYLOAD}; ${q}\\resume-picker.js`,
+      })
+      expect(outsideSingleQuotes(out)).not.toContain('PWNED')
+    }
+  })
+
+  it('posix: a single quote in the picker path cannot escape', () => {
+    const out = buildClaudeLaunchCommand({
+      platform: 'posix',
+      cwd: '/proj',
+      claudeBin: 'claude',
+      extraFlags: '',
+      agentsFlag: '',
+      useResumePicker: true,
+      pickerScript: `/res'; ${PAYLOAD}; '/resume-picker.js`,
+    })
+    expect(out).toContain("'/res'\\''; Write-Output PWNED; '\\''/resume-picker.js'")
+  })
+
+  it('refuses a resumeUuid that is not a uuid — the one value interpolated UNQUOTED', () => {
+    // Every current caller gates this with the same anchored regex, but the
+    // function is exported and "the caller checks" is a comment, not a
+    // boundary. Anchored, so a trailing `; …` is refused rather than launched.
+    for (const bad of [
+      `11111111-2222-3333-4444-555555555555; ${PAYLOAD}; `,
+      "11111111-2222-3333-4444-555555555555' ; echo x",
+      'not-a-uuid',
+      '11111111-2222-3333-4444-555555555555\n--dangerously-skip-permissions',
+    ]) {
+      expect(() =>
+        buildClaudeLaunchCommand({
+          platform: 'win32', cwd: 'C:\\p', claudeBin: 'claude',
+          extraFlags: '', agentsFlag: '', useResumePicker: false,
+          pickerScript: null, resumeUuid: bad,
+        }),
+      ).toThrow(/resumeUuid/)
+    }
+    // ...a real uuid still launches...
+    const ok = buildClaudeLaunchCommand({
+      platform: 'win32', cwd: 'C:\\p', claudeBin: 'claude',
+      extraFlags: '', agentsFlag: '', useResumePicker: false,
+      pickerScript: null, resumeUuid: '11111111-2222-3333-4444-555555555555',
+    })
+    expect(ok).toContain('--resume 11111111-2222-3333-4444-555555555555')
+    // ...and an absent/empty uuid is NOT an error, it is the no-resume path.
+    expect(() =>
+      buildClaudeLaunchCommand({
+        platform: 'win32', cwd: 'C:\\p', claudeBin: 'claude',
+        extraFlags: '', agentsFlag: '', useResumePicker: false,
+        pickerScript: null, resumeUuid: '',
+      }),
+    ).not.toThrow()
+  })
+
+  it('the outsideSingleQuotes oracle models double-quoted runs (it is the whole suite’s judge)', () => {
+    // An apostrophe inside a double-quoted value used to desynchronise the
+    // scanner, making it report "safe" for a line PowerShell really executed.
+    const real = `Set-Location 'C:\\p'; & 'C:\\claude.cmd' --agents "don't"; ${PAYLOAD}; exit`
+    expect(outsideSingleQuotes(real)).toContain('PWNED')
+    // ...and an unparseable line is refused rather than judged safe.
+    expect(() => outsideSingleQuotes("Set-Location 'C:\\unterminated")).toThrow(/unterminated/)
   })
 
   it('posix: a single quote in the paths still uses close-escape-reopen', () => {


### PR DESCRIPTION
Cuts **2.1.0-beta.10**. Fixes the upgrade failure reported today, settles the rename to one name, produces a Microsoft Store package, and folds in a privately-reported hardening.

## The upgrade failure — "AI Code Conductor cannot be closed"

Reproduced and traced against the real electron-builder 26 NSIS templates and a real broken install.

**The message is wrong about its own cause.** `$(appCannotBeClosed)` is emitted from three places; the one firing is `uninstallOldVersion` (`installUtil.nsh`), which runs the recorded **old uninstaller**, retries 5×, and reports "cannot be closed" when that keeps failing. Nothing needs to be running — which is why killing processes, rebooting and deleting folders all changed nothing, and why a fresh VM never saw it (no old uninstaller to run).

The affected install was three levels deep:

```
...\Programs\Claude Conductor Beta\Claude Command Center Beta\AI Code Conductor
```

`customInit` compared only the **last** path component against exactly `"Claude Command Center"` / `"Claude Conductor"`. The real folders carried a ` Beta` suffix, matched neither, so the relocation never fired and `instFilesPre` appended the new name *inside* the old folder — once per rename.

Fixes, all silent, no user action:
- `IsLegacyBrandFolder` knows every name the app has shipped under, including the ` Beta` variants.
- `customInit` walks the whole path (a nested install's tail is already the current brand name) and relocates *beside* the outermost legacy folder.
- `ForgetPreviousInstall` drops the recorded install on the two paths known to be unusable — a legacy tree about to be deleted, and a record whose binary is gone. With no `UninstallString`, `uninstallOldVersion` returns immediately. **A healthy same-folder upgrade is untouched and still runs its uninstaller normally.**

**Safety bound (472717f):** `customInstall` does `RMDir /r` on what the walk resolves to, so the climb stops at the first component that is neither a legacy name nor the app name. Without that, an install at `C:\Claude Conductor\dev\AI Code Conductor` would have deleted `C:\Claude Conductor` wholesale.

## One name

Releases published every installer twice, under the legacy and current names, because the updater in shipped clients matched the legacy prefix and a non-match reads as "up to date" — unfixable, since the fix would only ship in a build they can no longer see.

**That constraint expired at 2.1.0-beta.6**, which taught the updater *both* prefixes (`INSTALLER_PREFIXES`). electron-builder now emits `AI-Code-Conductor-*` directly, so `.blockmap` and `latest*.yml` — which reference the installer **by name** — finally match the installer that ships; the duplicates never had matching blockmaps.

Only installs on **beta.5 or older** are left behind; the release notes tell them to download by hand.

The brand-identity guard is **re-pointed, not relaxed**: it now pins the new names *and* pins the updater's tolerance of the legacy prefix, which is the half that makes the rename safe.

## Microsoft Store package

`appx` is built as a **separate** electron-builder invocation with `continue-on-error`, deliberately: folding it into `build.win.target` would put it in the same run as `nsis`, where a Store packaging failure would take the whole Windows release down.

Deliberately **unsigned** — `build.appx.publisher` is a Store identity, so electron-builder skips signing ("Windows Store only build") and Microsoft signs on ingestion; signing with our own certificate would make the publisher disagree with the manifest identity and be rejected.

Verified locally: a valid 237 MB package, manifest identity `nicholas-moger.AICodeConductor`, version `2.1.0.0`. Note MSIX has no prerelease concept, so `-beta.N` is dropped — two betas on one base version produce the same package version.

## Branding and version display

- The onboarding `--ob*` family was still the pre-rename **orange** while `BrandMark` had already been redrawn in the brand azure, so the tour showed a blue logo inside orange chrome. Retargeted to the monogram's own `#2F9BFF`, light values darkened for contrast, with an `--ob-on` token replacing a dark brown tuned for orange. `--brand` followed — it was literally the same orange, which is why the Beta pill still looked pre-rename.
- "What's new in 2.0" was hard-coded, so every 2.1 beta greeted testers with the wrong number. Now derived from `__APP_VERSION__` via `releaseLine()`.

## SSH shim write

The shim write in `generateRemoteSetupScript` lacked the `rmSync` + `flag:'wx'` its two sibling token writes were given: `chmod` stops a link planted *after* we harden the directory, not one already there, and a plain `writeFileSync` follows an existing symlink. Content is our own, so this is a redirected write rather than a leaked secret — weaker than the token files, and the last write in that function without the guard. Reported privately.

## Verification

`npm run typecheck` clean. Suite **4158 passed / 13 skipped**.

Every new guard was **mutation-tested**. Worth noting the first version of the legacy-names guard **did not bite** — those names also appear in the cleanup calls, so a whole-file `toContain` stayed green while the detection list was gutted. It is now scoped to the `IsLegacyBrandFolder` body, and dropping any single name turns the suite red.

## Reviewer note

This touches installer behaviour and `ssh-shim` (a credential-adjacent path), so per AGENTS.md / ADR-009 it is in adversarial-review territory. Flagging rather than assuming: the installer change is the one with teeth, since it deletes a registry record and `RMDir /r`s a directory.
