### PR TITLE
fix(canvas): serve the session worktree CCC designates (ADR-016)

### DIFF
--- a/CONTEXT.d/2026-08-17-canvas-serves-session-worktree.md
+++ b/CONTEXT.d/2026-08-17-canvas-serves-session-worktree.md
@@ -1,0 +1,37 @@
+## 2026-08-17 -- Canvas serves the session worktree CCC designates (ADR-016)
+
+Found dogfooding the canvas for the beta.13 mockups: session isolation puts the
+agent in `../ccc-wt/<id>` and blocks writes to the primary checkout, while the
+canvas served roots were exactly the primary checkout -- so `canvas_render`'s
+`htmlPath` was unusable from a worktree and the mockup had to go inline (the
+form the skill forbids). Two mandated features in conflict.
+
+Decision: CCC designates the worktree location itself and serves that.
+- `pty-manager` computes `<worktree base>/<first 8 of the CCC session id>` from
+  the CONFIGURED project directory + CCC's own session id (never the launch cwd),
+  puts it in the PTY env as `CCC_SESSION_WORKTREE`, and designates it as a
+  PENDING canvas root once the project itself is registered.
+- `canvas-store.designateCanvasWorktreeRoot`: lexical, floor-checked; live only
+  when it exists as a real directory whose realpath IS the path (junction /
+  symlink at or above it -> not served), re-evaluated on every resolution;
+  candidates still realpath'd; per session; revoked with the session.
+- `scripts/session-guard.mjs claim` honours the env var: creates there, or
+  ADOPTS the worktree an earlier conversation of the same CCC session left there
+  (`/clear`, restart) -- worktrees are now per tile under CCC, fewer orphans.
+  Held by another live session / not a worktree -> default location + a note.
+- Skill text: htmlPath / distRoot may live in the session worktree.
+
+Rejected: trusting the guard's lease, or git's worktree metadata (both
+agent-writable -- the class the 08-11/14/15 reviews closed); a user-configured
+extra-roots setting (sound, but not out-of-the-box and broader than one
+session's worktree; possible follow-up).
+
+Tests: canvas-worktree-root (store semantics incl. junction/symlink refusals,
+floor, per-session, revoke; pure naming helper), canvas-worktree-spawn (real
+spawnPty -> env var + store; poisoned resume target does not move it; no
+designation for non-primary / shell-only / home), session-guard-designated-
+worktree (real script against a throwaway repo: create / adopt / fall back /
+empty dir / relative hint ignored / unset). Mutation-checked: no anti-link
+check -> 3 tests fail; designate from the launch cwd -> poison test fails.
+
+Security-sensitive (served-root allowlist) -> ADR-009 adversarial pass on the PR.

--- a/CONTEXT.d/2026-08-17-canvas-serves-session-worktree.md
+++ b/CONTEXT.d/2026-08-17-canvas-serves-session-worktree.md
@@ -34,4 +34,23 @@ worktree (real script against a throwaway repo: create / adopt / fall back /
 empty dir / relative hint ignored / unset). Mutation-checked: no anti-link
 check -> 3 tests fail; designate from the launch cwd -> poison test fails.
 
+ADR-009 adversarial pass (7 attackers) found + fixed, all mutation-proven:
+- MAJOR guard adopted a worktree of a DIFFERENT repository at the designated path
+  (no this-repo check) -> compare git-common-dir (sameRepo) before adopting.
+- MAJOR same-tile adoption skipped liveness: a nested claude (same
+  CLAUDE_MULTI_SESSION_ID, own pid) stole the parent's LIVE worktree -> adopt a
+  same-tile worktree only when the prior process is gone/me.
+- MAJOR CCC_SESSION_WORKTREE was set-only, so an inherited value leaked into
+  non-designated (shell-only/codex/ssh/home) sessions -> scrub it from every
+  spawn env, set only when designating.
+- MAJOR designation derived from the LEXICAL project path, so a junction/symlink
+  in the configured path made it permanently unservable while the project root
+  served -> derive from the realpath.
+- MINOR 8-char segment collision -> 12 chars + the store refuses a designation
+  already recorded for another session; guard robustness (prune a stale
+  registration, drop own stale lease, fall back on worktree-add failure).
+The store security floor itself HELD every bypass (junction/symlink/hardlink/8.3/
+UNC/case/TOCTOU). One PRE-EXISTING note (UAT subordinate-asset hardlink exemption,
+identical on a plain live root) routed separately, not introduced here.
+
 Security-sensitive (served-root allowlist) -> ADR-009 adversarial pass on the PR.

--- a/architecture/decisions/2026-08-17-adr-016-canvas-serves-the-designated-session-worktree.md
+++ b/architecture/decisions/2026-08-17-adr-016-canvas-serves-the-designated-session-worktree.md
@@ -1,0 +1,92 @@
+# ADR-016: The canvas serves the session worktree CCC designates
+
+- Status: Accepted
+- Date: 2026-08-17
+
+## Context
+
+Two mandated features collided:
+
+- **Session isolation (ADR-012).** Every agent claims its own git worktree
+  (`<parent>/ccc-wt/<id>`) and a `PreToolUse` hook denies writes to the primary
+  checkout.
+- **Agent Canvas served roots.** `canvas_render { htmlPath }` and UAT `distRoot`
+  read files with the app's privileges, so they are confined to an allowlist
+  that is *exactly the session's configured project directory* -- the primary
+  checkout. Three adversarial reviews (2026-08-11, -14, -15) drove that
+  allowlist to where it is: per session, default-empty, realpath'd, floored
+  (never home, a volume root, or a dot-directory under home), and derived only
+  from the user's configuration -- **never from anything the agent can write**
+  (a transcript's cwd, a resume target, a plugin directory).
+
+So an agent that dutifully isolates itself writes its mockup into a directory
+the canvas refuses, and is forced to the inline `html` fallback -- the very
+form the skill tells it never to use (it floods the approval prompt with the
+whole document). Found while dogfooding the canvas for the beta.13 mockups.
+
+## Decision
+
+**CCC designates where the session's worktree lives, tells the guard, and
+serves that path -- pending until it really exists.**
+
+1. **Designation is CCC's own computation.** At spawn, `pty-manager` derives
+   `<worktree base>/<first 8 of the CCC session id>` from the *configured*
+   project directory (`resolveCwd(options.cwd)`, the same value the served root
+   uses -- never the transcript-derived launch cwd) and CCC's own session id.
+   The base mirrors the guard's default (`<parent of the primary checkout>/
+   ccc-wt`, or `CCC_WT_ROOT` from CCC's environment). Only for interactive
+   Claude sessions whose project is a primary git checkout (`.git` is a
+   directory); otherwise nothing is designated. (`src/main/canvas/canvas-worktree.ts`)
+2. **The guard is told, not asked.** The path goes into the PTY environment as
+   `CCC_SESSION_WORKTREE`. `session-guard claim` creates the worktree there, or
+   adopts the worktree an earlier conversation of the *same CCC session* left
+   there (a new `CLAUDE_CODE_SESSION_ID` after `/clear` or a restart). If the
+   directory is held by another live session or is not a worktree of this repo,
+   the guard falls back to its default location and says the canvas will not
+   serve it. Unset outside CCC: nothing changes.
+3. **The store treats it as a pending root.** `designateCanvasWorktreeRoot`
+   records the lexical path (floor-checked). At resolution it is honoured only
+   when it exists, is a real directory whose realpath *is* the designated path
+   (an agent that pre-creates it as a junction/symlink to somewhere it wants
+   read gets nothing), and passes the floor -- evaluated on every resolution, so
+   a directory swapped for a link stops serving immediately. Every candidate
+   file is still realpath'd itself, so a link planted inside cannot reach out.
+   The designation is per session and revoked with the session, like a live
+   root. (`src/main/canvas/canvas-store.ts`)
+
+Rejected alternatives -- both derive a served root from data the agent writes,
+the exact class the earlier reviews closed:
+
+- **Serve whatever the guard's lease says.** Leases live in
+  `<git-common-dir>/ccc-sessions/*.json`, written by a script the agent runs;
+  the agent can write any lease naming any directory.
+- **Serve any git worktree of a served root.** `.git/worktrees/*` and a
+  worktree's `.git` file are agent-writable; a forged entry names an arbitrary
+  directory. Even bidirectional verification only raises the bar to "write one
+  file outside cwd", and a served root must not rest on that.
+- **A user-configured "extra canvas roots" setting.** Sound (user-authorized)
+  and it would also cover other layouts, but it does not make the two mandated
+  features work together *out of the box*, and it grants the whole worktree
+  base rather than this session's worktree. Still a reasonable follow-up if a
+  project needs a served folder that is neither.
+
+## Consequences
+
+- An isolated agent's `htmlPath` and `distRoot` under its own worktree render.
+  The skill text now says so.
+- What a designated root can ever expose is *files physically under a directory
+  CCC named and the agent populated* -- the same trust level as the project
+  directory itself. Nothing an agent writes moves the designation; a link at or
+  above it disables it; a link inside it is contained.
+- Under CCC, a session's worktree is **per CCC session (tile)**, not per Claude
+  Code conversation: `/clear` and restarts adopt the same worktree (branch kept;
+  uncommitted work reported). Fewer orphaned worktrees. Outside CCC the guard is
+  unchanged. Two tiles whose ids share a prefix would collide on the directory;
+  the second falls back to the default location and is simply not served.
+- Limits: a project configured on a linked worktree or a non-repo gets no
+  designation (the guard has nothing to anchor to there either); a session that
+  claims elsewhere (a `CCC_WT_ROOT` set only in the agent's shell, an ignored
+  hint) is not served -- fail closed, today's behaviour, never misdirected.
+  Under a designation `--slug` names only the branch; the directory is CCC's.
+- Security-sensitive (served-root allowlist): ADR-009 adversarial pass required
+  and recorded on the PR.

--- a/architecture/decisions/2026-08-17-adr-016-canvas-serves-the-designated-session-worktree.md
+++ b/architecture/decisions/2026-08-17-adr-016-canvas-serves-the-designated-session-worktree.md
@@ -30,20 +30,32 @@ whole document). Found while dogfooding the canvas for the beta.13 mockups.
 serves that path -- pending until it really exists.**
 
 1. **Designation is CCC's own computation.** At spawn, `pty-manager` derives
-   `<worktree base>/<first 8 of the CCC session id>` from the *configured*
-   project directory (`resolveCwd(options.cwd)`, the same value the served root
-   uses -- never the transcript-derived launch cwd) and CCC's own session id.
-   The base mirrors the guard's default (`<parent of the primary checkout>/
-   ccc-wt`, or `CCC_WT_ROOT` from CCC's environment). Only for interactive
-   Claude sessions whose project is a primary git checkout (`.git` is a
-   directory); otherwise nothing is designated. (`src/main/canvas/canvas-worktree.ts`)
+   `<worktree base>/<first 12 of the CCC session id>` from the *configured*
+   project directory (`resolveCwd(options.cwd)`, canonicalised with `realpath` --
+   the same value the served root uses, never the transcript-derived launch cwd)
+   and CCC's own session id. Deriving from the realpath is what keeps the
+   designation live when the configured path reaches through a junction / symlink
+   / subst (the store serves a designated root only when its realpath is its own
+   lexical path). The base mirrors the guard's default (`<parent of the primary
+   checkout>/ccc-wt`, or `CCC_WT_ROOT` from CCC's environment). Only for
+   interactive Claude sessions whose project is a primary checkout (a `.git`
+   directory); otherwise nothing is designated, and any `CCC_SESSION_WORKTREE`
+   inherited from CCC's own environment is SCRUBBED from the child's PTY env so a
+   dev CCC launched from inside a guarded tile cannot leak the outer tile's
+   designation into a shell-only / non-repo session. (`src/main/canvas/canvas-worktree.ts`)
 2. **The guard is told, not asked.** The path goes into the PTY environment as
    `CCC_SESSION_WORKTREE`. `session-guard claim` creates the worktree there, or
-   adopts the worktree an earlier conversation of the *same CCC session* left
-   there (a new `CLAUDE_CODE_SESSION_ID` after `/clear` or a restart). If the
-   directory is held by another live session or is not a worktree of this repo,
-   the guard falls back to its default location and says the canvas will not
-   serve it. Unset outside CCC: nothing changes.
+   adopts the worktree a **previous conversation of the same CCC session whose
+   process has exited** left there (a new `CLAUDE_CODE_SESSION_ID` after `/clear`
+   or a restart). It does NOT adopt when a *concurrent live* process of the same
+   tile holds it -- a nested `claude` launched from inside the session inherits
+   `CLAUDE_MULTI_SESSION_ID` but has its own pid, and stealing its live worktree
+   would re-create the two-live-processes-one-branch collision ADR-012 exists to
+   prevent. It also falls back (to its default location, unserved) when the
+   directory is held by another tile, is a worktree of a *different* repository,
+   is on a detached HEAD, or cannot be created; and it prunes a stale
+   registration left by a hand-deleted worktree so a fixed per-tile path never
+   wedges. Unset outside CCC: nothing changes.
 3. **The store treats it as a pending root.** `designateCanvasWorktreeRoot`
    records the lexical path (floor-checked). At resolution it is honoured only
    when it exists, is a real directory whose realpath *is* the designated path
@@ -79,14 +91,18 @@ the exact class the earlier reviews closed:
   directory itself. Nothing an agent writes moves the designation; a link at or
   above it disables it; a link inside it is contained.
 - Under CCC, a session's worktree is **per CCC session (tile)**, not per Claude
-  Code conversation: `/clear` and restarts adopt the same worktree (branch kept;
-  uncommitted work reported). Fewer orphaned worktrees. Outside CCC the guard is
-  unchanged. Two tiles whose ids share a prefix would collide on the directory;
-  the second falls back to the default location and is simply not served.
+  Code conversation: `/clear` and restarts (a prior conversation whose process
+  exited) adopt the same worktree (branch kept; uncommitted work reported). Fewer
+  orphaned worktrees. Outside CCC the guard is unchanged. A cross-tile collision
+  on the 12-char segment is ~2^-48; were it to happen, the store refuses the
+  second session's designation (the first tile owns the directory it populated)
+  and the guard falls back -- the second tile is simply not served.
 - Limits: a project configured on a linked worktree or a non-repo gets no
   designation (the guard has nothing to anchor to there either); a session that
   claims elsewhere (a `CCC_WT_ROOT` set only in the agent's shell, an ignored
   hint) is not served -- fail closed, today's behaviour, never misdirected.
-  Under a designation `--slug` names only the branch; the directory is CCC's.
+  Under a designation `--slug` names only the branch; the directory is CCC's. The
+  same-tile liveness check uses a pid probe, so OS pid reuse can only make it
+  MORE conservative (fall back rather than adopt), never steal a live worktree.
 - Security-sensitive (served-root allowlist): ADR-009 adversarial pass required
   and recorded on the PR.

--- a/docs/session-isolation.md
+++ b/docs/session-isolation.md
@@ -36,11 +36,14 @@ environment carries `CCC_SESSION_WORKTREE` -- `../ccc-wt/<ccc-session>` -- and
 `claim` creates the worktree exactly there. That is the one path the Agent
 Canvas will serve, so a mockup written into your worktree renders by
 `htmlPath` (ADR-016). It is per CCC session (tile), not per conversation: after
-`/clear` or a restart, `claim` finds the earlier conversation's worktree there
-and **adopts it in place** -- same directory, same branch, uncommitted work
-reported in the output. Branch off `beta` yourself if you want a fresh start.
-If something else already holds the directory, `claim` says so and falls back
-to the default location (that worktree is then simply not canvas-served).
+`/clear` or a restart, `claim` finds the previous conversation's worktree there
+(its process having exited) and **adopts it in place** -- same directory, same
+branch, uncommitted work reported in the output. Branch off `beta` yourself if
+you want a fresh start. If the directory is held by a *concurrent live* process
+of the same tile (a nested `claude` you launched from inside the session), by
+another tile, or by a worktree of a different repository, `claim` says so and
+falls back to the default location (that worktree is then simply not
+canvas-served) -- it never takes over a worktree another live process is using.
 `--slug` names only the branch in this mode.
 
 Already standing in a worktree someone made for you -- by hand, or via Claude

--- a/docs/session-isolation.md
+++ b/docs/session-isolation.md
@@ -31,6 +31,18 @@ Creates `../ccc-wt/<session>` on `session/beta/<session>` branched from
 the branch and directory self-describing. Re-running is a no-op that reprints
 your existing worktree.
 
+**Under CCC (AI Code Conductor) the app chooses the directory.** The PTY
+environment carries `CCC_SESSION_WORKTREE` -- `../ccc-wt/<ccc-session>` -- and
+`claim` creates the worktree exactly there. That is the one path the Agent
+Canvas will serve, so a mockup written into your worktree renders by
+`htmlPath` (ADR-016). It is per CCC session (tile), not per conversation: after
+`/clear` or a restart, `claim` finds the earlier conversation's worktree there
+and **adopts it in place** -- same directory, same branch, uncommitted work
+reported in the output. Branch off `beta` yourself if you want a fresh start.
+If something else already holds the directory, `claim` says so and falls back
+to the default location (that worktree is then simply not canvas-served).
+`--slug` names only the branch in this mode.
+
 Already standing in a worktree someone made for you -- by hand, or via Claude
 Code's own `--worktree` / `EnterWorktree`? Take ownership of it instead:
 
@@ -125,7 +137,10 @@ shared checkout, and prefer `git -C` at a specific path over changing directory.
 - Leases live in `<git-common-dir>/ccc-sessions/` -- shared by every linked
   worktree, never tracked by git.
 - Worktree location defaults to `../ccc-wt/` beside the primary checkout;
-  override with `CCC_WT_ROOT`.
+  override with `CCC_WT_ROOT`. Under CCC the exact directory comes from
+  `CCC_SESSION_WORKTREE` (see "claim" above); CCC computes it from the same
+  `CCC_WT_ROOT` it was started with, so set that variable for the app, not just
+  in a shell, or the two disagree and the worktree is not canvas-served.
 - Worktrees share the primary checkout's object store, so they are cheap. They
   do **not** share `node_modules`; install per worktree, or junction it if the
   lockfile matches. Never run a native rebuild against a junctioned

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -189,6 +189,16 @@ function isPrimaryWorktree(dir) {
   return !!gitDir && !!common && samePath(gitDir, common)
 }
 
+/** True when dirA and dirB are worktrees of the SAME repository (shared object
+ *  store). A foreign repo's worktree at a designated path would have no lease in
+ *  this repo's registry, so every ownership check would pass and it would be
+ *  wrongly adopted -- this is the guard against that. */
+function sameRepo(dirA, dirB) {
+  const a = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd: dirA })
+  const b = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd: dirB })
+  return !!a && !!b && samePath(a, b)
+}
+
 /**
  * Take ownership of a worktree that already exists -- one made by hand, or by
  * Claude Code's own --worktree / EnterWorktree. Without this those arrive
@@ -259,6 +269,9 @@ function cmdClaim(args) {
     print(renderClaim(existing, 'already claimed'))
     return
   }
+  // Our previous worktree is gone (deleted by hand / release --remove-worktree):
+  // drop the stale own-lease so the writes below don't hit EEXIST ('wx').
+  if (existing) { try { fs.unlinkSync(existing._file) } catch { /* already gone */ } }
 
   const mainRoot = gitSafe(['rev-parse', '--path-format=absolute', '--show-toplevel'])
   if (!mainRoot) fail('run this from inside the repository (or a worktree of it).')
