### PR TITLE
fix(accounts): sign claude.ai web sessions in-app, without a debug port (#216)

### DIFF
--- a/CONTEXT.d/2026-08-17-account-web-inapp-signin.md
+++ b/CONTEXT.d/2026-08-17-account-web-inapp-signin.md
@@ -1,0 +1,47 @@
+## 2026-08-17 -- claude.ai web sign-in moved in-app (no debug port)
+
+The per-account claude.ai web sign-in (#216) looped on Cloudflare's "verify you
+are human" check indefinitely and could not complete. A controlled A/B on the
+target machine isolated the cause precisely:
+
+- plain Chrome, fresh profile, **with** `--remote-debugging-port` (nothing even
+  attached) -> challenge loops forever;
+- the **same** Chrome **without** that port -> signs in cleanly;
+- claude.ai loaded in an **Electron** window (no port) with a normal Chrome
+  user-agent -> signs in cleanly.
+
+So claude.ai's bot-detection flags the remote-debugging port itself, which the
+`system-browser` sign-in path opens to read the session cookie back over CDP.
+The earlier fixes (#269/#276 stopped scripting the page every poll, #282 survived
+a transient cookie read) reduced the aggravation but could not remove the port,
+which is the actual signal.
+
+**Fix:** for non-SSO accounts, sign in DIRECTLY inside an Electron window bound to
+the account's partition -- no launched browser, no debug port. The session cookie
+then lands in Electron's own store for that partition (the same store the
+artifacts window already reads), so there is nothing to harvest or inject and no
+automation signal to catch. One partition per account keeps the isolation model.
+
+- New `in-app-sign-in.ts`: the window flow. Sandboxed, context-isolated, no
+  preload/node, permissions denied. Auth-flow nav policy (https top-level allowed
+  for IdP hops; non-https blocked; popups denied). Presents a plain Chrome UA
+  (Electron token + app-name token stripped). Identity read runs page script only
+  after the session cookie exists and only when the frame's own origin is
+  claude.ai -- the same origin gate the CDP path used. Window destroyed the instant
+  sign-in completes or is cancelled, so a session-bearing window never lingers. A
+  post-read recheck refuses to report done if a sign-out cleared the partition
+  mid-read.
+- `sign-in.ts` routes by auth method: `sso` keeps the `system-browser` + CDP path
+  (its identity provider may need a policy-installed browser extension an Electron
+  window lacks); everything else goes in-app. The in-app path leaves no on-disk
+  browser profile, so the profile-lock/orphan machinery does not apply to it.
+- `cookie-harvest.ts` gains a pure `webSessionFromElectronCookies` (sessionKey
+  present + its expiry), mirroring the CDP harvest's success rule.
+- New `in-app` value on `WebSessionOrigin`. Renderer copy no longer claims the
+  user's own browser opens for every account.
+
+As a side effect this removes an attack surface the `system-browser` path's own
+comments flag: the loopback debug port that "anything that can reach it can read
+the cookies". Every new guard is mutation-proven; full suite green, typecheck +
+byte-scan clean. Security-sensitive (credential/account code) -> ran the ADR-009
+adversarial pass before merge.

--- a/src/main/account-web/cookie-harvest.ts
+++ b/src/main/account-web/cookie-harvest.ts
@@ -105,6 +105,44 @@ export function toElectronCookie(c: CdpCookie): ElectronCookie | null {
   return out
 }
 
+/**
+ * The subset of an Electron `Cookie` (as returned by `session.cookies.get`) this
+ * code reads. Used by the in-app sign-in path, where the user signs in DIRECTLY
+ * in the account's partition, so the session cookie is already in Electron's own
+ * store — there is nothing to convert or inject, only to read back.
+ */
+export interface ElectronReadCookie {
+  name: string
+  /** Electron reports seconds since epoch; absent for a session cookie. */
+  expirationDate?: number
+  /** True for a session cookie (no persistent expiry of its own). */
+  session?: boolean
+}
+
+/**
+ * PURE: decide whether an account's partition holds a usable claude.ai web
+ * session, from the cookies Electron reports for it.
+ *
+ * Mirrors `harvestClaudeCookies`'s success rule exactly — `sessionKey` present is
+ * the only meaningful signal, and the session's lifetime is `sessionKey`'s and
+ * nothing else's (NOT the earliest expiry across the jar, which would report a
+ * fresh session as half-expired the moment a 30-minute `__cf_bm` landed). Kept
+ * pure so the in-app path's completion rule is testable without Electron.
+ */
+export function webSessionFromElectronCookies(
+  cookies: readonly ElectronReadCookie[],
+): { hasSessionCookie: boolean; expiresAt: number | null } {
+  const session = (cookies ?? []).find((c) => c?.name === CLAUDE_SESSION_COOKIE)
+  if (!session) return { hasSessionCookie: false, expiresAt: null }
+  // Electron seconds -> epoch ms, matching everything else in the app. A session
+  // cookie (no expirationDate / session:true) reports null, treated as active.
+  const exp = session.expirationDate
+  return {
+    hasSessionCookie: true,
+    expiresAt: typeof exp === 'number' && exp > 0 ? exp * 1000 : null,
+  }
+}
+
 export interface HarvestResult {
   cookies: ElectronCookie[]
   /** True when the cookie that actually carries the session is present. */

--- a/src/main/account-web/in-app-sign-in.ts
+++ b/src/main/account-web/in-app-sign-in.ts
@@ -122,6 +122,14 @@ function bounded<T>(p: Promise<T>, what: string): Promise<T> {
  * session cookie exists. The origin check is evaluated in the same breath as the
  * fetch (both read the frame's CURRENT document), so "this is claude.ai" and "ask
  * claude.ai who I am" cannot disagree — a mid-flow IdP page answers null.
+ *
+ * The check is trustworthy even though `executeJavaScript` runs in the page's
+ * MAIN world (there is no preload, so nothing to isolate): `location` is
+ * [LegacyUnforgeable] in the HTML spec — a page cannot shadow or redefine it, and
+ * assigning `window.location` navigates rather than replacing the object — so
+ * `location.origin` is the frame's true origin. Completion itself does not rest
+ * on this at all: it is decided by the domain-scoped `sessionKey` cookie for
+ * claude.ai, which a page the window roamed to cannot write for that domain.
  */
 async function readAccountEmailInWindow(win: BrowserWindow): Promise<string | null> {
   if (win.isDestroyed()) return null
@@ -151,99 +159,125 @@ function isHttps(url: string): boolean {
 export async function runInAppSignIn(args: InAppSignInArgs): Promise<InAppSignInResult> {
   const { profileId, partition, timeoutMs } = args
   const pollMs = args.pollMs ?? 1200
-  const ses = electronSession.fromPartition(partition)
-  try { ses.setUserAgent(toChromeUserAgent(ses.getUserAgent())) } catch { /* non-fatal */ }
 
-  const win = new BrowserWindow({
-    width: 1200,
-    height: 860,
-    title: 'Sign in to claude.ai',
-    autoHideMenuBar: true,
-    webPreferences: {
-      partition,
-      sandbox: true,
-      contextIsolation: true,
-      nodeIntegration: false,
-      webviewTag: false,
-    },
-  })
-  signInWindow = win
-
-  // Block only NON-https top-level navigation (javascript:, file:, custom
-  // schemes). https is allowed so an identity-provider hop works; the window is
-  // destroyed on completion so it never lingers off-claude.ai with a session.
-  const blockNonHttps = (e: { preventDefault: () => void }, url: string): void => {
-    if (!isHttps(url)) e.preventDefault()
-  }
-  win.webContents.on('will-navigate', blockNonHttps)
-  win.webContents.on('will-redirect', blockNonHttps)
-  // No unhardened popups. A rare popup-based IdP is a system-browser/SSO case.
-  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
-  // A page has no business reaching a camera/mic/clipboard on its own say-so.
-  win.webContents.session.setPermissionRequestHandler((_wc, _perm, cb) => cb(false))
-
-  let windowClosed = false
-  win.on('closed', () => { windowClosed = true; if (signInWindow === win) signInWindow = null })
-
-  // loadURL can reject when the login page immediately 3xx-redirects; that is
-  // normal here and not a failure — the poll below is the real state machine.
-  try { await win.loadURL('https://claude.ai/login') } catch { /* redirect on load */ }
-
-  logInfo(`[account-web] in-app sign-in window opened for ${profileId}`)
-
-  const deadline = Date.now() + timeoutMs
-  // Accept a valid session without the display email after this grace — the
-  // sessionKey cookie, not the bootstrap email, is the source of truth for
-  // "signed in"; the email is only a label.
-  const EMAIL_GRACE_MS = args.emailGraceMs ?? 4_000
-  let sessionSeenAt = 0
-
-  const closedResult = (): InAppSignInResult => ({
-    ok: false,
-    error: 'The sign-in window was closed before sign-in completed. Open it again and leave it up until the panel says you are signed in.',
-  })
-
-  while (Date.now() < deadline) {
-    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
-    if (windowClosed) return closedResult()
-    await sleep(pollMs)
-    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
-    if (windowClosed) return closedResult()
-
-    let cookies
-    try {
-      cookies = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai' })), 'cookies.get')
-    } catch { continue }
-    const { hasSessionCookie, expiresAt } = webSessionFromElectronCookies(cookies)
-    if (!hasSessionCookie) { sessionSeenAt = 0; continue }
-    if (!sessionSeenAt) sessionSeenAt = Date.now()
-
-    const email = await readAccountEmailInWindow(win)
-    if (email === null && Date.now() - sessionSeenAt < EMAIL_GRACE_MS) continue
-
-    // RE-CHECK the cookie is still present: a sign-out could have cleared the
-    // partition during the email read, and reporting done then would save a
-    // record over an empty partition (every request under it would 401).
-    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
-    let recheck: ElectronReadCookie[] = []
-    try {
-      recheck = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai', name: CLAUDE_SESSION_COOKIE })), 'cookies.recheck')
-    } catch { recheck = [] }
-    if (!webSessionFromElectronCookies(recheck).hasSessionCookie) { sessionSeenAt = 0; continue }
-
-    const session: AccountWebSession = {
-      profileId,
-      accountEmail: email,
-      acquiredAt: Date.now(),
-      expiresAt,
-      origin: 'in-app',
-    }
-    logInfo(`[account-web] ${profileId}: signed in as ${email ?? '(email pending)'} via in-app window`)
+  const cancelledResult = (): InAppSignInResult => {
     closeInAppSignInWindow()
-    return { ok: true, session }
+    return { ok: false, cancelled: true, error: 'Sign-in cancelled.' }
   }
 
-  closeInAppSignInWindow()
-  logError(`[account-web] in-app sign-in for ${profileId} timed out`)
-  return { ok: false, error: 'Timed out waiting for sign-in to complete.' }
+  // NEVER-THROW contract (runSignIn depends on it, and a throw here would
+  // otherwise wedge the single-flight latch for every account). Any unexpected
+  // Electron error — fromPartition, window creation, a handler registration —
+  // fails closed: tear down any window and report (adversarial review).
+  try {
+    const ses = electronSession.fromPartition(partition)
+    try { ses.setUserAgent(toChromeUserAgent(ses.getUserAgent())) } catch { /* non-fatal */ }
+
+    const win = new BrowserWindow({
+      width: 1200,
+      height: 860,
+      title: 'Sign in to claude.ai',
+      autoHideMenuBar: true,
+      webPreferences: {
+        partition,
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false,
+        webviewTag: false,
+      },
+    })
+    signInWindow = win
+
+    // Block only NON-https top-level navigation (javascript:, file:, custom
+    // schemes). https is allowed so an identity-provider hop works; the window is
+    // destroyed on completion so it never lingers off-claude.ai with a session.
+    const blockNonHttps = (e: { preventDefault: () => void }, url: string): void => {
+      if (!isHttps(url)) e.preventDefault()
+    }
+    win.webContents.on('will-navigate', blockNonHttps)
+    win.webContents.on('will-redirect', blockNonHttps)
+    // No unhardened popups. A rare popup-based IdP is a system-browser/SSO case.
+    win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+    // A page has no business reaching a camera/mic/clipboard on its own say-so.
+    win.webContents.session.setPermissionRequestHandler((_wc, _perm, cb) => cb(false))
+
+    let windowClosed = false
+    win.on('closed', () => { windowClosed = true; if (signInWindow === win) signInWindow = null })
+
+    // loadURL can reject when the login page immediately 3xx-redirects (normal),
+    // and it must not HANG: a captive portal that accepts the connection then
+    // says nothing would otherwise park the poll — and single-flight with it — so
+    // it is bounded like every other IO here (adversarial review).
+    try { await bounded(Promise.resolve(win.loadURL('https://claude.ai/login')), 'loadURL') } catch { /* redirect or slow load */ }
+
+    logInfo(`[account-web] in-app sign-in window opened for ${profileId}`)
+
+    const deadline = Date.now() + timeoutMs
+    // Accept a valid session without the display email after this grace — the
+    // sessionKey cookie, not the bootstrap email, is the source of truth for
+    // "signed in"; the email is only a label.
+    const EMAIL_GRACE_MS = args.emailGraceMs ?? 4_000
+    let sessionSeenAt = 0
+
+    const closedResult = (): InAppSignInResult => ({
+      ok: false,
+      error: 'The sign-in window was closed before sign-in completed. Open it again and leave it up until the panel says you are signed in.',
+    })
+
+    while (Date.now() < deadline) {
+      if (args.shouldCancel()) return cancelledResult()
+      if (windowClosed) return closedResult()
+      await sleep(pollMs)
+      if (args.shouldCancel()) return cancelledResult()
+      if (windowClosed) return closedResult()
+
+      let cookies
+      try {
+        cookies = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai' })), 'cookies.get')
+      } catch { continue }
+      const { hasSessionCookie, expiresAt } = webSessionFromElectronCookies(cookies)
+      if (!hasSessionCookie) { sessionSeenAt = 0; continue }
+      if (!sessionSeenAt) sessionSeenAt = Date.now()
+
+      const email = await readAccountEmailInWindow(win)
+      if (email === null && Date.now() - sessionSeenAt < EMAIL_GRACE_MS) continue
+
+      // RE-CHECK the cookie is still present: a sign-out could have cleared the
+      // partition during the email read, and reporting done then would save a
+      // record over an empty partition (every request under it would 401).
+      if (args.shouldCancel()) return cancelledResult()
+      let recheck: ElectronReadCookie[] = []
+      try {
+        recheck = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai', name: CLAUDE_SESSION_COOKIE })), 'cookies.recheck')
+      } catch { recheck = [] }
+      if (!webSessionFromElectronCookies(recheck).hasSessionCookie) { sessionSeenAt = 0; continue }
+
+      // AND re-check cancel AFTER the recheck read. clearWebSession sets the
+      // cancel flag SYNCHRONOUSLY and only THEN awaits the partition wipe, so a
+      // sign-out landing during the recheck read leaves the cookie momentarily
+      // present — without this, done would be recorded over a partition about to
+      // be emptied. The system-browser path guards the same window after its
+      // teardown (adversarial review).
+      if (args.shouldCancel()) return cancelledResult()
+
+      const session: AccountWebSession = {
+        profileId,
+        accountEmail: email,
+        acquiredAt: Date.now(),
+        expiresAt,
+        origin: 'in-app',
+      }
+      logInfo(`[account-web] ${profileId}: signed in as ${email ?? '(email pending)'} via in-app window`)
+      closeInAppSignInWindow()
+      return { ok: true, session }
+    }
+
+    closeInAppSignInWindow()
+    logError(`[account-web] in-app sign-in for ${profileId} timed out`)
+    return { ok: false, error: 'Timed out waiting for sign-in to complete.' }
+  } catch (err) {
+    closeInAppSignInWindow()
+    logError(`[account-web] in-app sign-in for ${profileId} failed: ${(err as Error)?.message ?? err}`)
+    return { ok: false, error: (err as Error)?.message ?? 'in-app sign-in failed' }
+  }
 }

--- a/src/main/account-web/in-app-sign-in.ts
+++ b/src/main/account-web/in-app-sign-in.ts
@@ -1,0 +1,249 @@
+/**
+ * in-app-sign-in.ts — sign one account into claude.ai INSIDE an Electron window
+ * on its own partition, with no launched browser and no debug port (#265 follow-up).
+ *
+ * WHY THIS EXISTS. The `system-browser` path (sign-in.ts) launches Chrome/Edge
+ * with `--remote-debugging-port` and reads the session cookie back over CDP.
+ * claude.ai's bot-detection flags that port: a browser with it open is challenged
+ * indefinitely ("verify you are human" never clears), while the same browser
+ * WITHOUT it signs in cleanly. Proven by a controlled A/B on the target machine.
+ *
+ * The fix is to stop scraping a cookie out of a foreign browser and instead let
+ * the user sign in DIRECTLY in an Electron window bound to the account's
+ * partition. The session cookie then lands in Electron's own store for that
+ * partition — the same store the artifacts window already reads — so there is
+ * nothing to harvest or inject, and no automation signal for claude.ai to catch.
+ * One partition per account keeps the isolation model intact.
+ *
+ * The `system-browser` path is kept for SSO accounts, whose identity provider may
+ * need a policy-installed browser extension an Electron window does not carry.
+ *
+ * SECURITY NOTES (this is credential code):
+ *   - The window is sandboxed, context-isolated, no preload, no node. Permissions
+ *     are denied throughout. It is destroyed the instant sign-in completes or is
+ *     cancelled, so a session-bearing window never lingers.
+ *   - It is an AUTH flow, so top-level https navigation is allowed (claude.ai may
+ *     hop to an identity provider and back). Non-https navigation is blocked and
+ *     popups are denied.
+ *   - The identity read runs page script ONLY after the session cookie exists and
+ *     ONLY when the frame's own origin is claude.ai — the same origin gate the
+ *     CDP path used, so a captive-portal / IdP page cannot answer as the account.
+ *
+ * No default export (project convention).
+ */
+
+import { BrowserWindow, session as electronSession } from 'electron'
+import { logError, logInfo } from '../debug-logger'
+import { CLAUDE_SESSION_COOKIE, type AccountWebSession } from '../../shared/account-web-session'
+import { webSessionFromElectronCookies, type ElectronReadCookie } from './cookie-harvest'
+
+/** Upper bound on any single Electron call here, mirroring sign-in.ts. */
+const IO_CALL_TIMEOUT_MS = 10_000
+
+/**
+ * PURE: turn Electron's default user-agent into a plain Chrome one by dropping
+ * the two non-standard tokens Electron inserts — the ` <productName>/<ver>` that
+ * precedes `Chrome/` and the ` Electron/<ver>` after it. Leaves the real platform
+ * and Chrome-version tokens untouched, so claude.ai fingerprints this window like
+ * the Chrome it actually is rather than flagging an "Electron" UA. Exported for a
+ * unit test.
+ */
+export function toChromeUserAgent(ua: string): string {
+  return ua
+    .replace(/ Electron\/\S+/g, '')
+    // Collapse everything between "(KHTML, like Gecko) " and "Chrome/" — that span
+    // is the app-name token, which can contain spaces ("AI Code Conductor/2.1.0").
+    .replace(/(\(KHTML, like Gecko\) ).*?(Chrome\/)/, '$1$2')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+let signInWindow: BrowserWindow | null = null
+
+/** Close and forget the in-app sign-in window, if one is open. Idempotent. */
+export function closeInAppSignInWindow(): void {
+  const w = signInWindow
+  signInWindow = null
+  try {
+    // destroy(), not close(): a page can veto close() via beforeunload, and this
+    // window holds an emerging session we want gone on cancel/sign-out regardless.
+    if (w && !w.isDestroyed()) w.destroy()
+  } catch { /* already gone */ }
+}
+
+export interface InAppSignInArgs {
+  profileId: string
+  /** `persist:claude-web-<profileId>` — the caller resolves and validates it. */
+  partition: string
+  /** How long to wait for the human, ms. */
+  timeoutMs: number
+  /** Poll interval, ms. */
+  pollMs?: number
+  /**
+   * Accept a valid session without the display email after this grace, ms. The
+   * `sessionKey` cookie is the source of truth for "signed in"; the email is only
+   * a label. Defaults to 4s; a test can shorten it.
+   */
+  emailGraceMs?: number
+  /** Read the module-global cancel flag owned by sign-in.ts. */
+  shouldCancel: () => boolean
+}
+
+export interface InAppSignInResult {
+  ok: boolean
+  session?: AccountWebSession
+  error?: string
+  cancelled?: boolean
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => {
+    const t = setTimeout(r, ms)
+    if (typeof (t as { unref?: () => void }).unref === 'function') (t as { unref: () => void }).unref()
+  })
+}
+
+/** Bound any promise in time — nothing over IPC/IO is allowed to hang the poll. */
+function bounded<T>(p: Promise<T>, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`[account-web] in-app ${what} timed out`)), IO_CALL_TIMEOUT_MS)
+      if (typeof (timer as { unref?: () => void })?.unref === 'function') (timer as { unref: () => void }).unref()
+    }),
+  ]).finally(() => { if (timer) clearTimeout(timer) })
+}
+
+/**
+ * Read the signed-in account email from the live window, origin-gated.
+ *
+ * Runs at most one script call, and ONLY the caller invokes it after a real
+ * session cookie exists. The origin check is evaluated in the same breath as the
+ * fetch (both read the frame's CURRENT document), so "this is claude.ai" and "ask
+ * claude.ai who I am" cannot disagree — a mid-flow IdP page answers null.
+ */
+async function readAccountEmailInWindow(win: BrowserWindow): Promise<string | null> {
+  if (win.isDestroyed()) return null
+  const expr =
+    `(location.origin === 'https://claude.ai' || location.origin === 'https://www.claude.ai') ` +
+    `? fetch('/api/bootstrap',{credentials:'include'}).then(r=>r.json())` +
+    `.then(j=>(j&&j.account&&j.account.email_address)||null).catch(()=>null) ` +
+    `: Promise.resolve(null)`
+  try {
+    const v = await bounded(Promise.resolve(win.webContents.executeJavaScript(expr, true)), 'bootstrap evaluate')
+    return typeof v === 'string' ? v : null
+  } catch {
+    return null
+  }
+}
+
+/** True for an https URL; anything unparseable or non-https is not. */
+function isHttps(url: string): boolean {
+  try { return new URL(url).protocol === 'https:' } catch { return false }
+}
+
+/**
+ * Drive the in-app sign-in to completion. Never throws — resolves with a result
+ * the caller maps onto SignInState. The session cookie already lives in the
+ * partition when this returns ok, so the caller only records metadata.
+ */
+export async function runInAppSignIn(args: InAppSignInArgs): Promise<InAppSignInResult> {
+  const { profileId, partition, timeoutMs } = args
+  const pollMs = args.pollMs ?? 1200
+  const ses = electronSession.fromPartition(partition)
+  try { ses.setUserAgent(toChromeUserAgent(ses.getUserAgent())) } catch { /* non-fatal */ }
+
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 860,
+    title: 'Sign in to claude.ai',
+    autoHideMenuBar: true,
+    webPreferences: {
+      partition,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      webviewTag: false,
+    },
+  })
+  signInWindow = win
+
+  // Block only NON-https top-level navigation (javascript:, file:, custom
+  // schemes). https is allowed so an identity-provider hop works; the window is
+  // destroyed on completion so it never lingers off-claude.ai with a session.
+  const blockNonHttps = (e: { preventDefault: () => void }, url: string): void => {
+    if (!isHttps(url)) e.preventDefault()
+  }
+  win.webContents.on('will-navigate', blockNonHttps)
+  win.webContents.on('will-redirect', blockNonHttps)
+  // No unhardened popups. A rare popup-based IdP is a system-browser/SSO case.
+  win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  // A page has no business reaching a camera/mic/clipboard on its own say-so.
+  win.webContents.session.setPermissionRequestHandler((_wc, _perm, cb) => cb(false))
+
+  let windowClosed = false
+  win.on('closed', () => { windowClosed = true; if (signInWindow === win) signInWindow = null })
+
+  // loadURL can reject when the login page immediately 3xx-redirects; that is
+  // normal here and not a failure — the poll below is the real state machine.
+  try { await win.loadURL('https://claude.ai/login') } catch { /* redirect on load */ }
+
+  logInfo(`[account-web] in-app sign-in window opened for ${profileId}`)
+
+  const deadline = Date.now() + timeoutMs
+  // Accept a valid session without the display email after this grace — the
+  // sessionKey cookie, not the bootstrap email, is the source of truth for
+  // "signed in"; the email is only a label.
+  const EMAIL_GRACE_MS = args.emailGraceMs ?? 4_000
+  let sessionSeenAt = 0
+
+  const closedResult = (): InAppSignInResult => ({
+    ok: false,
+    error: 'The sign-in window was closed before sign-in completed. Open it again and leave it up until the panel says you are signed in.',
+  })
+
+  while (Date.now() < deadline) {
+    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
+    if (windowClosed) return closedResult()
+    await sleep(pollMs)
+    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
+    if (windowClosed) return closedResult()
+
+    let cookies
+    try {
+      cookies = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai' })), 'cookies.get')
+    } catch { continue }
+    const { hasSessionCookie, expiresAt } = webSessionFromElectronCookies(cookies)
+    if (!hasSessionCookie) { sessionSeenAt = 0; continue }
+    if (!sessionSeenAt) sessionSeenAt = Date.now()
+
+    const email = await readAccountEmailInWindow(win)
+    if (email === null && Date.now() - sessionSeenAt < EMAIL_GRACE_MS) continue
+
+    // RE-CHECK the cookie is still present: a sign-out could have cleared the
+    // partition during the email read, and reporting done then would save a
+    // record over an empty partition (every request under it would 401).
+    if (args.shouldCancel()) { closeInAppSignInWindow(); return { ok: false, cancelled: true, error: 'Sign-in cancelled.' } }
+    let recheck: ElectronReadCookie[] = []
+    try {
+      recheck = await bounded(Promise.resolve(ses.cookies.get({ url: 'https://claude.ai', name: CLAUDE_SESSION_COOKIE })), 'cookies.recheck')
+    } catch { recheck = [] }
+    if (!webSessionFromElectronCookies(recheck).hasSessionCookie) { sessionSeenAt = 0; continue }
+
+    const session: AccountWebSession = {
+      profileId,
+      accountEmail: email,
+      acquiredAt: Date.now(),
+      expiresAt,
+      origin: 'in-app',
+    }
+    logInfo(`[account-web] ${profileId}: signed in as ${email ?? '(email pending)'} via in-app window`)
+    closeInAppSignInWindow()
+    return { ok: true, session }
+  }
+
+  closeInAppSignInWindow()
+  logError(`[account-web] in-app sign-in for ${profileId} timed out`)
+  return { ok: false, error: 'Timed out waiting for sign-in to complete.' }
+}

