### PR TITLE
feat(updater): pre-emptive repo-rename soft-switch (claude-command-center → ai-code-conductor)

### DIFF
--- a/CONTEXT.d/2026-08-17-updater-repo-rename-softswitch.md
+++ b/CONTEXT.d/2026-08-17-updater-repo-rename-softswitch.md
@@ -1,0 +1,27 @@
+## 2026-08-17 -- Updater: pre-emptive repo-rename soft-switch
+
+The repo will be renamed claude-command-center -> ai-code-conductor after 2.1
+stable. Built BEFORE the rename so a shipped build follows it automatically.
+
+`github-update.ts`: `adoptRenamedRepoIfLive()` runs once at startup (index.ts,
+after registerUpdateHandlers, non-blocking):
+- a valid `GitHubRepo` registry override already set (manual, or a prior adopt)
+  WINS -- never second-guessed;
+- else probe `RENAMED_REPO = nubbymong/ai-code-conductor` via the public API.
+  GitHub 404s it until the rename; the moment it is live -> writeRegistry the
+  override + use it THIS session (activeRepo() cache), so no restart needed;
+- any 404/error/timeout -> stay on DEFAULT_REPO (fail-safe, never adopt on
+  uncertainty).
+The module-level `const REPO` became `activeRepo()` (cached, override-aware) at
+every fetch/download site. Only the SOURCE repo changes -- verification
+(checksums/signature) is unchanged, and the target is a hardcoded same-owner
+slug, not caller input.
+
+Security: touches the updater path (ADR-009). The switch cannot be steered to an
+arbitrary repo (hardcoded target; a registry override is REPO_PATTERN-validated
+and is a same-machine write). Run /adversarial-review before the official cut.
+
+Tests (injected deps, no network/registry): adopt+persist when live / stay on
+404 / stay on throw / respect a valid override (no re-probe) / ignore a malformed
+override / session-only when persist fails. Mutation-checked: adopt-on-uncertainty
+fails the fail-safe test.

--- a/src/main/github-update.ts
+++ b/src/main/github-update.ts
@@ -24,7 +24,7 @@ import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { logInfo, logError } from './debug-logger'
 import { readConfig } from './config-manager'
-import { readRegistry } from './registry'
+import { readRegistry, writeRegistry } from './registry'
 import { getDataDirectory } from './data-paths'
 
 const execFileAsync = promisify(execFile)
@@ -65,7 +65,90 @@ function getRepo(): string {
   return DEFAULT_REPO
 }
 
