### PR TITLE
fix(accounts): stop running page script during the Cloudflare challenge (#269)

### DIFF
--- a/CONTEXT.d/2026-08-14-269-cloudflare-cdp-challenge.md
+++ b/CONTEXT.d/2026-08-14-269-cloudflare-cdp-challenge.md
@@ -1,0 +1,64 @@
+## 2026-08-14 -- 269: stop running page script during the Cloudflare challenge
+
+Nubby found the #216 web sign-in loops forever on residential IPs and fresh VMs:
+claude.ai serves a Cloudflare managed challenge, and ticking "verify you are human"
+re-issues indefinitely. Root cause, well-diagnosed in the report: the poll loop ran
+`readAccountEmail` -- which calls `Runtime.evaluate` to run script IN the login page
+-- on EVERY 1.5s poll. Turnstile treats an attached debugger evaluating in the page
+as automation and re-arms the challenge, so the mechanism that READ the sign-in
+result was what made the sign-in un-clearable. Does not reproduce behind a corporate
+Cloudflare-trusted IP, which is how it got through review.
+
+### The fix (nubby's direction 1)
+
+Reorder the per-poll inner loop so no page script runs until the challenge is
+demonstrably cleared:
+
+  connect -> targetIsClaudeAi (Target.getTargetInfo, no page script)
+          -> Network.getAllCookies (no page script)
+          -> if NO session cookie: stop here (this is the whole challenge window)
+          -> only once a sessionKey exists: the single readAccountEmail evaluate
+
+`Runtime.evaluate` now runs at most once, after a real session cookie proves the
+challenge already passed. Pinned by test: with the session cookie withheld the run
+times out and evaluate is NEVER called; once granted it runs exactly once. Verified
+by reverting to the old order and watching both fail.
+
+Plus: a pure `isCloudflareChallenge()` classifier (url has challenges.cloudflare.com
+or /cdn-cgi/challenge-platform/, or title "just a moment...") surfaces a live notice
+so the challenge no longer looks like nothing happening until the 5-minute timeout
+blames a closed window. And a renderer gating fix: the account context-menu items
+(Authenticate / Open artifacts) were hidden when a session had no explicit
+profileId -- the fresh-install default-account case, exactly when a user first needs
+them. They now fall back to the primary profile, which is the account a
+no-explicit-profile local session actually runs as (pty-manager resolves the same).
+
+### Adversarial pass (ADR-009): PASS
+
+Independent attacker re-verified the three #216 hardening guarantees survive the
+reorder -- fail-closed dual-origin identity, claude.ai-only cookie harvesting, and
+completion requiring BOTH a real session cookie and a genuine account email. The
+classifier is pure and drives only a constant UI string (no attacker content into
+the renderer). All committed account-web suites pass. Two MINOR/cosmetic notes,
+neither a security impact: `tag()` lets a browser-substitution notice override the
+Cloudflare notice in the rare case both apply; and the Sidebar primary-fallback also
+covers shell-only local sessions (harmless -- signs the primary's own web partition).
+
+### The load-bearing caveat
+
+CANNOT be confirmed to fix #269 from here. The change removes the REPORTED detection
+vector (per-poll page script), but a page-target attach, getTargetInfo and
+getAllCookies still run each poll on the challenge page. If Turnstile keys on the
+debugger ATTACH itself rather than on script execution, this is necessary-but-not-
+sufficient and the fallback is nubby's direction 3: drop --remote-debugging-port
+entirely and read+decrypt the cookie DB off disk after the browser exits. The
+diagnostic that decides it -- offered by the reporter -- is whether the loop persists
+with --remote-debugging-port manually removed from the argv. This environment
+(corporate/Cloudflare-trusted IP) does not serve the challenge, so nubby is the only
+one who can verify.
+
+### State
+
+Gate: typecheck clean, build clean, unit suite 4213 passed. NOT merged, NOT
+desktop-verifiable here. On fix/269-cloudflare-cdp-challenge; PR opened for nubby to
+verify on the repro machine before any merge is recommended.

--- a/src/main/account-web/sign-in.ts
+++ b/src/main/account-web/sign-in.ts
@@ -326,6 +326,8 @@ export function sweepAbandonedProfiles(dataDir: string): void {
 export interface CdpTarget {
   type?: string
   url?: string
+  /** Page title — used only to spot a Cloudflare "Just a moment..." interstitial. */
+  title?: string
   id?: string
   webSocketDebuggerUrl?: string
 }
@@ -425,7 +427,47 @@ async function closeQuietly(client: any): Promise<void> {
   try { await withTimeout(Promise.resolve(client?.close?.()), IO_CALL_TIMEOUT_MS, 'CDP close') } catch { /* closing anyway */ }
 }
 
-/** Ask the page for the signed-in account, via claude.ai's own bootstrap. */
+/**
+ * True when the connected target's own reported URL is claude.ai.
+ *
+ * ORIGIN GATE, AND IT RUNS NO PAGE SCRIPT. `Target.getTargetInfo` reads target
+ * metadata over CDP; it does not execute anything in the document. That matters
+ * because this runs on every poll while the human is still on the page, and the
+ * one thing this flow must NOT do during that window is run script in the login
+ * page — see readAccountEmail (#269).
+ */
+async function targetIsClaudeAi(client: any): Promise<boolean> {
+  if (typeof client?.Target?.getTargetInfo !== 'function') return false
+  try {
+    const url = (await withTimeout<any>(client.Target.getTargetInfo(), IO_CALL_TIMEOUT_MS, 'getTargetInfo'))?.targetInfo?.url
+    return typeof url === 'string' && isClaudeUrl(url)
+  } catch {
+    return false   // asked, and could not find out. Not the same as "it is fine".
+  }
+}
+
+/** Cloudflare's managed-challenge surfaces, by target URL/title. Pure. */
+export function isCloudflareChallenge(t: CdpTarget): boolean {
+  const url = (t?.url ?? '').toLowerCase()
+  const title = (t?.title ?? '').toLowerCase()
+  return (
+    url.includes('challenges.cloudflare.com') ||
+    url.includes('/cdn-cgi/challenge-platform/') ||
+    title === 'just a moment...'
+  )
+}
+
+/**
+ * Ask the page for the signed-in account, via claude.ai's own bootstrap.
+ *
+ * THE ONE CALL IN THIS FLOW THAT RUNS SCRIPT IN THE LOGIN PAGE, and #269 is why
+ * it now runs at most once, only AFTER a real session cookie has appeared.
+ * Cloudflare's Turnstile treats an attached debugger evaluating in the page as
+ * automation and re-arms its "verify you are human" challenge indefinitely, so
+ * calling this every poll (as the first version did) made the very challenge it
+ * needed the user to clear un-clearable. Once the session cookie exists the
+ * challenge is demonstrably already cleared, so a single evaluate here is safe.
+ */
 async function readAccountEmail(client: any): Promise<string | null> {
   try {
     // The fetch below is ORIGIN-RELATIVE, so it only means what we think if the
@@ -622,6 +664,11 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
       let targets: CdpTarget[] = []
       try { targets = await withTimeout(getCDP().List({ port }), IO_CALL_TIMEOUT_MS, 'target list') } catch { continue }
 
+      // Tell the user when Cloudflare is challenging, from the target list alone
+      // (no attach). Without this the challenge just looked like nothing
+      // happening until the five-minute timeout blamed a closed window (#269).
+      const challenge = targets.some(isCloudflareChallenge)
+
       for (const t of pickSignInTargets(targets)) {
         let client: any = null
         try {
@@ -632,16 +679,38 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
           )
         } catch { continue }
 
-        const email = await readAccountEmail(client)
-        if (!email) { await closeQuietly(client); continue }
-
-        // Authenticated. Harvest.
-        current = tag({ phase: 'harvesting', profileId })
+        // ORIGIN FIRST, THEN COOKIES, THEN — ONLY IF SIGNED IN — the identity read.
+        // Reordered for #269: the old flow ran `readAccountEmail` (which executes
+        // script in the page) on EVERY poll, and Cloudflare's Turnstile treats
+        // that as automation and re-arms the challenge forever. Neither the origin
+        // check nor the cookie read runs page script, so during the challenge this
+        // loop now touches the page without ever scripting it, and the human can
+        // actually clear the check.
+        if (!(await targetIsClaudeAi(client))) { await closeQuietly(client); continue }
         const all: CdpCookie[] = (await withTimeout<any>(client.Network.getAllCookies(), IO_CALL_TIMEOUT_MS, 'getAllCookies'))?.cookies ?? []
         const harvest = harvestClaudeCookies(all)
 
         if (!harvest.hasSessionCookie) {
-          // Keep waiting rather than declaring success on a cookie-less jar.
+          // No session yet. This is where the whole Cloudflare challenge is spent,
+          // and the point is that NO page script has run to get here.
+          current = tag(challenge
+            ? {
+                phase: 'awaiting-user',
+                profileId,
+                notice: 'Cloudflare is verifying you are human — finish the check in the browser window. It can take a moment, and may re-appear once or twice before it clears.',
+              }
+            : { phase: 'awaiting-user', profileId })
+          await closeQuietly(client)
+          continue
+        }
+
+        // A real session cookie exists, so any challenge is already cleared. NOW
+        // it is safe to run the single page-script identity read.
+        current = tag({ phase: 'harvesting', profileId })
+        const email = await readAccountEmail(client)
+        if (!email) {
+          // Have the cookie but the identity call did not answer yet — do not
+          // store a session with no account. Try again next poll.
           current = tag({ phase: 'awaiting-user', profileId })
           await closeQuietly(client)
           continue

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -158,6 +158,12 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
   // session currently has its context menu open; it reads the live session and
   // no-ops when the chosen account equals the current one.
   const accountProfiles = useAccountProfilesStore((s) => s.profiles)
+  // A session with no EXPLICIT account profile runs on the default/global home,
+  // which is the primary account — so its web session and artifacts belong to the
+  // primary. Without this fallback the account context-menu items vanished on a
+  // fresh install (the common case: default account, no profile assigned), which
+  // is exactly when a user first needs them. #269.
+  const primaryProfileId = accountProfiles.find((p) => p.isPrimary)?.id
   const accountAliases = useSettingsStore((s) => s.settings.accountAliases)
   const menuSession = sessionContextMenu ? sessions.find((s) => s.id === sessionContextMenu.sessionId) ?? null : null
   const canSwitchAccount = canSwitchAccountForSession({ provider: menuSession?.provider, isSsh: !!menuSession?.sshConfig, shellOnly: !!menuSession?.shellOnly, profileCount: accountProfiles.length })
@@ -1057,15 +1063,15 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
             // session with a resolved account — an SSH session's browser and
             // credentials live on another machine, and a shell-only session has
             // no /login to run.
-            hasWebSession={!!s.profileId && webSessionAccounts.has(s.profileId)}
+            hasWebSession={!!(s.profileId ?? primaryProfileId) && webSessionAccounts.has((s.profileId ?? primaryProfileId)!)}
             onOpenArtifacts={
-              s.profileId && s.sessionType === 'local'
-                ? () => { void window.electronAPI.accountWeb.openArtifacts(s.profileId!) }
+              (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
+                ? () => { void window.electronAPI.accountWeb.openArtifacts((s.profileId ?? primaryProfileId)!) }
                 : undefined
             }
             onAuthenticateWeb={
-              s.profileId && s.sessionType === 'local'
-                ? () => { void authenticateWebForSession(s.profileId!) }
+              (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
+                ? () => { void authenticateWebForSession((s.profileId ?? primaryProfileId)!) }
                 : undefined
             }
             onSignInCode={

--- a/src/renderer/components/settings/AccountWebSession.tsx
+++ b/src/renderer/components/settings/AccountWebSession.tsx
@@ -67,7 +67,13 @@ export function AccountWebSession({ profileId, accountName }: Props) {
     if (!busy) return
     const t = setInterval(async () => {
       const r = await api.signInState()
-      if (r.ok) setPhase(r.state.phase)
+      if (r.ok) {
+        setPhase(r.state.phase)
+        // Mirror the live notice (e.g. a Cloudflare challenge in progress) while
+        // the sign-in runs, not only on the final result — and clear it once the
+        // challenge is gone, so a stale "verifying you" banner does not linger. #269.
+        setNotice(typeof r.state.notice === 'string' ? r.state.notice : '')
+      }
     }, 1000)
     return () => clearInterval(t)
   }, [busy])

--- a/tests/unit/account-web-cloudflare.test.ts
+++ b/tests/unit/account-web-cloudflare.test.ts
@@ -1,0 +1,134 @@
+// #269 — the sign-in must not run script in the login page while Cloudflare is
+// challenging.
+//
+// Cloudflare's Turnstile treats an attached debugger evaluating in the page as
+// automation and re-arms its "verify you are human" challenge indefinitely. The
+// first version of this feature ran `Runtime.evaluate` in the login page on EVERY
+// 1.5s poll, which made the challenge un-clearable on residential IPs and fresh
+// VMs. The fix: read the origin and the cookies (neither runs page script), and
+// only run the single identity `Runtime.evaluate` AFTER a real session cookie has
+// appeared -- by which point the challenge is demonstrably already cleared.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const cookiesSet = vi.fn()
+vi.mock('electron', () => ({
+  session: { fromPartition: vi.fn(() => ({ cookies: { set: cookiesSet }, clearStorageData: vi.fn() })) },
+}))
+vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+vi.mock('../../src/main/browser-paths', () => ({ getBrowserPaths: () => ['C:/present/chrome.exe'] }))
+vi.mock('node:child_process', () => ({
+  spawn: () => ({ exitCode: null, signalCode: null, killed: false, kill: vi.fn(), on: vi.fn(), pid: 4242, once: vi.fn((_e: string, cb: () => void) => cb()) }),
+  spawnSync: vi.fn(),
+}))
+vi.mock('node:fs', () => ({
+  existsSync: () => true, readFileSync: () => '51234\n', readdirSync: () => [], rmSync: vi.fn(),
+}))
+
+const { runSignIn, _setCdpForTest, isCloudflareChallenge } = await import('../../src/main/account-web/sign-in')
+const { CLAUDE_SESSION_COOKIE } = await import('../../src/shared/account-web-session')
+
+const sessionCookie = {
+  name: CLAUDE_SESSION_COOKIE, value: 'sk', domain: '.claude.ai', path: '/',
+  expires: 1_900_000_000, secure: true, httpOnly: true,
+}
+const analytics = { ...sessionCookie, name: 'ajs_anonymous_id' }
+
+const LOGIN = { type: 'page', url: 'https://claude.ai/login', id: 't1', webSocketDebuggerUrl: 'ws://t1' }
+const CF_FRAME = { type: 'iframe', url: 'https://challenges.cloudflare.com/turnstile/v0/x', id: 'cf' }
+
+/**
+ * A CDP fake with an `evaluate` SPY, whose cookie jar is produced fresh per poll
+ * by `cookiesFor()` -- so a test can withhold the session cookie for N polls to
+ * simulate the challenge, then grant it.
+ */
+function makeCdp(opts: { targets: any[]; cookiesFor: () => any[]; evaluate: ReturnType<typeof vi.fn> }) {
+  const f: any = () => Promise.resolve({
+    Target: { getTargetInfo: async () => ({ targetInfo: { url: 'https://claude.ai/login' } }) },
+    Runtime: { evaluate: opts.evaluate },
+    Network: { getAllCookies: async () => ({ cookies: opts.cookiesFor() }) },
+    close: async () => {},
+  })
+  f.List = async () => opts.targets
+  return f
+}
+
+const RUN = { profileId: 'profile-aaa111', dataDir: 'C:/data', pollMs: 5 } as const
+
+beforeEach(() => { cookiesSet.mockReset() })
+
+describe('isCloudflareChallenge', () => {
+  it('matches the challenge iframe, the cdn-cgi platform path, and the interstitial title', () => {
+    expect(isCloudflareChallenge({ type: 'iframe', url: 'https://challenges.cloudflare.com/x' })).toBe(true)
+    expect(isCloudflareChallenge({ type: 'page', url: 'https://claude.ai/cdn-cgi/challenge-platform/y' })).toBe(true)
+    expect(isCloudflareChallenge({ type: 'page', url: 'https://claude.ai/login', title: 'Just a moment...' })).toBe(true)
+  })
+
+  it('does not match an ordinary claude.ai page', () => {
+    expect(isCloudflareChallenge({ type: 'page', url: 'https://claude.ai/login', title: 'Claude' })).toBe(false)
+    expect(isCloudflareChallenge({ type: 'page', url: 'https://claude.ai/' })).toBe(false)
+    expect(isCloudflareChallenge({})).toBe(false)
+  })
+})
+
+describe('runSignIn — no page script while the challenge is unsolved (#269)', () => {
+  it('NEVER calls Runtime.evaluate when the session cookie never appears', async () => {
+    // This is the whole bug: a poll that runs evaluate re-arms the challenge. With
+    // no session cookie ever granted, the run must time out WITHOUT one evaluate.
+    const evaluate = vi.fn(async () => ({ result: { value: 'me@example.com' } }))
+    _setCdpForTest(makeCdp({ targets: [LOGIN, CF_FRAME], cookiesFor: () => [analytics], evaluate }))
+
+    const s = await runSignIn({ ...RUN, timeoutMs: 120 })
+
+    expect(s.phase).toBe('failed')
+    expect(evaluate).not.toHaveBeenCalled()   // <-- the guarantee
+    expect(cookiesSet).not.toHaveBeenCalled()
+  })
+
+  it('runs evaluate exactly once, AFTER the session cookie appears, then completes', async () => {
+    // The challenge clears (session cookie granted from the 3rd poll on). Only then
+    // may the single identity read run -- proving the evaluate is deferred past the
+    // challenge, not merely removed.
+    let polls = 0
+    const evaluate = vi.fn(async () => ({ result: { value: 'me@example.com' } }))
+    _setCdpForTest(makeCdp({
+      targets: [LOGIN, CF_FRAME],
+      cookiesFor: () => (++polls >= 3 ? [sessionCookie] : [analytics]),
+      evaluate,
+    }))
+
+    const s = await runSignIn({ ...RUN, timeoutMs: 3000 })
+
+    expect(s.phase).toBe('done')
+    expect(s.session?.accountEmail).toBe('me@example.com')
+    expect(evaluate).toHaveBeenCalledTimes(1)   // once, and only after clearance
+    expect(cookiesSet).toHaveBeenCalled()
+  })
+
+  it('surfaces a Cloudflare notice while the challenge is up and no session exists', async () => {
+    const { getSignInState } = await import('../../src/main/account-web/sign-in')
+    const evaluate = vi.fn(async () => ({ result: { value: 'me@example.com' } }))
+    _setCdpForTest(makeCdp({ targets: [LOGIN, CF_FRAME], cookiesFor: () => [analytics], evaluate }))
+
+    // Kick off a run and sample the live state mid-flight, then let it time out.
+    const run = runSignIn({ ...RUN, timeoutMs: 200 })
+    await new Promise((r) => setTimeout(r, 60))
+    const mid = getSignInState()
+    await run
+
+    expect(mid.phase).toBe('awaiting-user')
+    expect(mid.notice).toMatch(/Cloudflare is verifying/i)
+  })
+
+  it('shows NO Cloudflare notice when there is no challenge target', async () => {
+    const { getSignInState } = await import('../../src/main/account-web/sign-in')
+    const evaluate = vi.fn(async () => ({ result: { value: 'me@example.com' } }))
+    _setCdpForTest(makeCdp({ targets: [LOGIN], cookiesFor: () => [analytics], evaluate }))
+
+    const run = runSignIn({ ...RUN, timeoutMs: 200 })
+    await new Promise((r) => setTimeout(r, 60))
+    const mid = getSignInState()
+    await run
+
+    expect(mid.notice).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Addresses #269.

> **⚠ Needs verification on a machine that actually gets the Cloudflare challenge.** This environment sits behind a Cloudflare-trusted corporate IP and never sees the challenge, so I could not reproduce the loop or confirm the fix. Please verify on the repro machine before merging — see "How to verify" and "The load-bearing caveat" below.

## The bug (nubby's diagnosis, confirmed against the code)

The poll loop ran `readAccountEmail` — which calls `Runtime.evaluate` to run script **in the login page** — on **every 1.5s poll** (`sign-in.ts`, old order). Cloudflare's Turnstile treats an attached debugger evaluating in the page as automation and re-arms its "verify you are human" challenge indefinitely. So the mechanism that **read** the sign-in result was what made the sign-in **un-clearable** on residential IPs and fresh VMs.

## The fix (direction 1 from the report)

Reorder the per-poll inner loop so **no page script runs until the challenge is demonstrably cleared**:

```
connect → targetIsClaudeAi (Target.getTargetInfo — no page script)
        → Network.getAllCookies (no page script)
        → if NO session cookie: stop here   ← the whole challenge window lives here
        → only once a sessionKey exists: the single readAccountEmail evaluate
```

`Runtime.evaluate` now runs **at most once**, after a real session cookie proves the challenge already passed.

Plus two fork-independent fixes you asked to fold in:
- **Challenge detection** — a pure `isCloudflareChallenge()` classifier surfaces a live "Cloudflare is verifying you" notice, so the challenge no longer looks like nothing happening until the 5-min timeout blames a closed window (the third symptom in the report).
- **Sidebar gating** (third symptom, VM) — the account context-menu items were hidden when a session had no explicit `profileId` (the fresh-install default-account case). They now fall back to the primary profile, which is the account such a session actually runs as (`pty-manager` resolves the same).

## How to verify (on the repro machine)

1. Sign in to claude.ai from a session/account that gets the challenge. The challenge should now be **clearable** — tick the box and it should proceed instead of re-arming.
2. While it's challenging, the panel should show **"Cloudflare is verifying you are human…"** instead of appearing stuck.
3. On a fresh install (default account, no explicit profile), the session right-click should now **show** "Authenticate with claude.ai" and "Open my artifacts".

**The one diagnostic that decides escalation:** if it STILL loops, please run once with `--remote-debugging-port` removed from the argv (you offered this). If removing the port stops the loop but this PR doesn't, then Turnstile is detecting the debugger **attach itself**, not the script — and the fix must escalate to direction 3 (drop CDP entirely, decrypt the cookie DB off disk after exit).

## The load-bearing caveat

This removes the **reported** detection vector (per-poll page script), which the tests prove. But a page-target **attach** + `getTargetInfo` + `getAllCookies` still run each poll on the challenge page. If Turnstile keys on the attach itself rather than script execution, this is **necessary but not sufficient**. I can't tell from here — the diagnostic above resolves it.

## Adversarial review (ADR-009): PASS

Independent attacker re-verified the three #216 hardening guarantees survive the reorder — fail-closed dual-origin identity, claude.ai-only cookie harvesting, completion requiring BOTH a real session cookie AND a genuine account email. The classifier is pure and drives only a constant UI string (no attacker content into the renderer). Two MINOR/cosmetic notes, neither a security impact: `tag()` lets a browser-substitution notice override the Cloudflare notice in the rare case both apply; the Sidebar primary-fallback also covers shell-only local sessions (harmless — it would sign the primary's own web partition).

## Tests

`account-web-cloudflare.test.ts` (new, 6): pins the core guarantee — `Runtime.evaluate` is **never** called while the session cookie is withheld, and runs **exactly once** after it appears — plus the classifier and the live notice. Verified by reverting the reorder and watching the guarantee tests fail. All existing account-web suites pass.

## Gate

Typecheck clean. Build clean. Unit suite **4213 passed** across 478 files.
