### PR TITLE
style(settings): unify card surfaces, accent and inputs across every tab

### DIFF
--- a/CONTEXT.d/2026-08-17-settings-visual-consistency.md
+++ b/CONTEXT.d/2026-08-17-settings-visual-consistency.md
@@ -1,0 +1,36 @@
+## 2026-08-17 -- Settings visual consistency (one card / accent / input system)
+
+The Settings pages had diverged into several visual systems. Audited every tab
+(accent + background) and converged them.
+
+Backgrounds -- was FOUR card systems (semantic `--surface-raised`, utility
+`bg-surface0/30`, the GitHub tab's warm-black borderless `bg-mantle` -- the
+"different black" the owner flagged, which read SUNKEN against the stage and
+inverted in light mode -- and Hooks with no card at all). Now ONE:
+- new `.settings-card` / `.settings-panel` / `.settings-divider` classes in
+  styles.css (blue-tinted `--surface-raised` / `--surface-base` / `--border-subtle`,
+  both theme-aware). Every tab's section cards + nested boxes use them; the
+  shared `Section` helper now emits `.settings-card`.
+
+Accent -- was blue (dominant) + green toggles + teal TabsRail/focus + Chromium's
+un-themed native-control blue + a stray sapphire hover. Unified interactive
+chrome on the app BLUE (`--color-blue`, theme-aware):
+- `Toggle` on-state green -> blue (one edit, ~17 settings toggles); the mirrored
+  "ON" label too; TabsRail active teal -> blue; a global
+  `input[checkbox|radio|range] { accent-color: var(--color-blue) }` themes every
+  native checkbox + slider (previously stock Chromium blue, ignoring the theme);
+  sapphire hover -> blue.
+Semantic DATA colours preserved: success green / +added--removed / usage-bar
+ramps in the status-line preview, update-status text, the green "Install now"
+pill, destructive red, identity swatches, the mauve tri-state, Codex accent
+borders.
+
+Inputs -- folded the GitHub/Codex/Copilot/AccountWeb `bg-surface0`/`bg-base`
+variants onto the dominant `bg-crust/60 border-surface0/80 rounded ... focus:border-blue/50`.
+GitHubConfigTab dropped its double padding + `max-w-3xl` (parent already pads +
+centres). OAuthDeviceFlow modal scrim `bg-base/80` (a LIGHT scrim in light mode)
+-> `bg-black/60`, and its borderless panel got a border to match other modals.
+
+Renderer-only. typecheck + production build clean; settings/github/copilot
+component tests green; full suite green. Light + dark both covered (all via
+theme-aware tokens; no raw hex added). Owner to live-test the real pages.

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -434,7 +434,7 @@ export default function SettingsPage({ initialTab, onNavigateToSessions, onUpdat
                       onClick={() => save({ debugMode: !settings.debugMode })}
                       label="Verbose Logging"
                     />
-                    <span className={`text-xs font-medium ${settings.debugMode ? 'text-green' : 'text-overlay0'}`}>
+                    <span className={`text-xs font-medium ${settings.debugMode ? 'text-blue' : 'text-overlay0'}`}>
                       {settings.debugMode ? 'ON' : 'OFF'}
                     </span>
                   </div>
@@ -613,7 +613,7 @@ function StatusLineTab({
   return (
     <>
       {/* Master switch */}
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 px-4 py-3 flex items-center gap-3">
+      <div className="settings-card px-4 py-3 flex items-center gap-3">
         <Toggle on={statusLineEnabled} onClick={() => setMaster(!statusLineEnabled)} label="Status line" />
         <div className="min-w-0">
           <div className="text-sm text-text leading-tight">Show the status line</div>
@@ -628,8 +628,8 @@ function StatusLineTab({
         className={statusLineEnabled ? 'space-y-4' : 'space-y-4 opacity-40 pointer-events-none'}
       >
       {/* Live Preview */}
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
-        <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
+      <div className="settings-card overflow-hidden">
+        <div className="px-4 py-2.5 border-b settings-divider flex items-center gap-2">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
             <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" fill="none" />
             <path d="M2 6h12" stroke="currentColor" strokeWidth="1.2" />
@@ -647,8 +647,8 @@ function StatusLineTab({
       </div>
 
       {/* Toggle Grid */}
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
-        <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
+      <div className="settings-card overflow-hidden">
+        <div className="px-4 py-2.5 border-b settings-divider flex items-center gap-2">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
             <path d="M4 8h8M8 4v8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
           </svg>
@@ -711,8 +711,8 @@ function BucketToggleCard({ title, subtitle, labels, hidden, onToggle }: {
   onToggle: (label: string) => void
 }): React.ReactElement {
   return (
-    <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
-      <div className="px-4 py-2.5 border-b border-surface0/40">
+    <div className="settings-card overflow-hidden">
+      <div className="px-4 py-2.5 border-b settings-divider">
         <h3 className="text-xs font-semibold text-subtext0 uppercase tracking-wider">{title}</h3>
         <p className="text-[11px] text-overlay0 mt-0.5">{subtitle}</p>
       </div>
@@ -755,14 +755,14 @@ function UsageBucketToggles(): React.ReactElement | null {
 
   if (labels === null) {
     return (
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 px-4 py-3 text-[11px] text-overlay0">
+      <div className="settings-card px-4 py-3 text-[11px] text-overlay0">
         Loading your current usage limits…
       </div>
     )
   }
   if (labels.length === 0) {
     return (
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 px-4 py-3 text-[11px] text-overlay0">
+      <div className="settings-card px-4 py-3 text-[11px] text-overlay0">
         Per-limit toggles appear here once your usage limits load (start a session or open the account usage view once).
       </div>
     )
@@ -1164,10 +1164,9 @@ function FontSizeTab({ settings, save }: {
 export function Section({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
   return (
     <div
-      className="rounded-xl overflow-hidden"
-      style={{ background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)' }}
+      className="settings-card overflow-hidden"
     >
-      <div className="px-4 py-2.5 flex items-center gap-2" style={{ borderBottom: '1px solid var(--border-subtle)' }}>
+      <div className="px-4 py-2.5 flex items-center gap-2 border-b settings-divider">
         {icon && (
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="shrink-0" style={{ color: 'var(--text-secondary)' }}>
             {icon}
@@ -1209,7 +1208,7 @@ export function Toggle({ on, onClick, label }: { on: boolean; onClick: () => voi
       aria-pressed={on}
       aria-label={label}
       className="relative shrink-0 rounded-full transition-colors duration-200"
-      style={{ width: 44, height: 24, background: on ? 'var(--status-success)' : 'var(--surface-overlay)' }}
+      style={{ width: 44, height: 24, background: on ? 'var(--color-blue)' : 'var(--surface-overlay)' }}
     >
       <span
         className="absolute rounded-full bg-white shadow-sm transition-transform duration-200"
@@ -1230,9 +1229,9 @@ export function TabsRail({ activeTab, onChange }: { activeTab: SettingsTab; onCh
             onClick={() => onChange(tab.id)}
             className="w-full text-left px-3 py-1.5 text-xs transition-colors focus-ring"
             style={{
-              background: active ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'transparent',
-              color: active ? 'var(--accent)' : 'var(--text-secondary)',
-              borderLeft: `2px solid ${active ? 'var(--accent)' : 'transparent'}`,
+              background: active ? 'color-mix(in srgb, var(--color-blue) 15%, transparent)' : 'transparent',
+              color: active ? 'var(--color-blue)' : 'var(--text-secondary)',
+              borderLeft: `2px solid ${active ? 'var(--color-blue)' : 'transparent'}`,
             }}
           >
             {tab.label}

--- a/src/renderer/components/codex/CodexSettingsTab.tsx
+++ b/src/renderer/components/codex/CodexSettingsTab.tsx
@@ -72,7 +72,7 @@ export function CodexSettingsTab() {
   return (
     <div className="space-y-4">
       {/* Master switch (Beta) */}
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 px-4 py-3 flex items-center gap-3">
+      <div className="settings-card px-4 py-3 flex items-center gap-3">
         <input
           type="checkbox"
           checked={codexEnabled !== false}
@@ -101,7 +101,7 @@ export function CodexSettingsTab() {
       >
 
       {/* Status section */}
-      <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
+      <div className="settings-card overflow-hidden">
         <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
             <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.2" fill="none" />
@@ -132,7 +132,7 @@ export function CodexSettingsTab() {
 
       {/* Install hint -- shown only when not installed */}
       {!installed && (
-        <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
+        <div className="settings-card overflow-hidden">
           <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
               <path d="M8 2v8M5 7l3 3 3-3M3 13h10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
@@ -158,7 +158,7 @@ export function CodexSettingsTab() {
 
       {/* Auth actions -- shown when installed */}
       {installed && (
-        <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
+        <div className="settings-card overflow-hidden">
           <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
               <path d="M11 7H5a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1zM7 7V5a1 1 0 0 1 2 0v2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />

--- a/src/renderer/components/github/config/AccountPanel.tsx
+++ b/src/renderer/components/github/config/AccountPanel.tsx
@@ -164,7 +164,7 @@ export default function AccountPanel({ profile, index }: Props) {
   const initials = (profile.label || profile.username).trim().slice(0, 2).toUpperCase()
 
   return (
-    <div className="bg-mantle rounded overflow-hidden">
+    <div className="settings-card overflow-hidden">
       <ExpiryBanner profile={profile} onRenew={() => setAdding(true)} />
 
       {/* Header: click toggles open */}
@@ -183,7 +183,7 @@ export default function AccountPanel({ profile, index }: Props) {
         <div className="flex-1 min-w-0">
           {editing ? (
             <input
-              className="w-full bg-surface0 p-1 rounded text-sm"
+              className="w-full bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-sm focus:outline-none focus:border-blue/50 transition-colors"
               value={newLabel}
               onClick={(e) => e.stopPropagation()}
               onChange={(e) => setNewLabel(e.target.value)}
@@ -235,7 +235,7 @@ export default function AccountPanel({ profile, index }: Props) {
 
       {/* Body mounts/unmounts under a 200ms transition (app convention). */}
       {open && (
-        <div className="border-t border-surface0 transition-opacity duration-200 ease-out p-3 space-y-2">
+        <div className="border-t settings-divider transition-opacity duration-200 ease-out p-3 space-y-2">
           {/* Informational line (moved from the old Status tab). */}
           <div className="text-xs text-subtext0">
             Powers {coveredCount} of {AUTH_FEATURE_KEYS.length} auth features ·{' '}
@@ -258,7 +258,7 @@ export default function AccountPanel({ profile, index }: Props) {
             return (
               <div
                 key={key}
-                className={`bg-base p-2 rounded flex items-center gap-2 ${differs ? 'border border-mauve/40' : ''}`}
+                className={`settings-panel p-2 flex items-center gap-2 ${differs ? 'border border-mauve/40' : ''}`}
               >
                 <ToggleSwitch
                   state={on ? 'on' : 'off'}

--- a/src/renderer/components/github/config/AccountsSection.tsx
+++ b/src/renderer/components/github/config/AccountsSection.tsx
@@ -16,7 +16,7 @@ export default function AccountsSection() {
       <h3 className="text-sm uppercase text-subtext0 mb-3">Accounts</h3>
       <div className="space-y-2">
         {profiles.length === 0 && (
-          <div className="text-sm text-overlay1 bg-mantle p-3 rounded">
+          <div className="text-sm text-overlay1 settings-card p-3">
             No auth profiles yet. Sign in with GitHub, adopt a `gh` CLI account, or paste a PAT.
           </div>
         )}

--- a/src/renderer/components/github/config/AppWideFeatures.tsx
+++ b/src/renderer/components/github/config/AppWideFeatures.tsx
@@ -36,7 +36,7 @@ export default function AppWideFeatures() {
           // Legacy fallback for the one-frame race before appWideToggles hydrates.
           const on = config.appWideToggles?.[key] ?? config.featureToggles[key]
           return (
-            <div key={key} className="bg-mantle p-3 rounded flex items-start gap-3">
+            <div key={key} className="settings-card p-3 flex items-start gap-3">
               <div className="flex-1">
                 <div className="text-text text-sm">{meta.label}</div>
                 <div className="text-xs text-subtext0">{meta.description}</div>

--- a/src/renderer/components/github/config/GitHubConfigTab.tsx
+++ b/src/renderer/components/github/config/GitHubConfigTab.tsx
@@ -19,7 +19,7 @@ export default function GitHubConfigTab() {
   }
 
   return (
-    <div className="p-6 space-y-6 max-w-3xl">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg text-text">GitHub integration</h2>
         <label className="flex items-start gap-2 text-sm">
@@ -42,7 +42,7 @@ export default function GitHubConfigTab() {
       <PrivacySettings />
       <SyncSettings />
       <PermissionsSummary />
-      <div className="text-xs text-overlay0 pt-4 border-t border-surface0">
+      <div className="text-xs text-overlay0 pt-4 border-t settings-divider">
         <strong>No telemetry.</strong> This feature sends no usage data to Anthropic
         or third parties. All requests go to github.com using your configured auth.
       </div>

--- a/src/renderer/components/github/config/HooksGatewaySection.tsx
+++ b/src/renderer/components/github/config/HooksGatewaySection.tsx
@@ -75,7 +75,7 @@ export default function HooksGatewaySection() {
   }
 
   return (
-    <section className="space-y-3">
+    <section className="settings-card p-4 space-y-3">
       <div className="flex items-center justify-between gap-4">
         <div>
           <h3 className="text-sm font-semibold text-text">HTTP Hooks Gateway</h3>
@@ -173,7 +173,7 @@ function PortEditor({ initial, onCancel, onSave }: PortEditorProps) {
       />
       <button
         onClick={submit}
-        className="px-2 py-0.5 rounded bg-blue text-crust hover:bg-sapphire transition-colors duration-150"
+        className="px-2 py-0.5 rounded bg-blue text-crust hover:bg-blue/80 transition-colors duration-150"
         type="button"
       >
         Save

--- a/src/renderer/components/github/config/OAuthDeviceFlow.tsx
+++ b/src/renderer/components/github/config/OAuthDeviceFlow.tsx
@@ -93,11 +93,11 @@ export default function OAuthDeviceFlow({ flow, onDone, onCancel }: Props) {
 
   return (
     <div
-      className="fixed inset-0 bg-base/80 z-50 flex items-center justify-center"
+      className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center"
       role="dialog"
       aria-modal="true"
     >
-      <div className="bg-mantle p-6 rounded max-w-md w-full">
+      <div className="bg-mantle p-6 rounded-lg border border-surface0 max-w-md w-full">
         <h3 className="text-lg mb-3 text-text">Sign in with GitHub</h3>
         <p className="text-sm text-subtext0 mb-4">
           Open <code className="bg-surface0 px-1 rounded">{flow.verificationUri}</code> and enter

--- a/src/renderer/components/github/config/PermissionsSummary.tsx
+++ b/src/renderer/components/github/config/PermissionsSummary.tsx
@@ -110,7 +110,7 @@ export default function PermissionsSummary() {
         What each feature needs
       </button>
       {open && (
-        <div id="permissions-summary-body" className="bg-mantle p-3 rounded text-sm space-y-3 mt-3">
+        <div id="permissions-summary-body" className="settings-card p-3 text-sm space-y-3 mt-3">
           <div>
             <div className="text-subtext0 text-xs mb-1">
               OAuth / Classic PAT scopes (public repos only)

--- a/src/renderer/components/github/config/PrivacySettings.tsx
+++ b/src/renderer/components/github/config/PrivacySettings.tsx
@@ -8,7 +8,7 @@ export default function PrivacySettings() {
   return (
     <section>
       <h3 className="text-sm uppercase text-subtext0 mb-3">Privacy</h3>
-      <div className="bg-mantle p-3 rounded">
+      <div className="settings-card p-3">
         <label className="flex items-start gap-2 text-sm">
           <input
             type="checkbox"

--- a/src/renderer/components/github/config/SyncSettings.tsx
+++ b/src/renderer/components/github/config/SyncSettings.tsx
@@ -35,11 +35,11 @@ export default function SyncSettings() {
   return (
     <section>
       <h3 className="text-sm uppercase text-subtext0 mb-3">Sync</h3>
-      <div className="bg-mantle p-3 rounded space-y-3 text-sm">
+      <div className="settings-card p-3 space-y-3 text-sm">
         <label className="flex items-center justify-between">
           <span>Active session</span>
           <select
-            className="bg-surface0 p-1 rounded"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-sm focus:outline-none focus:border-blue/50 transition-colors"
             value={config.syncIntervals.activeSessionSec}
             onChange={(e) => setInt('activeSessionSec', Number(e.target.value))}
           >
@@ -53,7 +53,7 @@ export default function SyncSettings() {
         <label className="flex items-center justify-between">
           <span>Background sessions</span>
           <select
-            className="bg-surface0 p-1 rounded"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-sm focus:outline-none focus:border-blue/50 transition-colors"
             value={config.syncIntervals.backgroundSec}
             onChange={(e) => setInt('backgroundSec', Number(e.target.value))}
           >
@@ -67,7 +67,7 @@ export default function SyncSettings() {
         <label className="flex items-center justify-between">
           <span>Notifications</span>
           <select
-            className="bg-surface0 p-1 rounded"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-sm focus:outline-none focus:border-blue/50 transition-colors"
             value={config.syncIntervals.notificationsSec}
             onChange={(e) => setInt('notificationsSec', Number(e.target.value))}
           >

--- a/src/renderer/components/settings/AccountWebSession.tsx
+++ b/src/renderer/components/settings/AccountWebSession.tsx
@@ -122,7 +122,7 @@ export function AccountWebSession({ profileId, accountName }: Props) {
     ok ? 'bg-green' : warn ? 'bg-yellow' : 'bg-overlay0'
 
   return (
-    <div className="rounded border border-surface1 bg-mantle p-3 space-y-3">
+    <div className="settings-panel p-3 space-y-3">
       <div className="text-xs text-text font-medium">{accountName} — authentication</div>
 
       {/* Code session */}
@@ -157,7 +157,7 @@ export function AccountWebSession({ profileId, accountName }: Props) {
             <select
               value={authMethod}
               onChange={(e) => { void changeAuthMethod(e.target.value as CliAuthMethod) }}
-              className="bg-base border border-surface1 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue"
+              className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue/50 transition-colors"
             >
               {CLI_AUTH_METHODS.map((m) => (
                 <option key={m} value={m}>{CLI_AUTH_METHOD_LABELS[m]}</option>
@@ -193,7 +193,7 @@ export function AccountWebSession({ profileId, accountName }: Props) {
               value={authBrowser}
               disabled={busy}
               onChange={(e) => { void changeAuthBrowser(e.target.value as AuthBrowser) }}
-              className="bg-base border border-surface1 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue disabled:opacity-40"
+              className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 text-[11px] text-text focus:outline-none focus:border-blue/50 transition-colors disabled:opacity-40"
             >
               {AUTH_BROWSERS.map((b) => (
                 <option key={b} value={b}>{AUTH_BROWSER_LABELS[b]}</option>

--- a/src/renderer/components/settings/CopilotMeterSettings.tsx
+++ b/src/renderer/components/settings/CopilotMeterSettings.tsx
@@ -124,7 +124,7 @@ export default function CopilotMeterSettings() {
   const isSample = aiUsage == null || (cycleStart != null && aiUsageCycle == null)
 
   return (
-    <div className="rounded-xl bg-surface0/30 border border-surface0/60 overflow-hidden">
+    <div className="settings-card overflow-hidden">
       <div className="px-4 py-2.5 border-b border-surface0/40 flex items-center gap-2">
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none" className="text-overlay1 shrink-0">
           <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.2" />
@@ -144,7 +144,7 @@ export default function CopilotMeterSettings() {
         <Row label="Plan" hint="Shown next to the meter, e.g. Max, Pro, or Plus.">
           <input
             type="text"
-            className="bg-surface0 p-1 rounded w-24 text-right"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 focus:outline-none focus:border-blue/50 transition-colors w-24 text-right"
             value={planName ?? ''}
             placeholder="Max"
             onChange={(e) => onPlanChange(e.target.value)}
@@ -160,7 +160,7 @@ export default function CopilotMeterSettings() {
             min={0}
             step="1"
             inputMode="numeric"
-            className="bg-surface0 p-1 rounded w-24 text-right"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 focus:outline-none focus:border-blue/50 transition-colors w-24 text-right"
             value={cap ?? ''}
             placeholder="20000"
             onChange={(e) => onCapChange(e.target.value)}
@@ -173,7 +173,7 @@ export default function CopilotMeterSettings() {
         >
           <input
             type="date"
-            className="bg-surface0 p-1 rounded text-right"
+            className="bg-crust/60 border border-surface0/80 rounded px-2 py-1 focus:outline-none focus:border-blue/50 transition-colors text-right"
             value={cycleStart ?? ''}
             onChange={(e) => onCycleChange(e.target.value)}
           />

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -264,6 +264,34 @@ body {
   background: color-mix(in srgb, var(--color-blue) 30%, transparent);
 }
 
+/* Settings surfaces — ONE card / nested-panel definition every Settings page
+   shares, so tabs stop diverging (the blue-tinted --surface-raised, never a
+   per-tab grey or the GitHub tab's warm-black `mantle`). Both theme-aware: the
+   vars flip under [data-theme="light"]. */
+.settings-card {
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+}
+/* A nested box inside a card (feature rows, mock previews, inner groups). */
+.settings-panel {
+  background: var(--surface-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+}
+/* Header/section dividers inside a settings card. */
+.settings-divider { border-color: var(--border-subtle) !important; }
+
+/* Native form controls carried Chromium's stock accent (a blue that ignored
+   both the palette and the light/dark theme). Theme them to the app accent in
+   one place — checkboxes, radios, and range sliders across every Settings page.
+   accent-color flips with the theme via the var. */
+input[type="checkbox"],
+input[type="radio"],
+input[type="range"] {
+  accent-color: var(--color-blue);
+}
+
 /* Ensure xterm.js textarea can receive keyboard input */
 .xterm-helper-textarea {
   user-select: text !important;

--- a/tests/unit/renderer/settings-section-tokens.test.tsx
+++ b/tests/unit/renderer/settings-section-tokens.test.tsx
@@ -4,9 +4,19 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import React from 'react'
 import { Section } from '../../../src/renderer/components/SettingsPage'
 
+// Settings visual consistency: every settings card is the shared `.settings-card`
+// surface (blue-tinted --surface-raised + --border-subtle, defined once in
+// styles.css), so tabs no longer diverge between --surface-raised, bg-surface0/30
+// and the GitHub tab's bg-mantle. The token lives in the class now, not inline.
 describe('Settings Section helper (U5.1)', () => {
-  it('uses --surface-raised, not bg-surface0', () => {
+  it('uses the shared .settings-card surface, not a per-tab bg-surface0/mantle', () => {
     const html = renderToStaticMarkup(<Section title="X" icon={null}>body</Section>)
-    expect(html).toContain('--surface-raised')
+    expect(html).toContain('settings-card')
+    expect(html).not.toContain('bg-surface0')
+    expect(html).not.toContain('bg-mantle')
+  })
+  it('draws its header divider with the shared .settings-divider token', () => {
+    const html = renderToStaticMarkup(<Section title="X" icon={null}>body</Section>)
+    expect(html).toContain('settings-divider')
   })
 })

--- a/tests/unit/renderer/settings-tabsrail.test.tsx
+++ b/tests/unit/renderer/settings-tabsrail.test.tsx
@@ -4,13 +4,17 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import React from 'react'
 import { TabsRail } from '../../../src/renderer/components/SettingsPage'
 
+// Settings visual consistency: the active tab uses the app's ONE interactive
+// accent (blue, --color-blue) — the same accent as the toggles, segmented
+// controls, links and native controls — not the teal --accent it used before.
 describe('Settings tabs rail (U5.4)', () => {
-  it('renders the active tab with --accent token treatment', () => {
+  it('renders the active tab with the unified blue accent (--color-blue)', () => {
     const html = renderToStaticMarkup(<TabsRail activeTab="general" onChange={() => {}} />)
-    expect(html).toContain('--accent')
+    expect(html).toContain('--color-blue')
+    expect(html).not.toContain('--accent')
   })
 
-  it('does not use the old bg-blue palette for the active tab', () => {
+  it('does not use Tailwind bg-blue/text-blue utilities for the active tab (inline var, theme-aware)', () => {
     const html = renderToStaticMarkup(<TabsRail activeTab="general" onChange={() => {}} />)
     expect(html).not.toContain('bg-blue/15')
     expect(html).not.toContain('text-blue')

--- a/tests/unit/renderer/settings-toggle-tokens.test.tsx
+++ b/tests/unit/renderer/settings-toggle-tokens.test.tsx
@@ -4,10 +4,15 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import React from 'react'
 import { Toggle } from '../../../src/renderer/components/SettingsPage'
 
-describe('Settings Toggle uses --status-success when on (U5.3)', () => {
-  it('uses --status-success when on', () => {
+// Settings visual consistency: the Toggle "on" state uses the app's ONE
+// interactive accent (blue, --color-blue), matching the github ToggleSwitch,
+// segmented controls and links — not the green --status-success it used before
+// (which is now reserved for SEMANTIC success/positive data). Theme-aware.
+describe('Settings Toggle uses the unified blue accent when on (U5.3)', () => {
+  it('uses --color-blue when on (not the green success token)', () => {
     const html = renderToStaticMarkup(<Toggle on={true} onClick={() => {}} />)
-    expect(html).toContain('--status-success')
+    expect(html).toContain('--color-blue')
+    expect(html).not.toContain('--status-success')
   })
   it('uses --surface-overlay when off', () => {
     const html = renderToStaticMarkup(<Toggle on={false} onClick={() => {}} />)


### PR DESCRIPTION
## What

The Settings pages had drifted into several visual systems — different card backgrounds per tab, three-plus interactive accent colours, and four input styles. This audits **every** settings tab and converges them into one system. Renderer-only, both themes.

### Backgrounds — was FOUR card systems → now ONE
| Tab(s) | Was | Now |
|---|---|---|
| General / Accounts / Shortcuts / Font / About | semantic `--surface-raised` card | `.settings-card` |
| Status line / Codex / Copilot | utility `bg-surface0/30` card | `.settings-card` |
| **GitHub** | **borderless `bg-mantle`** — the *"different black"*: a warm black that read **sunken** vs the stage and **inverted in light mode** | `.settings-card` |
| Hooks | no card at all | `.settings-card` |

New `.settings-card` / `.settings-panel` / `.settings-divider` classes in `styles.css` (`--surface-raised` / `--surface-base` / `--border-subtle`, all theme-aware); the shared `Section` helper emits `.settings-card`.

### Accent — was blue + green + teal + un-themed → now ONE (blue)
- `Toggle` on-state **green → blue** (one edit, ~17 toggles) + its mirrored "ON" label
- TabsRail active **teal → blue**
- Native checkboxes + range sliders were **stock Chromium blue that ignored the theme** → global `input[checkbox|radio|range] { accent-color: var(--color-blue) }` (theme-aware)
- stray `sapphire` hover → blue

**Semantic data colours kept** (not repainted): success green, +added/−removed, usage-bar ramps, update status, the green "Install now" pill, destructive red, identity swatches, the mauve tri-state, Codex accent borders.

### Inputs / misc
- GitHub / Codex / Copilot / AccountWeb `bg-surface0`/`bg-base` inputs → the dominant `bg-crust/60 border-surface0/80 rounded focus:border-blue/50`
- GitHubConfigTab dropped its double padding + `max-w-3xl` (parent already pads + centres)
- OAuthDeviceFlow modal scrim `bg-base/80` (a **light** scrim in light mode) → `bg-black/60`; its borderless panel got a border to match other modals

## Files
`styles.css` (+3 classes, native-control accent) · `SettingsPage.tsx` (Toggle, TabsRail, Section, Status-line cards) · `github/config/*` (8 files — the "different black" + inputs + container) · `codex/CodexSettingsTab.tsx` · `settings/{AccountWebSession,CopilotMeterSettings}.tsx`

## Verification
- `npm run typecheck` clean; **production build** clean (CSS confirmed in the bundle)
- settings / github / copilot component tests green; the three U5 design-token tests updated to assert the unified system (blue accent, `.settings-card`)
- full suite **5353** green; touched files byte-scanned; no raw hex added (light mode via tokens)
- **Owner to live-test the real pages** (host can't render the live app here)

## Design decision
Unified on the app **blue** (`--color-blue`) — it already carried the large majority of interactive chrome; green toggles / teal rail were the outliers. If you'd rather the interactive accent be teal (`--accent`, the V2 semantic accent), it's a one-token swap in these same sites — say the word.
