### PR TITLE
fix(terminal): repaint stale WebGL glyphs on at-bottom streaming too (#273 follow-up)

### DIFF
--- a/CONTEXT.d/2026-08-17-webgl-ghost-at-bottom.md
+++ b/CONTEXT.d/2026-08-17-webgl-ghost-at-bottom.md
@@ -1,0 +1,27 @@
+## 2026-08-17 -- WebGL stale-glyph repaint covers at-bottom streaming (#273 follow-up, PR #292)
+
+beta.12's #283 repainted only while the user was scrolled up or had just
+wheeled; output streaming at the BOTTOM with no scroll (the owner's slicer
+stderr) still ghosted and stayed ghosted after the stream stopped, because
+nothing repainted. Owner confirmed on beta.12.
+
+Change (renderer-only, `staleGlyphRepaint.ts` + TerminalView wiring):
+- every normal-buffer output chunk qualifies for the strong repaint
+  (clearTextureAtlas + refresh); alternate-buffer skip and the WebGL-active
+  gate (no refresh on the DOM renderer) unchanged;
+- two paces: 4/sec while scrolled up / wheel-active (unchanged), 1/sec for
+  steady at-bottom streaming -- clearTextureAtlas rebuilds the atlas and re-warms
+  ASCII, so a minutes-long log should not pay four of those a second (#273's
+  open GPU-cost question);
+- one SETTLE repaint 300ms after output goes quiet (through the throttle) --
+  clears the ghost the LAST chunk left, which is what the user is otherwise
+  left staring at;
+- Copilot review: a fast (wheel) request arriving inside its window while a
+  slow trailing timer was armed waited on the slow timer; the repainter now
+  tracks the armed timer's due time and brings it forward for a faster pace.
+
+Tests: predicate, pace selection, per-call interval, settle (fires once after
+quiet, re-armed per chunk, never doubles up, cancelled by dispose), fast-forward
+of a slow timer, slow never pushes fast later. Mutation-checked (settle bypassing
+the throttle / interval ignored / old predicate / old timer logic each fail).
+Needs the owner's live confirm on the slicer case (host cannot repro).

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -8,6 +8,7 @@ import { installWebglWithRecovery, type WebglHandle } from './terminal/terminalW
 import {
   createStaleGlyphRepainter,
   shouldRepaintOnOutput,
+  outputRepaintIntervalMs,
   WHEEL_ACTIVE_MS,
   type StaleGlyphRepainter,
 } from './terminal/staleGlyphRepaint'
@@ -788,16 +789,23 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         if (follow.scrollToBottom) term?.scrollToBottom()
         if (follow.scrolledUp !== isScrolledUpRef.current) updateScrollState(follow.scrolledUp)
 
-        // #273: streaming output is when stale WebGL glyphs accumulate. Repaint
-        // when the reproducing conditions hold (normal buffer, and the user is
-        // scrolled up or has scrolled recently); the throttle bounds the cost.
-        if (term && repainter && shouldRepaintOnOutput({
-          alternateBuffer: term.buffer.active.type === 'alternate',
-          scrolledUp: isScrolledUpRef.current,
-          msSinceWheel: Date.now() - lastWheelAt,
-          wheelActiveMs: WHEEL_ACTIVE_MS,
-        })) {
-          repainter.schedule()
+        // #273: streaming output is when stale WebGL glyphs accumulate — at the
+        // bottom with no scroll too (follow-up: a slicer's stderr ghosted and
+        // stayed ghosted). Every normal-buffer chunk repaints, paced 4/sec while
+        // scrolled up / wheel-active and 1/sec for steady at-bottom streaming,
+        // and one settle repaint clears the last chunk's ghost once the stream
+        // goes quiet. The repainter skips the refresh when WebGL isn't active.
+        if (term && repainter) {
+          const repaintState = {
+            alternateBuffer: term.buffer.active.type === 'alternate',
+            scrolledUp: isScrolledUpRef.current,
+            msSinceWheel: Date.now() - lastWheelAt,
+            wheelActiveMs: WHEEL_ACTIVE_MS,
+          }
+          if (shouldRepaintOnOutput(repaintState)) {
+            repainter.schedule(outputRepaintIntervalMs(repaintState))
+            repainter.settle()
+          }
         }
 
         // Post-resume settle nudge: every chunk re-arms the timer; it fires only

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -803,8 +803,13 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
             wheelActiveMs: WHEEL_ACTIVE_MS,
           }
           if (shouldRepaintOnOutput(repaintState)) {
-            repainter.schedule(outputRepaintIntervalMs(repaintState))
-            repainter.settle()
+            const paceMs = outputRepaintIntervalMs(repaintState)
+            repainter.schedule(paceMs)
+            // Settle at the SAME pace: a between-chunks settle on a steady
+            // at-bottom stream must not repaint faster than the stream (it would
+            // defeat the 1/sec bound); when output truly stops it still clears
+            // the final ghost within one interval.
+            repainter.settle(undefined, paceMs)
           }
         }
 

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -107,10 +107,11 @@ export interface StaleGlyphRepainter {
    *  overrides the pace for this request (defaults to the repainter's). */
   schedule(intervalMs?: number): void
   /** Arm (or re-arm) ONE repaint for when requests go quiet: fires `quietMs`
-   *  after the last settle() call, through the normal throttle. A continuous
-   *  stream keeps pushing it out; the moment it stops, the last chunk's ghost is
-   *  cleared. */
-  settle(quietMs?: number): void
+   *  after the last settle() call, through the normal throttle at `intervalMs`
+   *  (default the repainter's). A continuous stream keeps pushing it out; the
+   *  moment it stops, the last chunk's ghost is cleared. Pass the stream's own
+   *  pace so a settle firing mid-stream cannot repaint faster than the stream. */
+  settle(quietMs?: number, intervalMs?: number): void
   /** Cancel any pending repaint and refuse further ones. */
   dispose(): void
 }
@@ -174,17 +175,21 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
     }, intervalMs - since)
   }
 