--- a/src/main/account-web/sign-in.ts
+++ b/src/main/account-web/sign-in.ts
@@ -592,16 +592,24 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
   // directly, so there is no harvest/injection and no on-disk profile to sweep.
   if ((opts.method ?? DEFAULT_CLI_AUTH_METHOD) !== 'sso') {
     current = { phase: 'awaiting-user', profileId }
-    const res = await runInAppSignIn({
-      profileId,
-      partition,
-      timeoutMs,
-      pollMs,
-      shouldCancel: () => cancelled,
-    })
-    current = res.session
-      ? { phase: 'done', profileId, session: res.session }
-      : { phase: 'failed', profileId, error: res.error ?? (res.cancelled ? 'Sign-in cancelled.' : 'Sign-in failed.') }
+    try {
+      const res = await runInAppSignIn({
+        profileId,
+        partition,
+        timeoutMs,
+        pollMs,
+        shouldCancel: () => cancelled,
+      })
+      current = res.session
+        ? { phase: 'done', profileId, session: res.session }
+        : { phase: 'failed', profileId, error: res.error ?? (res.cancelled ? 'Sign-in cancelled.' : 'Sign-in failed.') }
+    } catch (err) {
+      // runInAppSignIn is contracted never to throw; this is defence-in-depth so
+      // an unexpected throw still lands as a failed state and releases the
+      // single-flight latch, never propagating out of runSignIn (adversarial review).
+      closeInAppSignInWindow()
+      current = { phase: 'failed', profileId, error: (err as Error)?.message ?? String(err) }
+    }
     return current
   }
 

