### PR TITLE
fix(accounts): make the usage page aware of active/inactive accounts

### DIFF
--- a/src/main/usage/account-usage.ts
+++ b/src/main/usage/account-usage.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import { listProfiles, getProfileConfigDir, readProfileAccountEmail, atomicWriteSecure, hardenCredentialFile } from '../account-profiles'
+import { isAccountActive } from '../../shared/account-types'
 import { isProfileInUseByLiveSession } from '../claude-account-identity'
 import { parseUsage } from './usage-buckets'
 import type { AccountUsage, UsageBucket, CreditsInfo } from '../../shared/usage-types'
@@ -330,16 +331,25 @@ export async function fetchAccountUsage(profileId: string): Promise<AccountUsage
   const profiles = listProfiles()
   const profile = profiles.find((p) => p.id === profileId)
   const isPrimary = !!profile?.isPrimary
+  const active = profile ? isAccountActive(profile) : true
   const base: AccountUsage = {
     profileId,
     email: profile?.accountEmail || readProfileAccountEmail(profileId),
     name: profile?.name || 'Account',
     isPrimary,
+    active,
     status: 'error',
     buckets: [],
     fetchedAt: Date.now(),
   }
   if (!profile) return { ...base, detail: 'unknown profile' }
+
+  // Parked account: list it, but do NO network poll and NO token refresh. A
+  // refresh rotates the single-use token — doing that to an account the user
+  // deliberately parked is the opposite of parked, and burns a request against
+  // the IP burst limit for a card that only needs to say "inactive". Return
+  // before readProfileToken/refresh/fetch so none of that runs.
+  if (!active) return { ...base, status: 'inactive' }
 
   const creds = await readProfileToken(profileId, isPrimary)
   let token = creds.token
