### PR TITLE
feat(sessions): connection pills, footer account separation, and a 'Last used' launch line

### DIFF
--- a/src/renderer/components/AccountLaunchGate.tsx
+++ b/src/renderer/components/AccountLaunchGate.tsx
@@ -51,9 +51,14 @@ export default function AccountLaunchGate() {
 
   // "Last used" line: the account most recently launched, shown regardless of the
   // dropdown value so a new session can adopt it in one click. Only shown when it
-  // resolves to a real profile (skipped on a first-ever launch, or if that
-  // account was since deleted).
-  const lastUsedProfile = lastUsedAccountId ? profiles.find((p) => p.id === lastUsedAccountId) : undefined
+  // resolves to a real, SELECTABLE profile — skipped on a first-ever launch, if
+  // that account was since deleted, or if it has since been PARKED (inactive): a
+  // parked account must not be launchable, and this one-click shortcut bypasses
+  // the dropdown, so it has to apply the same isSelectable gate the dropdown does
+  // (adversarial review — otherwise Use -> launches a parked account).
+  const lastUsedProfile = lastUsedAccountId
+    ? profiles.find((p) => p.id === lastUsedAccountId && isSelectable(p))
+    : undefined
   const lastUsedLabel = lastUsedProfile
     ? (lastUsedProfile.accountEmail
         ? (() => {

--- a/src/renderer/components/AccountLaunchGate.tsx
+++ b/src/renderer/components/AccountLaunchGate.tsx
@@ -20,6 +20,7 @@ export default function AccountLaunchGate() {
   const profiles = useAccountProfilesStore((s) => s.profiles)
   const accountAliases = useSettingsStore((s) => s.settings.accountAliases)
   const accountColourOverrides = useSettingsStore((s) => s.settings.accountColourOverrides)
+  const lastUsedAccountId = useSettingsStore((s) => s.settings.lastUsedAccountId)
   const theme = useResolvedTheme()
   // Only active accounts are selectable at launch: an inactive account has been
   // parked and must not be chosen for a new session. The session's own pinned
@@ -48,6 +49,26 @@ export default function AccountLaunchGate() {
 
   const launch = () => resolveChoice(selected || undefined)
 
+  // "Last used" line: the account most recently launched, shown regardless of the
+  // dropdown value so a new session can adopt it in one click. Only shown when it
+  // resolves to a real profile (skipped on a first-ever launch, or if that
+  // account was since deleted).
+  const lastUsedProfile = lastUsedAccountId ? profiles.find((p) => p.id === lastUsedAccountId) : undefined
+  const lastUsedLabel = lastUsedProfile
+    ? (lastUsedProfile.accountEmail
+        ? (() => {
+            const r = resolveAccountName(lastUsedProfile.accountEmail, lastUsedProfile.name, accountAliases)
+            return r === lastUsedProfile.accountEmail ? middleTruncateEmail(lastUsedProfile.accountEmail) : r
+          })()
+        : (lastUsedProfile.name || 'New account'))
+    : ''
+  const lastUsedDot = lastUsedProfile
+    ? resolveIdentityColor(
+        resolveAccountColourKey(lastUsedProfile.accountEmail, accountColourOverrides, lastUsedProfile.colourKey),
+        theme,
+      )
+    : ''
+
   // Colour dot for the current selection: user override wins, else the profile's
   // stored colourKey, else neutral mauve.
   const selectedProfile = profiles.find((p) => p.id === selected)
@@ -69,6 +90,34 @@ export default function AccountLaunchGate() {
           Choose the account for{' '}
           <span className="text-text font-medium">{pending.sessionLabel || 'this session'}</span>
         </p>
+
+        {lastUsedProfile && (
+          <div
+            className="flex items-center gap-2 mb-4 rounded-md border border-surface1 bg-base/60 px-3 py-2"
+            data-testid="account-launch-lastused"
+          >
+            <span
+              className="w-2.5 h-2.5 rounded-full shrink-0"
+              style={{ backgroundColor: lastUsedDot }}
+              aria-hidden
+            />
+            <span className="text-sm text-text font-medium truncate" title={lastUsedProfile.accountEmail || undefined}>
+              {lastUsedLabel}
+            </span>
+            <span className="text-[10px] uppercase tracking-wide text-overlay1 ml-1 shrink-0">Last used</span>
+            {selected === lastUsedProfile.id ? (
+              <span className="ml-auto text-xs text-overlay1 shrink-0">selected</span>
+            ) : (
+              <button
+                onClick={() => setSelected(lastUsedProfile.id)}
+                data-testid="account-launch-lastused-use"
+                className="ml-auto text-xs text-blue hover:underline shrink-0 focus:outline-none focus-visible:ring-1 focus-visible:ring-blue/50 rounded"
+              >
+                Use →
+              </button>
+            )}
+          </div>
+        )}
 
         <label className="block text-xs text-subtext0 mb-1">Account</label>
         <div className="flex items-center gap-2 mb-5">

--- a/src/renderer/components/MultiAccountStatusline.tsx
+++ b/src/renderer/components/MultiAccountStatusline.tsx
@@ -173,7 +173,10 @@ function AccountPill({
 }) {
   return (
     <span
-      className={`flex items-center gap-2 ${compact ? 'min-w-0' : 'shrink-0'}`}
+      // Each account sits in its own subtle rounded pill so the boundary between
+      // accounts reads at a glance, rather than relying on whitespace alone.
+      className={`flex items-center gap-2 rounded-full border px-2.5 py-0.5 ${compact ? 'min-w-0' : 'shrink-0'}`}
+      style={{ borderColor: 'var(--surface1)', background: 'color-mix(in srgb, var(--surface1) 22%, transparent)' }}
       title={tooltip(account)}
       data-testid="multi-account-pill"
     >
@@ -393,7 +396,7 @@ export default function MultiAccountStatusline() {
       {rows.map((row, i) => (
         <div
           key={i}
-          className={`flex items-center justify-center min-w-0 ${multiRow ? 'gap-4' : 'gap-6'}`}
+          className={`flex items-center justify-center min-w-0 ${multiRow ? 'gap-2' : 'gap-3'}`}
           data-testid="multi-account-row"
         >
           {row.map((a) => (

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -111,9 +111,9 @@ function SessionAuthPills({ session }: { session: Session }) {
   const codeText = !known ? (pending ? '…' : 'unknown') : cliOk ? 'signed in' : 'signed out'
   const aiColor = !known ? 'var(--text-muted)' : web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
   const aiText = !known ? (pending ? '…' : 'unknown') : web === 'active' ? 'connected' : web === 'expired' ? 'expired' : 'not connected'
-  const errorSuffix = !known && status?.error ? ` — could not read status: ${status.error}` : ''
+  const errorSuffix = status?.error ? ` — could not read status: ${status.error}` : ''
 
-  const doRefresh = () => { if (profileId) void refresh(profileId) }
+  const doRefresh = () => { if (profileId) void refresh(profileId, { force: true }) }
 
   // Complements the title-bar service pills (Code / Claude.ai = is the SERVICE
   // up); these say whether THIS session's account is signed in / connected.

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -97,27 +97,34 @@ function SessionAuthPills({ session }: { session: Session }) {
 
   if (!applies || !profileId) return null
 
-  // Only show "…" before the FIRST result; later refreshes keep the last-known
-  // status visible (no flicker to "…").
-  const firstLoad = !!status?.loading && status?.fetchedAt === undefined
+  // Until the FIRST successful read (fetchedAt set) the status is UNKNOWN — the
+  // very first render precedes the fetch effect, and a failed first fetch leaves
+  // no result either. Never paint "signed out"/"not connected" for unknown: show
+  // "…" while a fetch is pending and "unknown" (error in the tooltip) after a
+  // failure. Later refreshes keep the last-known status visible (no flicker).
+  const known = status?.fetchedAt !== undefined
+  const pending = !known && !status?.error
   const cliOk = status?.cliAuthed === true
   const web = status?.web
 
-  const codeColor = cliOk ? 'var(--status-success)' : 'var(--text-muted)'
-  const codeText = firstLoad ? '…' : cliOk ? 'signed in' : 'signed out'
-  const aiColor = web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
-  const aiText = firstLoad ? '…' : web === 'active' ? 'connected' : web === 'expired' ? 'expired' : 'not connected'
+  const codeColor = known && cliOk ? 'var(--status-success)' : 'var(--text-muted)'
+  const codeText = !known ? (pending ? '…' : 'unknown') : cliOk ? 'signed in' : 'signed out'
+  const aiColor = !known ? 'var(--text-muted)' : web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
+  const aiText = !known ? (pending ? '…' : 'unknown') : web === 'active' ? 'connected' : web === 'expired' ? 'expired' : 'not connected'
+  const errorSuffix = !known && status?.error ? ` — could not read status: ${status.error}` : ''
 
   const doRefresh = () => { if (profileId) void refresh(profileId) }
 
+  // Complements the title-bar service pills (Code / Claude.ai = is the SERVICE
+  // up); these say whether THIS session's account is signed in / connected.
   return (
     <>
-      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title="Claude Code sign-in for this session's account" data-testid="session-pill-claudecode">
+      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title={`Claude Code sign-in for this session's account${errorSuffix}`} data-testid="session-pill-claudecode">
         <span>Claude Code</span>
         <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: codeColor }} aria-hidden />
         <span style={{ color: codeColor }}>{codeText}</span>
       </span>
-      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title="claude.ai web session for this session's account" data-testid="session-pill-claudeai">
+      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title={`claude.ai web session for this session's account${errorSuffix}`} data-testid="session-pill-claudeai">
         <span>claude.ai</span>
         <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: aiColor }} aria-hidden />
         <span style={{ color: aiColor }}>{aiText}</span>

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -7,6 +7,8 @@ import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegionTypography } from '../hooks/useTypography'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { useAccountAuthStore } from '../stores/accountAuthStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { resolveAccountName, resolveAccountColourKey, middleTruncateEmail } from '../../shared/account-chip-color'
 
 interface Props {
   session: Session
@@ -73,20 +75,87 @@ function SessionNameField({ session }: { session: Session }) {
 }
 
 /**
- * Per-session Claude Code + claude.ai connection pills (right cluster, beside the
- * GitHub pill). Shows this session's account's auth status at a glance so the
- * user isn't guessing whether they need to sign in. Status comes from the shared
- * accountAuthStore, fetched on activate + after any sign-in/out + manual refresh
- * (not polled — the Claude Code check is a heavy subprocess).
+ * A status pill styled to match the title-bar service pills (Services / Code /
+ * Claude.ai / Sentinel): a bordered chip with a coloured dot + label. The label
+ * is always shown; an extra status WORD appears only when the state needs
+ * attention (like the title bar showing "Degraded" but nothing for "Operational")
+ * -- a green dot alone means all-good. `tone` colours the dot (+ the word).
+ */
+function HeaderPill({
+  label, tone, word, title, testId, dotOnly, children,
+}: {
+  label: React.ReactNode
+  tone: string
+  word?: string
+  title?: string
+  testId?: string
+  dotOnly?: boolean
+  children?: React.ReactNode
+}) {
+  return (
+    <span
+      className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 shrink-0"
+      title={title}
+      data-testid={testId}
+    >
+      {!dotOnly && <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: tone }} aria-hidden />}
+      <span className="text-[10px] font-medium leading-none flex items-center gap-1" style={{ color: 'var(--text-muted)' }}>
+        {label}
+        {word && <span style={{ color: tone }}>{word}</span>}
+      </span>
+      {children}
+    </span>
+  )
+}
+
+/**
+ * The session's GitHub connection, as a title-bar-style pill. The repo slug is
+ * shown ON HOVER (title), never inline -- the pill just reads "GitHub" with a
+ * connection dot, so it sits quietly beside the Claude pills at the same weight.
+ */
+function SessionGitHubPill({ session }: { session: Session }) {
+  const gi = session.githubIntegration
+  const slug = gi?.repoSlug
+  if (!slug) return null
+  const connected = !!gi?.enabled
+  const tone = connected ? 'var(--status-success)' : 'var(--text-muted)'
+  return (
+    <HeaderPill
+      label={
+        <span className="flex items-center gap-1">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.5.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.6 9.6 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
+          <span>GitHub</span>
+        </span>
+      }
+      tone={tone}
+      word={connected ? undefined : 'detected'}
+      title={`GitHub: ${slug}${connected ? ' (connected)' : ' (detected — not connected)'}`}
+      testId="session-pill-github"
+    />
+  )
+}
+
+/**
+ * The session's status cluster (right side of the header), styled to complement
+ * the title-bar service pills. Order: account · claude.ai · Claude Code | GitHub.
+ * The account pill names the Claude account this session runs as; the two auth
+ * pills say whether it is signed in / connected (a green dot = good, a word only
+ * when action is needed). GitHub follows a separator, its repo slug on hover.
+ * Status comes from the shared accountAuthStore, fetched on activate + after any
+ * sign-in/out + manual refresh (never polled — the Claude Code check is heavy).
  */
 function SessionAuthPills({ session }: { session: Session }) {
-  const primaryId = useAccountProfilesStore((s) => s.profiles.find((p) => p.isPrimary)?.id)
+  const primary = useAccountProfilesStore((s) => s.profiles.find((p) => p.isPrimary))
   const refresh = useAccountAuthStore((s) => s.refresh)
+  const accountAliases = useSettingsStore((s) => s.settings.accountAliases)
+  const accountColourOverrides = useSettingsStore((s) => s.settings.accountColourOverrides)
+  const theme = useResolvedTheme()
   // Only LOCAL Claude sessions carry per-session Claude Code creds + a claude.ai
   // web session. SSH (remote creds), Codex (not profile-scoped) and shell-only
   // sessions show nothing — same gate the context-menu auth items use.
   const applies = !session.shellOnly && session.sessionType === 'local' && (session.provider ?? 'claude') === 'claude'
-  const profileId = session.profileId ?? primaryId
+  const profileId = session.profileId ?? primary?.id
+  const profile = useAccountProfilesStore((s) => (profileId ? s.profiles.find((p) => p.id === profileId) : undefined))
   const status = useAccountAuthStore((s) => (profileId ? s.byProfile[profileId] : undefined))
 
   React.useEffect(() => {
@@ -95,39 +164,71 @@ function SessionAuthPills({ session }: { session: Session }) {
     if (applies && profileId) void refresh(profileId)
   }, [applies, profileId, refresh, session.id])
 
-  if (!applies || !profileId) return null
+  const gitHub = <SessionGitHubPill session={session} />
+  if (!applies || !profileId) {
+    // Non-Claude sessions still show the GitHub pill (with its own leading
+    // separator) so the right cluster stays consistent.
+    return session.githubIntegration?.repoSlug
+      ? (<><div className="w-px h-4 bg-surface1 shrink-0" />{gitHub}</>)
+      : null
+  }
 
   // Until the FIRST successful read (fetchedAt set) the status is UNKNOWN — the
   // very first render precedes the fetch effect, and a failed first fetch leaves
   // no result either. Never paint "signed out"/"not connected" for unknown: show
-  // "…" while a fetch is pending and "unknown" (error in the tooltip) after a
-  // failure. Later refreshes keep the last-known status visible (no flicker).
+  // "…" while pending and "unknown" (error in the tooltip) after a failure.
   const known = status?.fetchedAt !== undefined
   const pending = !known && !status?.error
   const cliOk = status?.cliAuthed === true
   const web = status?.web
-
-  const codeColor = known && cliOk ? 'var(--status-success)' : 'var(--text-muted)'
-  const codeText = !known ? (pending ? '…' : 'unknown') : cliOk ? 'signed in' : 'signed out'
-  const aiColor = !known ? 'var(--text-muted)' : web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
-  const aiText = !known ? (pending ? '…' : 'unknown') : web === 'active' ? 'connected' : web === 'expired' ? 'expired' : 'not connected'
   const errorSuffix = status?.error ? ` — could not read status: ${status.error}` : ''
+
+  // Account pill: the Claude account this session runs as (name/alias, else a
+  // middle-truncated email), with the account's identity colour. Full email on
+  // hover.
+  const email = profile?.accountEmail ?? ''
+  const accountName = email
+    ? (() => {
+        const r = resolveAccountName(email, profile?.name, accountAliases)
+        return r === email ? middleTruncateEmail(email) : r
+      })()
+    : (profile?.name || 'Account')
+  const accountTone = resolveIdentityColor(
+    resolveAccountColourKey(email, accountColourOverrides, profile?.colourKey),
+    theme,
+  )
+
+  // A green dot = all good, no word; the word appears only when action is needed
+  // (signed out / not connected / expired / unknown), mirroring the title bar.
+  const codeTone = known && cliOk ? 'var(--status-success)' : known ? 'var(--text-muted)' : 'var(--text-muted)'
+  const codeWord = !known ? (pending ? '…' : 'unknown') : cliOk ? undefined : 'signed out'
+  const aiTone = !known ? 'var(--text-muted)' : web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
+  const aiWord = !known ? (pending ? '…' : 'unknown') : web === 'active' ? undefined : web === 'expired' ? 'expired' : 'not connected'
 
   const doRefresh = () => { if (profileId) void refresh(profileId, { force: true }) }
 
-  // Complements the title-bar service pills (Code / Claude.ai = is the SERVICE
-  // up); these say whether THIS session's account is signed in / connected.
   return (
     <>
-      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title={`Claude Code sign-in for this session's account${errorSuffix}`} data-testid="session-pill-claudecode">
-        <span>Claude Code</span>
-        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: codeColor }} aria-hidden />
-        <span style={{ color: codeColor }}>{codeText}</span>
-      </span>
-      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title={`claude.ai web session for this session's account${errorSuffix}`} data-testid="session-pill-claudeai">
-        <span>claude.ai</span>
-        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: aiColor }} aria-hidden />
-        <span style={{ color: aiColor }}>{aiText}</span>
+      <HeaderPill
+        label={accountName}
+        tone={accountTone}
+        title={email ? `Account: ${email}` : 'This session’s Claude account'}
+        testId="session-pill-account"
+      />
+      <HeaderPill
+        label="claude.ai"
+        tone={aiTone}
+        word={aiWord}
+        title={`claude.ai web session for this session's account${errorSuffix}`}
+        testId="session-pill-claudeai"
+      />
+      <HeaderPill
+        label="Claude Code"
+        tone={codeTone}
+        word={codeWord}
+        title={`Claude Code sign-in for this session's account${errorSuffix}`}
+        testId="session-pill-claudecode"
+      >
         <button
           onClick={doRefresh}
           disabled={!!status?.loading}
@@ -138,7 +239,10 @@ function SessionAuthPills({ session }: { session: Session }) {
         >
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M21 12a9 9 0 1 1-2.64-6.36M21 3v6h-6"/></svg>
         </button>
-      </span>
+      </HeaderPill>
+      {/* Separator, then GitHub — its own group, slug on hover. */}
+      <div className="w-px h-4 bg-surface1 shrink-0" />
+      {gitHub}
     </>
   )
 }
@@ -153,9 +257,6 @@ export default function SessionHeader({ session, onShowTip }: Props) {
   // working directory (middle) + GitHub repo slug/connection (right). One bar
   // instead of two.
   const cwd = session.workingDirectory || ''
-  const gi = session.githubIntegration
-  const slug = gi?.repoSlug
-  const connected = !!gi?.enabled && !!slug
   return (
     <div
       className="flex items-center gap-3 px-4 py-2 border-b shrink-0 relative"
@@ -185,19 +286,8 @@ export default function SessionHeader({ session, onShowTip }: Props) {
         <span className="text-xs text-mauve shrink-0">SSH: {session.sshConfig.username}@{session.sshConfig.host}</span>
       )}
 
-      {/* GitHub repo slug + connection state (right cluster, formerly RepoBreadcrumb). */}
-      {slug && (
-        <span className="flex items-center gap-1.5 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.5.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.6 9.6 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
-          <span className="truncate max-w-[180px]" title={gi?.repoUrl || slug}>{slug}</span>
-          <span className="flex items-center gap-1">
-            <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: connected ? 'var(--status-success)' : 'var(--text-muted)' }} aria-hidden />
-            <span style={{ color: connected ? 'var(--status-success)' : 'var(--text-muted)' }}>{connected ? 'connected' : 'detected'}</span>
-          </span>
-        </span>
-      )}
-
-      {/* Per-session Claude Code + claude.ai connection status. */}
+      {/* Right cluster: account · claude.ai · Claude Code | GitHub — styled to
+          match the title-bar service pills (GitHub slug shows on hover). */}
       <SessionAuthPills session={session} />
 
       {/* Separator before notes */}

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -5,6 +5,8 @@ import TipPill from './TipPill'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
 import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegionTypography } from '../hooks/useTypography'
+import { useAccountProfilesStore } from '../stores/accountProfilesStore'
+import { useAccountAuthStore } from '../stores/accountAuthStore'
 
 interface Props {
   session: Session
@@ -70,6 +72,70 @@ function SessionNameField({ session }: { session: Session }) {
   )
 }
 
+/**
+ * Per-session Claude Code + claude.ai connection pills (right cluster, beside the
+ * GitHub pill). Shows this session's account's auth status at a glance so the
+ * user isn't guessing whether they need to sign in. Status comes from the shared
+ * accountAuthStore, fetched on activate + after any sign-in/out + manual refresh
+ * (not polled — the Claude Code check is a heavy subprocess).
+ */
+function SessionAuthPills({ session }: { session: Session }) {
+  const primaryId = useAccountProfilesStore((s) => s.profiles.find((p) => p.isPrimary)?.id)
+  const refresh = useAccountAuthStore((s) => s.refresh)
+  // Only LOCAL Claude sessions carry per-session Claude Code creds + a claude.ai
+  // web session. SSH (remote creds), Codex (not profile-scoped) and shell-only
+  // sessions show nothing — same gate the context-menu auth items use.
+  const applies = !session.shellOnly && session.sessionType === 'local' && (session.provider ?? 'claude') === 'claude'
+  const profileId = session.profileId ?? primaryId
+  const status = useAccountAuthStore((s) => (profileId ? s.byProfile[profileId] : undefined))
+
+  React.useEffect(() => {
+    // This header renders only the ACTIVE session, so mounting/param-change is
+    // "on activate". Re-fetch when the session or its account changes.
+    if (applies && profileId) void refresh(profileId)
+  }, [applies, profileId, refresh, session.id])
+
+  if (!applies || !profileId) return null
+
+  // Only show "…" before the FIRST result; later refreshes keep the last-known
+  // status visible (no flicker to "…").
+  const firstLoad = !!status?.loading && status?.fetchedAt === undefined
+  const cliOk = status?.cliAuthed === true
+  const web = status?.web
+
+  const codeColor = cliOk ? 'var(--status-success)' : 'var(--text-muted)'
+  const codeText = firstLoad ? '…' : cliOk ? 'signed in' : 'signed out'
+  const aiColor = web === 'active' ? 'var(--status-success)' : web === 'expired' ? 'var(--status-warning)' : 'var(--text-muted)'
+  const aiText = firstLoad ? '…' : web === 'active' ? 'connected' : web === 'expired' ? 'expired' : 'not connected'
+
+  const doRefresh = () => { if (profileId) void refresh(profileId) }
+
+  return (
+    <>
+      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title="Claude Code sign-in for this session's account" data-testid="session-pill-claudecode">
+        <span>Claude Code</span>
+        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: codeColor }} aria-hidden />
+        <span style={{ color: codeColor }}>{codeText}</span>
+      </span>
+      <span className="flex items-center gap-1 shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }} title="claude.ai web session for this session's account" data-testid="session-pill-claudeai">
+        <span>claude.ai</span>
+        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: aiColor }} aria-hidden />
+        <span style={{ color: aiColor }}>{aiText}</span>
+        <button
+          onClick={doRefresh}
+          disabled={!!status?.loading}
+          title="Refresh auth status"
+          aria-label="Refresh auth status"
+          className="ml-0.5 opacity-50 hover:opacity-100 disabled:opacity-30 focus-ring rounded"
+          data-testid="session-pill-refresh"
+        >
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M21 12a9 9 0 1 1-2.64-6.36M21 3v6h-6"/></svg>
+        </button>
+      </span>
+    </>
+  )
+}
+
 export default function SessionHeader({ session, onShowTip }: Props) {
   const theme = useResolvedTheme()
   const headerType = useRegionTypography('header')
@@ -123,6 +189,9 @@ export default function SessionHeader({ session, onShowTip }: Props) {
           </span>
         </span>
       )}
+
+      {/* Per-session Claude Code + claude.ai connection status. */}
+      <SessionAuthPills session={session} />
 
       {/* Separator before notes */}
       <div className="w-px h-4 bg-surface1 shrink-0" />

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -108,15 +108,15 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
   // refreshes both. Fetched when a session context menu opens — not polled, since
   // the Claude Code check is a heavy subprocess.
   const authByProfile = useAccountAuthStore((s) => s.byProfile)
-  const refreshWebSessions = React.useCallback(async (profileId?: string) => {
+  const refreshWebSessions = React.useCallback(async (profileId?: string, force = false) => {
     if (!profileId) return
-    await useAccountAuthStore.getState().refresh(profileId)
+    await useAccountAuthStore.getState().refresh(profileId, { force })
   }, [])
 
   /** Acquire this account's claude.ai web session, then refresh the menu state. */
   const authenticateWebForSession = React.useCallback(async (profileId: string) => {
     await window.electronAPI.accountWeb.signIn(profileId)
-    await refreshWebSessions(profileId)
+    await refreshWebSessions(profileId, true)
   }, [refreshWebSessions])
   const [renamingSectionId, setRenamingSectionId] = useState<string | null>(null)
   const [sectionRenameValue, setSectionRenameValue] = useState('')

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useInsightsStore } from '../stores/insightsStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useCloudAgentStore } from '../stores/cloudAgentStore'
 import { useConductorMcpStore } from '../stores/conductorMcpStore'
+import { useAccountAuthStore } from '../stores/accountAuthStore'
 import SessionDialog from './SessionDialog'
 import { killSessionPty } from '../ptyTracker'
 import { ViewType } from '../types/views'
@@ -102,19 +103,14 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
   const [sessionRenameValue, setSessionRenameValue] = useState('')
   const [sessionContextMenu, setSessionContextMenu] = useState<{ sessionId: string; x: number; y: number } | null>(null)
 
-  // #216: which accounts currently hold a claude.ai web session. Refreshed when a
-  // session context menu opens, so "Open artifacts" is enabled only when it can
-  // actually work — an item that opens a sign-in wall is worse than a disabled one.
-  const [webSessionAccounts, setWebSessionAccounts] = useState<Set<string>>(new Set())
+  // #216: per-account auth status (Claude Code CLI + claude.ai web) via the SHARED
+  // store, so the session-header pills and this menu read one source and a sign-in
+  // refreshes both. Fetched when a session context menu opens — not polled, since
+  // the Claude Code check is a heavy subprocess.
+  const authByProfile = useAccountAuthStore((s) => s.byProfile)
   const refreshWebSessions = React.useCallback(async (profileId?: string) => {
     if (!profileId) return
-    const r = await window.electronAPI.accountWeb.status(profileId)
-    setWebSessionAccounts((prev) => {
-      const next = new Set(prev)
-      if (r.ok && r.web?.status === 'active') next.add(profileId)
-      else next.delete(profileId)
-      return next
-    })
+    await useAccountAuthStore.getState().refresh(profileId)
   }, [])
 
   /** Acquire this account's claude.ai web session, then refresh the menu state. */
@@ -1063,7 +1059,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
             // session with a resolved account — an SSH session's browser and
             // credentials live on another machine, and a shell-only session has
             // no /login to run.
-            hasWebSession={!s.shellOnly && !!(s.profileId ?? primaryProfileId) && webSessionAccounts.has((s.profileId ?? primaryProfileId)!)}
+            hasWebSession={!s.shellOnly && !!(s.profileId ?? primaryProfileId) && authByProfile[(s.profileId ?? primaryProfileId)!]?.web === 'active'}
+            codeSignedIn={!s.shellOnly && s.sessionType === 'local' && (s.provider ?? 'claude') === 'claude' && authByProfile[(s.profileId ?? primaryProfileId)!]?.cliAuthed === true}
             onOpenArtifacts={
               !s.shellOnly && (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
                 ? () => { void window.electronAPI.accountWeb.openArtifacts((s.profileId ?? primaryProfileId)!) }

--- a/src/renderer/components/sidebar/SessionContextMenu.tsx
+++ b/src/renderer/components/sidebar/SessionContextMenu.tsx
@@ -31,12 +31,15 @@ interface SessionContextMenuProps {
   /** True when this account already holds a claude.ai web session; drives the
    *  artifacts item's enabled state and the wording of the authenticate item. */
   hasWebSession?: boolean
+  /** True when this account's Claude Code CLI is already signed in; disables the
+   *  "Sign in to Claude Code" item so it isn't offered when it would be a no-op. */
+  codeSignedIn?: boolean
 }
 
 export default function SessionContextMenu({
   x, y, session, hasGroup, onRename, onRemoveFromGroup, onClose, onDismiss,
   canSwitchAccount, profiles, accountAliases, onSwitchAccount,
-  onOpenArtifacts, onAuthenticateWeb, onSignInCode, hasWebSession,
+  onOpenArtifacts, onAuthenticateWeb, onSignInCode, hasWebSession, codeSignedIn,
 }: SessionContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
   useClickOutside(menuRef, onDismiss)
@@ -104,15 +107,16 @@ export default function SessionContextMenu({
           )}
           {onSignInCode && (
             <button
-              onClick={() => { onSignInCode(); onDismiss() }}
-              title="Runs /login in this session’s terminal"
-              className="w-full text-left px-3 py-1.5 text-xs text-text hover:bg-surface1 transition-colors flex items-center gap-2"
+              onClick={() => { if (codeSignedIn) return; onSignInCode(); onDismiss() }}
+              disabled={codeSignedIn}
+              title={codeSignedIn ? 'Already signed in to Claude Code for this account' : 'Runs /login in this session’s terminal'}
+              className="w-full text-left px-3 py-1.5 text-xs text-text hover:bg-surface1 disabled:opacity-40 disabled:hover:bg-transparent transition-colors flex items-center gap-2"
             >
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
                 <path d="M7 1.5h2.5a1 1 0 011 1v7a1 1 0 01-1 1H7" strokeLinecap="round"/>
                 <path d="M5 8.5L7.5 6 5 3.5M7.5 6H1.5" strokeLinecap="round" strokeLinejoin="round"/>
               </svg>
-              Sign in to Claude Code
+              {codeSignedIn ? 'Signed in to Claude Code' : 'Sign in to Claude Code'}
             </button>
           )}
         </>

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -1,5 +1,6 @@
 import { useSessionStore } from './stores/sessionStore'
 import { useAccountGateStore } from './stores/accountGateStore'
+import { useSettingsStore } from './stores/settingsStore'
 import type { SessionState, SavedSession } from './types/electron'
 
 // Serialize the current sessionStore into the shape the main process persists.
@@ -135,6 +136,12 @@ export function markRestoredSessionsPredetermined(sessionIds: string[]): void {
 
 export async function persistLastUsedAccount(sessionId: string, profileId: string | undefined): Promise<void> {
   useSessionStore.getState().updateSession(sessionId, { profileId })
+  // Record it as the GLOBAL last-used account so the launch gate can offer it as
+  // a one-click default for the next new session. Only a real choice updates it
+  // (never clear it back to undefined). Best-effort persist.
+  if (profileId) {
+    try { void useSettingsStore.getState().updateSettings({ lastUsedAccountId: profileId }) } catch { /* non-fatal */ }
+  }
   try {
     await window.electronAPI.session.save(buildSessionState())
   } catch {

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -140,7 +140,11 @@ export async function persistLastUsedAccount(sessionId: string, profileId: strin
   // a one-click default for the next new session. Only a real choice updates it
   // (never clear it back to undefined). Best-effort persist.
   if (profileId) {
-    try { void useSettingsStore.getState().updateSettings({ lastUsedAccountId: profileId }) } catch { /* non-fatal */ }
+    // updateSettings returns a Promise: attach .catch (a bare try/catch would
+    // not see an async rejection and it would surface as unhandled).
+    try {
+      void useSettingsStore.getState().updateSettings({ lastUsedAccountId: profileId }).catch(() => { /* non-fatal */ })
+    } catch { /* non-fatal (synchronous set() failure) */ }
   }
   try {
     await window.electronAPI.session.save(buildSessionState())

--- a/src/renderer/stores/accountAuthStore.ts
+++ b/src/renderer/stores/accountAuthStore.ts
@@ -1,0 +1,77 @@
+// accountAuthStore.ts — per-account Claude Code (CLI) + claude.ai (web) auth
+// status, keyed by profileId, shared by the session-header pills and the sidebar
+// context menu so both read one source and a sign-in refreshes both.
+//
+// NOT continuously polled: the Claude Code check shells out to `claude auth
+// status` (up to ~10s), so status is fetched on demand — when a session becomes
+// active, after a sign-in/out, and on a manual pill refresh — and cached with the
+// time it was read. Callers dedupe concurrent refreshes per profile.
+import { create } from 'zustand'
+
+export type WebAuthStatus = 'none' | 'active' | 'expired'
+
+export interface AccountAuthStatus {
+  /** Claude Code CLI signed in for this account. undefined = not fetched yet. */
+  cliAuthed?: boolean
+  /** claude.ai web session. undefined = not fetched yet. */
+  web?: WebAuthStatus
+  /** A refresh is in flight. */
+  loading: boolean
+  /** Epoch ms of the last successful read; undefined until first success. */
+  fetchedAt?: number
+  /** Last error message, if the most recent fetch failed. */
+  error?: string
+}
+
+interface AccountAuthState {
+  byProfile: Record<string, AccountAuthStatus>
+  /** Fetch (or re-fetch) both statuses for one account. Deduped per profile. */
+  refresh: (profileId: string) => Promise<void>
+  /** Drop a profile's cached status (e.g. account deleted). */
+  clear: (profileId: string) => void
+}
+
+const inFlight = new Set<string>()
+
+export const useAccountAuthStore = create<AccountAuthState>((set, get) => ({
+  byProfile: {},
+
+  refresh: async (profileId: string) => {
+    if (!profileId) return
+    // Dedupe: a second request while one is running is a no-op — the running one
+    // will publish the fresh status to every subscriber.
+    if (inFlight.has(profileId)) return
+    inFlight.add(profileId)
+    set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: true, error: undefined } } }))
+    try {
+      const r = await window.electronAPI.accountWeb.status(profileId)
+      if (r.ok) {
+        set((s) => ({
+          byProfile: {
+            ...s.byProfile,
+            [profileId]: { cliAuthed: !!r.cli?.authenticated, web: r.web?.status ?? 'none', loading: false, fetchedAt: Date.now() },
+          },
+        }))
+      } else {
+        set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: false, error: r.error } } }))
+      }
+    } catch (err) {
+      set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: false, error: (err as Error)?.message ?? 'status failed' } } }))
+    } finally {
+      inFlight.delete(profileId)
+    }
+    void get
+  },
+
+  clear: (profileId: string) => set((s) => {
+    const next = { ...s.byProfile }
+    delete next[profileId]
+    return { byProfile: next }
+  }),
+}))
+
+/** Test seam: reset the in-flight dedupe set + store between tests. */
+export function _resetAccountAuthForTest(): void {
+  inFlight.clear()
+  useAccountAuthStore.setState({ byProfile: {} })
+}