--- a/src/main/account-web/sign-in.ts
+++ b/src/main/account-web/sign-in.ts
@@ -33,12 +33,15 @@ import { getBrowserPaths } from '../browser-paths'
 import {
   AUTH_BROWSER_LABELS,
   DEFAULT_AUTH_BROWSER,
+  DEFAULT_CLI_AUTH_METHOD,
   PROFILE_ID_RE,
   webPartitionForProfile,
   type AccountWebSession,
+  type CliAuthMethod,
 } from '../../shared/account-web-session'
 import { DEVTOOLS_PORT_FILE, authProfileDir, buildAuthBrowserArgs, type AuthBrowser } from './browser-launch'
 import { harvestClaudeCookies, type CdpCookie } from './cookie-harvest'
+import { closeInAppSignInWindow, runInAppSignIn } from './in-app-sign-in'
 
 /** Lazy require so a missing optional dep never crashes boot (mirrors vision-manager). */
 let CDP: any = null
@@ -519,6 +522,14 @@ async function readAccountEmail(client: any): Promise<string | null> {
 export interface RunSignInOpts {
   profileId: string
   dataDir: string
+  /**
+   * The account's CLI sign-in flow. Routes the web sign-in: 'sso' keeps the
+   * system-browser + CDP path (its identity provider may need a policy-installed
+   * browser extension an Electron window lacks); anything else signs in IN-APP
+   * (no launched browser, no debug port — claude.ai's bot-detection flags that
+   * port). Absent falls back to the default, which is non-SSO.
+   */
+  method?: CliAuthMethod
   /** How long to wait for the human, ms. SSO with MFA is not fast. */
   timeoutMs?: number
   pollMs?: number
@@ -570,6 +581,27 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
     profileDir = authProfileDir(dataDir, profileId)
   } catch (err) {
     current = { phase: 'failed', profileId, error: (err as Error)?.message ?? String(err) }
+    return current
+  }
+
+  // ROUTE (#265 follow-up). Non-SSO accounts sign in IN-APP — inside an Electron
+  // window on this partition, with no launched browser and no debug port, so
+  // claude.ai's bot-detection has nothing to flag. SSO keeps the system-browser
+  // flow below (its identity provider may need a policy-installed extension an
+  // Electron window does not carry). The session cookie lands in this partition
+  // directly, so there is no harvest/injection and no on-disk profile to sweep.
+  if ((opts.method ?? DEFAULT_CLI_AUTH_METHOD) !== 'sso') {
+    current = { phase: 'awaiting-user', profileId }
+    const res = await runInAppSignIn({
+      profileId,
+      partition,
+      timeoutMs,
+      pollMs,
+      shouldCancel: () => cancelled,
+    })
+    current = res.session
+      ? { phase: 'done', profileId, session: res.session }
+      : { phase: 'failed', profileId, error: res.error ?? (res.cancelled ? 'Sign-in cancelled.' : 'Sign-in failed.') }
     return current
   }
 
@@ -836,6 +868,10 @@ export async function runSignIn(opts: RunSignInOpts): Promise<SignInState> {
 export function cancelSignIn(profileId?: string): void {
   if (profileId && current.profileId && current.profileId !== profileId) return
   cancelled = true
+  // Close the in-app sign-in window NOW, not just at the next poll: a cancel from
+  // the UI (or a sign-out landing mid-sign-in) should take the window down at
+  // once. No-op when the system-browser path is the one running.
+  closeInAppSignInWindow()
 }
 
 /**

--- a/src/main/ipc/account-web-handlers.ts
+++ b/src/main/ipc/account-web-handlers.ts
@@ -69,9 +69,11 @@ export function registerAccountWebHandlers(): void {
       const state = await runSignIn({
         profileId: id,
         dataDir: getDataDirectory(),
-        // The ACCOUNT's browser, read here rather than inside the sign-in: the
-        // launcher takes what it is given, and the store is the one authority on
-        // what this account chose.
+        // The ACCOUNT's method + browser, read here rather than inside the
+        // sign-in: the store is the one authority on what this account chose.
+        // `method` routes the flow — 'sso' uses the system browser, everything
+        // else signs in in-app (no debug port; see sign-in.ts).
+        method: getAuthMethod(id),
         browser: getAuthBrowser(id),
       })
       if (state.phase === 'done' && state.session) saveWebSession(state.session)

--- a/src/renderer/components/settings/AccountWebSession.tsx
+++ b/src/renderer/components/settings/AccountWebSession.tsx
@@ -183,28 +183,30 @@ export function AccountWebSession({ profileId, accountName }: Props) {
               : 'Needed to import an organisation-scoped share and to open this account’s artifacts. Opens a window to sign in.'}
           </div>
 
-          {/* Browser is PER ACCOUNT and the user's call, because the two are not
-              interchangeable at the identity provider. The sign-in runs in a
-              fresh profile by design, and on a managed machine Chrome's
-              force-installed SSO extension is not there yet when claude.ai
-              loads — Edge does Entra SSO natively and has nothing to wait for.
-              Which one an account needs depends on its org, so CCC asks. */}
-          <div className="flex items-center gap-2 mt-1.5">
-            <span className="text-[10px] text-overlay0 shrink-0">Sign-in browser</span>
-            <select
-              value={authBrowser}
-              disabled={busy}
-              onChange={(e) => { void changeAuthBrowser(e.target.value as AuthBrowser) }}
-              className="bg-base border border-surface1 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue disabled:opacity-40"
-            >
-              {AUTH_BROWSERS.map((b) => (
-                <option key={b} value={b}>{AUTH_BROWSER_LABELS[b]}</option>
-              ))}
-            </select>
-            <span className="text-[10px] text-overlay0">
-              {authBrowser === 'edge' ? 'Handles SSO without an extension' : 'Needs your policy’s SSO extension'}
-            </span>
-          </div>
+          {/* SSO ONLY. Non-SSO accounts sign in inside an in-app window, which
+              launches no system browser, so this picker would be inert for them.
+              For SSO the browser IS the user's call: on a managed machine Chrome's
+              force-installed SSO extension is not there yet when claude.ai loads in
+              a fresh profile, while Edge does Entra SSO natively — which one an
+              account needs depends on its org, so CCC asks. */}
+          {authMethod === 'sso' && (
+            <div className="flex items-center gap-2 mt-1.5">
+              <span className="text-[10px] text-overlay0 shrink-0">Sign-in browser</span>
+              <select
+                value={authBrowser}
+                disabled={busy}
+                onChange={(e) => { void changeAuthBrowser(e.target.value as AuthBrowser) }}
+                className="bg-base border border-surface1 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue disabled:opacity-40"
+              >
+                {AUTH_BROWSERS.map((b) => (
+                  <option key={b} value={b}>{AUTH_BROWSER_LABELS[b]}</option>
+                ))}
+              </select>
+              <span className="text-[10px] text-overlay0">
+                {authBrowser === 'edge' ? 'Handles SSO without an extension' : 'Needs your policy’s SSO extension'}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/renderer/components/settings/AccountWebSession.tsx
+++ b/src/renderer/components/settings/AccountWebSession.tsx
@@ -8,8 +8,10 @@
  * alike, so a panel that showed only one would leave the other's symptoms
  * unexplained.
  *
- * Both sign-ins happen in the user's OWN browser, because a managed machine
- * requires an extension an in-app window cannot load. Doing the web sign-in
+ * The web sign-in opens a window: an in-app window for most accounts (no
+ * launched browser, no debug port — claude.ai's bot-detection flags that port),
+ * and the user's OWN browser for SSO accounts, whose identity provider may need a
+ * policy-installed extension an in-app window cannot load. Doing the web sign-in
  * first means the CLI's hop is a consent click rather than a second credential
  * entry.
  */
@@ -178,7 +180,7 @@ export function AccountWebSession({ profileId, accountName }: Props) {
           <div className="text-[10px] text-overlay0 leading-snug">
             {web.status === 'active'
               ? `Acquired ${fmt(web.acquiredAt)}${web.expiresAt ? `, expires ${fmt(web.expiresAt)}` : ''}.`
-              : 'Needed to import an organisation-scoped share and to open this account’s artifacts. Opens your own browser to sign in.'}
+              : 'Needed to import an organisation-scoped share and to open this account’s artifacts. Opens a window to sign in.'}
           </div>
 
           {/* Browser is PER ACCOUNT and the user's call, because the two are not
@@ -209,8 +211,8 @@ export function AccountWebSession({ profileId, accountName }: Props) {
       {busy && (
         <div className="text-[11px] text-blue">
           {phase === 'awaiting-user'
-            ? 'Waiting for you to finish signing in, in the browser window that just opened…'
-            : phase === 'harvesting' ? 'Signed in — collecting the session…' : 'Opening your browser…'}
+            ? 'Waiting for you to finish signing in, in the sign-in window that just opened…'
+            : phase === 'harvesting' ? 'Signed in — collecting the session…' : 'Opening the sign-in window…'}
         </div>
       )}
 

--- a/src/shared/account-web-session.ts
+++ b/src/shared/account-web-session.ts
@@ -21,8 +21,19 @@
  * No default export (project convention).
  */
 
-/** Where a web session came from. Recorded so a stale one can be explained. */
-export type WebSessionOrigin = 'system-browser'
+/**
+ * Where a web session came from. Recorded so a stale one can be explained.
+ *   - `system-browser`: signed in via a launched Chrome/Edge, cookies read over
+ *     CDP and injected into the partition. Kept for SSO accounts, whose identity
+ *     provider may need a policy-installed browser extension an in-app window
+ *     lacks (see the AuthBrowser note below).
+ *   - `in-app`: signed in directly inside an Electron window on the account's
+ *     partition — no launched browser, no debug port. This avoids claude.ai's
+ *     bot-detection, which flags the remote-debugging port `system-browser` uses
+ *     (proven: a browser with that port open is challenged indefinitely; the same
+ *     browser without it signs in cleanly). The default for non-SSO accounts.
+ */
+export type WebSessionOrigin = 'system-browser' | 'in-app'
 
 /**
  * How an account signs in to the Claude Code CLI.

--- a/tests/unit/account-web-adversarial-regressions.test.ts
+++ b/tests/unit/account-web-adversarial-regressions.test.ts
@@ -75,7 +75,10 @@ function cdp(email: string | null, targetInfo: 'ok' | 'throws' | 'missing-url' |
   return f
 }
 
-const RUN = { profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 400, pollMs: 5 } as const
+// method:'sso' keeps these on the system-browser + CDP path they exercise; the
+// non-SSO default now signs in in-app (in-app-sign-in.ts), which spawns no
+// browser and is covered by its own tests.
+const RUN = { profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 400, pollMs: 5, method: 'sso' } as const
 
 beforeEach(() => {
   cookiesSet.mockReset()

--- a/tests/unit/account-web-browser-fallback.test.ts
+++ b/tests/unit/account-web-browser-fallback.test.ts
@@ -83,7 +83,7 @@ describe('resolveBrowserBinary — the account’s preference decides the order'
 
 describe('runSignIn — a substitution is reported, never silent', () => {
   it('signs in with Chrome when Edge was asked for, and says so', async () => {
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'edge' })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'edge', method: 'sso' })
 
     expect(s.phase).toBe('done')
     // It still worked — the fallback is deliberate.
@@ -102,7 +102,7 @@ describe('runSignIn — a substitution is reported, never silent', () => {
     // sessionKey was left on disk -- the exact outcome the dedicated-profile
     // design exists to prevent.
     spawnSyncMock.mockClear()
-    await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'chrome' })
+    await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'chrome', method: 'sso' })
 
     if (process.platform === 'win32') {
       expect(spawnSyncMock).toHaveBeenCalled()
@@ -115,7 +115,7 @@ describe('runSignIn — a substitution is reported, never silent', () => {
   })
 
   it('says nothing when the browser that ran is the one that was asked for', async () => {
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'chrome' })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, browser: 'chrome', method: 'sso' })
 
     expect(s.phase).toBe('done')
     expect(s.browser).toBe('chrome')
@@ -132,7 +132,7 @@ describe('runSignIn — a substitution is reported, never silent', () => {
     })
     never.List = async () => TARGETS
     setCdp(never)
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5, browser: 'edge' })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5, browser: 'edge', method: 'sso' })
 
     expect(s.phase).toBe('failed')
     expect(s.browser).toBe('chrome')

--- a/tests/unit/account-web-cloudflare.test.ts
+++ b/tests/unit/account-web-cloudflare.test.ts
@@ -52,7 +52,10 @@ function makeCdp(opts: { targets: any[]; cookiesFor: () => any[]; evaluate: Retu
   return f
 }
 
-const RUN = { profileId: 'profile-aaa111', dataDir: 'C:/data', pollMs: 5 } as const
+// method:'sso' keeps these on the system-browser + CDP path (the Cloudflare
+// notice under test belongs to that flow). The non-SSO default now signs in
+// in-app, with its own tests.
+const RUN = { profileId: 'profile-aaa111', dataDir: 'C:/data', pollMs: 5, method: 'sso' } as const
 
 beforeEach(() => { cookiesSet.mockReset() })
 

--- a/tests/unit/account-web-in-app-sign-in.test.ts
+++ b/tests/unit/account-web-in-app-sign-in.test.ts
@@ -1,0 +1,214 @@
+// #265 follow-up — the in-app claude.ai sign-in (no launched browser, no debug
+// port). Covers the pure helpers and the window flow. Electron is mocked with a
+// controllable window + partition cookie store so the poll loop is exercised
+// without a GPU or a real browser.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+let uaValue = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) AI Code Conductor/2.1.0 Chrome/128.0.0.0 Electron/33.0.0 Safari/537.36'
+const setUA = vi.fn((v: string) => { uaValue = v })
+let cookieResponse: Array<Record<string, unknown>> = []
+let evalResult: string | null = null
+let onEval: (() => void) | null = null
+const cookiesGet = vi.fn(async () => cookieResponse)
+const fromPartition = vi.fn(() => ({
+  getUserAgent: () => uaValue,
+  setUserAgent: setUA,
+  cookies: { get: cookiesGet },
+}))
+
+const created: FakeWin[] = []
+const permHandlers: Array<(wc: unknown, perm: string, cb: (v: boolean) => void) => void> = []
+
+class FakeWin {
+  opts: Record<string, any>
+  destroyed = false
+  destroyCalls = 0
+  handlers: Record<string, Function> = {}
+  private closedCb?: () => void
+  webContents: Record<string, any>
+  constructor(opts: Record<string, any>) {
+    this.opts = opts
+    this.webContents = {
+      on: (ev: string, fn: Function) => { this.handlers[ev] = fn },
+      setWindowOpenHandler: (fn: Function) => { this.handlers.__open = fn },
+      session: { setPermissionRequestHandler: (fn: any) => { permHandlers.push(fn) } },
+      executeJavaScript: async () => { onEval?.(); return evalResult },
+      isDestroyed: () => this.destroyed,
+    }
+    created.push(this)
+  }
+  loadURL = vi.fn(async () => {})
+  isDestroyed() { return this.destroyed }
+  destroy() { this.destroyed = true; this.destroyCalls++; this.closedCb?.() }
+  on(ev: string, fn: () => void) { if (ev === 'closed') this.closedCb = fn }
+  /** Simulate the USER closing the window. */
+  userClose() { this.destroyed = true; this.closedCb?.() }
+}
+
+vi.mock('electron', () => ({
+  BrowserWindow: FakeWin,
+  session: { fromPartition },
+}))
+vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+
+const { runInAppSignIn, toChromeUserAgent, closeInAppSignInWindow } = await import('../../src/main/account-web/in-app-sign-in')
+const { webSessionFromElectronCookies } = await import('../../src/main/account-web/cookie-harvest')
+
+const SK = (over: Record<string, unknown> = {}) => ({ name: 'sessionKey', value: 'sk', ...over })
+
+beforeEach(() => {
+  created.length = 0
+  permHandlers.length = 0
+  setUA.mockClear()
+  cookiesGet.mockClear()
+  fromPartition.mockClear()
+  cookieResponse = []
+  evalResult = null
+  onEval = null
+  uaValue = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) AI Code Conductor/2.1.0 Chrome/128.0.0.0 Electron/33.0.0 Safari/537.36'
+  closeInAppSignInWindow()
+})
+
+const RUN = { profileId: 'profile-web1', partition: 'persist:claude-web-profile-web1', timeoutMs: 2000, pollMs: 5 }
+
+describe('toChromeUserAgent (pure)', () => {
+  it('strips the Electron token and the app-name token, keeping a real Chrome UA', () => {
+    const out = toChromeUserAgent(uaValue)
+    expect(out).not.toContain('Electron/')
+    expect(out).not.toContain('AI Code Conductor')
+    expect(out).toContain('Chrome/128.0.0.0')
+    expect(out).toBe('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36')
+  })
+  it('leaves an already-clean Chrome UA unchanged', () => {
+    const clean = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36'
+    expect(toChromeUserAgent(clean)).toBe(clean)
+  })
+})
+
+describe('webSessionFromElectronCookies (pure)', () => {
+  it('is not signed in without a sessionKey cookie', () => {
+    expect(webSessionFromElectronCookies([{ name: 'ajs_anonymous_id' }])).toEqual({ hasSessionCookie: false, expiresAt: null })
+    expect(webSessionFromElectronCookies([])).toEqual({ hasSessionCookie: false, expiresAt: null })
+  })
+  it('maps the sessionKey expiry (seconds) to epoch ms', () => {
+    expect(webSessionFromElectronCookies([SK({ expirationDate: 1_800_000_000 })])).toEqual({ hasSessionCookie: true, expiresAt: 1_800_000_000_000 })
+  })
+  it('treats a session cookie (no expiry) as active with null expiresAt', () => {
+    expect(webSessionFromElectronCookies([SK({ session: true })])).toEqual({ hasSessionCookie: true, expiresAt: null })
+  })
+})
+
+describe('runInAppSignIn — window flow', () => {
+  it('signs in when the sessionKey cookie appears, stamping origin in-app + expiry + email', async () => {
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = 'me@example.com'
+    const res = await runInAppSignIn({ ...RUN, shouldCancel: () => false })
+    expect(res.ok).toBe(true)
+    expect(res.session?.origin).toBe('in-app')
+    expect(res.session?.accountEmail).toBe('me@example.com')
+    expect(res.session?.expiresAt).toBe(1_800_000_000_000)
+    expect(res.session?.profileId).toBe('profile-web1')
+    // The window is torn down on success — a session-bearing window never lingers.
+    expect(created[0].destroyed).toBe(true)
+  })
+
+  it('opens on THAT account partition, hardened, presenting a Chrome UA', async () => {
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = 'me@example.com'
+    await runInAppSignIn({ ...RUN, shouldCancel: () => false })
+    expect(fromPartition).toHaveBeenCalledWith('persist:claude-web-profile-web1')
+    const wp = created[0].opts.webPreferences
+    expect(wp.partition).toBe('persist:claude-web-profile-web1')
+    expect(wp.sandbox).toBe(true)
+    expect(wp.contextIsolation).toBe(true)
+    expect(wp.nodeIntegration).toBe(false)
+    expect(wp.preload).toBeUndefined()
+    // UA presented as Chrome, not Electron.
+    expect(setUA).toHaveBeenCalledTimes(1)
+    expect(setUA.mock.calls[0][0]).not.toContain('Electron')
+    expect(setUA.mock.calls[0][0]).toContain('Chrome/')
+  })
+
+  it('denies permissions, blocks non-https navigation, allows https, denies popups', async () => {
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = 'me@example.com'
+    await runInAppSignIn({ ...RUN, shouldCancel: () => false })
+    const w = created[0]
+    // permission deny
+    expect(permHandlers).toHaveLength(1)
+    const pcb = vi.fn()
+    permHandlers[0](null, 'media', pcb)
+    expect(pcb).toHaveBeenCalledWith(false)
+    // https allowed (IdP hop), non-https blocked
+    for (const ev of ['will-navigate', 'will-redirect']) {
+      const okE = { preventDefault: vi.fn() }
+      w.handlers[ev](okE, 'https://accounts.google.com/o/oauth2/x')
+      expect(okE.preventDefault).not.toHaveBeenCalled()
+      const badE = { preventDefault: vi.fn() }
+      w.handlers[ev](badE, 'javascript:alert(1)')
+      expect(badE.preventDefault).toHaveBeenCalled()
+    }
+    // popups denied
+    expect(w.handlers.__open({ url: 'https://claude.ai/x' })).toEqual({ action: 'deny' })
+  })
+
+  it('completes with a null email after the grace when the identity read never answers', async () => {
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = null
+    const res = await runInAppSignIn({ ...RUN, emailGraceMs: 0, shouldCancel: () => false })
+    expect(res.ok).toBe(true)
+    expect(res.session?.accountEmail).toBeNull()
+    expect(res.session?.origin).toBe('in-app')
+  })
+
+  it('does NOT complete if the session cookie vanishes during the identity read (sign-out race)', async () => {
+    // sessionKey present on the first read, then cleared by a sign-out landing
+    // during the email read: the recheck must catch it and NOT report done.
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = 'me@example.com'
+    onEval = () => { cookieResponse = [] }   // partition cleared mid-read
+    const res = await runInAppSignIn({ ...RUN, timeoutMs: 120, pollMs: 5, shouldCancel: () => false })
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/Timed out/)
+  })
+
+  it('fails when the user closes the window before signing in', async () => {
+    cookieResponse = []   // never signs in
+    const p = runInAppSignIn({ ...RUN, shouldCancel: () => false })
+    created[0].userClose()
+    const res = await p
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/closed/)
+  })
+
+  it('returns cancelled and destroys the window when cancel is signalled', async () => {
+    cookieResponse = []
+    let cancel = false
+    const p = runInAppSignIn({ ...RUN, shouldCancel: () => cancel })
+    cancel = true
+    const res = await p
+    expect(res.cancelled).toBe(true)
+    expect(created[0].destroyed).toBe(true)
+  })
+
+  it('times out (and tears the window down) if the user never signs in', async () => {
+    cookieResponse = []
+    const res = await runInAppSignIn({ ...RUN, timeoutMs: 60, pollMs: 5, shouldCancel: () => false })
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/Timed out/)
+    expect(created[0].destroyed).toBe(true)
+  })
+})
+
+describe('closeInAppSignInWindow', () => {
+  it('destroys an open sign-in window (used by cancel / sign-out)', async () => {
+    cookieResponse = []
+    const p = runInAppSignIn({ ...RUN, timeoutMs: 5000, pollMs: 5, shouldCancel: () => false })
+    // Give the loop a tick to open the window.
+    await new Promise((r) => setTimeout(r, 10))
+    expect(created[0].destroyed).toBe(false)
+    closeInAppSignInWindow()
+    expect(created[0].destroyed).toBe(true)
+    await p
+  })
+})

