### PR TITLE
fix(attention): raise the pulse for subagent-escalated and elicitation prompts (#274)

### DIFF
--- a/src/main/attention-source.ts
+++ b/src/main/attention-source.ts
@@ -7,11 +7,34 @@ import { getGateway } from './hooks/index'
 import { pushAttention } from './ipc/channel-handlers'
 import type { HookEvent } from '../shared/hook-types'
 
+// Notification types that mean "Claude is blocked waiting on the USER" — each
+// should raise the sidebar attention pulse (#274). The original set was just the
+// idle + permission prompts, but Claude Code has since added more user-blocking
+// notifications, and a session sitting on ANY of them is the same user-facing
+// state: it waits, silently, until the user acts.
+//   - permission_prompt      a tool use is awaiting the user's Yes/No
+//   - idle_prompt            Claude finished ~60s ago; awaiting the next prompt
+//   - agent_needs_input      a (sub)agent escalated a decision to the user — the
+//                            case #274 calls out, where a subagent can't self-
+//                            approve a command and hands it up
+//   - elicitation_dialog     an MCP tool is asking the user a structured question
+//   - elicitation_url_dialog ...via a URL / OAuth-style prompt
+// Informational notifications (auth_success, agent_completed, elicitation_complete,
+// elicitation_response) are NOT here: they don't block the user, so they neither
+// raise nor clear — an unknown type is ignored rather than spuriously pulsing.
+export const ATTENTION_NOTIFICATIONS: ReadonlySet<string> = new Set([
+  'permission_prompt',
+  'idle_prompt',
+  'agent_needs_input',
+  'elicitation_dialog',
+  'elicitation_url_dialog',
+])
+
 // true = raise the flasher, false = clear it, null = ignore this event.
 export function attentionForEvent(e: HookEvent): boolean | null {
   if (e.event === 'Notification') {
     const t = (e.payload as { notification_type?: string }).notification_type
-    return t === 'idle_prompt' || t === 'permission_prompt' ? true : null
+    return typeof t === 'string' && ATTENTION_NOTIFICATIONS.has(t) ? true : null
   }
   if (e.event === 'UserPromptSubmit' || e.event === 'PreToolUse' || e.event === 'PostToolUse') return false
   return null

--- a/src/main/attention-source.ts
+++ b/src/main/attention-source.ts
@@ -22,7 +22,7 @@ import type { HookEvent } from '../shared/hook-types'
 // Informational notifications (auth_success, agent_completed, elicitation_complete,
 // elicitation_response) are NOT here: they don't block the user, so they neither
 // raise nor clear — an unknown type is ignored rather than spuriously pulsing.
-export const ATTENTION_NOTIFICATIONS: ReadonlySet<string> = new Set([
+const ATTENTION_NOTIFICATIONS: ReadonlySet<string> = new Set([
   'permission_prompt',
   'idle_prompt',
   'agent_needs_input',

--- a/tests/unit/main/attention-source.test.ts
+++ b/tests/unit/main/attention-source.test.ts
@@ -11,13 +11,23 @@ describe('attentionForEvent', () => {
   it('raises on Notification(permission_prompt) (unanswerable on-screen prompt)', () => {
     expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'permission_prompt' } }))).toBe(true)
   })
+  it('raises on Notification(agent_needs_input) — a subagent escalated a decision (#274)', () => {
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'agent_needs_input' } }))).toBe(true)
+  })
+  it('raises on the elicitation dialogs (an MCP tool is blocking on the user)', () => {
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'elicitation_dialog' } }))).toBe(true)
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'elicitation_url_dialog' } }))).toBe(true)
+  })
   it('clears on UserPromptSubmit / PreToolUse / PostToolUse', () => {
     expect(attentionForEvent(ev({ event: 'UserPromptSubmit' }))).toBe(false)
     expect(attentionForEvent(ev({ event: 'PreToolUse' }))).toBe(false)
     expect(attentionForEvent(ev({ event: 'PostToolUse' }))).toBe(false)
   })
-  it('ignores other events', () => {
+  it('ignores other events and informational notifications', () => {
     expect(attentionForEvent(ev({ event: 'Stop' }))).toBeNull()
     expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'auth_success' } }))).toBeNull()
+    expect(attentionForEvent(ev({ event: 'Notification', payload: { notification_type: 'agent_completed' } }))).toBeNull()
+    // A Notification with no type at all must not pulse.
+    expect(attentionForEvent(ev({ event: 'Notification', payload: {} }))).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes #274.

## Finding

I traced the whole chain first: the sidebar attention pulse for a permission
prompt was **already wired end-to-end** (hook → gateway/proxy → `attention-source`
→ `pushAttention` → renderer → sidebar), and `permission_prompt` has mapped to
"raise" since May. So the issue's guess ("permission isn't a recognised waiting
state") wasn't the real gap.

## The actual gap

`attentionForEvent` only knew two Notification types — `permission_prompt` and
`idle_prompt`. Claude Code has since added more **user-blocking** notification
types that fell straight through to "ignore" (no pulse):

- **`agent_needs_input`** — a subagent escalated a decision to the user. A
  subagent can't self-approve (e.g. a `cd`+redirection compound command), so it
  hands the choice up — **exactly the case #274 describes.**
- **`elicitation_dialog` / `elicitation_url_dialog`** — an MCP tool is asking the
  user a structured question.

All three are the same user-facing state: the session sits, silently, until the
user acts. This broadens the raise-set to cover them, while keeping informational
types (`auth_success`, `agent_completed`, `elicitation_complete/response`) as
"ignore" so an unknown/informational notification never spuriously pulses.

## Tests

- New cases for `agent_needs_input` + both elicitation dialogs (raise) and
  `agent_completed` / untyped Notification (no pulse). New coverage
  **mutation-proven** (drop a type → its test goes red).
- Typecheck clean.

## ⚠️ Live-confirm note

Like #273, the final proof is behavioural: it depends on Claude Code emitting
`agent_needs_input` for a subagent-escalated permission in the CCC PTY. If a live
test shows a **top-level** (non-subagent) prompt still going silent, the
emission-independent fallback is to detect a `PreToolUse` with no following
`PostToolUse`/`Stop` within N seconds — not added here to keep the change tight.