-const REPO = getRepo()
+/**
+ * The repo the app will be RENAMED to after 2.1 ships
+ * (claude-command-center -> ai-code-conductor). A build released BEFORE the
+ * rename follows it automatically via adoptRenamedRepoIfLive() below. Same owner
+ * (a GitHub rename keeps it); change here if that ever differs.
+ */
+export const RENAMED_REPO = 'nubbymong/ai-code-conductor'
+
+// The repo the updater currently talks to. Resolved lazily from the registry
+// override (else DEFAULT_REPO) and cached; the startup probe may switch it to
+// the renamed repo and persist that. Every fetch/download reads this, so a
+// switch takes effect the same session, not only after a restart.
+let activeRepoCache: string | null = null
+
+/** The GitHub `owner/repo` the updater currently uses. */
+export function activeRepo(): string {
+  if (activeRepoCache === null) activeRepoCache = getRepo()
+  return activeRepoCache
+}
+
+/** Test seam: forget the cached resolution. */
+export function _resetActiveRepoForTest(): void {
+  activeRepoCache = null
+}
+
+/** True iff the GitHub repo `slug` is reachable right now — a definite 2xx. A
+ *  404 (not renamed yet) or ANY error/timeout returns false: never adopt on
+ *  uncertainty. */
+async function repoIsLive(slug: string): Promise<boolean> {
+  if (!REPO_PATTERN.test(slug)) return false
+  try {
+    const { status, body } = await httpGetJson<unknown[]>(`https://api.github.com/repos/${slug}/releases?per_page=1`)
+    return status >= 200 && status < 300 && Array.isArray(body)
+  } catch {
+    return false
+  }
+}
+
+export interface AdoptRenamedDeps {
+  /** Current persisted GitHubRepo override, if any. */
+  readOverride: () => string | null
+  /** Persist a GitHubRepo override; returns whether it stuck. */
+  writeOverride: (slug: string) => boolean
+  /** Is this repo slug reachable right now? */
+  probe: (slug: string) => Promise<boolean>
+}
+
+const nodeAdoptRenamedDeps: AdoptRenamedDeps = {
+  readOverride: () => readRegistry('GitHubRepo'),
+  writeOverride: (slug) => writeRegistry('GitHubRepo', slug),
+  probe: repoIsLive,
+}
+
+/**
+ * Pre-emptive repo-rename handling (built before the rename so a shipped build
+ * follows it with no user action). Run once at startup:
+ *   - a valid GitHubRepo override already set (a manual choice, or a prior
+ *     adopt) WINS — we never second-guess an explicit selection;
+ *   - otherwise probe RENAMED_REPO. GitHub 404s it until the rename happens; the
+ *     moment it is live, persist the override and use it from now on;
+ *   - any probe error/timeout leaves the app on DEFAULT_REPO (fail-safe).
+ * This changes only WHICH same-owner repo releases come from — never how they
+ * are verified (checksums/signature are enforced regardless), and the target is
+ * a hardcoded slug, not anything a caller supplies (ADR-009: updater path).
+ */
+export async function adoptRenamedRepoIfLive(deps: AdoptRenamedDeps = nodeAdoptRenamedDeps): Promise<string> {
+  const override = deps.readOverride()
+  if (override && REPO_PATTERN.test(override)) {
+    activeRepoCache = override
+    return override
+  }
+  try {
+    if (await deps.probe(RENAMED_REPO)) {
+      const persisted = deps.writeOverride(RENAMED_REPO)
+      activeRepoCache = RENAMED_REPO
+      logInfo(`[github-update] renamed repo ${RENAMED_REPO} is live -> adopting it for updates${persisted ? ' (persisted)' : ' (persist failed; this session only)'}`)
+      return RENAMED_REPO
+    }
+  } catch (e) {
+    logInfo(`[github-update] renamed-repo probe failed, staying on ${DEFAULT_REPO}: ${(e as Error)?.message ?? e}`)
+  }
+  activeRepoCache = getRepo()
+  return activeRepoCache
+}
 
 export type UpdateChannel = 'stable' | 'beta'
 