--- a/tests/unit/account-web-in-app-sign-in.test.ts
+++ b/tests/unit/account-web-in-app-sign-in.test.ts
@@ -9,12 +9,18 @@ const setUA = vi.fn((v: string) => { uaValue = v })
 let cookieResponse: Array<Record<string, unknown>> = []
 let evalResult: string | null = null
 let onEval: (() => void) | null = null
-const cookiesGet = vi.fn(async () => cookieResponse)
-const fromPartition = vi.fn(() => ({
-  getUserAgent: () => uaValue,
-  setUserAgent: setUA,
-  cookies: { get: cookiesGet },
-}))
+let cookiesGetCalls = 0
+let onCookiesGet: ((call: number) => void) | null = null
+let throwOnPartition = false
+const cookiesGet = vi.fn(async () => { cookiesGetCalls++; onCookiesGet?.(cookiesGetCalls); return cookieResponse })
+const fromPartition = vi.fn(() => {
+  if (throwOnPartition) throw new Error('simulated Electron failure')
+  return {
+    getUserAgent: () => uaValue,
+    setUserAgent: setUA,
+    cookies: { get: cookiesGet },
+  }
+})
 
 const created: FakeWin[] = []
 const permHandlers: Array<(wc: unknown, perm: string, cb: (v: boolean) => void) => void> = []
