### PR TITLE
docs(launcher): correct ccc.cmd header to not overstate dev isolation (#264)

### DIFF
--- a/scripts/ccc.cmd
+++ b/scripts/ccc.cmd
@@ -28,8 +28,9 @@ REM registry keys, and the global ~/.claude home for any spawn not scoped to a
 REM profile -- none of which can destroy a prod login. See
 REM docs\dev-alongside-prod.md for the exact isolation table. The window
 REM auto-closes on exit and every dev process is killed (electron, vite,
-REM MCP/update servers, headless Chrome), so nothing leaks between runs or into
-REM your prod instance.
+REM MCP/update servers, headless Chrome), so no dev process is left running after
+REM a run or bleeds into your prod instance. (Dev DATA persists between runs by
+REM design -- reused unless you pass --clean.)
 REM ============================================================================
 
 if /I "%~1"=="__run" goto :run

--- a/scripts/ccc.cmd
+++ b/scripts/ccc.cmd
@@ -20,10 +20,16 @@ REM copying them leaves dev and prod sharing one refresh token -- whichever
 REM refreshes first invalidates the other. See scripts\seed-dev-accounts.mjs and
 REM issue #257.
 REM
-REM Dev is fully isolated from prod: its OWN data dir (CCC_DEV_DATA_DIR) and
-REM separate MCP/CDP/hooks/vite ports. The window auto-closes on exit and every
-REM dev process is killed (electron, vite, MCP/update servers, headless Chrome),
-REM so nothing leaks between runs or into your prod instance.
+REM Dev is STRONGLY isolated from prod: its OWN data dir (CCC_DEV_DATA_DIR)
+REM carries config, sessions, transcripts, logs, account profiles and the
+REM claude.ai partitions, and it uses separate MCP/CDP/hooks/vite ports. A few
+REM things are still shared -- the app's userData (source-hash.json), the HKCU
+REM registry keys, and the global ~/.claude home for any spawn not scoped to a
+REM profile -- none of which can destroy a prod login. See
+REM docs\dev-alongside-prod.md for the exact isolation table. The window
+REM auto-closes on exit and every dev process is killed (electron, vite,
+REM MCP/update servers, headless Chrome), so nothing leaks between runs or into
+REM your prod instance.
 REM ============================================================================
 
 if /I "%~1"=="__run" goto :run


### PR DESCRIPTION
Completes **#264**.

- **Item 2 (this PR):** the `ccc.cmd` header claimed dev is *"fully isolated from prod"*, stronger than the truth. Reworded to "strongly isolated" — naming what its own data dir carries (config, sessions, transcripts, logs, account profiles, claude.ai partitions + separate ports) and what is **still shared** (app userData `source-hash.json`, HKCU registry keys, the global `~/.claude` for non-profile-scoped spawns — none of which can destroy a prod login) — and pointing at `docs/dev-alongside-prod.md`'s isolation table. Comment-only.
- **Item 1 — already fixed on `beta`:** the `--clean` half-delete is handled; the wipe now verifies the dir is gone and refuses to launch (exit 3) against a half-deleted profile (`ccc.cmd`: *"FAILS LOUDLY ON A PARTIAL WIPE"*). No further work.
- **Item 3:** a correction, no work.

So this is the last piece of #264.