### PR TITLE
fix(terminal): repaint stale WebGL glyphs on scroll+streaming (#273)

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -4,7 +4,13 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
-import { installWebglWithRecovery } from './terminal/terminalWebgl'
+import { installWebglWithRecovery, type WebglHandle } from './terminal/terminalWebgl'
+import {
+  createStaleGlyphRepainter,
+  shouldRepaintOnOutput,
+  WHEEL_ACTIVE_MS,
+  type StaleGlyphRepainter,
+} from './terminal/staleGlyphRepaint'
 import { useSessionStore } from '../stores/sessionStore'
 import { persistLastUsedAccount } from '../session-persistence'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
@@ -283,6 +289,12 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let pendingParseData = ''
     let refreshTimer: ReturnType<typeof setTimeout> | null = null
     let handleWheel: ((e: WheelEvent) => void) | null = null
+    // #273 stale-glyph repaint: force a full WebGL repaint (clearTextureAtlas +
+    // term.refresh) on the triggers that correlate with the ghosting — scroll and
+    // streaming output — throttled so a firehose costs at most a few repaints/sec.
+    let webglHandle: WebglHandle | null = null
+    let repainter: StaleGlyphRepainter | null = null
+    let lastWheelAt = Number.NEGATIVE_INFINITY
 
     // PTY-integrity instrumentation (scoped to this session's mount; resets on
     // sessionId change because the effect re-runs).
@@ -398,10 +410,19 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // then we try ONE recreate in the next frame (GPU-blip recovery).
       // If recreate fails, we force term.refresh so the DOM renderer
       // repaints the viewport the dead WebGL canvas left garbled.
-      installWebglWithRecovery(term, {
+      webglHandle = installWebglWithRecovery(term, {
         WebglAddonCtor: WebglAddon,
         raf: requestAnimationFrame,
         isDisposed: () => disposed,
+      })
+      // #273: bust stale WebGL glyphs by reproducing the window-resize repaint
+      // (clearTextureAtlas + refresh) against whichever addon is currently live.
+      repainter = createStaleGlyphRepainter({
+        clearAtlas: () => { webglHandle?.clearTextureAtlas() },
+        refresh: () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } },
+        now: Date.now,
+        setTimer: (cb, ms) => setTimeout(cb, ms),
+        clearTimer: (h) => clearTimeout(h),
       })
 
       // #119: cursor options passed to the Terminal constructor do NOT reliably
@@ -698,6 +719,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
 
       handleWheel = () => {
         if (!term) return
+        // #273: record the scroll and bust any stale glyphs now. Normal buffer
+        // only — the alternate screen (TUI apps) owns its own repaints.
+        lastWheelAt = Date.now()
+        if (term.buffer.active.type !== 'alternate') repainter?.schedule()
         // After the wheel event settles, check viewport position
         if (refreshTimer) clearTimeout(refreshTimer)
         refreshTimer = setTimeout(() => {
@@ -759,6 +784,18 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
 
         if (follow.scrollToBottom) term?.scrollToBottom()
         if (follow.scrolledUp !== isScrolledUpRef.current) updateScrollState(follow.scrolledUp)
+
+        // #273: streaming output is when stale WebGL glyphs accumulate. Repaint
+        // when the reproducing conditions hold (normal buffer, and the user is
+        // scrolled up or has scrolled recently); the throttle bounds the cost.
+        if (term && repainter && shouldRepaintOnOutput({
+          alternateBuffer: term.buffer.active.type === 'alternate',
+          scrolledUp: isScrolledUpRef.current,
+          msSinceWheel: Date.now() - lastWheelAt,
+          wheelActiveMs: WHEEL_ACTIVE_MS,
+        })) {
+          repainter.schedule()
+        }
 
         // Post-resume settle nudge: every chunk re-arms the timer; it fires only
         // once a burst has gone quiet for 600ms, and only while shots remain.
@@ -962,6 +999,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handlePaste) container.removeEventListener('paste', handlePaste, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
+      repainter?.dispose()
       resizeObserver?.disconnect()
       unsubData?.()
       unsubExit?.()

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -418,7 +418,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // #273: bust stale WebGL glyphs by reproducing the window-resize repaint
       // (clearTextureAtlas + refresh) against whichever addon is currently live.
       repainter = createStaleGlyphRepainter({
-        clearAtlas: () => { webglHandle?.clearTextureAtlas() },
+        // Return whether the atlas was actually cleared (WebGL active). When it
+        // wasn't (DOM-renderer fallback / unrecovered context loss) the repainter
+        // skips the refresh — a DOM-renderer session has no atlas ghost to bust.
+        clearAtlas: () => webglHandle?.clearTextureAtlas() ?? false,
         refresh: () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } },
         now: Date.now,
         setTimer: (cb, ms) => setTimeout(cb, ms),

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -55,8 +55,10 @@ export function shouldRepaintOnOutput(s: OutputRepaintState): boolean {
 }
 
 export interface RepainterDeps {
-  /** Rebuild the WebGL glyph atlas (no-op whenever WebGL isn't active). */
-  clearAtlas: () => void
+  /** Rebuild the WebGL glyph atlas. Returns true when WebGL was active and the
+   *  atlas was actually cleared; false on the DOM-renderer fallback (or an
+   *  unrecovered context loss) — nothing to clear, so nothing to repaint. */
+  clearAtlas: () => boolean
   /** Mark the viewport dirty so it re-renders (term.refresh(0, rows-1)). */
   refresh: () => void
   now: () => number
@@ -91,10 +93,13 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
 
   const paint = () => {
     lastPaintAt = deps.now()
-    // clearAtlas() first so refresh() re-rasters against a rebuilt atlas — the
-    // programmatic equivalent of the window-move full repaint.
-    deps.clearAtlas()
-    deps.refresh()
+    // clearAtlas() rebuilds the WebGL glyph atlas; refresh() then re-rasters
+    // against it (the programmatic equivalent of the window-move full repaint).
+    // When WebGL isn't active clearAtlas() returns false — there is no atlas
+    // ghost — so skip the full-viewport refresh rather than tax a DOM-renderer
+    // session that never had the bug (#273 adversarial review). lastPaintAt is
+    // still advanced above so the throttle keeps pacing the (now cheap) checks.
+    if (deps.clearAtlas()) deps.refresh()
   }
 
   const schedule = () => {

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -55,7 +55,7 @@ export function shouldRepaintOnOutput(s: OutputRepaintState): boolean {
 }
 
 export interface RepainterDeps {
-  /** Rebuild the WebGL glyph atlas (no-op on the DOM renderer). */
+  /** Rebuild the WebGL glyph atlas (no-op whenever WebGL isn't active). */
   clearAtlas: () => void
   /** Mark the viewport dirty so it re-renders (term.refresh(0, rows-1)). */
   refresh: () => void

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -1,0 +1,124 @@
+/**
+ * Stale-glyph repaint scheduler (#273).
+ *
+ * The xterm WebGL renderer can leave STALE glyph cells painted over the live
+ * viewport: a frozen fragment of recent output overlapping the current rows. The
+ * cell BUFFER is correct — only the painted surface is stale — which is why a
+ * window resize (a full GPU repaint) clears it instantly. It shows up during
+ * continuous output combined with mouse-wheel scrolling, and is aggravated by a
+ * nested console program that writes DIRECT to the console (CONOUT$): those
+ * writes bypass any redirected stdout/stderr, reach the ConPTY transiently,
+ * flash on screen, and the WebGL damage tracking freezes them as stale cells.
+ *
+ * The fix is to reproduce the resize's full repaint programmatically —
+ * `WebglAddon.clearTextureAtlas()` (rebuild the glyph atlas + re-raster the
+ * viewport) followed by `term.refresh()` — on the triggers that correlate with
+ * the bug, THROTTLED so a firehose of output costs at most a few repaints a
+ * second rather than one per chunk.
+ *
+ * Everything here is pure and dependency-injected so the throttle boundaries and
+ * the trigger predicate are unit-testable without a DOM or a GPU.
+ */
+
+/** At most one strong repaint per this interval — 4/sec under a firehose. */
+export const REPAINT_MIN_INTERVAL_MS = 250
+
+/** After a wheel event, treat the user as "actively scrolling" for this long, so
+ *  streaming output keeps busting ghosts until the scroll settles. */
+export const WHEEL_ACTIVE_MS = 3000
+
+export interface OutputRepaintState {
+  /** term.buffer.active.type === 'alternate'. TUI apps (Claude's own UI) run in
+   *  the alternate screen: no scrollback, they own their full repaints, and they
+   *  do not accumulate the scroll-driven stale cells this targets. Skip them so
+   *  the common case pays nothing. */
+  alternateBuffer: boolean
+  /** Viewport parked above the bottom (the user scrolled up). */
+  scrolledUp: boolean
+  /** Milliseconds since the last wheel event (Infinity if none yet). */
+  msSinceWheel: number
+  /** How long after a wheel a repaint stays warranted (WHEEL_ACTIVE_MS). */
+  wheelActiveMs: number
+}
+
+/**
+ * Should arriving output trigger a stale-glyph repaint?
+ *
+ * Only in the NORMAL buffer, and only when the user is either scrolled up or has
+ * scrolled recently — the exact conditions under which #273 reproduces. Steady
+ * at-bottom output with no recent scroll (an idle shell tailing a log, a TUI in
+ * the alternate buffer) is left alone.
+ */
+export function shouldRepaintOnOutput(s: OutputRepaintState): boolean {
+  if (s.alternateBuffer) return false
+  return s.scrolledUp || s.msSinceWheel < s.wheelActiveMs
+}
+
+export interface RepainterDeps {
+  /** Rebuild the WebGL glyph atlas (no-op on the DOM renderer). */
+  clearAtlas: () => void
+  /** Mark the viewport dirty so it re-renders (term.refresh(0, rows-1)). */
+  refresh: () => void
+  now: () => number
+  setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  /** Override the throttle interval (tests). Defaults to REPAINT_MIN_INTERVAL_MS. */
+  minIntervalMs?: number
+}
+
+export interface StaleGlyphRepainter {
+  /** Request a strong repaint soon. Leading-edge immediate, then coalesced into
+   *  at most one repaint per interval for the rest of a burst. */
+  schedule(): void
+  /** Cancel any pending repaint and refuse further ones. */
+  dispose(): void
+}
+
+/**
+ * A leading-edge throttle around a "strong repaint".
+ *
+ *   - The first call after an idle gap repaints IMMEDIATELY (leading edge), so a
+ *     ghost is cleared without waiting out the interval.
+ *   - Calls inside the throttle window coalesce into a SINGLE trailing repaint at
+ *     the window edge — a continuous firehose calling schedule() every frame
+ *     still repaints only every `minIntervalMs`.
+ */
+export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepainter {
+  const minInterval = deps.minIntervalMs ?? REPAINT_MIN_INTERVAL_MS
+  let lastPaintAt = Number.NEGATIVE_INFINITY
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const paint = () => {
+    lastPaintAt = deps.now()
+    // clearAtlas() first so refresh() re-rasters against a rebuilt atlas — the
+    // programmatic equivalent of the window-move full repaint.
+    deps.clearAtlas()
+    deps.refresh()
+  }
+
+  const schedule = () => {
+    if (disposed) return
+    const since = deps.now() - lastPaintAt
+    if (since >= minInterval) {
+      if (timer) { deps.clearTimer(timer); timer = null }
+      paint()
+      return
+    }
+    // Inside the window: one trailing repaint at the edge. Already-armed → let it
+    // stand rather than pushing it later (that would starve a steady stream).
+    if (timer) return
+    timer = deps.setTimer(() => {
+      timer = null
+      if (disposed) return
+      paint()
+    }, minInterval - since)
+  }
+
+  const dispose = () => {
+    disposed = true
+    if (timer) { deps.clearTimer(timer); timer = null }
+  }
+
+  return { schedule, dispose }
+}

--- a/src/renderer/components/terminal/terminalWebgl.ts
+++ b/src/renderer/components/terminal/terminalWebgl.ts
@@ -15,6 +15,24 @@ export interface WebglRecoveryOptions {
 }
 
 /**
+ * A handle onto the LIVE WebGL addon, valid across context-loss recreations.
+ *
+ * The addon instance is replaced on every recovery, so callers must not cache
+ * their own reference — they go through this handle, which always targets the
+ * current addon (or is a no-op when WebGL isn't active).
+ */
+export interface WebglHandle {
+  /**
+   * Rebuild the WebGL glyph atlas and re-raster the viewport — the programmatic
+   * equivalent of the full repaint a window resize forces (see #273). Returns
+   * true if it ran, false when WebGL isn't active (initial load failed, or a
+   * context loss dropped us to the DOM renderer) — in which case the caller's
+   * `term.refresh()` is the repaint that matters.
+   */
+  clearTextureAtlas(): boolean
+}
+
+/**
  * Loads a WebGL addon onto `term` and wires a self-reloading context-loss handler.
  *
  * On context loss the addon fires its callback; we:
@@ -23,10 +41,17 @@ export interface WebglRecoveryOptions {
  *   3. If the recreate throws (GPU genuinely gone), call `term.refresh(0, rows-1)` so the
  *      DOM renderer repaints the viewport that the dead WebGL canvas left garbled.
  *
- * The happy path (WebGL works, no context loss) is identical to the original single-line version.
+ * Returns a WebglHandle so the caller can force a full repaint (#273) against
+ * whichever addon is currently live. The happy path (WebGL works, no context
+ * loss) is otherwise identical to the original single-line version.
  */
-export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOptions): void {
+export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOptions): WebglHandle {
   const { WebglAddonCtor, raf, isDisposed } = opts
+
+  // The addon currently loaded on the terminal, or null when WebGL isn't active
+  // (never loaded, or dropped to the DOM renderer after a context loss). Kept in
+  // sync so the returned handle always targets the live addon.
+  let currentAddon: WebglAddon | null = null
 
   /**
    * Attempt to create and load a WebGL addon.
@@ -36,6 +61,10 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
   const createAndLoad = () => {
     const addon = new WebglAddonCtor()          // may throw
     addon.onContextLoss(() => {
+      // The atlas is gone the moment the context is lost — drop the reference
+      // before disposing so a repaint racing the recovery no-ops instead of
+      // touching a dead addon.
+      currentAddon = null
       addon.dispose()
       raf(() => {
         if (isDisposed()) return
@@ -49,11 +78,27 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
       })
     })
     term.loadAddon(addon)                        // may throw
+    // Only after loadAddon succeeds — a throw above leaves currentAddon null.
+    currentAddon = addon
   }
 
   try {
     createAndLoad()
   } catch {
     // Initial WebGL load failed (unavailable env) — stay on DOM renderer.
+  }
+
+  return {
+    clearTextureAtlas() {
+      if (!currentAddon) return false
+      try {
+        currentAddon.clearTextureAtlas()
+        return true
+      } catch {
+        // Addon disposed mid-call, or an internal WebGL error — treat as "not
+        // active" so the caller falls back to a plain refresh.
+        return false
+      }
+    },
   }
 }

--- a/src/renderer/components/terminal/terminalWebgl.ts
+++ b/src/renderer/components/terminal/terminalWebgl.ts
@@ -56,7 +56,9 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
   /**
    * Attempt to create and load a WebGL addon.
    * Throws if construction or loadAddon fails (so callers can distinguish
-   * "initial failure — stay on canvas" from "recreate failed — need refresh").
+   * "initial failure — stay on the DOM renderer" from "recreate failed — need
+   * refresh"). xterm's default non-WebGL renderer is the DOM renderer; this app
+   * loads no canvas addon, so that is always the fallback.
    */
   const createAndLoad = () => {
     const addon = new WebglAddonCtor()          // may throw

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -34,8 +34,10 @@ describe('shouldRepaintOnOutput', () => {
   })
 })
 
-/** A manual clock + timer queue so throttle boundaries are exercised exactly. */
-function makeHarness() {
+/** A manual clock + timer queue so throttle boundaries are exercised exactly.
+ *  webglActive controls what clearAtlas() reports (true = WebGL active/atlas
+ *  cleared; false = DOM-renderer fallback with nothing to clear). */
+function makeHarness({ webglActive = true }: { webglActive?: boolean } = {}) {
   let time = 0
   let nextId = 1
   const timers: Array<{ id: number; cb: () => void; at: number }> = []
@@ -43,7 +45,7 @@ function makeHarness() {
   let refresh = 0
 
   const deps = {
-    clearAtlas: () => { clearAtlas++ },
+    clearAtlas: () => { clearAtlas++; return webglActive },
     refresh: () => { refresh++ },
     now: () => time,
     setTimer: (cb: () => void, ms: number) => {
@@ -87,6 +89,20 @@ describe('createStaleGlyphRepainter', () => {
     const r = createStaleGlyphRepainter(h.deps)
     r.schedule()
     expect(h.counts()).toEqual({ clearAtlas: 1, refresh: 1 })
+  })
+
+  // #273 adversarial review: a DOM-renderer session (no WebGL) has no atlas
+  // ghost, so clearAtlas() returns false and the expensive full-viewport
+  // refresh must be skipped — otherwise those sessions pay ~4/sec forced
+  // reflows for a bug they don't have.
+  it('skips the refresh when WebGL is inactive (clearAtlas returns false)', () => {
+    const h = makeHarness({ webglActive: false })
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule()                 // leading edge: atlas is probed...
+    expect(h.counts()).toEqual({ clearAtlas: 1, refresh: 0 })  // ...but no refresh
+    // And under a firehose it stays refresh-free (still throttled to ~4 probes/sec).
+    for (let i = 0; i < 63; i++) { r.schedule(); h.advance(16) }
+    expect(h.counts().refresh).toBe(0)
   })
 
   it('coalesces a burst inside the window into a single trailing repaint', () => {

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the #273 stale-glyph repaint scheduler.
+ *
+ * Both units are pure and dependency-injected: the trigger predicate and the
+ * leading-edge throttle are exercised with a fake clock + fake timers, no DOM.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  shouldRepaintOnOutput,
+  createStaleGlyphRepainter,
+  REPAINT_MIN_INTERVAL_MS,
+  WHEEL_ACTIVE_MS,
+} from '../../../src/renderer/components/terminal/staleGlyphRepaint'
+
+describe('shouldRepaintOnOutput', () => {
+  const base = { alternateBuffer: false, scrolledUp: false, msSinceWheel: Infinity, wheelActiveMs: WHEEL_ACTIVE_MS }
+
+  it('never repaints in the alternate buffer, even when scrolled up', () => {
+    expect(shouldRepaintOnOutput({ ...base, alternateBuffer: true, scrolledUp: true })).toBe(false)
+    expect(shouldRepaintOnOutput({ ...base, alternateBuffer: true, msSinceWheel: 0 })).toBe(false)
+  })
+
+  it('repaints in the normal buffer when the user is scrolled up', () => {
+    expect(shouldRepaintOnOutput({ ...base, scrolledUp: true })).toBe(true)
+  })
+
+  it('repaints in the normal buffer shortly after a wheel event', () => {
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS - 1 })).toBe(true)
+  })
+
+  it('does NOT repaint at the bottom with no recent scroll', () => {
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(false)
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(false)
+  })
+})
+
+/** A manual clock + timer queue so throttle boundaries are exercised exactly. */
+function makeHarness() {
+  let time = 0
+  let nextId = 1
+  const timers: Array<{ id: number; cb: () => void; at: number }> = []
+  let clearAtlas = 0
+  let refresh = 0
+
+  const deps = {
+    clearAtlas: () => { clearAtlas++ },
+    refresh: () => { refresh++ },
+    now: () => time,
+    setTimer: (cb: () => void, ms: number) => {
+      const id = nextId++
+      timers.push({ id, cb, at: time + ms })
+      return id as unknown as ReturnType<typeof setTimeout>
+    },
+    clearTimer: (h: ReturnType<typeof setTimeout>) => {
+      const i = timers.findIndex((t) => t.id === (h as unknown as number))
+      if (i >= 0) timers.splice(i, 1)
+    },
+  }
+
+  const advance = (ms: number) => {
+    const target = time + ms
+    for (;;) {
+      timers.sort((a, b) => a.at - b.at)
+      if (timers.length === 0 || timers[0].at > target) break
+      const t = timers.shift()!
+      time = t.at
+      t.cb()
+    }
+    time = target
+  }
+
+  return {
+    deps,
+    advance,
+    counts: () => ({ clearAtlas, refresh }),
+    pendingTimers: () => timers.length,
+  }
+}
+
+describe('createStaleGlyphRepainter', () => {
+  it('exposes the documented throttle interval default', () => {
+    expect(REPAINT_MIN_INTERVAL_MS).toBe(250)
+  })
+
+  it('repaints immediately on the leading edge (atlas THEN refresh)', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule()
+    expect(h.counts()).toEqual({ clearAtlas: 1, refresh: 1 })
+  })
+
+  it('coalesces a burst inside the window into a single trailing repaint', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+
+    r.schedule()               // leading paint at t=0
+    expect(h.counts().clearAtlas).toBe(1)
+
+    h.advance(50)
+    r.schedule()               // within window → arms one trailing timer
+    r.schedule()               // still within window, timer armed → no-op
+    r.schedule()
+    expect(h.counts().clearAtlas).toBe(1) // no extra immediate paints
+    expect(h.pendingTimers()).toBe(1)
+
+    h.advance(200)             // reaches t=250, trailing fires
+    expect(h.counts().clearAtlas).toBe(2)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('leads again once a full interval has elapsed', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule()               // t=0 → paint 1
+    h.advance(REPAINT_MIN_INTERVAL_MS)
+    r.schedule()               // t=250, since>=interval → immediate paint 2
+    expect(h.counts().clearAtlas).toBe(2)
+  })
+
+  it('holds a continuous per-frame firehose to one repaint per interval', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    // 1000ms of output scheduled every 16ms.
+    for (let i = 0; i < 63; i++) { r.schedule(); h.advance(16) }
+    // Leading paint at 0, then trailing at 250/500/750/1000 → 4-5 total, never 63.
+    expect(h.counts().clearAtlas).toBeLessThanOrEqual(6)
+    expect(h.counts().clearAtlas).toBeGreaterThanOrEqual(4)
+  })
+
+  it('dispose() cancels a pending repaint and refuses further ones', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule()               // paint 1
+    h.advance(50)
+    r.schedule()               // arms trailing timer
+    expect(h.pendingTimers()).toBe(1)
+    r.dispose()
+    expect(h.pendingTimers()).toBe(0)
+    h.advance(1000)
+    r.schedule()               // disposed → ignored
+    expect(h.counts().clearAtlas).toBe(1)
+  })
+})

--- a/tests/unit/renderer/terminal-webgl-handle.test.ts
+++ b/tests/unit/renderer/terminal-webgl-handle.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the WebglHandle returned by installWebglWithRecovery (#273).
+ *
+ * The handle must target whichever addon is CURRENTLY live — including after a
+ * context-loss recreation — and cleanly no-op (return false) when WebGL isn't
+ * active, so the caller falls back to a plain term.refresh().
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { installWebglWithRecovery } from '../../../src/renderer/components/terminal/terminalWebgl'
+
+interface FakeInstance {
+  clearTextureAtlas: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  contextLoss?: () => void
+}
+
+function setup(opts?: { throwOnConstruct?: (n: number) => boolean; throwOnClear?: boolean }) {
+  const instances: FakeInstance[] = []
+  let n = 0
+  const FakeWebglAddon = class {
+    clearTextureAtlas = vi.fn(() => { if (opts?.throwOnClear) throw new Error('gl gone') })
+    dispose = vi.fn()
+    contextLoss?: () => void
+    constructor() {
+      n += 1
+      if (opts?.throwOnConstruct?.(n)) throw new Error('no webgl')
+      instances.push(this as unknown as FakeInstance)
+    }
+    onContextLoss(cb: () => void) { (this as unknown as FakeInstance).contextLoss = cb }
+  }
+  const term = { rows: 24, loadAddon: vi.fn(), refresh: vi.fn() }
+  const syncRaf = (cb: () => void) => { cb(); return 0 }
+  const handle = installWebglWithRecovery(term as never, {
+    WebglAddonCtor: FakeWebglAddon as never,
+    raf: syncRaf,
+    isDisposed: () => false,
+  })
+  return { handle, term, instances }
+}
+
+describe('installWebglWithRecovery — WebglHandle', () => {
+  it('clearTextureAtlas() targets the loaded addon and returns true', () => {
+    const { handle, instances } = setup()
+    expect(handle.clearTextureAtlas()).toBe(true)
+    expect(instances[0].clearTextureAtlas).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false when WebGL never loaded (initial construction threw)', () => {
+    const { handle, term } = setup({ throwOnConstruct: (n) => n === 1 })
+    expect(handle.clearTextureAtlas()).toBe(false)
+    expect(term.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('after a context loss + successful recreate, targets the NEW addon', () => {
+    const { handle, instances } = setup()
+    instances[0].contextLoss!()          // recreate succeeds → instances[1]
+    expect(instances).toHaveLength(2)
+
+    expect(handle.clearTextureAtlas()).toBe(true)
+    expect(instances[1].clearTextureAtlas).toHaveBeenCalledTimes(1)
+    expect(instances[0].clearTextureAtlas).not.toHaveBeenCalled()
+  })
+
+  it('returns false after a context loss whose recreate fails (dropped to DOM)', () => {
+    const { handle, term, instances } = setup({ throwOnConstruct: (n) => n === 2 })
+    instances[0].contextLoss!()          // recreate throws → DOM fallback
+    expect(handle.clearTextureAtlas()).toBe(false)
+    // The recreate-failure path forces a DOM repaint.
+    expect(term.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('returns false (not throws) when the live addon clearTextureAtlas throws', () => {
+    const { handle } = setup({ throwOnClear: true })
+    expect(() => handle.clearTextureAtlas()).not.toThrow()
+    expect(handle.clearTextureAtlas()).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #273.

## What

The xterm WebGL renderer leaves **stale glyph cells** painted over the live
viewport during continuous output combined with mouse-wheel scrolling — a frozen
fragment of recent output overlapping the current rows. The cell buffer is
correct; only the paint is stale, which is why **moving/resizing the window
clears it** (a full GPU repaint).

It's aggravated by a nested console program that writes **direct to the console
(CONOUT$)**: those writes bypass any redirected stdout/stderr (e.g. a
`… | Select-Object -Last N` pipe), reach the ConPTY transiently, flash on
screen, and the WebGL damage tracking freezes them as stale cells.

## Why the prior mitigation missed it

`term.refresh(0, rows-1)` only fired on **wheel-settle while scrolled up**
(`TerminalView.tsx`) and in the resume-nudge burst path. During at-bottom
streaming — the reproducing case — nothing forced a repaint, so the ghost
persisted until a resize.

## Fix

Reproduce the window-resize repaint programmatically —
`WebglAddon.clearTextureAtlas()` + `term.refresh(0, rows-1)` — on the triggers
that correlate with the bug, **leading-edge throttled** to ~4/sec so a firehose
of output costs a few repaints a second rather than one per chunk.

- `installWebglWithRecovery` now returns a `WebglHandle` that targets the
  **current** addon across context-loss recreations (no-op when WebGL is
  inactive → caller's plain `refresh` still runs).
- New pure `terminal/staleGlyphRepaint.ts`: the throttle + a trigger predicate.
  Repaints **only in the normal buffer** when the user is scrolled up or has
  scrolled recently — so the Claude-TUI alternate-screen hot path pays nothing.

## Tests

- 15 new unit tests (throttle boundaries, trigger predicate, handle across
  context loss). Both new guards **mutation-proven** (disable → named test red).
- Full suite green (5297 passing), typecheck clean.

## ⚠️ Needs a live confirm before merge

The GPU-paint clearing itself **cannot be reproduced on the dev host** — it needs
the real slicer-stream repro (or the test VM). The wiring is verified; whether
`clearTextureAtlas` + `refresh` fully clears the stale cells on the actual GPU is
the one thing to confirm live. If a throttled repaint proves insufficient, the
next escalation is dispose+reload the addon (as the context-loss path does) or a
DOM-renderer escape hatch.