@@ -270,7 +283,8 @@ function cmdClaim(args) {
   const commonDir = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'])
   const primaryRoot = commonDir ? path.dirname(commonDir) : mainRoot
   const wtRoot = process.env.CCC_WT_ROOT || path.join(path.dirname(primaryRoot), 'ccc-wt')
-  let dir = path.join(wtRoot, slug ? `${short}-${slug}` : short)
+  const defaultDir = path.join(wtRoot, slug ? `${short}-${slug}` : short)
+  let dir = defaultDir
 
   // CCC designated a location for this session's worktree (the path the canvas
   // serves). Use it: create there, or adopt what an earlier conversation of the
@@ -314,7 +328,22 @@ function cmdClaim(args) {
   try {
     git(['worktree', 'add', '-b', branch, dir, startPoint])
   } catch (e) {
-    fail(`could not create worktree/branch '${branch}':\n${e.stderr || e.message}`)
+    // A CCC-designated location that could not be created (a race, leftover
+    // content) must not fail the whole claim -- fall back to the default
+    // location (unserved by the canvas) rather than leave the session with no
+    // worktree at all.
+    if (designated && samePath(dir, designated) && !samePath(dir, defaultDir)) {
+      print(`  note: could not create the worktree at the CCC-designated location (${(e.stderr || e.message || '').trim().split(/\r?\n/)[0]}); using the default location (the canvas will not serve this worktree).`)
+      dir = defaultDir
+      fs.mkdirSync(path.dirname(dir), { recursive: true })
+      try {
+        git(['worktree', 'add', '-b', branch, dir, startPoint])
+      } catch (e2) {
+        fail(`could not create worktree/branch '${branch}':\n${e2.stderr || e2.message}`)
+      }
+    } else {
+      fail(`could not create worktree/branch '${branch}':\n${e.stderr || e.message}`)
+    }
   }
 
   const lease = {
@@ -362,29 +391,58 @@ function isEmptyDir(p) {
  *   null                 -- unusable: fall back to the default location
  */
 function claimDesignated(designated, me, base) {
-  if (!fs.existsSync(designated) || isEmptyDir(designated)) return { dir: designated }
+  if (!fs.existsSync(designated) || isEmptyDir(designated)) {
+    // A worktree used to live here and its directory was removed by hand: git
+    // still has it registered and would refuse `worktree add`. Prune the stale
+    // registration first (safe + idempotent: prune only drops admin files for
+    // worktrees whose directory is gone) so a fixed per-tile path never wedges.
+    const registered = (gitSafe(['worktree', 'list', '--porcelain']) || '')
+      .split(/\r?\n/)
+      .some((l) => l.startsWith('worktree ') && samePath(l.slice('worktree '.length).trim(), designated))
+    if (registered) gitSafe(['worktree', 'prune'])
+    return { dir: designated }
+  }
   const root = worktreeRoot(designated)
   if (!root || !samePath(root, designated) || isPrimaryWorktree(root)) {
     print(`  note: CCC designated ${designated} for this session, but something else is there; using the default location (the canvas will not serve this worktree).`)
     return null
   }
+  // Must be a worktree of THIS repository. A foreign repo's worktree here has no
+  // lease in this repo's registry, so every check below would pass and we would
+  // adopt -- and be told to git -C -- the wrong repository (adversarial review).
+  if (!sameRepo(root, process.cwd())) {
+    print(`  note: CCC designated ${designated} for this session, but a worktree of a DIFFERENT repository is there; using the default location (the canvas will not serve this worktree).`)
+    return null
+  }
   const lease = readLeases(process.cwd()).find((l) => samePath(l.worktree, root))
   const myCccSession = process.env.CLAUDE_MULTI_SESSION_ID || null
   const sameCccSession = !!(lease && myCccSession && lease.multiSessionId === myCccSession)
-  if (lease && lease.sessionId !== me && lease._alive && !sameCccSession) {
-    print(`  note: CCC designated ${designated} for this session, but session ${shortId(lease.sessionId)} still holds it; using the default location (the canvas will not serve this worktree).`)
+  const myPid = Number(process.env.CLAUDE_PID) || process.ppid
+  // Adopt an earlier conversation of the SAME tile ONLY when its process is gone
+  // (or is me). A DIFFERENT live process with the same tile id -- a nested claude
+  // launched from inside the session, which inherits CLAUDE_MULTI_SESSION_ID but
+  // gets its own CLAUDE_CODE_SESSION_ID/pid -- must NOT steal the parent's live
+  // worktree; that re-creates the two-live-processes-one-branch collision the
+  // guard exists to prevent (adversarial review). pid reuse can only make this
+  // MORE conservative (fall back rather than adopt), never less.
+  const priorProcessGone = !lease || lease.sessionId === me || lease.pid === myPid || !pidAlive(lease.pid)
+  if (lease && lease.sessionId !== me && lease._alive && !(sameCccSession && priorProcessGone)) {
+    const who = sameCccSession
+      ? `a concurrent process of this CCC session (pid ${lease.pid}) holds it -- a nested claude? use that worktree, or the default here`
+      : `session ${shortId(lease.sessionId)} still holds it`
+    print(`  note: CCC designated ${designated} for this session, but ${who}; using the default location (the canvas will not serve this worktree).`)
     return null
   }
   const branch = gitSafe(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root }) || 'HEAD'
   if (branch === 'HEAD') {
-    print(`  note: CCC designated ${designated} for this session, but the worktree there is on a detached HEAD; using the default location.`)
+    print(`  note: CCC designated ${designated} for this session, but the worktree there is on a detached HEAD (finish/abort the rebase or check out a branch there, or set CCC_SESSION_GUARD=off to work in it); using the default location.`)
     return null
   }
   if (lease && lease.sessionId !== me) {
-    print(`  clearing lease of session ${shortId(lease.sessionId)} (${sameCccSession ? 'an earlier conversation of this CCC session' : `pid ${lease.pid}, not running`})`)
+    print(`  clearing lease of session ${shortId(lease.sessionId)} (${sameCccSession ? 'a previous conversation of this CCC session, exited' : `pid ${lease.pid}, not running`})`)
     fs.unlinkSync(lease._file)
   }
-  const dirty = (gitSafe(['status', '--porcelain'], { cwd: root }) || '').split('\n').filter((l) => l.trim().length > 0).length
+  const dirty = (gitSafe(['status', '--porcelain'], { cwd: root }) || '').split(/\r?\n/).filter((l) => l.trim().length > 0).length
   return { adopt: { root, branch, dirty }, base }
 }
 

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -322,22 +322,30 @@ function cmdClaim(args) {
   const startPoint = gitSafe(['rev-parse', '--verify', '--quiet', `origin/${base}`]) ? `origin/${base}` : base
   if (!gitSafe(['rev-parse', '--verify', '--quiet', startPoint])) fail(`base ref '${base}' does not exist.`)
 
-  fs.mkdirSync(path.dirname(dir), { recursive: true })
-  // `git worktree add -b` is the atomic step: if two sessions race the same
-  // branch, exactly one succeeds and the other lands here.
+  // Create the worktree. `-b <branch>` from the base for a fresh claim; a branch
+  // that already exists (a re-claim after `release --remove-worktree` left it
+  // behind) is REUSED at the new path, never recreated -- recreating would either
+  // double-fail on '-b' or discard the commits still on it. The whole step,
+  // including the parent mkdir, is one try so a bad DESIGNATED location (a file
+  // parent, a race, leftover content) falls back to the default location rather
+  // than fail the claim or throw a raw stack trace.
+  const addWorktreeAt = (targetDir) => {
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true })
+    const branchExists = !!gitSafe(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`])
+    if (branchExists) git(['worktree', 'add', targetDir, branch])
+    else git(['worktree', 'add', '-b', branch, targetDir, startPoint])
+  }
   try {
-    git(['worktree', 'add', '-b', branch, dir, startPoint])
+    addWorktreeAt(dir)
   } catch (e) {
-    // A CCC-designated location that could not be created (a race, leftover
-    // content) must not fail the whole claim -- fall back to the default
-    // location (unserved by the canvas) rather than leave the session with no
-    // worktree at all.
+    // A CCC-designated location that could not be created must not fail the whole
+    // claim -- fall back to the default location (unserved by the canvas) rather
+    // than leave the session with no worktree at all.
     if (designated && samePath(dir, designated) && !samePath(dir, defaultDir)) {
       print(`  note: could not create the worktree at the CCC-designated location (${(e.stderr || e.message || '').trim().split(/\r?\n/)[0]}); using the default location (the canvas will not serve this worktree).`)
       dir = defaultDir
-      fs.mkdirSync(path.dirname(dir), { recursive: true })
       try {
-        git(['worktree', 'add', '-b', branch, dir, startPoint])
+        addWorktreeAt(dir)
       } catch (e2) {
         fail(`could not create worktree/branch '${branch}':\n${e2.stderr || e2.message}`)
       }

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -23,6 +23,12 @@
 //   node scripts/session-guard.mjs hook            (PreToolUse; JSON on stdin)
 //
 // Escape hatch: CCC_SESSION_GUARD=off disables the hook's blocking.
+//
+// Under CCC (AI Code Conductor), CCC_SESSION_WORKTREE names the directory the
+// app has designated for THIS session's worktree -- the one path the Agent
+// Canvas will serve, so a mockup written there is renderable by htmlPath
+// (ADR-016). `claim` creates the worktree there, or adopts the one an earlier
+// conversation of the same CCC session left there. Unset outside CCC.
 
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -264,13 +270,45 @@ function cmdClaim(args) {
   const commonDir = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'])
   const primaryRoot = commonDir ? path.dirname(commonDir) : mainRoot
   const wtRoot = process.env.CCC_WT_ROOT || path.join(path.dirname(primaryRoot), 'ccc-wt')
-  const dir = path.join(wtRoot, slug ? `${short}-${slug}` : short)
+  let dir = path.join(wtRoot, slug ? `${short}-${slug}` : short)
+
+  // CCC designated a location for this session's worktree (the path the canvas
+  // serves). Use it: create there, or adopt what an earlier conversation of the
+  // same CCC session left there. When it is unusable, say so and fall back to
+  // the default location -- the worktree then simply is not canvas-served.
+  const designated = designatedWorktreeDir()
+  if (designated) {
+    const d = claimDesignated(designated, me, base)
+    if (d && d.adopt) {
+      const lease = {
+        sessionId: me,
+        multiSessionId: process.env.CLAUDE_MULTI_SESSION_ID || null,
+        pid: Number(process.env.CLAUDE_PID) || process.ppid,
+        worktree: d.adopt.root,
+        branch: d.adopt.branch,
+        base,
+        startPoint: null,
+        host: os.hostname(),
+        createdAt: new Date().toISOString(),
+        adopted: true,
+        designated: true,
+      }
+      fs.writeFileSync(path.join(leaseDir(process.cwd()), `${me}.json`), JSON.stringify(lease, null, 2), { flag: 'wx' })
+      print(renderClaim(lease, 'adopted (this CCC session\'s existing worktree)'))
+      if (d.adopt.dirty > 0) {
+        print(`  note: ${d.adopt.dirty} uncommitted change(s) from the previous conversation are still in it.`)
+      }
+      print(`  note: it is on branch ${d.adopt.branch}; branch off ${base} yourself if you want a fresh start.`)
+      return
+    }
+    if (d && d.dir) dir = d.dir
+  }
 
   // Prefer the remote base so a session never inherits another session's local drift.
   const startPoint = gitSafe(['rev-parse', '--verify', '--quiet', `origin/${base}`]) ? `origin/${base}` : base
   if (!gitSafe(['rev-parse', '--verify', '--quiet', startPoint])) fail(`base ref '${base}' does not exist.`)
 
-  fs.mkdirSync(wtRoot, { recursive: true })
+  fs.mkdirSync(path.dirname(dir), { recursive: true })
   // `git worktree add -b` is the atomic step: if two sessions race the same
   // branch, exactly one succeeds and the other lands here.
   try {
@@ -289,11 +327,65 @@ function cmdClaim(args) {
     startPoint,
     host: os.hostname(),
     createdAt: new Date().toISOString(),
+    designated: !!(designated && samePath(designated, dir)),
   }
   // 'wx' => fail if a lease for this session already exists (no silent clobber).
   fs.writeFileSync(path.join(leaseDir(process.cwd()), `${me}.json`), JSON.stringify(lease, null, 2), { flag: 'wx' })
 
   print(renderClaim(lease, 'claimed'))
+}
+
+/** The directory CCC designated for this session's worktree, or null. Must be
+ *  absolute; anything else is ignored (this is a hint from the app, not a
+ *  security boundary -- the canvas store enforces its own on the app side). */
+function designatedWorktreeDir() {
+  const raw = process.env.CCC_SESSION_WORKTREE
+  if (!raw || typeof raw !== 'string' || !path.isAbsolute(raw)) return null
+  return path.resolve(raw)
+}
+
+function isEmptyDir(p) {
+  try {
+    return fs.statSync(p).isDirectory() && fs.readdirSync(p).length === 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Decide what `claim` does with a CCC-designated directory:
+ *   { dir }              -- nothing (or an empty dir) is there: create the worktree at `dir`
+ *   { adopt: {...} }     -- a linked worktree of THIS repo is there and is free
+ *                           to take (unowned, its owner is dead, or its owner
+ *                           was an earlier conversation of this same CCC
+ *                           session): adopt it in place
+ *   null                 -- unusable: fall back to the default location
+ */
+function claimDesignated(designated, me, base) {
+  if (!fs.existsSync(designated) || isEmptyDir(designated)) return { dir: designated }
+  const root = worktreeRoot(designated)
+  if (!root || !samePath(root, designated) || isPrimaryWorktree(root)) {
+    print(`  note: CCC designated ${designated} for this session, but something else is there; using the default location (the canvas will not serve this worktree).`)
+    return null
+  }
+  const lease = readLeases(process.cwd()).find((l) => samePath(l.worktree, root))
+  const myCccSession = process.env.CLAUDE_MULTI_SESSION_ID || null
+  const sameCccSession = !!(lease && myCccSession && lease.multiSessionId === myCccSession)
+  if (lease && lease.sessionId !== me && lease._alive && !sameCccSession) {
+    print(`  note: CCC designated ${designated} for this session, but session ${shortId(lease.sessionId)} still holds it; using the default location (the canvas will not serve this worktree).`)
+    return null
+  }
+  const branch = gitSafe(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root }) || 'HEAD'
+  if (branch === 'HEAD') {
+    print(`  note: CCC designated ${designated} for this session, but the worktree there is on a detached HEAD; using the default location.`)
+    return null
+  }
+  if (lease && lease.sessionId !== me) {
+    print(`  clearing lease of session ${shortId(lease.sessionId)} (${sameCccSession ? 'an earlier conversation of this CCC session' : `pid ${lease.pid}, not running`})`)
+    fs.unlinkSync(lease._file)
+  }
+  const dirty = (gitSafe(['status', '--porcelain'], { cwd: root }) || '').split('\n').filter((l) => l.trim().length > 0).length
+  return { adopt: { root, branch, dirty }, base }
 }
 
 function renderClaim(lease, verb) {

--- a/src/main/canvas/canvas-plugin.ts
+++ b/src/main/canvas/canvas-plugin.ts
@@ -65,12 +65,16 @@ Tools (conductor MCP): \`canvas_render\`, \`canvas_snapshot\`, \`canvas_review\`
    canvas_render { mode: "design", htmlPath: "<absolute path>" }
 
    The canvas only reads files under THIS session's own project folder — the
-   directory configured for this session in CCC. A path outside it is refused,
-   so do not write the mockup to a temp or scratch directory, and note that
-   another session's project folder is refused too. (A session whose configured
-   folder is the user's home folder has no project folder at all and cannot
-   render by path; nor can one resuming a conversation from outside its
-   configured folder — say so and move on.) Never pass the document inline in \`html\` when you can write
+   directory configured for this session in CCC — and, if the project uses
+   session isolation (\`node scripts/session-guard.mjs claim\`), the worktree
+   CCC set aside for this session (the directory \`claim\` printed; also in
+   \`CCC_SESSION_WORKTREE\`). Write the mockup in whichever of those you are
+   working in. A path anywhere else is refused, so do not write it to a temp
+   or scratch directory, and note that another session's project folder or
+   worktree is refused too. (A session whose configured folder is the user's
+   home folder has no project folder at all and cannot render by path; nor can
+   one resuming a conversation from outside its configured folder — say so and
+   move on.) Never pass the document inline in \`html\` when you can write
    a file: the inline form floods the user's approval prompt with the whole
    document (it once cost a user eleven minutes on one render).
 4. Self-check before handing back: \`canvas_snapshot\` scoped to the
@@ -88,9 +92,10 @@ Build the project to a static directory with its own build command, then:
 
    canvas_render { mode: "uat", distRoot: "<absolute dist path>" }
 
-- \`distRoot\` must sit inside THIS session's own project folder — build there
-  (\`<project>/dist\`), not into a temp directory. There is no way for the user
-  to grant another folder, so if it is refused, move the build and retry.
+- \`distRoot\` must sit inside THIS session's own project folder or its
+  session worktree — build there (\`<project>/dist\`), not into a temp
+  directory. There is no way for the user to grant another folder, so if it is
+  refused, move the build and retry.
 - Pages that need a backend: mock the data layer inside the build. The canvas
   serves static files only, and a dead fetch shows up as a broken page.
 
@@ -117,8 +122,9 @@ resolved yourself — resolution is theirs.
 ## Exceptions you may hit
 
 - Render refused ("not inside this session's project folder"): write or build
-  the file inside the project folder configured for this session, then retry.
-  Do not ask the user to allow a folder — nothing in the app grants one.
+  the file inside the project folder configured for this session (or the
+  worktree CCC set aside for it), then retry. Do not ask the user to allow a
+  folder — nothing in the app grants one.
 - "version limit" on render: the canvas is full — continue in a new session.
 - Snapshot "did not finish loading in time": heavy page — retry once, then
   continue without the self-check and say you did.

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -205,6 +205,14 @@ export function designateCanvasWorktreeRoot(sessionId: string, dir: string): boo
   if (isHomeOrAncestor(lexical)) return false
   if (isVolumeRoot(lexical)) return false
   if (isDotDirUnderHome(lexical)) return false
+  // Refuse a path already designated for a DIFFERENT session. Distinct tiles
+  // derive distinct segments, so this only fires on a segment collision — and
+  // there the FIRST tile owns the directory it populated; serving it to a second
+  // tile would cross the per-session boundary (adversarial review). Fail closed:
+  // the second tile is simply not canvas-served.
+  for (const [otherSession, roots] of designatedRootsBySession) {
+    if (otherSession !== sessionId && roots.has(lexical)) return false
+  }
   let set = designatedRootsBySession.get(sessionId)
   if (!set) {
     set = new Set<string>()

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -72,6 +72,42 @@ const PROFILE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
  */
 const uatRootsBySession = new Map<string, Set<string>>()
 
+/**
+ * A session's DESIGNATED worktree root — a directory CCC named for it, that may
+ * or may not exist yet.
+ *
+ * Why this exists (2026-08-17): session isolation (ADR-012) has every agent
+ * claim its own git worktree beside the project (`<parent>/ccc-wt/<id>`) and
+ * the guard hook blocks writes to the primary checkout. The canvas served
+ * roots, meanwhile, are exactly the configured project directory. So an
+ * agent that dutifully isolates itself writes its mockup into a directory the
+ * canvas refuses to read: `canvas_render`'s `htmlPath` fails and it is forced
+ * to the inline fallback. Two mandated features in conflict.
+ *
+ * WHY NOT the obvious fixes. "Serve whatever the guard's lease says the
+ * session's worktree is" and "serve any git worktree of a served root" both
+ * derive a served root from data the AGENT writes (`.git/ccc-sessions/*.json`,
+ * `.git/worktrees/*`, a worktree's `.git` file). That is the exact class the
+ * three earlier canvas reviews closed (transcript cwd, resume cwd, plugin dir):
+ * a model that names its own allowlist entry. So instead CCC DESIGNATES the
+ * location — `<worktree base>/<ccc-session-short>`, computed in pty-manager
+ * from the CONFIGURED project directory and CCC's own session id, nothing the
+ * agent supplies — tells the guard where via CCC_SESSION_WORKTREE, and records
+ * it here. The guard creates the worktree there; if the agent claims anywhere
+ * else, its worktree is simply not served (fail closed, today's behaviour).
+ *
+ * A designated root is PENDING: it is stored lexically and consulted only at
+ * resolution time, when it must (a) exist, (b) be a real directory whose
+ * realpath IS the designated path — an agent that pre-creates the directory
+ * as a junction / symlink to somewhere else gets nothing, because serving is
+ * containment under the REALPATH and that would point elsewhere — and (c)
+ * pass the same floor as a live root. Only files physically under the
+ * designated directory can ever be served through it, and every candidate is
+ * still realpath'd itself, so a link planted inside cannot reach out.
+ * Revoked with the session, like a live root.
+ */
+const designatedRootsBySession = new Map<string, Set<string>>()
+
 /** `C:\`, `D:\`, `/`, `\\server\share\` — a whole volume is not a project. */
 function isVolumeRoot(p: string): boolean {
   // `C:\` → dirname is itself; `path.parse('/').root === '/'`. Both spellings
@@ -153,27 +189,102 @@ export function registerCanvasUatRoot(sessionId: string, baseDir: string): boole
   return true
 }
 
-/** Drop every root a session was allowed to serve. Called when its PTY is gone
- *  (pty-manager cleanupSessionResources) — a root outlives nothing. */
+/**
+ * Designate the directory the session's isolated worktree is expected at (see
+ * designatedRootsBySession). Nothing is checked on disk now — the directory
+ * usually does not exist yet — beyond the lexical floor: absolute, normalised,
+ * not home or an ancestor of it, not a volume root, not a dot-directory under
+ * home. Idempotent; returns true when recorded. Consulted by
+ * `resolveInsideCanvasRoot` / UAT `distRoot` only once it exists as a real,
+ * un-linked directory.
+ */
+export function designateCanvasWorktreeRoot(sessionId: string, dir: string): boolean {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return false
+  if (typeof dir !== 'string' || dir.length === 0 || !path.isAbsolute(dir)) return false
+  const lexical = path.resolve(dir)
+  if (isHomeOrAncestor(lexical)) return false
+  if (isVolumeRoot(lexical)) return false
+  if (isDotDirUnderHome(lexical)) return false
+  let set = designatedRootsBySession.get(sessionId)
+  if (!set) {
+    set = new Set<string>()
+    designatedRootsBySession.set(sessionId, set)
+  }
+  set.add(lexical)
+  return true
+}
+
+/** Same-path test for the anti-link check: the filesystem's own notion of
+ *  equality — case-insensitive on Windows and macOS, exact elsewhere. */
+function sameFsPath(a: string, b: string): boolean {
+  const norm = (p: string) => {
+    const r = p.replace(/[\\/]+$/, '')
+    return process.platform === 'win32' || process.platform === 'darwin' ? r.toLowerCase() : r
+  }
+  return norm(a) === norm(b)
+}
+
+/**
+ * The live real path of a designated root, or null while it is not servable:
+ * missing, not a directory, a junction/symlink (its realpath is somewhere else
+ * — the agent pre-created it pointing at a directory it wants read), or a
+ * realpath the floor refuses. Evaluated on EVERY resolution: a directory that
+ * was real yesterday and is a junction today stops serving today.
+ */
+function liveDesignatedRoot(lexical: string): string | null {
+  let real: string
+  try {
+    real = fs.realpathSync.native(lexical)
+  } catch {
+    return null // not there (yet)
+  }
+  if (!sameFsPath(real, lexical)) return null // a link, or a link on the way
+  try {
+    if (!fs.statSync(real).isDirectory()) return null
+  } catch {
+    return null
+  }
+  if (isHomeOrAncestor(real)) return null
+  if (isVolumeRoot(real)) return null
+  if (isDotDirUnderHome(real)) return null
+  return real
+}
+
+/** Drop every root a session was allowed to serve — live and designated.
+ *  Called when its PTY is gone (pty-manager cleanupSessionResources) — a root
+ *  outlives nothing. */
 export function revokeCanvasUatRoots(sessionId: string): void {
   uatRootsBySession.delete(sessionId)
+  designatedRootsBySession.delete(sessionId)
 }
 
 /** True iff `candidate` physically resolves at/under a base registered for
- *  THIS session. realpath both sides so a symlinked base or candidate cannot
- *  dodge the check. Unknown session ⇒ no roots ⇒ false (fail closed). */
+ *  THIS session — a live root, or a designated worktree root that is live
+ *  right now (liveDesignatedRoot). realpath both sides so a symlinked base or
+ *  candidate cannot dodge the check. Unknown session ⇒ no roots ⇒ false (fail
+ *  closed). */
 function resolvesUnderSessionRoot(candidate: string, sessionId: string): string | null {
   if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return null
   const roots = uatRootsBySession.get(sessionId)
-  if (!roots || roots.size === 0) return null
+  const designated = designatedRootsBySession.get(sessionId)
+  if ((!roots || roots.size === 0) && (!designated || designated.size === 0)) return null
   let real: string
   try {
     real = fs.realpathSync.native(candidate)
   } catch {
     return null
   }
-  for (const base of roots) {
-    if (real === base || real.startsWith(base + path.sep)) return real
+  if (roots) {
+    for (const base of roots) {
+      if (real === base || real.startsWith(base + path.sep)) return real
+    }
+  }
+  if (designated) {
+    for (const lexical of designated) {
+      const base = liveDesignatedRoot(lexical)
+      if (base === null) continue
+      if (real === base || real.startsWith(base + path.sep)) return real
+    }
   }
   return null
 }
@@ -990,6 +1101,7 @@ export function _resetCanvasStoreForTest(): void {
   canvases.clear()
   sessionIndex.clear()
   uatRootsBySession.clear()
+  designatedRootsBySession.clear()
   diskScanned = false
   sessionInfoResolver = null
   _canvasRecordKey = null

--- a/src/main/canvas/canvas-worktree.ts
+++ b/src/main/canvas/canvas-worktree.ts
@@ -1,0 +1,77 @@
+// Agent Canvas — where a session's isolated git worktree is designated to live.
+//
+// Session isolation (ADR-012, scripts/session-guard.mjs) puts every agent in
+// its own worktree beside the project and blocks writes to the primary
+// checkout. The canvas serves only the configured project directory. So an
+// agent that isolates itself cannot `canvas_render` a file it wrote (its
+// worktree is not a served root) and falls back to inline HTML.
+//
+// The fix is for CCC — not the agent, not the guard's lease, not git metadata
+// — to DECIDE the worktree location, tell the guard (CCC_SESSION_WORKTREE) and
+// designate the same path as a pending canvas root
+// (canvas-store.designateCanvasWorktreeRoot). Every input here is CCC's own:
+// the CONFIGURED project directory (resolveCwd of the session config) and the
+// CCC session id. The naming mirrors the guard's own default so a session that
+// runs the guard OUTSIDE CCC lands in the same neighbourhood; only the last
+// segment differs (CCC's session id rather than Claude Code's, which CCC cannot
+// know before the CLI starts). See docs/session-isolation.md and ADR-016.
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+/** The worktree base directory the guard uses: `CCC_WT_ROOT` when CCC's own
+ *  environment sets it (the guard reads the same variable, inherited from
+ *  CCC), else `<parent of the primary checkout>/ccc-wt`. */
+export function worktreeBaseDir(primaryCheckout: string, env: NodeJS.ProcessEnv): string {
+  const configured = env.CCC_WT_ROOT
+  if (typeof configured === 'string' && configured.trim().length > 0 && path.isAbsolute(configured.trim())) {
+    return path.resolve(configured.trim())
+  }
+  return path.join(path.dirname(primaryCheckout), 'ccc-wt')
+}
+
+/** The guard names worktrees by the first id segment; CCC ids are 24 hex chars
+ *  with no dashes, so take the first 8 (path-safe by the IPC charset guard). */
+export function shortSessionId(sessionId: string): string {
+  return sessionId.slice(0, 8)
+}
+
+export interface DesignateDeps {
+  env: NodeJS.ProcessEnv
+  /** True when `dir/.git` is a DIRECTORY — a primary checkout. The guard anchors
+   *  worktrees to the primary checkout; from a linked worktree (`.git` is a
+   *  file) or a non-repo we would only be guessing, and a guess is not a
+   *  served root. */
+  isPrimaryCheckout: (dir: string) => boolean
+}
+
+export const nodeDesignateDeps: DesignateDeps = {
+  env: process.env,
+  isPrimaryCheckout: (dir) => {
+    try {
+      return fs.statSync(path.join(dir, '.git')).isDirectory()
+    } catch {
+      return false
+    }
+  },
+}
+
+/**
+ * The directory the session's guard worktree is designated to live in, or null
+ * when it cannot be derived (the configured project is not a primary git
+ * checkout). Pure given deps: `<worktreeBaseDir>/<shortSessionId>`.
+ *
+ * Callers pass the CONFIGURED project directory (`resolvedCwd`), never a
+ * transcript-derived launch cwd — the same rule the served roots follow.
+ */
+export function designatedWorktreeDir(
+  projectDir: string,
+  sessionId: string,
+  deps: DesignateDeps = nodeDesignateDeps,
+): string | null {
+  if (typeof projectDir !== 'string' || !path.isAbsolute(projectDir)) return null
+  if (typeof sessionId !== 'string' || !/^[A-Za-z0-9_-]{8,128}$/.test(sessionId)) return null
+  const project = path.resolve(projectDir)
+  if (!deps.isPrimaryCheckout(project)) return null
+  return path.join(worktreeBaseDir(project, deps.env), shortSessionId(sessionId))
+}

--- a/src/main/canvas/canvas-worktree.ts
+++ b/src/main/canvas/canvas-worktree.ts
@@ -30,14 +30,18 @@ export function worktreeBaseDir(primaryCheckout: string, env: NodeJS.ProcessEnv)
   return path.join(path.dirname(primaryCheckout), 'ccc-wt')
 }
 
-/** The guard names worktrees by the first id segment; CCC ids are 24 hex chars
- *  with no dashes, so take the first 8 (path-safe by the IPC charset guard). */
+/** The segment CCC names the session's worktree by. CCC ids are 24 hex chars
+ *  with no dashes; 12 keeps the directory short while making a cross-tile
+ *  collision on the segment (which would let one tile's canvas serve another's
+ *  worktree) ~2^-48 rather than ~2^-32. Path-safe by the IPC charset guard. */
 export function shortSessionId(sessionId: string): string {
-  return sessionId.slice(0, 8)
+  return sessionId.slice(0, 12)
 }
 
 export interface DesignateDeps {
   env: NodeJS.ProcessEnv
+  /** Canonicalise a path (fs.realpathSync.native). Injected for tests. */
+  realpath: (p: string) => string
   /** True when `dir/.git` is a DIRECTORY — a primary checkout. The guard anchors
    *  worktrees to the primary checkout; from a linked worktree (`.git` is a
    *  file) or a non-repo we would only be guessing, and a guess is not a
@@ -47,6 +51,7 @@ export interface DesignateDeps {
 
 export const nodeDesignateDeps: DesignateDeps = {
   env: process.env,
+  realpath: (p) => fs.realpathSync.native(p),
   isPrimaryCheckout: (dir) => {
     try {
       return fs.statSync(path.join(dir, '.git')).isDirectory()
@@ -70,8 +75,21 @@ export function designatedWorktreeDir(
   deps: DesignateDeps = nodeDesignateDeps,
 ): string | null {
   if (typeof projectDir !== 'string' || !path.isAbsolute(projectDir)) return null
-  if (typeof sessionId !== 'string' || !/^[A-Za-z0-9_-]{8,128}$/.test(sessionId)) return null
-  const project = path.resolve(projectDir)
+  if (typeof sessionId !== 'string' || !/^[A-Za-z0-9_-]{12,128}$/.test(sessionId)) return null
+  // Canonicalise the project directory: the guard creates the worktree at a real
+  // path, and the canvas store only serves a designated root whose realpath IS
+  // its lexical path. If the CONFIGURED project reaches through a junction /
+  // symlink / subst (a Dev Drive junction, a symlinked ~/projects, macOS /tmp),
+  // a lexical designation would derive from the link spelling and could never go
+  // live even though the guard populated it. Deriving from the realpath lines
+  // the two up. Fall back to lexical if it does not resolve (it must exist —
+  // isPrimaryCheckout stat'd its .git — but never throw here).
+  let project: string
+  try {
+    project = deps.realpath(path.resolve(projectDir))
+  } catch {
+    project = path.resolve(projectDir)
+  }
   if (!deps.isPrimaryCheckout(project)) return null
   return path.join(worktreeBaseDir(project, deps.env), shortSessionId(sessionId))
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -36,7 +36,8 @@ import {
 } from './hooks/per-session-settings'
 import { registerCodexReviewSession, unregisterCodexReviewSession } from './conductor-mcp-server'
 import { ensureCanvasPlugin } from './canvas/canvas-plugin'
-import { registerCanvasUatRoot, revokeCanvasUatRoots } from './canvas/canvas-store'
+import { registerCanvasUatRoot, revokeCanvasUatRoots, designateCanvasWorktreeRoot } from './canvas/canvas-store'
+import { designatedWorktreeDir } from './canvas/canvas-worktree'
 import { forgetSessionForCanvas } from './canvas/canvas-session-link'
 import { disposeSession as disposeCodexReviewUsage } from './codex-review-usage'
 import { readCodexAccountEmail } from './account-identity'
@@ -1077,6 +1078,20 @@ export function spawnPty(
     // session-state.json and label conversations with their CCC work name
     // (customName). Read-only, best-effort — never block the spawn (#130).
     try { finalSpawnEnv.CCC_CONFIG_DIR = getConfigDir() } catch { /* best-effort */ }
+    // Session isolation + Agent Canvas (ADR-016): CCC DESIGNATES where this
+    // session's guard worktree lives — `<worktree base>/<ccc-session-short>`,
+    // derived from the CONFIGURED project directory and CCC's own session id,
+    // never from anything the agent writes — tells the guard through
+    // CCC_SESSION_WORKTREE, and (below, once the project itself is registered
+    // as a served root) designates the same path as a pending canvas root, so
+    // a mockup the agent writes into its own worktree is renderable by
+    // htmlPath. Interactive Claude sessions only: the canvas is bound to those.
+    // Null when the project is not a primary git checkout (the guard has
+    // nothing to anchor to there either).
+    const designatedWorktree = !shellOnly && !isHomeOrAncestor(resolvedCwd)
+      ? designatedWorktreeDir(resolvedCwd, sessionId)
+      : null
+    if (designatedWorktree) finalSpawnEnv.CCC_SESSION_WORKTREE = designatedWorktree
     logInfo(`[profiles] session ${sessionId} account spawn: requestedProfileId=${wantProfileId ?? '(none)'} resolvedProfileId=${resolvedProfileId ?? '(none/bare-global)'} shellOnly=${shellOnly} USERPROFILE=${home ?? '(real home)'}`)
     // Reliable, drift-immune account identity: capture once at spawn from the
     // session's profile (or the default ~/.claude.json), never re-read.
@@ -1300,6 +1315,17 @@ export function spawnPty(
         // between a prompt-injected agent and a file read with the app's
         // privileges.
         logWarn(`[pty] canvas serving root NOT registered for ${sessionId}: the configured project directory was refused by the canvas store.`)
+      } else if (designatedWorktree) {
+        // The project is servable, so the worktree CCC designated beside it is
+        // too — PENDING: the store consults it only once it exists as a real,
+        // un-linked directory (canvas-store.designateCanvasWorktreeRoot). The
+        // path is CCC's, the contents are the agent's own; nothing an agent can
+        // write moves it (ADR-016).
+        if (designateCanvasWorktreeRoot(sessionId, designatedWorktree)) {
+          logInfo(`[pty] canvas: designated session worktree ${designatedWorktree} for ${sessionId} (served once it exists)`)
+        } else {
+          logWarn(`[pty] canvas: designated session worktree ${designatedWorktree} for ${sessionId} was refused by the canvas store floor.`)
+        }
       }
 
       // Explicitly cd to the project directory, then launch Claude.

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -424,12 +424,17 @@ export function spawnPty(
 
     const sshBinary = os.platform() === 'win32' ? 'ssh.exe' : 'ssh'
 
+    // SSH sessions never designate a canvas worktree (their cwd is remote); pass
+    // a clone with any inherited CCC_SESSION_WORKTREE removed, never process.env
+    // by reference (which we must not mutate).
+    const sshEnv = { ...(process.env as Record<string, string>) }
+    delete sshEnv.CCC_SESSION_WORKTREE
     ptyProcess = pty.spawn(sshBinary, sshArgs, {
       name: 'xterm-256color',
       cols,
       rows,
       cwd: os.homedir(),
-      env: process.env as Record<string, string>,
+      env: sshEnv,
       useConpty: true
     })
 
@@ -959,6 +964,8 @@ export function spawnPty(
         codexOptions: options?.codexOptions,
       })
       logInfo(`[pty-manager] Launching Codex PTY: ${spawnCmd} ${spawnArgs.join(' ')} cwd=${resolvedCwd}`)
+      // Codex sessions never designate a canvas worktree; drop any inherited hint.
+      delete (spawnEnv as Record<string, string>).CCC_SESSION_WORKTREE
       // Capture timestamp before spawn so the watch-and-claim window starts no later than PTY launch.
       const codexSpawnTimestamp = Date.now()
       ptyProcess = pty.spawn(spawnCmd, spawnArgs, {
@@ -1091,7 +1098,12 @@ export function spawnPty(
     const designatedWorktree = !shellOnly && !isHomeOrAncestor(resolvedCwd)
       ? designatedWorktreeDir(resolvedCwd, sessionId)
       : null
+    // Set only when THIS session designates; otherwise DELETE any value inherited
+    // from CCC's own environment (a dev CCC launched from inside a guarded tile
+    // inherits the outer tile's CCC_SESSION_WORKTREE — it must not leak into a
+    // shell-only / home-project / non-designated session and misdirect its guard).
     if (designatedWorktree) finalSpawnEnv.CCC_SESSION_WORKTREE = designatedWorktree
+    else delete finalSpawnEnv.CCC_SESSION_WORKTREE
     logInfo(`[profiles] session ${sessionId} account spawn: requestedProfileId=${wantProfileId ?? '(none)'} resolvedProfileId=${resolvedProfileId ?? '(none/bare-global)'} shellOnly=${shellOnly} USERPROFILE=${home ?? '(real home)'}`)
     // Reliable, drift-immune account identity: capture once at spawn from the
     // session's profile (or the default ~/.claude.json), never re-read.

--- a/tests/unit/main/canvas-worktree-root.test.ts
+++ b/tests/unit/main/canvas-worktree-root.test.ts
@@ -144,6 +144,19 @@ describe('designateCanvasWorktreeRoot — a pending root that serves only once i
     expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), SID)).toThrow(/registered canvas root/i)
   })
 
+  it('refuses a designation already recorded for a DIFFERENT session (segment collision → second not served)', () => {
+    const base = tmp('ccc-wt-coll-')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'mock.html'), 'm')
+    // Two sessions whose 12-char segments collided onto the same directory.
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(designateCanvasWorktreeRoot(OTHER, designated)).toBe(false)   // refused
+    // The first session it belongs to serves it; the second never does.
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).not.toThrow()
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'mock.html'), OTHER)).toThrow(/registered canvas root/i)
+  })
+
   it('coexists with a live root: the project AND the designated worktree both resolve', () => {
     const project = tmp('ccc-wt-proj-')
     fs.writeFileSync(path.join(project, 'index.html'), 'p')
@@ -160,21 +173,23 @@ describe('designateCanvasWorktreeRoot — a pending root that serves only once i
 
 describe('designatedWorktreeDir — CCC names the location from its own inputs', () => {
   const primary = (dir: string) => path.basename(dir) === 'project'
+  // realpath identity: the synthetic paths here do not exist on disk.
+  const rp = (x: string) => x
   const noEnv = {} as NodeJS.ProcessEnv
 
   it('is <parent of the primary checkout>/ccc-wt/<first 8 of the CCC session id>', () => {
     const project = path.join(os.tmpdir(), 'somewhere', 'project')
-    expect(designatedWorktreeDir(project, SID, { env: noEnv, isPrimaryCheckout: primary })).toBe(
-      path.join(os.tmpdir(), 'somewhere', 'ccc-wt', 'wt1111wt'),
+    expect(designatedWorktreeDir(project, SID, { env: noEnv, realpath: rp, isPrimaryCheckout: primary })).toBe(
+      path.join(os.tmpdir(), 'somewhere', 'ccc-wt', 'wt1111wt1111'),
     )
-    expect(shortSessionId(SID)).toBe('wt1111wt')
+    expect(shortSessionId(SID)).toBe('wt1111wt1111')
   })
 
   it('honours CCC_WT_ROOT from CCC’s own environment (the guard inherits the same variable)', () => {
     const project = path.join(os.tmpdir(), 'somewhere', 'project')
     const wt = path.join(os.tmpdir(), 'my-wt')
-    expect(designatedWorktreeDir(project, SID, { env: { CCC_WT_ROOT: wt }, isPrimaryCheckout: primary })).toBe(
-      path.join(wt, 'wt1111wt'),
+    expect(designatedWorktreeDir(project, SID, { env: { CCC_WT_ROOT: wt }, realpath: rp, isPrimaryCheckout: primary })).toBe(
+      path.join(wt, 'wt1111wt1111'),
     )
     // A relative CCC_WT_ROOT is ignored (the guard would resolve it against ITS
     // cwd — a place CCC cannot predict).
@@ -183,11 +198,34 @@ describe('designatedWorktreeDir — CCC names the location from its own inputs',
 
   it('returns null when the project is not a primary git checkout, or inputs are malformed', () => {
     const notPrimary = path.join(os.tmpdir(), 'somewhere', 'worktree')
-    expect(designatedWorktreeDir(notPrimary, SID, { env: noEnv, isPrimaryCheckout: primary })).toBeNull()
+    expect(designatedWorktreeDir(notPrimary, SID, { env: noEnv, realpath: rp, isPrimaryCheckout: primary })).toBeNull()
     const project = path.join(os.tmpdir(), 'somewhere', 'project')
-    expect(designatedWorktreeDir('relative/project', SID, { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
-    expect(designatedWorktreeDir(project, 'short', { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
-    expect(designatedWorktreeDir(project, 'bad id with spaces!', { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
+    expect(designatedWorktreeDir('relative/project', SID, { env: noEnv, realpath: rp, isPrimaryCheckout: () => true })).toBeNull()
+    expect(designatedWorktreeDir(project, 'short', { env: noEnv, realpath: rp, isPrimaryCheckout: () => true })).toBeNull()
+    expect(designatedWorktreeDir(project, 'bad id with spaces!', { env: noEnv, realpath: rp, isPrimaryCheckout: () => true })).toBeNull()
+  })
+
+  it('derives from the REALPATH of the project, so a junction in the configured path still yields a servable designation', () => {
+    // Configured project reached through a junction: <base>/link -> <base>/real,
+    // project = <base>/link/project. A LEXICAL designation (<base>/link/ccc-wt/..)
+    // could never go live (its realpath differs); deriving from the realpath
+    // (<base>/real/ccc-wt/..) is what the guard actually creates.
+    const base = tmp('ccc-wt-jxproj-')
+    const real = path.join(base, 'real')
+    fs.mkdirSync(path.join(real, 'project'), { recursive: true })
+    linkDir(real, path.join(base, 'link'))
+    const configured = path.join(base, 'link', 'project')
+    const designated = designatedWorktreeDir(configured, SID, {
+      env: {} as NodeJS.ProcessEnv,
+      realpath: (x) => fs.realpathSync.native(x),
+      isPrimaryCheckout: () => true,
+    })
+    expect(designated).toBe(path.join(real, 'ccc-wt', shortSessionId(SID)))
+    // And that designated dir, once created, is servable (realpath === lexical).
+    fs.mkdirSync(designated!, { recursive: true })
+    fs.writeFileSync(path.join(designated!, 'mock.html'), 'm')
+    expect(designateCanvasWorktreeRoot(SID, designated!)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(designated!, 'mock.html'), SID)).not.toThrow()
   })
 
   it('the real isPrimaryCheckout dep: `.git` directory → yes; `.git` file (linked worktree) or none → no', async () => {

--- a/tests/unit/main/canvas-worktree-root.test.ts
+++ b/tests/unit/main/canvas-worktree-root.test.ts
@@ -1,0 +1,204 @@
+// Agent Canvas serves the session's DESIGNATED worktree (ADR-016).
+//
+// Session isolation puts every agent in `<parent>/ccc-wt/<id>` and blocks
+// writes to the primary checkout; the canvas served roots were exactly the
+// primary checkout. So an isolated agent could not `canvas_render` a file it
+// wrote. CCC now designates the worktree location itself (canvas-worktree.ts)
+// and records it as a PENDING root (canvas-store.designateCanvasWorktreeRoot):
+// consulted only once it exists as a real, un-linked directory that passes the
+// floor. These tests pin the store semantics and the pure naming helper.
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import {
+  designateCanvasWorktreeRoot,
+  registerCanvasUatRoot,
+  resolveInsideCanvasRoot,
+  revokeCanvasUatRoots,
+  _resetCanvasStoreForTest,
+} from '../../../src/main/canvas/canvas-store'
+import { designatedWorktreeDir, worktreeBaseDir, shortSessionId } from '../../../src/main/canvas/canvas-worktree'
+
+const SID = 'wt1111wt1111wt1111wt1111'
+const OTHER = 'ot2222ot2222ot2222ot2222'
+
+const tempDirs: string[] = []
+function tmp(prefix: string): string {
+  const d = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tempDirs.push(d)
+  return d
+}
+afterAll(() => {
+  for (const d of tempDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
+})
+
+/** A directory link: junction on Windows (no privilege needed), symlink elsewhere. */
+function linkDir(target: string, link: string): void {
+  fs.symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir')
+}
+
+beforeEach(() => _resetCanvasStoreForTest())
+
+describe('designateCanvasWorktreeRoot — a pending root that serves only once it is real', () => {
+  it('serves nothing while the designated directory does not exist, then serves it once it does', () => {
+    const base = tmp('ccc-wt-base-')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+
+    // Not there yet → refused (fail closed), and the store does not throw or create it.
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).toThrow(/registered canvas root/i)
+    expect(fs.existsSync(designated)).toBe(false)
+
+    // The agent's guard claims the worktree there and writes a mockup → served.
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'mock.html'), '<html></html>')
+    expect(resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).toBe(
+      fs.realpathSync.native(path.join(designated, 'mock.html')),
+    )
+    // Containment still holds: a sibling of the designated dir is not served.
+    fs.writeFileSync(path.join(base, 'ccc-wt', 'other.html'), '<html></html>')
+    expect(() => resolveInsideCanvasRoot(path.join(base, 'ccc-wt', 'other.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('refuses a designated directory the agent pre-created as a junction / symlink to somewhere else', () => {
+    const base = tmp('ccc-wt-link-')
+    const secrets = path.join(base, 'secrets')
+    fs.mkdirSync(secrets)
+    fs.writeFileSync(path.join(secrets, 'token.html'), 'PRIVATE')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    fs.mkdirSync(path.dirname(designated), { recursive: true })
+    linkDir(secrets, designated)
+    expect(fs.existsSync(path.join(designated, 'token.html'))).toBe(true) // the link works…
+
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    // …but the realpath of the designated dir is `secrets`, not itself → not live.
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'token.html'), SID)).toThrow(/registered canvas root/i)
+    expect(() => resolveInsideCanvasRoot(path.join(secrets, 'token.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('refuses when a PARENT of the designated directory is a link (realpath differs anywhere on the way)', () => {
+    const base = tmp('ccc-wt-plink-')
+    const elsewhere = path.join(base, 'elsewhere')
+    fs.mkdirSync(path.join(elsewhere, 'abcd1234'), { recursive: true })
+    fs.writeFileSync(path.join(elsewhere, 'abcd1234', 'x.html'), 'x')
+    linkDir(elsewhere, path.join(base, 'ccc-wt')) // ccc-wt → elsewhere
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'x.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('a link planted INSIDE a live designated worktree cannot reach out (candidate is realpath’d)', () => {
+    const base = tmp('ccc-wt-inner-')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    fs.mkdirSync(designated, { recursive: true })
+    const outside = path.join(base, 'outside')
+    fs.mkdirSync(outside)
+    fs.writeFileSync(path.join(outside, 'secret.html'), 'PRIVATE')
+    linkDir(outside, path.join(designated, 'esc'))
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'esc', 'secret.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('stops serving the moment the real directory is swapped for a link (evaluated on every resolution)', () => {
+    const base = tmp('ccc-wt-swap-')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'a.html'), 'a')
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), SID)).not.toThrow()
+
+    fs.rmSync(designated, { recursive: true, force: true })
+    const secrets = path.join(base, 'secrets')
+    fs.mkdirSync(secrets)
+    fs.writeFileSync(path.join(secrets, 'a.html'), 'PRIVATE')
+    linkDir(secrets, designated)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('applies the same floor as a live root at designation time', () => {
+    const home = fs.realpathSync.native(os.homedir())
+    expect(designateCanvasWorktreeRoot(SID, home)).toBe(false)
+    expect(designateCanvasWorktreeRoot(SID, path.dirname(home))).toBe(false) // ancestor of home
+    expect(designateCanvasWorktreeRoot(SID, path.join(home, '.claude', 'ccc-wt', 'x'))).toBe(false) // dot-dir under home
+    expect(designateCanvasWorktreeRoot(SID, path.parse(home).root)).toBe(false) // volume root
+    expect(designateCanvasWorktreeRoot(SID, 'relative/ccc-wt/x')).toBe(false)
+    expect(designateCanvasWorktreeRoot('', path.join(os.tmpdir(), 'x'))).toBe(false)
+    expect(designateCanvasWorktreeRoot('bad id!', path.join(os.tmpdir(), 'x'))).toBe(false)
+  })
+
+  it('is per session: another session cannot resolve through it, and revoke drops it', () => {
+    const base = tmp('ccc-wt-sess-')
+    const designated = path.join(base, 'ccc-wt', 'abcd1234')
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'a.html'), 'a')
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), SID)).not.toThrow()
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), OTHER)).toThrow(/registered canvas root/i)
+
+    revokeCanvasUatRoots(SID)
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'a.html'), SID)).toThrow(/registered canvas root/i)
+  })
+
+  it('coexists with a live root: the project AND the designated worktree both resolve', () => {
+    const project = tmp('ccc-wt-proj-')
+    fs.writeFileSync(path.join(project, 'index.html'), 'p')
+    const designated = path.join(path.dirname(project), 'ccc-wt-test-' + path.basename(project), 'abcd1234')
+    tempDirs.push(path.dirname(designated))
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'mock.html'), 'm')
+    expect(registerCanvasUatRoot(SID, project)).toBe(true)
+    expect(designateCanvasWorktreeRoot(SID, designated)).toBe(true)
+    expect(() => resolveInsideCanvasRoot(path.join(project, 'index.html'), SID)).not.toThrow()
+    expect(() => resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).not.toThrow()
+  })
+})
+
+describe('designatedWorktreeDir — CCC names the location from its own inputs', () => {
+  const primary = (dir: string) => path.basename(dir) === 'project'
+  const noEnv = {} as NodeJS.ProcessEnv
+
+  it('is <parent of the primary checkout>/ccc-wt/<first 8 of the CCC session id>', () => {
+    const project = path.join(os.tmpdir(), 'somewhere', 'project')
+    expect(designatedWorktreeDir(project, SID, { env: noEnv, isPrimaryCheckout: primary })).toBe(
+      path.join(os.tmpdir(), 'somewhere', 'ccc-wt', 'wt1111wt'),
+    )
+    expect(shortSessionId(SID)).toBe('wt1111wt')
+  })
+
+  it('honours CCC_WT_ROOT from CCC’s own environment (the guard inherits the same variable)', () => {
+    const project = path.join(os.tmpdir(), 'somewhere', 'project')
+    const wt = path.join(os.tmpdir(), 'my-wt')
+    expect(designatedWorktreeDir(project, SID, { env: { CCC_WT_ROOT: wt }, isPrimaryCheckout: primary })).toBe(
+      path.join(wt, 'wt1111wt'),
+    )
+    // A relative CCC_WT_ROOT is ignored (the guard would resolve it against ITS
+    // cwd — a place CCC cannot predict).
+    expect(worktreeBaseDir(project, { CCC_WT_ROOT: 'rel/wt' })).toBe(path.join(os.tmpdir(), 'somewhere', 'ccc-wt'))
+  })
+
+  it('returns null when the project is not a primary git checkout, or inputs are malformed', () => {
+    const notPrimary = path.join(os.tmpdir(), 'somewhere', 'worktree')
+    expect(designatedWorktreeDir(notPrimary, SID, { env: noEnv, isPrimaryCheckout: primary })).toBeNull()
+    const project = path.join(os.tmpdir(), 'somewhere', 'project')
+    expect(designatedWorktreeDir('relative/project', SID, { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
+    expect(designatedWorktreeDir(project, 'short', { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
+    expect(designatedWorktreeDir(project, 'bad id with spaces!', { env: noEnv, isPrimaryCheckout: () => true })).toBeNull()
+  })
+
+  it('the real isPrimaryCheckout dep: `.git` directory → yes; `.git` file (linked worktree) or none → no', async () => {
+    const { nodeDesignateDeps } = await import('../../../src/main/canvas/canvas-worktree')
+    const a = tmp('ccc-wt-prim-')
+    fs.mkdirSync(path.join(a, '.git'))
+    expect(nodeDesignateDeps.isPrimaryCheckout(a)).toBe(true)
+    const b = tmp('ccc-wt-linked-')
+    fs.writeFileSync(path.join(b, '.git'), 'gitdir: /somewhere/.git/worktrees/x\n')
+    expect(nodeDesignateDeps.isPrimaryCheckout(b)).toBe(false)
+    const c = tmp('ccc-wt-norepo-')
+    expect(nodeDesignateDeps.isPrimaryCheckout(c)).toBe(false)
+  })
+})

--- a/tests/unit/main/canvas-worktree-spawn.test.ts
+++ b/tests/unit/main/canvas-worktree-spawn.test.ts
@@ -99,7 +99,10 @@ vi.mock('../../../src/main/conductor-mcp-server', () => ({
 
 vi.mock('../../../src/main/providers', () => ({
   getProvider: () => ({
-    buildSpawnCommand: () => ({ cmd: 'pwsh', args: [], env: {} }),
+    // Stand in for the real providers, which spread process.env: hand back a
+    // STALE inherited CCC_SESSION_WORKTREE so every 'not designated' assertion
+    // below verifies it is SCRUBBED, not merely absent.
+    buildSpawnCommand: () => ({ cmd: 'pwsh', args: [], env: { CCC_SESSION_WORKTREE: STALE_WT } }),
     ingestSessionTelemetry: () => ({ stop: () => {} }),
   }),
 }))
@@ -203,7 +206,8 @@ function makePrimaryProject(prefix: string): { parent: string; project: string; 
   fs.writeFileSync(path.join(project, 'dist', 'index.html'), '<html><head></head><body>app</body></html>')
   return { parent, project, wtBase: path.join(parent, 'ccc-wt') }
 }
-const SHORT = SID.slice(0, 8)
+const SHORT = SID.slice(0, 12)
+const STALE_WT = path.join('F:', 'stale-outer', 'ccc-wt', 'deadbeefdead')
 
 afterAll(() => {
   try {
@@ -280,6 +284,21 @@ describe('CCC designates the session worktree and serves it once it exists', () 
     const { project } = makePrimaryProject('ccc-wt-spawn-shell-')
     const why2 = spawn({ cwd: project, shellOnly: true })
     expect(h.spawnEnvs[0]?.CCC_SESSION_WORKTREE, why2).toBeUndefined()
+    killPty(SID)
+  })
+
+  it('SCRUBS an inherited CCC_SESSION_WORKTREE from a non-designated session (never leaks CCC’s own env)', () => {
+    // A dev CCC launched from inside a guarded tile inherits the OUTER tile’s
+    // CCC_SESSION_WORKTREE; a shell-only / non-repo child must not carry it, or
+    // its guard would target the outer tile’s worktree.
+    const plain = makeDir('ccc-wt-spawn-scrub-')   // no .git
+    const why = spawn({ cwd: plain })
+    expect(h.spawnEnvs[0].CCC_SESSION_WORKTREE, why).toBeUndefined()   // scrubbed, not the stale value
+    killPty(SID)
+    h.spawnEnvs = []
+    const { project } = makePrimaryProject('ccc-wt-spawn-scrub2-')
+    const why2 = spawn({ cwd: project, shellOnly: true })
+    expect(h.spawnEnvs[0].CCC_SESSION_WORKTREE, why2).toBeUndefined()  // shell-only never designates
     killPty(SID)
   })
 

--- a/tests/unit/main/canvas-worktree-spawn.test.ts
+++ b/tests/unit/main/canvas-worktree-spawn.test.ts
@@ -1,0 +1,302 @@
+// Agent Canvas serves the session's DESIGNATED worktree — end to end (ADR-016).
+//
+// Drives the REAL `spawnPty` (everything around it mocked, as in
+// canvas-root-provenance.test.ts) and asks two real things: what CCC told the
+// guard through CCC_SESSION_WORKTREE, and what the real canvas store will serve.
+// The designated path must come from the CONFIGURED project directory and CCC's
+// own session id — a poisoned resume target must not move it — and it must
+// serve only once the directory really exists.
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const h = vi.hoisted(() => ({
+  /** What the transcript claims the conversation's cwd is. Set per test. */
+  resumeTargetCwd: null as string | null,
+  /** Set when the self-captured (in-session Restart / Switch-account) route is
+   *  the one under test — that route reads the transcript through the binder. */
+  bindTranscript: false,
+  codexReviewRoots: [] as Array<{ sessionId: string; cwd: string }>,
+  /** The env each pty.spawn was given (CCC_SESSION_WORKTREE lives here). */
+  spawnEnvs: [] as Array<Record<string, string>>,
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: (_cmd: string, _args: string[], opts: { env?: Record<string, string> }) => {
+    h.spawnEnvs.push(opts?.env ?? {})
+    return {
+      pid: 4242,
+      process: 'pwsh',
+      onData: () => ({ dispose: () => {} }),
+      onExit: () => ({ dispose: () => {} }),
+      write: () => {},
+      resize: () => {},
+      kill: () => {},
+    }
+  },
+}))
+
+// The canvas store writes under `getResourcesDirectory()/canvas`. Unmocked that
+// resolves to the platform fallback (`/mock/...` here, since `app.getPath` is a
+// stub), which happens to be creatable at the drive root on Windows and is NOT
+// creatable at `/` on macOS or Linux — so the store's first mkdir threw there
+// and the whole file was Windows-only by accident. Give it a real temp root.
+vi.mock('../../../src/main/ipc/setup-handlers', () => {
+  const nodeFs = require('node:fs') as typeof import('node:fs')
+  const nodeOs = require('node:os') as typeof import('node:os')
+  const nodePath = require('node:path') as typeof import('node:path')
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'ccc-wt-spawn-res-'))
+  return {
+    getResourcesDirectory: () => dir,
+    getDataDirectory: () => dir,
+    registerSetupHandlers: () => {},
+    writeCliSetupPty: () => {},
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/mock/userData', getAppPath: () => process.cwd(), on: () => {}, quit: () => {} },
+  ipcMain: { handle: () => {}, on: () => {} },
+  BrowserWindow: class {},
+  nativeTheme: { shouldUseDarkColors: false },
+  protocol: { registerSchemesAsPrivileged: () => {}, handle: () => {} },
+  safeStorage: { isEncryptionAvailable: () => false },
+}))
+
+// The resume gate itself is upstream of what is under test: these tests are
+// about what pty-manager DOES with a resolved launch, not about whether the
+// transcript file exists. The stub returns exactly what the real helper returns
+// on a successful gate — `{ resumeUuid: target.uuid, claudeCwd: target.cwd }` —
+// so the poisoned value arrives by the production route.
+vi.mock('../../../src/main/spawn-claude-command', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/spawn-claude-command')>()),
+  resolveResumeLaunch: (target?: { uuid: string; cwd: string }) =>
+    target ? { resumeUuid: target.uuid, claudeCwd: target.cwd } : null,
+}))
+
+vi.mock('../../../src/main/logging/transcript-discovery', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/logging/transcript-discovery')>()),
+  // The verbatim first-`cwd`-in-the-JSONL read, standing in for a poisoned file.
+  resolveResumeTargetFromTranscript: () =>
+    h.resumeTargetCwd ? { uuid: '11111111-2222-3333-4444-555555555555', cwd: h.resumeTargetCwd } : null,
+}))
+
+vi.mock('../../../src/main/logging/logging-service', () => ({
+  getLogSupervisor: () => null,
+  getTranscriptBinder: () =>
+    h.bindTranscript ? { getLatestTranscriptPath: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl' } : null,
+}))
+
+vi.mock('../../../src/main/conductor-mcp-server', () => ({
+  getConductorMcpPort: () => 0,
+  registerCodexReviewSession: (sessionId: string, cwd: string) => {
+    h.codexReviewRoots.push({ sessionId, cwd })
+  },
+  unregisterCodexReviewSession: () => {},
+}))
+
+vi.mock('../../../src/main/providers', () => ({
+  getProvider: () => ({
+    buildSpawnCommand: () => ({ cmd: 'pwsh', args: [], env: {} }),
+    ingestSessionTelemetry: () => ({ stop: () => {} }),
+  }),
+}))
+
+vi.mock('../../../src/main/providers/claude/spawn', () => ({
+  resolveClaudeBinary: () => ({ cmd: 'claude', source: 'system' }),
+  resolveHostColorScheme: () => 'dark',
+}))
+
+vi.mock('../../../src/main/vision-manager', () => ({
+  isGlobalVisionRunning: () => false,
+  getGlobalVisionConfig: () => null,
+  teardownVisionSession: () => {},
+}))
+
+vi.mock('../../../src/main/canvas/canvas-plugin', () => ({ ensureCanvasPlugin: () => null }))
+vi.mock('../../../src/main/hooks', () => ({ getGateway: () => null }))
+vi.mock('../../../src/main/hooks/session-hooks-writer', () => ({ injectHooks: () => {} }))
+vi.mock('../../../src/main/hooks/per-session-settings', () => ({
+  writeLocalSessionSettings: () => null,
+  removeLocalSessionSettings: () => {},
+  writeLocalSessionMcpConfig: () => null,
+  removeLocalSessionMcpConfig: () => {},
+}))
+vi.mock('../../../src/main/claude-account-identity', () => ({
+  captureClaudeAccount: () => {},
+  clearClaudeAccount: () => {},
+  getAccountIdentity: () => null,
+  pushAccountIdentity: () => {},
+  startWatchingAccountIdentity: () => {},
+  stopWatchingAccountIdentity: () => {},
+  getWatchedProfileId: () => null,
+}))
+vi.mock('../../../src/main/session-registry', () => ({ updateSessionMeta: () => {}, clearSessionMeta: () => {} }))
+vi.mock('../../../src/main/services/pty-integrity-monitor', () => ({ getPtyIntegrityMonitor: () => null }))
+vi.mock('../../../src/main/config-manager', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/main/config-manager')>()),
+  readConfig: () => ({}),
+  getConfigDir: () => os.tmpdir(),
+}))
+vi.mock('../../../src/main/account-profiles', async (importOriginal) => ({
+  // mkdirSecure / atomicWriteSecure are the canvas store's own writers — keep them.
+  ...(await importOriginal<typeof import('../../../src/main/account-profiles')>()),
+  isValidProfileId: () => false,
+  getPrimaryProfileId: () => null,
+  getProfileConfigDir: () => path.join(os.tmpdir(), 'ccc-no-such-profile'),
+  setupProfileLinks: () => {},
+  syncPrimaryCredentialsWithGlobal: () => {},
+  backupProfileHomeToCanonical: () => {},
+}))
+
+const store = await import('../../../src/main/canvas/canvas-store')
+const { spawnPty, killPty } = await import('../../../src/main/pty-manager')
+
+const SID = 'wtsp1111wtsp1111wtsp1111'
+
+const tempDirs: string[] = []
+function makeDir(prefix: string): string {
+  const dir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tempDirs.push(dir)
+  fs.mkdirSync(path.join(dir, 'dist'))
+  fs.writeFileSync(path.join(dir, 'dist', 'index.html'), '<html><head></head><body>app</body></html>')
+  fs.writeFileSync(path.join(dir, 'secret.txt'), 'PRIVATE')
+  return dir
+}
+
+const fakeWin = {
+  isDestroyed: () => false,
+  webContents: { send: () => {} },
+} as unknown as Parameters<typeof spawnPty>[0]
+
+/** Run the real spawn. It may throw somewhere PAST the registration block (the
+ *  mock stack stops well short of a complete session); the registration has
+ *  already happened by then, and the thrown text is carried into the assertions
+ *  so a failure that is really an incomplete mock says so. */
+function spawn(options: Parameters<typeof spawnPty>[2]): string {
+  try {
+    spawnPty(fakeWin, SID, options)
+    return ''
+  } catch (err) {
+    return ` (spawnPty threw: ${(err as Error)?.message ?? err})`
+  }
+}
+
+beforeEach(() => {
+  h.resumeTargetCwd = null
+  h.bindTranscript = false
+  h.codexReviewRoots = []
+  h.spawnEnvs = []
+  store._resetCanvasStoreForTest()
+})
+
+/** A project that is a PRIMARY checkout (`.git` is a directory), plus the
+ *  worktree base beside it, both under one temp parent so cleanup is one rm. */
+function makePrimaryProject(prefix: string): { parent: string; project: string; wtBase: string } {
+  const parent = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tempDirs.push(parent)
+  const project = path.join(parent, 'project')
+  fs.mkdirSync(path.join(project, '.git'), { recursive: true })
+  fs.mkdirSync(path.join(project, 'dist'))
+  fs.writeFileSync(path.join(project, 'dist', 'index.html'), '<html><head></head><body>app</body></html>')
+  return { parent, project, wtBase: path.join(parent, 'ccc-wt') }
+}
+const SHORT = SID.slice(0, 8)
+
+afterAll(() => {
+  try {
+    killPty(SID)
+  } catch {
+    /* best-effort */
+  }
+  for (const dir of tempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+})
+
+describe('CCC designates the session worktree and serves it once it exists', () => {
+  it('tells the guard where (CCC_SESSION_WORKTREE) and serves that directory only once it is real', () => {
+    const { project, wtBase } = makePrimaryProject('ccc-wt-spawn-plain-')
+    const designated = path.join(wtBase, SHORT)
+    const why = spawn({ cwd: project })
+
+    // The env the shell got names the CCC-designated location…
+    expect(h.spawnEnvs.length, why).toBeGreaterThan(0)
+    expect(h.spawnEnvs[0].CCC_SESSION_WORKTREE, why).toBe(designated)
+    // …the project itself is served, as before…
+    expect(() => store.resolveInsideCanvasRoot(path.join(project, 'dist', 'index.html'), SID), why).not.toThrow()
+    // …the designated worktree is NOT served while it does not exist…
+    expect(() => store.resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).toThrow(/registered canvas root/i)
+    // …and IS served once the guard has created it and the agent wrote there.
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'mock.html'), '<html></html>')
+    expect(() => store.resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID), why).not.toThrow()
+    // A sibling worktree (another session's) is not.
+    fs.mkdirSync(path.join(wtBase, 'other000'), { recursive: true })
+    fs.writeFileSync(path.join(wtBase, 'other000', 'mock.html'), '<html></html>')
+    expect(() => store.resolveInsideCanvasRoot(path.join(wtBase, 'other000', 'mock.html'), SID)).toThrow(/registered canvas root/i)
+    killPty(SID)
+  })
+
+  it('a poisoned resume target does not move the designation (configured cwd + CCC id only)', () => {
+    const { project, wtBase } = makePrimaryProject('ccc-wt-spawn-poison-')
+    const poisonedParent = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-wt-spawn-poisoned-')))
+    tempDirs.push(poisonedParent)
+    const poisoned = path.join(poisonedParent, 'project')
+    fs.mkdirSync(path.join(poisoned, '.git'), { recursive: true })
+    h.resumeTargetCwd = poisoned
+    h.bindTranscript = true
+
+    const why = spawn({ cwd: project })
+    expect(h.codexReviewRoots, why).toEqual([{ sessionId: SID, cwd: poisoned }]) // the launch really moved
+    expect(h.spawnEnvs[0].CCC_SESSION_WORKTREE, why).toBe(path.join(wtBase, SHORT))
+    // The transcript-named neighbourhood is not designated: even if the agent
+    // creates it, nothing under it is served.
+    const wrong = path.join(poisonedParent, 'ccc-wt', SHORT)
+    fs.mkdirSync(wrong, { recursive: true })
+    fs.writeFileSync(path.join(wrong, 'mock.html'), '<html></html>')
+    expect(() => store.resolveInsideCanvasRoot(path.join(wrong, 'mock.html'), SID)).toThrow(/registered canvas root/i)
+    killPty(SID)
+  })
+
+  it('designates nothing for a project that is not a primary checkout, nor for a shell-only session', () => {
+    const plain = makeDir('ccc-wt-spawn-norepo-') // no .git at all
+    const why = spawn({ cwd: plain })
+    expect(h.spawnEnvs[0]?.CCC_SESSION_WORKTREE, why).toBeUndefined()
+    const guess = path.join(path.dirname(plain), 'ccc-wt', SHORT)
+    fs.mkdirSync(guess, { recursive: true })
+    tempDirs.push(path.dirname(guess))
+    fs.writeFileSync(path.join(guess, 'mock.html'), '<html></html>')
+    expect(() => store.resolveInsideCanvasRoot(path.join(guess, 'mock.html'), SID)).toThrow(/registered canvas root/i)
+    killPty(SID)
+
+    h.spawnEnvs = []
+    const { project } = makePrimaryProject('ccc-wt-spawn-shell-')
+    const why2 = spawn({ cwd: project, shellOnly: true })
+    expect(h.spawnEnvs[0]?.CCC_SESSION_WORKTREE, why2).toBeUndefined()
+    killPty(SID)
+  })
+
+  it('designates nothing when the project itself is refused (home directory)', () => {
+    const why = spawn({ cwd: '.' }) // resolveCwd('.') → home
+    expect(h.spawnEnvs[0]?.CCC_SESSION_WORKTREE, why).toBeUndefined()
+    killPty(SID)
+  })
+
+  it('drops the designated root with the session (revoke on PTY gone)', () => {
+    const { project, wtBase } = makePrimaryProject('ccc-wt-spawn-revoke-')
+    const designated = path.join(wtBase, SHORT)
+    const why = spawn({ cwd: project })
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'mock.html'), '<html></html>')
+    expect(() => store.resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID), why).not.toThrow()
+    killPty(SID)
+    expect(() => store.resolveInsideCanvasRoot(path.join(designated, 'mock.html'), SID)).toThrow(/registered canvas root/i)
+  })
+})

--- a/tests/unit/session-guard-designated-worktree.test.ts
+++ b/tests/unit/session-guard-designated-worktree.test.ts
@@ -1,0 +1,159 @@
+// scripts/session-guard.mjs — `claim` honours the worktree location CCC
+// designates through CCC_SESSION_WORKTREE (ADR-016), so the Agent Canvas can
+// serve the session's worktree. Runs the real script against a throwaway repo.
+//
+//   - set → the worktree is created exactly there (lease.designated = true)
+//   - set, and an earlier conversation of the SAME CCC session left a worktree
+//     there → adopted in place (its lease is cleared, ours written)
+//   - set, but another live session (a different CCC session) holds it, or
+//     something that is not a worktree is there → falls back to the default
+//     location with a note; nothing is clobbered
+//   - unset → the default location, unchanged
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const GUARD = path.resolve(__dirname, '..', '..', 'scripts', 'session-guard.mjs')
+
+let root: string
+let repo: string
+let wtBase: string
+const CCC_A = 'aaaa1111aaaa1111aaaa1111'
+const CCC_B = 'bbbb2222bbbb2222bbbb2222'
+const CC_1 = '11111111-1111-4111-8111-111111111111'
+const CC_2 = '22222222-2222-4222-8222-222222222222'
+const CC_3 = '33333333-3333-4333-8333-333333333333'
+
+function git(args: string[], cwd = repo): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+}
+
+function claim(env: Record<string, string | undefined>, args: string[] = ['claim', '--base', 'main']): { out: string; code: number } {
+  const merged: Record<string, string> = {}
+  for (const [k, v] of Object.entries({ ...process.env, ...env })) if (typeof v === 'string') merged[k] = v
+  // Never let the developer's own session leak into the throwaway repo.
+  delete merged.CCC_SESSION_GUARD
+  delete merged.CCC_WT_ROOT // the throwaway repo's own <parent>/ccc-wt, whatever the developer's box says
+  try {
+    const out = execFileSync(process.execPath, [GUARD, ...args], { cwd: repo, encoding: 'utf8', env: merged, stdio: ['ignore', 'pipe', 'pipe'] })
+    return { out, code: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number }
+    return { out: `${e.stdout ?? ''}${e.stderr ?? ''}`, code: e.status ?? 1 }
+  }
+}
+
+function leases(): Array<Record<string, unknown>> {
+  const dir = path.join(repo, '.git', 'ccc-sessions')
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir).filter((f) => f.endsWith('.json')).map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+}
+
+beforeAll(() => {
+  root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-guard-wt-')))
+  repo = path.join(root, 'project')
+  wtBase = path.join(root, 'ccc-wt')
+  fs.mkdirSync(repo)
+  git(['init', '-q', '-b', 'main'])
+  git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '--allow-empty', '-m', 'init'])
+})
+
+afterAll(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }) } catch { /* best-effort */ }
+})
+
+describe('session-guard claim with a CCC-designated worktree', () => {
+  it('creates the worktree exactly where CCC_SESSION_WORKTREE points and marks the lease designated', () => {
+    const designated = path.join(wtBase, CCC_A.slice(0, 8))
+    const r = claim({ CLAUDE_CODE_SESSION_ID: CC_1, CLAUDE_MULTI_SESSION_ID: CCC_A, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('session-guard: claimed')
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(true) // a linked worktree lives there
+    const l = leases().find((x) => x.sessionId === CC_1)!
+    expect(l, r.out).toBeTruthy()
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(designated.toLowerCase())
+    expect(l.designated).toBe(true)
+    expect(l.multiSessionId).toBe(CCC_A)
+    expect(String(l.branch)).toBe('session/main/11111111')
+  }, 30_000)
+
+  it('a later conversation of the SAME CCC session adopts that worktree in place (old lease cleared)', () => {
+    const designated = path.join(wtBase, CCC_A.slice(0, 8))
+    // Leave uncommitted work behind so the note about it is exercised.
+    fs.writeFileSync(path.join(designated, 'wip.txt'), 'unfinished')
+    const r = claim({ CLAUDE_CODE_SESSION_ID: CC_2, CLAUDE_MULTI_SESSION_ID: CCC_A, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('adopted')
+    expect(r.out).toContain('1 uncommitted change')
+    const all = leases()
+    expect(all.find((x) => x.sessionId === CC_1)).toBeUndefined() // earlier conversation's lease cleared
+    const l = all.find((x) => x.sessionId === CC_2)!
+    expect(l, r.out).toBeTruthy()
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(designated.toLowerCase())
+    expect(l.adopted).toBe(true)
+    expect(l.designated).toBe(true)
+    // No second worktree was created for it.
+    expect(fs.existsSync(path.join(wtBase, '22222222'))).toBe(false)
+  }, 30_000)
+
+  it('a DIFFERENT live CCC session pointed at the same directory falls back to the default location', () => {
+    const designated = path.join(wtBase, CCC_A.slice(0, 8)) // still held by CC_2 (alive: our pid)
+    const r = claim({ CLAUDE_CODE_SESSION_ID: CC_3, CLAUDE_MULTI_SESSION_ID: CCC_B, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('still holds it')
+    expect(r.out).toContain('the canvas will not serve this worktree')
+    const l = leases().find((x) => x.sessionId === CC_3)!
+    expect(l, r.out).toBeTruthy()
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '33333333').toLowerCase())
+    expect(l.designated).toBe(false)
+    // CC_2 still owns the designated worktree.
+    const l2 = leases().find((x) => x.sessionId === CC_2)!
+    expect(path.resolve(String(l2.worktree)).toLowerCase()).toBe(designated.toLowerCase())
+  }, 30_000)
+
+  it('something that is not a worktree at the designated path → default location, nothing clobbered', () => {
+    const designated = path.join(wtBase, CCC_B.slice(0, 8))
+    fs.mkdirSync(designated, { recursive: true })
+    fs.writeFileSync(path.join(designated, 'precious.txt'), 'do not touch')
+    const cc = '44444444-4444-4444-8444-444444444444'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: CCC_B, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('something else is there')
+    expect(fs.readFileSync(path.join(designated, 'precious.txt'), 'utf8')).toBe('do not touch')
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(false)
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '44444444').toLowerCase())
+  }, 30_000)
+
+  it('an EMPTY directory at the designated path is fine to create into', () => {
+    const designated = path.join(wtBase, 'emptyone')
+    fs.mkdirSync(designated, { recursive: true })
+    const cc = '55555555-5555-4555-8555-555555555555'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: 'cccc3333cccc3333cccc3333', CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(true)
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(l.designated).toBe(true)
+  }, 30_000)
+
+  it('without CCC_SESSION_WORKTREE the default location is used, as before', () => {
+    const cc = '66666666-6666-4666-8666-666666666666'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: undefined, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: undefined })
+    expect(r.code, r.out).toBe(0)
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '66666666').toLowerCase())
+    expect(l.designated).toBe(false)
+  }, 30_000)
+
+  it('a relative CCC_SESSION_WORKTREE is ignored (hint must be absolute)', () => {
+    const cc = '77777777-7777-4777-8777-777777777777'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: 'dddd4444dddd4444dddd4444', CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: 'relative/place' })
+    expect(r.code, r.out).toBe(0)
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '77777777').toLowerCase())
+    expect(l.designated).toBe(false)
+  }, 30_000)
+})

