### PR TITLE
fix(dev): ccc --clean must not launch against a half-wiped data dir (#264)

### DIFF
--- a/scripts/ccc.cmd
+++ b/scripts/ccc.cmd
@@ -96,7 +96,27 @@ if defined CCC_SEED_ACCOUNTS echo [ccc]   --seed-accounts: copying prod account 
 echo.
 
 REM --- clean the dev data dir BEFORE the log dir is created ---
-if defined CCC_CLEAN powershell -NoProfile -ExecutionPolicy Bypass -Command "if (Test-Path $env:CCC_DEV_DATA_DIR) { Remove-Item -LiteralPath $env:CCC_DEV_DATA_DIR -Recurse -Force -EA SilentlyContinue; Write-Host '[ccc] dev data dir wiped.' }"
+REM FAILS LOUDLY ON A PARTIAL WIPE. Since #261 moved Electron's sessionData under
+REM the dev data root, `--clean` now deletes a LIVE session store if an instance is
+REM using this data dir. Chromium holds locks on LevelDB and Network files, so
+REM Remove-Item leaves those behind -- and swallowing that (the old
+REM `-EA SilentlyContinue` with no check) launched straight into a half-deleted
+REM profile holding a stale-but-live claude.ai session. The port-5173 refusal above
+REM covers the usual case, but it races an instance that has not bound the port yet
+REM and does not help when CCC_DEV_DATA_DIR is pointed by hand at a dir another
+REM instance owns. So: attempt the wipe, then VERIFY it is gone; if not, stop rather
+REM than run against wreckage.
+if defined CCC_CLEAN (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "$d=$env:CCC_DEV_DATA_DIR; if (Test-Path $d) { Remove-Item -LiteralPath $d -Recurse -Force -EA SilentlyContinue; if (Test-Path $d) { Write-Host '[ccc] --clean: could NOT fully wipe the dev data dir -- files are locked, which means an instance is still using it:'; Write-Host ('[ccc]   ' + $d); exit 3 } else { Write-Host '[ccc] dev data dir wiped.' } }"
+  if errorlevel 3 (
+    echo.
+    echo [ccc] Refusing to launch against a half-deleted data dir. Close any running
+    echo [ccc] dev instance ^(or one sharing this CCC_DEV_DATA_DIR^) and try again.
+    echo.
+    pause
+    goto :eof
+  )
+)
 
 REM --- log setup (DEV-scoped, under the dev data root) ---
 REM DELIBERATELY BEFORE THE SEED STEPS. It used to come after them, so anything

--- a/tests/unit/ccc-launcher.test.ts
+++ b/tests/unit/ccc-launcher.test.ts
@@ -74,6 +74,26 @@ describe('ccc.cmd — a failing run has to leave something behind', () => {
   })
 })
 
+describe('ccc.cmd — --clean must not launch against a half-wiped data dir (#264)', () => {
+  it('re-checks that the data dir is actually gone after the wipe', () => {
+    // Since #261 moved sessionData under the dev data root, --clean deletes a LIVE
+    // session store when an instance is using the dir. Chromium's locked files
+    // survive Remove-Item, and the old code swallowed that and launched anyway.
+    const clean = CMD.slice(CMD.indexOf('if defined CCC_CLEAN'))
+    // The wipe is followed by a second Test-Path on the SAME dir, i.e. a verify.
+    expect(clean).toMatch(/Remove-Item[\s\S]*Test-Path \$d/)
+  })
+
+  it('aborts loudly instead of continuing when the wipe was incomplete', () => {
+    const clean = CMD.slice(CMD.indexOf('if defined CCC_CLEAN'))
+    const abort = clean.slice(0, clean.indexOf('--- log setup'))
+    expect(abort).toMatch(/exit 3/)          // the powershell side signals it
+    expect(abort).toMatch(/if errorlevel 3/) // the batch side catches it
+    expect(abort).toMatch(/pause/)           // and holds the window so it is seen
+    expect(abort).toMatch(/goto :eof/)       // and does NOT fall through to launch
+  })
+})
+
 describe('ccc.cmd — flags stay distinct', () => {
   it('parses --seed and --seed-accounts as separate flags', () => {
     // Different things at different risk: CONFIG is settings, accounts are live


### PR DESCRIPTION
Addresses the first half of #264 (leaves the header-overstatement item open there).

## The bug — a regression from #261

#261 moved Electron's `sessionData` under the dev data root so dev and prod stop
sharing claude.ai web sessions. Side effect: `ccc --clean` deletes the dev data
dir, so it now deletes a **live** session store when an instance is using that dir.
Chromium holds locks on its LevelDB and `Network` files, `Remove-Item` leaves those
behind, and the old line swallowed it (`-EA SilentlyContinue`, no check) then
launched straight into a half-deleted profile holding a stale-but-live session.

The port-5173 refusal covers the common case but races an instance that has not
bound the port yet, and does nothing when `CCC_DEV_DATA_DIR` is pointed by hand at a
dir another instance owns.

## Fix

After the wipe, verify the dir is actually gone. If not: the PowerShell side
`exit 3`, the batch catches `errorlevel 3`, prints why, pauses, and `goto :eof`
instead of falling through to launch. Fail loudly rather than run against wreckage.
Deliberately does **not** try to kill the other instance — that is the more
dangerous move, and refusing is enough.

## Tests

Two guards in `ccc-launcher.test.ts`, both verified by reverting to the old
swallow-and-continue and watching them fail:
- the wipe is followed by a re-check `Test-Path` on the same dir
- the incomplete-wipe branch `exit 3` / `if errorlevel 3` / `pause` / `goto :eof`

## Scope

#264's other half — the `ccc.cmd` header still saying "fully isolated from prod" —
is pre-existing and not caused by this work, so it stays on #264 as a docs cleanup.
This PR is only the `--clean` regression.

## Gate

Typecheck clean. Unit suite 4164 passed across 474 files. `.cmd`-only change plus
its structural guards; no runtime code touched.