@@ -65,6 +71,9 @@ beforeEach(() => {
   cookieResponse = []
   evalResult = null
   onEval = null
+  cookiesGetCalls = 0
+  onCookiesGet = null
+  throwOnPartition = false
   uaValue = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) AI Code Conductor/2.1.0 Chrome/128.0.0.0 Electron/33.0.0 Safari/537.36'
   closeInAppSignInWindow()
 })
@@ -170,6 +179,32 @@ describe('runInAppSignIn — window flow', () => {
     const res = await runInAppSignIn({ ...RUN, timeoutMs: 120, pollMs: 5, shouldCancel: () => false })
     expect(res.ok).toBe(false)
     expect(res.error).toMatch(/Timed out/)
+  })
+
+  it('does NOT record done if cancel fires during the recheck read (sign-out race)', async () => {
+    // clearWebSession sets the cancel flag SYNCHRONOUSLY, then awaits the
+    // partition wipe — so a cancel can land after the pre-recheck gate while the
+    // recheck read still sees the cookie. The post-recheck cancel check must
+    // catch it rather than saving a record over a partition about to be emptied.
+    cookieResponse = [SK({ expirationDate: 1_800_000_000 })]
+    evalResult = 'me@example.com'
+    let cancel = false
+    // 1st get = main poll read; 2nd get = the recheck — signal cancel THEN, so the
+    // cookie is still present on that read but cancel is set right after it.
+    onCookiesGet = (n) => { if (n === 2) cancel = true }
+    const res = await runInAppSignIn({ ...RUN, shouldCancel: () => cancel })
+    expect(res.ok).toBe(false)
+    expect(res.cancelled).toBe(true)
+    expect(created[0].destroyed).toBe(true)
+  })
+
+  it('never throws, even when Electron fails to build the window (single-flight stays releasable)', async () => {
+    throwOnPartition = true
+    const res = await runInAppSignIn({ ...RUN, shouldCancel: () => false })
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/simulated Electron failure/)
+    // No window was created, and nothing was left dangling.
+    expect(created).toHaveLength(0)
   })
 
   it('fails when the user closes the window before signing in', async () => {

--- a/tests/unit/account-web-sign-in.test.ts
+++ b/tests/unit/account-web-sign-in.test.ts
@@ -39,6 +39,19 @@ vi.mock('node:fs', () => ({
   rmSync: vi.fn(),
 }))
 
+// The in-app path (BrowserWindow) is tested on its own; here it is mocked so the
+// ROUTING decision can be checked without a window. A non-SSO account must take
+// this path (no browser spawn); an SSO account must NOT.
+const runInAppSignInMock = vi.fn(async () => ({
+  ok: true,
+  session: { profileId: 'profile-aaa111', accountEmail: 'inapp@example.com', acquiredAt: 1, expiresAt: null, origin: 'in-app' as const },
+}))
+const closeInAppMock = vi.fn()
+vi.mock('../../src/main/account-web/in-app-sign-in', () => ({
+  runInAppSignIn: (...a: any[]) => runInAppSignInMock(...a),
+  closeInAppSignInWindow: () => closeInAppMock(),
+}))
+
 const { runSignIn, _setCdpForTest, getSignInState } = await import('../../src/main/account-web/sign-in')
 const { CLAUDE_SESSION_COOKIE } = await import('../../src/shared/account-web-session')
 
@@ -67,12 +80,14 @@ beforeEach(() => {
   cookiesSet.mockReset()
   clearStorageData.mockReset()
   spawned.length = 0
+  runInAppSignInMock.mockClear()
+  closeInAppMock.mockClear()
 })
 
 describe('runSignIn', () => {
   it('injects the cookies and reports the account once signed in', async () => {
     _setCdpForTest(fakeCdp('me@example.com', [sessionCookie]))
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5 })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, method: 'sso' })
 
     expect(s.phase).toBe('done')
     expect(s.session?.accountEmail).toBe('me@example.com')
@@ -85,7 +100,7 @@ describe('runSignIn', () => {
     // Authenticated bootstrap, but only an analytics cookie: injecting this
     // yields a partition that looks signed in and 401s on every request.
     _setCdpForTest(fakeCdp('me@example.com', [{ ...sessionCookie, name: 'ajs_anonymous_id' }]))
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5 })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5, method: 'sso' })
 
     expect(s.phase).toBe('failed')
     expect(s.error).toMatch(/Timed out/)
