### PR TITLE
fix(ssh): harden the SSH argv boundary (charset-gate host/username/sessionId + sink guard) (#265)

### DIFF
--- a/CONTEXT.d/2026-08-16-ssh-argv-hardening-265.md
+++ b/CONTEXT.d/2026-08-16-ssh-argv-hardening-265.md
@@ -1,0 +1,37 @@
+## 2026-08-16 -- SSH argv boundary hardening (#265)
+
+Defence-in-depth around SSH argv / remote-setup construction. Four controls the
+#241 ControlMaster fix (shipped beta.9 via #260) did not carry, surfaced by an
+adversarial pass on a parallel implementation. None is a completing exploit on
+beta today -- issue #265 is public, non-exploitable -- each is a control that
+should exist and didn't. Same threat model throughout: a caller that already
+controls the renderer or local config (real ids/hosts never trip these).
+
+- **host / username charset-gated at the IPC boundary** (`ipc/pty-handlers.ts`).
+  Both were `z.string().min(1)`, then fused into `${username}@${host}` = argv[0].
+  ssh parses any argv entry beginning with `-` as an OPTION, so `-oProxyCommand=...`
+  is an argument-injection primitive (local RCE). It does not complete on today's
+  builder -- consuming argv[0] as an option leaves ssh no destination, so it
+  usage-errors first -- but that safety is accidental. Gate rejects a leading `-`
+  and any whitespace (`/^[^-\s]\S*$/`), matching the remotePath precedent from #188
+  while still admitting IPv6 (`[::1]`), internal dashes, and `DOMAIN\user`.
+
+- **sink-side guard in `buildSshArgs`** (`ssh-args.ts`). The builder now re-asserts
+  the same charset at the point of interpolation, so a call site that bypasses the
+  Zod schema cannot rebuild the primitive -- mirrors `assertSafeRemotePath`.
+
+- **sessionId charset-gated** (`sessionIdSchema`, now `/^[A-Za-z0-9_-]+$/`) and the
+  one remaining raw embedding fixed: the statusLine `command` in `ssh-shim.ts` used
+  the raw id, which lands inside a single-quoted JS literal in the base64'd remote
+  setup script AND becomes the command claude runs via `sh -c`. Now uses `safeSid`
+  (a no-op for real hex ids); every other embedding was already neutralised (URL via
+  encodeURIComponent, filenames via safeSid).
+
+- **call-site test** pins that the spawn path actually CALLS `buildSshArgs`
+  (`ssh-spawn-callsite.test.ts`): mocks node-pty + `os.platform()`=win32 and asserts
+  the argv pty.spawn receives, so a revert to an inline array -- dropping the #241
+  win32 mux flags -- fails instead of leaving the suite green.
+
+Every guard mutation-proven (revert -> named test red). Full suite green, typecheck
+clean, byte-scan clean. Security-sensitive (PTY argv / IPC boundary) so ran the
+ADR-009 adversarial pass before merge is recommended.

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -20,10 +20,18 @@ interface RendererSSHOptions {
   postCommand?: string
 }
 
+// host/username are fused into `${username}@${host}` and handed to ssh as
+// argv[0]. ssh parses any argv entry beginning with `-` as an OPTION, so a
+// leading dash (e.g. `-oProxyCommand=...`) is an argument-injection primitive.
+// Charset-gate both here — reject a leading `-` and any whitespace — matching
+// the remotePath precedent from #188; the ssh-args builder re-asserts the same
+// as a sink-side backstop (#265). `[^-\s]` first char excludes a leading dash
+// and whitespace; `\S*` keeps IPv6 (`[::1]`), internal `-`, and `DOMAIN\user`.
+const sshFieldRe = /^[^-\s]\S*$/
 const sshSchema = z.object({
-  host: z.string().min(1),
+  host: z.string().min(1).regex(sshFieldRe, 'host has invalid characters'),
   port: z.number().int().min(1).max(65535),
-  username: z.string().min(1),
+  username: z.string().min(1).regex(sshFieldRe, 'username has invalid characters'),
   // Charset-gated at the IPC boundary (mirrors ssh-shim SAFE_REMOTE_PATH_RE):
   // the remote path is interpolated into the remote setup command, and the
   // shim's own assertSafeRemotePath throws from inside a setTimeout — which the
@@ -177,7 +185,13 @@ export const spawnOptionsSchema = z.object({
   }
 }).optional()
 
-const sessionIdSchema = z.string().min(1).max(200)
+// Charset-gate the session id (#265). It is interpolated into the remote setup
+// script (base64'd and piped to `node` on the remote) and into filenames on the
+// remote. Real ids are CSPRNG hex (src/shared/id.ts), so this only ever rejects
+// a caller that already controls the renderer or local config — a defence-in-depth
+// gate, not an embargoed bug. ssh-shim re-sanitises via safeSid as a backstop.
+// Exported so the boundary contract is unit-tested against the real schema.
+export const sessionIdSchema = z.string().min(1).max(200).regex(/^[A-Za-z0-9_-]+$/, 'session id has invalid characters')
 
 export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('pty:spawn', async (_event, sessionId: string, options?: {

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -153,7 +153,15 @@ export function generateRemoteSetupScript(
   // no statusLine key (the shim file is still staged but inert without it).
   const sesCfgParts: string[] = []
   if (includeStatusLine) {
-    sesCfgParts.push(`statusLine:{type:'command',command:'CLAUDE_MULTI_SESSION_ID=${sessionId} node '+shimPath}`)
+    // Use safeSid, not the raw sessionId (#265): this value is embedded in a
+    // single-quoted JS string literal inside the setup script AND becomes the
+    // `command` claude later runs via `sh -c`. A raw id bearing a quote/space/
+    // metacharacter would break out of the literal (remote code execution) or
+    // split the command. The IPC boundary already charset-gates the id; this is
+    // the sink-side backstop, and a no-op for real (hex) ids. Every OTHER
+    // embedding is already neutralised — the URL via encodeURIComponent, the
+    // filenames via safeSid — so this was the last raw path.
+    sesCfgParts.push(`statusLine:{type:'command',command:'CLAUDE_MULTI_SESSION_ID=${safeSid} node '+shimPath}`)
   }
   if (hooksLiteral) sesCfgParts.push(`hooks:${hooksLiteral}`)
 

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -10,6 +10,34 @@ export interface SshArgsTarget {
 }
 
 /**
+ * Sink-side guard (#265). `username` and `host` are fused into
+ * `${username}@${host}` and handed to ssh/ssh.exe as argv[0]. ssh treats any
+ * argv entry that begins with `-` as an OPTION, so a value like
+ * `-oProxyCommand=...` is an argument-injection primitive (ProxyCommand runs an
+ * arbitrary local command). It does not complete on today's builder — consuming
+ * argv[0] as an option leaves ssh with no destination, so it usage-errors before
+ * connecting — but that safety is accidental: it holds only because argv[0] is
+ * the single bare token this builder emits, and any future change adding a
+ * second bare token converts it straight into code execution.
+ *
+ * The IPC boundary already charset-gates these fields, but every argv/shell sink
+ * in this codebase re-asserts its own inputs at the point of interpolation (cf.
+ * `assertSafeRemotePath` in ssh-shim.ts) so a call site that bypasses the Zod
+ * schema cannot rebuild the primitive. Reject a leading `-` and any whitespace;
+ * an internal `-` (real hostnames, usernames) is fine, so this is a targeted gate
+ * for the argv context, not the full shell-safe allowlist `remotePath` needs.
+ */
+const SAFE_SSH_FIELD_RE = /^[^-\s]\S*$/
+
+function assertSafeSshField(name: 'username' | 'host', value: string): void {
+  if (!SAFE_SSH_FIELD_RE.test(value)) {
+    throw new Error(
+      `Refusing to build SSH args: ${name} must not be empty, begin with "-", or contain whitespace.`,
+    )
+  }
+}
+
+/**
  * Build the argument list passed to `ssh`/`ssh.exe`.
  *
  * @param ssh      connection target (user, host, port)
@@ -27,6 +55,9 @@ export interface SshArgsTarget {
  *                 untouched.
  */
 export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: NodeJS.Platform): string[] {
+  assertSafeSshField('username', ssh.username)
+  assertSafeSshField('host', ssh.host)
+
   const args = [
     `${ssh.username}@${ssh.host}`,
     '-p', String(ssh.port),

--- a/tests/unit/main/ssh-argv-boundary-schema.test.ts
+++ b/tests/unit/main/ssh-argv-boundary-schema.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #265: the IPC boundary is the primary charset gate for the three fields that
+ * reach the SSH argv / remote setup script. These import the REAL shipped
+ * schemas (not mirrors) — reverting the source regex must turn these red, the
+ * vacuous-guard failure mode this repo has hit before (see extra-args-guard).
+ *
+ * Finding 1: `host`/`username` are fused into `${username}@${host}` = argv[0];
+ * ssh reads a leading `-` as an option (`-oProxyCommand=...` = local RCE).
+ * Finding 3: the sessionId is interpolated into the base64'd remote setup script
+ * and into remote filenames.
+ */
+import { describe, it, expect } from 'vitest'
+import { spawnOptionsSchema, sessionIdSchema } from '../../../src/main/ipc/pty-handlers'
+
+const baseSsh = { host: 'example.com', port: 22, username: 'me', remotePath: '~/proj' }
+const sshAccepts = (patch: Record<string, unknown>): boolean =>
+  spawnOptionsSchema.safeParse({ ssh: { ...baseSsh, ...patch } }).success
+
+describe('sshSchema charset-gates host/username at the IPC boundary (#265 finding 1)', () => {
+  it.each([
+    { username: '-oProxyCommand=touch /tmp/pwn' },
+    { username: '-l' },
+    { host: '-oProxyCommand=id' },
+    { host: '-p2222' },
+  ])('rejects a leading-dash value %o', (patch) => {
+    expect(sshAccepts(patch)).toBe(false)
+  })
+
+  it.each([
+    { username: 'me evil' },
+    { username: 'me\tx' },
+    { host: 'example.com host2' },
+    { host: 'example.com\nrm' },
+  ])('rejects whitespace %o', (patch) => {
+    expect(sshAccepts(patch)).toBe(false)
+  })
+
+  it.each([
+    { username: 'me', host: 'example.com' },
+    { username: 'my-user', host: 'my-host.example.com' },   // internal dashes
+    { username: 'root', host: '[2001:db8::1]' },            // IPv6 literal
+    { username: 'DOMAIN\\me', host: '10.0.0.5' },           // Windows domain user
+  ])('accepts legitimate values %o', (patch) => {
+    expect(sshAccepts(patch)).toBe(true)
+  })
+})
+
+describe('sessionIdSchema charset-gate (#265 finding 3)', () => {
+  const accepts = (v: string): boolean => sessionIdSchema.safeParse(v).success
+
+  it.each([
+    "a'b",                    // breaks the single-quoted JS literal in the setup script
+    'a b',                    // whitespace splits the sh -c command
+    'a;rm -rf ~',             // shell metacharacters
+    'a/b',                    // path separator into a remote filename
+    'a.b',                    // dot — not in the real (hex) charset
+    '$(id)',
+    '`whoami`',
+  ])('rejects an injection-shaped id %j', (v) => {
+    expect(accepts(v)).toBe(false)
+  })
+
+  it.each([
+    '9f1f147ea02f2cf7d1eec041',           // a real 24-hex CSPRNG id (generateId())
+    'ABCdef0123456789',
+    'sess_1-2_3',                          // alnum + underscore + dash
+  ])('accepts a path-safe id %j', (v) => {
+    expect(accepts(v)).toBe(true)
+  })
+
+  it('rejects empty and over-long ids', () => {
+    expect(accepts('')).toBe(false)
+    expect(accepts('a'.repeat(201))).toBe(false)
+  })
+})

--- a/tests/unit/providers/claude/ssh-shim.test.ts
+++ b/tests/unit/providers/claude/ssh-shim.test.ts
@@ -157,6 +157,23 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
     expect(script).toContain(`statusLine:{type:'command'`)
   })
 
+  // #265 finding 3: the sessionId embedded in the statusLine `command` was the
+  // one raw-value path left in this file. That value lands inside a
+  // single-quoted JS string literal in the emitted setup script AND becomes the
+  // command claude runs via `sh -c`, so a raw id with a quote/space/
+  // metacharacter is remote code execution / command splitting. It must be the
+  // sanitised safeSid (a no-op for real hex ids).
+  it('embeds the sanitised safeSid — not the raw id — in the statusLine command', () => {
+    const script = generateRemoteSetupScript("a'b", null)
+    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=a_b node')
+    expect(script).not.toContain("CLAUDE_MULTI_SESSION_ID=a'b")
+  })
+
+  it('leaves a real (hex) id untouched in the statusLine command', () => {
+    const script = generateRemoteSetupScript('9f1f147ea02f2cf7d1eec041', null)
+    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=9f1f147ea02f2cf7d1eec041 node')
+  })
+
   it('includeStatusLine=false omits the statusLine stanza from the per-session settings', () => {
     const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false })
     const parts = script.split(`Object.assign({},sBase,{`)

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -44,3 +44,42 @@ describe('buildSshArgs', () => {
     expect(buildSshArgs(target, 5111, 'win32')).not.toContain('5111:localhost:5111')
   })
 })
+
+// #265 finding 2: the builder is the argv SINK for `${username}@${host}`. ssh
+// parses a leading `-` as an option (`-oProxyCommand=...` = local RCE), so the
+// builder re-asserts the charset the IPC schema also gates — defence-in-depth
+// against a call site that bypasses Zod and rebuilds the primitive directly.
+describe('buildSshArgs rejects an option-like or whitespace host/username (sink guard)', () => {
+  const rejects = /Refusing to build SSH args/
+  it.each([
+    ['username', '-oProxyCommand=touch /tmp/pwn'],
+    ['username', '-l'],
+    ['username', '- '],
+    ['host', '-oProxyCommand=id'],
+    ['host', '-p2222'],
+  ])('throws on a leading-dash %s (%s)', (field, bad) => {
+    const t = { ...target, [field]: bad }
+    expect(() => buildSshArgs(t, 0, 'win32')).toThrow(rejects)
+  })
+
+  it.each([
+    ['username', 'me evil'],
+    ['username', 'me\tx'],
+    ['host', 'example.com host2'],
+    ['host', 'example.com\nrm'],
+  ])('throws on whitespace in %s (%s)', (field, bad) => {
+    const t = { ...target, [field]: bad }
+    expect(() => buildSshArgs(t, 0, 'linux')).toThrow(rejects)
+  })
+
+  it('throws on an empty username or host', () => {
+    expect(() => buildSshArgs({ ...target, username: '' }, 0, 'linux')).toThrow(rejects)
+    expect(() => buildSshArgs({ ...target, host: '' }, 0, 'linux')).toThrow(rejects)
+  })
+
+  it('still accepts real hosts/usernames with internal dashes, IPv6, and DOMAIN\\user', () => {
+    expect(() => buildSshArgs({ username: 'my-user', host: 'my-host.example.com', port: 22 }, 0, 'linux')).not.toThrow()
+    expect(() => buildSshArgs({ username: 'root', host: '[2001:db8::1]', port: 22 }, 0, 'linux')).not.toThrow()
+    expect(() => buildSshArgs({ username: 'DOMAIN\\me', host: '10.0.0.5', port: 22 }, 0, 'win32')).not.toThrow()
+  })
+})

--- a/tests/unit/ssh-spawn-callsite.test.ts
+++ b/tests/unit/ssh-spawn-callsite.test.ts
@@ -1,0 +1,92 @@
+/**
+ * #265 finding 4: all existing coverage exercises the PURE buildSshArgs. Nothing
+ * pinned that the spawn path actually CALLS it, so a revert to an inline argv
+ * array — dropping the #241 win32 ControlMaster override or the reverse tunnel —
+ * would leave the suite green.
+ *
+ * This drives the real spawnPty SSH branch and captures the argv that reaches
+ * node-pty's spawn, with os.platform() mocked to win32 so the win32-only flags
+ * run on a Linux CI runner. node-pty's spawn captures its args then throws, to
+ * short-circuit before spawnPty's post-spawn state machine (which needs a real
+ * IPty + BrowserWindow); the SSH branch calls pty.spawn early, right after
+ * buildSshArgs, so the capture is faithful.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return { ...actual, platform: vi.fn(() => 'linux') }
+})
+
+let captured: { file: string; args: string[] } | null = null
+vi.mock('node-pty', () => ({
+  spawn: (file: string, args: string[]) => {
+    captured = { file, args }
+    // Abort the rest of spawnPty — we only need the argv it hands to spawn.
+    throw new Error('__spawn_captured__')
+  },
+}))
+
+import * as osMod from 'os'
+import type { SessionProvider } from '../../src/main/providers/types'
+import { spawnPty } from '../../src/main/pty-manager'
+import { registerProvider } from '../../src/main/providers'
+import { buildSshArgs } from '../../src/main/ssh-args'
+import { getConductorMcpPort } from '../../src/main/conductor-mcp-server'
+
+// Minimal SSH-capable Claude provider so getProvider('claude') + isSshCapable
+// pass. Only the three SshCapableProvider methods' PRESENCE matters here (the
+// spawn short-circuits before any of them is invoked).
+const fakeProvider = {
+  id: 'claude',
+  displayName: 'Claude',
+  resolveBinary: () => null,
+  buildSpawnCommand: () => ({ cmd: '', args: [], env: {} }),
+  detectUiRunning: () => false,
+  ingestSessionTelemetry: () => ({ stop() {} }),
+  listHistorySessions: async () => [],
+  resumeCommand: () => ({ cmd: '', args: [] }),
+  configureMcpServer: async () => {},
+  getSshSettingsPath: () => '',
+  getSshMcpConfigPath: () => '',
+  configureRemoteSettings: () => '',
+} as unknown as SessionProvider
+
+const fakeWin = { webContents: { send() {} }, isDestroyed: () => false } as never
+
+describe('SSH spawn path uses buildSshArgs (call-site pin, #265 finding 4)', () => {
+  beforeEach(() => {
+    captured = null
+    registerProvider(fakeProvider)
+  })
+
+  it('hands buildSshArgs output (incl. the #241 win32 mux flags) to pty.spawn', () => {
+    vi.mocked(osMod.platform).mockReturnValue('win32' as NodeJS.Platform)
+
+    const ssh = { username: 'me', host: 'example.com', port: 2222, remotePath: '~/proj' }
+    expect(() => spawnPty(fakeWin, 'sidcallsite', { ssh, cwd: osMod.homedir() })).toThrow('__spawn_captured__')
+
+    expect(captured).not.toBeNull()
+    // win32 => ssh.exe binary
+    expect(captured!.file).toBe('ssh.exe')
+    // The EXACT argv the pure builder produces for win32. Computed with the same
+    // live MCP port the spawn path reads, so this equals what pty-manager built.
+    // A revert to an inline array that drops ControlMaster/ControlPath fails here.
+    expect(captured!.args).toEqual(buildSshArgs(ssh, getConductorMcpPort(), 'win32'))
+    // Belt-and-braces: the win32 mux override is actually present in what spawned.
+    expect(captured!.args).toContain('ControlMaster=no')
+    expect(captured!.args).toContain('ControlPath=none')
+    expect(captured!.args[0]).toBe('me@example.com')
+  })
+
+  it('selects the posix ssh binary and omits the win32 mux flags on linux', () => {
+    vi.mocked(osMod.platform).mockReturnValue('linux' as NodeJS.Platform)
+
+    const ssh = { username: 'me', host: 'example.com', port: 22, remotePath: '~/proj' }
+    expect(() => spawnPty(fakeWin, 'sidcallsite2', { ssh, cwd: osMod.homedir() })).toThrow('__spawn_captured__')
+
+    expect(captured!.file).toBe('ssh')
+    expect(captured!.args).toEqual(buildSshArgs(ssh, getConductorMcpPort(), 'linux'))
+    expect(captured!.args).not.toContain('ControlMaster=no')
+  })
+})

--- a/tests/unit/ssh-spawn-callsite.test.ts
+++ b/tests/unit/ssh-spawn-callsite.test.ts
@@ -89,4 +89,15 @@ describe('SSH spawn path uses buildSshArgs (call-site pin, #265 finding 4)', () 
     expect(captured!.args).toEqual(buildSshArgs(ssh, getConductorMcpPort(), 'linux'))
     expect(captured!.args).not.toContain('ControlMaster=no')
   })
+
+  // #265 sink-guard backstop on the REAL spawn path. Calling spawnPty directly
+  // bypasses the IPC sshSchema — exactly the "call site that skips Zod" the
+  // buildSshArgs guard defends against. It must throw before anything spawns, so
+  // an option-injecting host/username can never reach argv even off the IPC path.
+  it('the buildSshArgs sink guard fires on the real spawn path (schema-bypass backstop)', () => {
+    vi.mocked(osMod.platform).mockReturnValue('win32' as NodeJS.Platform)
+    const ssh = { username: '-oProxyCommand=touch /tmp/pwn', host: 'example.com', port: 22, remotePath: '~/proj' }
+    expect(() => spawnPty(fakeWin, 'sidmalicious', { ssh, cwd: osMod.homedir() })).toThrow(/Refusing to build SSH args/)
+    expect(captured).toBeNull() // nothing was ever handed to pty.spawn
+  })
 })


### PR DESCRIPTION
Closes #265 on merge to beta (label `in-beta`).

Defence-in-depth around SSH argv / remote-setup construction — the four controls the #241 ControlMaster fix (beta.9, #260) did not carry, surfaced by the #241 adversarial pass. **Non-exploitable on beta today** (finding 1's incompleteness is why), so public per #265, not embargoed.

## Changes
1. **host/username charset-gated at the IPC boundary** (`ipc/pty-handlers.ts`). Both were `z.string().min(1)`, then fused into `${username}@${host}` = argv[0]; ssh reads a leading `-` as an option (`-oProxyCommand=...` = local RCE). Gate rejects a leading `-` and whitespace (`/^[^-\s]\S*$/`) — still admits IPv6, internal dashes, `DOMAIN\user`. Matches the remotePath precedent (#188).
2. **Sink-side guard in `buildSshArgs`** (`ssh-args.ts`) re-asserts the same charset at the interpolation point, so a call site bypassing Zod can't rebuild the primitive (mirrors `assertSafeRemotePath`).
3. **sessionId charset-gated** (`/^[A-Za-z0-9_-]+$/`) and the one raw embedding fixed: the statusLine `command` in `ssh-shim.ts` used the raw id (lands in a single-quoted JS literal in the base64'd remote script AND the `sh -c` command) → now `safeSid` (no-op for real hex ids).
4. **Call-site test** pins that the spawn path CALLS `buildSshArgs` (mocks node-pty + `os.platform()`=win32) so a revert to an inline argv array — dropping the #241 mux flags — fails.

## Verification
- Every guard **mutation-proven** (revert → named test red).
- Full suite green (**5320**, +38), typecheck clean, byte-scan clean.
- ADR-009 security-sensitive (PTY argv / IPC boundary) → adversarial-review PASS to be recorded before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)