@@ -294,7 +377,7 @@ const RELEASE_FETCH_LIMIT = 100
 
 async function fetchReleasesPublic(limit = RELEASE_FETCH_LIMIT): Promise<PublicFetchResult> {
   try {
-    const url = `https://api.github.com/repos/${REPO}/releases?per_page=${limit}`
+    const url = `https://api.github.com/repos/${activeRepo()}/releases?per_page=${limit}`
     const { status, headers, body } = await httpGetJson<GitHubRelease[]>(url)
 
     if (status >= 200 && status < 300 && Array.isArray(body)) {
@@ -357,7 +440,7 @@ async function fetchReleasesAuthenticated(limit = RELEASE_FETCH_LIMIT): Promise<
   }
 
   try {
-    const url = `https://api.github.com/repos/${REPO}/releases?per_page=${limit}`
+    const url = `https://api.github.com/repos/${activeRepo()}/releases?per_page=${limit}`
     const { status, body } = await httpGetJson<GitHubRelease[]>(url, 10000, token)
 
     if (status >= 200 && status < 300 && Array.isArray(body)) {
@@ -379,7 +462,7 @@ async function fetchReleasesGhCli(limit = RELEASE_FETCH_LIMIT): Promise<GitHubRe
   try {
     const { stdout } = await execFileAsync(
       'gh',
-      ['release', 'list', '--repo', REPO, '--limit', String(limit), '--json', 'tagName,isPrerelease,isDraft,assets'],
+      ['release', 'list', '--repo', activeRepo(), '--limit', String(limit), '--json', 'tagName,isPrerelease,isDraft,assets'],
       { encoding: 'utf-8', timeout: 15000, windowsHide: true }
     )
     const releases = JSON.parse(stdout) as Array<{
@@ -818,7 +901,7 @@ function readManifest(filePath: string): string | null {
  * becomes `...App.exe#/x/CHECKSUMS.txt`, and since `https.get` drops the
  * fragment, that FETCHES THE INSTALLER as the manifest. GitHub always supplies
  * a clean path today, so this is not reachable in production -- but the
- * function is exported, REPO is registry-overridable, and the guarantee is
+ * function is exported, the active repo is registry-overridable, and the guarantee is
  * stated unconditionally, so parse properly instead of pattern-matching.
  */
 function deriveManifestUrl(directUrl?: string | null): string | null {
@@ -874,7 +957,7 @@ async function fetchChecksumManifest(tagName: string, stageDir: string, directUr
     //    threat model already concedes.
     await execFileAsync(
       'gh',
-      ['release', 'download', tagName, '--repo', REPO, '--pattern', 'CHECKSUMS.txt', '--dir', stageDir, '--clobber'],
+      ['release', 'download', tagName, '--repo', activeRepo(), '--pattern', 'CHECKSUMS.txt', '--dir', stageDir, '--clobber'],
       { encoding: 'utf-8', timeout: 60000, windowsHide: true }
     )
     if (fs.existsSync(tmpPath)) return readManifest(tmpPath)
@@ -1250,7 +1333,7 @@ export async function downloadInstallerFile(tagName: string, assetName: string, 
   try {
     await execFileAsync(
       'gh',
-      ['release', 'download', tagName, '--repo', REPO, '--pattern', safeName, '--dir', stageDir, '--clobber'],
+      ['release', 'download', tagName, '--repo', activeRepo(), '--pattern', safeName, '--dir', stageDir, '--clobber'],
       { encoding: 'utf-8', timeout: 300000, windowsHide: true }
     )
     if (fs.existsSync(destPath)) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,7 @@ import { CodexProvider } from './providers/codex'
 import { registerDebugHandlers } from './ipc/debug-handlers'
 import { disableDebugMode } from './debug-capture'
 import { registerUpdateHandlers } from './ipc/update-handlers'
+import { adoptRenamedRepoIfLive } from './github-update'
 import { registerSetupHandlers, getResourcesDirectory, getDataDirectory } from './ipc/setup-handlers'
 // Direct from data-paths, not the handlers barrel: this runs at module scope
 // before app-ready, so it must not pull the IPC registration side of that module
@@ -879,6 +880,10 @@ if (!gotTheLock) {
     })
     registerDebugHandlers()
     registerUpdateHandlers()
+    // Pre-emptive repo-rename handling: if the app has been renamed on GitHub
+    // (claude-command-center -> ai-code-conductor) adopt + persist the new repo
+    // for updates; else stay on the current one. Non-blocking, fail-safe.
+    void adoptRenamedRepoIfLive()
     registerSetupHandlers()
     registerRegistryHandlers(getResourcesDirectory())
     // Sentinel (spec 2026-06-11): optional service; OFF = no init, dot hidden, zero impact.

--- a/tests/unit/main/github-update-repo-rename.test.ts
+++ b/tests/unit/main/github-update-repo-rename.test.ts
@@ -1,0 +1,79 @@
+// Pre-emptive repo-rename soft-switch (adoptRenamedRepoIfLive):
+//   - a valid existing override wins (manual choice / prior adopt)
+//   - no override + renamed repo LIVE  -> adopt + persist + use it this session
+//   - no override + renamed repo 404/error -> stay on the current repo (fail-safe)
+// Deps are injected so this needs no network or registry.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  adoptRenamedRepoIfLive,
+  activeRepo,
+  RENAMED_REPO,
+  _resetActiveRepoForTest,
+  type AdoptRenamedDeps,
+} from '../../../src/main/github-update'
+
+const DEFAULT_REPO = 'nubbymong/claude-command-center'
+
+function deps(over: Partial<AdoptRenamedDeps> = {}): AdoptRenamedDeps & { writes: string[] } {
+  const writes: string[] = []
+  return {
+    readOverride: over.readOverride ?? (() => null),
+    writeOverride: over.writeOverride ?? ((s) => { writes.push(s); return true }),
+    probe: over.probe ?? (async () => false),
+    writes,
+  }
+}
+
+beforeEach(() => _resetActiveRepoForTest())
+
+describe('adoptRenamedRepoIfLive', () => {
+  it('adopts + persists the renamed repo once it is live, and uses it this session', async () => {
+    const d = deps({ probe: async (slug) => slug === RENAMED_REPO })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe(RENAMED_REPO)
+    expect(d.writes).toEqual([RENAMED_REPO])   // persisted
+    expect(activeRepo()).toBe(RENAMED_REPO)     // in effect immediately, no restart
+  })
+
+  it('stays on the current repo while the renamed repo 404s (not renamed yet)', async () => {
+    const d = deps({ probe: async () => false })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe(DEFAULT_REPO)
+    expect(d.writes).toEqual([])                // nothing persisted
+    expect(activeRepo()).toBe(DEFAULT_REPO)
+  })
+
+  it('stays on the current repo when the probe throws (network error / timeout)', async () => {
+    const d = deps({ probe: async () => { throw new Error('ENOTFOUND') } })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe(DEFAULT_REPO)
+    expect(d.writes).toEqual([])
+  })
+
+  it('respects an existing valid override and never re-probes', async () => {
+    const probe = vi.fn(async () => true)
+    const d = deps({ readOverride: () => 'someorg/custom-fork', probe })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe('someorg/custom-fork')
+    expect(probe).not.toHaveBeenCalled()
+    expect(activeRepo()).toBe('someorg/custom-fork')
+  })
+
+  it('ignores a malformed override and still adopts the renamed repo when live', async () => {
+    const d = deps({ readOverride: () => 'not a valid slug!!', probe: async () => true })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe(RENAMED_REPO)
+  })
+
+  it('uses this session even if persisting the override fails', async () => {
+    const d = deps({ probe: async () => true, writeOverride: () => false })
+    const got = await adoptRenamedRepoIfLive(d)
+    expect(got).toBe(RENAMED_REPO)
+    expect(activeRepo()).toBe(RENAMED_REPO)
+  })
+
+  it('the renamed target is a well-formed same-owner slug (nubbymong/ai-code-conductor)', () => {
+    expect(RENAMED_REPO).toBe('nubbymong/ai-code-conductor')
+    expect(/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(RENAMED_REPO)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Pre-emptive handling for the upcoming GitHub repo rename **claude-command-center → ai-code-conductor** (post-2.1-stable). Built into beta *now* so a build shipped before the rename follows it automatically, with no user action.

At startup (`adoptRenamedRepoIfLive()`, non-blocking):
- a valid `GitHubRepo` override already set (manual, or a prior adopt) **wins** — never second-guessed;
- otherwise probe `nubbymong/ai-code-conductor`. GitHub 404s it until the rename happens; the **moment it's live**, persist the override (`writeRegistry`) and use it the same session (no restart);
- any 404 / error / timeout → stay on `claude-command-center` (**fail-safe — never adopt on uncertainty**).

The module-level `REPO` became `activeRepo()` (cached, override-aware) at every fetch/download site, so a switch takes effect immediately.

## Security (ADR-009 — updater path)
This changes only **which same-owner repo** releases come from — never how they're verified: checksums/signature enforcement is untouched, and the target is a **hardcoded** slug, not caller input. A registry override is `REPO_PATTERN`-validated, and writing it requires same-machine access. **An `/adversarial-review` pass should run before the official cut.**

## Files
- `src/main/github-update.ts` — `RENAMED_REPO`, `activeRepo()`, `repoIsLive()`, `adoptRenamedRepoIfLive()`; `REPO` → `activeRepo()` at all sites
- `src/main/index.ts` — fire the probe at startup
- `tests/unit/main/github-update-repo-rename.test.ts` — adopt+persist / stay-on-404 / stay-on-throw / respect-override / ignore-malformed / persist-failure (injected deps; mutation-checked)

## Verification
- `npm run typecheck` clean; 7/7 unit tests; mutation-checked (adopt-on-uncertainty fails the fail-safe test)
- Included in the everything-test installer on the owner's desktop (probe currently 404s → stays on `claude-command-center`, as expected pre-rename)