@@ -94,7 +109,7 @@ describe('runSignIn', () => {
 
   it('times out rather than hanging when the user never signs in', async () => {
     _setCdpForTest(fakeCdp(null, []))
-    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5 })
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5, method: 'sso' })
 
     expect(s.phase).toBe('failed')
     expect(cookiesSet).not.toHaveBeenCalled()
@@ -106,7 +121,7 @@ describe('runSignIn', () => {
       { ...sessionCookie, name: 'SID', domain: 'mail.google.com' },
       { ...sessionCookie, name: 'user_session', domain: 'github.com' },
     ]))
-    await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5 })
+    await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, method: 'sso' })
 
     expect(cookiesSet).toHaveBeenCalledTimes(1)
     expect(cookiesSet.mock.calls[0][0].name).toBe(CLAUDE_SESSION_COOKIE)
@@ -114,10 +129,40 @@ describe('runSignIn', () => {
 
   it('refuses a profile id that is not the expected shape, before launching anything', async () => {
     _setCdpForTest(fakeCdp('me@example.com', [sessionCookie]))
-    const s = await runSignIn({ profileId: '../evil', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5 })
+    const s = await runSignIn({ profileId: '../evil', dataDir: 'C:/data', timeoutMs: 120, pollMs: 5, method: 'sso' })
 
     expect(s.phase).toBe('failed')
     expect(s.error).toMatch(/unexpected profile id/)
     expect(spawned.length).toBe(0)
+  })
+})
+
+describe('runSignIn — routing by auth method (#265 follow-up)', () => {
+  it('a non-SSO account signs in IN-APP: no browser is spawned, no CDP is used', async () => {
+    _setCdpForTest(fakeCdp('me@example.com', [sessionCookie]))   // would succeed IF the CDP path ran
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5 })
+
+    expect(runInAppSignInMock).toHaveBeenCalledTimes(1)
+    expect(spawned.length).toBe(0)              // the system browser was never launched
+    expect(cookiesSet).not.toHaveBeenCalled()   // no CDP harvest/injection
+    expect(s.phase).toBe('done')
+    expect(s.session?.origin).toBe('in-app')
+  })
+
+  it('the console method also routes in-app', async () => {
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, method: 'console' })
+    expect(runInAppSignInMock).toHaveBeenCalledTimes(1)
+    expect(spawned.length).toBe(0)
+    expect(s.session?.origin).toBe('in-app')
+  })
+
+  it('an SSO account keeps the system-browser path: in-app is NOT used', async () => {
+    _setCdpForTest(fakeCdp('me@example.com', [sessionCookie]))
+    const s = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5, method: 'sso' })
+
+    expect(runInAppSignInMock).not.toHaveBeenCalled()
+    expect(spawned.length).toBe(1)              // the system browser WAS launched
+    expect(s.phase).toBe('done')
+    expect(s.session?.origin).toBe('system-browser')
   })
 })