--- a/src/renderer/stores/accountAuthStore.ts
+++ b/src/renderer/stores/accountAuthStore.ts
@@ -25,19 +25,37 @@ export interface AccountAuthStatus {
 
 interface AccountAuthState {
   byProfile: Record<string, AccountAuthStatus>
-  /** Fetch (or re-fetch) both statuses for one account. Deduped per profile. */
-  refresh: (profileId: string) => Promise<void>
+  /** Fetch (or re-fetch) both statuses for one account. Deduped per profile.
+   *  An AUTO refresh (the default, e.g. on session activate) is skipped when a
+   *  successful read is younger than AUTO_REFRESH_TTL_MS — the Claude Code probe
+   *  shells out and rotates the single-use refresh token, so tabbing between
+   *  sessions must not re-probe every time. `force` (a manual pill refresh, or a
+   *  refresh right after a sign-in/out) always probes. */
+  refresh: (profileId: string, opts?: { force?: boolean }) => Promise<void>
   /** Drop a profile's cached status (e.g. account deleted). */
   clear: (profileId: string) => void
 }
 
 const inFlight = new Set<string>()
 
+/** How long a successful status read is reused for an AUTO refresh before the
+ *  next one re-probes. Long enough that tabbing between sessions of one account
+ *  does not shell out repeatedly; short enough that status is not badly stale.
+ *  A sign-in/out refreshes with force:true, so it is never gated by this. */
+export const AUTO_REFRESH_TTL_MS = 30_000
+
 export const useAccountAuthStore = create<AccountAuthState>((set, get) => ({
   byProfile: {},
 
-  refresh: async (profileId: string) => {
+  refresh: async (profileId: string, opts?: { force?: boolean }) => {
     if (!profileId) return
+    // Freshness window: an auto refresh reuses a recent SUCCESSFUL read (fetchedAt
+    // set, no error) rather than re-probing. A failed/never-read status is not
+    // fresh, so it still retries; force bypasses the window entirely.
+    if (!opts?.force) {
+      const cur = get().byProfile[profileId]
+      if (cur && cur.fetchedAt !== undefined && !cur.error && Date.now() - cur.fetchedAt < AUTO_REFRESH_TTL_MS) return
+    }
     // Dedupe: a second request while one is running is a no-op — the running one
     // will publish the fresh status to every subscriber.
     if (inFlight.has(profileId)) return
@@ -53,7 +71,7 @@ export const useAccountAuthStore = create<AccountAuthState>((set, get) => ({
           },
         }))
       } else {
-        set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: false, error: r.error } } }))
+        set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: false, error: r.error || 'status failed' } } }))
       }
     } catch (err) {
       set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: false, error: (err as Error)?.message ?? 'status failed' } } }))

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -175,6 +175,10 @@ export interface AppSettings {
   /** v1.5.19: friendly names for accounts WITHOUT a profile (the default/single
    *  account), keyed by canonical email. Profiles carry their own `name`. */
   accountAliases?: Record<string, string>
+  /** The profile id of the account the user most recently launched a session
+   *  under (global, across sessions). Surfaced as a "Last used" line in the
+   *  account-launch gate so a new session can adopt it in one click. */
+  lastUsedAccountId?: string
   /** v1.5.12: when true, CCC writes `disableWorkflows: true` into every
    *  per-session Claude settings file so Claude Code's dynamic-workflow
    *  feature is disabled at session boot. Affects newly spawned sessions

--- a/tests/unit/renderer/account-auth-store.test.ts
+++ b/tests/unit/renderer/account-auth-store.test.ts
@@ -43,11 +43,43 @@ describe('accountAuthStore.refresh', () => {
     expect(useAccountAuthStore.getState().byProfile['profile-c'].web).toBe('expired')
   })
 
-  it('a later refresh runs again once the first settles (dedupe is per-flight, not permanent)', async () => {
+  it('a forced refresh runs again once the first settles (dedupe is per-flight, not permanent)', async () => {
     statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
     await useAccountAuthStore.getState().refresh('profile-d')
-    await useAccountAuthStore.getState().refresh('profile-d')
+    await useAccountAuthStore.getState().refresh('profile-d', { force: true })
     expect(statusMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('an AUTO refresh within the freshness window reuses the last SUCCESSFUL read (heavy CLI probe is not re-run)', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-ttl')   // probes once
+    await useAccountAuthStore.getState().refresh('profile-ttl')   // within TTL → skipped
+    await useAccountAuthStore.getState().refresh('profile-ttl')   // still within TTL → skipped
+    expect(statusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('force re-probes even inside the freshness window (the manual pill refresh)', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-force')
+    await useAccountAuthStore.getState().refresh('profile-force', { force: true })
+    expect(statusMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('a FAILED read is not fresh — the next auto refresh retries it', async () => {
+    statusMock.mockResolvedValueOnce({ ok: false, error: 'boom' })
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-retry')  // error
+    await useAccountAuthStore.getState().refresh('profile-retry')  // auto, but error ⇒ not fresh ⇒ retries
+    expect(statusMock).toHaveBeenCalledTimes(2)
+    expect(useAccountAuthStore.getState().byProfile['profile-retry'].web).toBe('active')
+  })
+
+  it('an empty error string still yields a definite failed status, never a stuck pending', async () => {
+    statusMock.mockResolvedValue({ ok: false, error: '' })
+    await useAccountAuthStore.getState().refresh('profile-empty')
+    const rec = useAccountAuthStore.getState().byProfile['profile-empty']
+    expect(rec.loading).toBe(false)
+    expect(rec.error).toBe('status failed')  // not '' — otherwise the pill sticks on '…'
   })
 
   it('records the error and clears loading when the status call is not ok', async () => {

--- a/tests/unit/renderer/account-auth-store.test.ts
+++ b/tests/unit/renderer/account-auth-store.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+// The shared per-account auth store behind the session-header pills + the sidebar
+// context menu. Covers the status mapping, the per-profile dedupe (the CLI probe
+// is heavy, so a second concurrent refresh must not fire a second fetch), and the
+// error path.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAccountAuthStore, _resetAccountAuthForTest } from '../../../src/renderer/stores/accountAuthStore'
+
+let statusMock: ReturnType<typeof vi.fn>
+beforeEach(() => {
+  _resetAccountAuthForTest()
+  statusMock = vi.fn()
+  ;(globalThis as any).window.electronAPI = { accountWeb: { status: statusMock } }
+})
+
+describe('accountAuthStore.refresh', () => {
+  it('maps cli.authenticated + web.status into the per-profile record', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-a')
+    const rec = useAccountAuthStore.getState().byProfile['profile-a']
+    expect(rec.cliAuthed).toBe(true)
+    expect(rec.web).toBe('active')
+    expect(rec.loading).toBe(false)
+    expect(typeof rec.fetchedAt).toBe('number')
+  })
+
+  it('reports signed-out / not-connected without inventing a truthy status', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: false }, web: { status: 'none' } })
+    await useAccountAuthStore.getState().refresh('profile-b')
+    const rec = useAccountAuthStore.getState().byProfile['profile-b']
+    expect(rec.cliAuthed).toBe(false)
+    expect(rec.web).toBe('none')
+  })
+
+  it('dedupes concurrent refreshes for the same profile — one fetch, not two', async () => {
+    let resolve!: (v: unknown) => void
+    statusMock.mockReturnValue(new Promise((r) => { resolve = r }))
+    const p1 = useAccountAuthStore.getState().refresh('profile-c')
+    const p2 = useAccountAuthStore.getState().refresh('profile-c') // should be a no-op
+    resolve({ ok: true, cli: { authenticated: true }, web: { status: 'expired' } })
+    await Promise.all([p1, p2])
+    expect(statusMock).toHaveBeenCalledTimes(1)
+    expect(useAccountAuthStore.getState().byProfile['profile-c'].web).toBe('expired')
+  })
+
+  it('a later refresh runs again once the first settles (dedupe is per-flight, not permanent)', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-d')
+    await useAccountAuthStore.getState().refresh('profile-d')
+    expect(statusMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('records the error and clears loading when the status call is not ok', async () => {
+    statusMock.mockResolvedValue({ ok: false, error: 'boom' })
+    await useAccountAuthStore.getState().refresh('profile-e')
+    const rec = useAccountAuthStore.getState().byProfile['profile-e']
+    expect(rec.loading).toBe(false)
+    expect(rec.error).toBe('boom')
+  })
+
+  it('ignores an empty profile id (no fetch)', async () => {
+    await useAccountAuthStore.getState().refresh('')
+    expect(statusMock).not.toHaveBeenCalled()
+  })
+
+  it('clear() drops a profile record', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-f')
+    useAccountAuthStore.getState().clear('profile-f')
+    expect(useAccountAuthStore.getState().byProfile['profile-f']).toBeUndefined()
+  })
+})

--- a/tests/unit/renderer/account-launch-gate-lastused.test.tsx
+++ b/tests/unit/renderer/account-launch-gate-lastused.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+// AccountLaunchGate "Last used" line — it is a one-click shortcut that bypasses
+// the account dropdown, so it must apply the SAME active-only gate the dropdown
+// does. Adversarial review found it offered (and launched) a PARKED account.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const gateState: any = { queue: [], resolveChoice: vi.fn(), cancelChoice: vi.fn() }
+const profilesState: any = { profiles: [] }
+const settingsState: any = { settings: { accountAliases: {}, accountColourOverrides: {}, lastUsedAccountId: undefined } }
+
+vi.mock('../../../src/renderer/stores/accountGateStore', () => ({ useAccountGateStore: (sel: any) => sel(gateState) }))
+vi.mock('../../../src/renderer/stores/accountProfilesStore', () => ({ useAccountProfilesStore: (sel: any) => sel(profilesState) }))
+vi.mock('../../../src/renderer/stores/settingsStore', () => ({ useSettingsStore: (sel: any) => sel(settingsState) }))
+vi.mock('../../../src/renderer/hooks/useThemeController', () => ({ useResolvedTheme: () => 'dark' }))
+
+const { default: AccountLaunchGate } = await import('../../../src/renderer/components/AccountLaunchGate')
+
+function profile(over: Partial<any> = {}): any {
+  return { id: 'p1', name: 'Acct', accountEmail: 'a@b.co', isPrimary: false, active: true, ...over }
+}
+
+let container: HTMLDivElement
+let root: Root
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  gateState.resolveChoice = vi.fn()
+  gateState.queue = [{ sessionId: 's1', sessionLabel: 'web', currentProfileId: undefined, resolve: () => {} }]
+  profilesState.profiles = []
+  settingsState.settings = { accountAliases: {}, accountColourOverrides: {}, lastUsedAccountId: undefined }
+})
+afterEach(() => { act(() => root.unmount()); container.remove() })
+const render = () => act(() => root.render(<AccountLaunchGate />))
+const q = (sel: string) => container.querySelector(sel) as HTMLElement | null
+
+describe('AccountLaunchGate — Last used line', () => {
+  it('shows the Last used line for an ACTIVE last-used account', () => {
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-active', accountEmail: 'used@b.co' })]
+    settingsState.settings.lastUsedAccountId = 'p-active'
+    render()
+    expect(q('[data-testid="account-launch-lastused"]')).not.toBeNull()
+    expect(container.textContent).toContain('Last used')
+  })
+
+  it('does NOT show the Last used line when the last-used account has been PARKED (inactive)', () => {
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-parked', accountEmail: 'parked@b.co', active: false })]
+    settingsState.settings.lastUsedAccountId = 'p-parked'
+    render()
+    // The parked account must not be offered as a one-click launch shortcut.
+    expect(q('[data-testid="account-launch-lastused"]')).toBeNull()
+    expect(q('[data-testid="account-launch-lastused-use"]')).toBeNull()
+  })
+
+  it('still shows a parked last-used account IF it is the session’s own pinned account (relaunch stays possible)', () => {
+    // isSelectable keeps the session's currently pinned account selectable even
+    // when parked, so a session already on it can relaunch — the Last used line
+    // must follow the same rule, not a blanket active-only one.
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-pinned', accountEmail: 'pinned@b.co', active: false })]
+    settingsState.settings.lastUsedAccountId = 'p-pinned'
+    gateState.queue = [{ sessionId: 's1', sessionLabel: 'web', currentProfileId: 'p-pinned', resolve: () => {} }]
+    render()
+    expect(q('[data-testid="account-launch-lastused"]')).not.toBeNull()
+  })
+
+  it('does not show the line when there is no last-used account, or it was deleted', () => {
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true })]
+    settingsState.settings.lastUsedAccountId = undefined
+    render()
+    expect(q('[data-testid="account-launch-lastused"]')).toBeNull()
+    act(() => root.unmount()); root = createRoot(container)
+    settingsState.settings.lastUsedAccountId = 'gone'
+    render()
+    expect(q('[data-testid="account-launch-lastused"]')).toBeNull()
+  })
+
+  it('Use → then Launch resolves the gate with an ACTIVE last-used account', () => {
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-active', accountEmail: 'used@b.co' })]
+    settingsState.settings.lastUsedAccountId = 'p-active'
+    render()
+    act(() => q('[data-testid="account-launch-lastused-use"]')!.click())
+    // Launch is the primary button; find it by text.
+    const launchBtn = Array.from(container.querySelectorAll('button')).find((b) => /launch|start/i.test(b.textContent || '')) as HTMLButtonElement
+    expect(launchBtn, 'a launch button').toBeTruthy()
+    act(() => launchBtn.click())
+    expect(gateState.resolveChoice).toHaveBeenCalledWith('p-active')
+  })
+})

--- a/tests/unit/renderer/multi-account-statusline-render.test.tsx
+++ b/tests/unit/renderer/multi-account-statusline-render.test.tsx
@@ -103,17 +103,30 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     expect(toggle()).toBeNull()
   })
 
-  it('the one-row layout is visually unchanged: gap-6, no extra vertical padding, no truncation', () => {
+  it('the one-row layout keeps the tighter gap and no extra vertical padding, no truncation', () => {
     useAccounts(3)
     render()
     const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
     expect(strip.className).not.toContain('py-1') // the bar does not grow
-    expect(rows()[0].className).toContain('gap-6') // the original inter-pill gap
-    expect(rows()[0].className).not.toContain('gap-4')
+    // The boxed-pill design carries the visual boundary, so the inter-pill gap
+    // tightened from gap-6 to gap-3.
+    expect(rows()[0].className).toContain('gap-3')
+    expect(rows()[0].className).not.toContain('gap-6')
     // Pills keep their full width (email un-truncated) exactly as before.
     for (const p of pills()) {
       expect(p.className).toContain('shrink-0')
       expect(p.innerHTML).not.toContain('truncate')
+    }
+  })
+
+  it('every account sits in its own bounded pill (border + rounded), separating them structurally', () => {
+    useAccounts(3)
+    render()
+    for (const p of pills()) {
+      expect(p.className).toContain('rounded-full')
+      expect(p.className).toContain('border')
+      // A visible boundary, not whitespace alone.
+      expect(p.getAttribute('style') ?? '').toContain('border-color')
     }
   })
 
@@ -122,7 +135,7 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     render()
     const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
     expect(strip.className).toContain('py-1')
-    expect(rows()[0].className).toContain('gap-4')
+    expect(rows()[0].className).toContain('gap-2')
     // Pills may shrink and the email ellipsises so three fit at the 1280px
     // minimum window width; the full address stays in the pill's title.
     for (const p of pills()) {

--- a/tests/unit/renderer/persist-last-used-account.test.ts
+++ b/tests/unit/renderer/persist-last-used-account.test.ts
@@ -48,6 +48,23 @@ describe('persistLastUsedAccount', () => {
     expect(useSettingsStore.getState().settings.lastUsedAccountId).toBe('profile-z')
   })
 
+  it('survives a rejected settings save without an unhandled rejection', async () => {
+    // updateSettings returns a Promise; a bare try/catch would not see its
+    // rejection (vitest fails the run on an unhandled rejection). NOTE: a plain
+    // function, not vi.fn() -- vi.fn attaches its own handlers to a returned
+    // promise (to record settled results), which would mask the rejection.
+    const original = useSettingsStore.getState().updateSettings
+    useSettingsStore.setState({ updateSettings: (() => Promise.reject(new Error('settings save failed'))) as any })
+    try {
+      await expect(persistLastUsedAccount('s1', 'profile-r')).resolves.toBeUndefined()
+      // Give the rejected promise a tick to surface if it were unhandled.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(useSessionStore.getState().sessions[0].profileId).toBe('profile-r')
+    } finally {
+      useSettingsStore.setState({ updateSettings: original })
+    }
+  })
+
   it('does NOT clear the global last-used when a session switches to the default (undefined) account', async () => {
     await persistLastUsedAccount('s1', 'profile-keep')
     await persistLastUsedAccount('s1', undefined)

--- a/tests/unit/renderer/persist-last-used-account.test.ts
+++ b/tests/unit/renderer/persist-last-used-account.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { persistLastUsedAccount } from '../../../src/renderer/session-persistence'
 import { useSessionStore } from '../../../src/renderer/stores/sessionStore'
+import { useSettingsStore } from '../../../src/renderer/stores/settingsStore'
 
 let saved: any[] = []
 beforeEach(() => {
@@ -16,6 +17,7 @@ beforeEach(() => {
     sessions: [{ id: 's1', label: 'a', workingDirectory: '/', model: 'opus', color: '#fff', status: 'idle', createdAt: 0, sessionType: 'local', provider: 'claude' } as any],
     activeSessionId: 's1',
   })
+  useSettingsStore.setState((s) => ({ settings: { ...s.settings, lastUsedAccountId: undefined } }))
 })
 
 describe('persistLastUsedAccount', () => {
@@ -39,5 +41,19 @@ describe('persistLastUsedAccount', () => {
     ;(window.electronAPI.session.save as any).mockRejectedValueOnce(new Error('disk full'))
     await expect(persistLastUsedAccount('s1', 'profile-y')).resolves.toBeUndefined()
     expect(useSessionStore.getState().sessions[0].profileId).toBe('profile-y')
+  })
+
+  it('records the global "last used" account so the launch gate can offer it', async () => {
+    await persistLastUsedAccount('s1', 'profile-z')
+    expect(useSettingsStore.getState().settings.lastUsedAccountId).toBe('profile-z')
+  })
+
+  it('does NOT clear the global last-used when a session switches to the default (undefined) account', async () => {
+    await persistLastUsedAccount('s1', 'profile-keep')
+    await persistLastUsedAccount('s1', undefined)
+    // The per-session pin cleared, but the global "last used" survives as a
+    // useful default for the next new session.
+    expect(useSessionStore.getState().sessions[0].profileId).toBeUndefined()
+    expect(useSettingsStore.getState().settings.lastUsedAccountId).toBe('profile-keep')
   })
 })

--- a/tests/unit/renderer/session-header.test.tsx
+++ b/tests/unit/renderer/session-header.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../../src/renderer/components/TipPill', () => ({ default: () => null
 const { default: SessionHeader } = await import('../../../src/renderer/components/SessionHeader')
 import type { Session } from '../../../src/renderer/stores/sessionStore'
 import { useAccountAuthStore, _resetAccountAuthForTest } from '../../../src/renderer/stores/accountAuthStore'
+import { useAccountProfilesStore } from '../../../src/renderer/stores/accountProfilesStore'
 
 function makeSession(over: Partial<Session> = {}): Session {
   return {
@@ -65,8 +66,12 @@ describe('SessionHeader', () => {
 
   it('renders repo slug + connected state when GitHub integration is enabled', () => {
     render(makeSession({ githubIntegration: { enabled: true, repoSlug: 'nubbymong/web', autoDetected: true } as any }))
-    expect(container.textContent).toContain('nubbymong/web')
-    expect(container.textContent).toContain('connected')
+    // The repo slug is on HOVER now (title), not inline; the pill reads "GitHub".
+    const gh = container.querySelector('[data-testid="session-pill-github"]')
+    expect(gh).not.toBeNull()
+    expect(gh?.getAttribute('title')).toContain('nubbymong/web')
+    expect(container.textContent).toContain('GitHub')
+    expect(container.textContent).not.toContain('nubbymong/web') // not inline
   })
 
   it('renders no repo slug when there is no GitHub integration', () => {
@@ -77,10 +82,15 @@ describe('SessionHeader', () => {
   it('shows the Claude Code + claude.ai pills with this account status for a local Claude session', () => {
     useAccountAuthStore.setState({ byProfile: { 'profile-x': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
     render(makeSession({ profileId: 'profile-x', provider: 'claude', sessionType: 'local' }))
+    // The good state is a green dot + label, NO word (matches the title-bar pills:
+    // a word only when action is needed).
+    expect(container.querySelector('[data-testid="session-pill-claudecode"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-claudeai"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-account"]')).not.toBeNull()
     expect(container.textContent).toContain('Claude Code')
-    expect(container.textContent).toContain('signed in')
     expect(container.textContent).toContain('claude.ai')
-    expect(container.textContent).toContain('connected')
+    expect(container.textContent).not.toContain('signed out')
+    expect(container.textContent).not.toContain('not connected')
   })
 
   it('shows an expired claude.ai and signed-out Claude Code', () => {
@@ -100,11 +110,11 @@ describe('SessionHeader', () => {
     expect(container.textContent).not.toContain('signed out')
     expect(container.textContent).not.toContain('not connected')
     expect(container.textContent).toContain('…')
-    // Once the read lands, the real status replaces the placeholder.
+    // Once the read lands, the good state shows the dot + label, no word.
     await act(async () => { resolveStatus({ ok: true, cli: { authenticated: true }, web: { status: 'active' } }) })
-    expect(container.textContent).toContain('signed in')
-    expect(container.textContent).toContain('connected')
     expect(container.textContent).not.toContain('…')
+    expect(container.textContent).not.toContain('signed out')
+    expect(container.textContent).not.toContain('not connected')
   })
 
   it('shows "unknown" (not "signed out") when the first status read fails', async () => {
@@ -123,11 +133,29 @@ describe('SessionHeader', () => {
     useAccountAuthStore.setState({ byProfile: { 'profile-e': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 5 } } })
     ;(window.electronAPI.accountWeb.status as any).mockImplementation(async () => ({ ok: false, error: 'probe crashed' }))
     await act(async () => { root.render(<SessionHeader session={makeSession({ profileId: 'profile-e', provider: 'claude', sessionType: 'local' })} />) })
-    // last-known status still shown...
-    expect(container.textContent).toContain('signed in')
-    expect(container.textContent).toContain('connected')
+    // last-known GOOD status still shown (dot, no problem word)...
+    expect(container.textContent).not.toContain('signed out')
+    expect(container.textContent).not.toContain('not connected')
     // ...and the error is in the tooltip.
     expect(container.querySelector('[data-testid="session-pill-claudecode"]')?.getAttribute('title')).toContain('probe crashed')
+  })
+
+  it('the account pill shows the session account name (resolved from the profile)', () => {
+    useAccountProfilesStore.setState({ profiles: [{ id: 'profile-x', name: 'Work', accountEmail: 'me@work.co' } as any] })
+    useAccountAuthStore.setState({ byProfile: { 'profile-x': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
+    render(makeSession({ profileId: 'profile-x', provider: 'claude', sessionType: 'local' }))
+    const acct = container.querySelector('[data-testid="session-pill-account"]')
+    expect(acct).not.toBeNull()
+    expect(acct?.textContent).toContain('Work')
+    expect(acct?.getAttribute('title')).toContain('me@work.co')
+    useAccountProfilesStore.setState({ profiles: [] })
+  })
+
+  it('an SSH session still shows the GitHub pill (on hover) but not the Claude pills', () => {
+    render(makeSession({ provider: 'claude', sessionType: 'ssh', sshConfig: { host: 'h', port: 22, username: 'u', remotePath: '~' } as any, githubIntegration: { enabled: true, repoSlug: 'nubbymong/web', autoDetected: true } as any }))
+    expect(container.querySelector('[data-testid="session-pill-github"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-claudecode"]')).toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-account"]')).toBeNull()
   })
 
   it('does NOT show the auth pills for an SSH session (remote creds)', () => {

--- a/tests/unit/renderer/session-header.test.tsx
+++ b/tests/unit/renderer/session-header.test.tsx
@@ -90,6 +90,32 @@ describe('SessionHeader', () => {
     expect(container.textContent).toContain('expired')
   })
 
+  it('shows "…" (not "signed out") before the first status read completes', async () => {
+    // First render precedes the fetch effect; then the fetch is in flight. Neither
+    // state may be painted as a definite "signed out"/"not connected".
+    let resolveStatus: (v: unknown) => void = () => {}
+    ;(window.electronAPI.accountWeb.status as any).mockImplementation(() => new Promise((r) => { resolveStatus = r }))
+    render(makeSession({ profileId: 'profile-p', provider: 'claude', sessionType: 'local' }))
+    expect(container.textContent).toContain('Claude Code')
+    expect(container.textContent).not.toContain('signed out')
+    expect(container.textContent).not.toContain('not connected')
+    expect(container.textContent).toContain('…')
+    // Once the read lands, the real status replaces the placeholder.
+    await act(async () => { resolveStatus({ ok: true, cli: { authenticated: true }, web: { status: 'active' } }) })
+    expect(container.textContent).toContain('signed in')
+    expect(container.textContent).toContain('connected')
+    expect(container.textContent).not.toContain('…')
+  })
+
+  it('shows "unknown" (not "signed out") when the first status read fails', async () => {
+    ;(window.electronAPI.accountWeb.status as any).mockImplementation(async () => ({ ok: false, error: 'probe crashed' }))
+    await act(async () => { root.render(<SessionHeader session={makeSession({ profileId: 'profile-q', provider: 'claude', sessionType: 'local' })} />) })
+    expect(container.textContent).not.toContain('signed out')
+    expect(container.textContent).not.toContain('not connected')
+    expect(container.textContent).toContain('unknown')
+    expect(container.querySelector('[data-testid="session-pill-claudecode"]')?.getAttribute('title')).toContain('probe crashed')
+  })
+
   it('does NOT show the auth pills for an SSH session (remote creds)', () => {
     useAccountAuthStore.setState({ byProfile: { 'profile-z': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
     render(makeSession({ profileId: 'profile-z', provider: 'claude', sessionType: 'ssh', sshConfig: { host: 'h', port: 22, username: 'u', remotePath: '~' } as any }))

--- a/tests/unit/renderer/session-header.test.tsx
+++ b/tests/unit/renderer/session-header.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../../src/renderer/components/TipPill', () => ({ default: () => null
 
 const { default: SessionHeader } = await import('../../../src/renderer/components/SessionHeader')
 import type { Session } from '../../../src/renderer/stores/sessionStore'
+import { useAccountAuthStore, _resetAccountAuthForTest } from '../../../src/renderer/stores/accountAuthStore'
 
 function makeSession(over: Partial<Session> = {}): Session {
   return {
@@ -34,6 +35,11 @@ beforeEach(() => {
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
+  _resetAccountAuthForTest()
+  // The auth pills' effect calls this on mount; resolve it so it never errors.
+  ;(globalThis as any).window.electronAPI = {
+    accountWeb: { status: vi.fn(async () => ({ ok: true, cli: { authenticated: false }, web: { status: 'none' } })) },
+  }
 })
 afterEach(() => {
   act(() => { root.unmount() })
@@ -66,5 +72,28 @@ describe('SessionHeader', () => {
   it('renders no repo slug when there is no GitHub integration', () => {
     render(makeSession({ githubIntegration: undefined }))
     expect(container.textContent).not.toContain('nubbymong')
+  })
+
+  it('shows the Claude Code + claude.ai pills with this account status for a local Claude session', () => {
+    useAccountAuthStore.setState({ byProfile: { 'profile-x': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
+    render(makeSession({ profileId: 'profile-x', provider: 'claude', sessionType: 'local' }))
+    expect(container.textContent).toContain('Claude Code')
+    expect(container.textContent).toContain('signed in')
+    expect(container.textContent).toContain('claude.ai')
+    expect(container.textContent).toContain('connected')
+  })
+
+  it('shows an expired claude.ai and signed-out Claude Code', () => {
+    useAccountAuthStore.setState({ byProfile: { 'profile-y': { cliAuthed: false, web: 'expired', loading: false, fetchedAt: 1 } } })
+    render(makeSession({ profileId: 'profile-y', provider: 'claude', sessionType: 'local' }))
+    expect(container.textContent).toContain('signed out')
+    expect(container.textContent).toContain('expired')
+  })
+
+  it('does NOT show the auth pills for an SSH session (remote creds)', () => {
+    useAccountAuthStore.setState({ byProfile: { 'profile-z': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
+    render(makeSession({ profileId: 'profile-z', provider: 'claude', sessionType: 'ssh', sshConfig: { host: 'h', port: 22, username: 'u', remotePath: '~' } as any }))
+    expect(container.textContent).not.toContain('Claude Code')
+    expect(container.textContent).not.toContain('claude.ai')
   })
 })

--- a/tests/unit/renderer/session-header.test.tsx
+++ b/tests/unit/renderer/session-header.test.tsx
@@ -116,6 +116,20 @@ describe('SessionHeader', () => {
     expect(container.querySelector('[data-testid="session-pill-claudecode"]')?.getAttribute('title')).toContain('probe crashed')
   })
 
+  it('surfaces a failed refresh in the tooltip even after a prior successful read (stale status is not silent)', async () => {
+    // A prior success is on record; the mount's refresh then FAILS. The pills
+    // keep the last-known text/colour, but the error must appear in the tooltip
+    // so the stale status is not invisible.
+    useAccountAuthStore.setState({ byProfile: { 'profile-e': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 5 } } })
+    ;(window.electronAPI.accountWeb.status as any).mockImplementation(async () => ({ ok: false, error: 'probe crashed' }))
+    await act(async () => { root.render(<SessionHeader session={makeSession({ profileId: 'profile-e', provider: 'claude', sessionType: 'local' })} />) })
+    // last-known status still shown...
+    expect(container.textContent).toContain('signed in')
+    expect(container.textContent).toContain('connected')
+    // ...and the error is in the tooltip.
+    expect(container.querySelector('[data-testid="session-pill-claudecode"]')?.getAttribute('title')).toContain('probe crashed')
+  })
+
   it('does NOT show the auth pills for an SSH session (remote creds)', () => {
     useAccountAuthStore.setState({ byProfile: { 'profile-z': { cliAuthed: true, web: 'active', loading: false, fetchedAt: 1 } } })
     render(makeSession({ profileId: 'profile-z', provider: 'claude', sessionType: 'ssh', sshConfig: { host: 'h', port: 22, username: 'u', remotePath: '~' } as any }))


### PR DESCRIPTION
Three owner-approved UX improvements (canvas-reviewed). Part of the beta.13 batch.

### 1. Session connection pills (SessionHeader.tsx)
Two pills beside the GitHub pill show THIS session's account's Claude Code (signed in / out) and claude.ai (connected / expired / not connected) status. Backed by a shared accountAuthStore (keyed by profileId) so the header + sidebar menu read one source and a sign-in refreshes both. Fetched on session-activate + after auth actions + manual refresh — never polled (the Claude Code check is a ~10s subprocess), deduped per profile. SSH/Codex/shell-only show no pills. The right-click 'Sign in to Claude Code' is now disabled when already signed in.

### 2. Footer account separation (MultiAccountStatusline.tsx)
Each account sits in its own subtle rounded pill (border + faint fill) with a tighter gap. Canvas review: option B.

### 3. 'Last used' launch line (AccountLaunchGate.tsx)
A labelled 'Last used' line at the top of the account picker, always visible regardless of the dropdown, one-click 'Use →'. Tracks the most recently launched account (global, settings.lastUsedAccountId); dropdown default unchanged; switching to the default account doesn't clear it.

## Verification
- Full suite green (5365), typecheck + byte-scan clean.
- New coverage: accountAuthStore (mapping + heavy-probe dedupe + error), pills render/hide, footer pill boundary, global last-used (don't-clear-on-undefined mutation-proven).
- Renderer-only; not on the ADR-009 security-path list.

Holds for beta.13 alongside #290 and the two remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)