--- a/tests/unit/session-guard-designated-worktree.test.ts
+++ b/tests/unit/session-guard-designated-worktree.test.ts
@@ -11,7 +11,7 @@
 //   - unset → the default location, unchanged
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { execFileSync } from 'child_process'
+import { execFileSync, spawn as spawnProc } from 'child_process'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
@@ -155,5 +155,80 @@ describe('session-guard claim with a CCC-designated worktree', () => {
     const l = leases().find((x) => x.sessionId === cc)!
     expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '77777777').toLowerCase())
     expect(l.designated).toBe(false)
+  }, 30_000)
+
+  // --- Adversarial-review regressions -------------------------------------
+
+  it('does NOT adopt a worktree of a DIFFERENT repository at the designated path', () => {
+    // A second repo, and one of ITS worktrees parked at our designated path.
+    const otherRepo = path.join(root, 'other-repo')
+    fs.mkdirSync(otherRepo)
+    git(['init', '-q', '-b', 'main'], otherRepo)
+    git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '--allow-empty', '-m', 'init'], otherRepo)
+    const designated = path.join(wtBase, 'foreignrepo01')
+    git(['worktree', 'add', '-q', designated], otherRepo)   // a worktree of otherRepo, not ours
+    fs.writeFileSync(path.join(designated, 'their-secret.txt'), 'do not touch')
+
+    const cc = '88888888-8888-4888-8888-888888888888'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: 'eeee5555eeee5555eeee5555', CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('DIFFERENT repository')
+    // We got the DEFAULT location, not the foreign worktree.
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, '88888888').toLowerCase())
+    expect(l.designated).toBe(false)
+    // The foreign worktree is untouched (still otherRepo's, file intact).
+    expect(fs.readFileSync(path.join(designated, 'their-secret.txt'), 'utf8')).toBe('do not touch')
+  }, 30_000)
+
+  it('does NOT steal a worktree held by a CONCURRENT LIVE process of the same CCC session (nested claude)', async () => {
+    // A live child process to stand in for the parent conversation whose lease is
+    // alive with a DIFFERENT pid than the claimer. Same tile id, still running.
+    const child = spawnProc(process.execPath, ['-e', 'setTimeout(()=>{}, 60000)'], { stdio: 'ignore' })
+    try {
+      await new Promise((r) => setTimeout(r, 50))
+      const tile = 'ffff6666ffff6666ffff6666'
+      const designated = path.join(wtBase, 'nestedlive01')
+      const parent = 'aa000001-0000-4000-8000-000000000001'
+      // Parent conversation claims and OWNS the designated worktree, pid = child.
+      const rp = claim({ CLAUDE_CODE_SESSION_ID: parent, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(child.pid), CCC_SESSION_WORKTREE: designated })
+      expect(rp.code, rp.out).toBe(0)
+      expect(fs.existsSync(path.join(designated, '.git'))).toBe(true)
+      // A nested claude: same tile, a DIFFERENT (this test's) live pid.
+      const nested = 'aa000002-0000-4000-8000-000000000002'
+      const rn = claim({ CLAUDE_CODE_SESSION_ID: nested, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+      expect(rn.code, rn.out).toBe(0)
+      expect(rn.out).toContain('concurrent process of this CCC session')
+      // The nested session got the DEFAULT location; the parent's lease is intact.
+      const ln = leases().find((x) => x.sessionId === nested)!
+      expect(path.resolve(String(ln.worktree)).toLowerCase()).toBe(path.join(wtBase, 'aa000002').toLowerCase())
+      const lp = leases().find((x) => x.sessionId === parent)!
+      expect(lp, 'parent lease still present').toBeTruthy()
+      expect(path.resolve(String(lp.worktree)).toLowerCase()).toBe(designated.toLowerCase())
+    } finally {
+      child.kill()
+    }
+  }, 30_000)
+
+  it('prunes a stale worktree registration so a hand-deleted designated dir does not wedge the tile', () => {
+    const tile = 'ab120000ab120000ab120000'
+    const designated = path.join(wtBase, 'prunewedge01')
+    const conv1 = 'ba000001-0000-4000-8000-000000000001'
+    const r1 = claim({ CLAUDE_CODE_SESSION_ID: conv1, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r1.code, r1.out).toBe(0)
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(true)
+    // The directory is removed by hand; git still has it registered. Its lease
+    // (conv1) is also cleared, standing in for a later conversation.
+    fs.rmSync(designated, { recursive: true, force: true })
+    const leaseFile = path.join(repo, '.git', 'ccc-sessions', `${conv1}.json`)
+    if (fs.existsSync(leaseFile)) fs.rmSync(leaseFile)
+    const conv2 = 'ba000002-0000-4000-8000-000000000002'
+    const r2 = claim({ CLAUDE_CODE_SESSION_ID: conv2, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    // Pre-fix this failed hard ("missing but already registered worktree").
+    expect(r2.code, r2.out).toBe(0)
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(true)
+    const l = leases().find((x) => x.sessionId === conv2)!
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(designated.toLowerCase())
+    expect(l.designated).toBe(true)
   }, 30_000)
 })

--- a/tests/unit/session-guard-designated-worktree.test.ts
+++ b/tests/unit/session-guard-designated-worktree.test.ts
@@ -46,6 +46,20 @@ function claim(env: Record<string, string | undefined>, args: string[] = ['claim
   }
 }
 
+function execRun(cmd: [string, string[], string], env: Record<string, string | undefined>): { out: string; code: number } {
+  const merged: Record<string, string> = {}
+  for (const [k, v] of Object.entries({ ...process.env, ...env })) if (typeof v === 'string') merged[k] = v
+  delete merged.CCC_SESSION_GUARD
+  delete merged.CCC_WT_ROOT
+  try {
+    const out = execFileSync(cmd[0], cmd[1], { cwd: cmd[2], encoding: 'utf8', env: merged, stdio: ['ignore', 'pipe', 'pipe'] })
+    return { out, code: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number }
+    return { out: `${e.stdout ?? ''}${e.stderr ?? ''}`, code: e.status ?? 1 }
+  }
+}
+
 function leases(): Array<Record<string, unknown>> {
   const dir = path.join(repo, '.git', 'ccc-sessions')
   if (!fs.existsSync(dir)) return []
@@ -208,6 +222,49 @@ describe('session-guard claim with a CCC-designated worktree', () => {
     } finally {
       child.kill()
     }
+  }, 30_000)
+
+  it('re-claims a designated worktree after release --remove-worktree, reusing the leftover branch (no double-fail)', () => {
+    const tile = 'ac340000ac340000ac340000'
+    const designated = path.join(wtBase, 'reclaimbrch1')
+    const conv1 = 'ca000001-0000-4000-8000-000000000001'
+    const r1 = claim({ CLAUDE_CODE_SESSION_ID: conv1, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r1.code, r1.out).toBe(0)
+    // A commit lands on the worktree's branch, then it is released WITH the dir
+    // removed (the branch survives — that is what used to wedge the reclaim).
+    fs.writeFileSync(path.join(designated, 'work.txt'), 'in progress')
+    git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'add', '-A'], designated)
+    git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '-m', 'wip'], designated)
+    const rel = execRun([process.execPath, [GUARD, 'release', '--remove-worktree'], repo], { CLAUDE_CODE_SESSION_ID: conv1, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid) })
+    expect(rel.code, rel.out).toBe(0)
+    expect(fs.existsSync(designated)).toBe(false)
+    // The SAME session re-claims (its branch survived the release). Pre-fix this
+    // double-failed on 'branch already exists' (both the designated add and the
+    // fallback used -b). Now the existing branch is REUSED at the same path.
+    const r2 = claim({ CLAUDE_CODE_SESSION_ID: conv1, CLAUDE_MULTI_SESSION_ID: tile, CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    expect(r2.code, r2.out).toBe(0)
+    expect(fs.existsSync(path.join(designated, '.git'))).toBe(true)
+    // The commit is still there (the branch was reused, not recreated).
+    expect(fs.existsSync(path.join(designated, 'work.txt'))).toBe(true)
+    const l = leases().find((x) => x.sessionId === conv1)!
+    expect(l.designated).toBe(true)
+  }, 30_000)
+
+  it('falls back to the default location when the designated path has a FILE parent (no raw mkdir throw)', () => {
+    const parentFile = path.join(wtBase, 'notadir')
+    fs.mkdirSync(wtBase, { recursive: true })
+    fs.writeFileSync(parentFile, 'i am a file')
+    const designated = path.join(parentFile, 'wt')   // parent is a file
+    const cc = 'da000001-0000-4000-8000-000000000001'
+    const r = claim({ CLAUDE_CODE_SESSION_ID: cc, CLAUDE_MULTI_SESSION_ID: 'ad560000ad560000ad560000', CLAUDE_PID: String(process.pid), CCC_SESSION_WORKTREE: designated })
+    // Pre-fix: an uncaught EEXIST stack trace and no worktree. Now: fall back.
+    expect(r.code, r.out).toBe(0)
+    expect(r.out).toContain('using the default location')
+    const l = leases().find((x) => x.sessionId === cc)!
+    expect(l, r.out).toBeTruthy()
+    expect(path.resolve(String(l.worktree)).toLowerCase()).toBe(path.join(wtBase, 'da000001').toLowerCase())
+    expect(l.designated).toBe(false)
+    expect(fs.readFileSync(parentFile, 'utf8')).toBe('i am a file')  // untouched
   }, 30_000)
 
   it('prunes a stale worktree registration so a hand-deleted designated dir does not wedge the tile', () => {


### PR DESCRIPTION
## What

**Session isolation and the Agent Canvas conflicted.** ADR-012 puts every agent in its own worktree (`../ccc-wt/<id>`) and blocks writes to the primary checkout; the canvas served roots were exactly the primary checkout. So an isolated agent could not `canvas_render { htmlPath }` a mockup it wrote — refused — and was forced to the inline `html` fallback the skill forbids. Found dogfooding the canvas for the beta.13 mockups (see the beta.13 handoff).

**Fix: CCC designates where the session's worktree lives, tells the guard, and serves that path — pending until it really exists.** ADR-016 (in this PR) records the decision and the rejected alternatives.

| Piece | Change |
|---|---|
| `src/main/canvas/canvas-worktree.ts` (new) | `designatedWorktreeDir(configuredCwd, cccSessionId)` = `<worktree base>/<first 8 of the CCC session id>`; base mirrors the guard (`<parent of primary checkout>/ccc-wt`, or `CCC_WT_ROOT` from CCC's env). Null unless the project is a primary checkout (`.git` is a directory). |
| `src/main/pty-manager.ts` | Interactive Claude sessions: put the path in the PTY env as **`CCC_SESSION_WORKTREE`**; once the project itself registers as a served root, **designate** the same path as a pending canvas root. Computed from the *configured* cwd + CCC's own id — never the transcript-derived launch cwd. |
| `src/main/canvas/canvas-store.ts` | `designateCanvasWorktreeRoot`: lexical, floor-checked. Live only when it **exists**, is a **real directory whose realpath IS the designated path** (a junction/symlink at or above it → not served), and passes the floor — re-evaluated on every resolution. Candidates are still realpath'd (a link planted inside cannot reach out). Per session; revoked with the session. |
| `scripts/session-guard.mjs` | `claim` honours `CCC_SESSION_WORKTREE`: creates the worktree there, or **adopts** the one an earlier conversation of the same CCC session left there (`/clear`, restart — worktrees are per *tile* under CCC now, fewer orphans). Held by another live session / not a worktree of this repo → default location + a note that the canvas won't serve it. Unset outside CCC → unchanged. |
| `src/main/canvas/canvas-plugin.ts` | Skill text: `htmlPath` / `distRoot` may live in the session worktree. |
| docs | ADR-016; `docs/session-isolation.md`; CONTEXT.d fragment. |

### Why not the two obvious fixes (from the handoff)
Both derive a served root from data the **agent** writes — the exact class the 08-11 / 08-14 / 08-15 canvas reviews closed (transcript cwd, resume cwd, plugin dir):
- *trust the guard's lease* — `.git/ccc-sessions/*.json` is written by a script the agent runs; any lease can name any directory;
- *serve any git worktree of a served root* — `.git/worktrees/*` and a worktree's `.git` file are agent-writable; a forged entry names an arbitrary directory.

With designation, what a served worktree root can ever expose is *files physically under a directory CCC named and the agent populated* — the same trust level as the project directory. Nothing an agent writes moves it; a link at/above it disables it; a link inside it is contained.

## Tests (24 new; full suite 5376 green, typecheck clean)
- `tests/unit/main/canvas-worktree-root.test.ts` — store semantics: pending → served once real; junction/symlink at the dir, at a parent, planted inside, swapped-in later → all refused; floor at designation; per-session; revoke; coexistence with the live root; the pure naming helper (incl. `CCC_WT_ROOT`, non-primary → null).
- `tests/unit/main/canvas-worktree-spawn.test.ts` — the **real `spawnPty`** (provenance-test harness): env var + store; a poisoned resume target does **not** move the designation; nothing for non-primary / shell-only / home; revoke on PTY gone.
- `tests/unit/session-guard-designated-worktree.test.ts` — the real script against a throwaway repo: create / adopt (old lease cleared, uncommitted work reported) / other live session → fallback / non-worktree → fallback, nothing clobbered / empty dir OK / relative hint ignored / unset unchanged.
- Mutation-checked: removing the anti-link check → 3 tests fail; designating from the launch cwd → the poison test fails.

## Security
Touches the served-root allowlist (a security boundary) → **ADR-009 adversarial pass required**; to be run as part of the beta.13 batch review and recorded here before merge.

## Owner live-check
After merge, from a CCC tile on this repo: `node scripts/session-guard.mjs claim --base beta` should print the CCC-designated directory (`F:\ccc-wt\<8 chars of the tile's id>`), and `canvas_render { htmlPath: "<that dir>\...\mock.html" }` should render.

Refs the beta.13 batch (#290, #291, #292).