--- a/tests/unit/account-web-sign-in.test.ts
+++ b/tests/unit/account-web-sign-in.test.ts
@@ -165,4 +165,19 @@ describe('runSignIn — routing by auth method (#265 follow-up)', () => {
     expect(s.phase).toBe('done')
     expect(s.session?.origin).toBe('system-browser')
   })
+
+  it('a throw from the in-app path lands as failed, not a wedged single-flight latch', async () => {
+    // runInAppSignIn is contracted never to throw, but if it ever did, runSignIn
+    // must fail the state (releasing the latch) rather than propagate — otherwise
+    // getSignInState stays 'awaiting-user' and every account's sign-in is refused.
+    runInAppSignInMock.mockRejectedValueOnce(new Error('boom in window'))
+    const s1 = await runSignIn({ profileId: 'profile-aaa111', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5 })
+    expect(s1.phase).toBe('failed')
+    expect(getSignInState().phase).toBe('failed')   // latch released, not stuck awaiting-user
+
+    // A second sign-in for another account is accepted, not blocked by a wedge.
+    const s2 = await runSignIn({ profileId: 'profile-bbb222', dataDir: 'C:/data', timeoutMs: 3000, pollMs: 5 })
+    expect(s2.phase).toBe('done')
+    expect(s2.session?.origin).toBe('in-app')
+  })
 })


