### PR TITLE
fix(status): bracket subagent/workflow effort by the spawning tool call (#285)

### DIFF
--- a/src/main/background-context.ts
+++ b/src/main/background-context.ts
@@ -5,23 +5,34 @@
 // the pills reflect the MAIN window only (user report 2026-07-03: pills flicker
 // to the model/effort of subagents and dynamic-workflow agents).
 //
-// Two independent signals, either of which marks "background":
-//   1. Subagent depth — CC brackets subagent execution with SubagentStart /
-//      SubagentStop hook events. A depth counter handles nested/parallel agents.
-//      Reliable for the hook path (these events have tiny, always-delivered
-//      payloads). Covers dynamic-workflow agents too when CC brackets them.
-//   2. Transcript mismatch — CC gives the main conversation a stable
+// Three independent signals, any of which marks "background":
+//   1. Spawn-tool bracket — a subagent or a dynamic workflow is launched by a
+//      BLOCKING tool call on the MAIN conversation (Task/Agent for subagents,
+//      Workflow for dynamic workflows). That tool's PreToolUse fires on the main
+//      transcript BEFORE the background agent runs and its PostToolUse fires
+//      AFTER it finishes — both strictly ordered and always delivered to the
+//      main endpoint. Bracketing on them is RACE-FREE, which the SubagentStart
+//      signal below is not (see #2). This is the primary signal.
+//   2. Subagent depth — CC also brackets subagent execution with SubagentStart /
+//      SubagentStop hook events. Kept as a backstop, but these are fire-and-
+//      forget POSTs that can land AFTER the (blocking) first subagent tool event
+//      they are meant to precede, so on their own they let the agent's first
+//      effort tick leak. The spawn-tool bracket closes that window.
+//   3. Transcript mismatch — CC gives the main conversation a stable
 //      transcript_path (captured from the SessionStart hook); a subagent or a
 //      workflow agent runs against its own sidechain transcript. A statusline
 //      tick or hook event whose transcript differs from the anchored main one
-//      is a background context. This is the signal that catches a
-//      dynamic-workflow agent even if it does not fire SubagentStart.
+//      is a background context. Catches a dynamic-workflow agent that runs on a
+//      sidechain even if no bracket fired.
 //
-// Fail-open: with neither signal present (older CC, hooks disabled, or a
+// Fail-open: with none of the signals present (older CC, hooks disabled, or a
 // background agent genuinely indistinguishable from the main thread) nothing is
 // gated and behaviour is identical to before this module existed.
 
 const depthBySession = new Map<string, number>()
+// Open spawn-tool brackets (Task/Agent/Workflow PreToolUse without its
+// PostToolUse yet). A COUNT, not a flag, so nested/parallel spawns balance.
+const toolDepthBySession = new Map<string, number>()
 const mainTranscriptBySession = new Map<string, string>()
 
 /** SessionStart: (re)anchor the main transcript and clear stale depth. CC
@@ -30,6 +41,7 @@ const mainTranscriptBySession = new Map<string, string>()
 export function noteSessionStart(sessionId: string, transcriptPath?: string): void {
   if (!sessionId) return
   depthBySession.delete(sessionId)
+  toolDepthBySession.delete(sessionId)
   if (transcriptPath) mainTranscriptBySession.set(sessionId, transcriptPath)
 }
 
@@ -45,24 +57,46 @@ export function noteSubagentStop(sessionId: string): void {
   else depthBySession.delete(sessionId)
 }
 
-/** Turn end (Stop): clear any dangling depth so a missed SubagentStop can't
- *  freeze the pills into the next turn. Keeps the transcript anchor. */
+/** A background-spawning tool call opened (Task/Agent/Workflow PreToolUse). The
+ *  main window is now waiting on a background agent; keep the pills pinned until
+ *  the matching PostToolUse. */
+export function noteBackgroundToolStart(sessionId: string): void {
+  if (!sessionId) return
+  toolDepthBySession.set(sessionId, (toolDepthBySession.get(sessionId) ?? 0) + 1)
+}
+
+/** A background-spawning tool call closed (its PostToolUse). Back on the main
+ *  window once the count returns to zero. */
+export function noteBackgroundToolStop(sessionId: string): void {
+  if (!sessionId) return
+  const next = (toolDepthBySession.get(sessionId) ?? 0) - 1
+  if (next > 0) toolDepthBySession.set(sessionId, next)
+  else toolDepthBySession.delete(sessionId)
+}
+
+/** Turn end (Stop): clear any dangling depth so a missed SubagentStop /
+ *  PostToolUse can't freeze the pills into the next turn. Keeps the transcript
+ *  anchor. */
 export function noteTurnEnd(sessionId: string): void {
   if (!sessionId) return
   depthBySession.delete(sessionId)
+  toolDepthBySession.delete(sessionId)
 }
 
 /** Session teardown: drop all state for the session. */
 export function forgetSession(sessionId: string): void {
   depthBySession.delete(sessionId)
+  toolDepthBySession.delete(sessionId)
   mainTranscriptBySession.delete(sessionId)
 }
 
-/** True when this session is running a subagent/workflow agent right now, or
- *  when `transcriptPath` (from a statusline tick or hook event) belongs to a
- *  sidechain rather than the anchored main transcript. */
+/** True when this session is running a subagent/workflow agent right now (an
+ *  open spawn-tool bracket or subagent depth), or when `transcriptPath` (from a
+ *  statusline tick or hook event) belongs to a sidechain rather than the
+ *  anchored main transcript. */
 export function isBackgroundContext(sessionId: string, transcriptPath?: string): boolean {
   if (!sessionId) return false
+  if ((toolDepthBySession.get(sessionId) ?? 0) > 0) return true
   if ((depthBySession.get(sessionId) ?? 0) > 0) return true
   const main = mainTranscriptBySession.get(sessionId)
   if (transcriptPath && main && transcriptPath !== main) return true
@@ -72,5 +106,6 @@ export function isBackgroundContext(sessionId: string, transcriptPath?: string):
 /** Test seam. */
 export function _resetBackgroundContextForTest(): void {
   depthBySession.clear()
+  toolDepthBySession.clear()
   mainTranscriptBySession.clear()
 }

--- a/src/main/effort-tracker.ts
+++ b/src/main/effort-tracker.ts
@@ -76,13 +76,19 @@ function track(e: HookEvent): void {
   if (e.event === 'Stop') { lastBySession.delete(e.sessionId); noteTurnEnd(e.sessionId); return }
 
   // A background-spawning tool call (Task/Agent/Workflow) brackets the whole
-  // background agent race-free. Its PostToolUse ENDS the window: exit background
-  // BEFORE this event's own effort, which is the main window's again. Its
-  // PreToolUse BEGINS the window: enter AFTER this event's own effort, which is
-  // still the main window's. This is the primary fix for the pills flickering to
-  // a subagent's / dynamic-workflow agent's effort.
+  // background agent race-free. BOTH bracket ops run AFTER this event's own
+  // effort is evaluated, so the spawn tool's own Pre/PostToolUse events are
+  // themselves treated as still-background at the effort check:
+  //   - PreToolUse: the main window's effort is still active, so it is pushed,
+  //     THEN we enter background for the agent about to run.
+  //   - PostToolUse: the closing event's own effort.level is the finishing
+  //     agent's, not the main window's, so it stays SUPPRESSED (still in
+  //     background); we exit only after. This mirrors SubagentStop, which never
+  //     trusts its own event's effort, and closes a one-tick flicker to the
+  //     subagent's / workflow agent's effort on the closing event that trusting
+  //     it there would open (adversarial review, #285). The next genuine
+  //     main-window event repaints the strip.
   const spawnTool = !!e.toolName && BACKGROUND_SPAWN_TOOLS.has(e.toolName)
-  if (spawnTool && e.event === 'PostToolUse') noteBackgroundToolStop(e.sessionId)
 
   const level = effortFromEvent(e)
   // A subagent / workflow agent's effort must not repaint the main strip: its
@@ -96,6 +102,7 @@ function track(e: HookEvent): void {
   }
 
   if (spawnTool && e.event === 'PreToolUse') noteBackgroundToolStart(e.sessionId)
+  if (spawnTool && e.event === 'PostToolUse') noteBackgroundToolStop(e.sessionId)
 }
 
 /** Test seam. */

--- a/src/main/effort-tracker.ts
+++ b/src/main/effort-tracker.ts
@@ -14,9 +14,19 @@ import {
   noteSessionStart,
   noteSubagentStart,
   noteSubagentStop,
+  noteBackgroundToolStart,
+  noteBackgroundToolStop,
   noteTurnEnd,
   isBackgroundContext,
 } from './background-context'
+
+// Tool calls that launch a BACKGROUND agent whose model/effort must not repaint
+// the main strip. The tool's Pre/PostToolUse bracket the background window
+// RACE-FREE (they fire on the main transcript, in order, around the whole
+// agent), which is what the fire-and-forget SubagentStart signal cannot do.
+// Names span CC versions/features: Task + Agent launch subagents; Workflow
+// launches a dynamic workflow.
+export const BACKGROUND_SPAWN_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent', 'Workflow'])
 
 // DELIBERATE behaviour change (spec 2026-06-11 §3/§4): unknown effort levels
 // now display verbatim instead of being silently dropped. A hardcoded VALID set
@@ -64,15 +74,28 @@ function track(e: HookEvent): void {
   // unbounded, and clear any dangling subagent depth. Mirrors
   // channel-permissions.ts clearing per-session state on Stop.
   if (e.event === 'Stop') { lastBySession.delete(e.sessionId); noteTurnEnd(e.sessionId); return }
+
+  // A background-spawning tool call (Task/Agent/Workflow) brackets the whole
+  // background agent race-free. Its PostToolUse ENDS the window: exit background
+  // BEFORE this event's own effort, which is the main window's again. Its
+  // PreToolUse BEGINS the window: enter AFTER this event's own effort, which is
+  // still the main window's. This is the primary fix for the pills flickering to
+  // a subagent's / dynamic-workflow agent's effort.
+  const spawnTool = !!e.toolName && BACKGROUND_SPAWN_TOOLS.has(e.toolName)
+  if (spawnTool && e.event === 'PostToolUse') noteBackgroundToolStop(e.sessionId)
+
   const level = effortFromEvent(e)
-  if (!level || !e.sessionId) return
   // A subagent / workflow agent's effort must not repaint the main strip: its
   // PreToolUse/PostToolUse events reach the main session's hook endpoint, but
   // the effort is the agent's, not the main window's.
-  if (isBackgroundContext(e.sessionId, transcriptOf(e))) return
-  if (lastBySession.get(e.sessionId) === level) return
-  lastBySession.set(e.sessionId, level)
-  pushEffort(e.sessionId, level)
+  if (level && e.sessionId
+      && !isBackgroundContext(e.sessionId, transcriptOf(e))
+      && lastBySession.get(e.sessionId) !== level) {
+    lastBySession.set(e.sessionId, level)
+    pushEffort(e.sessionId, level)
+  }
+
+  if (spawnTool && e.event === 'PreToolUse') noteBackgroundToolStart(e.sessionId)
 }
 
 /** Test seam. */

--- a/src/main/effort-tracker.ts
+++ b/src/main/effort-tracker.ts
@@ -26,7 +26,7 @@ import {
 // agent), which is what the fire-and-forget SubagentStart signal cannot do.
 // Names span CC versions/features: Task + Agent launch subagents; Workflow
 // launches a dynamic workflow.
-export const BACKGROUND_SPAWN_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent', 'Workflow'])
+const BACKGROUND_SPAWN_TOOLS: ReadonlySet<string> = new Set(['Task', 'Agent', 'Workflow'])
 
 // DELIBERATE behaviour change (spec 2026-06-11 §3/§4): unknown effort levels
 // now display verbatim instead of being silently dropped. A hardcoded VALID set

--- a/tests/unit/background-context.test.ts
+++ b/tests/unit/background-context.test.ts
@@ -4,6 +4,8 @@ import {
   noteSessionStart,
   noteSubagentStart,
   noteSubagentStop,
+  noteBackgroundToolStart,
+  noteBackgroundToolStop,
   noteTurnEnd,
   forgetSession,
   isBackgroundContext,
@@ -46,6 +48,58 @@ describe('background-context — subagent depth', () => {
   it('turn end clears a dangling subagent depth (missed SubagentStop)', () => {
     noteSubagentStart('s1')
     noteTurnEnd('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+  })
+})
+
+describe('background-context — spawn-tool bracket (Task/Agent/Workflow)', () => {
+  it('an open spawn-tool bracket marks background until the matching close', () => {
+    noteBackgroundToolStart('s1')
+    expect(isBackgroundContext('s1')).toBe(true)
+    noteBackgroundToolStop('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+  })
+
+  it('handles nested / parallel spawns via a depth counter', () => {
+    noteBackgroundToolStart('s1')
+    noteBackgroundToolStart('s1')
+    noteBackgroundToolStop('s1')
+    expect(isBackgroundContext('s1')).toBe(true) // one still open
+    noteBackgroundToolStop('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+  })
+
+  it('never goes negative on an unmatched close', () => {
+    noteBackgroundToolStop('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+    noteBackgroundToolStart('s1')
+    expect(isBackgroundContext('s1')).toBe(true)
+  })
+
+  it('turn end clears a dangling tool bracket (missed PostToolUse)', () => {
+    noteBackgroundToolStart('s1')
+    noteTurnEnd('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+  })
+
+  it('SessionStart clears a stale tool bracket', () => {
+    noteBackgroundToolStart('s1')
+    noteSessionStart('s1', MAIN)
+    expect(isBackgroundContext('s1', MAIN)).toBe(false)
+  })
+
+  it('is independent of subagent depth — both must close to leave background', () => {
+    noteBackgroundToolStart('s1')
+    noteSubagentStart('s1')
+    noteBackgroundToolStop('s1')
+    expect(isBackgroundContext('s1')).toBe(true) // subagent depth still open
+    noteSubagentStop('s1')
+    expect(isBackgroundContext('s1')).toBe(false)
+  })
+
+  it('forgetSession drops a tool bracket too', () => {
+    noteBackgroundToolStart('s1')
+    forgetSession('s1')
     expect(isBackgroundContext('s1')).toBe(false)
   })
 })

--- a/tests/unit/effort-tracker.test.ts
+++ b/tests/unit/effort-tracker.test.ts
@@ -95,6 +95,49 @@ describe('effort gating — subagents + dynamic-workflow agents must not repaint
   })
 })
 
+describe('effort gating — spawn-tool bracket covers subagents AND dynamic workflows race-free', () => {
+  beforeEach(() => { sent.length = 0; _resetEffort(); _resetBackgroundContextForTest(); _setEffortObserverForTest(null) })
+
+  const levels = () => sent.map((s) => (s.payload as { effortLevel: string }).effortLevel)
+
+  it('suppresses a subagent effort bracketed by Task Pre/PostToolUse even with NO SubagentStart', () => {
+    _emitForTest(ev({ payload: { effort: { level: 'high' } } }))                // main
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Task', payload: {} }))    // enter background
+    _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))               // subagent — gated
+    _emitForTest(ev({ event: 'PostToolUse', toolName: 'Task', payload: {} }))   // exit background
+    _emitForTest(ev({ payload: { effort: { level: 'max' } } }))                 // main again
+    expect(levels()).toEqual(['high', 'max'])
+  })
+
+  it('brackets a dynamic-workflow agent via the Workflow tool', () => {
+    _emitForTest(ev({ payload: { effort: { level: 'high' } } }))                    // main
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Workflow', payload: {} }))    // enter
+    _emitForTest(ev({ payload: { effort: { level: 'low' } } }))                     // workflow agent — gated
+    _emitForTest(ev({ event: 'PostToolUse', toolName: 'Workflow', payload: {} }))   // exit
+    _emitForTest(ev({ payload: { effort: { level: 'medium' } } }))                  // main
+    expect(levels()).toEqual(['high', 'medium'])
+  })
+
+  it('the Agent tool also brackets (subagent spawner name across CC versions)', () => {
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Agent', payload: {} }))
+    _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))   // gated
+    expect(sent).toHaveLength(0)
+  })
+
+  it('the spawning tool call still applies its OWN (main) effort before entering background', () => {
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Task', payload: { effort: { level: 'high' } } }))
+    expect(levels()).toEqual(['high'])                             // main 'high' applied
+    _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))  // now inside the bracket — gated
+    expect(levels()).toEqual(['high'])
+  })
+
+  it('a non-spawn tool call (e.g. Bash) does NOT enter background', () => {
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Bash', payload: { effort: { level: 'high' } } }))
+    _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))
+    expect(levels()).toEqual(['high', 'xhigh'])
+  })
+})
+
 describe('effort observer seam (Sentinel Trigger A)', () => {
   beforeEach(() => { sent.length = 0; _resetEffort(); _setEffortObserverForTest(null) })
 

--- a/tests/unit/effort-tracker.test.ts
+++ b/tests/unit/effort-tracker.test.ts
@@ -136,6 +136,20 @@ describe('effort gating — spawn-tool bracket covers subagents AND dynamic work
     _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))
     expect(levels()).toEqual(['high', 'xhigh'])
   })
+
+  // #285 adversarial review: the closing PostToolUse's OWN effort.level is the
+  // finishing agent's, not the main window's. The bracket must exit background
+  // only AFTER this event's effort is evaluated, or the strip flashes the
+  // subagent's effort for one tick. (Mirrors how SubagentStop never trusts its
+  // own event's effort.)
+  it('does NOT flicker when the closing PostToolUse carries the finishing agent\'s own effort', () => {
+    _emitForTest(ev({ payload: { effort: { level: 'high' } } }))                // main 'high'
+    _emitForTest(ev({ event: 'PreToolUse', toolName: 'Task', payload: {} }))    // enter background
+    _emitForTest(ev({ payload: { effort: { level: 'xhigh' } } }))               // subagent — gated
+    _emitForTest(ev({ event: 'PostToolUse', toolName: 'Task', payload: { effort: { level: 'xhigh' } } })) // close, carrying the agent's effort
+    _emitForTest(ev({ payload: { effort: { level: 'max' } } }))                 // next real main event
+    expect(levels()).toEqual(['high', 'max'])                                  // never a stray 'xhigh'
+  })
 })
 
 describe('effort observer seam (Sentinel Trigger A)', () => {


### PR DESCRIPTION
Fixes #285.

## Problem

The model/effort pills flicker to a **subagent's or dynamic-workflow agent's**
values while that background agent runs. `background-context.ts` already gated
this (2026-07-03) via subagent **depth** (`SubagentStart`/`SubagentStop`) +
**transcript mismatch**, but both can miss the *first* background tick:

- `SubagentStart` is a **fire-and-forget** POST — it can land *after* the
  (blocking) first subagent tool event it's meant to precede, so the effort leaks
  in that window.
- Transcript mismatch only fires when the background event carries a *different*
  transcript_path; if it carries the main one (or none) and depth isn't set yet,
  nothing gates it.

## Fix — a race-free third signal

Bracket the background window on the **spawning tool call itself** — `Task` /
`Agent` (subagents) and `Workflow` (dynamic workflows). That tool's
`PreToolUse`/`PostToolUse` fire on the **main** transcript, strictly ordered, and
wrap the whole background agent: `Pre` lands *before* its first event, `Post`
*after* its last. No race. Kept alongside the existing depth + transcript signals
as belt-and-braces.

- `background-context.ts`: new `toolDepth` counter + `noteBackgroundToolStart/Stop`,
  folded into `isBackgroundContext`; cleared on SessionStart / turn-end / teardown.
- `effort-tracker.ts`: enter background on the spawn tool's `PreToolUse` (after
  applying its own main effort), exit on its `PostToolUse` (before re-applying the
  main effort). Both the hook effort path and the statusline path benefit, since
  both gate on `isBackgroundContext`.

Covers **both** subagents and dynamic-workflow agents.

## Tests

- New bracket tests in `background-context.test.ts` + `effort-tracker.test.ts`,
  including a subagent suppressed **with no `SubagentStart`** (the race case) and
  a `Workflow`-bracketed dynamic workflow. New signal **mutation-proven**.
- Full suite green (5311), typecheck clean.

## ⚠️ Live-confirm note

The tool names (`Task`/`Agent`/`Workflow`) are the spawner names across CC
versions/features; the final proof is behavioural. Owner is running extensive
testing on beta.12 to confirm the flicker is gone for both subagents and dynamic
workflows.
