### PR TITLE
fix(accounts): correct #258 CLI-auth credential path; async, non-blocking probe

### DIFF
--- a/src/main/account-web/claude-cli-auth.ts
+++ b/src/main/account-web/claude-cli-auth.ts
@@ -24,12 +24,16 @@
  * No default export (project convention).
  */
 
-import { execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { logError, logInfo } from '../debug-logger'
 import { getProfileConfigDir, getProfilesRoot } from '../account-profiles'
+import { acquireProfileConsumer } from '../profile-consumers'
 import { DEFAULT_CLI_AUTH_METHOD, PROFILE_ID_RE, isCliAuthMethod, type CliAuthMethod } from '../../shared/account-web-session'
+
+const execFileAsync = promisify(execFile)
 
 export interface ClaudeCliAuthStatus {
   /** True when this account is signed in to the CLI. */
@@ -99,8 +103,14 @@ export function parseCliAuth(raw: string): ClaudeCliAuthStatus {
  *
  * Reads only the SHAPE — whether a token exists and when it expires. The token
  * value is never returned, logged, or copied.
+ *
+ * ASYNC (#258 follow-up): the CLI probe is a subprocess with a 10s timeout, run
+ * once per account and triggered from the Sidebar (every session right-click)
+ * and the accounts panel (every row on mount). Running it synchronously blocked
+ * the Electron main event loop for up to 10s each time — long enough to trip the
+ * usage fetch's own 8s socket timeout. execFileAsync keeps it off the loop.
  */
-export function readClaudeCliAuth(profileId: string): ClaudeCliAuthStatus {
+export async function readClaudeCliAuth(profileId: string): Promise<ClaudeCliAuthStatus> {
   // VALIDATE HERE, not only at the IPC boundary. `join` does not sandbox: with
   // `../../..` segments it walks straight out of the profiles root, and the id
   // below becomes both a filesystem path and the HOME of a spawned process. The
@@ -114,30 +124,45 @@ export function readClaudeCliAuth(profileId: string): ClaudeCliAuthStatus {
   // 1. Ask the CLI. Setting USERPROFILE to the profile home is how a session is
   //    already spawned under an account, and `claude auth status` honours it —
   //    verified against two profiles, which reported two different emails.
+  //
+  //    Register as a transient credential consumer for the probe's lifetime:
+  //    `claude auth status` reads this profile's credentials under its home and
+  //    can make the CLI rotate the (single-use) refresh token. Without this, the
+  //    usage page's auto token-refresh — which gates on isProfileInUseByLiveSession
+  //    and knows only about PTY sessions — could rotate the same token
+  //    concurrently and strand the account (log it out). See profile-consumers.ts.
+  const release = acquireProfileConsumer(profileId)
   try {
     const home = join(getProfilesRoot(), profileId)
     if (existsSync(home)) {
-      const out = execFileSync('claude', ['auth', 'status'], {
+      const { stdout } = await execFileAsync('claude', ['auth', 'status'], {
         encoding: 'utf-8',
         timeout: 10_000,
         windowsHide: true,
         shell: true,          // resolves claude.cmd on Windows, as elsewhere in the app
         env: { ...process.env, USERPROFILE: home, HOME: home },
       })
-      const parsed = parseAuthStatus(out)
+      const parsed = parseAuthStatus(stdout)
       if (parsed) return parsed
     }
   } catch {
     // CLI absent, slow, or erroring — fall through to the file.
+  } finally {
+    release()
   }
 
-  // 2. Fall back to the credential file. Less informative (no email/org) but it
-  //    needs no subprocess, so a missing or broken CLI still yields a usable
-  //    signed-in/out answer rather than an error.
+  // 2. Fall back to the credential file at <profileHome>/.claude/.credentials.json
+  //    — the location EVERY writer and reader in the app uses (account-usage.ts,
+  //    account-auth-info.ts, account-profiles.ts). The previous path omitted the
+  //    `.claude` segment, so the file could never be found: whenever the CLI probe
+  //    above failed (absent/slow/non-zero, all swallowed) a fully signed-in
+  //    account rendered "not signed in", telling the user to /login. Less
+  //    informative than the CLI (no email/org) but needs no subprocess, so a
+  //    missing or broken CLI still yields a usable signed-in/out answer.
   try {
     const configDir = getProfileConfigDir(profileId)
     if (!configDir) return { authenticated: false }
-    const path = join(configDir, '.credentials.json')
+    const path = join(configDir, '.claude', '.credentials.json')
     if (!existsSync(path)) return { authenticated: false }
     return { ...parseCliAuth(readFileSync(path, 'utf-8')), source: 'credential-file' }
   } catch (err) {

--- a/src/main/claude-account-identity.ts
+++ b/src/main/claude-account-identity.ts
@@ -6,6 +6,7 @@
 import fs, { promises as fsp } from 'node:fs'; import path from 'node:path'
 import { BrowserWindow } from 'electron'
 import { readProfileAccountEmail, getProfileConfigDir, sharedRoot, listProfiles, isValidProfileId } from './account-profiles'
+import { hasTransientProfileConsumer } from './profile-consumers'
 import { IPC } from '../shared/ipc-channels'
 import { colourForEmail } from './account-color'
 import { canonicaliseEmail } from '../shared/account-chip-color'
@@ -164,12 +165,16 @@ export function getWatchedProfileId(sessionId: string): string | undefined {
   return watched.get(sessionId)
 }
 
-/** True when any LIVE session is running under `profileId` -- i.e. that profile's
- *  home is the active USERPROFILE/credential store of an open session. Used to
- *  refuse a profile delete that would half-destroy a live account's creds (R-006).
- *  Checks both the active-watcher map (added at spawn, removed at exit) and the
- *  spawn-captured map (cleared on exit) for defense in depth.
- *  KNOWN GAP: SSH sessions never enter either map (they spawn ssh.exe without
+/** True when `profileId` is in use by a live session OR a transient credential
+ *  consumer -- i.e. that profile's home is the active USERPROFILE/credential
+ *  store of something running now. Used to refuse a profile delete that would
+ *  half-destroy a live account's creds (R-006) and to gate the usage page's auto
+ *  token refresh (a rotation under a live consumer strands its token).
+ *  Checks the active-watcher map (added at spawn, removed at exit), the
+ *  spawn-captured map (cleared on exit), AND the transient-consumer registry
+ *  (the `claude auth status` probe, #258 -- which spawns the CLI under a profile
+ *  home and can rotate the token itself; it registers for its short duration).
+ *  KNOWN GAP: SSH sessions never enter any of these (they spawn ssh.exe without
  *  account capture). Safe today because SSH sessions don't use account-home
  *  isolation -- nothing of theirs lives in the profile dir -- but if SSH ever
  *  gains profile binding this check must learn about it. */
@@ -177,6 +182,7 @@ export function isProfileInUseByLiveSession(profileId: string): boolean {
   if (!profileId) return false
   for (const pid of watched.values()) if (pid === profileId) return true
   for (const pid of profileBySession.values()) if (pid === profileId) return true
+  if (hasTransientProfileConsumer(profileId)) return true
   return false
 }
 

--- a/src/main/ipc/account-web-handlers.ts
+++ b/src/main/ipc/account-web-handlers.ts
@@ -46,7 +46,7 @@ export function registerAccountWebHandlers(): void {
   ipcMain.handle(IPC.ACCOUNT_WEB_STATUS, async (_e, profileId: unknown) => {
     try {
       const id = profileIdSchema.parse(profileId)
-      const cli = readClaudeCliAuth(id)
+      const cli = await readClaudeCliAuth(id)
       const authMethod = getAuthMethod(id)
       return {
         ok: true,

--- a/src/main/profile-consumers.ts
+++ b/src/main/profile-consumers.ts
@@ -1,0 +1,47 @@
+/**
+ * Transient (non-session) consumers of an account profile's credentials.
+ *
+ * `isProfileInUseByLiveSession` (claude-account-identity) was built for one kind
+ * of consumer: an open PTY session running under a profile home. The usage
+ * page's auto token-refresh (usage/account-usage.ts) gates on it before rotating
+ * a single-use refresh token — the rule being "don't rotate under a live
+ * consumer, or its copy of the token is stranded and the account logs out".
+ *
+ * #258 added a SECOND kind of consumer that has no session id: the
+ * `claude auth status` probe (account-web/claude-cli-auth), which spawns the CLI
+ * under a profile home to read its auth state and can itself make the CLI rotate
+ * the token. Nothing registered it, so the auto-refresh guard could fire
+ * concurrently and strand the account. This registry lets such short-lived
+ * consumers mark a profile in-use for the duration of the probe so the same
+ * guard covers them. It is ref-counted because probes for one profile can
+ * overlap (Sidebar right-click + AccountsPanel mount).
+ *
+ * Deliberately its own tiny module: it has no Electron/session dependencies, so
+ * both the identity module (which reads it) and the auth probe (which writes it)
+ * can import it without a cycle, and it is unit-testable on its own.
+ */
+
+const refCounts = new Map<string, number>()
+
+/**
+ * Mark `profileId` as having a live transient consumer. Returns a release
+ * function; call it exactly once (in a `finally`) when the consumer is done.
+ * The release is idempotent so a double-call cannot drive the count negative.
+ */
+export function acquireProfileConsumer(profileId: string): () => void {
+  if (!profileId) return () => { /* nothing to track */ }
+  refCounts.set(profileId, (refCounts.get(profileId) ?? 0) + 1)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const next = (refCounts.get(profileId) ?? 1) - 1
+    if (next <= 0) refCounts.delete(profileId)
+    else refCounts.set(profileId, next)
+  }
+}
+
+/** True while any transient consumer holds `profileId`. */
+export function hasTransientProfileConsumer(profileId: string): boolean {
+  return !!profileId && (refCounts.get(profileId) ?? 0) > 0
+}

--- a/src/main/usage/account-usage.ts
+++ b/src/main/usage/account-usage.ts
@@ -356,11 +356,14 @@ export async function fetchAccountUsage(profileId: string): Promise<AccountUsage
   //  - PRIMARY is excluded outright: its credentials are shared with the global
   //    ~/.claude (credsPath can literally BE the global file), which `claude` runs
   //    OUTSIDE CCC read — rotating under them strands every external terminal.
-  //    Non-primary profiles live in CCC-managed isolated homes, so CCC sessions
-  //    are their only consumers and the live-session guard below is sufficient.
-  //  - isProfileInUseByLiveSession covers BOTH interactive sessions and the
-  //    profile-pinned shell-only login shells (re-auth / add-account), whose
-  //    in-flight /login a refresh could otherwise clobber.
+  //    Non-primary profiles live in CCC-managed isolated homes, so their only
+  //    consumers are things CCC knows about, and the live-session guard below
+  //    covers them.
+  //  - isProfileInUseByLiveSession covers interactive sessions, the profile-pinned
+  //    shell-only login shells (re-auth / add-account) whose in-flight /login a
+  //    refresh could clobber, AND — since #258 — the `claude auth status` probe,
+  //    which registers as a transient consumer while it runs (profile-consumers.ts)
+  //    because it too reads and can rotate the profile's token.
   if (!tokenUsable && creds.signedIn && creds.refreshToken && creds.credsPath && !isPrimary && !isProfileInUseByLiveSession(profileId)) {
     const refreshed = await refreshProfileToken(profileId, creds.refreshToken, creds.credsPath)
     if (refreshed) {

--- a/tests/unit/account-web-store-and-cli.test.ts
+++ b/tests/unit/account-web-store-and-cli.test.ts
@@ -12,7 +12,12 @@ vi.mock('../../src/main/channel-storage', () => ({
 vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
 vi.mock('../../src/main/account-profiles', () => ({ getProfileConfigDir: () => '' }))
 
-vi.mock('node:child_process', () => ({ execFileSync: () => { throw new Error('no cli') } }))
+// claude-cli-auth promisifies execFile at module load, so the mock must expose
+// execFile as a function. This suite doesn't call readClaudeCliAuth, so the stub
+// is never invoked; it only needs to satisfy promisify() at import time.
+vi.mock('node:child_process', () => ({
+  execFile: (_cmd: string, _args: string[], _opts: unknown, cb: (e: Error) => void) => cb(new Error('no cli')),
+}))
 
 const { statusOf } = await import('../../src/main/account-web/session-store')
 const { parseCliAuth, parseAuthStatus, claudeAuthCommand } = await import('../../src/main/account-web/claude-cli-auth')

--- a/tests/unit/claude-cli-auth-read.test.ts
+++ b/tests/unit/claude-cli-auth-read.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+//
+// readClaudeCliAuth — the CODE-session auth resolver (#258). Nothing tested this
+// end to end, which is why a credential-file path that could never resolve
+// shipped: it omitted the `.claude` segment every writer/reader uses, so a
+// signed-in account rendered "not signed in" whenever the CLI probe failed.
+//
+// These tests use a REAL temp dir (real fs) and mock only the profile-root
+// resolvers and the CLI subprocess, so the path the code actually joins is under
+// test — revert the `.claude` fix and the credential-file case goes RED.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+
+let root: string
+
+// Per-test CLI behaviour. Default: the CLI errors (absent/slow/non-zero), which
+// is the common real case and the one that forced the file fallback into use.
+// Mock shape matches util.promisify(child_process.execFile): resolve the 2nd
+// callback arg as { stdout, stderr }.
+type ExecCb = (err: Error | null, res?: { stdout: string; stderr: string }) => void
+let execFileImpl: (cmd: string, args: string[], opts: unknown, cb: ExecCb) => void
+
+vi.mock('node:child_process', () => ({
+  execFile: (cmd: string, args: string[], opts: unknown, cb: ExecCb) => execFileImpl(cmd, args, opts, cb),
+}))
+vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+vi.mock('../../src/main/account-profiles', () => ({
+  getProfilesRoot: () => root,
+  getProfileConfigDir: (id: string) => join(root, id),
+}))
+
+const { readClaudeCliAuth } = await import('../../src/main/account-web/claude-cli-auth')
+const { hasTransientProfileConsumer } = await import('../../src/main/profile-consumers')
+
+const ID = 'profile-abc-123'
+const NOW = 1_700_000_000_000
+
+function writeCredFile(id: string, relDir: string) {
+  const dir = join(root, id, relDir)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    join(dir, '.credentials.json'),
+    JSON.stringify({ claudeAiOauth: { accessToken: 'tok', subscriptionType: 'max', expiresAt: NOW } }),
+  )
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(join(os.tmpdir(), 'ccc-cli-auth-'))
+  execFileImpl = (_cmd, _args, _opts, cb) => cb(new Error('no cli'))
+})
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('readClaudeCliAuth — credential-file fallback path', () => {
+  it('finds the file at <home>/.claude/.credentials.json (the path every writer uses)', async () => {
+    writeCredFile(ID, '.claude')
+    const r = await readClaudeCliAuth(ID)
+    expect(r.authenticated).toBe(true)
+    expect(r.source).toBe('credential-file')
+    expect(r.subscriptionType).toBe('max')
+  })
+
+  it('does NOT resolve a file at the old profile-root path (the shipped bug)', async () => {
+    // The file at <home>/.credentials.json — where the pre-fix code looked — must
+    // NOT count as signed in, because nothing in the app ever writes it there.
+    writeCredFile(ID, '.') // <home>/.credentials.json
+    const r = await readClaudeCliAuth(ID)
+    expect(r.authenticated).toBe(false)
+  })
+
+  it('reports not-signed-in (no error) when neither the CLI nor a file answers', async () => {
+    fs.mkdirSync(join(root, ID), { recursive: true }) // home exists, no creds
+    const r = await readClaudeCliAuth(ID)
+    expect(r.authenticated).toBe(false)
+    expect(r.source).toBeUndefined()
+  })
+
+  it('rejects a traversal id before touching the filesystem', async () => {
+    const r = await readClaudeCliAuth('../../etc')
+    expect(r.authenticated).toBe(false)
+    expect(r.error).toMatch(/could not determine/)
+  })
+})
+
+describe('readClaudeCliAuth — CLI probe preferred, and registered as a consumer', () => {
+  it('returns the CLI status (with the identity the file cannot carry) when it answers', async () => {
+    fs.mkdirSync(join(root, ID), { recursive: true })
+    execFileImpl = (_c, _a, _o, cb) =>
+      cb(null, { stdout: JSON.stringify({ loggedIn: true, email: 'a@example.com', orgName: 'Acme' }), stderr: '' })
+    const r = await readClaudeCliAuth(ID)
+    expect(r.authenticated).toBe(true)
+    expect(r.email).toBe('a@example.com')
+    expect(r.source).toBe('cli-status')
+  })
+
+  it('marks the profile in-use FOR THE DURATION of the probe, then releases it', async () => {
+    fs.mkdirSync(join(root, ID), { recursive: true })
+    let inUseDuringProbe: boolean | undefined
+    execFileImpl = (_c, _a, _o, cb) => {
+      // The auto token-refresh guard reads exactly this while the probe runs.
+      inUseDuringProbe = hasTransientProfileConsumer(ID)
+      cb(null, { stdout: JSON.stringify({ loggedIn: true }), stderr: '' })
+    }
+    expect(hasTransientProfileConsumer(ID)).toBe(false)
+    await readClaudeCliAuth(ID)
+    expect(inUseDuringProbe).toBe(true)
+    // Released in the finally — no leak that would block refresh forever.
+    expect(hasTransientProfileConsumer(ID)).toBe(false)
+  })
+
+  it('releases the consumer even when the probe throws', async () => {
+    fs.mkdirSync(join(root, ID), { recursive: true })
+    execFileImpl = (_c, _a, _o, cb) => cb(new Error('boom'))
+    await readClaudeCliAuth(ID)
+    expect(hasTransientProfileConsumer(ID)).toBe(false)
+  })
+})

--- a/tests/unit/profile-consumers.test.ts
+++ b/tests/unit/profile-consumers.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+//
+// The transient-consumer registry (#258): a non-session credential consumer (the
+// `claude auth status` probe) marks a profile in-use so the usage page's auto
+// token-refresh treats it like a live session and won't rotate under it. The
+// contract is ref-counted and release-idempotent — a leaked or double-released
+// count would either block refresh forever or expose the profile mid-probe.
+import { describe, it, expect } from 'vitest'
+import { acquireProfileConsumer, hasTransientProfileConsumer } from '../../src/main/profile-consumers'
+
+describe('profile-consumers', () => {
+  it('is not in use until acquired, and is once acquired', () => {
+    const id = 'profile-a-1'
+    expect(hasTransientProfileConsumer(id)).toBe(false)
+    const release = acquireProfileConsumer(id)
+    expect(hasTransientProfileConsumer(id)).toBe(true)
+    release()
+    expect(hasTransientProfileConsumer(id)).toBe(false)
+  })
+
+  it('ref-counts overlapping consumers — in-use until the LAST release', () => {
+    const id = 'profile-b-2'
+    const r1 = acquireProfileConsumer(id)
+    const r2 = acquireProfileConsumer(id)
+    expect(hasTransientProfileConsumer(id)).toBe(true)
+    r1()
+    expect(hasTransientProfileConsumer(id)).toBe(true) // r2 still holds it
+    r2()
+    expect(hasTransientProfileConsumer(id)).toBe(false)
+  })
+
+  it('release is idempotent — a double call cannot drop another holder', () => {
+    const id = 'profile-c-3'
+    const r1 = acquireProfileConsumer(id)
+    const r2 = acquireProfileConsumer(id)
+    r1(); r1(); r1() // extra releases must be no-ops
+    expect(hasTransientProfileConsumer(id)).toBe(true) // r2 unaffected
+    r2()
+    expect(hasTransientProfileConsumer(id)).toBe(false)
+  })
+
+  it('an empty profileId never registers', () => {
+    const release = acquireProfileConsumer('')
+    expect(hasTransientProfileConsumer('')).toBe(false)
+    release()
+  })
+})


### PR DESCRIPTION
## The defect (MEDIUM) — the ssbn miss the owner sensed

Settings › Accounts renders **"Code session — not signed in"** for a fully signed-in account. `readClaudeCliAuth`'s credential-file fallback joined `<profileHome>/.credentials.json`, but **every** writer and **every** other reader in the app uses `<profileHome>/.claude/.credentials.json` (`account-usage.ts:65`, `account-auth-info.ts:37`, `account-profiles.ts` throughout). So the fallback file could never be found: whenever the `claude auth status` probe failed — absent, slow, or non-zero, all swallowed by the `catch` — the code returned `authenticated:false` and the UI told the user to `/login`, while the usage page showed live usage for that same account.

Introduced by #258 (`23061795`). No test referenced `readClaudeCliAuth`, which is exactly why a path that can never resolve shipped.

## The fix

1. **Path** — `join(configDir, '.claude', '.credentials.json')`, matching every other site. Mutation-proven: reverting the `.claude` segment turns two tests red.
2. **Async probe** — the probe was `execFileSync(timeout: 10_000)`, **synchronous on the main loop**, run per account from `Sidebar.tsx` (every session right-click) and `AccountsPanel.tsx` (every row on mount) — long enough to trip the usage fetch's own 8s socket timeout. Now `promisify(execFile)`; the sole caller (`account-web-handlers.ts`) was already an async IPC handler.
3. **Registered consumer** — the probe spawns the CLI under a profile home and can make it rotate the single-use refresh token, but it registered nowhere, so the usage page's auto token-refresh (`account-usage.ts:364`, gated on `isProfileInUseByLiveSession`, which knew only PTY sessions) could rotate the same token concurrently and **strand the account**. Added a small ref-counted transient-consumer registry (`profile-consumers.ts`); the probe holds it for its duration, `isProfileInUseByLiveSession` now checks it, and the two stale guard comments are corrected.

## Tests

- New `claude-cli-auth-read.test.ts` — real temp-dir fs, mocked CLI: the `.claude` path is found, the old profile-root path is **not**, traversal ids are rejected, the CLI status is preferred when it answers, and the consumer is held during the probe and released after (even on throw).
- New `profile-consumers.test.ts` — ref-count + idempotent-release contract.
- Existing `account-web-store-and-cli.test.ts` mock updated (module now promisifies `execFile` at load).
- Full suite **5233 green**, typecheck clean. Path fix and consumer registration both mutation-proven.

## Scope / not here

- The `active`/inactive-account handling on the usage page is a **separate PR** (BUG 2). This PR is only the credential-path + probe fixes.
- No adversarial pass required (ordinary defect, not a new security boundary — the probe's argv is static literals and the profile id is validated before it becomes a path or a spawn HOME).

Independent of #278 (BUG 1) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)