### PR DESCRIPTION
## The bug
The per-account claude.ai web sign-in (#216) loops on Cloudflare's "verify you are human" check forever and never completes.

## Root cause (proven by a controlled A/B on the affected machine)
- plain Chrome, fresh profile, **with** `--remote-debugging-port` (nothing attached) → loops forever
- the **same** Chrome **without** that port → signs in cleanly
- claude.ai in an **Electron** window (no port, normal Chrome UA) → signs in cleanly

claude.ai's bot-detection flags the remote-debugging port itself — the port the `system-browser` path opens to read the session cookie over CDP. The earlier fixes (#269/#276/#282) reduced the aggravation but couldn't remove the port, which is the actual signal.

## Fix
Non-SSO accounts sign in **directly inside an Electron window** bound to the account's partition — no launched browser, no debug port. The session cookie lands in Electron's own store for that partition (the same store the artifacts window already reads), so there is **nothing to harvest or inject** and no automation signal. One partition per account keeps the isolation model intact.

- `in-app-sign-in.ts` (new): sandboxed, context-isolated, no preload/node, permissions denied. Auth-flow nav policy (https top-level allowed for IdP hops, non-https blocked, popups denied). Presents a plain Chrome UA. Identity read runs page script **only** after the session cookie exists and **only** when the frame's own origin is claude.ai (same origin gate the CDP path used). Window destroyed the instant sign-in completes/cancels; a post-read recheck refuses to report done if a sign-out cleared the partition mid-read.
- `sign-in.ts` routes by auth method: **`sso` keeps the system-browser + CDP path** (its IdP may need a policy-installed browser extension an Electron window lacks); everything else goes in-app. The in-app path leaves no on-disk browser profile, so the profile-lock/orphan machinery doesn't apply.
- Pure `webSessionFromElectronCookies` mirrors the CDP harvest's success rule. New `in-app` `WebSessionOrigin`. Renderer copy no longer claims the user's own browser opens for every account.

Side benefit: removes the loopback debug-port surface the system-browser path's own comments flag ("anything that can reach it can read the cookies").

## Verification
- Every new guard **mutation-proven** (routing + sign-out-race recheck).
- Full suite green (**5369**, +17), typecheck + byte-scan clean.
- ADR-009 security-sensitive (credential/account code) → adversarial-review PASS to be recorded before merge.
- Empirically confirmed the Electron-window sign-in clears Cloudflare on the affected machine (the A/B above).

Part of the batch heading to **beta.13** (holding for the owner's other fixes; do not release on this alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)