-  const settle = (quietMs: number = SETTLE_QUIET_MS) => {
+  const settle = (quietMs: number = SETTLE_QUIET_MS, intervalMs: number = minInterval) => {
     if (disposed) return
     // Debounce: every call pushes the settle repaint out to quietMs from NOW.
     if (settleTimer) deps.clearTimer(settleTimer)
     settleTimer = deps.setTimer(() => {
       settleTimer = null
       if (disposed) return
-      // Through the throttle (default pace) so a settle can never double up on a
-      // repaint that just happened; the ghost the final chunk left is cleared
-      // within one interval of the stream going quiet.
-      schedule(minInterval)
+      // Through the throttle AT THE STREAM'S PACE (not always the fast default):
+      // a log line every ~350ms leaves a >SETTLE_QUIET_MS gap between chunks, so
+      // the settle fires between them EVERY time. Routed through schedule(1000)
+      // that just re-arms the 1/sec trailing timer (it coalesces) so a steady
+      // at-bottom stream stays at its 1/sec pace instead of the settle dragging
+      // it up to the chunk rate; when the stream truly stops, the final ghost is
+      // still cleared within one interval. See BOTTOM_STREAM_INTERVAL_MS.
+      schedule(intervalMs)
     }, quietMs)
   }
 

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -128,6 +128,9 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
   const minInterval = deps.minIntervalMs ?? REPAINT_MIN_INTERVAL_MS
   let lastPaintAt = Number.NEGATIVE_INFINITY
   let timer: ReturnType<typeof setTimeout> | null = null
+  /** When the armed trailing timer is due (deps.now() clock), so a faster-paced
+   *  request can tell whether it would fire sooner and bring it forward. */
+  let timerDueAt = Number.POSITIVE_INFINITY
   let settleTimer: ReturnType<typeof setTimeout> | null = null
   let disposed = false
 
@@ -146,18 +149,26 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
     if (disposed) return
     const since = deps.now() - lastPaintAt
     if (since >= intervalMs) {
-      if (timer) { deps.clearTimer(timer); timer = null }
+      if (timer) { deps.clearTimer(timer); timer = null; timerDueAt = Number.POSITIVE_INFINITY }
       paint()
       return
     }
-    // Inside the window: one trailing repaint at the edge. Already-armed → let it
-    // stand rather than pushing it later (that would starve a steady stream). A
-    // faster-paced request arriving while a slower one's timer is armed either
-    // paints now (its own window has elapsed, above) or rides that timer, which
-    // is never further out than the slower interval.
-    if (timer) return
+    // Inside the window: one trailing repaint at the edge of THIS request's
+    // window (lastPaintAt + intervalMs). An armed timer that is due no later
+    // stands (never push a repaint out — that would starve a steady stream); a
+    // faster-paced request — a wheel landing mid at-bottom stream — brings an
+    // armed slow timer FORWARD to its own edge rather than waiting up to the
+    // slow interval on it (#292 review).
+    const dueAt = lastPaintAt + intervalMs
+    if (timer) {
+      if (dueAt >= timerDueAt) return
+      deps.clearTimer(timer)
+      timer = null
+    }
+    timerDueAt = dueAt
     timer = deps.setTimer(() => {
       timer = null
+      timerDueAt = Number.POSITIVE_INFINITY
       if (disposed) return
       paint()
     }, intervalMs - since)
@@ -179,7 +190,7 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
 
   const dispose = () => {
     disposed = true
-    if (timer) { deps.clearTimer(timer); timer = null }
+    if (timer) { deps.clearTimer(timer); timer = null; timerDueAt = Number.POSITIVE_INFINITY }
     if (settleTimer) { deps.clearTimer(settleTimer); settleTimer = null }
   }
 

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -16,12 +16,35 @@
  * the bug, THROTTLED so a firehose of output costs at most a few repaints a
  * second rather than one per chunk.
  *
+ * Trigger coverage (#273 follow-up): the first cut repainted only while the user
+ * was scrolled up or had just wheeled, so output streaming at the BOTTOM with no
+ * scroll at all (a slicer's stderr, a build log) still ghosted and stayed
+ * ghosted after the stream stopped. Every normal-buffer output chunk now
+ * qualifies, at two paces: the original 4/sec while scrolled up / wheel-active
+ * (where the artifact is worst), a gentler 1/sec for steady at-bottom streaming
+ * (bounds a ghost to about a second while output flows), plus ONE "settle"
+ * repaint once output has been quiet for a moment — the ghost the last chunk
+ * left is what the user is otherwise left staring at.
+ *
  * Everything here is pure and dependency-injected so the throttle boundaries and
  * the trigger predicate are unit-testable without a DOM or a GPU.
  */
 
-/** At most one strong repaint per this interval — 4/sec under a firehose. */
+/** At most one strong repaint per this interval while scrolled up / wheel-active
+ *  — 4/sec under a firehose. Also the repainter's default interval. */
 export const REPAINT_MIN_INTERVAL_MS = 250
+
+/** Steady at-bottom streaming with no scroll: at most one strong repaint per
+ *  second. clearTextureAtlas() rebuilds the glyph atlas (re-warms the ASCII set,
+ *  re-rasters every viewport glyph), so a build log that streams for minutes
+ *  should not pay 4 of those a second; a ghost lives at most ~1s while output
+ *  flows and the settle repaint clears the final one when it stops. */
+export const BOTTOM_STREAM_INTERVAL_MS = 1000
+
+/** Output quiet for this long → one settle repaint. Long enough that a
+ *  continuous stream keeps re-arming it (the periodic pace covers that), short
+ *  enough that a ghost never sits on a finished stream for long. */
+export const SETTLE_QUIET_MS = 300
 
 /** After a wheel event, treat the user as "actively scrolling" for this long, so
  *  streaming output keeps busting ghosts until the scroll settles. */
@@ -44,14 +67,24 @@ export interface OutputRepaintState {
 /**
  * Should arriving output trigger a stale-glyph repaint?
  *
- * Only in the NORMAL buffer, and only when the user is either scrolled up or has
- * scrolled recently — the exact conditions under which #273 reproduces. Steady
- * at-bottom output with no recent scroll (an idle shell tailing a log, a TUI in
- * the alternate buffer) is left alone.
+ * Every NORMAL-buffer chunk qualifies — at the bottom too, since the ghost also
+ * forms under steady at-bottom streaming with no scroll (#273 follow-up). The
+ * alternate screen (a TUI, Claude's own UI) owns its full repaints and does not
+ * accumulate these stale cells, so it is left alone. How OFTEN a qualifying
+ * stream repaints is `outputRepaintIntervalMs`.
  */
 export function shouldRepaintOnOutput(s: OutputRepaintState): boolean {
-  if (s.alternateBuffer) return false
-  return s.scrolledUp || s.msSinceWheel < s.wheelActiveMs
+  return !s.alternateBuffer
+}
+
+/**
+ * How closely to space repaints for a qualifying output stream: the original
+ * 4/sec while the user is scrolled up or has wheeled recently (the conditions
+ * where the artifact is worst and the user is looking at it), 1/sec for steady
+ * at-bottom streaming.
+ */
+export function outputRepaintIntervalMs(s: OutputRepaintState): number {
+  return s.scrolledUp || s.msSinceWheel < s.wheelActiveMs ? REPAINT_MIN_INTERVAL_MS : BOTTOM_STREAM_INTERVAL_MS
 }
 
 export interface RepainterDeps {
@@ -70,8 +103,14 @@ export interface RepainterDeps {
 
 export interface StaleGlyphRepainter {
   /** Request a strong repaint soon. Leading-edge immediate, then coalesced into
-   *  at most one repaint per interval for the rest of a burst. */
-  schedule(): void
+   *  at most one repaint per interval for the rest of a burst. `intervalMs`
+   *  overrides the pace for this request (defaults to the repainter's). */
+  schedule(intervalMs?: number): void
+  /** Arm (or re-arm) ONE repaint for when requests go quiet: fires `quietMs`
+   *  after the last settle() call, through the normal throttle. A continuous
+   *  stream keeps pushing it out; the moment it stops, the last chunk's ghost is
+   *  cleared. */
+  settle(quietMs?: number): void
   /** Cancel any pending repaint and refuse further ones. */
   dispose(): void
 }
@@ -89,6 +128,7 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
   const minInterval = deps.minIntervalMs ?? REPAINT_MIN_INTERVAL_MS
   let lastPaintAt = Number.NEGATIVE_INFINITY
   let timer: ReturnType<typeof setTimeout> | null = null
+  let settleTimer: ReturnType<typeof setTimeout> | null = null
   let disposed = false
 
   const paint = () => {
@@ -102,28 +142,46 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
     if (deps.clearAtlas()) deps.refresh()
   }
 
-  const schedule = () => {
+  const schedule = (intervalMs: number = minInterval) => {
     if (disposed) return
     const since = deps.now() - lastPaintAt
-    if (since >= minInterval) {
+    if (since >= intervalMs) {
       if (timer) { deps.clearTimer(timer); timer = null }
       paint()
       return
     }
     // Inside the window: one trailing repaint at the edge. Already-armed → let it
-    // stand rather than pushing it later (that would starve a steady stream).
+    // stand rather than pushing it later (that would starve a steady stream). A
+    // faster-paced request arriving while a slower one's timer is armed either
+    // paints now (its own window has elapsed, above) or rides that timer, which
+    // is never further out than the slower interval.
     if (timer) return
     timer = deps.setTimer(() => {
       timer = null
       if (disposed) return
       paint()
-    }, minInterval - since)
+    }, intervalMs - since)
+  }
+
+  const settle = (quietMs: number = SETTLE_QUIET_MS) => {
+    if (disposed) return
+    // Debounce: every call pushes the settle repaint out to quietMs from NOW.
+    if (settleTimer) deps.clearTimer(settleTimer)
+    settleTimer = deps.setTimer(() => {
+      settleTimer = null
+      if (disposed) return
+      // Through the throttle (default pace) so a settle can never double up on a
+      // repaint that just happened; the ghost the final chunk left is cleared
+      // within one interval of the stream going quiet.
+      schedule(minInterval)
+    }, quietMs)
   }
 
   const dispose = () => {
     disposed = true
     if (timer) { deps.clearTimer(timer); timer = null }
+    if (settleTimer) { deps.clearTimer(settleTimer); settleTimer = null }
   }
 
-  return { schedule, dispose }
+  return { schedule, settle, dispose }
 }

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -7,8 +7,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   shouldRepaintOnOutput,
+  outputRepaintIntervalMs,
   createStaleGlyphRepainter,
   REPAINT_MIN_INTERVAL_MS,
+  BOTTOM_STREAM_INTERVAL_MS,
+  SETTLE_QUIET_MS,
   WHEEL_ACTIVE_MS,
 } from '../../../src/renderer/components/terminal/staleGlyphRepaint'
 
@@ -28,9 +31,26 @@ describe('shouldRepaintOnOutput', () => {
     expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS - 1 })).toBe(true)
   })
 
-  it('does NOT repaint at the bottom with no recent scroll', () => {
-    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(false)
-    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(false)
+  // #273 follow-up: the ghost also forms under steady at-bottom streaming with
+  // no scroll at all (a slicer's stderr) — and stayed, because nothing repainted.
+  it('repaints at the bottom with no recent scroll too (ghost-at-bottom follow-up)', () => {
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(true)
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(true)
+  })
+})
+
+describe('outputRepaintIntervalMs', () => {
+  const base = { alternateBuffer: false, scrolledUp: false, msSinceWheel: Infinity, wheelActiveMs: WHEEL_ACTIVE_MS }
+
+  it('paces scrolled-up / wheel-active streams at the fast interval (4/sec)', () => {
+    expect(outputRepaintIntervalMs({ ...base, scrolledUp: true })).toBe(REPAINT_MIN_INTERVAL_MS)
+    expect(outputRepaintIntervalMs({ ...base, msSinceWheel: WHEEL_ACTIVE_MS - 1 })).toBe(REPAINT_MIN_INTERVAL_MS)
+  })
+
+  it('paces steady at-bottom streams at the gentle interval (1/sec)', () => {
+    expect(outputRepaintIntervalMs({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(BOTTOM_STREAM_INTERVAL_MS)
+    expect(outputRepaintIntervalMs(base)).toBe(BOTTOM_STREAM_INTERVAL_MS)
+    expect(BOTTOM_STREAM_INTERVAL_MS).toBeGreaterThan(REPAINT_MIN_INTERVAL_MS)
   })
 })
 
@@ -141,6 +161,74 @@ describe('createStaleGlyphRepainter', () => {
     // Leading paint at 0, then trailing at 250/500/750/1000 → 4-5 total, never 63.
     expect(h.counts().clearAtlas).toBeLessThanOrEqual(6)
     expect(h.counts().clearAtlas).toBeGreaterThanOrEqual(4)
+  })
+
+  it('honours a per-call interval: an at-bottom stream repaints once per second, not 4x', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    // 3000ms of at-bottom output every 16ms at the gentle pace.
+    for (let i = 0; i < 188; i++) { r.schedule(BOTTOM_STREAM_INTERVAL_MS); h.advance(16) }
+    // Leading paint at 0, then trailing at ~1000/2000/3000 → 3-4 total, never 12+.
+    expect(h.counts().clearAtlas).toBeGreaterThanOrEqual(3)
+    expect(h.counts().clearAtlas).toBeLessThanOrEqual(5)
+  })
+
+  it('a wheel (fast pace) arriving mid at-bottom stream paints as soon as ITS window allows', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)      // t=0 paint 1
+    h.advance(100)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)      // arms the slow trailing timer at t=1000
+    h.advance(200)                             // t=300: ≥ fast interval since paint 1
+    r.schedule(REPAINT_MIN_INTERVAL_MS)        // fast request → immediate paint 2 (timer replaced)
+    expect(h.counts().clearAtlas).toBe(2)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('settle(): one repaint after output goes quiet, re-armed by every chunk', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS); r.settle()   // t=0 leading paint 1
+    // A stream that keeps arriving inside the quiet window never lets it fire...
+    for (let i = 1; i <= 10; i++) { h.advance(100); r.settle() }   // t=1000
+    expect(h.counts().clearAtlas).toBe(1)
+    // ...then output stops: the settle repaint lands one quiet window later —
+    // through the throttle, so it is a normal (fast-pace) leading paint.
+    h.advance(SETTLE_QUIET_MS)                        // t=1300
+    expect(h.counts().clearAtlas).toBe(2)
+    expect(h.pendingTimers()).toBe(0)
+    // And it does not keep firing on its own.
+    h.advance(5000)
+    expect(h.counts().clearAtlas).toBe(2)
+  })
+
+  it('settle() never doubles up on a repaint that just happened', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(); r.settle()          // t=0 paint 1, settle armed for t=300
+    h.advance(200)
+    r.schedule()                      // t=200: inside the fast window → trailing at t=250
+    h.advance(50)                     // t=250: trailing paint 2
+    expect(h.counts().clearAtlas).toBe(2)
+    h.advance(50)                     // t=300: settle fires; 50ms since paint 2 → coalesces
+    expect(h.counts().clearAtlas).toBe(2)
+    expect(h.pendingTimers()).toBe(1) // one trailing repaint at t=500, not an extra now
+    h.advance(250)
+    expect(h.counts().clearAtlas).toBe(3)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('dispose() cancels a pending settle repaint too', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.settle()
+    expect(h.pendingTimers()).toBe(1)
+    r.dispose()
+    expect(h.pendingTimers()).toBe(0)
+    h.advance(5000)
+    r.settle()                        // disposed → ignored
+    expect(h.pendingTimers()).toBe(0)
+    expect(h.counts().clearAtlas).toBe(0)
   })
 
   it('dispose() cancels a pending repaint and refuses further ones', () => {

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -231,6 +231,42 @@ describe('createStaleGlyphRepainter', () => {
     expect(h.counts().clearAtlas).toBe(2)
   })
 
+  // #292 cross-check (MAJOR): SETTLE_QUIET_MS (300ms) is below typical log-line
+  // cadence, so a steady at-bottom stream leaves a >quiet gap between chunks and
+  // the settle fires between them every time. If the settle repaints at the FAST
+  // pace it drags the stream up to ~chunk rate, defeating BOTTOM_STREAM_INTERVAL.
+  // Routed at the stream's own pace it stays ~1/sec.
+  it('a steady at-bottom stream whose gaps exceed the quiet window still holds ~1/sec (settle at stream pace)', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    // 30 chunks, 350ms apart (>SETTLE_QUIET_MS): the TerminalView wiring for an
+    // at-bottom stream — schedule(1000) + settle(_, 1000) per chunk.
+    for (let i = 0; i < 30; i++) {
+      r.schedule(BOTTOM_STREAM_INTERVAL_MS)
+      r.settle(undefined, BOTTOM_STREAM_INTERVAL_MS)
+      h.advance(350)
+    }
+    // ~10.5s of output → about 1/sec, NOT ~3/sec. Generous upper bound catches
+    // the regression (which produced ~31) while tolerating boundary paints.
+    expect(h.counts().clearAtlas).toBeLessThanOrEqual(13)
+    expect(h.counts().clearAtlas).toBeGreaterThanOrEqual(10)
+  })
+
+  it('the settle still clears the final ghost within one interval once output stops', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)                 // t=0 paint 1
+    r.settle(undefined, BOTTOM_STREAM_INTERVAL_MS)
+    h.advance(350)                                        // one more chunk...
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)                 // t=350: trailing armed for t=1000
+    r.settle(undefined, BOTTOM_STREAM_INTERVAL_MS)        // settle armed for t=650
+    const before = h.counts().clearAtlas
+    // ...then output STOPS. Within one BOTTOM_STREAM_INTERVAL the ghost clears.
+    h.advance(BOTTOM_STREAM_INTERVAL_MS)                  // to t=1350
+    expect(h.counts().clearAtlas).toBeGreaterThan(before)
+    expect(h.pendingTimers()).toBe(0)
+  })
+
   it('settle() never doubles up on a repaint that just happened', () => {
     const h = makeHarness()
     const r = createStaleGlyphRepainter(h.deps)

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -185,6 +185,35 @@ describe('createStaleGlyphRepainter', () => {
     expect(h.pendingTimers()).toBe(0)
   })
 
+  // #292 review: a fast request INSIDE its own window while a slow timer is
+  // armed must bring the repaint forward to the fast edge, not wait ~1s.
+  it('a wheel inside the fast window brings an armed slow trailing timer forward to the fast edge', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)      // t=0 paint 1
+    h.advance(100)
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)      // slow trailing timer due at t=1000
+    h.advance(50)                              // t=150: inside the fast window too
+    r.schedule(REPAINT_MIN_INTERVAL_MS)        // fast request → timer re-armed for t=250
+    expect(h.counts().clearAtlas).toBe(1)
+    expect(h.pendingTimers()).toBe(1)
+    h.advance(100)                             // t=250
+    expect(h.counts().clearAtlas).toBe(2)      // NOT still waiting on t=1000
+    expect(h.pendingTimers()).toBe(0)
+  })
+
+  it('a slower request never pushes an armed faster timer later', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule()                               // t=0 paint 1 (fast pace)
+    h.advance(100)
+    r.schedule()                               // fast trailing timer due at t=250
+    r.schedule(BOTTOM_STREAM_INTERVAL_MS)      // slow request: due t=1000 ≥ 250 → let the fast one stand
+    expect(h.pendingTimers()).toBe(1)
+    h.advance(150)                             // t=250
+    expect(h.counts().clearAtlas).toBe(2)
+  })
+
   it('settle(): one repaint after output goes quiet, re-armed by every chunk', () => {
     const h = makeHarness()
     const r = createStaleGlyphRepainter(h.deps)


### PR DESCRIPTION
## What

beta.12's stale-glyph repaint (#283) fired only while the user was **scrolled up or had just wheeled**, so output streaming at the **bottom with no scroll** (the slicer stderr case) still ghosted — and stayed ghosted after the stream stopped, because nothing ever repainted. Owner confirmed it on beta.12.

Every normal-buffer output chunk now qualifies for the strong repaint (`clearTextureAtlas()` + `refresh`), at two paces, plus a settle repaint:

| Situation | Pace |
|---|---|
| scrolled up / wheel-active (unchanged) | 4/sec |
| steady at-bottom streaming | 1/sec |
| output goes quiet for 300 ms | one settle repaint (through the throttle) |

Why 1/sec at the bottom instead of 4: `clearTextureAtlas()` clears the atlas pages + glyph cache + render model and re-warms the ASCII set on the next frame — a build log that streams for minutes shouldn't pay four of those a second (#273's open GPU-cost question). A ghost lives ~1 s at most while output flows; the **settle** repaint is the one that matters for the reported case: it clears the ghost the *last* chunk left, which is what the user is otherwise left staring at.

Unchanged: alternate-buffer skip (TUIs / Claude's own UI own their repaints) and the WebGL-active gate (no refresh on the DOM renderer — #283 adversarial finding).

## Files
- `src/renderer/components/terminal/staleGlyphRepaint.ts` — predicate = any normal-buffer output; new `outputRepaintIntervalMs`; repainter `schedule(intervalMs?)` + `settle(quietMs?)`; dispose cancels the settle timer
- `src/renderer/components/TerminalView.tsx` — wiring (schedule at the chosen pace + settle on every chunk)
- `tests/unit/renderer/stale-glyph-repaint.test.ts` — 18 tests

## Verification
- `npm run typecheck` clean; repaint tests 18/18
- Mutation-checked: settle bypassing the throttle / per-call interval ignored / old predicate → each fails the new tests
- Renderer-only, not an ADR-009 path
- Needs the owner's **live confirm** on the slicer case (host can't repro; VM only)

Refs #273 (follow-up to #283).