@@ -395,9 +405,16 @@ export async function fetchAccountUsage(profileId: string): Promise<AccountUsage
 export async function fetchAllAccountsUsage(): Promise<AccountUsage[]> {
   const profiles = listProfiles()
   const out: AccountUsage[] = []
-  for (let i = 0; i < profiles.length; i++) {
-    if (i > 0) await sleep(STAGGER_MS)
-    out.push(await fetchAccountUsage(profiles[i].id))
+  // Stagger only between accounts that actually hit the network. A parked
+  // account short-circuits in fetchAccountUsage (no request), so it must not
+  // consume a stagger slot — otherwise N parked accounts add N*STAGGER_MS of
+  // dead wait before the active ones load.
+  let networkedCount = 0
+  for (const p of profiles) {
+    const willNetwork = isAccountActive(p)
+    if (willNetwork && networkedCount > 0) await sleep(STAGGER_MS)
+    out.push(await fetchAccountUsage(p.id))
+    if (willNetwork) networkedCount++
   }
   return out
 }

--- a/src/renderer/components/AccountUsagePanel.tsx
+++ b/src/renderer/components/AccountUsagePanel.tsx
@@ -136,7 +136,7 @@ function creditsText(c: NonNullable<AccountUsage['credits']>): string {
   return `${fmtMoney(c.used, c.currency)} used`
 }
 
-function AccountCard({
+export function AccountCard({
   row,
   auth,
   theme,
@@ -148,22 +148,29 @@ function AccountCard({
   onSignIn: () => void
 }) {
   const dot = resolveIdentityColor(resolveAccountColourKey(row.email ?? undefined, undefined, undefined), theme)
+  // Parked account: undefined active is treated as active (a main process that
+  // predates the field never greys a card). Inactive accounts are never network
+  // fetched, so they carry no live buckets — the card just states that and
+  // offers no sign-in (opening a login shell for an account the user parked
+  // bypasses the switcher's own active-guard).
+  const isInactive = row.status === 'inactive' || row.active === false
   // Computed at render against the wall clock; the calculation itself is pure and
   // lives in shared/ so main and renderer cannot disagree about what a credential
   // state means.
   const window_ = auth ? describeAuthWindow(auth, Date.now()) : null
   const duplicates = auth?.duplicateOfProfileIds ?? []
   return (
-    <div className="rounded-xl border border-surface0/70 bg-surface0/20 px-4 py-3.5">
+    <div className={`rounded-xl border border-surface0/70 px-4 py-3.5 ${isInactive ? 'bg-surface0/10 opacity-60' : 'bg-surface0/20'}`}>
       <div className="flex items-center gap-2 mb-2.5">
         <span className="w-2.5 h-2.5 rounded-[3px] shrink-0" style={{ backgroundColor: dot }} />
         {/* Full email, never truncated (accounts are distinct even when emails look similar). */}
         <span className="text-[0.9375rem] text-text font-medium break-all">{row.email || row.name}</span>
         {row.isPrimary && <span className="text-[0.625rem] text-overlay0 border border-surface1 rounded-full px-1.5 py-px shrink-0">Primary</span>}
+        {isInactive && <span className="ml-auto text-[0.625rem] text-overlay0 border border-surface1 rounded-full px-1.5 py-px shrink-0">Inactive</span>}
         {/* A working sign-in gets a refresh too, not just a broken one: the whole
             point is to act BEFORE the forced login, and previously the only way to
-            learn it was coming was for it to arrive. */}
-        {row.status !== 'needs-login' && (
+            learn it was coming was for it to arrive. Never for a parked account. */}
+        {!isInactive && row.status !== 'needs-login' && (
           <button
             onClick={onSignIn}
             title="Sign in again now to reset this account's countdown"
@@ -174,7 +181,13 @@ function AccountCard({
         )}
       </div>
 
-      {duplicates.length > 0 && (
+      {isInactive && (
+        <p className="text-[0.8125rem] text-overlay0">
+          Parked — not polled. Reactivate this account in Settings › Accounts to use it again.
+        </p>
+      )}
+
+      {!isInactive && duplicates.length > 0 && (
         <div className="mb-2.5 px-2.5 py-1.5 rounded-lg bg-red/10 border border-red/25 text-[0.75rem] text-red">
           This profile and {duplicates.length === 1 ? 'another profile' : `${duplicates.length} other profiles`} are
           signed into the SAME account. Each time one refreshes, the others&apos; sign-ins are invalidated — which is
@@ -182,7 +195,7 @@ function AccountCard({
         </div>
       )}
 
-      {auth?.identityMismatch && duplicates.length === 0 && (
+      {!isInactive && auth?.identityMismatch && duplicates.length === 0 && (
         <div className="mb-2.5 px-2.5 py-1.5 rounded-lg bg-yellow/10 border border-yellow/25 text-[0.75rem] text-yellow">
           Labelled {auth.accountEmail} but signed in as {auth.oauthEmail}.
         </div>
@@ -224,18 +237,20 @@ function AccountCard({
         </p>
       )}
 
-      <div className="flex items-center justify-between gap-2 mt-2">
-        {row.status === 'ok' ? (
-          <p className="text-[0.6875rem] text-overlay0">
-            {row.stale ? `Last updated ${relAgo(row.fetchedAt)} · couldn't refresh` : `Updated ${relAgo(row.fetchedAt)}`}
-          </p>
-        ) : (
-          <span />
-        )}
-        {window_ && (
-          <p className={`text-[0.6875rem] tabular-nums shrink-0 ${TONE_TEXT[window_.tone]}`}>{window_.label}</p>
-        )}
-      </div>
+      {!isInactive && (
+        <div className="flex items-center justify-between gap-2 mt-2">
+          {row.status === 'ok' ? (
+            <p className="text-[0.6875rem] text-overlay0">
+              {row.stale ? `Last updated ${relAgo(row.fetchedAt)} · couldn't refresh` : `Updated ${relAgo(row.fetchedAt)}`}
+            </p>
+          ) : (
+            <span />
+          )}
+          {window_ && (
+            <p className={`text-[0.6875rem] tabular-nums shrink-0 ${TONE_TEXT[window_.tone]}`}>{window_.label}</p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/shared/usage-types.ts
+++ b/src/shared/usage-types.ts
@@ -39,7 +39,10 @@ export interface ParsedUsage {
   credits?: CreditsInfo
 }
 
-export type AccountUsageStatus = 'ok' | 'needs-login' | 'error'
+// 'inactive' = the account is parked (isAccountActive false): the usage page
+// still lists it, greyed, but it is never network-polled or token-refreshed and
+// offers no sign-in. See fetchAccountUsage's early return.
+export type AccountUsageStatus = 'ok' | 'needs-login' | 'error' | 'inactive'
 
 export interface AccountUsage {
   profileId: string
@@ -56,4 +59,9 @@ export interface AccountUsage {
   /** True when `status: 'ok'` figures are served from cache — a live refresh
    *  couldn't complete but the account is still signed in. */
   stale?: boolean
+  /** Whether the account is active (selectable). False = parked: the page greys
+   *  it and offers no sign-in, and it is not polled/refreshed. Undefined is
+   *  treated as active by the renderer, so a main process that predates this
+   *  field never greys a card. Mirrors AccountProfile.active / isAccountActive. */
+  active?: boolean
 }

--- a/tests/unit/account-usage-inactive.test.ts
+++ b/tests/unit/account-usage-inactive.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+//
+// BUG 2 (#239 follow-up): a parked (inactive) account must be LISTED on the usage
+// page but never network-polled or token-refreshed. fetchAccountUsage short-
+// circuits to status 'inactive' before it reads credentials, refreshes a token,
+// or hits the network. These tests prove that short-circuit: remove it and an
+// inactive account falls through to the normal (needs-login/error) path, so the
+// status assertion fails.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { AccountProfile } from '../../src/shared/account-types'
+
+let profiles: AccountProfile[] = []
+
+vi.mock('../../src/main/account-profiles', () => ({
+  listProfiles: () => profiles,
+  // Reached only if the short-circuit is REMOVED (readProfileToken path). Point
+  // it at a dir with no credentials so a fall-through resolves to signed-out,
+  // which is a different status than 'inactive' — that difference is the proof.
+  getProfileConfigDir: (id: string) => `/nonexistent/${id}`,
+  readProfileAccountEmail: () => null,
+  atomicWriteSecure: vi.fn(),
+  hardenCredentialFile: vi.fn(),
+}))
+vi.mock('../../src/main/claude-account-identity', () => ({
+  isProfileInUseByLiveSession: () => false,
+}))
+vi.mock('../../src/main/debug-logger', () => ({ logWarn: vi.fn(), logInfo: vi.fn() }))
+
+const { fetchAccountUsage, fetchAllAccountsUsage } = await import('../../src/main/usage/account-usage')
+
+const profile = (over: Partial<AccountProfile>): AccountProfile => ({
+  id: 'profile-x-1',
+  name: 'Acct',
+  accountEmail: 'x@example.com',
+  createdAt: 0,
+  ...over,
+})
+
+beforeEach(() => { profiles = [] })
+
+describe('fetchAccountUsage — parked accounts short-circuit', () => {
+  it('an inactive account reports status "inactive" with active:false and no buckets', async () => {
+    profiles = [profile({ id: 'profile-parked-1', active: false })]
+    const r = await fetchAccountUsage('profile-parked-1')
+    expect(r.status).toBe('inactive')
+    expect(r.active).toBe(false)
+    expect(r.buckets).toEqual([])
+  })
+
+  it('does NOT short-circuit an active account (undefined active = active)', async () => {
+    // No creds on disk, so it lands on needs-login/error — the point is only that
+    // it is NOT 'inactive': an active account still takes the live path.
+    profiles = [profile({ id: 'profile-active-1' })] // active undefined => active
+    const r = await fetchAccountUsage('profile-active-1')
+    expect(r.status).not.toBe('inactive')
+    expect(r.active).toBe(true)
+  })
+
+  it('the PRIMARY account is always active even if marked inactive', async () => {
+    profiles = [profile({ id: 'profile-primary-1', isPrimary: true, active: false })]
+    const r = await fetchAccountUsage('profile-primary-1')
+    expect(r.status).not.toBe('inactive')
+    expect(r.active).toBe(true)
+  })
+})
+
+describe('fetchAllAccountsUsage — inactive rows are listed but not networked', () => {
+  it('returns a row for every account, inactive ones marked and short-circuited', async () => {
+    profiles = [
+      profile({ id: 'profile-parked-1', active: false }),
+      profile({ id: 'profile-parked-2', active: false }),
+    ]
+    const rows = await fetchAllAccountsUsage()
+    expect(rows.map((r) => r.profileId)).toEqual(['profile-parked-1', 'profile-parked-2'])
+    expect(rows.every((r) => r.status === 'inactive' && r.active === false)).toBe(true)
+  })
+})

--- a/tests/unit/renderer/account-usage-panel.test.tsx
+++ b/tests/unit/renderer/account-usage-panel.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+//
+// BUG 2 (#239 follow-up): the account-usage page was blind to active/inactive.
+// The behavioural hole was the sign-in buttons — they opened a login shell for
+// an account the user deliberately parked, bypassing the switcher's own
+// active-guard. AccountCard now renders a parked card with NO sign-in and greys
+// it. These tests pin exactly that: an inactive row offers neither button and
+// shows the parked message; an active row still does.
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { AccountCard } from '../../../src/renderer/components/AccountUsagePanel'
+import type { AccountUsage } from '../../../src/shared/usage-types'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  act(() => { root.render(ui) })
+  return { container, unmount: () => { act(() => root.unmount()); container.remove() } }
+}
+
+const row = (over: Partial<AccountUsage>): AccountUsage => ({
+  profileId: 'profile-x-1',
+  email: 'x@example.com',
+  name: 'Acct',
+  isPrimary: false,
+  status: 'ok',
+  buckets: [],
+  fetchedAt: 0,
+  ...over,
+})
+
+function buttonTexts(c: HTMLElement): string[] {
+  return Array.from(c.querySelectorAll('button')).map((b) => b.textContent?.trim() ?? '')
+}
+
+describe('AccountCard — active/inactive awareness', () => {
+  it('an inactive account shows NO sign-in button and the parked message', () => {
+    const onSignIn = vi.fn()
+    const r = render(<AccountCard row={row({ status: 'inactive', active: false })} theme="dark" onSignIn={onSignIn} />)
+    expect(buttonTexts(r.container)).toEqual([]) // neither "Sign in" nor "Refresh sign-in"
+    expect(r.container.textContent).toContain('Inactive')
+    expect(r.container.textContent).toMatch(/Parked/i)
+    r.unmount()
+  })
+
+  it('treats active:false as inactive even if status was left ok (defensive gate)', () => {
+    const r = render(<AccountCard row={row({ status: 'ok', active: false, buckets: [] })} theme="dark" onSignIn={vi.fn()} />)
+    expect(buttonTexts(r.container)).toEqual([])
+    expect(r.container.textContent).toMatch(/Parked/i)
+    r.unmount()
+  })
+
+  it('an active signed-out account still offers "Sign in"', () => {
+    const r = render(<AccountCard row={row({ status: 'needs-login', active: true })} theme="dark" onSignIn={vi.fn()} />)
+    expect(buttonTexts(r.container)).toContain('Sign in')
+    expect(r.container.textContent).not.toMatch(/Parked/i)
+    r.unmount()
+  })
+
+  it('an active signed-in account still offers "Refresh sign-in"', () => {
+    const r = render(<AccountCard row={row({ status: 'ok', active: true, buckets: [] })} theme="dark" onSignIn={vi.fn()} />)
+    expect(buttonTexts(r.container)).toContain('Refresh sign-in')
+    r.unmount()
+  })
+
+  it('an undefined active field is treated as active (no migration, no greying)', () => {
+    const r = render(<AccountCard row={row({ status: 'needs-login' })} theme="dark" onSignIn={vi.fn()} />)
+    expect(buttonTexts(r.container)).toContain('Sign in')
+    r.unmount()
+  })
+})


### PR DESCRIPTION
## The defect (LOW-MEDIUM)

An account deactivated via Settings › Accounts (`active: false`, #239) is honoured on every *switching* surface but was invisible to the account-usage page. A parked account was still:

- **network-polled** every refresh, and counted in the per-IP stagger budget;
- **auto token-refreshed** (`account-usage.ts:364`) — rotating the single-use refresh token of an account the user deliberately parked;
- offered **"Sign in" / "Refresh sign-in"**, which open a login shell pinned to that account, **bypassing the switcher's own active-guard** (`AccountLaunchGate` / `useSwitchAccount`). Per the review this button hole is the real defect; the rest is inconsistency.

The state never crossed IPC: `AccountUsage` had no `active` field, so `fetchAccountUsage` dropped it.

## The fix

- `AccountUsage` gains `active?` (undefined = active, so a main process predating the field never greys a card — mirrors `AccountProfile.active`). New `'inactive'` status, consumed only by the panel.
- `fetchAccountUsage` sets `active` from `isAccountActive` and **short-circuits a parked account to `status:'inactive'` before** reading credentials, refreshing, or hitting the network. The primary is always active (as everywhere).
- `fetchAllAccountsUsage` still lists every account but skips the 300 ms stagger slot for parked ones (N parked accounts no longer add N×300 ms of dead wait).
- `AccountUsagePanel`: greys the parked card, badges it **Inactive**, shows a "Parked — reactivate in Settings" line, and renders **neither** sign-in button. The buttons are gated on the active flag (not just status) as defence.

## Tests

- `account-usage-panel.test.tsx` (new; `AccountCard` now exported) — inactive → no buttons + parked message; `active:false` with any status → parked (defensive gate); active needs-login → "Sign in"; active ok → "Refresh sign-in"; undefined active → active.
- `account-usage-inactive.test.ts` (new) — `fetchAccountUsage` short-circuits inactive (never the primary); `fetchAllAccountsUsage` lists parked rows without networking them.
- Full suite **5263 green**, typecheck clean. Both guards mutation-proven (disable the short-circuit → 2 red; neuter the panel gate → 2 red).

## Scope / not here

- The nav-rail gate (`SidebarNav`, `profiles.length >= 2` counting inactive) is left for an **owner decision** — a visibility choice, not a defect.
- No adversarial pass required (display + fetch-gating, no new security boundary).

Rebased onto beta after #279 (BUG 3) merged; `account-usage.ts` regions are disjoint (BUG 3 = guard comment, this = early-return + fetch loop) and merged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)