### PR TITLE
fix(profiles): heal self-referential shared junctions (memory/projects ELOOP)

### DIFF
--- a/src/main/account-profiles.ts
+++ b/src/main/account-profiles.ts
@@ -879,6 +879,30 @@ function samePath(a: string, b: string): boolean {
   return norm(a) === norm(b)
 }
 
+/**
+ * Would junctioning `link` -> `target` create a SELF-REFERENCE (link resolving to
+ * itself)? Checks the plain resolved strings first -- catches the reachable field
+ * case, where CCC sets USERPROFILE to `getProfileConfigDir(id)` verbatim so
+ * `sharedRoot()` yields a byte-identical `<profileDir>/.claude`. Then, best-effort,
+ * canonicalises both so an ALTERNATE SPELLING cannot fool it: an 8.3 short name, a
+ * `\\?\` extended prefix, or INDIRECTION (a symlinked shared root that resolves
+ * back into the profile). Each side is realpath'd via its PARENT + basename -- the
+ * leaf (`target`/`link`) usually does NOT exist yet (a junction about to be
+ * created) or may loop, but its parent dir does. If a parent can't be resolved the
+ * string check stands. realpath can only add TRUE positives here -- two paths that
+ * canonicalise to one location genuinely are a loop -- so this never wrongly
+ * refuses a valid, distinct junction.
+ */
+function isSelfReferentialLink(target: string, link: string): boolean {
+  if (samePath(target, link)) return true
+  try {
+    const canon = (p: string): string => path.join(fs.realpathSync.native(path.dirname(p)), path.basename(p))
+    return samePath(canon(target), canon(link))
+  } catch {
+    return false // a parent isn't resolvable -> rely on the string check above
+  }
+}
+
 /** The real user home (parent of the shared ~/.claude). Test-overridable seam. */
 function realHomeDir(): string {
   return rootsOverride ? path.dirname(rootsOverride.sharedRoot) : os.homedir()
@@ -971,8 +995,8 @@ function ensureLink(target: string, link: string, mergeOrphans = false): void {
   // leave any existing (correct) link untouched -- deleting a good junction to
   // plant a self-referential one is strictly worse (adversarial review,
   // 2026-08-18; the field incident that wedged one profile's memory recall).
-  if (samePath(target, link)) {
-    logWarn(`[profiles] refusing to create a self-referential junction at ${link} (target === link) -- the shared root resolved to a profile home; leaving the existing entry intact`)
+  if (isSelfReferentialLink(target, link)) {
+    logWarn(`[profiles] refusing to create a self-referential junction at ${link} (target resolves to the link itself) -- the shared root resolved to a profile home; leaving the existing entry intact`)
     return
   }
   // Replace any existing entry at `link` (safely: never recurse a junction).
@@ -1126,9 +1150,9 @@ export function repairSharedProjectJunctions(): void {
       const link = path.join(claudeDir, name)
       const target = path.join(sharedRoot(), name)
       // Fail closed: NEVER heal into a self-reference. If the correct target
-      // equals the link, the shared root itself resolved to this profile's home
-      // (redirected USERPROFILE) -- skip rather than re-plant the ELOOP.
-      if (samePath(target, link)) continue
+      // resolves to the link, the shared root itself resolved to this profile's
+      // home (redirected USERPROFILE) -- skip rather than re-plant the ELOOP.
+      if (isSelfReferentialLink(target, link)) continue
       let st: fs.Stats
       try { st = fs.lstatSync(link) } catch { continue }  // absent -> nothing to repair
       if (st.isSymbolicLink()) {

--- a/src/main/account-profiles.ts
+++ b/src/main/account-profiles.ts
@@ -13,6 +13,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { getResourcesDirectory } from './ipc/setup-handlers'
 import { atomicWriteFileSync } from './atomic-write'
+import { logWarn } from './debug-logger'
 import { canonicaliseEmail } from '../shared/account-chip-color'
 import type { AccountProfile, AccountProfilesConfig } from '../shared/account-types'
 
@@ -864,6 +865,20 @@ export function createProfile(name?: string): AccountProfile {
 
 const isWin = process.platform === 'win32'
 
+/**
+ * Path equality that folds case on the case-insensitive filesystems (Windows,
+ * macOS) and is exact elsewhere; both inputs are resolved to absolute first. Used
+ * to detect a would-be SELF-REFERENTIAL junction (`target === link`), which is
+ * catastrophic and must never be created.
+ */
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string): string => {
+    const r = path.resolve(p)
+    return isWin || process.platform === 'darwin' ? r.toLowerCase() : r
+  }
+  return norm(a) === norm(b)
+}
+
 /** The real user home (parent of the shared ~/.claude). Test-overridable seam. */
 function realHomeDir(): string {
   return rootsOverride ? path.dirname(rootsOverride.sharedRoot) : os.homedir()
@@ -946,6 +961,20 @@ function removeTreeIfDrained(dir: string): boolean {
  * this pass rather than lose data.
  */
 function ensureLink(target: string, link: string, mergeOrphans = false): void {
+  // A junction/symlink pointing at ITSELF is catastrophic: it is an ELOOP that
+  // wedges every traversal INTO `link` -- Claude's memory/projects recall, the
+  // shared agents/skills/commands/plugins config, `--continue`/resume reading a
+  // transcript. It arises when `sharedRoot()` resolves to the profile's OWN
+  // `.claude` -- i.e. os.homedir() read a REDIRECTED profile USERPROFILE rather
+  // than the real home (CCC spawns child sessions with USERPROFILE=<profileDir>,
+  // so any junction (re)built under that env self-references). Refuse it and
+  // leave any existing (correct) link untouched -- deleting a good junction to
+  // plant a self-referential one is strictly worse (adversarial review,
+  // 2026-08-18; the field incident that wedged one profile's memory recall).
+  if (samePath(target, link)) {
+    logWarn(`[profiles] refusing to create a self-referential junction at ${link} (target === link) -- the shared root resolved to a profile home; leaving the existing entry intact`)
+    return
+  }
   // Replace any existing entry at `link` (safely: never recurse a junction).
   try {
     const st = fs.lstatSync(link)
@@ -1070,26 +1099,61 @@ export function setupProfileLinks(id: string): void {
 }
 
 /**
- * Startup repair (#131): recover sessions orphaned in a profile's REAL
- * `.claude/projects` dir (a junction that never established) by merging them into
- * the shared store and junctioning, for EVERY profile -- so orphans are visible
- * cross-account at launch, not only when that account is next spawned. Idempotent
- * and best-effort: an already-junctioned profile is skipped; a per-profile failure
- * never aborts the sweep. Only ever touches a profile's own `.claude/projects` and
- * the shared store.
+ * Startup self-heal of the per-profile shared junctions, over EVERY profile and
+ * EVERY shared dir (projects/memory/agents/skills/commands/plugins). Two failure
+ * modes are repaired:
+ *  1. #131 orphaned REAL dir -- `.claude/<name>` is a real directory (the junction
+ *     never established, e.g. Claude wrote transcripts there first): merge into the
+ *     shared store (projects only -- union-safe transcripts) / replace-if-empty,
+ *     then junction. So orphans are visible cross-account at launch, not only when
+ *     that account is next spawned.
+ *  2. BROKEN junction -- `.claude/<name>` is a junction whose target is NOT the
+ *     correct shared dir, most importantly a SELF-REFERENTIAL one (target === link),
+ *     an ELOOP that wedges memory/projects recall and resume. Seen in the field
+ *     when a junction was (re)built under a redirected profile USERPROFILE, so
+ *     sharedRoot() resolved to the profile's own `.claude` (adversarial review,
+ *     2026-08-18). The earlier version SKIPPED anything already a junction, so it
+ *     could never heal this.
+ * Idempotent (a correct junction is left alone), best-effort (a per-entry failure
+ * never aborts the sweep), and fail-closed (never creates a self-reference itself).
+ * Only ever touches a profile's own `.claude/<name>` links and the shared store.
  */
 export function repairSharedProjectJunctions(): void {
-  const shared = path.join(sharedRoot(), 'projects')
   for (const p of listProfiles()) {
     if (!isValidProfileId(p.id)) continue
-    const link = path.join(getProfileConfigDir(p.id), '.claude', 'projects')
-    let st: fs.Stats
-    try { st = fs.lstatSync(link) } catch { continue }   // absent -> nothing to repair
-    if (st.isSymbolicLink() || !st.isDirectory()) continue // already a junction (or a file)
-    try {
-      fs.mkdirSync(shared, { recursive: true })
-      ensureLink(shared, link, true)                     // merge orphaned transcripts -> junction
-    } catch { /* best-effort; retried next launch/spawn */ }
+    const claudeDir = path.join(getProfileConfigDir(p.id), '.claude')
+    for (const name of SHARED_DIR_NAMES) {
+      const link = path.join(claudeDir, name)
+      const target = path.join(sharedRoot(), name)
+      // Fail closed: NEVER heal into a self-reference. If the correct target
+      // equals the link, the shared root itself resolved to this profile's home
+      // (redirected USERPROFILE) -- skip rather than re-plant the ELOOP.
+      if (samePath(target, link)) continue
+      let st: fs.Stats
+      try { st = fs.lstatSync(link) } catch { continue }  // absent -> nothing to repair
+      if (st.isSymbolicLink()) {
+        // A junction/symlink. Repair ONLY if it does NOT already point at the
+        // correct shared target -- i.e. self-referential (the field ELOOP),
+        // stale, or otherwise wrong; an unreadable/looping link counts as broken.
+        // A correct junction is left alone (idempotent).
+        let cur: string | null = null
+        try { cur = fs.readlinkSync(link) } catch { cur = null }
+        if (cur !== null && samePath(cur, target)) continue
+        try {
+          fs.mkdirSync(target, { recursive: true })
+          ensureLink(target, link, name === 'projects')  // rebuild -> correct target
+        } catch { /* best-effort; retried next launch/spawn */ }
+      } else if (st.isDirectory()) {
+        // #131 orphaned REAL dir (the junction never established, e.g. Claude
+        // wrote transcripts here first): merge into the shared store (projects
+        // only -- union-safe transcripts) or replace-if-empty, then junction.
+        try {
+          fs.mkdirSync(target, { recursive: true })
+          ensureLink(target, link, name === 'projects')
+        } catch { /* best-effort */ }
+      }
+      // A real FILE at `link` is unexpected -- leave it (never clobber user data).
+    }
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -910,10 +910,13 @@ if (!gotTheLock) {
     // profiles isolated only CLAUDE_CONFIG_DIR, which never isolated the account
     // identity). Idempotent + best-effort; never touches the real home.
     try { migrateProfilesToHomeLayout() } catch (e) { logInfo(`[profiles] home-layout migration skipped: ${e}`) }
-    // Recover sessions orphaned in a profile's REAL projects dir (a junction that
-    // never established) into the shared store so they're resumable cross-account
-    // (#131). Idempotent + best-effort; only touches per-profile projects + shared.
-    try { repairSharedProjectJunctions() } catch (e) { logInfo(`[profiles] project-junction repair skipped: ${e}`) }
+    // Self-heal the per-profile shared junctions (projects/memory/agents/skills/
+    // commands/plugins): recover an orphaned REAL projects dir into the shared
+    // store (#131), AND rebuild any BROKEN junction -- most importantly a
+    // self-referential one (target === link), an ELOOP that wedges memory/projects
+    // recall and resume. Idempotent + best-effort; only touches per-profile shared
+    // links + the shared store.
+    try { repairSharedProjectJunctions() } catch (e) { logInfo(`[profiles] shared-junction repair skipped: ${e}`) }
     // Capture the current global login into a protected "primary" profile so no
     // session runs on the bare global ~/.claude (idempotent; best-effort).
     try { runFirstRunCapture() } catch (e) { logInfo(`[profiles] first-run capture skipped: ${e}`) }

--- a/tests/unit/account-profiles-self-junction.test.ts
+++ b/tests/unit/account-profiles-self-junction.test.ts
@@ -1,0 +1,133 @@
+// tests/unit/account-profiles-self-junction.test.ts
+//
+// A per-profile shared junction that points at ITSELF (target === link) is an
+// ELOOP that wedges every traversal into it -- Claude memory/projects recall,
+// resume, the shared agents/skills/commands/plugins config. It happened in the
+// field when a junction was (re)built under a REDIRECTED profile USERPROFILE, so
+// sharedRoot() resolved to the profile's own `.claude` and ensureLink junctioned
+// each shared dir to itself (adversarial review, 2026-08-18). Two guarantees:
+//   1. ensureLink (via setupProfileLinks) must REFUSE to create a self-reference
+//      even when the shared root is poisoned to the profile home.
+//   2. repairSharedProjectJunctions must HEAL an existing self-referential (or
+//      otherwise wrong-target) junction to the correct shared dir -- the old
+//      version skipped anything already a junction, so it could never fix this.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  _setRootsForTest, getProfileConfigDir, setupProfileLinks,
+  repairSharedProjectJunctions, upsertProfile, SHARED_DIR_NAMES,
+} from '../../src/main/account-profiles'
+
+const isWin = process.platform === 'win32'
+const linkType: fs.symlink.Type = isWin ? 'junction' : 'dir'
+
+let tmp: string
+let resources: string
+let shared: string
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ap-selfjxn-'))
+  resources = path.join(tmp, 'resources')
+  shared = path.join(tmp, 'shared')
+  fs.mkdirSync(resources, { recursive: true })
+})
+afterEach(() => { _setRootsForTest(null); try { fs.rmSync(tmp, { recursive: true, force: true }) } catch { /* ignore */ } })
+
+/** True when `link` is a symlink/junction that resolves to itself (or loops). */
+function isSelfRef(link: string): boolean {
+  let st: fs.Stats
+  try { st = fs.lstatSync(link) } catch { return false }
+  if (!st.isSymbolicLink()) return false
+  let tgt: string
+  try { tgt = fs.readlinkSync(link) } catch { return true } // unreadable/looping = broken
+  const norm = (p: string) => (isWin ? path.resolve(p).toLowerCase() : path.resolve(p))
+  return norm(tgt) === norm(link)
+}
+
+/** Reproduce the field state: a junction/symlink at `link` whose target is `link`. */
+function makeSelfRefJunction(link: string): void {
+  fs.mkdirSync(path.dirname(link), { recursive: true })
+  fs.symlinkSync(link, link, linkType)
+}
+
+describe('shared-junction self-reference guard + heal (adversarial review 2026-08-18)', () => {
+  it('setupProfileLinks REFUSES to create self-referential junctions when the shared root resolves to the profile home (poisoned USERPROFILE)', () => {
+    // Point the shared root at THIS profile's own `.claude`: target === link for
+    // every shared dir -- exactly what os.homedir()==<profileDir> produces.
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: path.join(resources, 'account-profiles', 'p1', '.claude') })
+
+    // Must not throw, and must not plant a single self-referential junction.
+    expect(() => setupProfileLinks('p1')).not.toThrow()
+
+    const claudeDir = path.join(getProfileConfigDir('p1'), '.claude')
+    for (const name of SHARED_DIR_NAMES) {
+      expect(isSelfRef(path.join(claudeDir, name)), `${name} must not be a self-referential junction`).toBe(false)
+    }
+  })
+
+  it('repairSharedProjectJunctions HEALS an existing self-referential projects junction to the correct shared dir', () => {
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: shared })
+    // A real transcript in the shared store the healed junction must reach.
+    fs.mkdirSync(path.join(shared, 'projects', 'C--proj'), { recursive: true })
+    fs.writeFileSync(path.join(shared, 'projects', 'C--proj', 'u.jsonl'), 'transcript\n')
+
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    const link = path.join(getProfileConfigDir('p1'), '.claude', 'projects')
+    makeSelfRefJunction(link)
+    expect(isSelfRef(link)).toBe(true) // broken before
+
+    repairSharedProjectJunctions()
+
+    expect(isSelfRef(link)).toBe(false) // healed
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true) // still a junction...
+    // ...now reaching the shared transcript.
+    expect(fs.readFileSync(path.join(link, 'C--proj', 'u.jsonl'), 'utf8')).toBe('transcript\n')
+  })
+
+  it('repairSharedProjectJunctions heals EVERY shared dir, not just projects', () => {
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: shared })
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    const claudeDir = path.join(getProfileConfigDir('p1'), '.claude')
+    for (const name of SHARED_DIR_NAMES) makeSelfRefJunction(path.join(claudeDir, name))
+
+    repairSharedProjectJunctions()
+
+    for (const name of SHARED_DIR_NAMES) {
+      const link = path.join(claudeDir, name)
+      expect(isSelfRef(link), `${name} should be healed`).toBe(false)
+      const tgt = fs.readlinkSync(link)
+      const norm = (p: string) => (isWin ? path.resolve(p).toLowerCase() : path.resolve(p))
+      expect(norm(tgt)).toBe(norm(path.join(shared, name)))
+    }
+  })
+
+  it('leaves an ALREADY-CORRECT junction untouched (idempotent)', () => {
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: shared })
+    fs.mkdirSync(path.join(shared, 'projects'), { recursive: true })
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    setupProfileLinks('p1') // builds correct junctions
+    const link = path.join(getProfileConfigDir('p1'), '.claude', 'projects')
+    const before = fs.readlinkSync(link)
+
+    repairSharedProjectJunctions()
+    repairSharedProjectJunctions() // twice: still a no-op
+
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(fs.readlinkSync(link)).toBe(before)
+  })
+
+  it('repair FAILS CLOSED under a poisoned shared root: never re-plants a self-reference, never throws', () => {
+    // Shared root == the profile home again -> the correct target would equal the
+    // link, so repair must SKIP (not rebuild a self-reference).
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: path.join(resources, 'account-profiles', 'p1', '.claude') })
+    upsertProfile({ id: 'p1', name: 'A', accountEmail: 'a@x.com', createdAt: 1 })
+    const link = path.join(getProfileConfigDir('p1'), '.claude', 'projects')
+    makeSelfRefJunction(link) // pre-broken (as the field left it)
+
+    expect(() => repairSharedProjectJunctions()).not.toThrow()
+    // Still a junction (we couldn't fix it without the real root) but repair did
+    // not delete-and-recreate another self-reference or crash the sweep.
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true)
+  })
+})

--- a/tests/unit/account-profiles-self-junction.test.ts
+++ b/tests/unit/account-profiles-self-junction.test.ts
@@ -117,6 +117,30 @@ describe('shared-junction self-reference guard + heal (adversarial review 2026-0
     expect(fs.readlinkSync(link)).toBe(before)
   })
 
+  it('catches INDIRECT self-reference: a symlinked shared root that resolves back into the profile home', () => {
+    // sharedRoot is a SYMLINK whose real target is the profile's own `.claude`.
+    // The plain strings differ (so a string-only guard would be fooled), but the
+    // realpath'd identities collapse -> the guard must still refuse.
+    const claudeDir = path.join(resources, 'account-profiles', 'p1', '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    const sharedLink = path.join(tmp, 'shared-link')
+    fs.symlinkSync(claudeDir, sharedLink, linkType) // shared-link -> <p1>/.claude
+    _setRootsForTest({ resourcesDir: resources, sharedRoot: sharedLink })
+
+    expect(() => setupProfileLinks('p1')).not.toThrow()
+
+    // The guard must REFUSE outright: an indirect loop reads as a normal symlink
+    // (readlink != link) and `existsSync` on a loop is silently false, so the only
+    // sound assertion is that NO junction was created at these links at all. A
+    // string-only guard would build them (each an indirect ELOOP) -> this fails.
+    for (const name of SHARED_DIR_NAMES) {
+      const link = path.join(claudeDir, name)
+      let isLink = false
+      try { isLink = fs.lstatSync(link).isSymbolicLink() } catch { /* absent -> refused, good */ }
+      expect(isLink, `${name} must not have been created as a junction (indirect self-reference)`).toBe(false)
+    }
+  })
+
   it('repair FAILS CLOSED under a poisoned shared root: never re-plants a self-reference, never throws', () => {
     // Shared root == the profile home again -> the correct target would equal the
     // link, so repair must SKIP (not rebuild a self-reference).


### PR DESCRIPTION
## What

Fixes a **self-referential shared junction** bug in the account-profiles layer that wedged Claude memory/projects recall — surfaced live this session (one profile's `projects/memory/agents/skills/commands/plugins` junctions all pointed at *themselves* → an `ELOOP` on every traversal).

## Root cause

Each account profile junctions the shared dirs (`projects, memory, agents, skills, commands, plugins`) from its `.claude/<name>` back to the real `~/.claude/<name>`, so accounts share one store. The junction **target** comes from `sharedRoot()` = `path.join(os.homedir(), '.claude')`, and `os.homedir()` reads `USERPROFILE`. CCC spawns child sessions with `USERPROFILE` **redirected to the profile dir**, so any junction (re)built under that env resolves the shared root to the profile's *own* `.claude` → `ensureLink(target, link)` junctions each shared dir to itself. **No data is ever lost** (it lives at the real `~/.claude`); only the profile's links to it loop.

## Fix (two parts, both mutation-proven)

1. **`ensureLink` refuses a self-referential junction.** New `isSelfReferentialLink(target, link)`: plain-string equality first (the reachable field case — CCC sets `USERPROFILE` to `getProfileConfigDir(id)` verbatim, so the strings are byte-identical), then a best-effort realpath canonicalisation (parent + basename) so an **indirect** loop — a symlinked shared root, an 8.3 short name, a `\\?\` prefix — can't slip past. It leaves any existing correct link untouched (deleting a good junction to plant a looping one is strictly worse). realpath here only adds *true* positives, so it never refuses a valid distinct junction.
2. **`repairSharedProjectJunctions` now self-heals broken junctions.** Broadened from "orphaned REAL projects dir only" to a startup sweep over **every** profile × **every** shared dir that also rebuilds a junction whose target is wrong (self-referential / stale / looping) to the correct shared dir. The prior version `continue`d on anything already a junction, so it could never heal this. Still idempotent (a correct junction is left alone) and fail-closed (never re-plants a self-reference under a poisoned root).

Existing/affected profiles auto-heal on next app launch; the live incident was also manually repaired (removing a junction never touches the target data).

## Tests

`tests/unit/account-profiles-self-junction.test.ts`: setup refuses to create self-referential junctions under a poisoned shared root; repair heals a self-referential projects junction and reaches the shared transcript; repair heals **every** shared dir; an already-correct junction is left untouched; repair fails closed under a poisoned root (no re-plant, no throw); and an **indirect** (symlinked shared root) loop is refused. Every guard is mutation-proven (fails when reverted). Full suite green; typecheck clean.

## Adversarial review (ADR-009 — profile/credential + junction path resolution)

Two independent attacker lenses (data-loss/traversal/guard-bypass + regression/robustness/platform-parity) ran against the change. **Verdict: PASS** — no data loss in any construction (`rmdir`/`unlink` on a junction removes only the reparse point; targets survive byte-for-byte across self-ref / sibling-populated / dangling / looping / non-empty-non-`projects` / real-file links), heal is idempotent and non-regressive (zero fs churn on a healthy profile), fails closed, cross-platform sound. The one MINOR (string-only guard blind to indirect loops) was fixed by the realpath hardening in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
