### PR TITLE
feat(ssh): tmux persistence enhancements, and fail-posture hardening for the ladder

### DIFF
--- a/CONTEXT.d/2026-08-18-ssh-tmux-enhancements-and-hardening.md
+++ b/CONTEXT.d/2026-08-18-ssh-tmux-enhancements-and-hardening.md
@@ -1,0 +1,84 @@
+## 2026-08-18 -- SSH tmux persistence: the enhancement batch, and the five majors the follow-up pass found in the substrate (#295)
+
+Two things landed together here. The first is the agreed enhancement backlog on top of #295's
+five-tier tmux ladder -- a "Detachable" config toggle (default on, and it never silently installs
+tmux), Windows client support, a true End-vs-Leave-running close path, the reconnect cascade
+(no host = fail intact, live remote = reattach, gone = resume or fresh), the fix for the silent
+blank chat on `--continue`, resume-outcome messaging, a persistence pill, and the remote account
+surfaced in the session header. That batch was built and real-host tested before this branch
+existed: x86_64 Linux, an aarch64 Pi, Hyper-V (as both remote and client) and macOS (both), which
+is also where its one bug was found and fixed -- the close path missed a Homebrew tmux on macOS
+because a non-login shell does not carry Homebrew's PATH.
+
+The second is the remediation of the pre-merge adversarial pass on #295 itself. That pass ran three
+independent lenses against #295's head. The injection / command-sink / argv lens came back clean and
+proven: a spoofed valid-nonce stage sentinel still produced the fixed `"$HOME"/.claude/bin/tmux`
+token, `singleQuote()` survived quote/`$()`/backtick/20k-char/unicode payloads through a real shell
+as exactly one argv element, and a write-only attacker could not latch completion. The round-3
+wire-path removal holds. What the other two lenses found was a different failure class entirely --
+five majors, none of them a boundary bypass, all of them "the feature makes claude fail to launch,
+or lies about what it did":
+
+- **The terminfo smoke test never tested terminfo.** Both the stage and push scripts smoke-test the
+  binary they install with `tmux -V` followed by `tmux new-session -d`, and both doc comments claim
+  that surfaces "missing or unsuitable terminal". It cannot: a DETACHED new-session never opens a
+  client tty, so terminfo is never consulted, and the pinned static build carries no compiled-in
+  fallback entries. On a remote with no terminfo database for `$TERM` -- the minimal container this
+  tier exists to serve -- staging reports `ok`, the ATTACHED launch dies, and the tier-2 probe
+  re-selects the same binary on every later connect. Nothing recovers: claude never started and
+  Launch Claude is inert once `claudeSent` latched.
+- **The tier-1 launch token broke under a shell alias.** Detection runs `command -v tmux` through
+  `execSync` -- a non-interactive `sh -c`, where aliases do not exist -- but the launch token
+  `"$(command -v tmux)"` is expanded by the INTERACTIVE login shell, where `command -v` prints an
+  alias definition rather than a path. Quoted as a single word that is exit 127. Same class: a login
+  shell that auto-attaches tmux makes `new-session -A` fail with "sessions should be nested with
+  care", on every connect.
+- **The remote fetch was unbounded against a 20 s host-side deadline.** No `--connect-timeout` or
+  `--max-time` on curl, no `-T`/`-t` on wget, so a host whose egress is DROPped rather than rejected
+  blocks for minutes. The host gives up at `STAGE_TIMEOUT_MS` and writes the claude launch into a
+  tty whose foreground pipeline is still running with echo off -- the line is queued invisibly, and
+  a user's Ctrl-C flushes it, leaving an echo-less shell and no claude. Because the script never
+  printed `fail=download`, tier 4 -- the tier that exists precisely for a host with no egress --
+  was never attempted.
+- **The `destroyed` invariant was enforced on the writes but not on the emits.** Destroying a flow
+  mid-tier and then feeding the stage sentinel drove a settings-patch write into the torn-down PTY
+  and re-armed the idle fallback; destroying during the tier-4 download let the resolving promise
+  emit onto `ssh:flowState:<sessionId>` -- the channel a RESPAWNED session with the same id is
+  already subscribed to, so a dead flow could paint the new session's overlay and falsely latch
+  "reached claude-running" on it (which then adds `--continue` with nothing to continue).
+- **The host-side downloader's guards had no failing test.** Raising `TMUX_ARCHIVE_MAX_BYTES` to
+  `Number.MAX_SAFE_INTEGER`, and separately deleting the https-only redirect refusal, both left the
+  entire targeted suite green. This is the function whose unbounded body was a round-4 BLOCKER; it
+  is module-private and every test stubs the archive resolver above it.
+
+The fixes, in the same order. The smoke test is not taught to predict every way a remote can refuse
+to run tmux -- instead a short watchdog watches the PTY after a WRAPPED launch and falls back to the
+bare launch the moment the remote says it failed (`open terminal failed`, `sessions should be
+nested`, `exec format error`, `command not found`, ...). That is safe precisely because a failed
+wrap means nothing is running: the pane is back at a shell prompt. The window closes the instant
+claude latches, so it can never fire against claude's own output. It also covers the wrong-arch and
+truncated-binary cases the smoke test would have to enumerate. `ON_PATH_TMUX_BIN_EXPR` becomes
+`command tmux` -- alias- and function-proof, still a compile-time literal with no wire-reported
+operand, still resolved by the authenticated user's own shell -- and the probe reports `none` when
+`$TMUX` is already set, so the user's own outer tmux is left to do the persisting. The fetch is
+bounded at 5 s connect / 15 s total, with the wget leg written twice because GNU wget needs `-t 1`
+to stay inside the budget while busybox wget (Alpine, OpenWrt -- exactly these hosts) has no `-t` at
+all and would exit on a usage error. `destroyed` now bails at the top of `setFlowState`,
+`armIdleFallback` and `writeClaudeCmd`, and in the onData handler immediately after the renderer
+data forward, so terminal bytes still reach xterm while every latch, parse and write below stops.
+The downloader is exported for tests. The tier-2 probe now actually EXECUTES its candidate (`-V`,
+bounded) instead of trusting `access(X_OK)`, which was satisfied by a zero-byte file, a half-written
+download, a wrong-arch binary and even a directory named `tmux`.
+
+Two things worth keeping from how this went. The first: every one of these majors lived in a code
+path whose doc comment asserted the opposite, and each doc comment was written in good faith after a
+previous adversarial round closed a real bug at the same spot. A comment describing a guarantee is
+not evidence the guarantee holds, and the more rounds a file has survived the more confidently wrong
+its comments can be. The second: the tests for the tier-1 token compared the generated command
+against the imported constant, so changing the constant changed both sides and every test stayed
+green -- a self-referential assertion is indistinguishable from no assertion. The new tests pin the
+literal text and were each mutation-proven by breaking the source and watching them fail.
+
+Gate: typecheck clean across the three projects, full suite 5744 passing. The watchdog's live
+behaviour against a genuinely terminfo-less remote is unit-simulated, not host-confirmed -- that
+joins the standing acceptance check the ladder has carried since #242.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.13-test.2",
+  "version": "2.1.0-beta.12",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",
@@ -129,7 +129,14 @@
             "x64"
           ]
         }
-      ]
+      ],
+      "signtoolOptions": {
+        "signingHashAlgorithms": [
+          "sha256"
+        ],
+        "rfc3161TimeStampServer": "http://ts.ssl.com",
+        "publisherName": "Nicholas Moger"
+      }
     },
     "mac": {
       "executableName": "AI Code Conductor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.12",
+  "version": "2.1.0-beta.13-test.2",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",
@@ -129,14 +129,7 @@
             "x64"
           ]
         }
-      ],
-      "signtoolOptions": {
-        "signingHashAlgorithms": [
-          "sha256"
-        ],
-        "rfc3161TimeStampServer": "http://ts.ssl.com",
-        "publisherName": "Nicholas Moger"
-      }
+      ]
     },
     "mac": {
       "executableName": "AI Code Conductor",

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { z } from 'zod'
-import { spawnPty, writePty, resizePty, killPty, getSshFlow, SSHOptions } from '../pty-manager'
+import { spawnPty, writePty, resizePty, killPty, getSshFlow, endSshRemote, SSHOptions } from '../pty-manager'
 import { logUserInput, isDebugModeEnabled } from '../debug-capture'
 import { logInfo } from '../debug-logger'
 import { isVersionInstalled, installVersion } from '../legacy-version-manager'
@@ -24,6 +24,12 @@ interface RendererSSHOptions {
    *  verbatim into SSHOptions.reconnect; see its doc comment in
    *  pty-manager.ts for how it's consumed. */
   reconnect?: boolean
+  /** SSH tmux enhancement (item 1): "Detachable" toggle. Only `false`
+   *  disables the tmux-persistence ladder; undefined/true = ON. */
+  detachable?: boolean
+  /** SSH tmux enhancement (item 3): remote OS. 'windows' selects the Windows
+   *  setup path; 'auto'/'unix'/undefined use POSIX unchanged. */
+  remoteOs?: 'auto' | 'unix' | 'windows'
 }
 
 // host/username are fused into `${username}@${host}` and handed to ssh as
@@ -47,6 +53,8 @@ const sshSchema = z.object({
   remotePath: z.string().min(1).regex(/^[~A-Za-z0-9_./-]+$/, 'remote path has invalid characters'),
   postCommand: z.string().optional(),
   reconnect: z.boolean().optional(),
+  detachable: z.boolean().optional(),
+  remoteOs: z.enum(['auto', 'unix', 'windows']).optional(),
 }).optional()
 
 export const spawnOptionsSchema = z.object({
@@ -353,5 +361,13 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
   ipcMain.handle(IPC.SSH_FLOW_GET_STATE, async (_event, sessionId: string) => {
     sessionIdSchema.parse(sessionId)
     return getSshFlow(sessionId)?.getState() ?? { state: 'connecting' }
+  })
+
+  // SSH tmux enhancement (item 4): deliberately END a persistent remote session
+  // (tmux kill-session + sidecar cleanup over a SEPARATE ssh exec). The renderer
+  // still tears down the local PTY itself (killSessionPty) after this resolves.
+  ipcMain.handle(IPC.SSH_END_REMOTE, async (_event, sessionId: string) => {
+    sessionIdSchema.parse(sessionId)
+    endSshRemote(sessionId)
   })
 }

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -100,7 +100,7 @@ process.stdin.on('data',c=>input+=c);
 process.stdin.on('end',()=>{
 try{
 const data=JSON.parse(input);
-const sid=process.env.CLAUDE_MULTI_SESSION_ID||'unknown';
+const sid=process.argv[2]||process.env.CLAUDE_MULTI_SESSION_ID||(data&&data.session_id)||'unknown';
 const cw=data.context_window||{};
 const u=cw.current_usage||{};
 const it=(u.input_tokens||0)+(u.cache_creation_input_tokens||0)+(u.cache_read_input_tokens||0);
@@ -112,7 +112,7 @@ const iso=(t)=>typeof t==='number'?new Date(t*1000).toISOString():(t||'');
 if(rl.five_hour){s.rateLimitCurrent=Math.round(Number(rl.five_hour.used_percentage)||0);s.rateLimitCurrentResets=iso(rl.five_hour.resets_at);}
 if(rl.seven_day){s.rateLimitWeekly=Math.round(Number(rl.seven_day.used_percentage)||0);s.rateLimitWeeklyResets=iso(rl.seven_day.resets_at);}
 const sentinel='\\x1b]9999;CMSTATUS='+JSON.stringify(s)+'\\x07';
-let ok=false;
+let ok=false;if(process.platform==='win32'){try{fs.writeFileSync(String.fromCharCode(92,92,46,92)+'CONOUT$',sentinel);ok=true;trace('conout-ok sid='+sid);}catch(e0){trace('conout-fail sid='+sid+' err='+(e0&&e0.code||e0.message||'unknown'));}}
 if(process.env.TMUX){const tb=process.env.CCC_TMUX_BIN||'';if(tb){try{const out=require('child_process').execFileSync(tb,['display-message','-p','#{client_tty}'],{encoding:'utf8',timeout:2000});const tty=out.split('\\n')[0].trim();if(tty){try{if(tty.indexOf('/dev/')!==0)throw new Error('not-under-dev');if(!fs.statSync(tty).isCharacterDevice())throw new Error('not-a-chardev');fs.writeFileSync(tty,sentinel);ok=true;trace('tmux-clienttty-ok sid='+sid+' dev='+tty);}catch(e4){trace('tmux-fail sid='+sid+' dev='+tty+' err='+(e4&&e4.code||e4.message||'unknown'));}}else{ok=true;trace('tmux-detached sid='+sid);}}catch(e5){trace('tmux-fail sid='+sid+' err='+(e5&&e5.code||e5.message||'unknown'));}}else{trace('tmux-fail sid='+sid+' err=no-ccc-tmux-bin');}}
 if(!ok){try{fs.writeFileSync('/dev/tty',sentinel);ok=true;}catch(e){trace('tty-fail sid='+sid+' err='+(e&&e.code||e.message||'unknown'));}}
 if(!ok){const pts=findPty();if(pts){try{fs.writeFileSync(pts,sentinel);ok=true;trace('pts-ok sid='+sid+' dev='+pts);}catch(e2){trace('pts-fail sid='+sid+' dev='+pts+' err='+(e2&&e2.code||e2.message||'unknown'));}}else{trace('pts-none sid='+sid);}}
@@ -362,7 +362,15 @@ export function generateRemoteSetupScript(
     // back to either file -- --mcp-config supersedes both.
     `if(s.mcpServers){if(s.mcpServers['conductor-vision'])delete s.mcpServers['conductor-vision'];if(s.mcpServers['conductor'])delete s.mcpServers['conductor']}`,
     `try{fs.writeFileSync(sp,JSON.stringify(s,null,2))}catch{}`,
-    `try{const cj=path.join(home,'.claude.json');if(fs.existsSync(cj)){let c=JSON.parse(fs.readFileSync(cj,'utf-8'));let mut=false;if(c.mcpServers){if(c.mcpServers['conductor-vision']){delete c.mcpServers['conductor-vision'];mut=true}if(c.mcpServers['conductor']){delete c.mcpServers['conductor'];mut=true}}if(mut)fs.writeFileSync(cj,JSON.stringify(c,null,2))}}catch{}`,
+    // SSH tmux enhancement (item 10): while ~/.claude.json is already open for
+    // the mcpServers heal, also grab oauthAccount.emailAddress -- the SAME
+    // field the LOCAL identity reader uses (claude-account-identity.ts) -- so a
+    // remote session can show which account it runs as. base64 the value here
+    // so the wire token carries no space/shell/regex metacharacter; the host
+    // decodes + charset/length-caps it for DISPLAY only (parseSetupAccountSentinel,
+    // pty-manager.ts), never interpreting it. `acctB64` stays '' when there is
+    // no account or the file is unreadable.
+    `let acctB64='';try{const cj=path.join(home,'.claude.json');if(fs.existsSync(cj)){let c=JSON.parse(fs.readFileSync(cj,'utf-8'));if(c&&c.oauthAccount&&typeof c.oauthAccount.emailAddress==='string')acctB64=Buffer.from(c.oauthAccount.emailAddress,'utf-8').toString('base64');let mut=false;if(c.mcpServers){if(c.mcpServers['conductor-vision']){delete c.mcpServers['conductor-vision'];mut=true}if(c.mcpServers['conductor']){delete c.mcpServers['conductor'];mut=true}}if(mut)fs.writeFileSync(cj,JSON.stringify(c,null,2))}}catch{}`,
     `try{const md=path.join(claudeDir,'CLAUDE.md');let c=fs.readFileSync(md,'utf-8');const rx=/\\n?\\n?<!-- VISION-INSTRUCTIONS-START -->[\\s\\S]*?<!-- VISION-INSTRUCTIONS-END -->\\n?/g;if(rx.test(c)){c=c.replace(rx,'').trim();fs.writeFileSync(md,c?c+'\\n':'')}}catch{}`,
     // Sentinel now carries the tmux result alongside the original
     // completion marker: pty-manager's parseTmuxSentinel requires an EXACT
@@ -382,7 +390,12 @@ export function generateRemoteSetupScript(
     // `$HOME/.claude/bin/tmux` literal for `home`) from a host-authored
     // literal table keyed on this class, so there is no wire-reported path
     // for a spoofed sentinel to influence even with a stolen/copied nonce.
-    `process.stdout.write('setup ok ${nonce} tmux='+tmuxClass+'\\n')`,
+    // item 10: the account descriptor rides the SAME nonce'd sentinel, AFTER
+    // the tmux class, as `acct=<base64email>` (empty when unknown). Kept a
+    // fixed b64 charset so parseTmuxSentinel's completion latch (which now
+    // tolerates an optional ` acct=<b64>` suffix before the line terminator)
+    // still resolves, and so the value can't smuggle a space/metacharacter.
+    `process.stdout.write('setup ok ${nonce} tmux='+tmuxClass+' acct='+acctB64+'\\n')`,
   ]
   return lines.join(';')
 }
@@ -417,6 +430,44 @@ export function remoteSessionMcpConfigPath(sessionId: string): string {
  */
 export function buildRemoteSessionCleanupCommand(sessionId: string): string {
   return `rm -f ${remoteSessionSettingsPath(sessionId)} ${remoteSessionMcpConfigPath(sessionId)}\n`
+}
+
+/**
+ * SSH tmux enhancement (item 4): the remote command run over a SEPARATE ssh
+ * exec (NOT down the live PTY -- see endSshRemote in pty-manager.ts) when the
+ * user deliberately ENDS a persistent session. It kills the named tmux session
+ * AND removes the per-session sidecars.
+ *
+ * The tmux session name is `ccc-<safeSid>` (mirrors buildTmuxLaunchCommand).
+ * We do not know at end-time which tier staged tmux, so BOTH host-authored
+ * locations are tried -- `command -v tmux` (tier 1) and the fixed
+ * `"$HOME"/.claude/bin/tmux` (tiers 2/3/4) -- exactly the same two fixed
+ * literals buildTmuxLaunchCommand embeds, with NO wire-reported path anywhere
+ * (the #242 RCE-sink discipline). safeSid is the ONLY interpolated value and is
+ * sanitized to `[A-Za-z0-9_-]`, so it cannot carry a shell metacharacter into
+ * the `-t` argument. Each step is best-effort (`2>/dev/null`, trailing `true`)
+ * so a missing binary / already-dead session still cleans the sidecars.
+ */
+export function buildRemoteTmuxKillCommand(sessionId: string): string {
+  const safeSid = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')
+  const target = `ccc-${safeSid}`
+  // The kill runs over a SEPARATE, NON-LOGIN ssh exec (endSshRemote), whose PATH
+  // is minimal — `command -v tmux` alone MISSES a Homebrew tmux on macOS
+  // (/opt/homebrew/bin is added only by a login shell), which would orphan the
+  // session (found on real Macs in testing). So try each known tmux location in
+  // turn: PATH (`tmux`, for Linux where /usr/bin is in the minimal PATH), the
+  // two Homebrew prefixes (arm64 + intel), the system path, and the CCC-staged
+  // tier-2 binary. All are host-authored literals; `target` is the only
+  // interpolated value and is safeSid-sanitized, so nothing an attacker controls
+  // reaches the `-t` argument. Each attempt is silenced; a missing binary or
+  // already-dead session is a no-op, and the trailing `true` keeps the exec 0.
+  const tmuxBins = ['tmux', '/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '"$HOME/.claude/bin/tmux"']
+  const kills = tmuxBins.map((b) => `${b} kill-session -t ${target} 2>/dev/null`).join('; ')
+  return [
+    kills,
+    `rm -f ${remoteSessionSettingsPath(sessionId)} ${remoteSessionMcpConfigPath(sessionId)} 2>/dev/null`,
+    `true`,
+  ].join('; ')
 }
 
 /**
@@ -551,4 +602,152 @@ export function buildTmuxBinPatchCommand(sessionId: string): string {
   ].join(';')
   const b64 = Buffer.from(script).toString('base64')
   return `echo '${b64}' | base64 -d | node 2>/dev/null`
+}
+
+// ===========================================================================
+// SSH tmux enhancement (item 3): Windows remote support — PROTOTYPE.
+//
+// A Windows SSH remote has no tmux (so no persistence tier: the session is a
+// bare `claude` that resumes via --continue on reconnect), and its login shell
+// is cmd.exe, so the POSIX delivery (`stty; echo b64 | base64 -d | node`) and
+// the POSIX statusline shim (/dev/tty, /proc pts-walk) do not apply. This
+// block is the Windows equivalent, kept entirely separate from the POSIX path
+// so it cannot regress Unix. It is selected only when SshConfig.remoteOs ===
+// 'windows'. Validated on Hyper-V: the PowerShell-delivered node setup runs and
+// emits `setup ok <nonce> tmux=none acct=<b64>`, and the shim's CONOUT$ branch
+// (SSH_STATUSLINE_SHIM above) reaches the SSH client.
+// ===========================================================================
+
+/**
+ * The Windows remote setup node program. Cross-platform node handles fs/path/
+ * os fine on Windows; the differences from the POSIX generator are: NO tmux
+ * detection (Windows has none — tmuxClass is fixed 'none'), the per-session
+ * statusLine command is `node "<shim>" <sid>` (cmd.exe cannot env-prefix, so
+ * the session id rides argv — the shim reads process.argv[2]), and directory
+ * modes/chmod are dropped (NTFS ACLs, not POSIX 0700). The account descriptor
+ * (item 10) is read the same way. Emits the SAME nonce'd sentinel shape the
+ * POSIX path does, so pty-manager's existing parseTmuxSentinel latch handles
+ * Windows completion with no special-casing.
+ */
+/**
+ * item 3: a MINIMAL Windows statusline shim (CONOUT$ only). The full POSIX
+ * shim (SSH_STATUSLINE_SHIM) is ~3KB of tmux/dev-tty/proc fallback logic that
+ * is dead weight on Windows AND blows past cmd.exe's 8191-char command-line
+ * limit once base64'd for delivery. This keeps only what Windows needs: read
+ * the statusline JSON on stdin, build the SAME status object + CMSTATUS OSC
+ * sentinel the parser (pty-manager.ts) expects, and write it to the console
+ * device (built via String.fromCharCode to avoid backslash escaping), which
+ * reaches the SSH client (verified on Hyper-V). Session id rides argv (cmd.exe
+ * cannot env-prefix a statusLine command).
+ */
+const SSH_STATUSLINE_SHIM_WINDOWS = "const fs=require('fs');let input='';process.stdin.setEncoding('utf8');process.stdin.on('data',c=>input+=c);process.stdin.on('end',()=>{try{const data=JSON.parse(input);const sid=process.argv[2]||process.env.CLAUDE_MULTI_SESSION_ID||(data&&data.session_id)||'unknown';const cw=data.context_window||{},u=cw.current_usage||{},cost=data.cost||{},m=data.model||{},rl=data.rate_limits||{};const it=(u.input_tokens||0)+(u.cache_creation_input_tokens||0)+(u.cache_read_input_tokens||0);const s={sessionId:sid,model:m.display_name||m.id,contextUsedPercent:cw.used_percentage,contextRemainingPercent:cw.remaining_percentage,contextWindowSize:cw.context_window_size,inputTokens:it||undefined,outputTokens:u.output_tokens,costUsd:cost.total_cost_usd,totalDurationMs:cost.total_duration_ms,linesAdded:cost.total_lines_added,linesRemoved:cost.total_lines_removed,timestamp:Date.now()};const iso=(t)=>typeof t==='number'?new Date(t*1000).toISOString():(t||'');if(rl.five_hour){s.rateLimitCurrent=Math.round(Number(rl.five_hour.used_percentage)||0);s.rateLimitCurrentResets=iso(rl.five_hour.resets_at);}if(rl.seven_day){s.rateLimitWeekly=Math.round(Number(rl.seven_day.used_percentage)||0);s.rateLimitWeeklyResets=iso(rl.seven_day.resets_at);}const sentinel=String.fromCharCode(27)+']9999;CMSTATUS='+JSON.stringify(s)+String.fromCharCode(7);try{fs.writeFileSync(String.fromCharCode(92,92,46,92)+'CONOUT$',sentinel);}catch(e){try{process.stderr.write(sentinel);}catch(e2){}}process.stdout.write(' ');}catch(e){process.stdout.write(' ');}});"
+
+export function generateWindowsRemoteSetupScript(
+  sessionId: string,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  nonce: string,
+): string {
+  if (!/^[A-Za-z0-9]+$/.test(nonce)) {
+    throw new Error(`generateWindowsRemoteSetupScript: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
+  }
+  const { includeStatusLine = true, includeConductorMcp = true } = opts ?? {}
+  const mcpPort = getConductorMcpPort()
+  const hasVision = mcpPort > 0 && includeConductorMcp
+  const shimLiteral = JSON.stringify(SSH_STATUSLINE_SHIM_WINDOWS)
+  const safeSid = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')
+  const mcpConfigLiteral = hasVision
+    ? JSON.stringify({
+        mcpServers: {
+          conductor: {
+            type: 'sse',
+            url: `http://localhost:${mcpPort}/sse?cccSessionId=${encodeURIComponent(sessionId)}&token=${mcpSessionToken(sessionId)}`,
+          },
+        },
+      })
+    : JSON.stringify({ mcpServers: {} })
+
+  // statusLine.command: `node "<shimPath>" <safeSid>` — argv carries the sid,
+  // which the shim (SSH_STATUSLINE_SHIM) reads via process.argv[2]. shimPath is
+  // JSON.stringify'd at RUNTIME on the remote so its backslashes are escaped
+  // correctly for the JSON settings file, exactly as the POSIX generator embeds
+  // `+shimPath+`.
+  const sesCfgParts: string[] = []
+  if (includeStatusLine) {
+    sesCfgParts.push(`statusLine:{type:'command',command:'node '+JSON.stringify(shimPath)+' ${safeSid}'}`)
+  }
+
+  const lines = [
+    `const fs=require('fs'),path=require('path'),os=require('os')`,
+    `const home=os.homedir(),claudeDir=path.join(home,'.claude')`,
+    `try{fs.mkdirSync(claudeDir,{recursive:true})}catch{}`,
+    `const shimPath=path.join(claudeDir,'conductor-ssh-statusline.js')`,
+    `try{fs.rmSync(shimPath,{force:true})}catch{}try{fs.writeFileSync(shimPath,${shimLiteral},{flag:'wx'})}catch{}`,
+    `const sp=path.join(claudeDir,'settings.json')`,
+    `let s={};try{s=JSON.parse(fs.readFileSync(sp,'utf-8'))}catch{}`,
+    `const sBase=Object.assign({},s);delete sBase.mcpServers`,
+    `if(sBase.statusLine&&typeof sBase.statusLine.command==='string'&&sBase.statusLine.command.includes('conductor-ssh-statusline'))delete sBase.statusLine`,
+    `const sesPath=path.join(claudeDir,'settings-${safeSid}.json')`,
+    `const sesCfg=Object.assign({},sBase,{${sesCfgParts.join(',')}})`,
+    `try{fs.rmSync(sesPath,{force:true})}catch{}try{fs.writeFileSync(sesPath,JSON.stringify(sesCfg,null,2),{flag:'wx'})}catch{}`,
+    `const mcpPath=path.join(claudeDir,'mcp-${safeSid}.json')`,
+    `try{fs.rmSync(mcpPath,{force:true})}catch{}try{fs.writeFileSync(mcpPath,${JSON.stringify(mcpConfigLiteral)},{flag:'wx'})}catch{}`,
+    `if(s.statusLine&&typeof s.statusLine.command==='string'&&s.statusLine.command.includes('conductor-ssh-statusline'))delete s.statusLine`,
+    `if(s.mcpServers){if(s.mcpServers['conductor-vision'])delete s.mcpServers['conductor-vision'];if(s.mcpServers['conductor'])delete s.mcpServers['conductor']}`,
+    `try{fs.writeFileSync(sp,JSON.stringify(s,null,2))}catch{}`,
+    // item 10: read the remote account descriptor (base64) — same field as POSIX.
+    `let acctB64='';try{const cj=path.join(home,'.claude.json');if(fs.existsSync(cj)){const c=JSON.parse(fs.readFileSync(cj,'utf-8'));if(c&&c.oauthAccount&&typeof c.oauthAccount.emailAddress==='string')acctB64=Buffer.from(c.oauthAccount.emailAddress,'utf-8').toString('base64')}}catch{}`,
+    // tmux is fixed 'none' on Windows — the ladder never runs, launch is bare.
+    `process.stdout.write('setup ok ${nonce} tmux=none acct='+acctB64+'\\n')`,
+  ]
+  return lines.join(';')
+}
+
+/**
+ * Wrap generateWindowsRemoteSetupScript in a single cmd.exe-typed line that
+ * runs it via PowerShell (cmd.exe has no base64/stty). The node program is
+ * UTF-8 base64'd, then a small PowerShell command decodes it and pipes it to
+ * `node`; that PowerShell command is itself UTF-16LE base64'd for
+ * `-EncodedCommand` (so no quoting of the payload is needed on the cmd line at
+ * all). `$ProgressPreference='SilentlyContinue'` suppresses PowerShell's CLIXML
+ * "Preparing modules" progress noise so only the sentinel line comes back.
+ */
+export function getWindowsRemoteSetupCommand(
+  sessionId: string,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  nonce: string,
+): string {
+  const script = generateWindowsRemoteSetupScript(sessionId, opts, nonce)
+  // Single base64 of the node program (its alphabet is [A-Za-z0-9+/=], so it
+  // carries no cmd.exe metacharacter and needs no quoting). Delivered via
+  // `powershell -Command`, NOT `-EncodedCommand`: EncodedCommand re-encodes the
+  // whole thing as UTF-16LE base64, ~2.6x larger, blowing past cmd.exe's
+  // 8191-char command-line limit. The minimal Windows shim keeps the payload
+  // comfortably under that limit.
+  const nodeB64 = Buffer.from(script, 'utf-8').toString('base64')
+  return `powershell -NoProfile -NonInteractive -Command "$ProgressPreference='SilentlyContinue';$s=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${nodeB64}'));$s|node"`
+}
+
+/**
+ * The Windows claude launch line (cmd.exe). Env vars use `set "X=Y"&&` (cmd
+ * syntax, not the POSIX `X=Y claude` prefix), settings/mcp paths use
+ * `%USERPROFILE%\.claude\...` (cmd expands %USERPROFILE%; `~` does not expand
+ * in cmd), and `claude` resolves to claude.cmd on PATH. No tmux wrap (Windows
+ * has none). `extraFlags` is the SAME claude flag string the POSIX path builds
+ * MINUS --settings/--mcp-config (re-added here with Windows paths);
+ * `continueFlag` is '--continue' on a reconnect or ''.
+ */
+export function buildWindowsClaudeCommand(input: {
+  sessionId: string
+  envPrefixVars: string[]
+  extraFlags: string
+  continueFlag: string
+}): string {
+  const safeSid = input.sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')
+  const settings = `"%USERPROFILE%\\.claude\\settings-${safeSid}.json"`
+  const mcp = `"%USERPROFILE%\\.claude\\mcp-${safeSid}.json"`
+  const sets = input.envPrefixVars.map((kv) => `set "${kv}"&& `).join('')
+  const flags = [`--settings ${settings}`, `--mcp-config ${mcp}`, input.extraFlags, input.continueFlag]
+    .filter((f) => f && f.trim())
+    .join(' ')
+  return `${sets}claude ${flags}`
 }

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -293,7 +293,24 @@ export function generateRemoteSetupScript(
     // remote-reported path for either tier at all, so there is nothing left
     // for a wire-carried path to influence.
     `let tmuxPath='';let tmuxClass='none';try{tmuxPath=require('child_process').execSync('command -v tmux',{encoding:'utf8'}).trim();if(tmuxPath)tmuxClass='path'}catch{}`,
-    `if(!tmuxPath){const cb=path.join(claudeDir,'bin','tmux');try{fs.accessSync(cb,fs.constants.X_OK);tmuxPath=cb;tmuxClass='home'}catch{}}`,
+    // Follow-up adversarial pass (fail-posture MINOR): the tier-2 probe used
+    // fs.accessSync(X_OK) alone, which is satisfied by a zero-byte file, a
+    // half-written download, a wrong-architecture binary and even a DIRECTORY
+    // named `tmux` (POSIX X_OK on a searchable directory succeeds). Any of
+    // those got reported as `home`, wrapping every future launch on this host
+    // in a binary that cannot run. Actually EXECUTING it (`-V`, bounded) is the
+    // only check that answers the question the class claims to answer.
+    `if(!tmuxPath){const cb=path.join(claudeDir,'bin','tmux');try{fs.accessSync(cb,fs.constants.X_OK);require('child_process').execFileSync(cb,['-V'],{timeout:5000,stdio:'ignore'});tmuxPath=cb;tmuxClass='home'}catch{}}`,
+    // Follow-up adversarial pass (fail-posture MAJOR): if the remote login
+    // shell is ALREADY inside tmux (a very common `[ -z "$TMUX" ] && exec tmux
+    // new -A` in a user's rc file), wrapping the launch in another
+    // `new-session -A` is refused by tmux itself ("sessions should be nested
+    // with care, unset $TMUX to force") -- exit 1, no claude, on every single
+    // connect. Report `none` so the launch stays bare: the user's own outer
+    // tmux is already providing the persistence this tier would have added,
+    // and a session that starts is strictly better than a pill that says
+    // "persistent" over a session that never launched.
+    `if(process.env.TMUX){tmuxPath='';tmuxClass='none'}`,
     // #242 MAJOR (round 2, adversarial review): allowlist guard on tmuxPath,
     // BEFORE its one remaining consumer below (CCC_TMUX_BIN). `command -v
     // tmux` and the ~/.claude/bin access check both hand back a value this

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -703,13 +703,22 @@ export function generateWindowsRemoteSetupScript(
 }
 
 /**
- * Wrap generateWindowsRemoteSetupScript in a single cmd.exe-typed line that
- * runs it via PowerShell (cmd.exe has no base64/stty). The node program is
- * UTF-8 base64'd, then a small PowerShell command decodes it and pipes it to
- * `node`; that PowerShell command is itself UTF-16LE base64'd for
- * `-EncodedCommand` (so no quoting of the payload is needed on the cmd line at
- * all). `$ProgressPreference='SilentlyContinue'` suppresses PowerShell's CLIXML
- * "Preparing modules" progress noise so only the sentinel line comes back.
+ * Wrap generateWindowsRemoteSetupScript in a single line that runs it via
+ * PowerShell (cmd.exe has no base64/stty). The node program is UTF-8 base64'd
+ * and a small PowerShell command decodes it and pipes it to `node`.
+ *
+ * The `-Command` payload MUST contain NO `$`. The remote's sshd DefaultShell is
+ * commonly PowerShell (not cmd.exe), and a PowerShell parent expands any `$var`
+ * inside the double-quoted argument BEFORE the child powershell runs -- so the
+ * earlier `$ProgressPreference=…;$s=…;$s|node` form had `$s` expanded to empty
+ * by the parent, yielding `…;|node` -> "An empty pipe element is not allowed"
+ * and setup silently never ran (adversarial review, 2026-08-18, live-confirmed).
+ * The `$`-free `<decode-expr>|node` form parses identically under cmd.exe AND a
+ * PowerShell login shell. `-NonInteractive -NoProfile` already suppress the
+ * CLIXML "Preparing modules" noise the dropped `$ProgressPreference` guarded, and
+ * a plain decode|node pipeline imports no module, so nothing but the sentinel
+ * line comes back. NOT `-EncodedCommand`: that re-encodes as UTF-16LE base64,
+ * ~2.6x larger, blowing past cmd.exe's 8191-char limit.
  */
 export function getWindowsRemoteSetupCommand(
   sessionId: string,
@@ -718,13 +727,9 @@ export function getWindowsRemoteSetupCommand(
 ): string {
   const script = generateWindowsRemoteSetupScript(sessionId, opts, nonce)
   // Single base64 of the node program (its alphabet is [A-Za-z0-9+/=], so it
-  // carries no cmd.exe metacharacter and needs no quoting). Delivered via
-  // `powershell -Command`, NOT `-EncodedCommand`: EncodedCommand re-encodes the
-  // whole thing as UTF-16LE base64, ~2.6x larger, blowing past cmd.exe's
-  // 8191-char command-line limit. The minimal Windows shim keeps the payload
-  // comfortably under that limit.
+  // carries no cmd.exe / PowerShell metacharacter and needs no quoting).
   const nodeB64 = Buffer.from(script, 'utf-8').toString('base64')
-  return `powershell -NoProfile -NonInteractive -Command "$ProgressPreference='SilentlyContinue';$s=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${nodeB64}'));$s|node"`
+  return `powershell -NoProfile -NonInteractive -Command "[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${nodeB64}'))|node"`
 }
 
 /**

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -397,6 +397,22 @@ const TMUX_DOWNLOAD_REQUEST_TIMEOUT_MS = 20000
  */
 const TMUX_ARCHIVE_MAX_BYTES = 8 * 1024 * 1024
 
+/**
+ * Follow-up adversarial pass (coverage MAJOR): exported for tests.
+ *
+ * Every guard in this function was previously unreachable from the suite --
+ * `attemptTmuxPush` goes through the `tmuxArchiveResolver` seam, which tests
+ * stub ABOVE this level, so raising TMUX_ARCHIVE_MAX_BYTES to
+ * Number.MAX_SAFE_INTEGER, or deleting the https-only redirect refusal
+ * outright, left the entire targeted suite green. This is the function whose
+ * unbounded body was a round-4 BLOCKER; its guards must be able to fail a test.
+ * Exported (rather than reached through a new seam) so the tests drive the real
+ * https path with a mocked `https.get`.
+ */
+export function _downloadAndCacheTmuxArchiveForTest(arch: TmuxStageTarget): Promise<Buffer | null> {
+  return downloadAndCacheTmuxArchive(arch)
+}
+
 function downloadAndCacheTmuxArchive(arch: TmuxStageTarget): Promise<Buffer | null> {
   // #242 finding F6: same URL parts buildTmuxStageScript's remote curl/wget
   // fragment builds its `_url` from (ssh-tmux-stage.ts) -- see
@@ -1240,6 +1256,16 @@ export function spawnPty(
     const DOWNLOAD_TIMEOUT_MS = 45000
 
     const setFlowState = (s: SshFlowState, info?: string) => {
+      // Follow-up adversarial pass (lifecycle MAJOR): `destroyed` used to gate
+      // only the PTY WRITES, not this emit. A flow torn down mid-tier (the
+      // download promise, a push abort) still resolved afterwards and emitted
+      // onto `ssh:flowState:<sessionId>` -- a channel a RESPAWNED session with
+      // the same id is already subscribed to, so the dead flow's
+      // 'running-claude'/failure state painted the new session's overlay and
+      // could falsely latch "reached claude-running" on it (which then adds
+      // --continue with no conversation to continue). A destroyed flow emits
+      // nothing: it no longer exists as far as the renderer is concerned.
+      if (destroyed) return
       currentFlowState = s
       currentFlowInfo = info
       logInfo(`[ssh] ${sessionId}: flow → ${s}${info ? ` (${info})` : ''}`)
@@ -1257,6 +1283,11 @@ export function spawnPty(
     let idleFallbackHandle: ReturnType<typeof setTimeout> | null = null
     let receivedAnyData = false
     const armIdleFallback = () => {
+      // Follow-up adversarial pass (lifecycle MAJOR): destroy() clears this
+      // timer, but any data arriving during the PTY's teardown grace window
+      // re-armed it immediately afterwards -- resurrecting the whole ladder
+      // (up to a 'claude-running' emit) on a session that no longer exists.
+      if (destroyed) return
       if (idleFallbackHandle) clearTimeout(idleFallbackHandle)
       idleFallbackHandle = setTimeout(() => {
         idleFallbackHandle = null
@@ -1524,6 +1555,14 @@ export function spawnPty(
     // the reason. Passing it through here means the state a listener
     // actually observes carries the info.
     const writeClaudeCmd = (runningClaudeInfo?: string) => {
+      // Follow-up adversarial pass (lifecycle MAJOR): bail at the TOP, not just
+      // in the deferred write callback below. Reached from a resolving download
+      // / push promise after teardown, the old code still ran the whole body --
+      // emitting flow state and session-info onto the id's channels and
+      // mutating sshTmuxWrappedBySession -- and only the final write was
+      // suppressed. Everything this function does is meaningless for a
+      // destroyed flow, and harmful once the id has been respawned.
+      if (destroyed) return
       // Idempotent. shellOnly is intentionally NOT gated: this writer
       // only runs after the user clicked Launch Claude (or after a
       // user-consented chain reached this stage), so the click is
@@ -1603,10 +1642,71 @@ export function spawnPty(
         if (destroyed) return
         try {
           ptyProcess.write(cmdToWrite + '\r')
+          // Follow-up adversarial pass (fail-posture MAJOR): arm the
+          // wrapped-launch watchdog only once the wrapped command has actually
+          // been written -- see tmuxLaunchWatchUntil's doc comment.
+          if (tmuxWrapped) tmuxLaunchWatchUntil = Date.now() + TMUX_LAUNCH_WATCH_MS
         } catch (err) {
           logError(`[ssh] ${sessionId}: writeClaudeCmd's write failed post-schedule: ${(err as Error)?.message ?? err}`)
         }
       }, 200)
+    }
+
+    /**
+     * Follow-up adversarial pass (fail-posture MAJOR): the umbrella fallback for
+     * a tmux-wrapped launch that the remote refuses.
+     *
+     * The stage/push scripts smoke-test the binary they install with `tmux -V`
+     * and `tmux new-session -d`, and their doc comments claim that surfaces the
+     * "missing or unsuitable terminal" (terminfo) failure. It does not: a
+     * DETACHED new-session never opens a client tty, so terminfo is never
+     * consulted, and the pinned static build ships without compiled-in fallback
+     * entries. On a remote with no terminfo database for $TERM -- the minimal
+     * container that is exactly this tier's target -- staging reports `ok`, the
+     * ATTACHED launch then dies with `open terminal failed`, and tier 2 selects
+     * the same binary on every later connect. Nothing recovered: claude never
+     * started, and Launch Claude is inert once `claudeSent` latched.
+     *
+     * Rather than teach the smoke test to predict every way a remote can refuse
+     * to run tmux (terminfo, an already-nested session, a wrong-arch or
+     * truncated binary, a tmux too old for `new-session -A`), watch the PTY for
+     * a short window after the wrapped launch and fall back to the BARE launch
+     * the moment the remote says it failed. That is safe precisely because a
+     * failed wrap means nothing is running: the pane is back at a shell prompt.
+     *
+     * The window is deliberately short and closes the instant claude latches, so
+     * this can never fire against claude's own output; every pattern below is a
+     * message a shell or tmux emits about the command we just typed.
+     */
+    const TMUX_LAUNCH_WATCH_MS = 6000
+    /** Deadline (epoch ms) until which the wrapped launch is being watched; 0 = not watching. */
+    let tmuxLaunchWatchUntil = 0
+    let tmuxLaunchFellBack = false
+    const TMUX_LAUNCH_FAILURE_RE = /open terminal failed|sessions should be nested|missing or unsuitable terminal|no server running on|not a terminal|exec format error|cannot execute binary file|command not found|permission denied|is a directory/i
+    const handleWrappedLaunchFailure = (data: string): void => {
+      if (destroyed || tmuxLaunchFellBack || !tmuxLaunchWatchUntil) return
+      if (Date.now() > tmuxLaunchWatchUntil) { tmuxLaunchWatchUntil = 0; return }
+      if (claudeRunning) { tmuxLaunchWatchUntil = 0; return }
+      const m = data.match(TMUX_LAUNCH_FAILURE_RE)
+      if (!m) return
+      tmuxLaunchFellBack = true
+      tmuxLaunchWatchUntil = 0
+      logError(`[ssh] ${sessionId}: tmux-wrapped launch was refused by the remote (${m[0]}) -- falling back to a bare claude launch`)
+      // The wrap is off for this session: correct the persistence signal the
+      // wrapped write already emitted, and stop close/quit from trying to
+      // DETACH from a tmux session that was never created.
+      sshTmuxWrappedBySession.delete(sessionId)
+      emitSshSessionInfo(win, sessionId, { tmuxPersistent: false, remoteAccount })
+      // Reconnecting with no tmux in play is exactly the case tier 5 exists
+      // for, so the bare retry carries --continue when this spawn is a respawn.
+      const bareFlags = buildSshClaudeFlags({ reconnect: !!ssh.reconnect, tmuxInPlay: false })
+      const bareCmd = bareFlags ? `${claudeCmd} ${bareFlags}` : claudeCmd
+      setFlowState('running-claude', 'tmux-launch-refused')
+      try {
+        ptyProcess.write(bareCmd + '\r')
+      } catch (err) {
+        logError(`[ssh] ${sessionId}: bare-launch fallback write failed: ${(err as Error)?.message ?? err}`)
+      }
     }
 
     /**
@@ -2101,6 +2201,23 @@ export function spawnPty(
       const data = extractSshOscSentinels(sessionId, rawData)
       getPtyIntegrityMonitor()?.recordPtyData(sessionId, data.length)
       win.webContents.send(`pty:data:${sessionId}`, data)
+
+      // Follow-up adversarial pass (lifecycle MAJOR): once the flow is
+      // destroyed, terminal bytes still belong on the renderer's data channel
+      // (above) but NOTHING below this line does -- every latch, sentinel
+      // parse, settings-patch write and claude launch beneath is flow logic for
+      // a session that has been torn down. Proven reachable: destroying
+      // mid-tier-3 and then feeding the stage sentinel drove a
+      // buildTmuxBinPatchCommand write into the dead PTY and re-armed the idle
+      // fallback. The individual `destroyed` guards on setFlowState /
+      // writeClaudeCmd / armIdleFallback stay as defence in depth for the
+      // promise-driven call sites that never pass through here.
+      if (destroyed) return
+
+      // Follow-up adversarial pass (fail-posture MAJOR): watch a tmux-wrapped
+      // launch for a remote refusal and fall back to the bare launch. No-op
+      // unless a wrapped command was just written -- see its doc comment.
+      handleWrappedLaunchFailure(data)
 
       // Arm the idle-data fallback. Re-arms on every chunk so the timer
       // tracks the most recent activity. The handler itself decides

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1682,12 +1682,43 @@ export function spawnPty(
     /** Deadline (epoch ms) until which the wrapped launch is being watched; 0 = not watching. */
     let tmuxLaunchWatchUntil = 0
     let tmuxLaunchFellBack = false
-    const TMUX_LAUNCH_FAILURE_RE = /open terminal failed|sessions should be nested|missing or unsuitable terminal|no server running on|not a terminal|exec format error|cannot execute binary file|command not found|permission denied|is a directory/i
+    /**
+     * Round-2 adversarial pass (MAJOR): the first cut of this regex matched
+     * bare `command not found` / `permission denied` / `is a directory`
+     * anywhere in the chunk, which fires on output that has nothing to do with
+     * the wrap -- claude's own `EACCES: permission denied` startup stderr, and
+     * (worse) the transcript redraw when a RECONNECT successfully attaches to a
+     * live session, since a coding transcript routinely contains those exact
+     * words. The cost of a false positive is not cosmetic: the bare claude line
+     * is typed into a pane where claude is already running (so it lands in the
+     * composer as a chat message) and the session is dropped from
+     * sshTmuxWrappedBySession, which turns a later close into a KILL of the
+     * remote rather than a detach.
+     *
+     * Split in two, so a generic error only counts when it is demonstrably
+     * about tmux:
+     *  - UNAMBIGUOUS: phrases only tmux itself emits; match anywhere.
+     *  - GENERIC: shell/exec failures that must share a LINE with the word
+     *    `tmux` (every wrapped launch names the binary, so a real failure to
+     *    run it always does).
+     * `no server running on` was dropped entirely: buildTmuxLaunchCommand's own
+     * `|| <fresh create>` leg already self-heals that race, and reacting to it
+     * here fought the wrapper for the same case.
+     */
+    const TMUX_LAUNCH_FAILED_UNAMBIGUOUS_RE = /open terminal failed|sessions should be nested|missing or unsuitable terminal/i
+    const TMUX_LAUNCH_FAILED_GENERIC_RE = /^[^\r\n]*\btmux\b[^\r\n]*(command not found|not found|permission denied|exec format error|cannot execute binary file|is a directory)/im
     const handleWrappedLaunchFailure = (data: string): void => {
       if (destroyed || tmuxLaunchFellBack || !tmuxLaunchWatchUntil) return
       if (Date.now() > tmuxLaunchWatchUntil) { tmuxLaunchWatchUntil = 0; return }
       if (claudeRunning) { tmuxLaunchWatchUntil = 0; return }
-      const m = data.match(TMUX_LAUNCH_FAILURE_RE)
+      // Round-2 adversarial pass (MAJOR): claude's UI appearing in THIS chunk is
+      // proof the wrap worked, and it is checked BEFORE the failure match --
+      // the claudeRunning latch below runs later in the same handler, so on a
+      // reattach the transcript's own text used to be judged before the UI that
+      // accompanied it. Any chunk carrying claude's UI closes the window for
+      // good.
+      if (detectClaudeUi(data, claudeSent)) { tmuxLaunchWatchUntil = 0; return }
+      const m = data.match(TMUX_LAUNCH_FAILED_UNAMBIGUOUS_RE) ?? data.match(TMUX_LAUNCH_FAILED_GENERIC_RE)
       if (!m) return
       tmuxLaunchFellBack = true
       tmuxLaunchWatchUntil = 0

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -550,6 +550,14 @@ export function _getSshNonceForTest(sessionId: string): string | undefined {
   return sshNonceBySession.get(sessionId)
 }
 
+/** Test-only: whether this session still has a captured end-remote target. Pins
+ *  the lifecycle fix that the target must SURVIVE a natural PTY exit (a transient
+ *  drop, so a later End can still reach the host) and be dropped only on a
+ *  deliberate close (killPty) -- adversarial review 2026-08-18. */
+export function _hasSshTargetForTest(sessionId: string): boolean {
+  return sshTargetBySession.has(sessionId)
+}
+
 /**
  * #242 finding I1: per-session buffer for the not-yet-terminated tail of
  * the `setup ok` completion sentinel line, mirroring `sshOscBuffers`/
@@ -782,8 +790,26 @@ function clearLastResumeTarget(sessionId: string): void {
 // SSH tmux enhancement (item 4): the connection target for each live SSH
 // session, captured at spawn so endSshRemote can open a SEPARATE ssh exec to
 // kill the remote tmux session + sidecars without touching the live PTY (where
-// the keystrokes would land in Claude). Cleared in cleanupSessionResources.
+// the keystrokes would land in Claude). Cleared on DELIBERATE close (killPty),
+// NOT on a natural PTY exit: after a transient drop the tab stays (Retry), and
+// a later "End remote" must still be able to reach the host to kill the
+// now-detached remote -- clearing it on every exit made End a silent no-op
+// after any wifi blip (adversarial review, 2026-08-18).
 const sshTargetBySession = new Map<string, { username: string; host: string; port: number }>()
+
+// SSH tmux enhancement (items 1/4): sessions whose launch actually wrapped in a
+// tmux persistence session (`tmuxWrapped` at writeClaudeCmd). The remote for
+// these SURVIVES a local PTY teardown, so close/quit must DETACH, never destroy:
+//   - killPty must NOT type the U8 in-band `rm` cleanup down the live PTY -- for
+//     a tmux-wrapped launch the foreground is Claude, so the bytes land in its
+//     composer (LF doesn't submit) and are left PRE-TYPED in a session the user
+//     chose to leave running; the End-remote exec already removes the sidecars.
+//   - gracefulExitPty (app quit) must NOT send `/exit` -- inside tmux that quits
+//     Claude and tears the session down; killing the local PTY detaches instead.
+// Both are the exact regressions the persistence feature introduced against the
+// pre-existing close/quit paths (adversarial review, 2026-08-18). Cleared on
+// deliberate close alongside sshTargetBySession.
+const sshTmuxWrappedBySession = new Set<string>()
 
 /**
  * SSH tmux enhancement (item 4): deliberately END a persistent remote session.
@@ -1333,10 +1359,23 @@ export function spawnPty(
     const claudeEnvPrefix = claudeEnvVars.join(' ')
     // Flags common to POSIX + Windows (everything EXCEPT --settings/--mcp-config,
     // which differ by path shape: POSIX adds them inline below; the Windows
-    // builder re-adds them with %USERPROFILE% paths).
+    // builder re-adds them with %USERPROFILE% paths). The remote shell differs:
+    // POSIX single-quotes the model id (zsh globs `opus[1m]` otherwise, #144),
+    // but cmd.exe does NOT strip single quotes, so modelFlag()'s POSIX form gave
+    // a Windows launch a model id WITH literal quotes (adversarial review,
+    // 2026-08-18). cmd.exe uses DOUBLE quotes (claude.cmd strips them), so the
+    // Windows branch double-quotes via a local var -- the `${options.model}`
+    // shape the #144 source-scan forbids (correctly, for POSIX) never appears,
+    // and this is genuinely a different shell. effort/permissionMode/extraArgs
+    // are charset-safe in both shells (extraArgs is IPC-charset-guarded against
+    // every cmd + POSIX metachar).
+    const winModelId = options?.model ?? ''
+    const claudeModelCommonFlag = isWindowsRemote
+      ? (winModelId ? `--model "${winModelId}"` : '')
+      : modelFlag(options?.model, false)
     const claudeCommonFlags = [
       options?.effortLevel ? `--effort ${options.effortLevel}` : '',
-      modelFlag(options?.model, false),
+      claudeModelCommonFlag,
       options?.permissionMode && options.permissionMode !== 'default' ? `--permission-mode ${options.permissionMode}` : '',
       options?.extraArgs && options.extraArgs.trim() ? options.extraArgs.trim() : '',
     ].filter(Boolean).join(' ')
@@ -1546,6 +1585,10 @@ export function spawnPty(
       // the launch actually wrapped in tmux. Re-send the account alongside so a
       // renderer that missed the latch push still gets both.
       emitSshSessionInfo(win, sessionId, { tmuxPersistent: tmuxWrapped, remoteAccount })
+      // Track locally so close/quit (killPty, gracefulExitPty) DETACH rather
+      // than destroy this session's surviving remote -- see the map's doc above.
+      if (tmuxWrapped) sshTmuxWrappedBySession.add(sessionId)
+      else sshTmuxWrappedBySession.delete(sessionId)
       logInfo(`[ssh] ${sessionId}: writing claudeCmd${tmuxWrapped ? ' (tmux-wrapped)' : ''}${continueFlag ? ' (+continue)' : ''}`)
       setTimeout(() => {
         // #242 finding F3 (adversarial review round 4, MAJOR): this write is
@@ -1920,7 +1963,13 @@ export function spawnPty(
       if (pushSent && !pushDone) return
       // item 1: skip tier-3/4 staging entirely when persistence is off -- this
       // is the "no silent tmux install" guarantee; go straight to bare claude.
-      if (persistenceEnabled && !detectedTmuxSource && !stagingAttempted) {
+      // item 3: also skip on a Windows remote -- the POSIX staging ladder
+      // (`stty`/`uname`/`base64 -d | sh`) is meaningless on cmd.exe and, since
+      // the Windows setup deliberately reports tmux=none, this gate would fire
+      // and type ~3 KB of POSIX shell into cmd.exe + stall 20s + show a false
+      // "Installing tmux…" overlay. Windows never persists via tmux; go straight
+      // to the bare cmd.exe launch (adversarial review, 2026-08-18).
+      if (persistenceEnabled && !isWindowsRemote && !detectedTmuxSource && !stagingAttempted) {
         writeTmuxStageCmd()
         return
       }
@@ -3053,15 +3102,6 @@ export function spawnPty(
 
   ptyProcess.onExit(({ exitCode }) => {
     logInfo(`[pty] PTY exited for session ${sessionId} with code ${exitCode}`)
-    // item 5 (resume cascade): an SSH session whose ssh process exited before
-    // reaching claude-running failed to connect -- tell the overlay so it can
-    // offer Retry (never strand). Runs only while the flow still exists (a
-    // deliberate close destroys it first), so this fires for a genuine
-    // connection failure/drop, not for a user-initiated close.
-    if (sshFlows.has(sessionId)) {
-      try { getSshFlow(sessionId)?.handlePtyExit() } catch { /* best-effort */ }
-    }
-
     // Restart-race guard: the renderer's restart flow kills the old PTY
     // and re-spawns synchronously with the SAME sessionId. node-pty's
     // exit callback is async — by the time it fires, the new PTY has
@@ -3077,6 +3117,20 @@ export function spawnPty(
     const current = ptySessions.get(sessionId)
     const weAreCurrent = !current || current.ptyProcess === ptyProcess
     if (weAreCurrent) {
+      // item 5 (resume cascade): an SSH session whose ssh process exited before
+      // reaching claude-running failed to connect -- tell the overlay so it can
+      // offer Retry (never strand). Runs only while the flow still exists (a
+      // deliberate close destroys it first). CRITICAL: this MUST sit inside the
+      // weAreCurrent guard. sshFlows is keyed by sessionId only, so on a restart
+      // it holds the NEW flow while the OLD pty exits; poking it here (as the
+      // first cut did, above this guard) flipped a healthy just-respawned session
+      // to failed('connection'), and the overlay's only escape was Retry -> the
+      // same restart -> the same stale exit, wedged forever (adversarial review,
+      // 2026-08-18, BLOCKER). When we are NOT current a newer spawn owns the flow;
+      // its own onExit handles its own drops.
+      if (sshFlows.has(sessionId)) {
+        try { getSshFlow(sessionId)?.handlePtyExit() } catch { /* best-effort */ }
+      }
       ptySessions.delete(sessionId)
       clearSessionMeta(sessionId)
       // Close the run (the worker final-drains + retires its transcript tails).
@@ -3295,8 +3349,12 @@ function cleanupSessionResources(sessionId: string): void {
   // #242 finding F1 (b): drop this session's nonce so it can never leak into
   // a future, unrelated spawn reusing the same sessionId.
   sshNonceBySession.delete(sessionId)
-  // item 4: drop the SSH connection target alongside the nonce.
-  sshTargetBySession.delete(sessionId)
+  // item 4: the SSH connection target + tmux-persistence flag are DELIBERATELY
+  // NOT cleared here -- cleanupSessionResources runs on a natural PTY exit (a
+  // transient drop) too, where the tab stays and a later End must still reach
+  // the host. They are cleared only on deliberate close, in killPty (a respawn
+  // overwrites them, so a stale entry from an exited-but-open session is bounded
+  // and self-healing). See the maps' doc comment (adversarial review 2026-08-18).
   pasteQueues.get(sessionId)?.cancel() // stop draining + drop pending before dropping the ref (P1.5)
   pasteQueues.delete(sessionId)
   // Delete the per-session statusline status file so the watcher's poll
@@ -3352,18 +3410,30 @@ const REMOTE_CLEANUP_GRACE_MS = 400
 
 export function killPty(sessionId: string): void {
   const entry = ptySessions.get(sessionId)
+  // Read persistence BEFORE cleanupSessionResources runs (it no longer clears
+  // these, but killPty does, at the end).
+  const tmuxPersistent = sshTmuxWrappedBySession.has(sessionId)
   if (entry) {
-    logInfo(`[pty] Killing PTY for session ${sessionId}`)
-    if (sshFlows.has(sessionId)) {
+    logInfo(`[pty] Killing PTY for session ${sessionId}${tmuxPersistent ? ' (tmux-persistent: detach only)' : ''}`)
+    if (sshFlows.has(sessionId) && !tmuxPersistent) {
       // U8: sweep the per-session files we planted on the remote, in-band down the
       // still-live PTY, then kill after a short grace so the `rm` runs before the
       // tunnel dies. No SSH creds retained. A crash / natural exit can't do this
       // (the tunnel is already gone), which is acceptable -- the files are inert.
       // ptySessions.delete below means the delayed kill's onExit no-ops.
+      //
+      // Only for a NON-persistent SSH session. For a tmux-WRAPPED one the remote
+      // survives this teardown, so (a) the foreground is Claude and this line
+      // would land in its composer and stay pre-typed (LF doesn't submit), and
+      // (b) the sidecars must either survive (Leave running -- Claude still uses
+      // them) or be removed by the End-remote exec (which does its own rm). So we
+      // write nothing and just detach (adversarial review, 2026-08-18).
       const proc = entry.ptyProcess
       try { proc.write(buildRemoteSessionCleanupCommand(sessionId)) } catch { /* best-effort */ }
       setTimeout(() => { try { proc.kill() } catch { /* already gone */ } }, REMOTE_CLEANUP_GRACE_MS)
     } else {
+      // Non-SSH, or a tmux-persistent SSH session (killing the local PTY detaches
+      // the tmux client; the remote survives for reattach on relaunch).
       try { entry.ptyProcess.kill() } catch (err) {
         logError(`[pty] Error killing PTY ${sessionId}:`, err)
       }
@@ -3371,6 +3441,11 @@ export function killPty(sessionId: string): void {
     ptySessions.delete(sessionId)
   }
   cleanupSessionResources(sessionId)
+  // Deliberate close: NOW drop the end-target + persistence flag (see the maps'
+  // doc). A natural exit reaches cleanupSessionResources but not here, so the
+  // target survives a transient drop for a later End.
+  sshTargetBySession.delete(sessionId)
+  sshTmuxWrappedBySession.delete(sessionId)
 }
 
 export function killAllPty(): void {
@@ -3405,6 +3480,18 @@ export function gracefulExitPty(sessionId: string, timeoutMs = 5000): Promise<vo
       killPty(sessionId)
       resolve()
     }, timeoutMs)
+
+    // SSH tmux enhancement (item 4): a tmux-persistent remote must be DETACHED,
+    // not exited, on app quit. `/exit` inside the tmux-wrapped pane quits Claude
+    // and tears the remote session down -- defeating the persistence the header
+    // pill just promised, on the most common exit path. Killing the local PTY
+    // detaches the tmux client; the remote survives for reattach on relaunch
+    // (adversarial review, 2026-08-18). The onExit listener above resolves.
+    if (sshTmuxWrappedBySession.has(sessionId)) {
+      logInfo(`[pty-manager] ${sessionId} is tmux-persistent -- detaching (no /exit) so the remote survives app quit`)
+      try { entry.ptyProcess.kill() } catch { /* already gone */ }
+      return
+    }
 
     // Send Escape (cancel any pending input), then /exit
     entry.ptyProcess.write('\x1b')  // Escape

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -10,7 +10,7 @@ import { buildTmuxPushCommand, buildArchProbeCommandBracketed, parseArchProbeSen
 import * as os from 'os'
 import * as https from 'https'
 import * as crypto from 'crypto'
-import { execSync } from 'child_process'
+import { execSync, execFile } from 'child_process'
 import { logPtyOutput, isDebugModeEnabled } from './debug-capture'
 import { shouldRegisterRun } from './logging/should-register-run'
 import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service'
@@ -19,10 +19,10 @@ import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPat
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
-import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand } from './providers/claude/ssh-shim'
+import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand, buildRemoteTmuxKillCommand, getWindowsRemoteSetupCommand, buildWindowsClaudeCommand } from './providers/claude/ssh-shim'
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
-import { buildSshArgs } from './ssh-args'
+import { buildSshArgs, buildSshExecArgs } from './ssh-args'
 import { resolveClaudeBinary, resolveHostColorScheme } from './providers/claude/spawn'
 import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
@@ -205,10 +205,44 @@ export type TmuxDetectionClass = 'path' | 'home'
  * arbitrary one.
  */
 export function parseTmuxSentinel(data: string, nonce: string): TmuxDetectionClass | null | undefined {
-  const m = data.match(new RegExp(`setup ok ${escapeRegExp(nonce)} tmux=(path|home|none)(?=[\\r\\n])`))
+  const m = data.match(new RegExp(`setup ok ${escapeRegExp(nonce)} tmux=(path|home|none)(?: acct=[A-Za-z0-9+/=]*)?(?=[\\r\\n])`))
   if (!m) return undefined
   if (m[1] === 'none') return null
   return m[1] as TmuxDetectionClass
+}
+
+/**
+ * SSH tmux enhancement (item 10): parse the `acct=<base64email>` field the
+ * setup-ok sentinel now carries AFTER the tmux class (generateRemoteSetupScript,
+ * ssh-shim.ts). Same chunk-boundary + nonce discipline as parseTmuxSentinel:
+ * requires the FULL nonce-bearing line (anchored on the line terminator via
+ * the tmux-class lookahead), so a truncated or spoofed sentinel yields nothing.
+ *
+ * The wire token is base64 of the remote's oauthAccount.emailAddress. This is
+ * a DESCRIPTOR the remote host controls, surfaced only as a label -- treated as
+ * UNTRUSTED-FOR-DISPLAY: after base64-decode it is charset-filtered to the
+ * characters a real email uses and length-capped, and anything else yields
+ * `undefined` (no account shown) rather than passing an arbitrary string to the
+ * renderer. It is never interpreted, never a credential, never an auth key.
+ *
+ * Returns the sanitized descriptor, or `undefined` when the field is absent,
+ * empty, undecodable, or fails the display charset (never throws).
+ */
+const SSH_REMOTE_ACCOUNT_MAX = 254
+const SSH_REMOTE_ACCOUNT_DISPLAY_RE = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
+export function parseSetupAccountSentinel(data: string, nonce: string): string | undefined {
+  const m = data.match(new RegExp(`setup ok ${escapeRegExp(nonce)} tmux=(?:path|home|none) acct=([A-Za-z0-9+/=]*)(?=[\\r\\n])`))
+  if (!m || !m[1]) return undefined
+  let decoded: string
+  try {
+    decoded = Buffer.from(m[1], 'base64').toString('utf-8')
+  } catch {
+    return undefined
+  }
+  if (!decoded || decoded.length > SSH_REMOTE_ACCOUNT_MAX) return undefined
+  // Display-charset gate: an email address only. Anything else (a hostile
+  // host trying to plant markup / control chars in the label) is dropped.
+  return SSH_REMOTE_ACCOUNT_DISPLAY_RE.test(decoded) ? decoded : undefined
 }
 
 /**
@@ -646,6 +680,21 @@ export interface SSHOptions {
    * to continue.
    */
   reconnect?: boolean
+  /**
+   * SSH tmux enhancement (item 1): "Detachable" (persistent remote session)
+   * toggle, from SshConfig.detachable. DEFAULT ON — only an explicit `false`
+   * disables the #242 tmux-persistence ladder (no detection, no staging, no
+   * silent install), leaving a bare `claude` that resumes via `--continue`
+   * on reconnect. Owner requirement: tmux must never be installed silently,
+   * so persistence is user-controlled by this flag.
+   */
+  detachable?: boolean
+  /**
+   * SSH tmux enhancement (item 3): remote OS. 'windows' selects the Windows
+   * setup path (PowerShell delivery + CONOUT$ shim + cmd.exe launch, no tmux);
+   * 'auto'/'unix'/undefined keep the POSIX path unchanged. PROTOTYPE.
+   */
+  remoteOs?: 'auto' | 'unix' | 'windows'
 }
 
 /**
@@ -657,6 +706,12 @@ export interface SshFlowController {
   launchClaude: () => void
   skip: () => void
   destroy: () => void
+  /** item 5 (resume cascade, "no host"): called from the shared PTY onExit when
+   *  the ssh process dies. If the flow never reached a good terminal state
+   *  (i.e. the connection failed at/around connect), emit `failed` with a
+   *  'connection' reason so the overlay can offer Retry rather than sitting on
+   *  a dead "connecting…". A no-op once claude-running/shell-only/skipped. */
+  handlePtyExit: () => void
   /** Returns the latest emitted state, used by the renderer overlay
    * on mount to catch up if it missed earlier emits. */
   getState: () => { state: SshFlowState; info?: string }
@@ -688,6 +743,20 @@ function emitSshFlowState(win: BrowserWindow, sessionId: string, state: SshFlowS
   } catch { /* renderer gone */ }
 }
 
+/**
+ * SSH tmux enhancement (items 8/9/10): push per-session persistence status +
+ * the remote account descriptor to the renderer. Separate from the flow-state
+ * channel because these outlive the connect flow (they label the session in
+ * the sidebar/header for its whole life) and update the session store, not the
+ * transient overlay. Fire-and-forget; a destroyed window is a no-op.
+ */
+function emitSshSessionInfo(win: BrowserWindow, sessionId: string, info: { tmuxPersistent?: boolean; remoteAccount?: string }): void {
+  if (win.isDestroyed()) return
+  try {
+    win.webContents.send(`ssh:sessionInfo:${sessionId}`, info)
+  } catch { /* renderer gone */ }
+}
+
 const ptySessions = new Map<string, PtySession>()
 
 // Codex-provider telemetry sources: keyed by sessionId, stopped on PTY exit / kill.
@@ -708,6 +777,44 @@ function getLastResumeTarget(sessionId: string): { uuid: string; cwd: string } |
 
 function clearLastResumeTarget(sessionId: string): void {
   lastResumeTarget.delete(sessionId)
+}
+
+// SSH tmux enhancement (item 4): the connection target for each live SSH
+// session, captured at spawn so endSshRemote can open a SEPARATE ssh exec to
+// kill the remote tmux session + sidecars without touching the live PTY (where
+// the keystrokes would land in Claude). Cleared in cleanupSessionResources.
+const sshTargetBySession = new Map<string, { username: string; host: string; port: number }>()
+
+/**
+ * SSH tmux enhancement (item 4): deliberately END a persistent remote session.
+ * Opens a fresh, non-interactive ssh exec (buildSshExecArgs) that runs
+ * buildRemoteTmuxKillCommand -- `tmux kill-session -t ccc-<sid>` (both
+ * host-authored tmux-bin forms) plus sidecar cleanup -- then exits. Fire-and-
+ * forget with a bounded lifetime; the caller kills the local PTY separately.
+ *
+ * A no-op when we have no target for the session (never an SSH session, or
+ * already cleaned up). Best-effort by design: BatchMode means a password-only
+ * host's exec fails fast rather than hanging, in which case the remote simply
+ * detaches and survives -- exactly the pre-enhancement behaviour, never worse.
+ */
+const END_REMOTE_TIMEOUT_MS = 12000
+export function endSshRemote(sessionId: string): void {
+  const target = sshTargetBySession.get(sessionId)
+  if (!target) return
+  try {
+    const bin = os.platform() === 'win32' ? 'ssh.exe' : 'ssh'
+    const args = buildSshExecArgs(target, buildRemoteTmuxKillCommand(sessionId), os.platform())
+    logInfo(`[ssh] ${sessionId}: ending remote session (tmux kill-session + sidecar cleanup over a separate exec)`)
+    const child = execFile(bin, args, { timeout: END_REMOTE_TIMEOUT_MS, windowsHide: true }, (err) => {
+      if (err) logInfo(`[ssh] ${sessionId}: end-remote exec exited non-zero (host may use password auth, or was already gone): ${err.message}`)
+      else logInfo(`[ssh] ${sessionId}: end-remote exec completed`)
+    })
+    // Never let a stuck child keep a handle alive; execFile's own timeout also
+    // covers this, but unref so it can't hold the process open.
+    try { child.unref() } catch { /* noop */ }
+  } catch (err) {
+    logError(`[ssh] ${sessionId}: endSshRemote failed to dispatch: ${(err as Error)?.message ?? err}`)
+  }
 }
 
 // === SSH OSC sentinel parser ===
@@ -903,6 +1010,13 @@ export function spawnPty(
 
     // SSH session: spawn ssh command, then chain claude after cd
     const ssh = options.ssh
+    // SSH tmux enhancement (item 1): the "Detachable" toggle. DEFAULT ON --
+    // only an explicit `false` opts out of the #242 tmux-persistence ladder.
+    // When off: no tier-3/4 staging (proceedAfterSetup skips it, so nothing is
+    // ever installed on the remote) AND no wrap even if the host already has
+    // tmux (writeClaudeCmd's gate), leaving a bare `claude` that resumes via
+    // `--continue` on reconnect.
+    const persistenceEnabled = ssh.detachable !== false
     // Lift: SSH setup script + per-session settings path live on the
     // ClaudeProvider's SSH-capable surface (see providers/claude/ssh-shim.ts).
     const claudeProvider = getProvider('claude')
@@ -995,6 +1109,9 @@ export function spawnPty(
     // accessor and cleanupSessionResources' teardown can both reach it.
     const sshNonce = randomId()
     sshNonceBySession.set(sessionId, sshNonce)
+    // item 4: remember this session's connection target so a deliberate End can
+    // reach the host over a separate exec. Cleared in cleanupSessionResources.
+    sshTargetBySession.set(sessionId, { username: ssh.username, host: ssh.host, port: ssh.port })
     // #242 round-3 correction (I3): which entry of buildTmuxLaunchCommand's
     // fixed literal table to use, once a 'setup ok'/stage/push sentinel
     // reports a usable tmux -- never a wire-reported path. `null` means "not
@@ -1005,6 +1122,10 @@ export function spawnPty(
     // `STAGED_TMUX_BIN_EXPR` -- both are the SAME fixed remote location, so
     // tier 2 and tier 3/4 share one outcome here.
     let detectedTmuxSource: 'onpath' | 'staged' | null = null
+    // item 10: the remote account descriptor parsed off the setup-ok sentinel
+    // (charset/length-capped, display-only). Emitted to the renderer on latch
+    // and re-sent alongside the persistence flag at launch.
+    let remoteAccount: string | undefined = undefined
     // #242 tier 3: staging flags. `stagingAttempted` gates a SINGLE staging
     // attempt per session regardless of which setup path (host vs
     // container) reaches it -- host and container setup never both run in
@@ -1201,10 +1322,23 @@ export function spawnPty(
     // Settings toggle applies to the next session without a restart.
     const spawnCfg = readConfig<{ clickableQuestions?: boolean; disableBackgroundTasks?: boolean }>('settings')
     const clickableQuestions = spawnCfg?.clickableQuestions === true
-    const claudeEnvPrefix = [
+    // item 3: PROTOTYPE Windows remote. Isolated behind this flag; every branch
+    // below falls back to the unchanged POSIX path for auto/unix/undefined.
+    const isWindowsRemote = ssh.remoteOs === 'windows'
+    const claudeEnvVars = [
       options?.disableAutoMemory ? 'CLAUDE_CODE_DISABLE_AUTO_MEMORY=1' : '',
       clickableQuestions ? '' : 'CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1',
       spawnCfg?.disableBackgroundTasks !== false ? 'CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1' : '',
+    ].filter(Boolean)
+    const claudeEnvPrefix = claudeEnvVars.join(' ')
+    // Flags common to POSIX + Windows (everything EXCEPT --settings/--mcp-config,
+    // which differ by path shape: POSIX adds them inline below; the Windows
+    // builder re-adds them with %USERPROFILE% paths).
+    const claudeCommonFlags = [
+      options?.effortLevel ? `--effort ${options.effortLevel}` : '',
+      modelFlag(options?.model, false),
+      options?.permissionMode && options.permissionMode !== 'default' ? `--permission-mode ${options.permissionMode}` : '',
+      options?.extraArgs && options.extraArgs.trim() ? options.extraArgs.trim() : '',
     ].filter(Boolean).join(' ')
     const claudeFlags = [
       // --settings loads per-session config so concurrent sessions to the same
@@ -1230,7 +1364,11 @@ export function spawnPty(
       // Advanced escape hatch: extra CLI args verbatim (IPC-charset-guarded).
       options?.extraArgs && options.extraArgs.trim() ? options.extraArgs.trim() : '',
     ].filter(Boolean).join(' ')
-    const claudeCmd = [claudeEnvPrefix, 'claude', claudeFlags].filter(Boolean).join(' ')
+    const claudeCmd = isWindowsRemote
+      // item 3: cmd.exe launch (set X=Y&& claude --settings "%USERPROFILE%\.claude\..."). No
+      // tmux wrap ever (Windows has none); writeClaudeCmd appends --continue on reconnect.
+      ? buildWindowsClaudeCommand({ sessionId, envPrefixVars: claudeEnvVars, extraFlags: claudeCommonFlags, continueFlag: '' })
+      : [claudeEnvPrefix, 'claude', claudeFlags].filter(Boolean).join(' ')
     const password = ssh.password
     const postCommand = ssh.postCommand
     const sudoPassword = ssh.sudoPassword
@@ -1276,10 +1414,15 @@ export function spawnPty(
         // is defence-in-depth for any path that reaches here.
         try {
           const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
-          const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
+          const setupOpts = {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
-          }, sshNonce)
+          }
+          // item 3: Windows uses the PowerShell-delivered setup (no POSIX
+          // base64/stty, no tmux); auto/unix keep the POSIX path unchanged.
+          const setupCmd = isWindowsRemote
+            ? getWindowsRemoteSetupCommand(sessionId, setupOpts, sshNonce)
+            : claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, setupOpts, sshNonce)
           ptyProcess.write(setupCmd + '\r')
         } catch (err) {
           logError(`[ssh] ${sessionId}: host setup failed: ${(err as Error)?.message ?? err}`)
@@ -1313,10 +1456,15 @@ export function spawnPty(
         // handler; fail the flow instead (adversarial review, #188).
         try {
           const s = readConfig<{ statusLineEnabled?: boolean; conductorToolsEnabled?: boolean }>('settings')
-          const setupCmd = claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, {
+          const setupOpts = {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
-          }, sshNonce)
+          }
+          // item 3: Windows uses the PowerShell-delivered setup (no POSIX
+          // base64/stty, no tmux); auto/unix keep the POSIX path unchanged.
+          const setupCmd = isWindowsRemote
+            ? getWindowsRemoteSetupCommand(sessionId, setupOpts, sshNonce)
+            : claudeProvider.configureRemoteSettings(sessionId, remotePath, hooksConfig, setupOpts, sshNonce)
           ptyProcess.write(setupCmd + '\r')
         } catch (err) {
           logError(`[ssh] ${sessionId}: container setup failed: ${(err as Error)?.message ?? err}`)
@@ -1352,7 +1500,8 @@ export function spawnPty(
       // pre-#242 behaviour.
       let cmdToWrite = claudeCmd
       let tmuxWrapped = false
-      if (detectedTmuxSource) {
+      // item 1: even a detected tmux is NOT used when persistence is off.
+      if (persistenceEnabled && detectedTmuxSource) {
         // #242 round-3 correction (I3): buildTmuxLaunchCommand no longer
         // takes a tmuxBin at all -- it picks ON_PATH_TMUX_BIN_EXPR /
         // STAGED_TMUX_BIN_EXPR from `staged` alone, so there is no
@@ -1364,7 +1513,7 @@ export function spawnPty(
         // (adversarial review, #188, same shape documented on
         // assertNotOptionLike in ssh-args.ts).
         try {
-          cmdToWrite = buildTmuxLaunchCommand({ sessionId, innerCmd: claudeCmd, staged: detectedTmuxSource === 'staged' })
+          cmdToWrite = buildTmuxLaunchCommand({ sessionId, innerCmd: claudeCmd, staged: detectedTmuxSource === 'staged', reconnect: !!ssh.reconnect })
           tmuxWrapped = true
         } catch (err) {
           logError(`[ssh] ${sessionId}: tmux launch command build failed, writing bare claudeCmd instead: ${(err as Error)?.message ?? err}`)
@@ -1386,7 +1535,17 @@ export function spawnPty(
       // call site that reaches here unwrapped with no reason still tells
       // the renderer SOMETHING rather than emitting 'running-claude' with
       // no info at all -- the "failing silently" gap this tier closes.
-      setFlowState('running-claude', resolveRunningClaudeInfo(runningClaudeInfo, tmuxWrapped))
+      // item 7 (resume-outcome messaging): on a reconnect that actually
+      // reattached (tmux in play), surface a friendly 'reattach' marker instead
+      // of the silent success (undefined) so the overlay can say "reconnecting
+      // to your session" rather than "launching Claude". Only when there is no
+      // failure reason to show (tmuxWrapped ⇒ runningClaudeInfo is undefined).
+      const runInfo = resolveRunningClaudeInfo(runningClaudeInfo, tmuxWrapped)
+      setFlowState('running-claude', (ssh.reconnect && tmuxWrapped) ? 'reattach' : runInfo)
+      // items 8/9: authoritative persistence signal for THIS session -- whether
+      // the launch actually wrapped in tmux. Re-send the account alongside so a
+      // renderer that missed the latch push still gets both.
+      emitSshSessionInfo(win, sessionId, { tmuxPersistent: tmuxWrapped, remoteAccount })
       logInfo(`[ssh] ${sessionId}: writing claudeCmd${tmuxWrapped ? ' (tmux-wrapped)' : ''}${continueFlag ? ' (+continue)' : ''}`)
       setTimeout(() => {
         // #242 finding F3 (adversarial review round 4, MAJOR): this write is
@@ -1759,7 +1918,9 @@ export function spawnPty(
       // sentinel/timeout/build-error handler (not this choke point) may
       // call writeClaudeCmd from here on while a push is open.
       if (pushSent && !pushDone) return
-      if (!detectedTmuxSource && !stagingAttempted) {
+      // item 1: skip tier-3/4 staging entirely when persistence is off -- this
+      // is the "no silent tmux install" guarantee; go straight to bare claude.
+      if (persistenceEnabled && !detectedTmuxSource && !stagingAttempted) {
         writeTmuxStageCmd()
         return
       }
@@ -1830,6 +1991,19 @@ export function spawnPty(
       },
       skip: () => {
         setFlowState('skipped')
+      },
+      handlePtyExit: () => {
+        // Only a connection failure BEFORE a good terminal state matters here.
+        // A mid-session drop (already claude-running) is left to the user's
+        // Restart; a deliberate close destroys the flow first, so this never
+        // runs for it (sshFlows no longer has the session by onExit time).
+        if (
+          currentFlowState === 'claude-running'
+          || currentFlowState === 'shell-only'
+          || currentFlowState === 'skipped'
+          || currentFlowState === 'failed'
+        ) return
+        setFlowState('failed', 'connection')
       },
       destroy: () => {
         // #242 finding F3 (adversarial review round 4, MAJOR): flip this
@@ -1959,6 +2133,10 @@ export function spawnPty(
             setupTimeoutHandle = null
           }
           logInfo(`[ssh] ${sessionId}: host setup ok received (tmux=${tmuxResult ?? 'none'})`)
+          // item 10: stamp + push the remote account descriptor (if the sentinel
+          // carried a decodable, display-valid one).
+          const hostAcct = parseSetupAccountSentinel(combined, sshNonce)
+          if (hostAcct) { remoteAccount = hostAcct; emitSshSessionInfo(win, sessionId, { remoteAccount }) }
         }
       }
 
@@ -1977,6 +2155,8 @@ export function spawnPty(
             setupTimeoutHandle = null
           }
           logInfo(`[ssh] ${sessionId}: container setup ok received (tmux=${tmuxResult ?? 'none'})`)
+          const contAcct = parseSetupAccountSentinel(combined, sshNonce)
+          if (contAcct) { remoteAccount = contAcct; emitSshSessionInfo(win, sessionId, { remoteAccount }) }
         }
       }
 
@@ -2873,6 +3053,14 @@ export function spawnPty(
 
   ptyProcess.onExit(({ exitCode }) => {
     logInfo(`[pty] PTY exited for session ${sessionId} with code ${exitCode}`)
+    // item 5 (resume cascade): an SSH session whose ssh process exited before
+    // reaching claude-running failed to connect -- tell the overlay so it can
+    // offer Retry (never strand). Runs only while the flow still exists (a
+    // deliberate close destroys it first), so this fires for a genuine
+    // connection failure/drop, not for a user-initiated close.
+    if (sshFlows.has(sessionId)) {
+      try { getSshFlow(sessionId)?.handlePtyExit() } catch { /* best-effort */ }
+    }
 
     // Restart-race guard: the renderer's restart flow kills the old PTY
     // and re-spawns synchronously with the SAME sessionId. node-pty's
@@ -3107,6 +3295,8 @@ function cleanupSessionResources(sessionId: string): void {
   // #242 finding F1 (b): drop this session's nonce so it can never leak into
   // a future, unrelated spawn reusing the same sessionId.
   sshNonceBySession.delete(sessionId)
+  // item 4: drop the SSH connection target alongside the nonce.
+  sshTargetBySession.delete(sessionId)
   pasteQueues.get(sessionId)?.cancel() // stop draining + drop pending before dropping the ref (P1.5)
   pasteQueues.delete(sessionId)
   // Delete the per-session statusline status file so the watcher's poll

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -86,3 +86,36 @@ export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: Node
 
   return args
 }
+
+/**
+ * SSH tmux enhancement (item 4): argv for a ONE-SHOT, non-interactive ssh exec
+ * that runs `remoteCommand` on the host and exits -- used by endSshRemote
+ * (pty-manager.ts) to `tmux kill-session` + remove sidecars over a SEPARATE
+ * connection, so the kill never lands in the live Claude pane.
+ *
+ * Deliberately minimal vs. buildSshArgs: no `-t` (no TTY -- a batch command,
+ * not an interactive session), no `-R` MCP tunnel, and BatchMode=yes + a short
+ * ConnectTimeout so it FAILS FAST rather than blocking on a password prompt (it
+ * relies on key/agent auth; a password-only host simply detaches as before --
+ * the remote survives, exactly today's behaviour). `username`/`host` go through
+ * the SAME assertSafeSshField argv guard as buildSshArgs, and `remoteCommand`
+ * is a host-authored literal with a single sanitized safeSid operand
+ * (buildRemoteTmuxKillCommand, ssh-shim.ts) passed to ssh as ONE positional
+ * argument, so there is no local shell parse of it.
+ */
+export function buildSshExecArgs(ssh: SshArgsTarget, remoteCommand: string, platform: NodeJS.Platform): string[] {
+  assertSafeSshField('username', ssh.username)
+  assertSafeSshField('host', ssh.host)
+  const args = [
+    `${ssh.username}@${ssh.host}`,
+    '-p', String(ssh.port),
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', 'BatchMode=yes',
+    '-o', 'ConnectTimeout=8',
+  ]
+  if (platform === 'win32') {
+    args.push('-o', 'ControlMaster=no', '-o', 'ControlPath=none')
+  }
+  args.push(remoteCommand)
+  return args
+}

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -102,20 +102,39 @@ export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: Node
  * is a host-authored literal with a single sanitized safeSid operand
  * (buildRemoteTmuxKillCommand, ssh-shim.ts) passed to ssh as ONE positional
  * argument, so there is no local shell parse of it.
+ *
+ * NOTE (see SAFE_SSH_FIELD_RE above): this builder DOES emit a second bare token
+ * (`remoteCommand`) after the destination -- the very shape that comment flags
+ * as an argument-injection primitive if the destination were option-like. It is
+ * safe ONLY because assertSafeSshField rejects a leading-`-` username/host, so
+ * the destination can never be consumed as an option and `remoteCommand` can
+ * never slide into argv[0]. That guard is now load-bearing here, not merely
+ * defence-in-depth -- do not remove it.
+ *
+ * ControlMaster/ControlPath are forced OFF on ALL platforms (not just win32):
+ * this exec is dispatched right before the caller tears down the live PTY (the
+ * shared connection's master), so on a POSIX client with `ControlMaster auto`
+ * in ~/.ssh/config the exec would otherwise multiplex over that master and be
+ * cut off mid-kill when the PTY dies ~400ms later (adversarial review,
+ * 2026-08-18). A standalone connection is immune. win32 additionally needs this
+ * because Windows OpenSSH has no multiplexing and errors out if config enables
+ * it (#241), which is why the flags began win32-only.
  */
 export function buildSshExecArgs(ssh: SshArgsTarget, remoteCommand: string, platform: NodeJS.Platform): string[] {
   assertSafeSshField('username', ssh.username)
   assertSafeSshField('host', ssh.host)
+  // `platform` retained for signature parity with buildSshArgs / call sites even
+  // though the mux flags are now unconditional.
+  void platform
   const args = [
     `${ssh.username}@${ssh.host}`,
     '-p', String(ssh.port),
     '-o', 'StrictHostKeyChecking=accept-new',
     '-o', 'BatchMode=yes',
     '-o', 'ConnectTimeout=8',
+    '-o', 'ControlMaster=no',
+    '-o', 'ControlPath=none',
   ]
-  if (platform === 'win32') {
-    args.push('-o', 'ControlMaster=no', '-o', 'ControlPath=none')
-  }
   args.push(remoteCommand)
   return args
 }

--- a/src/main/ssh-tmux-stage.ts
+++ b/src/main/ssh-tmux-stage.ts
@@ -292,13 +292,23 @@ export function buildTmuxStageScript(nonce: string): string {
       // The wget leg is written twice on purpose: GNU wget defaults to
       // --tries=20, so `-t 1` is required to keep it inside the budget, but
       // busybox wget (Alpine, OpenWrt -- exactly the minimal hosts this tier
-      // targets) has no `-t` at all and would exit on a usage error. The second
-      // form drops `-t` and keeps `-T`, which BOTH implementations accept, and
-      // busybox makes a single attempt anyway. The usage-error path costs no
-      // wall-clock, so the worst case stays ~5s + ~5s.
+      // targets) has no `-t` at all and exits on a usage error before trying.
+      // The second form drops `-t` and keeps `-T`, which both implementations
+      // accept.
+      //
+      // Round-2 adversarial pass (MAJOR): that second form MUST be gated on the
+      // wget actually being busybox. Ungated it also runs after a GENUINE
+      // (non-usage) failure of leg 2 -- so on a GNU-wget-only host with DROPped
+      // egress (no curl, common on minimal Debian/RHEL images) leg 3 re-ran GNU
+      // wget WITHOUT `-t`, restoring the default 20 retries: ~100s, far past the
+      // 20s STAGE_TIMEOUT_MS this whole fix exists to stay inside. busybox
+      // prints its name on the first line of `--help`, so probing for it costs
+      // no network time and cannot itself hang. Worst case is now ~5s (curl) +
+      // ~5s (one bounded wget), whichever implementation is present.
       `(curl -fsSL --connect-timeout 5 --max-time 15 "$_url" -o "$_tmp" 2>/dev/null ` +
         `|| wget -q -T 5 -t 1 -O "$_tmp" "$_url" 2>/dev/null ` +
-        `|| wget -q -T 5 -O "$_tmp" "$_url" 2>/dev/null); ` +
+        `|| { wget --help 2>&1 | head -n 1 | grep -qi busybox ` +
+          `&& wget -q -T 5 -O "$_tmp" "$_url" 2>/dev/null; }); ` +
       `if [ ! -s "$_tmp" ]; then rm -f "$_tmp"; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=download"; else ` +
         `if command -v sha256sum >/dev/null 2>&1; then ` +
           `echo "$_sha256  $_tmp" | sha256sum -c - >/dev/null 2>&1; _dgok=$?; ` +

--- a/src/main/ssh-tmux-stage.ts
+++ b/src/main/ssh-tmux-stage.ts
@@ -276,7 +276,29 @@ export function buildTmuxStageScript(nonce: string): string {
       // the temp file inside a directory only this user can write to, the
       // same trust boundary the final install path already lives in.
       `_tmp=$(mktemp 2>/dev/null || { mkdir -p "$HOME/.claude/bin" 2>/dev/null; echo "$HOME/.claude/bin/.ccc-tmux-stage.$$"; }); ` +
-      `(curl -fsSL "$_url" -o "$_tmp" 2>/dev/null || wget -qO- "$_url" > "$_tmp" 2>/dev/null); ` +
+      // Follow-up adversarial pass (fail-posture MAJOR): both fetchers MUST be
+      // bounded well inside the host's 20s STAGE_TIMEOUT_MS. Unbounded, on a
+      // host whose egress is DROPped rather than rejected (the common
+      // enterprise firewall shape), curl blocks on SYN retries for ~127s and
+      // wget then retries 20 times -- minutes to tens of minutes. The host
+      // gives up at 20s and writes the claude launch into a tty whose
+      // foreground pipeline is STILL RUNNING with echo off: the line is queued
+      // invisibly, and a user's Ctrl-C flushes it (leaving an echo-less shell
+      // and no claude). Worse, because the script never gets to print
+      // `fail=download`, tier 4 -- the tier that exists precisely for a host
+      // with no egress -- is never attempted. 5s to connect + 15s total keeps
+      // BOTH fetchers inside the 20s budget, so the failure is reported as a
+      // sentinel and the ladder proceeds instead of stalling.
+      // The wget leg is written twice on purpose: GNU wget defaults to
+      // --tries=20, so `-t 1` is required to keep it inside the budget, but
+      // busybox wget (Alpine, OpenWrt -- exactly the minimal hosts this tier
+      // targets) has no `-t` at all and would exit on a usage error. The second
+      // form drops `-t` and keeps `-T`, which BOTH implementations accept, and
+      // busybox makes a single attempt anyway. The usage-error path costs no
+      // wall-clock, so the worst case stays ~5s + ~5s.
+      `(curl -fsSL --connect-timeout 5 --max-time 15 "$_url" -o "$_tmp" 2>/dev/null ` +
+        `|| wget -q -T 5 -t 1 -O "$_tmp" "$_url" 2>/dev/null ` +
+        `|| wget -q -T 5 -O "$_tmp" "$_url" 2>/dev/null); ` +
       `if [ ! -s "$_tmp" ]; then rm -f "$_tmp"; echo "${TMUX_STAGE_SENTINEL_PREFIX} ${nonce} fail=download"; else ` +
         `if command -v sha256sum >/dev/null 2>&1; then ` +
           `echo "$_sha256  $_tmp" | sha256sum -c - >/dev/null 2>&1; _dgok=$?; ` +

--- a/src/main/ssh-tmux.ts
+++ b/src/main/ssh-tmux.ts
@@ -200,7 +200,7 @@ export interface TmuxLaunchInput {
  * on an attach it does not double-launch.
  *
  * #242 round-3 correction (I3): an earlier version took a `tmuxBin` string
- * (I3): an earlier version took a `tmuxBin` string here for the `staged:
+ * here for the `staged:
  * false` case, validated it (`isPinnedTmuxPath`) against exactly the same
  * "absolute, no traversal" shape STAGED_TMUX_BIN_EXPR's own doc comment
  * already admitted was insufficient for the staged case -- a real PATH tmux
@@ -238,10 +238,19 @@ export function buildTmuxLaunchCommand(input: TmuxLaunchInput): string {
   // where the remote session was gone. Appended to innerCmd BEFORE quoting so
   // it rides inside tmux's single `<shell-cmd>` argument, next to `claude`.
   const freshInner = input.reconnect ? `${input.innerCmd} --continue` : input.innerCmd
+  const fresh = `${tmuxBinToken} new-session -s ${target} ${singleQuote(freshInner)}`
+  // has-session/attach is NOT atomic: the session can die (claude exits, remote
+  // reboots) in the gap between `has-session` returning 0 and `attach` running
+  // (measured ~10ms on a real host), and a bare `attach` then fails with
+  // "no sessions"/"can't find session", leaving NO claude while CCC's idle
+  // fallback still latches claude-running -- a blank remote shell reported as a
+  // live session (adversarial review, 2026-08-18). Fall the attach THROUGH to a
+  // fresh create (with --continue on a reconnect, exactly like the else branch)
+  // so a lost race self-heals instead of stranding the user.
   return (
     `if ${tmuxBinToken} has-session -t ${target} 2>/dev/null; ` +
-    `then ${tmuxBinToken} attach -t ${target}; ` +
-    `else ${tmuxBinToken} new-session -s ${target} ${singleQuote(freshInner)}; fi`
+    `then ${tmuxBinToken} attach -t ${target} || ${fresh}; ` +
+    `else ${fresh}; fi`
   )
 }
 
@@ -269,7 +278,7 @@ export interface SshContinueFlagInput {
   /** SSHOptions.reconnect (#242) — true when this spawn respawns a session
    *  that had previously reached claude-running, set by the renderer. */
   reconnect: boolean
-  /** True when THIS write wraps the launch in `tmux new-session -A`
+  /** True when THIS write wraps the launch in the tmux has-session wrapper
    *  (pty-manager's `tmuxWrapped`) — i.e. a usable binary was detected,
    *  staged, or pushed for this session. */
   tmuxInPlay: boolean

--- a/src/main/ssh-tmux.ts
+++ b/src/main/ssh-tmux.ts
@@ -4,10 +4,14 @@
  * pty-manager (mirroring the #241 ssh-args.ts pattern) so the argv/command
  * shape is unit-testable without the full pty-manager dependency graph.
  *
- * `tmux new-session -A -s ccc-<safeSid> <cmd>` — `-A` means "attach if a
- * session by this name already exists, else create it", so a fresh SSH
- * connection and a reconnect run through the EXACT SAME command. There is
- * no separate "reconnect" code path to keep in sync with the first launch.
+ * The wrapper is a has-session conditional: `if tmux has-session -t
+ * ccc-<safeSid>; then tmux attach; else tmux new-session -s ccc-<safeSid>
+ * <cmd>; fi`. The attach branch reattaches a still-running claude; the
+ * fresh branch (reached when the session is gone, e.g. after a remote
+ * reboot) creates a new one, resuming the conversation via `--continue`
+ * on a reconnect. See buildTmuxLaunchCommand for why the earlier
+ * `new-session -A` one-liner could not tell those two cases apart and so
+ * launched a blank chat on reconnect-after-reboot (item 6).
  *
  * No default export (project convention).
  */
@@ -141,19 +145,61 @@ export interface TmuxLaunchInput {
    * tmux's `sh -c` carries the env vars through to claude — they must NOT
    * be exported as separate tokens before the tmux binary token, because
    * tmux's own launch environment does not come from this command line.
+   *
+   * IMPORTANT: pass the BARE claude command WITHOUT `--continue`. This
+   * builder appends `--continue` itself, and ONLY on the fresh-create
+   * branch of the has-session wrapper (see `reconnect` below and
+   * buildTmuxLaunchCommand's doc comment) -- never on the attach branch,
+   * where a second claude in an already-live pane would be wrong.
    */
   innerCmd: string
+  /**
+   * SSH tmux enhancement (item 6 — silent-blank-chat fix): true when this
+   * spawn respawns a session that had previously reached claude-running
+   * (SSHOptions.reconnect). Gates whether the wrapper's FRESH-create branch
+   * appends `--continue` to `innerCmd`.
+   *
+   * The bug this closes: the pre-enhancement wrapper was `new-session -A`,
+   * which cannot tell "attach to the still-running claude" from "the tmux
+   * server/session is gone (remote reboot), create a fresh one" -- and
+   * `--continue` was statically suppressed whenever tmux was in play. So a
+   * reconnect after the remote rebooted created a fresh session and launched
+   * claude with NO `--continue`, i.e. a blank chat even though the remote
+   * transcript still existed. The has-session wrapper splits those two cases
+   * apart: the attach branch reattaches the live claude (no flag, correct),
+   * and the fresh branch — reached only when the session is genuinely gone —
+   * launches with `--continue` on a reconnect so the conversation resumes.
+   */
+  reconnect: boolean
 }
 
 /**
  * Build the tmux wrapper around a Claude launch command for an SSH session.
  *
- * Produces, for a tier-1 (`staged: false`) binary:
- *   `"$(command -v tmux)" new-session -A -s ccc-<safeSid> '<innerCmd>'`
- * and for a tier-2/3/4 (`staged: true`) binary:
- *   `"$HOME"/.claude/bin/tmux new-session -A -s ccc-<safeSid> '<innerCmd>'`
- * -- literally `ON_PATH_TMUX_BIN_EXPR` / `STAGED_TMUX_BIN_EXPR`, NEVER a
- * value this function receives from the caller. #242 round-3 correction
+ * SSH tmux enhancement (item 6): the wrapper is now an explicit has-session
+ * conditional rather than `new-session -A`, so a reconnect can tell "the
+ * session is still alive, attach to it" apart from "the session is gone
+ * (remote reboot), create a fresh one and resume the conversation". Produces,
+ * for a tier-1 (`staged: false`) binary:
+ *   `if "$(command -v tmux)" has-session -t ccc-<sid> 2>/dev/null; then`
+ *   ` "$(command -v tmux)" attach -t ccc-<sid>;`
+ *   ` else "$(command -v tmux)" new-session -s ccc-<sid> '<innerCmd[ --continue]>'; fi`
+ * and for a tier-2/3/4 (`staged: true`) binary the identical shape with
+ * `"$HOME"/.claude/bin/tmux` as the token. The leading token is literally
+ * `ON_PATH_TMUX_BIN_EXPR` / `STAGED_TMUX_BIN_EXPR`, NEVER a value this
+ * function receives from the caller (the #242 RCE sink is unchanged: no
+ * wire-reported path reaches the command). `has-session`/`attach`/
+ * `new-session`/`then`/`else`/`fi`/`2>/dev/null` are all compile-time
+ * literals with no operand an attacker controls; `ccc-<sid>` is safeSid-
+ * sanitized; `<innerCmd>` is single-quoted exactly as before.
+ *
+ * `--continue` is appended to the FRESH-create branch's inner command only
+ * (never the attach branch, never on a first connect) — see TmuxLaunchInput.
+ * reconnect. That is the whole silent-blank-chat fix: on a reconnect where
+ * the remote session vanished, the fresh claude resumes the conversation;
+ * on an attach it does not double-launch.
+ *
+ * #242 round-3 correction (I3): an earlier version took a `tmuxBin` string
  * (I3): an earlier version took a `tmuxBin` string here for the `staged:
  * false` case, validated it (`isPinnedTmuxPath`) against exactly the same
  * "absolute, no traversal" shape STAGED_TMUX_BIN_EXPR's own doc comment
@@ -187,7 +233,16 @@ export interface TmuxLaunchInput {
 export function buildTmuxLaunchCommand(input: TmuxLaunchInput): string {
   const sid = safeSid(input.sessionId)
   const tmuxBinToken = input.staged ? STAGED_TMUX_BIN_EXPR : ON_PATH_TMUX_BIN_EXPR
-  return `${tmuxBinToken} new-session -A -s ccc-${sid} ${singleQuote(input.innerCmd)}`
+  const target = `ccc-${sid}`
+  // Fresh-create branch only: resume the prior conversation on a reconnect
+  // where the remote session was gone. Appended to innerCmd BEFORE quoting so
+  // it rides inside tmux's single `<shell-cmd>` argument, next to `claude`.
+  const freshInner = input.reconnect ? `${input.innerCmd} --continue` : input.innerCmd
+  return (
+    `if ${tmuxBinToken} has-session -t ${target} 2>/dev/null; ` +
+    `then ${tmuxBinToken} attach -t ${target}; ` +
+    `else ${tmuxBinToken} new-session -s ${target} ${singleQuote(freshInner)}; fi`
+  )
 }
 
 /**
@@ -201,16 +256,14 @@ export function buildTmuxLaunchCommand(input: TmuxLaunchInput): string {
  * exiting) is gone and a fresh one starts with no history.
  *
  * `tmuxInPlay` gates this OFF, not just `reconnect` gating it ON: when a
- * tmux binary is available, `buildTmuxLaunchCommand`'s `-A` already
- * reattaches to whatever `claude` is still running inside the named
- * session — that IS the reconnect path, and it needs no `--continue` at
- * all. Adding it anyway would run a SECOND `claude` inside the SAME
- * attached tmux pane (the first one, if still alive, never exited), which
- * is wrong regardless of `reconnect`. See buildTmuxLaunchCommand's own doc
- * comment for why `-A` makes reconnect and first-connect the identical
- * command — this function is the deliberate exception to that story: the
- * bare (non-tmux) launch has NO such single code path, so reconnect has to
- * be signalled explicitly via a flag instead.
+ * tmux binary is available, `buildTmuxLaunchCommand`'s has-session wrapper
+ * OWNS the `--continue` decision itself — its attach branch reattaches the
+ * still-running `claude` (no flag) and its fresh-create branch appends
+ * `--continue` on a reconnect. So the bare-launch flag this function
+ * computes must stay OFF whenever tmux is in play, or a reconnect would get
+ * `--continue` twice (once here, once inside the wrapper's fresh branch).
+ * The bare (non-tmux) launch has no such internal branch, so reconnect has
+ * to be signalled explicitly via this flag instead.
  */
 export interface SshContinueFlagInput {
   /** SSHOptions.reconnect (#242) — true when this spawn respawns a session

--- a/src/main/ssh-tmux.ts
+++ b/src/main/ssh-tmux.ts
@@ -194,9 +194,9 @@ export interface TmuxLaunchInput {
  * session is still alive, attach to it" apart from "the session is gone
  * (remote reboot), create a fresh one and resume the conversation". Produces,
  * for a tier-1 (`staged: false`) binary:
- *   `if "$(command -v tmux)" has-session -t ccc-<sid> 2>/dev/null; then`
- *   ` "$(command -v tmux)" attach -t ccc-<sid>;`
- *   ` else "$(command -v tmux)" new-session -s ccc-<sid> '<innerCmd[ --continue]>'; fi`
+ *   `if command tmux has-session -t ccc-<sid> 2>/dev/null; then`
+ *   ` command tmux attach -t ccc-<sid>;`
+ *   ` else command tmux new-session -s ccc-<sid> '<innerCmd[ --continue]>'; fi`
  * and for a tier-2/3/4 (`staged: true`) binary the identical shape with
  * `"$HOME"/.claude/bin/tmux` as the token. The leading token is literally
  * `ON_PATH_TMUX_BIN_EXPR` / `STAGED_TMUX_BIN_EXPR`, NEVER a value this

--- a/src/main/ssh-tmux.ts
+++ b/src/main/ssh-tmux.ts
@@ -90,10 +90,23 @@ export const STAGED_TMUX_BIN_EXPR = '"$HOME"/.claude/bin/tmux'
  * question tier 1 needs ("is tmux on this user's PATH") with no
  * wire-reported operand in the sink at all -- generateRemoteSetupScript
  * (ssh-shim.ts) now emits a CLASS (`path`/`home`/`none`), never a path, for
- * exactly this reason. Quoted as a single command-substitution token so a
- * PATH entry containing whitespace can't split the argument.
+ * exactly this reason.
+ *
+ * Follow-up adversarial pass (fail-posture MAJOR): this used to be
+ * `"$(command -v tmux)"`. The DETECTION probe runs `command -v tmux` through
+ * `execSync` (a non-interactive `sh -c`, where aliases do not exist), but this
+ * token is expanded by the remote's INTERACTIVE login shell -- and there
+ * `command -v` prints an alias DEFINITION (`alias tmux='tmux -2'`) rather than a
+ * path for anyone who aliases tmux in their rc file. Quoted as one word that is
+ * exit 127 and no claude, on every connect, where the pre-#242 bare launch
+ * always worked. `command tmux` is the alias- AND function-proof form: `command`
+ * is a POSIX special builtin that bypasses shell functions, and `tmux` sits in
+ * argument position where alias expansion never applies. It remains a
+ * compile-time literal with no wire-reported operand, which is the property
+ * this constant exists to guarantee, and the remote's own PATH lookup still
+ * happens in the authenticated user's shell at launch time.
  */
-export const ON_PATH_TMUX_BIN_EXPR = '"$(command -v tmux)"'
+export const ON_PATH_TMUX_BIN_EXPR = 'command tmux'
 
 /**
  * Sanitize a CCC session id into a tmux-safe session name. Mirrors the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -87,6 +87,12 @@ export interface ElectronAPI {
          *  claude-running -- drives `--continue` when no tmux persistence
          *  is available. See SSHOptions.reconnect in pty-manager.ts. */
         reconnect?: boolean
+        /** SSH tmux enhancement (item 1): "Detachable" toggle (default ON;
+         *  only false disables tmux persistence). */
+        detachable?: boolean
+        /** SSH tmux enhancement (item 3): remote OS ('windows' uses the Windows
+         *  setup path; auto/unix use POSIX). */
+        remoteOs?: 'auto' | 'unix' | 'windows'
       }
       configId?: string
       configLabel?: string
@@ -133,6 +139,12 @@ export interface ElectronAPI {
     getState: (sessionId: string) => Promise<{ state: string; info?: string }>
     /** Subscribe to flow-state changes for a session. */
     onFlowState: (sessionId: string, callback: (msg: { state: string; info?: string }) => void) => () => void
+    /** SSH tmux enhancement (items 8/9/10): subscribe to per-session
+     *  persistence + remote-account descriptors pushed by main. */
+    onSessionInfo: (sessionId: string, callback: (msg: { tmuxPersistent?: boolean; remoteAccount?: string }) => void) => () => void
+    /** item 4: END the remote session (tmux kill-session + sidecar cleanup via
+     *  a separate ssh exec) then kill the local PTY. */
+    endRemote: (sessionId: string) => Promise<void>
   }
   statusline: {
     onUpdate: (callback: (data: StatuslineData) => void) => () => void
@@ -642,6 +654,13 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.on(channel, handler)
       return () => ipcRenderer.removeListener(channel, handler)
     },
+    onSessionInfo: (sessionId: string, callback: (msg: { tmuxPersistent?: boolean; remoteAccount?: string }) => void) => {
+      const channel = `${IPC.SSH_SESSION_INFO}:${sessionId}`
+      const handler = (_: unknown, msg: { tmuxPersistent?: boolean; remoteAccount?: string }) => callback(msg)
+      ipcRenderer.on(channel, handler)
+      return () => ipcRenderer.removeListener(channel, handler)
+    },
+    endRemote: (sessionId: string) => ipcRenderer.invoke(IPC.SSH_END_REMOTE, sessionId),
   },
   statusline: {
     onUpdate: (callback) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,7 @@ import TipModal from './components/TipModal'
 import { useTipsStore, trackUsage } from './stores/tipsStore'
 import ErrorBoundary from './components/ErrorBoundary'
 import CloseDialog from './components/CloseDialog'
+import SshCloseDialog from './components/SshCloseDialog'
 import { useSessionStore, structuralSessionsEqual, Session } from './stores/sessionStore'
 import { useStoreWithEqualityFn } from 'zustand/traditional'
 import { useConfigStore } from './stores/configStore'
@@ -1159,6 +1160,7 @@ export default function App() {
           </div>
         )}
 
+        <SshCloseDialog />
         {closeDialog && (
           <CloseDialog
             mode={closeDialog}

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -94,6 +94,10 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
   const [sshRemotePath, setSshRemotePath] = useState(initial?.sshConfig?.remotePath ?? '~')
   const [machineName, setMachineName] = useState(initial?.machineName ?? '')
   const [postCommand, setPostCommand] = useState(initial?.sshConfig?.postCommand ?? '')
+  // SSH tmux enhancement (item 1): "Detachable" (persistent remote session).
+  // DEFAULT ON -- only an explicit false disables it, so a config saved before
+  // this field existed (undefined) opens ticked.
+  const [detachable, setDetachable] = useState(initial?.sshConfig?.detachable !== false)
   // Secrets: `stored*` tracks whether the keychain currently holds one (the
   // "Remove stored password" link clears it); `save*` is the honest opt-in —
   // a typed password is only handed to the caller for storage when it's on.
@@ -371,6 +375,8 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
         hasPassword: passwordSaved,
         postCommand: postCommand.trim() || undefined,
         hasSudoPassword: sudoSaved,
+        // item 1: persist only the opt-OUT (false); ON is the default/undefined.
+        detachable: detachable ? undefined : false,
       } : undefined,
       claudeOptions,
       codexOptions,
@@ -720,6 +726,32 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
                       )}
                     </div>
                   )}
+                  {/* SSH tmux enhancement (item 1): Detachable (persistent
+                      remote session). Default ON. When on, CCC keeps the remote
+                      Claude alive in a tmux session so a dropped connection can
+                      reattach; if the host lacks tmux it installs a small static
+                      build (surfaced in the connect overlay, never silent). Off
+                      = a bare claude that resumes via --continue on reconnect. */}
+                  <div className="rounded-md border border-surface1 bg-surface0/40 px-3 py-2">
+                    <label className="flex items-start gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={detachable}
+                        onChange={(e) => setDetachable(e.target.checked)}
+                        className="mt-0.5 rounded border-surface1"
+                        data-testid="ssh-detachable"
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-xs text-text font-medium">Detachable (persistent remote session)</span>
+                        <span className="block text-[11px] text-subtext0 leading-snug">
+                          Keeps the remote session alive if the connection drops, so reconnecting
+                          resumes it in place. Needs tmux on the host — CCC installs a lightweight
+                          copy if it's missing (you'll see it happen). Turn off to run a plain
+                          session that resumes with --continue instead.
+                        </span>
+                      </span>
+                    </label>
+                  </div>
                 </div>
               )}
 

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -287,40 +287,40 @@ export default function SessionHeader({ session, onShowTip }: Props) {
           <span className="text-xs text-mauve">SSH: {session.sshConfig.username}@{session.sshConfig.host}</span>
           {/* item 8: persistence indicator. Only shown once main has reported a
               definite status for this session (undefined = not yet known). */}
+          {/* Rendered through the shared HeaderPill (#291's title-bar-style pill
+              system) so the SSH pills sit at the same weight as the account /
+              GitHub pills instead of carrying their own copy of the chrome. */}
           {session.sshTmuxPersistent === true && (
-            <span
-              className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium"
-              style={{ color: 'var(--text-muted)' }}
+            <HeaderPill
+              label={
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"/></svg>
+              }
+              tone="var(--status-success)"
+              word="persistent"
+              dotOnly
               title="This remote session runs inside tmux — a dropped connection stays alive and reconnecting resumes it in place."
-              data-testid="ssh-persistent-pill"
-            >
-              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"/></svg>
-              <span style={{ color: 'var(--status-success)' }}>persistent</span>
-            </span>
+              testId="ssh-persistent-pill"
+            />
           )}
           {session.sshTmuxPersistent === false && (
-            <span
-              className="px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium"
-              style={{ color: 'var(--text-muted)' }}
+            <HeaderPill
+              label="not persistent"
+              tone="var(--text-muted)"
+              dotOnly
               title="This remote session is not persistent — a dropped connection ends it; reconnecting resumes the conversation via --continue."
-              data-testid="ssh-nonpersistent-pill"
-            >
-              not persistent
-            </span>
+              testId="ssh-nonpersistent-pill"
+            />
           )}
           {/* item 10: the account the REMOTE session is signed in as (descriptor
               only). Distinct from the local SessionAuthPills, which never apply
               to SSH. */}
           {session.sshRemoteAccount && (
-            <span
-              className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium max-w-[160px]"
-              style={{ color: 'var(--text-muted)' }}
+            <HeaderPill
+              label={<span className="truncate max-w-[140px]">{session.sshRemoteAccount}</span>}
+              tone="var(--color-mauve, #cba6f7)"
               title={`Remote Claude account: ${session.sshRemoteAccount}`}
-              data-testid="ssh-remote-account-pill"
-            >
-              <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: 'var(--color-mauve, #cba6f7)' }} aria-hidden />
-              <span className="truncate">{session.sshRemoteAccount}</span>
-            </span>
+              testId="ssh-remote-account-pill"
+            />
           )}
         </span>
       )}

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -283,7 +283,46 @@ export default function SessionHeader({ session, onShowTip }: Props) {
       </span>
 
       {session.sessionType === 'ssh' && session.sshConfig && (
-        <span className="text-xs text-mauve shrink-0">SSH: {session.sshConfig.username}@{session.sshConfig.host}</span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          <span className="text-xs text-mauve">SSH: {session.sshConfig.username}@{session.sshConfig.host}</span>
+          {/* item 8: persistence indicator. Only shown once main has reported a
+              definite status for this session (undefined = not yet known). */}
+          {session.sshTmuxPersistent === true && (
+            <span
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium"
+              style={{ color: 'var(--text-muted)' }}
+              title="This remote session runs inside tmux — a dropped connection stays alive and reconnecting resumes it in place."
+              data-testid="ssh-persistent-pill"
+            >
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"/></svg>
+              <span style={{ color: 'var(--status-success)' }}>persistent</span>
+            </span>
+          )}
+          {session.sshTmuxPersistent === false && (
+            <span
+              className="px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium"
+              style={{ color: 'var(--text-muted)' }}
+              title="This remote session is not persistent — a dropped connection ends it; reconnecting resumes the conversation via --continue."
+              data-testid="ssh-nonpersistent-pill"
+            >
+              not persistent
+            </span>
+          )}
+          {/* item 10: the account the REMOTE session is signed in as (descriptor
+              only). Distinct from the local SessionAuthPills, which never apply
+              to SSH. */}
+          {session.sshRemoteAccount && (
+            <span
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-surface0/60 bg-surface0/40 text-[10px] font-medium max-w-[160px]"
+              style={{ color: 'var(--text-muted)' }}
+              title={`Remote Claude account: ${session.sshRemoteAccount}`}
+              data-testid="ssh-remote-account-pill"
+            >
+              <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: 'var(--color-mauve, #cba6f7)' }} aria-hidden />
+              <span className="truncate">{session.sshRemoteAccount}</span>
+            </span>
+          )}
+        </span>
       )}
 
       {/* Right cluster: account · claude.ai · Claude Code | GitHub — styled to

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -317,7 +317,7 @@ export default function SessionHeader({ session, onShowTip }: Props) {
           {session.sshRemoteAccount && (
             <HeaderPill
               label={<span className="truncate max-w-[140px]">{session.sshRemoteAccount}</span>}
-              tone="var(--color-mauve, #cba6f7)"
+              tone="var(--color-mauve)"
               title={`Remote Claude account: ${session.sshRemoteAccount}`}
               testId="ssh-remote-account-pill"
             />

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { useConductorMcpStore } from '../stores/conductorMcpStore'
 import { useAccountAuthStore } from '../stores/accountAuthStore'
 import SessionDialog from './SessionDialog'
 import { killSessionPty } from '../ptyTracker'
+import { requestCloseSession } from '../stores/sshCloseStore'
 import { ViewType } from '../types/views'
 import { trackUsage } from '../stores/tipsStore'
 import { generateId } from '../utils/id'
@@ -937,8 +938,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
           } else if (e.key === 'Delete' && focusedSessionIndex >= 0 && focusedSessionIndex < sessions.length) {
             e.preventDefault()
             const s = sessions[focusedSessionIndex]
-            killSessionPty(s.id)
-            removeSession(s.id)
+            requestCloseSession(s.id)
             setFocusedSessionIndex(prev => Math.min(prev, sessions.length - 2))
           } else if (e.key === 'Escape') {
             setSelectedSessionIds(new Set())
@@ -1046,8 +1046,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowHe
               setSessionContextMenu(null)
             }}
             onClose={() => {
-              killSessionPty(sessionContextMenu.sessionId)
-              removeSession(sessionContextMenu.sessionId)
+              // item 4: persistent SSH sessions get the End-vs-Leave choice.
+              requestCloseSession(sessionContextMenu.sessionId)
               setSessionContextMenu(null)
             }}
             onDismiss={() => setSessionContextMenu(null)}

--- a/src/renderer/components/SshCloseDialog.tsx
+++ b/src/renderer/components/SshCloseDialog.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { useSshCloseStore, endRemoteAndClose, leaveRunningAndClose } from '../stores/sshCloseStore'
+
+// SSH tmux enhancement (items 4 + 11): the confirmation shown when closing a
+// PERSISTENT remote session. "End remote session" runs tmux kill-session +
+// sidecar cleanup on the host (over a separate ssh exec) then closes the tab.
+// "Leave running" detaches only — the remote stays alive so it can be
+// reattached later. Closing straight away (the old behaviour) silently
+// stranded the remote, which is the exact wart this closes.
+export default function SshCloseDialog() {
+  const pending = useSshCloseStore((s) => s.pending)
+  const clear = useSshCloseStore((s) => s.clear)
+  const [busy, setBusy] = React.useState(false)
+
+  if (!pending) return null
+
+  const end = async () => {
+    setBusy(true)
+    try {
+      await endRemoteAndClose(pending.sessionId)
+    } finally {
+      setBusy(false)
+    }
+  }
+  const leave = () => leaveRunningAndClose(pending.sessionId)
+
+  return (
+    <div className="absolute inset-0 bg-base/80 z-[60] flex items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="ssh-close-heading">
+      <div className="bg-surface0 border border-surface1 rounded-lg shadow-2xl p-6 max-w-sm w-full mx-4">
+        <h2 id="ssh-close-heading" className="text-lg font-semibold text-text mb-2">
+          Close “{pending.label}”?
+        </h2>
+        <p className="text-sm text-overlay1 mb-1">
+          This session is running <span className="text-text font-medium">persistently</span> on the remote host
+          {pending.host ? <> (<span className="font-mono text-xs">{pending.host}</span>)</> : null}.
+        </p>
+        <p className="text-xs text-overlay0 mb-4">
+          End it to stop the remote tmux session and clean up, or leave it running so you can
+          reattach later{pending.remoteAccount ? <> — signed in as <span className="font-mono">{pending.remoteAccount}</span></> : null}.
+        </p>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={end}
+            disabled={busy}
+            className="w-full py-2 px-4 text-sm font-medium rounded bg-red hover:bg-red/85 text-crust transition-colors disabled:opacity-50"
+            data-testid="ssh-close-end"
+          >
+            {busy ? 'Ending…' : 'End remote session'}
+          </button>
+          <button
+            onClick={leave}
+            disabled={busy}
+            className="w-full py-2 px-4 text-sm font-medium rounded bg-surface1 hover:bg-surface2 text-text transition-colors disabled:opacity-50"
+            data-testid="ssh-close-leave"
+          >
+            Leave running (reattach later)
+          </button>
+          <button
+            onClick={clear}
+            disabled={busy}
+            className="w-full py-1.5 px-4 text-xs text-overlay0 hover:text-overlay1 transition-colors disabled:opacity-50"
+            data-testid="ssh-close-cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/SshFlowOverlay.tsx
+++ b/src/renderer/components/SshFlowOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { isSshPersistenceFailureReason, formatPersistenceUnavailableMessage } from '../../shared/ssh-tmux-persistence'
+import { useSessionStore } from '../stores/sessionStore'
 
 interface Props {
   sessionId: string
@@ -40,6 +41,9 @@ type FlowState =
 export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, enabled, onRetry }: Props) {
   const [state, setState] = useState<FlowState>('connecting')
   const [info, setInfo] = useState<string | undefined>(undefined)
+  // Copilot review, #298: only a session main has REPORTED as tmux-wrapped has
+  // something running on the far side to come back to.
+  const isPersistent = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId)?.sshTmuxPersistent) === true
   const [busy, setBusy] = useState(false)
   const [errorText, setErrorText] = useState<string | null>(null)
 
@@ -255,9 +259,15 @@ export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, e
       )}
       {state === 'failed' && info === 'connection' && (
         <div className="space-y-1.5">
+          {/* Copilot review, #298: the reassurance is only TRUE when this
+              session is known to have reached a persistent (tmux-wrapped)
+              remote. On a first connect that never got that far, or one that
+              died before tmux started, there is nothing on the far side to pick
+              back up, and promising otherwise is worse than saying nothing. */}
           <p className="text-red text-[11px] leading-snug">
-            Couldn’t reach the host — it may be offline or asleep. Nothing was lost; a remote
-            session (if any) is still running and reconnecting will pick it back up.
+            {isPersistent
+              ? 'Couldn’t reach the host — it may be offline or asleep. Nothing was lost: your remote session is still running there, and reconnecting will pick it back up.'
+              : 'Couldn’t reach the host — it may be offline or asleep. Check the address and that the machine is awake, then retry.'}
           </p>
           <div className="flex gap-1.5">
             <button

--- a/src/renderer/components/SshFlowOverlay.tsx
+++ b/src/renderer/components/SshFlowOverlay.tsx
@@ -8,6 +8,10 @@ interface Props {
   /** When true, skip the overlay entirely and let pty-manager run the
    * legacy auto state machine. Local sessions also skip via not-mounting. */
   enabled: boolean
+  /** item 5 (resume cascade): respawn the whole session. Used by the "no host"
+   *  connection-failure branch's Retry, which cannot recover by re-writing the
+   *  claude command (the PTY is dead) -- only a full re-spawn reconnects. */
+  onRetry?: () => void
 }
 
 type FlowState =
@@ -33,7 +37,7 @@ type FlowState =
  * remains fully interactive at all times — the overlay sits in a
  * top-right corner of the pane, not over the whole pane.
  */
-export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, enabled }: Props) {
+export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, enabled, onRetry }: Props) {
   const [state, setState] = useState<FlowState>('connecting')
   const [info, setInfo] = useState<string | undefined>(undefined)
   const [busy, setBusy] = useState(false)
@@ -118,14 +122,19 @@ export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, e
     try { await window.electronAPI.ssh.skip(sessionId) } catch { /* noop */ }
   }
 
+  // item 1/2 honesty: a tmux stage/push IS an install on the host -- say so
+  // plainly rather than the cryptic "Injecting statusline (tmux-stage)".
+  const isTmuxInstall = state === 'running-setup' && (info === 'tmux-stage' || info === 'tmux-push' || (typeof info === 'string' && info.startsWith('staging tmux')))
   const headline =
     state === 'connecting' ? 'Connecting…' :
     isAwaitingPostCommand ? (hasPostCommand ? 'Run post-connect command?' : 'Launch Claude?') :
     isAwaitingClaude ? (info === 'inner' ? 'Inner shell ready — launch Claude?' : 'Launch Claude?') :
     state === 'running-postcommand' ? 'Running post-connect command…' :
+    isTmuxInstall ? 'Installing a lightweight tmux…' :
     state === 'running-setup' ? `Injecting statusline (${info || 'host'})…` :
-    state === 'running-claude' ? 'Launching Claude…' :
-    state === 'failed' ? 'Setup failed' :
+    // item 7: distinguish a reconnect-reattach from a first launch.
+    state === 'running-claude' ? (info === 'reattach' ? 'Reconnecting to your session…' : 'Launching Claude…') :
+    state === 'failed' ? (info === 'connection' ? 'Couldn’t reach the host' : 'Setup failed') :
     ''
 
   return (
@@ -213,6 +222,19 @@ export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, e
           </div>
         </div>
       )}
+      {state === 'running-claude' && info === 'reattach' && (
+        <div className="text-overlay1 text-[11px] leading-snug mb-1">
+          Your remote session was still alive — reattaching. If it had ended, we resume your
+          conversation automatically.
+        </div>
+      )}
+      {isTmuxInstall && (
+        <div className="text-overlay1 text-[11px] leading-snug mb-1">
+          The host doesn’t have tmux, so we’re installing a small static copy under
+          <span className="font-mono"> ~/.claude/bin</span> to keep this session alive if the
+          connection drops. Nothing is installed system-wide.
+        </div>
+      )}
       {/* #242 tier 5: every tmux-ladder tier that gave up already forwards its
           reason onto this SAME 'running-claude' info field (tmux-stage-fail:*,
           tmux-push-fail:*, or the probe=none default) -- this was previously
@@ -231,7 +253,25 @@ export default function SshFlowOverlay({ sessionId, hasPostCommand, shellOnly, e
           Watching for completion sentinel. App.log has step-by-step trace.
         </div>
       )}
-      {state === 'failed' && (
+      {state === 'failed' && info === 'connection' && (
+        <div className="space-y-1.5">
+          <p className="text-red text-[11px] leading-snug">
+            Couldn’t reach the host — it may be offline or asleep. Nothing was lost; a remote
+            session (if any) is still running and reconnecting will pick it back up.
+          </p>
+          <div className="flex gap-1.5">
+            <button
+              onClick={() => onRetry?.()}
+              disabled={!onRetry}
+              className="px-3 py-1 text-xs rounded bg-blue text-crust hover:bg-blue/85 font-medium disabled:opacity-50"
+              data-testid="ssh-retry-connection"
+            >
+              Retry connection
+            </button>
+          </div>
+        </div>
+      )}
+      {state === 'failed' && info !== 'connection' && (
         <div className="space-y-1.5">
           <p className="text-red text-[11px]">{errorText || 'Step did not complete.'}</p>
           <div className="flex gap-1.5">

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { requestCloseSession } from '../stores/sshCloseStore'
 import { useSessionStore } from '../stores/sessionStore'
-import { killSessionPty } from './TerminalView'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
 import { useResolvedTheme } from '../hooks/useThemeController'
 import { useRegionTypography } from '../hooks/useTypography'

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { requestCloseSession } from '../stores/sshCloseStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { killSessionPty } from './TerminalView'
 import { resolveIdentityColor, bucketLegacyColorToKey } from '../../shared/identity-colors'
@@ -124,8 +125,8 @@ export default function TabBar() {
   if (sessions.length === 0) return null
 
   const closeSession = (id: string) => {
-    killSessionPty(id)
-    removeSession(id)
+    // item 4: a persistent SSH session gets the End-vs-Leave-running choice.
+    requestCloseSession(id)
   }
 
   return (

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -13,6 +13,7 @@ import {
   type StaleGlyphRepainter,
 } from './terminal/staleGlyphRepaint'
 import { useSessionStore } from '../stores/sessionStore'
+import { useRestartSession } from '../hooks/useRestartSession'
 import { persistLastUsedAccount } from '../session-persistence'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { useAccountGateStore, GATE_CANCELLED } from '../stores/accountGateStore'
@@ -137,6 +138,9 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   }, [isActive])
   const updateSession = useSessionStore((s) => s.updateSession)
   const session = useSessionStore((s) => s.sessions.find((sess) => sess.id === sessionId))
+  // item 5 (resume cascade): the overlay's "no host" Retry re-spawns the whole
+  // session (a dead PTY can't be recovered by re-writing the claude command).
+  const { restart: sshRestart } = useRestartSession(session)
 
   // Extracted hooks
   useStatuslineSubscription(sessionId)
@@ -151,6 +155,21 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // folder prompt's Enter goes to nothing. Subscribe to the flow state
   // here and pull focus into xterm the moment Claude is up. Skipped
   // when a modal is open so the walkthrough's focus trap wins.
+  // SSH tmux enhancement (items 8/9/10): persistence status + remote account,
+  // pushed by main. Merged into the session store so the sidebar icon + header
+  // pills reflect them for the session's whole life (this TerminalView stays
+  // mounted per session, hidden when inactive). Renderer-only fields, never
+  // persisted -- re-established by main's push on each spawn.
+  useEffect(() => {
+    if (!ssh) return
+    return window.electronAPI.ssh.onSessionInfo(sessionId, (msg) => {
+      const patch: { sshTmuxPersistent?: boolean; sshRemoteAccount?: string } = {}
+      if (typeof msg.tmuxPersistent === 'boolean') patch.sshTmuxPersistent = msg.tmuxPersistent
+      if (typeof msg.remoteAccount === 'string' && msg.remoteAccount) patch.sshRemoteAccount = msg.remoteAccount
+      if (Object.keys(patch).length > 0) updateSession(sessionId, patch)
+    })
+  }, [sessionId, ssh, updateSession])
+
   useEffect(() => {
     if (!ssh) return
     return window.electronAPI.ssh.onFlowState(sessionId, (msg) => {
@@ -1110,6 +1129,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           hasPostCommand={!!ssh.postCommand}
           shellOnly={!!shellOnly}
           enabled
+          onRetry={sshRestart}
         />
       )}
       {isScrolledUp && (

--- a/src/renderer/components/sidebar/Badges.tsx
+++ b/src/renderer/components/sidebar/Badges.tsx
@@ -43,6 +43,28 @@ export function SshBadge() {
   )
 }
 
+// SSH tmux enhancement (item 9): a distinct badge for a PERSISTENT SSH session
+// (running inside a tmux wrapper that survives a dropped connection), so
+// persistent vs. plain SSH is legible at a glance in the list. The chain-link
+// glyph reads as "stays connected"; the green tint matches the header
+// persistence indicator.
+export function SshPersistentBadge() {
+  return (
+    <div
+      className="flex items-center justify-center h-4 px-1 gap-0.5 rounded shrink-0 bg-green/15 text-green"
+      title="Persistent SSH session — kept alive in tmux; a dropped connection reattaches"
+      style={{ fontSize: '8px', fontWeight: 700, letterSpacing: '0.5px' }}
+      data-testid="ssh-persistent-badge"
+    >
+      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+      SSH
+    </div>
+  )
+}
+
 export function CodexBadge({ needsAttention }: { needsAttention: boolean }) {
   const isWorking = !needsAttention
   return (

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Session } from '../../stores/sessionStore'
-import { CodexBadge, ShellBadge, SshBadge } from './Badges'
+import { CodexBadge, ShellBadge, SshBadge, SshPersistentBadge } from './Badges'
 import { type SessionState } from '../ui/StatusDot'
 import { EffortPill } from '../ui/EffortPill'
 import { FastBolt } from '../ui/FastBolt'
@@ -139,7 +139,7 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
           deliberately or add min-w-0 + flex-shrink rules at that point. */}
       <span className="nm relative z-10 row-start-1 flex items-center gap-1.5">
         <span className="text-[13px] truncate" style={{ fontWeight: isActive ? 700 : 600 }} title={session.customName?.trim() ? `${session.customName.trim()} · ${session.label}` : session.label}>{session.customName?.trim() || session.label}</span>
-        {session.sessionType === 'ssh' && <SshBadge />}
+        {session.sessionType === 'ssh' && (session.sshTmuxPersistent === true ? <SshPersistentBadge /> : <SshBadge />)}
         {session.shellOnly ? <ShellBadge /> : (session.provider ?? 'claude') === 'codex' ? <CodexBadge needsAttention={needsAttention} /> : null}
       </span>
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { killSessionPty } from '../ptyTracker'
 import { requestCloseSession } from '../stores/sshCloseStore'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
 import { sendImageToSession } from '../utils/imageTransfer'

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { killSessionPty } from '../ptyTracker'
+import { requestCloseSession } from '../stores/sshCloseStore'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
 import { sendImageToSession } from '../utils/imageTransfer'
 import { usePasteHintStore } from '../stores/pasteHintStore'
@@ -29,11 +30,8 @@ export function useKeyboardShortcuts(
       // Close current session
       if (matchesShortcut(e, shortcuts.closeSession)) {
         e.preventDefault()
-        if (activeSessionId) {
-          killSessionPty(activeSessionId)
-          killSessionPty(activeSessionId + '-partner')
-          useSessionStore.getState().removeSession(activeSessionId)
-        }
+        // item 4: persistent SSH sessions route through the End-vs-Leave choice.
+        if (activeSessionId) requestCloseSession(activeSessionId)
       }
       // Next/Previous session
       if (matchesShortcut(e, shortcuts.nextSession) || matchesShortcut(e, shortcuts.prevSession)) {

--- a/src/renderer/hooks/useLaunchConfig.ts
+++ b/src/renderer/hooks/useLaunchConfig.ts
@@ -51,6 +51,15 @@ export function useLaunchConfig(): (config: TerminalConfig) => string {
         hasPassword: config.sshConfig.hasPassword,
         postCommand: config.sshConfig.postCommand,
         hasSudoPassword: config.sshConfig.hasSudoPassword,
+        dockerContainer: config.sshConfig.dockerContainer,
+        // SSH tmux enhancement (items 1/3): these MUST ride through to the
+        // launched session or the spawn never sees them. Dropping `detachable`
+        // here left the owner's "never silently install tmux" opt-out inert
+        // (main defaulted persistence ON) and made remoteOs:'windows'
+        // unreachable -- same field-by-field-rebuild drop the comment below
+        // records for the indexing opt-out (adversarial review, 2026-08-18).
+        detachable: config.sshConfig.detachable,
+        remoteOs: config.sshConfig.remoteOs,
       } : undefined,
       legacyVersion: config.claudeOptions?.legacyVersion,
       agentIds: config.claudeOptions?.agentIds,

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -34,6 +34,8 @@ export function buildSessionState(): SessionState {
           hasPassword: s.sshConfig.hasPassword,
           postCommand: s.sshConfig.postCommand,
           hasSudoPassword: s.sshConfig.hasSudoPassword,
+          detachable: s.sshConfig.detachable,
+          remoteOs: s.sshConfig.remoteOs,
         }
       : undefined,
     machineName: s.machineName,

--- a/src/renderer/stores/configStore.ts
+++ b/src/renderer/stores/configStore.ts
@@ -33,6 +33,8 @@ export interface TerminalConfig {
     postCommand?: string      // Command to run after SSH connects (e.g., docker exec)
     hasSudoPassword?: boolean // Whether sudo password is needed for postCommand
     dockerContainer?: string  // Docker container name (enables docker cp for screenshots)
+    detachable?: boolean      // item 1: "Detachable" persistent tmux session (default ON; only false disables)
+    remoteOs?: 'auto' | 'unix' | 'windows'  // item 3: remote OS (windows = prototype Windows setup path)
   }
   pinned?: boolean
   machineName?: string // Identifies which machine this session runs on

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -15,6 +15,8 @@ export interface SSHConfig {
   postCommand?: string
   hasSudoPassword?: boolean
   dockerContainer?: string  // Docker container name (enables docker cp for screenshots)
+  detachable?: boolean      // item 1: "Detachable" persistent tmux session (default ON; only false disables)
+  remoteOs?: 'auto' | 'unix' | 'windows'  // item 3: remote OS (windows = prototype Windows setup path)
 }
 
 export interface Session {
@@ -128,6 +130,19 @@ export interface Session {
    *  without clearing it), which is the actual respawn path this exists
    *  for. */
   sshReachedClaudeRunning?: boolean
+  /** SSH tmux enhancement (item 8/9): true once main confirms this SSH
+   *  session is running inside a tmux persistence wrapper (survives a dropped
+   *  connection). Drives the persistence indicator + the distinct
+   *  persistent-SSH icon. Renderer-only, never persisted -- re-established by
+   *  main's ssh:sessionInfo push on each spawn. undefined = not yet known;
+   *  false = SSH but non-persistent (bare launch). */
+  sshTmuxPersistent?: boolean
+  /** SSH tmux enhancement (item 10): the Claude account the REMOTE session is
+   *  signed in as (oauthAccount.emailAddress from the remote ~/.claude.json),
+   *  read off the nonce'd setup sentinel. DESCRIPTOR ONLY -- never a
+   *  credential; already charset/length-capped host-side before it reaches
+   *  here. Renderer-only, not persisted. */
+  sshRemoteAccount?: string
   codexOptions?: CodexOptions
   // Optional per-session GitHub integration state. Hydrated from SavedSession
   // on restore so the panel can gate on the per-session `enabled` flag instead

--- a/src/renderer/stores/sshCloseStore.ts
+++ b/src/renderer/stores/sshCloseStore.ts
@@ -1,0 +1,77 @@
+import { create } from 'zustand'
+import { useSessionStore } from './sessionStore'
+import { killSessionPty } from '../ptyTracker'
+
+// SSH tmux enhancement (item 4): a one-slot store for the "you're closing a
+// PERSISTENT remote session" confirmation. Any close call site (tab close,
+// sidebar context menu, Delete key) routes through `requestCloseSession`; for a
+// persistent SSH session that opens the dialog rather than tearing the tab down
+// immediately, so the user can choose to END the remote (tmux kill-session) or
+// LEAVE it running (detach + reattach later). Every other session closes
+// straight away, exactly as before.
+
+interface PendingSshClose {
+  sessionId: string
+  /** Display name for the dialog copy. */
+  label: string
+  /** The remote account descriptor, when known — shown so the user knows which
+   *  remote they're ending. */
+  remoteAccount?: string
+  host?: string
+}
+
+interface SshCloseState {
+  pending: PendingSshClose | null
+  request: (p: PendingSshClose) => void
+  clear: () => void
+}
+
+export const useSshCloseStore = create<SshCloseState>((set) => ({
+  pending: null,
+  request: (p) => set({ pending: p }),
+  clear: () => set({ pending: null }),
+}))
+
+/** Close a session, first checking whether it is a persistent SSH session that
+ *  warrants the End-vs-Leave-running choice. Non-persistent / non-SSH sessions
+ *  close immediately (kill the local PTY + drop the tab). */
+export function requestCloseSession(sessionId: string): void {
+  const store = useSessionStore.getState()
+  const session = store.sessions.find((s) => s.id === sessionId)
+  // Only a session confirmed running inside a tmux persistence wrapper gets the
+  // choice — a non-persistent SSH session's remote dies with the connection, so
+  // there is nothing to leave running or to end.
+  if (session && session.sessionType === 'ssh' && session.sshTmuxPersistent === true) {
+    useSshCloseStore.getState().request({
+      sessionId,
+      label: session.customName?.trim() || session.label,
+      remoteAccount: session.sshRemoteAccount,
+      host: session.sshConfig ? `${session.sshConfig.username}@${session.sshConfig.host}` : undefined,
+    })
+    return
+  }
+  killSessionPty(sessionId)
+  store.removeSession(sessionId)
+}
+
+/** "End remote": kill the remote tmux session + sidecars over a separate ssh
+ *  exec, then tear down the local tab. */
+export async function endRemoteAndClose(sessionId: string): Promise<void> {
+  try {
+    await window.electronAPI.ssh.endRemote(sessionId)
+  } catch {
+    // Best-effort — even if the end exec couldn't be dispatched, still close the
+    // local tab (the remote at worst detaches, exactly the pre-enhancement path).
+  }
+  killSessionPty(sessionId)
+  useSessionStore.getState().removeSession(sessionId)
+  useSshCloseStore.getState().clear()
+}
+
+/** "Leave running": detach only — the remote tmux session survives for a later
+ *  reattach. Identical to a plain close (which, for a live SSH PTY, detaches). */
+export function leaveRunningAndClose(sessionId: string): void {
+  killSessionPty(sessionId)
+  useSessionStore.getState().removeSession(sessionId)
+  useSshCloseStore.getState().clear()
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -166,6 +166,10 @@ export interface ElectronAPI {
          *  claude-running -- drives `--continue` when no tmux persistence
          *  is available. See SSHOptions.reconnect in pty-manager.ts. */
         reconnect?: boolean
+        /** SSH tmux enhancement (item 1): "Detachable" toggle (default ON). */
+        detachable?: boolean
+        /** SSH tmux enhancement (item 3): remote OS ('windows' uses the Windows setup path). */
+        remoteOs?: 'auto' | 'unix' | 'windows'
       }
       shellOnly?: boolean
       elevated?: boolean
@@ -212,6 +216,8 @@ export interface ElectronAPI {
     skip: (sessionId: string) => Promise<void>
     getState: (sessionId: string) => Promise<{ state: string; info?: string }>
     onFlowState: (sessionId: string, callback: (msg: { state: string; info?: string }) => void) => () => void
+    onSessionInfo: (sessionId: string, callback: (msg: { tmuxPersistent?: boolean; remoteAccount?: string }) => void) => () => void
+    endRemote: (sessionId: string) => Promise<void>
   }
   statusline: {
     onUpdate: (callback: (data: StatuslineData) => void) => () => void

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -58,6 +58,12 @@ export const IPC = {
   SSH_FLOW_RUN_POSTCOMMAND: 'ssh:flow:runPostCommand',
   SSH_FLOW_LAUNCH_CLAUDE: 'ssh:flow:launchClaude',
   SSH_FLOW_SKIP: 'ssh:flow:skip',
+  // SSH tmux enhancement (items 8/9/10): push per-session persistence +
+  // remote-account descriptors to the renderer. Suffix :<sessionId>.
+  SSH_SESSION_INFO: 'ssh:sessionInfo',
+  // item 4: renderer asks main to END the remote (tmux kill-session + sidecar
+  // cleanup over a separate ssh exec) before/instead of a plain close.
+  SSH_END_REMOTE: 'ssh:endRemote',
 
   // Statusline
   STATUSLINE_UPDATE: 'statusline:update',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -43,6 +43,25 @@ export interface SshConfig {
   postCommand?: string
   hasSudoPassword?: boolean
   dockerContainer?: string
+  /**
+   * SSH tmux enhancement (item 3) — the remote OS. 'auto' (default) and 'unix'
+   * both use the POSIX setup path unchanged (no regression). 'windows' uses a
+   * PowerShell-delivered setup + a CONOUT$ statusline shim + a cmd.exe claude
+   * launch, with NO tmux (Windows has none) so the session falls back to a bare
+   * `claude` that resumes via --continue. PROTOTYPE, isolated behind this flag.
+   */
+  remoteOs?: 'auto' | 'unix' | 'windows'
+  /**
+   * SSH tmux enhancement (item 1) — "Detachable" (persistent remote session).
+   * DEFAULT ON: undefined/true means the tmux-persistence ladder (#242) is
+   * attempted so a dropped connection survives and reconnects reattach. Set
+   * to false to opt OUT entirely — no tmux detection, no provisioning, no
+   * silent install; the session is a bare `claude` that resumes via
+   * `--continue` on reconnect. Owner explicitly dislikes tmux being installed
+   * silently, so this makes persistence user-controlled. Only `false`
+   * disables (mirrors loggingEnabled's default-true shape).
+   */
+  detachable?: boolean
 }
 
 // ── Legacy Version ──

--- a/tests/unit/providers/claude/ssh-shim-runtime-harness.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-runtime-harness.test.ts
@@ -109,6 +109,13 @@ function runShim(shimSource: string, opts: HarnessOptions): HarnessResult {
   const fakeProcess = {
     env: opts.env,
     pid: 4242,
+    // A real node process ALWAYS has argv (>= ['node', script]) and platform.
+    // The shim reads process.argv[2] (the Windows argv session id) and
+    // process.platform (the win32 CONOUT$ branch); model both so the harness
+    // exercises the Linux path (argv[2] undefined -> env sid; platform linux ->
+    // CONOUT$ branch skipped) exactly as a POSIX remote would.
+    argv: ['node', '/fake-home/.claude/conductor-ssh-statusline.js'],
+    platform: 'linux',
     stdin: fakeStdin,
     stdout: { write: (s: string) => { result.stdout.push(s); return true } },
     stderr: { write: (s: string) => { result.stderr.push(s); return true } },

--- a/tests/unit/providers/claude/ssh-shim-tmux-statusline.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-tmux-statusline.test.ts
@@ -162,8 +162,11 @@ describe('SSH statusline shim -- $TMUX client_tty branch (#242 item 2)', () => {
   describe('setup ok sentinel carries a tmux CLASS, not a path (#242 finding I3)', () => {
     it('emits tmux=+tmuxClass in the sentinel, not tmuxPath', () => {
       const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
-      expect(script).toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxClass+'\\n')`)
+      expect(script).toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxClass+' acct='+acctB64+'\\n')`)
       expect(script).not.toContain(`process.stdout.write('setup ok ${NONCE} tmux='+tmuxPath`)
+      // item 10: the account descriptor is captured (base64) from the remote
+      // ~/.claude.json oauthAccount.emailAddress and appended as acct=<b64>.
+      expect(script).toContain("acctB64=Buffer.from(c.oauthAccount.emailAddress,'utf-8').toString('base64')")
     })
 
     it('sets tmuxClass to "path" when tier 1 (command -v tmux) succeeds', () => {

--- a/tests/unit/providers/claude/ssh-shim.test.ts
+++ b/tests/unit/providers/claude/ssh-shim.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { readFileSync } from 'fs'
+import * as nodePath from 'path'
 
 // P7.8: getConductorMcpPort returns 0 unless the server has actually bound,
 // which never happens in the test sandbox. Mock to a non-zero port so the
@@ -392,6 +393,171 @@ describe('SSH remote setup script -- tmux detection (#242)', () => {
     // else on the line -- assert that exact literal is gone, not merely
     // that the new one was added alongside it.
     expect(script).not.toContain(`process.stdout.write('setup ok\\n')`)
+  })
+})
+
+// ===========================================================================
+// Follow-up adversarial pass (fail-posture) — two remote-probe fixes:
+//   1. tier-2 must EXECUTE the ~/.claude/bin/tmux candidate (`-V`, bounded)
+//      before reporting class `home` — X_OK alone is satisfied by a zero-byte
+//      file, a half-written download, a wrong-arch binary and even a DIRECTORY
+//      named `tmux` (POSIX X_OK on a searchable dir succeeds), each of which
+//      wrapped every future launch on that host in a binary that cannot run;
+//   2. a login shell ALREADY inside tmux ($TMUX set — the common
+//      `[ -z "$TMUX" ] && exec tmux new -A` rc pattern) must report `none`:
+//      nesting `new-session -A` is refused by tmux ("sessions should be
+//      nested with care"), exit 1, no claude, on every connect.
+// Text pins first, then a runtime harness (mirroring
+// ssh-shim-runtime-harness.test.ts) that actually EXECUTES the generated
+// setup script — substring assertions alone survive any refactor that keeps
+// the text but reorders/loses the behaviour.
+// ===========================================================================
+describe('SSH remote setup script — tier-2 -V execution probe + nested-tmux override (fail-posture follow-up)', () => {
+  // Mutation to prove this can fail: drop the execFileSync('-V') call from
+  // the tier-2 probe line — both the containment and the ordering fail.
+  it('the tier-2 probe EXECUTES the candidate (`-V`, bounded, output discarded) between the X_OK check and the `home` class assignment', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    expect(script).toContain(`execFileSync(cb,['-V'],{timeout:5000,stdio:'ignore'})`)
+    // Order inside the one shared try: access -> execute -> assign, so a
+    // throw from EITHER probe prevents `home` from ever being reported.
+    const accessIdx = script.indexOf('fs.accessSync(cb,fs.constants.X_OK)')
+    const execIdx = script.indexOf(`execFileSync(cb,['-V'],{timeout:5000,stdio:'ignore'})`)
+    const assignHomeIdx = script.indexOf(`tmuxClass='home'`)
+    expect(accessIdx).toBeGreaterThan(-1)
+    expect(execIdx).toBeGreaterThan(accessIdx)
+    expect(assignHomeIdx).toBeGreaterThan(execIdx)
+  })
+
+  // Mutation to prove this can fail: delete the override line — the
+  // existence assertion fails (and the runtime tests below fail too).
+  // Order matters: the override must come AFTER both the tier-1 and tier-2
+  // assignments, or an assignment would simply overwrite it and the nested
+  // remote would still get the doomed wrap.
+  it('contains the $TMUX -> tmuxClass=none override, AFTER both tier-1 and tier-2 assignments (it must win)', () => {
+    const script = generateRemoteSetupScript('sid-x', null, undefined, NONCE)
+    const override = `if(process.env.TMUX){tmuxPath='';tmuxClass='none'}`
+    const overrideIdx = script.indexOf(override)
+    expect(overrideIdx).toBeGreaterThan(-1)
+    const tier1Idx = script.indexOf(`tmuxClass='path'`)
+    const tier2Idx = script.indexOf(`tmuxClass='home'`)
+    expect(tier1Idx).toBeGreaterThan(-1)
+    expect(tier2Idx).toBeGreaterThan(-1)
+    expect(overrideIdx).toBeGreaterThan(tier1Idx)
+    expect(overrideIdx).toBeGreaterThan(tier2Idx)
+  })
+})
+
+// Runtime harness for the WHOLE generated setup script (the outer node
+// script, not the statusline shim ssh-shim-runtime-harness.test.ts runs):
+// `new Function('require','process',script)` with `require`/`process`
+// shadowed by scripted stand-ins, capturing the sentinel the real remote
+// would write to stdout. What class the sentinel carries under each remote
+// condition IS the behaviour under test.
+interface SetupRunResult {
+  stdout: string
+  execFileCalls: Array<{ file: string; args: string[] }>
+}
+
+function runSetupScript(opts: {
+  env: Record<string, string>
+  /** tier 1 (`command -v tmux` via execSync): throw = not on PATH. */
+  execSync: (cmd: string) => string
+  /** tier 2 access probe: throw = candidate missing / not executable. */
+  accessSync?: (p: string) => void
+  /** tier 2 execution probe (`-V`): throw = candidate cannot actually run. */
+  execFileSync?: (file: string, args: string[]) => string
+}): SetupRunResult {
+  const result: SetupRunResult = { stdout: '', execFileCalls: [] }
+  const enoent = (): Error => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+  const fakeFs = {
+    mkdirSync: () => {},
+    chmodSync: () => {},
+    rmSync: () => {},
+    writeFileSync: () => {},
+    readFileSync: () => { throw enoent() },
+    existsSync: () => false,
+    accessSync: (p: string) => { (opts.accessSync ?? (() => { throw enoent() }))(p) },
+    constants: { X_OK: 1 },
+  }
+  const fakeChildProcess = {
+    execSync: (cmd: string) => opts.execSync(cmd),
+    execFileSync: (file: string, args: string[]) => {
+      result.execFileCalls.push({ file, args })
+      return (opts.execFileSync ?? (() => ''))(file, args)
+    },
+  }
+  const fakeRequire = (name: string): unknown => {
+    if (name === 'fs') return fakeFs
+    if (name === 'os') return { homedir: () => '/fake-home' }
+    // posix flavour deliberately: the script runs on a POSIX remote; the
+    // host-side win32 path module would splice backslashes into the tier-2
+    // candidate and trip the script's own charset guard for reasons no real
+    // remote can reproduce.
+    if (name === 'path') return nodePath.posix
+    if (name === 'child_process') return fakeChildProcess
+    throw new Error('setup-script harness: unexpected require: ' + name)
+  }
+  const fakeProcess = {
+    env: opts.env,
+    stdout: { write: (s: string) => { result.stdout += s; return true } },
+  }
+  const script = generateRemoteSetupScript('sid-rt', null, undefined, NONCE)
+  // eslint-disable-next-line no-new-func -- deliberate: this IS the harness.
+  new Function('require', 'process', script)(fakeRequire, fakeProcess)
+  return result
+}
+
+/** The one location tier 2 ever probes, as the fake remote resolves it. */
+const TIER2_CANDIDATE = '/fake-home/.claude/bin/tmux'
+
+function sentinelTmuxClass(stdout: string): string | undefined {
+  return stdout.match(new RegExp(`setup ok ${NONCE} tmux=(\\S+) acct=`))?.[1]
+}
+
+describe('SSH remote setup script — runtime behaviour of the tmux probes (fail-posture follow-up)', () => {
+  // Mutation to prove this can fail: drop the execFileSync('-V') from the
+  // tier-2 probe — with only X_OK consulted this reports `home` and
+  // execFileCalls stays empty.
+  it('a candidate that passes X_OK but cannot execute -V (zero-byte file, wrong arch, a directory) is NOT reported as home', () => {
+    const r = runSetupScript({
+      env: {},
+      execSync: () => { throw new Error('command -v: not found') }, // tier 1 misses
+      accessSync: () => {}, // X_OK passes — exactly the pre-fix trap
+      execFileSync: () => { throw Object.assign(new Error('spawnSync ENOEXEC'), { code: 'ENOEXEC' }) },
+    })
+    expect(sentinelTmuxClass(r.stdout)).toBe('none')
+    // The probe really EXECUTED the candidate, with -V, output discarded.
+    expect(r.execFileCalls).toEqual([{ file: TIER2_CANDIDATE, args: ['-V'] }])
+  })
+
+  it('control: a candidate that passes X_OK AND runs -V IS reported as home', () => {
+    const r = runSetupScript({
+      env: {},
+      execSync: () => { throw new Error('command -v: not found') },
+      accessSync: () => {},
+      execFileSync: () => 'tmux 3.5a\n',
+    })
+    expect(sentinelTmuxClass(r.stdout)).toBe('home')
+  })
+
+  // Mutation to prove this can fail: delete the
+  // `if(process.env.TMUX){tmuxPath='';tmuxClass='none'}` line — this reports
+  // `path` and pty-manager wraps the launch in a nested new-session tmux
+  // refuses on every connect.
+  it('a login shell ALREADY inside tmux ($TMUX set) reports tmux=none even when tier 1 found tmux on PATH', () => {
+    const r = runSetupScript({
+      env: { TMUX: '/tmp/tmux-1000/default,1234,0' },
+      execSync: () => '/usr/bin/tmux\n', // tier 1 HITS — the override must beat it
+    })
+    expect(sentinelTmuxClass(r.stdout)).toBe('none')
+  })
+
+  it('control: without $TMUX the same tier-1 hit reports tmux=path', () => {
+    const r = runSetupScript({
+      env: {},
+      execSync: () => '/usr/bin/tmux\n',
+    })
+    expect(sentinelTmuxClass(r.stdout)).toBe('path')
   })
 })
 

--- a/tests/unit/providers/claude/ssh-shim.test.ts
+++ b/tests/unit/providers/claude/ssh-shim.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../../../src/main/conductor-mcp-server', () => ({
 }))
 
 import { ClaudeProvider } from '../../../../src/main/providers/claude'
-import { generateRemoteSetupScript, assertSafeRemotePath, getRemoteSetupCommand, buildTmuxBinPatchCommand } from '../../../../src/main/providers/claude/ssh-shim'
+import { generateRemoteSetupScript, assertSafeRemotePath, getRemoteSetupCommand, buildTmuxBinPatchCommand, buildRemoteTmuxKillCommand, generateWindowsRemoteSetupScript, getWindowsRemoteSetupCommand, buildWindowsClaudeCommand } from '../../../../src/main/providers/claude/ssh-shim'
 
 // #242 finding F1 (b): generateRemoteSetupScript/getRemoteSetupCommand/
 // configureRemoteSettings now require a nonce.
@@ -405,5 +405,93 @@ describe('SSH statusline shim -- tmux client-tty bypass (#242)', () => {
     expect(script).toContain('process.env.TMUX')
     expect(script).toContain('#{client_tty}')
     expect(script).toContain('display-message')
+  })
+})
+
+// SSH tmux enhancement (item 4): buildRemoteTmuxKillCommand — the remote
+// command run over the SEPARATE end-remote exec. Verified end-to-end on 185.
+describe('buildRemoteTmuxKillCommand (item 4)', () => {
+  it('kills the ccc-<safeSid> session across every known tmux location and removes both sidecars', () => {
+    const cmd = buildRemoteTmuxKillCommand('sess-1')
+    // Targets the tmux session name, mirroring buildTmuxLaunchCommand.
+    expect(cmd).toContain('kill-session -t ccc-sess-1')
+    // Tries PATH + both Homebrew prefixes (macOS non-login exec has a minimal
+    // PATH, so `command -v tmux` alone would miss /opt/homebrew/bin) + system +
+    // the CCC-staged tier-2 binary.
+    expect(cmd).toContain('tmux kill-session -t ccc-sess-1')
+    expect(cmd).toContain('/opt/homebrew/bin/tmux kill-session -t ccc-sess-1')
+    expect(cmd).toContain('/usr/local/bin/tmux kill-session -t ccc-sess-1')
+    expect(cmd).toContain('/usr/bin/tmux kill-session -t ccc-sess-1')
+    expect(cmd).toContain('"$HOME/.claude/bin/tmux" kill-session -t ccc-sess-1')
+    // Removes the two per-session sidecars.
+    expect(cmd).toContain('rm -f ~/.claude/settings-sess-1.json ~/.claude/mcp-sess-1.json')
+    // Every step best-effort; the whole exec still exits 0.
+    expect(cmd.trim().endsWith('true')).toBe(true)
+  })
+  it('sanitizes a session id with shell metacharacters into the -t argument', () => {
+    const cmd = buildRemoteTmuxKillCommand('a;b c$(x)')
+    expect(cmd).toContain('kill-session -t ccc-a_b_c__x_')
+    // No raw metacharacter reaches the target token.
+    expect(cmd).not.toContain('ccc-a;b')
+  })
+})
+
+// SSH tmux enhancement (item 3): Windows remote setup — PROTOTYPE. Verified on
+// Hyper-V (setup sentinel + statusline shim reaching the client).
+describe('generateWindowsRemoteSetupScript (item 3)', () => {
+  const NONCE = 'winnonce123'
+  it('emits a tmux=none sentinel with the account descriptor (no tmux on Windows)', () => {
+    const script = generateWindowsRemoteSetupScript('winsid', { includeStatusLine: true, includeConductorMcp: true }, NONCE)
+    expect(script).toContain(`process.stdout.write('setup ok ${NONCE} tmux=none acct='+acctB64+'`)
+    // No tmux detection at all (no `command -v tmux`, no accessSync bin probe).
+    expect(script).not.toContain('command -v tmux')
+    // Reads the account the SAME way the POSIX path does.
+    expect(script).toContain("Buffer.from(c.oauthAccount.emailAddress,'utf-8').toString('base64')")
+  })
+  it('bakes a Windows statusLine command that passes the session id via argv (cmd.exe cannot env-prefix)', () => {
+    const script = generateWindowsRemoteSetupScript('winsid', { includeStatusLine: true }, NONCE)
+    // `node "<shimPath>" <safeSid>` — shimPath JSON.stringify'd at runtime.
+    expect(script).toContain(`command:'node '+JSON.stringify(shimPath)+' winsid'`)
+  })
+  it('rejects a bad nonce (charset guard, fail-closed like the POSIX generator)', () => {
+    expect(() => generateWindowsRemoteSetupScript('winsid', undefined, 'bad nonce!')).toThrow(/charset guard/)
+  })
+})
+
+describe('getWindowsRemoteSetupCommand (item 3 — cmd.exe delivery)', () => {
+  it('delivers via powershell -Command with a single base64 payload that fits cmd.exe 8191 limit', () => {
+    const cmd = getWindowsRemoteSetupCommand('winsid', { includeStatusLine: true, includeConductorMcp: true }, 'winnonce123')
+    expect(cmd.startsWith('powershell -NoProfile -NonInteractive -Command "')).toBe(true)
+    // NOT -EncodedCommand (double-base64 would blow past the cmd line limit).
+    expect(cmd).not.toContain('-EncodedCommand')
+    expect(cmd).toContain('FromBase64String')
+    expect(cmd).toContain('$ProgressPreference=')
+    // Well under cmd.exe's 8191-char command-line limit (measured ~4.8k on Hyper-V).
+    expect(cmd.length).toBeLessThan(8191)
+  })
+})
+
+describe('buildWindowsClaudeCommand (item 3 — cmd.exe launch)', () => {
+  it('uses cmd set-syntax env vars and %USERPROFILE% settings/mcp paths', () => {
+    const cmd = buildWindowsClaudeCommand({
+      sessionId: 'winsid',
+      envPrefixVars: ['CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1', 'CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1'],
+      extraFlags: '--effort high',
+      continueFlag: '--continue',
+    })
+    expect(cmd).toContain('set "CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1"&& ')
+    expect(cmd).toContain('set "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1"&& ')
+    expect(cmd).toContain('claude --settings "%USERPROFILE%\\.claude\\settings-winsid.json"')
+    expect(cmd).toContain('--mcp-config "%USERPROFILE%\\.claude\\mcp-winsid.json"')
+    expect(cmd).toContain('--effort high')
+    expect(cmd).toContain('--continue')
+    // POSIX `~` never appears (does not expand in cmd.exe).
+    expect(cmd).not.toContain('~/.claude')
+  })
+  it('omits empty flags (no double spaces, no stray --continue on a first connect)', () => {
+    const cmd = buildWindowsClaudeCommand({ sessionId: 'winsid', envPrefixVars: [], extraFlags: '', continueFlag: '' })
+    expect(cmd).toContain('claude --settings')
+    expect(cmd).not.toContain('--continue')
+    expect(cmd).not.toContain('  ')
   })
 })

--- a/tests/unit/providers/claude/ssh-shim.test.ts
+++ b/tests/unit/providers/claude/ssh-shim.test.ts
@@ -465,7 +465,14 @@ describe('getWindowsRemoteSetupCommand (item 3 — cmd.exe delivery)', () => {
     // NOT -EncodedCommand (double-base64 would blow past the cmd line limit).
     expect(cmd).not.toContain('-EncodedCommand')
     expect(cmd).toContain('FromBase64String')
-    expect(cmd).toContain('$ProgressPreference=')
+    expect(cmd).toContain('|node')
+    // The -Command payload MUST contain NO `$`: a PowerShell login shell expands
+    // any $var inside the double-quoted argument before the child runs, and the
+    // earlier `$ProgressPreference=…;$s=…;$s|node` form had $s expanded to empty
+    // -> `;|node` ParserError, so setup silently never ran (adversarial review,
+    // 2026-08-18). Mutation to prove this can fail: reintroduce a `$` anywhere in
+    // the -Command string.
+    expect(cmd).not.toContain('$')
     // Well under cmd.exe's 8191-char command-line limit (measured ~4.8k on Hyper-V).
     expect(cmd.length).toBeLessThan(8191)
   })

--- a/tests/unit/pty-manager-ssh-tmux.test.ts
+++ b/tests/unit/pty-manager-ssh-tmux.test.ts
@@ -90,15 +90,35 @@ function applyLineDiscipline(text: string): string {
 }
 
 const writeMock = vi.fn()
-const spawnMock = vi.fn(() => ({
-  onData: (cb: (data: string) => void) => {
-    onDataListeners.push(cb)
-  },
-  onExit: () => {},
-  write: writeMock,
-  kill: () => {},
-  pid: 123,
-}))
+// Every pty node-pty.spawn hands back, in spawn order, so a test can fire a
+// SPECIFIC pty's exit (needed for the restart-race regression: the OLD pty must
+// be able to exit AFTER a new one took over the same sessionId). The real mock
+// used to discard the onExit callback (`onExit: () => {}`), which is exactly why
+// handlePtyExit + the restart-race guard were untestable (adversarial review,
+// 2026-08-18). Each instance's __fireExit runs every onExit listener registered
+// on it (spawnPty's, and gracefulExitPty's own).
+interface FakePty {
+  onData: (cb: (data: string) => void) => void
+  onExit: (cb: (e: { exitCode: number }) => void) => void
+  write: typeof writeMock
+  kill: () => void
+  pid: number
+  __fireExit: (exitCode?: number) => void
+}
+const ptyInstances: FakePty[] = []
+const spawnMock = vi.fn(() => {
+  const exits: Array<(e: { exitCode: number }) => void> = []
+  const inst: FakePty = {
+    onData: (cb: (data: string) => void) => { onDataListeners.push(cb) },
+    onExit: (cb: (e: { exitCode: number }) => void) => { exits.push(cb) },
+    write: writeMock,
+    kill: () => {},
+    pid: 123,
+    __fireExit: (exitCode = 0) => { for (const cb of exits.slice()) cb({ exitCode }) },
+  }
+  ptyInstances.push(inst)
+  return inst
+})
 vi.mock('node-pty', () => ({ spawn: spawnMock }))
 vi.mock('electron', () => ({
   BrowserWindow: class {},
@@ -106,7 +126,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/tmp' },
 }))
 
-const { spawnPty, getSshFlow, killPty, parseTmuxSentinel, parseSetupAccountSentinel, parseTmuxStageSentinel, _setTmuxArchiveResolverForTest, _getSshNonceForTest, _getSetupLineBufferLenForTest } = await import('../../src/main/pty-manager')
+const { spawnPty, getSshFlow, killPty, gracefulExitPty, parseTmuxSentinel, parseSetupAccountSentinel, parseTmuxStageSentinel, _setTmuxArchiveResolverForTest, _getSshNonceForTest, _getSetupLineBufferLenForTest, _hasSshTargetForTest } = await import('../../src/main/pty-manager')
 const { registerProvider } = await import('../../src/main/providers')
 const { ClaudeProvider } = await import('../../src/main/providers/claude')
 // Pure module, no node-pty/electron deps -- safe to import directly (unlike
@@ -1737,11 +1757,15 @@ describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the 
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
     expect(written).toContain('new-session -s ccc-s-reconnect-tmux')
-    // Item 6: attach branch (reattach live claude) carries no --continue; fresh branch does.
-    const attachBranch = written.slice(written.indexOf('then'), written.indexOf('else'))
-    const freshBranch = written.slice(written.indexOf('else'))
-    expect(attachBranch).not.toContain('--continue')
-    expect(freshBranch).toContain('--continue')
+    // Item 6: a LIVE reattach (`attach -t X` before its `|| <fresh>` backstop)
+    // carries no --continue -- relaunching a running claude would be wrong.
+    // Every fresh-create (the attach fallback AND the else) resumes with it.
+    expect(written).toContain('attach -t ccc-s-reconnect-tmux || ')
+    expect(written).not.toMatch(/attach -t ccc-s-reconnect-tmux --continue/)
+    const creates = written.split('new-session -s ccc-s-reconnect-tmux ').slice(1)
+    expect(creates.length).toBe(2)
+    for (const c of creates) expect(c.startsWith(`'`)).toBe(true)
+    expect(written).toContain('--continue')
   })
 
   // Mutation to prove this can fail: drop the `reconnect` gate itself (add
@@ -1790,7 +1814,7 @@ describe('parseSetupAccountSentinel (item 10)', () => {
     // A hostile host trying to plant markup / a control sequence in the label.
     const evil = `setup ok ${NONCE} tmux=path acct=${b64('<img src=x onerror=alert(1)>')}\r\n`
     expect(parseSetupAccountSentinel(evil, NONCE)).toBeUndefined()
-    const ctrl = `setup ok ${NONCE} tmux=path acct=${b64('a@b.co;rm -rf')}\r\n`
+    const ctrl = `setup ok ${NONCE} tmux=path acct=${b64('a@b.co\x07;rm -rf')}\r\n`
     expect(parseSetupAccountSentinel(ctrl, NONCE)).toBeUndefined()
   })
   it('requires the correct nonce (spoof-resistant)', () => {
@@ -1804,5 +1828,146 @@ describe('parseSetupAccountSentinel (item 10)', () => {
   it('caps length -- an over-long decoded value is dropped', () => {
     const long = `setup ok ${NONCE} tmux=path acct=${b64('a'.repeat(300) + '@b.co')}\r\n`
     expect(parseSetupAccountSentinel(long, NONCE)).toBeUndefined()
+  })
+})
+
+// ===========================================================================
+// Adversarial-review regression tests (2026-08-18). Every block below pins a
+// fix for a finding the mutation lens proved had NO failing-capable test:
+// restart-race flow poisoning (BLOCKER), the in-band cleanup / gracefulExit
+// self-injection into the tmux-wrapped Claude pane, end-target lifecycle, and
+// the Windows staging gate.
+// ===========================================================================
+describe('spawnPty SSH branch — handlePtyExit + restart-race guard (adversarial review, BLOCKER)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('a STALE PTY exit from a restarted session does NOT poison the new flow', () => {
+    onDataListeners.length = 0
+    const i0 = ptyInstances.length
+    // spawn A, then the renderer restart: kill A + respawn B with the SAME id.
+    spawnPty(fakeWin, 's-restart', { ssh: SSH } as never)
+    const flowA = getSshFlow('s-restart')
+    killPty('s-restart')
+    spawnPty(fakeWin, 's-restart', { ssh: SSH } as never)
+    const flowB = getSshFlow('s-restart')
+    expect(flowB).toBeDefined()
+    expect(flowB).not.toBe(flowA)
+    expect(flowB!.getState().state).toBe('connecting')
+    // The OLD ssh finally dies (~400ms later in prod). Its exit must NOT reach
+    // the new flow: ptySessions[s-restart] now points at B, so weAreCurrent is
+    // false and handlePtyExit is skipped. Before the fix this flipped B to
+    // failed('connection') and the overlay's only escape (Retry) re-raced it.
+    ptyInstances[i0].__fireExit(0)
+    expect(flowB!.getState().state).toBe('connecting')
+    expect(flowB!.getState().info).not.toBe('connection')
+  })
+
+  it('a GENUINE PTY exit before claude-running emits failed(connection) so the overlay can Retry', () => {
+    onDataListeners.length = 0
+    const idx = ptyInstances.length
+    spawnPty(fakeWin, 's-drop', { ssh: SSH } as never)
+    const flow = getSshFlow('s-drop')!
+    expect(flow.getState().state).toBe('connecting')
+    ptyInstances[idx].__fireExit(255)
+    // Captured ref survives the cleanup that follows in the same onExit.
+    expect(flow.getState()).toEqual({ state: 'failed', info: 'connection' })
+  })
+
+  it('does NOT emit failed() when the flow already reached a terminal state (skipped)', () => {
+    onDataListeners.length = 0
+    const idx = ptyInstances.length
+    spawnPty(fakeWin, 's-skip', { ssh: SSH } as never)
+    const flow = getSshFlow('s-skip')!
+    flow.skip()
+    expect(flow.getState().state).toBe('skipped')
+    ptyInstances[idx].__fireExit(0)
+    expect(flow.getState().state).toBe('skipped')
+  })
+})
+
+describe('killPty / gracefulExitPty — a tmux-persistent remote is DETACHED, never destroyed (adversarial review)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('killPty on a tmux-PERSISTENT SSH session writes NO in-band `rm` into the live Claude pane (detach only)', () => {
+    driveToClaudeWrite('s-persist-close', 'setup ok {NONCE} tmux=path\r\n')
+    // Confirm the launch actually wrapped in tmux (so the session is persistent).
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('has-session -t ccc-s-persist-close'))).toBe(true)
+    writeMock.mockClear()
+    killPty('s-persist-close')
+    // The destructive `rm -f ~/.claude/...` would land in Claude's composer and
+    // stay pre-typed in a session the user chose to leave running.
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('rm -f'))).toBe(false)
+  })
+
+  it('killPty on a NON-persistent SSH session still sweeps its sidecars in-band (unchanged behaviour)', () => {
+    driveToClaudeWrite('s-nonpersist-close', 'setup ok {NONCE} tmux=none\r\n')
+    // tmux=none -> staging fails (helper) -> bare launch, so NOT persistent.
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('has-session'))).toBe(false)
+    writeMock.mockClear()
+    killPty('s-nonpersist-close')
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('rm -f'))).toBe(true)
+  })
+
+  it('gracefulExitPty DETACHES a tmux-persistent SSH session (no ESC/Ctrl-C/`/exit`) so the remote survives app quit', () => {
+    driveToClaudeWrite('s-persist-quit', 'setup ok {NONCE} tmux=path\r\n')
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('has-session'))).toBe(true)
+    writeMock.mockClear()
+    const idx = ptyInstances.length - 1
+    void gracefulExitPty('s-persist-quit', 5000)
+    // No exit-key sequence at all -- the fix kills the local PTY instead.
+    vi.advanceTimersByTime(500)
+    const wroteExitSeq = writeMock.mock.calls.some((c) => typeof c[0] === 'string' && (c[0].includes('/exit') || c[0] === '\x1b' || c[0] === '\x03'))
+    expect(wroteExitSeq).toBe(false)
+    // Resolve the pending promise (the fix's kill() is a no-op in the mock).
+    ptyInstances[idx].__fireExit(0)
+  })
+})
+
+describe('endSshRemote target lifecycle — survives a drop, cleared on deliberate close (adversarial review)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('captures the end-target at spawn, KEEPS it across a natural PTY exit (so End works after a drop), and drops it only on killPty', () => {
+    onDataListeners.length = 0
+    const idx = ptyInstances.length
+    spawnPty(fakeWin, 's-endtarget', { ssh: SSH } as never)
+    expect(_hasSshTargetForTest('s-endtarget')).toBe(true)
+    // A transient drop (natural exit): cleanupSessionResources runs, but the
+    // target must SURVIVE -- otherwise a later "End remote" is a silent no-op.
+    ptyInstances[idx].__fireExit(255)
+    expect(_hasSshTargetForTest('s-endtarget')).toBe(true)
+    // Deliberate close drops it.
+    killPty('s-endtarget')
+    expect(_hasSshTargetForTest('s-endtarget')).toBe(false)
+  })
+})
+
+describe('spawnPty SSH branch — Windows remote skips the POSIX tmux staging ladder (item 3, adversarial review)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('remoteOs:windows delivers the PowerShell setup and never runs the POSIX `base64 -d | sh` staging on tmux=none', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-win-remote', { ssh: { ...SSH, remoteOs: 'windows' }, model: 'opus[1m]' } as never)
+    writeMock.mockClear()
+    getSshFlow('s-win-remote')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    // Windows setup is PowerShell-delivered, not the POSIX base64|node form.
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('powershell'))).toBe(true)
+    feedPtyData(nonceSentinel('s-win-remote', 'setup ok {NONCE} tmux=none acct=\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    // No POSIX staging ladder typed into cmd.exe, and no 20s stall path.
+    expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(false)
+    // The launch is the cmd.exe form (set "X=Y"&& claude), never tmux-wrapped.
+    const claudeWrite = writeMock.mock.calls.map((c) => c[0]).find((a) => typeof a === 'string' && a.includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite as string).not.toContain('has-session')
+    // m1: the model id reaches cmd.exe DOUBLE-quoted (claude.cmd strips them),
+    // never POSIX single-quoted (cmd.exe leaves those literal -> a broken flag).
+    expect(claudeWrite as string).toContain('--model "opus[1m]"')
+    expect(claudeWrite as string).not.toContain(`--model 'opus[1m]'`)
   })
 })

--- a/tests/unit/pty-manager-ssh-tmux.test.ts
+++ b/tests/unit/pty-manager-ssh-tmux.test.ts
@@ -1944,6 +1944,307 @@ describe('endSshRemote target lifecycle — survives a drop, cleared on delibera
   })
 })
 
+// ===========================================================================
+// Follow-up adversarial pass (2026-08-18) — regression tests for two fixes:
+//
+//  1. The wrapped-launch WATCHDOG (handleWrappedLaunchFailure): the stage/push
+//     smoke test runs `tmux new-session -d`, which never opens a client tty
+//     and therefore never exercises terminfo — so a remote with no terminfo
+//     db reports `ok`, the ATTACHED launch dies (`open terminal failed`), and
+//     tier 2 re-selects the same binary forever with no recovery. The fix
+//     watches the PTY for a bounded window after a tmux-WRAPPED launch and
+//     falls back to the BARE claude launch on any refusal the remote reports.
+//
+//  2. The `destroyed` INVARIANT: destroying the flow mid-tier and then feeding
+//     the stage sentinel used to drive a buildTmuxBinPatchCommand write into
+//     the torn-down PTY and re-arm the idle fallback; and a destroy during the
+//     tier-4 download/push made the resolving promise emit 'running-claude' on
+//     `ssh:flowState:<sessionId>` — the channel a RESPAWNED session with the
+//     same id is already subscribed to. Guards now sit in the onData handler
+//     (right after the renderer data forward) and, as defence in depth, at the
+//     top of setFlowState / armIdleFallback / writeClaudeCmd.
+// ===========================================================================
+
+/** Like makeSpyWin above, but records the RAW payload for every channel —
+ *  needed to observe ssh:sessionInfo:<id> messages ({tmuxPersistent, ...}) and
+ *  pty:data:<id> chunks, which makeSpyWin's {state, info} projection drops. */
+function makeRecordingWin(): { win: unknown; sends: Array<{ channel: string; payload: unknown }> } {
+  const sends: Array<{ channel: string; payload: unknown }> = []
+  const win = {
+    webContents: {
+      send: (channel: string, payload: unknown) => {
+        sends.push({ channel, payload })
+      },
+    },
+    isDestroyed: () => false,
+  }
+  return { win, sends }
+}
+
+/**
+ * Drive the manual SSH flow to a tmux-WRAPPED claude launch write (tier 1,
+ * tmux=path). The wrapped-launch watchdog arms only when the wrapped command
+ * is actually WRITTEN (inside writeClaudeCmd's 200ms-deferred write), so after
+ * this helper returns the watch window is open and claude has NOT latched.
+ */
+function driveToWrappedLaunch(sessionId: string, win: unknown, sshExtra: Record<string, unknown> = {}): void {
+  onDataListeners.length = 0
+  spawnPty(win as never, sessionId, { ssh: { ...SSH, ...sshExtra } } as never)
+  writeMock.mockClear()
+  getSshFlow(sessionId)!.launchClaude()
+  vi.advanceTimersByTime(300) // past writeHostSetupCmd's 200ms setup write
+  feedPtyData(nonceSentinel(sessionId, 'setup ok {NONCE} tmux=path\r\n'))
+  vi.advanceTimersByTime(1500) // idle fallback: setupDone -> proceedAfterSetup -> writeClaudeCmd scheduled
+  vi.advanceTimersByTime(300) // writeClaudeCmd's 200ms write delay: wrapped write lands + watchdog arms
+}
+
+/** The exact refusal shape the fix was filed against (terminfo-less remote). */
+const TMUX_REFUSAL = 'open terminal failed: missing or unsuitable terminal: xterm-256color\r\n'
+
+/** Every write so far that is a claude launch NOT wrapped in tmux. */
+function bareClaudeWrites(): string[] {
+  return writeMock.mock.calls
+    .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+    .filter((s) => s.includes('claude ') && !s.includes('has-session'))
+}
+
+describe('spawnPty SSH branch — wrapped-launch watchdog falls back to the bare launch (fail-posture follow-up)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  // Mutation to prove this can fail: make handleWrappedLaunchFailure return
+  // immediately — no bare write ever lands, tmuxPersistent stays true, and
+  // the flow info never carries 'tmux-launch-refused'.
+  it('(a)+(c) a remote refusal within the window writes a BARE claude launch, corrects tmuxPersistent to false, and carries tmux-launch-refused', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-refused', win)
+    // Precondition: the launch really was tmux-wrapped (and announced as
+    // persistent) before the refusal arrives.
+    expect(writeMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('has-session -t ccc-s-wd-refused'))).toBe(true)
+    expect(sends.some((s) => s.channel === 'ssh:sessionInfo:s-wd-refused' && (s.payload as { tmuxPersistent?: boolean }).tmuxPersistent === true)).toBe(true)
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData(TMUX_REFUSAL)
+    // The bare fallback write lands synchronously off the refusal chunk.
+    const bare = bareClaudeWrites()
+    expect(bare).toHaveLength(1)
+    expect(bare[0]).not.toMatch(/new-session\s+-s\s+ccc-/)
+    expect(bare[0]).toContain('claude ')
+    // The persistence signal the wrapped write already emitted is corrected.
+    const corrected = sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-refused' && (s.payload as { tmuxPersistent?: boolean }).tmuxPersistent === false)
+    expect(corrected).toHaveLength(1)
+    // And the observable flow state carries the reason.
+    expect(getSshFlow('s-wd-refused')!.getState()).toEqual({ state: 'running-claude', info: 'tmux-launch-refused' })
+  })
+
+  // Tier 5's whole point: reconnecting with no tmux in play is exactly the
+  // case --continue exists for, so the bare RETRY carries it on a respawn.
+  it('(b) the bare fallback carries --continue when the spawn was a reconnect', () => {
+    const { win } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-recon', win, { reconnect: true })
+    writeMock.mockClear()
+    feedPtyData(TMUX_REFUSAL)
+    const bare = bareClaudeWrites()
+    expect(bare).toHaveLength(1)
+    expect(bare[0]).toContain('--continue')
+    expect(bare[0]).not.toContain('has-session')
+  })
+
+  it('(b) the bare fallback does NOT carry --continue on a first connect', () => {
+    const { win } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-first', win) // no reconnect flag
+    writeMock.mockClear()
+    feedPtyData(TMUX_REFUSAL)
+    const bare = bareClaudeWrites()
+    expect(bare).toHaveLength(1)
+    expect(bare[0]).not.toContain('--continue')
+  })
+
+  it('(d) fires AT MOST ONCE — a second refusal chunk produces no second bare write and no second sessionInfo emit', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-once', win)
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData(TMUX_REFUSAL)
+    feedPtyData(TMUX_REFUSAL)
+    expect(bareClaudeWrites()).toHaveLength(1)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-once' && (s.payload as { tmuxPersistent?: boolean }).tmuxPersistent === false)).toHaveLength(1)
+  })
+
+  it('(e) does NOT fire for an UNwrapped launch — refusal-shaped output after a bare launch writes nothing', () => {
+    // tmux=none: the helper routes through staging (fails it) and lands on
+    // the bare launch, so the watchdog was never armed.
+    driveToClaudeWrite('s-wd-unwrapped', 'setup ok {NONCE} tmux=none\r\n')
+    expect(bareClaudeWrites()).toHaveLength(1)
+    writeMock.mockClear()
+    feedPtyData('sh: tmux: command not found\r\n')
+    expect(writeMock.mock.calls).toHaveLength(0)
+  })
+
+  it('(f) does NOT fire once claude has latched as running — a refusal-shaped chunk after the UI latch writes nothing and leaves state alone', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-latched', win)
+    // Claude's UI renders: the strict box-drawing latch flips claudeRunning.
+    feedPtyData('╭──────────╮\r\n')
+    expect(getSshFlow('s-wd-latched')!.getState().state).toBe('claude-running')
+    writeMock.mockClear()
+    sends.length = 0
+    // e.g. claude's own output happens to quote a matching phrase.
+    feedPtyData(TMUX_REFUSAL)
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-latched')).toHaveLength(0)
+    expect(getSshFlow('s-wd-latched')!.getState().state).toBe('claude-running')
+  })
+
+  it('(g) does NOT fire once the 6s window has elapsed', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-elapsed', win)
+    // No refusal inside the window; the fake clock (Date is faked by
+    // vi.useFakeTimers) crosses TMUX_LAUNCH_WATCH_MS = 6000.
+    vi.advanceTimersByTime(6001)
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData(TMUX_REFUSAL)
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-elapsed')).toHaveLength(0)
+  })
+})
+
+describe('spawnPty SSH branch — the destroyed invariant (lifecycle follow-up)', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => {
+    vi.useRealTimers()
+    _setTmuxArchiveResolverForTest(null)
+  })
+
+  // The attacker probe this pins: destroy mid-tier-3, then feed a VALID
+  // (correct-nonce) stage-ok sentinel — pre-fix this drove a
+  // buildTmuxBinPatchCommand write into the torn-down PTY and re-armed the
+  // idle fallback. Mutation to prove this can fail: remove the
+  // `if (destroyed) return` from the SSH onData handler — the stage-sentinel
+  // block then runs and its synchronous settings-patch write lands
+  // (writeMock gains a call), failing the zero-writes assertion.
+  it('(a) destroy mid-tier-3: a later VALID stage-ok sentinel drives ZERO PTY writes and ZERO ssh:flowState/ssh:sessionInfo emits', () => {
+    const { win, sends } = makeRecordingWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-destroyed-stage', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-destroyed-stage')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-destroyed-stage', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300) // staging fragment written; the stage sentinel is now awaited
+    // Build the genuine sentinel BEFORE destroy so the test cannot depend on
+    // the nonce registry's post-destroy lifetime.
+    const sentinel = nonceSentinel('s-destroyed-stage', 'ccc-tmux-stage {NONCE} ok path=/home/dev/.claude/bin/tmux\r\n')
+    getSshFlow('s-destroyed-stage')!.destroy()
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData(sentinel)
+    vi.advanceTimersByTime(1000) // past writeClaudeCmd's 200ms delay, had one been scheduled
+    expect(writeMock.mock.calls).toHaveLength(0) // no CCC_TMUX_BIN patch write, no claude write
+    expect(sends.filter((s) => s.channel.startsWith('ssh:flowState:'))).toHaveLength(0)
+    expect(sends.filter((s) => s.channel.startsWith('ssh:sessionInfo:'))).toHaveLength(0)
+  })
+
+  // The second attacker probe: a destroy during the tier-4 download let the
+  // resolving promise emit 'running-claude' on ssh:flowState:<id> — a channel
+  // a RESPAWNED session with the same id is already subscribed to. Mutation to
+  // prove this can fail: remove writeClaudeCmd's top `if (destroyed) return` —
+  // the aborted-push recovery path (writeClaudeCmd('tmux-push-fail:aborted'))
+  // then runs its body and emitSshSessionInfo lands on ssh:sessionInfo:<id>,
+  // failing the zero-sessionInfo assertion. (Its setFlowState call is caught
+  // by setFlowState's own guard — that layer is pinned by (b2) below.)
+  it('(b) destroy during the tier-4 download: the resolver settling afterwards writes nothing and emits nothing on ssh:flowState/ssh:sessionInfo', async () => {
+    let resolveArchive!: (b: Buffer | null) => void
+    _setTmuxArchiveResolverForTest(() => new Promise<Buffer | null>((res) => { resolveArchive = res }))
+    const { win, sends } = makeRecordingWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-destroyed-push', { ssh: SSH } as never)
+    writeMock.mockClear()
+    getSshFlow('s-destroyed-push')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-destroyed-push', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    feedPtyData('ccc-tmux-push-arch Linux-x86_64\r\n')
+    feedPtyData(nonceSentinel('s-destroyed-push', 'ccc-tmux-stage {NONCE} fail=download\r\n')) // attemptTmuxPush: download now pending
+    getSshFlow('s-destroyed-push')!.destroy()
+    writeMock.mockClear()
+    sends.length = 0
+    resolveArchive(FAKE_TMUX_ARCHIVE)
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(6000) // would drain the transfer + writeClaudeCmd's delay if unguarded
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel.startsWith('ssh:flowState:'))).toHaveLength(0)
+    expect(sends.filter((s) => s.channel.startsWith('ssh:sessionInfo:'))).toHaveLength(0)
+  })
+
+  // Defence-in-depth layer for the promise/captured-reference call sites that
+  // never pass through onData: the flowController object outlives its sshFlows
+  // entry (teardown races reach these methods through captured references —
+  // the same seam M3's direct-destroy test uses). Mutation to prove this can
+  // fail: remove the `if (destroyed) return` at the top of setFlowState — both
+  // calls below then emit on ssh:flowState:<id> AND mutate the state a
+  // still-held getState() reports.
+  it('(b2) setFlowState itself is destroyed-guarded: a captured controller driven after destroy neither emits nor mutates state', () => {
+    const { win, sends } = makeRecordingWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-destroyed-direct', { ssh: SSH } as never)
+    const flow = getSshFlow('s-destroyed-direct')!
+    expect(flow.getState().state).toBe('connecting')
+    flow.destroy()
+    sends.length = 0
+    flow.handlePtyExit() // would setFlowState('failed', 'connection')
+    flow.skip() //          would setFlowState('skipped')
+    expect(sends.filter((s) => s.channel.startsWith('ssh:flowState:'))).toHaveLength(0)
+    expect(flow.getState().state).toBe('connecting') // not even locally mutated
+  })
+
+  // The guard must sit AFTER the renderer data forward: a destroyed flow's
+  // terminal is still a terminal. Mutation to prove this can fail: move the
+  // onData `if (destroyed) return` ABOVE the win.webContents.send data
+  // forward — the pty:data send below disappears.
+  it('(c) terminal bytes STILL reach pty:data:<sessionId> after destroy', () => {
+    const { win, sends } = makeRecordingWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-destroyed-data', { ssh: SSH } as never)
+    getSshFlow('s-destroyed-data')!.destroy()
+    sends.length = 0
+    feedPtyData('post-destroy shell output\r\n')
+    const dataSends = sends.filter((s) => s.channel === 'pty:data:s-destroyed-data')
+    expect(dataSends).toHaveLength(1)
+    expect(dataSends[0].payload).toContain('post-destroy shell output')
+  })
+
+  // Belt-and-braces by design, like the staging-timer destroy test above: the
+  // re-arm is blocked TWICE (the onData guard bails before armIdleFallback is
+  // ever called, and armIdleFallback's own guard bails if reached some other
+  // way), so no SINGLE mutation fails this test — verified: removing only the
+  // onData guard leaves it green (armIdleFallback's guard catches it), and
+  // removing only armIdleFallback's guard leaves it green (onData bails
+  // first). Removing BOTH (the full pre-fix shape) is what makes the
+  // timer-count assertion fail. Recorded precisely so nobody later trusts a
+  // single-mutation sensitivity this test does not have.
+  it('(d) post-destroy data does not re-arm the idle fallback: no new timer, no state advance past 1.5s', () => {
+    const { win, sends } = makeRecordingWin()
+    onDataListeners.length = 0
+    spawnPty(win as never, 's-destroyed-idle', { ssh: SSH } as never)
+    const flow = getSshFlow('s-destroyed-idle')!
+    // 'connecting' is the state whose idle handler WOULD advance (to
+    // awaiting-claude) if the fallback re-armed and fired.
+    expect(flow.getState().state).toBe('connecting')
+    flow.destroy()
+    sends.length = 0
+    const timersBefore = vi.getTimerCount()
+    feedPtyData('late teardown chatter\r\n')
+    expect(vi.getTimerCount()).toBe(timersBefore) // nothing re-armed
+    vi.advanceTimersByTime(5000) // way past IDLE_FALLBACK_MS (1.5s)
+    expect(flow.getState().state).toBe('connecting')
+    expect(sends.filter((s) => s.channel.startsWith('ssh:flowState:'))).toHaveLength(0)
+  })
+})
+
 describe('spawnPty SSH branch — Windows remote skips the POSIX tmux staging ladder (item 3, adversarial review)', () => {
   beforeEach(() => { vi.useFakeTimers() })
   afterEach(() => { vi.useRealTimers() })

--- a/tests/unit/pty-manager-ssh-tmux.test.ts
+++ b/tests/unit/pty-manager-ssh-tmux.test.ts
@@ -106,7 +106,7 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/tmp' },
 }))
 
-const { spawnPty, getSshFlow, killPty, parseTmuxSentinel, parseTmuxStageSentinel, _setTmuxArchiveResolverForTest, _getSshNonceForTest, _getSetupLineBufferLenForTest } = await import('../../src/main/pty-manager')
+const { spawnPty, getSshFlow, killPty, parseTmuxSentinel, parseSetupAccountSentinel, parseTmuxStageSentinel, _setTmuxArchiveResolverForTest, _getSshNonceForTest, _getSetupLineBufferLenForTest } = await import('../../src/main/pty-manager')
 const { registerProvider } = await import('../../src/main/providers')
 const { ClaudeProvider } = await import('../../src/main/providers/claude')
 // Pure module, no node-pty/electron deps -- safe to import directly (unlike
@@ -180,24 +180,66 @@ describe('spawnPty SSH branch — writeClaudeCmd tmux wrapping (#242)', () => {
     vi.useRealTimers()
   })
 
-  it('wraps claudeCmd in tmux new-session -A when the setup sentinel reports tmux=path (tier 1, found on PATH)', () => {
+  // SSH tmux enhancement (item 1): the "Detachable" toggle (SSHOptions.detachable).
+  // Off => the tmux ladder is fully bypassed: no wrap even when the host HAS
+  // tmux, and no tier-3/4 staging write on a tmux-less host (the "no silent
+  // install" guarantee). Both are separate gates, hence two tests.
+  it('detachable:false writes a BARE claude even when the sentinel reports tmux=path', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-detach-off-hit', { ssh: { ...SSH, detachable: false } } as never)
+    writeMock.mockClear()
+    getSshFlow('s-detach-off-hit')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-detach-off-hit', 'setup ok {NONCE} tmux=path\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    const written = claudeWrite![0] as string
+    expect(written).not.toContain('has-session')
+    expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
+    expect(written).toContain('claude ')
+  })
+
+  it('detachable:false does NOT attempt tier-3/4 staging on a tmux=none host (no silent install)', () => {
+    onDataListeners.length = 0
+    spawnPty(fakeWin, 's-detach-off-miss', { ssh: { ...SSH, detachable: false } } as never)
+    writeMock.mockClear()
+    getSshFlow('s-detach-off-miss')!.launchClaude()
+    vi.advanceTimersByTime(300)
+    feedPtyData(nonceSentinel('s-detach-off-miss', 'setup ok {NONCE} tmux=none\r\n'))
+    vi.advanceTimersByTime(1500)
+    vi.advanceTimersByTime(300)
+    expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(false)
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect(claudeWrite).toBeDefined()
+    expect(claudeWrite![0] as string).not.toContain('has-session')
+  })
+
+  it('detachable default (undefined) still wraps in tmux on tmux=path', () => {
+    driveToClaudeWrite('s-detach-default', 'setup ok {NONCE} tmux=path\r\n')
+    const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
+    expect((claudeWrite![0] as string)).toContain('has-session -t ccc-s-detach-default')
+  })
+
+  it('wraps claudeCmd in the tmux has-session wrapper when the setup sentinel reports tmux=path (tier 1, found on PATH)', () => {
     driveToClaudeWrite('s-tmux-hit', 'setup ok {NONCE} tmux=path\r\n')
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
-    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-s-tmux-hit`)
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-s-tmux-hit`)
     expect(written).toContain('claude ')
   })
 
   // #242 round-3 correction (I3): tier 2 (a pre-existing ~/.claude/bin/tmux)
   // shares the SAME fixed launch token as tier 3/4 -- STAGED_TMUX_BIN_EXPR --
   // since all three install/detect at the identical remote location.
-  it('wraps claudeCmd in tmux new-session -A when the setup sentinel reports tmux=home (tier 2, pre-existing ~/.claude/bin/tmux)', () => {
+  it('wraps claudeCmd in the tmux has-session wrapper when the setup sentinel reports tmux=home (tier 2, pre-existing ~/.claude/bin/tmux)', () => {
     driveToClaudeWrite('s-tmux-home', 'setup ok {NONCE} tmux=home\r\n')
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
-    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-s-tmux-home`)
+    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -s ccc-s-tmux-home`)
     expect(written).toContain('claude ')
   })
 
@@ -211,7 +253,7 @@ describe('spawnPty SSH branch — writeClaudeCmd tmux wrapping (#242)', () => {
     // paths regardless of wrapping. Assert the WRAPPER shape is absent and
     // the claude invocation is not embedded inside a single-quoted argument
     // (which is how the tmux wrap would present it).
-    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
     expect(written).not.toContain(`'`)
     expect(written).toContain('claude ')
   })
@@ -297,7 +339,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
     feedPtyData(`setup ok ${nonce} tmux=pa`)
     feedPtyData(`th\r\n`)
     const written = finishAndGetClaudeWrite()
-    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   it('still wraps in tmux when the chunk boundary lands mid-nonce', () => {
@@ -308,7 +350,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
     feedPtyData(`setup ok ${nonce.slice(0, mid)}`)
     feedPtyData(`${nonce.slice(mid)} tmux=home\r\n`)
     const written = finishAndGetClaudeWrite()
-    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(written).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   it('still wraps in tmux across a three-way split of the sentinel line', () => {
@@ -319,7 +361,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
     feedPtyData(`${nonce} tmux=pa`)
     feedPtyData(`th\r\n`)
     const written = finishAndGetClaudeWrite()
-    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   // A chunk that never arrives with the terminating newline must still
@@ -353,7 +395,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
     // 4096 mirrors MAX_SETUP_LINE_BUFFER in pty-manager.ts (not exported).
     feedPtyData(`setup ok ${nonce} tmux=path\r\n` + 'y'.repeat(4096 + 1))
     const written = finishAndGetClaudeWrite()
-    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   // Isolating control for the test above: comfortably UNDER the cap, this
@@ -365,7 +407,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
     const nonce = _getSshNonceForTest(sessionId)!
     feedPtyData(`setup ok ${nonce} tmux=path\r\n` + 'y'.repeat(1000))
     const written = finishAndGetClaudeWrite()
-    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(written).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   // ROUND-2 MAJOR: two of the three properties this buffer is required to
@@ -401,7 +443,7 @@ describe('spawnPty SSH branch — sentinel split across PTY chunks (#242 finding
 
 // #242 finding F1, BLOCKER (adversarial review round 5). Demonstrated attack:
 // "feeding a line shaped like a wall broadcast made CCC write
-// /tmp/.x/tmux new-session -A -s ccc-victim1 '...claude...' into the
+// /tmp/.x/tmux new-session -s ccc-victim1 '...claude...' into the
 // victim's shell" and "a bare relative name ('setup ok tmux=tmux') also
 // works". These drive the REAL flow (spawnPty -> launchClaude -> feed
 // bytes), not the pure builders, because the vulnerability is in what the
@@ -501,9 +543,9 @@ describe('spawnPty SSH branch — F1 spoofed-sentinel regressions (#242 BLOCKER)
       // Staging still genuinely succeeded (a real binary really was
       // installed) -- the launch IS tmux-wrapped, just never with the
       // attacker-reported operand.
-      expect(written).toMatch(/new-session\s+-A\s+-s/)
+      expect(written).toMatch(/new-session\s+-s\s+ccc-/)
       expect(written).not.toContain(hostilePath)
-      expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -A')
+      expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -s ccc-')
     }
   })
 
@@ -513,7 +555,7 @@ describe('spawnPty SSH branch — F1 spoofed-sentinel regressions (#242 BLOCKER)
     driveToClaudeWrite('s-f1-genuine-tier12', 'setup ok {NONCE} tmux=path\r\n')
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect((claudeWrite![0] as string)).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-s-f1-genuine-tier12`)
+    expect((claudeWrite![0] as string)).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-s-f1-genuine-tier12`)
   })
 
   it('the genuine nonce-carrying tier-3 staged-ok sentinel still wraps claude in tmux end to end', () => {
@@ -526,7 +568,7 @@ describe('spawnPty SSH branch — F1 spoofed-sentinel regressions (#242 BLOCKER)
     // #242 finding F1(a), round-2 correction: the launch always embeds the
     // fixed $HOME expression for a staged tier, never the reported path --
     // see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
-    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-f1-genuine-tier3')
+    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -s ccc-s-f1-genuine-tier3')
   })
 })
 
@@ -568,7 +610,7 @@ describe('#242 I1: tier-3/4 sentinels split across PTY chunks', () => {
     expect(claudeWrite).toBeDefined()
     // Staged tier never trusts the reported path -- it launches the host-side
     // literal expression. The point here is that it WRAPS at all.
-    expect(claudeWrite).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(claudeWrite).toContain(`${STAGED_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 
   it('reaches the bare launch promptly when a stage fail= sentinel is split across two chunks', () => {
@@ -585,7 +627,7 @@ describe('#242 I1: tier-3/4 sentinels split across PTY chunks', () => {
     // Without buffering this only arrives via the 20s STAGE_TIMEOUT, so the
     // 300ms advance above is the assertion: it resolved from the sentinel.
     expect(claudeWrite).toBeDefined()
-    expect(claudeWrite).not.toContain('new-session -A')
+    expect(claudeWrite).not.toContain('has-session')
   })
 
   it('still reaches tier 4 when the arch probe is split across two chunks', async () => {
@@ -672,7 +714,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
     expect(writeMock.mock.calls.some((c) => isStagingWrite(c[0]))).toBe(false)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect((claudeWrite![0] as string)).toContain('new-session -A -s ccc-s-stage-skip')
+    expect((claudeWrite![0] as string)).toContain('new-session -s ccc-s-stage-skip')
   })
 
   // Acceptance: "fails when a `ccc-tmux-stage fail=terminfo` chunk no
@@ -688,7 +730,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
-    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
     expect(written).toContain('claude ')
   })
 
@@ -702,7 +744,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
     const written = claudeWrite![0] as string
     // #242 finding F1(a), round-2 correction: the reported path is never
     // used to build the launch -- see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
-    expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-stage-ok')
+    expect(written).toContain('"$HOME"/.claude/bin/tmux new-session -s ccc-s-stage-ok')
     expect(written).not.toContain('/home/dev/.claude/bin/tmux new-session')
   })
 
@@ -718,7 +760,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
-    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
     expect(written).not.toContain('-oProxyCommand')
   })
 
@@ -729,7 +771,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     const written = claudeWrite![0] as string
-    expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // #242 finding F3 (adversarial review round 4, MAJOR): stagingTimeoutHandle
@@ -869,7 +911,7 @@ describe('spawnPty SSH branch — tmux tier-3 staging call site (#242)', () => {
       const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
       expect(claudeWrite).toBeDefined()
       const written = claudeWrite![0] as string
-      expect(written).not.toMatch(/new-session\s+-A\s+-s/)
+      expect(written).not.toMatch(/new-session\s+-s\s+ccc-/)
       expect(getSshFlow('s-m5-build-error')!.getState()).toEqual({
         state: 'running-claude',
         info: 'tmux-stage-fail:build-error',
@@ -1215,7 +1257,7 @@ describe('spawnPty SSH branch — container-flow sentinel split across PTY chunk
     vi.advanceTimersByTime(300) // writeClaudeCmd's own 200ms write delay
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect(claudeWrite![0] as string).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-${sessionId}`)
+    expect(claudeWrite![0] as string).toContain(`${ON_PATH_TMUX_BIN_EXPR} new-session -s ccc-${sessionId}`)
   })
 })
 
@@ -1279,7 +1321,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     expect(pushActivityDetected()).toBe(false)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // Acceptance (d), second half: a stage failure for any reason OTHER than
@@ -1302,7 +1344,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     expect(pushActivityDetected()).toBe(false)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // Acceptance (a): push chunk writes are issued, and no 'claude ' write
@@ -1342,7 +1384,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     expect(claudeWrite).toBeDefined()
     // #242 finding F1(a), round-2 correction: same fixed-$HOME rule as tier
     // 3 -- see STAGED_TMUX_BIN_EXPR (ssh-tmux.ts).
-    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -A -s ccc-s-push-ok')
+    expect((claudeWrite![0] as string)).toContain('"$HOME"/.claude/bin/tmux new-session -s ccc-s-push-ok')
   })
 
   // Acceptance (c), second half: `fail=...` after a completed push produces
@@ -1356,7 +1398,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     await vi.advanceTimersByTimeAsync(300)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // #242 round-3 MAJOR fix. Modeled on the tier-3 "second Launch-Claude
@@ -1450,7 +1492,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     await vi.advanceTimersByTimeAsync(300) // writeClaudeCmd's own 200ms write delay
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // #242 finding F1 (adversarial review round 4, BLOCKER): the tier-4
@@ -1482,7 +1524,7 @@ describe('spawnPty SSH branch — tmux tier-4 push (#242 round-3)', () => {
     await vi.advanceTimersByTimeAsync(10000) // crosses DOWNLOAD_TIMEOUT_MS (+ writeClaudeCmd's own 200ms write delay)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-A\s+-s/)
+    expect((claudeWrite![0] as string)).not.toMatch(/new-session\s+-s\s+ccc-/)
     expect(getSshFlow('s-push-download-hang')!.getState().state).toBe('running-claude')
   })
 
@@ -1674,7 +1716,7 @@ describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the 
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     expect(claudeWrite![0]).toContain('--continue')
-    expect(claudeWrite![0]).not.toMatch(/new-session\s+-A\s+-s/)
+    expect(claudeWrite![0]).not.toMatch(/new-session\s+-s\s+ccc-/)
   })
 
   // Mutation to prove this can fail: drop the `tmuxInPlay` gate inside
@@ -1682,7 +1724,7 @@ describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the 
   // this) -- here it additionally proves pty-manager actually WIRES
   // `tmuxWrapped` (the real outcome of the wrap attempt) through, not just
   // that the pure helper itself is correct.
-  it('does NOT write --continue when reconnect is true but tmux IS in play', () => {
+  it('routes --continue into the tmux wrapper fresh-create branch only when reconnect is true and tmux IS in play', () => {
     onDataListeners.length = 0
     spawnPty(fakeWin, 's-reconnect-tmux', { ssh: { ...SSH, reconnect: true } } as never)
     writeMock.mockClear()
@@ -1693,8 +1735,13 @@ describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the 
     vi.advanceTimersByTime(300)
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
-    expect(claudeWrite![0]).toContain('new-session -A -s ccc-s-reconnect-tmux')
-    expect(claudeWrite![0]).not.toContain('--continue')
+    const written = claudeWrite![0] as string
+    expect(written).toContain('new-session -s ccc-s-reconnect-tmux')
+    // Item 6: attach branch (reattach live claude) carries no --continue; fresh branch does.
+    const attachBranch = written.slice(written.indexOf('then'), written.indexOf('else'))
+    const freshBranch = written.slice(written.indexOf('else'))
+    expect(attachBranch).not.toContain('--continue')
+    expect(freshBranch).toContain('--continue')
   })
 
   // Mutation to prove this can fail: drop the `reconnect` gate itself (add
@@ -1715,5 +1762,47 @@ describe('spawnPty SSH branch — SSHOptions.reconnect drives --continue on the 
     const claudeWrite = writeMock.mock.calls.find((c) => typeof c[0] === 'string' && c[0].includes('claude '))
     expect(claudeWrite).toBeDefined()
     expect(claudeWrite![0]).not.toContain('--continue')
+  })
+})
+
+
+// SSH tmux enhancement (item 10): parseSetupAccountSentinel -- decode the
+// nonce'd `acct=<base64email>` field, gate it to a display-valid email, and
+// treat anything else as untrusted-for-display (dropped, not passed through).
+describe('parseSetupAccountSentinel (item 10)', () => {
+  const NONCE = 'abc123'
+  const b64 = (v: string) => Buffer.from(v, 'utf-8').toString('base64')
+  it('decodes a valid email from a full nonce-bearing sentinel', () => {
+    const line = `setup ok ${NONCE} tmux=path acct=${b64('dev@example.com')}\r\n`
+    expect(parseSetupAccountSentinel(line, NONCE)).toBe('dev@example.com')
+  })
+  it('works with tmux=none and tmux=home too', () => {
+    expect(parseSetupAccountSentinel(`setup ok ${NONCE} tmux=none acct=${b64('a@b.co')}\r\n`, NONCE)).toBe('a@b.co')
+    expect(parseSetupAccountSentinel(`setup ok ${NONCE} tmux=home acct=${b64('a@b.co')}\r\n`, NONCE)).toBe('a@b.co')
+  })
+  it('returns undefined when the account field is absent (back-compat sentinel)', () => {
+    expect(parseSetupAccountSentinel(`setup ok ${NONCE} tmux=path\r\n`, NONCE)).toBeUndefined()
+  })
+  it('returns undefined for an empty acct field', () => {
+    expect(parseSetupAccountSentinel(`setup ok ${NONCE} tmux=path acct=\r\n`, NONCE)).toBeUndefined()
+  })
+  it('drops a decoded value that is not a display-valid email (untrusted-for-display)', () => {
+    // A hostile host trying to plant markup / a control sequence in the label.
+    const evil = `setup ok ${NONCE} tmux=path acct=${b64('<img src=x onerror=alert(1)>')}\r\n`
+    expect(parseSetupAccountSentinel(evil, NONCE)).toBeUndefined()
+    const ctrl = `setup ok ${NONCE} tmux=path acct=${b64('a@b.co;rm -rf')}\r\n`
+    expect(parseSetupAccountSentinel(ctrl, NONCE)).toBeUndefined()
+  })
+  it('requires the correct nonce (spoof-resistant)', () => {
+    const line = `setup ok WRONGNONCE tmux=path acct=${b64('dev@example.com')}\r\n`
+    expect(parseSetupAccountSentinel(line, NONCE)).toBeUndefined()
+  })
+  it('requires the full line terminator (no partial-chunk match)', () => {
+    const partial = `setup ok ${NONCE} tmux=path acct=${b64('dev@example.com')}`
+    expect(parseSetupAccountSentinel(partial, NONCE)).toBeUndefined()
+  })
+  it('caps length -- an over-long decoded value is dropped', () => {
+    const long = `setup ok ${NONCE} tmux=path acct=${b64('a'.repeat(300) + '@b.co')}\r\n`
+    expect(parseSetupAccountSentinel(long, NONCE)).toBeUndefined()
   })
 })

--- a/tests/unit/pty-manager-ssh-tmux.test.ts
+++ b/tests/unit/pty-manager-ssh-tmux.test.ts
@@ -2108,6 +2108,56 @@ describe('spawnPty SSH branch — wrapped-launch watchdog falls back to the bare
     expect(writeMock.mock.calls).toHaveLength(0)
     expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-elapsed')).toHaveLength(0)
   })
+
+  // ---- Round-2 adversarial pass: the FALSE-POSITIVE half of the watchdog. ----
+  // The first cut matched bare `permission denied` / `command not found` /
+  // `is a directory` anywhere in the chunk. Two proven false positives followed,
+  // and the cost is not cosmetic: the bare claude line is typed into a pane that
+  // already has claude running (landing in its composer as a chat message), and
+  // dropping the session from sshTmuxWrappedBySession turns a later close into a
+  // KILL of the remote instead of a detach.
+
+  it('(h) does NOT fire when the chunk carries claude UI — a successful REATTACH redraw whose transcript contains "Permission denied"', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-attach', win, { reconnect: true })
+    writeMock.mockClear()
+    sends.length = 0
+    // The redraw of an attached, live session: transcript text that happens to
+    // quote a shell error, arriving in the SAME chunk as claude's UI. The UI
+    // check must be consulted BEFORE the failure match (the claudeRunning latch
+    // runs later in the same handler, so it cannot protect this chunk).
+    feedPtyData("╭──────────╮\r\n│ ❯ ls: cannot open '/root': Permission denied\r\n")
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-attach' && (s.payload as { tmuxPersistent?: boolean }).tmuxPersistent === false)).toHaveLength(0)
+  })
+
+  it('(i) does NOT fire on a generic error that never names tmux — claude\'s own EACCES startup stderr inside a working tmux', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-eacces', win)
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData("Error: EACCES: permission denied, open '/home/u/.claude/settings.json'\r\n")
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-eacces')).toHaveLength(0)
+  })
+
+  it('(j) does NOT fire on "no server running on" — buildTmuxLaunchCommand\'s own || fresh-create leg already self-heals that race', () => {
+    const { win, sends } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-norace', win)
+    writeMock.mockClear()
+    sends.length = 0
+    feedPtyData('no server running on /tmp/tmux-1000/default\r\n')
+    expect(writeMock.mock.calls).toHaveLength(0)
+    expect(sends.filter((s) => s.channel === 'ssh:sessionInfo:s-wd-norace')).toHaveLength(0)
+  })
+
+  it('(k) STILL fires on a generic exec error that DOES name tmux on the line', () => {
+    const { win } = makeRecordingWin()
+    driveToWrappedLaunch('s-wd-generic', win)
+    writeMock.mockClear()
+    feedPtyData('bash: /home/u/.claude/bin/tmux: cannot execute binary file: Exec format error\r\n')
+    expect(bareClaudeWrites()).toHaveLength(1)
+  })
 })
 
 describe('spawnPty SSH branch — the destroyed invariant (lifecycle follow-up)', () => {

--- a/tests/unit/pty-manager-tmux-download.test.ts
+++ b/tests/unit/pty-manager-tmux-download.test.ts
@@ -1,0 +1,440 @@
+// tests/unit/pty-manager-tmux-download.test.ts
+//
+// #242 tier 4, follow-up adversarial pass (coverage MAJOR): every guard in
+// pty-manager's host-side downloadAndCacheTmuxArchive was previously
+// unreachable from the suite -- attemptTmuxPush goes through the
+// tmuxArchiveResolver seam, which pty-manager-ssh-tmux.test.ts stubs ABOVE
+// this level, so raising TMUX_ARCHIVE_MAX_BYTES to Number.MAX_SAFE_INTEGER
+// or deleting the https-only redirect refusal left the whole targeted suite
+// green. These tests drive the REAL function (via the
+// _downloadAndCacheTmuxArchiveForTest export) with a mocked `https` module:
+// an EventEmitter-based IncomingMessage-alike plus a fake ClientRequest, so
+// every wire-level guard (size cap, redirect policy, sha256 pin, request
+// timeouts, status handling, cache-write resilience) can actually fail.
+//
+// Mock harness (os / node-pty / electron) copied from
+// pty-manager-ssh-tmux.test.ts, which proves pty-manager's import graph
+// loads under vitest with exactly these three mocked.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as crypto from 'crypto'
+
+// vi.mock factories are hoisted above every import, so the mutable state they
+// close over must be hoisted too.
+const h = vi.hoisted(() => ({
+  // Installed per-test; null = "no https.get expected yet". The wrapper in the
+  // factory below throws when called with no impl installed, which the source
+  // converts to a resolve(null) via its own try/catch -- tests therefore
+  // always ALSO assert on the recorded call count, not just the null result.
+  getImpl: null as null | ((url: unknown, options: unknown, cb: unknown) => unknown),
+  // What the mocked electron app.getPath('userData') returns -- pty-manager's
+  // tmuxCacheDir() reads it lazily per call, so tests can point it at a fresh
+  // temp dir (or at a deliberately unwritable path) before each download.
+  userDataDir: '',
+}))
+
+vi.mock('os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('os')>()),
+  platform: () => 'linux',
+}))
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  nativeTheme: { shouldUseDarkColors: false, on: () => {} },
+  app: { getPath: () => h.userDataDir },
+}))
+// pty-manager does `import * as https from 'https'` (bare specifier, not
+// node:https) -- spread the real module so anything else in the import graph
+// keeps working, and override only `get`.
+vi.mock('https', async (importOriginal) => {
+  const real = await importOriginal<typeof import('https')>()
+  const get = (...args: unknown[]): unknown => {
+    if (!h.getImpl) throw new Error('https.get called before the test installed an impl')
+    return h.getImpl(args[0], args[1], args[2])
+  }
+  return { ...real, get, default: { ...real, get } }
+})
+
+const { _downloadAndCacheTmuxArchiveForTest } = await import('../../src/main/pty-manager')
+const { TMUX_STAGE_SHA256, tmuxStageAssetUrl } = await import('../../src/main/ssh-tmux-stage')
+type TmuxStageTarget = keyof typeof TMUX_STAGE_SHA256
+
+const ARCH: TmuxStageTarget = 'linux-x86_64'
+const ASSET_URL = tmuxStageAssetUrl(ARCH)
+const CAP_BYTES = 8 * 1024 * 1024 // mirrors TMUX_ARCHIVE_MAX_BYTES (module-private)
+const REQUEST_TIMEOUT_MS = 20000 // mirrors TMUX_DOWNLOAD_REQUEST_TIMEOUT_MS (module-private)
+
+/** IncomingMessage-alike: statusCode + headers + resume/destroy spies, with
+ *  data/end/error delivered via real EventEmitter semantics. */
+class FakeRes extends EventEmitter {
+  statusCode: number | undefined
+  headers: Record<string, string | undefined>
+  resume = vi.fn()
+  destroy = vi.fn()
+  constructor(statusCode: number | undefined, headers: Record<string, string | undefined> = {}) {
+    super()
+    this.statusCode = statusCode
+    this.headers = headers
+  }
+}
+
+/** ClientRequest-alike. destroy(err) emits 'error' the way a real destroyed
+ *  request does, so the source's req.on('error') fallback path runs. */
+class FakeReq extends EventEmitter {
+  destroy = vi.fn((err?: Error) => {
+    this.emit('error', err ?? new Error('destroyed'))
+  })
+}
+
+interface RecordedGet {
+  url: string
+  options: { timeout?: number } | undefined
+  req: FakeReq
+}
+
+type GetHandler = (cb: (res: unknown) => void, req: FakeReq, call: RecordedGet) => void
+
+/**
+ * Script the mocked https.get: the Nth call is served by handlers[N]. Returns
+ * the recorded calls (url as a string -- the source passes a string for the
+ * initial request and a WHATWG URL for redirect hops; String() covers both).
+ * A call beyond the script throws, which the source's try/catch converts to
+ * resolve(null) -- the recorded call COUNT is what catches that case.
+ */
+function scriptGets(handlers: GetHandler[]): RecordedGet[] {
+  const calls: RecordedGet[] = []
+  h.getImpl = (rawUrl, rawOptions, rawCb) => {
+    const req = new FakeReq()
+    const call: RecordedGet = {
+      url: String(rawUrl),
+      options: rawOptions as { timeout?: number } | undefined,
+      req,
+    }
+    calls.push(call)
+    const handler = handlers[calls.length - 1]
+    if (!handler) throw new Error(`unexpected https.get call #${calls.length} to ${call.url}`)
+    handler(rawCb as (res: unknown) => void, req, call)
+    return req
+  }
+  return calls
+}
+
+/** Serve a 200 whose body arrives in `chunks`, then ends. */
+function serveBody(chunks: Buffer[]): GetHandler {
+  return (cb) => {
+    const res = new FakeRes(200)
+    cb(res)
+    for (const c of chunks) res.emit('data', c)
+    res.emit('end')
+  }
+}
+
+/** Serve a redirect status carrying a Location header. */
+function serveRedirect(location: string | undefined, statusCode = 302): { handler: GetHandler; res: () => FakeRes } {
+  let served: FakeRes | undefined
+  return {
+    handler: (cb) => {
+      served = new FakeRes(statusCode, { location })
+      cb(served)
+    },
+    res: () => {
+      if (!served) throw new Error('redirect response never served')
+      return served
+    },
+  }
+}
+
+function sha256Hex(bufs: Buffer[]): string {
+  const hash = crypto.createHash('sha256')
+  for (const b of bufs) hash.update(b)
+  return hash.digest('hex')
+}
+
+// The pinned digests point at the real v3.7b archives, which these tests
+// obviously don't ship -- so tests that need the digest gate to PASS mutate
+// the (plain-object, const-binding-only) TMUX_STAGE_SHA256 entry to the test
+// body's own hash, exactly the technique ssh-tmux-stage.test.ts already uses
+// for its corrupted-digest guard test. Restored after every test.
+const REAL_SHA256 = { ...TMUX_STAGE_SHA256 }
+
+const tempDirs: string[] = []
+function freshUserDataDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-tmux-dl-'))
+  tempDirs.push(dir)
+  h.userDataDir = dir
+  return dir
+}
+function cachePathIn(userDataDir: string): string {
+  return path.join(userDataDir, 'tmux-cache', `tmux-${ARCH}.tar.gz`)
+}
+
+beforeEach(() => {
+  freshUserDataDir()
+})
+
+afterEach(() => {
+  h.getImpl = null
+  Object.assign(TMUX_STAGE_SHA256, REAL_SHA256)
+  for (const dir of tempDirs.splice(0)) {
+    try { fs.rmSync(dir, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
+})
+
+describe('downloadAndCacheTmuxArchive (tier-4 host-side downloader)', () => {
+  describe('success path', () => {
+    it('fetches the pinned per-arch asset URL, resolves the verified bytes, and writes them to the cache dir', async () => {
+      const body = Buffer.from('fake-tmux-archive-payload')
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([body])
+      const calls = scriptGets([serveBody([body])])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(calls).toHaveLength(1)
+      // #242 F6: the host-side downloader and the remote curl/wget script must
+      // fetch the SAME pinned URL.
+      expect(calls[0].url).toBe(ASSET_URL)
+      expect(result).not.toBeNull()
+      expect(result!.equals(body)).toBe(true)
+      // Verified bytes are cached for the next session needing this arch.
+      const cached = fs.readFileSync(cachePathIn(h.userDataDir))
+      expect(cached.equals(body)).toBe(true)
+    })
+
+    it('still resolves the verified bytes when the cache write throws', async () => {
+      // Point userData at an existing FILE: mkdirSync('<file>/tmux-cache')
+      // inside the cache-write try block then throws for real -- no fs mock.
+      const parent = freshUserDataDir()
+      const blocker = path.join(parent, 'blocker-file')
+      fs.writeFileSync(blocker, 'not a directory')
+      h.userDataDir = blocker
+
+      const body = Buffer.from('cache-write-will-fail-payload')
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([body])
+      scriptGets([serveBody([body])])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      // The cache write really did fail...
+      expect(fs.existsSync(cachePathIn(blocker))).toBe(false)
+      // ...and that must NOT invalidate the already-verified bytes in hand.
+      expect(result).not.toBeNull()
+      expect(result!.equals(body)).toBe(true)
+    })
+  })
+
+  describe('size cap (TMUX_ARCHIVE_MAX_BYTES, enforced on the wire)', () => {
+    it('destroys the response and resolves null the moment the body exceeds 8 MiB, without buffering on', async () => {
+      const big = Buffer.alloc(4 * 1024 * 1024) // reused -- never allocate the overage repeatedly
+      const one = Buffer.alloc(1)
+      // If the cap were absent, the FULL emitted body (8 MiB + 1 + 4 MiB)
+      // would assemble and VERIFY -- so a mutated/removed cap makes this test
+      // fail on the result too, not only on the destroy assertion.
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([big, big, one, big])
+      let res!: FakeRes
+      scriptGets([
+        (cb) => {
+          res = new FakeRes(200)
+          cb(res)
+          res.emit('data', big) // 4 MiB
+          res.emit('data', big) // 8 MiB exactly -- still allowed (cap is >, not >=)
+          expect(res.destroy).not.toHaveBeenCalled()
+          res.emit('data', one) // 8 MiB + 1 -- over the cap
+          // A misbehaving server keeps sending after the destroy: the handler
+          // must short-circuit, not keep accumulating or destroy again.
+          res.emit('data', big)
+          res.emit('end')
+        },
+      ])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(res.destroy).toHaveBeenCalledTimes(1)
+      expect(result).toBeNull()
+      // Nothing over-limit ever lands in the cache.
+      expect(fs.existsSync(cachePathIn(h.userDataDir))).toBe(false)
+    })
+
+    it('accepts a body of exactly 8 MiB (the cap is exclusive)', async () => {
+      const big = Buffer.alloc(4 * 1024 * 1024)
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([big, big])
+      let res!: FakeRes
+      scriptGets([
+        (cb) => {
+          res = new FakeRes(200)
+          cb(res)
+          res.emit('data', big)
+          res.emit('data', big)
+          res.emit('end')
+        },
+      ])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(res.destroy).not.toHaveBeenCalled()
+      expect(result).not.toBeNull()
+      expect(result!.length).toBe(CAP_BYTES)
+    })
+  })
+
+  describe('redirect policy', () => {
+    it('follows a cross-host https Location (the real GitHub-to-S3 shape) and resolves the redirected body', async () => {
+      const signedUrl = 'https://objects.example-cdn.test/signed/tmux.tar.gz?token=abc'
+      const body = Buffer.from('redirected-archive-bytes')
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([body])
+      const redirect = serveRedirect(signedUrl)
+      const calls = scriptGets([redirect.handler, serveBody([body])])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(calls).toHaveLength(2)
+      expect(calls[1].url).toBe(signedUrl)
+      // The redirect response's body is drained, not left dangling.
+      expect(redirect.res().resume).toHaveBeenCalled()
+      expect(result).not.toBeNull()
+      expect(result!.equals(body)).toBe(true)
+    })
+
+    it('resolves a relative Location against the current request URL, the way browsers/curl do', async () => {
+      const body = Buffer.from('relative-redirect-bytes')
+      TMUX_STAGE_SHA256[ARCH] = sha256Hex([body])
+      const redirect = serveRedirect('/rel/asset.tar.gz')
+      const calls = scriptGets([redirect.handler, serveBody([body])])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(calls).toHaveLength(2)
+      expect(calls[1].url).toBe(new URL('/rel/asset.tar.gz', ASSET_URL).toString())
+      expect(result).not.toBeNull()
+      expect(result!.equals(body)).toBe(true)
+    })
+
+    it('refuses a Location that resolves to a non-https scheme: null, and NO further request is made', async () => {
+      const redirect = serveRedirect('http://captive-portal.test/login')
+      const calls = scriptGets([redirect.handler])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(result).toBeNull()
+      // The refusal must happen BEFORE any second https.get -- a mutated
+      // guard that "follows then fails" would record a second call here.
+      expect(calls).toHaveLength(1)
+    })
+
+    it('resolves null on a malformed Location instead of throwing out of the response callback', async () => {
+      // 'http://' has a scheme (so the base is ignored) but no host --
+      // new URL('http://', base) throws ERR_INVALID_URL.
+      const redirect = serveRedirect('http://')
+      const calls = scriptGets([redirect.handler])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(result).toBeNull()
+      expect(calls).toHaveLength(1)
+    })
+
+    it('follows at most 2 redirect hops: a third consecutive redirect is not followed', async () => {
+      const hop1 = serveRedirect('https://r1.example.test/a')
+      const hop2 = serveRedirect('https://r2.example.test/b')
+      // The third response is ANOTHER redirect, but redirectsLeft is now 0 --
+      // it must be treated as a terminal (empty-body) response, not followed.
+      const calls = scriptGets([
+        hop1.handler,
+        hop2.handler,
+        (cb) => {
+          const res = new FakeRes(302, { location: 'https://r3.example.test/c' })
+          cb(res)
+          res.emit('end') // empty body -> digest mismatch -> null
+        },
+      ])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(calls).toHaveLength(3) // initial + exactly 2 followed hops, never a 4th request
+      expect(calls[1].url).toBe('https://r1.example.test/a')
+      expect(calls[2].url).toBe('https://r2.example.test/b')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('sha256 pin', () => {
+    it('resolves null and caches nothing when the body does not match the pinned per-arch digest', async () => {
+      // Real pinned digest left in place: this body cannot match it.
+      const calls = scriptGets([serveBody([Buffer.from('definitely-not-the-real-archive')])])
+
+      const result = await _downloadAndCacheTmuxArchiveForTest(ARCH)
+
+      expect(calls).toHaveLength(1)
+      expect(result).toBeNull()
+      // A digest-failing body must never land in the cache either.
+      expect(fs.existsSync(cachePathIn(h.userDataDir))).toBe(false)
+    })
+  })
+
+  describe('request timeouts', () => {
+    it('passes a 20s timeout option on the initial request and destroys it when the timeout fires', async () => {
+      const calls = scriptGets([
+        () => {
+          /* never respond -- the request is going to time out */
+        },
+      ])
+
+      const pending = _downloadAndCacheTmuxArchiveForTest(ARCH)
+      expect(calls).toHaveLength(1)
+      expect(calls[0].options?.timeout).toBe(REQUEST_TIMEOUT_MS)
+      // The 'timeout' event alone aborts nothing in node -- only the handler
+      // destroying the request does. FakeReq.destroy emits 'error', which the
+      // source's error handler turns into the null resolution awaited below.
+      calls[0].req.emit('timeout')
+      expect(calls[0].req.destroy).toHaveBeenCalledTimes(1)
+      expect(calls[0].req.destroy.mock.calls[0][0]).toBeInstanceOf(Error)
+
+      await expect(pending).resolves.toBeNull()
+    })
+
+    it('passes the same 20s timeout on the redirect hop and destroys it when the timeout fires', async () => {
+      const redirect = serveRedirect('https://objects.example-cdn.test/slow')
+      const calls = scriptGets([
+        redirect.handler,
+        () => {
+          /* redirect hop never responds */
+        },
+      ])
+
+      const pending = _downloadAndCacheTmuxArchiveForTest(ARCH)
+      expect(calls).toHaveLength(2)
+      expect(calls[1].options?.timeout).toBe(REQUEST_TIMEOUT_MS)
+      calls[1].req.emit('timeout')
+      expect(calls[1].req.destroy).toHaveBeenCalledTimes(1)
+
+      await expect(pending).resolves.toBeNull()
+    })
+  })
+
+  describe('error statuses', () => {
+    it('resolves null on a 4xx, draining the response', async () => {
+      let res!: FakeRes
+      scriptGets([
+        (cb) => {
+          res = new FakeRes(404)
+          cb(res)
+        },
+      ])
+
+      await expect(_downloadAndCacheTmuxArchiveForTest(ARCH)).resolves.toBeNull()
+      expect(res.resume).toHaveBeenCalled()
+    })
+
+    it('resolves null on a 5xx', async () => {
+      scriptGets([(cb) => cb(new FakeRes(500))])
+      await expect(_downloadAndCacheTmuxArchiveForTest(ARCH)).resolves.toBeNull()
+    })
+
+    it('resolves null when the response carries no status code at all', async () => {
+      scriptGets([(cb) => cb(new FakeRes(undefined))])
+      await expect(_downloadAndCacheTmuxArchiveForTest(ARCH)).resolves.toBeNull()
+    })
+  })
+})

--- a/tests/unit/renderer/use-launch-config.test.tsx
+++ b/tests/unit/renderer/use-launch-config.test.tsx
@@ -78,3 +78,39 @@ describe('useLaunchConfig loggingEnabled mapping (#188)', () => {
     expect(session.enableCodexReview).toBeUndefined()
   })
 })
+
+// SSH tmux enhancement (items 1/3, adversarial review 2026-08-18): the SAME
+// field-by-field-rebuild drop that made loggingEnabled inert (#188 above) also
+// dropped the SSH persistence controls -- `detachable` (the owner's "never
+// silently install tmux" opt-out) and `remoteOs` (the Windows path selector) --
+// so unticking Detachable did nothing and remoteOs could never reach main. These
+// pin that every SshConfig control survives config -> launched session.
+describe('useLaunchConfig SSH persistence fields (items 1/3)', () => {
+  beforeEach(() => { addSession.mockClear() })
+
+  const sshBase = {
+    id: 'cfg-ssh',
+    label: 'remote',
+    workingDirectory: '',
+    color: '#fff',
+    sessionType: 'ssh' as const,
+    provider: 'claude' as const,
+    sshConfig: { host: 'h', port: 22, username: 'u', remotePath: '~', hasPassword: false },
+  }
+
+  it('carries detachable:false (the opt-out) onto the launched session', () => {
+    const session = launchWith({ ...sshBase, sshConfig: { ...sshBase.sshConfig, detachable: false } })
+    expect(session.sshConfig.detachable).toBe(false)
+  })
+
+  it('carries remoteOs:windows onto the launched session', () => {
+    const session = launchWith({ ...sshBase, sshConfig: { ...sshBase.sshConfig, remoteOs: 'windows' } })
+    expect(session.sshConfig.remoteOs).toBe('windows')
+  })
+
+  it('leaves detachable/remoteOs undefined (defaults) when unset -- persistence ON, POSIX', () => {
+    const session = launchWith({ ...sshBase })
+    expect(session.sshConfig.detachable).toBeUndefined()
+    expect(session.sshConfig.remoteOs).toBeUndefined()
+  })
+})

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildSshArgs } from '../../src/main/ssh-args'
+import { buildSshArgs, buildSshExecArgs } from '../../src/main/ssh-args'
 
 // pty-manager builds the ssh argv from this helper; these pin the EXACT argv
 // (order, pairing, and length) reaching ssh/ssh.exe per platform. Whole-array
@@ -110,5 +110,44 @@ describe('buildSshArgs rejects an option-like or whitespace host/username (sink 
     expect(() => buildSshArgs({ username: 'my-user', host: 'my-host.example.com', port: 22 }, 0, 'linux')).not.toThrow()
     expect(() => buildSshArgs({ username: 'root', host: '[2001:db8::1]', port: 22 }, 0, 'linux')).not.toThrow()
     expect(() => buildSshArgs({ username: 'DOMAIN\\me', host: '10.0.0.5', port: 22 }, 0, 'win32')).not.toThrow()
+  })
+})
+
+
+// SSH tmux enhancement (item 4): buildSshExecArgs — the argv for the SEPARATE
+// non-interactive ssh exec that ends a remote session (tmux kill-session +
+// sidecar cleanup). Validated against real ssh.exe on Windows and ssh on Linux
+// in headless testing; these pin the exact shape + guards.
+describe('buildSshExecArgs (item 4 — one-shot end-remote exec)', () => {
+  const target = { username: 'dev', host: 'box.example.com', port: 2222 }
+  it('builds a batch, non-TTY argv with the remote command as the final positional arg', () => {
+    const args = buildSshExecArgs(target, 'tmux kill-session -t ccc-x; true', 'linux')
+    expect(args[0]).toBe('dev@box.example.com')
+    expect(args).toContain('-p'); expect(args).toContain('2222')
+    // Batch: no interactive password prompt, fail-fast connect.
+    expect(args).toContain('BatchMode=yes')
+    expect(args).toContain('ConnectTimeout=8')
+    expect(args).toContain('StrictHostKeyChecking=accept-new')
+    // No TTY and no MCP tunnel (unlike buildSshArgs).
+    expect(args).not.toContain('-t')
+    expect(args).not.toContain('-R')
+    // The remote command is the LAST arg (ssh joins trailing args with spaces).
+    expect(args[args.length - 1]).toBe('tmux kill-session -t ccc-x; true')
+  })
+  it('adds ControlMaster/ControlPath off only on win32', () => {
+    const win = buildSshExecArgs(target, 'true', 'win32')
+    expect(win).toContain('ControlMaster=no')
+    expect(win).toContain('ControlPath=none')
+    const lin = buildSshExecArgs(target, 'true', 'linux')
+    expect(lin).not.toContain('ControlMaster=no')
+    expect(lin).not.toContain('ControlPath=none')
+    // darwin is treated like linux (POSIX multiplexing is fine).
+    const mac = buildSshExecArgs(target, 'true', 'darwin')
+    expect(mac).not.toContain('ControlMaster=no')
+  })
+  it('re-asserts the same argv field guard as buildSshArgs (leading dash / whitespace / empty)', () => {
+    expect(() => buildSshExecArgs({ ...target, username: '-oProxyCommand=x' }, 'true', 'linux')).toThrow()
+    expect(() => buildSshExecArgs({ ...target, host: 'a b' }, 'true', 'linux')).toThrow()
+    expect(() => buildSshExecArgs({ ...target, host: '' }, 'true', 'linux')).toThrow()
   })
 })

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -134,16 +134,22 @@ describe('buildSshExecArgs (item 4 — one-shot end-remote exec)', () => {
     // The remote command is the LAST arg (ssh joins trailing args with spaces).
     expect(args[args.length - 1]).toBe('tmux kill-session -t ccc-x; true')
   })
-  it('adds ControlMaster/ControlPath off only on win32', () => {
-    const win = buildSshExecArgs(target, 'true', 'win32')
-    expect(win).toContain('ControlMaster=no')
-    expect(win).toContain('ControlPath=none')
-    const lin = buildSshExecArgs(target, 'true', 'linux')
-    expect(lin).not.toContain('ControlMaster=no')
-    expect(lin).not.toContain('ControlPath=none')
-    // darwin is treated like linux (POSIX multiplexing is fine).
-    const mac = buildSshExecArgs(target, 'true', 'darwin')
-    expect(mac).not.toContain('ControlMaster=no')
+  it('forces ControlMaster/ControlPath OFF on EVERY platform (the exec must not multiplex over the live PTY that is about to be killed)', () => {
+    // Unlike buildSshArgs (win32-only #241), the end-remote exec disables
+    // multiplexing everywhere: it is dispatched right before the caller tears
+    // down the shared connection's master, so on a POSIX client with
+    // `ControlMaster auto` a multiplexed exec would be cut off mid-kill
+    // (adversarial review, 2026-08-18). Each `-o` must have its own flag so a
+    // single-`-o` mutant leaves an orphaned positional.
+    for (const platform of ['win32', 'linux', 'darwin'] as const) {
+      const args = buildSshExecArgs(target, 'true', platform)
+      const i = args.indexOf('ControlMaster=no')
+      const j = args.indexOf('ControlPath=none')
+      expect(i).toBeGreaterThan(0)
+      expect(args[i - 1]).toBe('-o')
+      expect(j).toBeGreaterThan(0)
+      expect(args[j - 1]).toBe('-o')
+    }
   })
   it('re-asserts the same argv field guard as buildSshArgs (leading dash / whitespace / empty)', () => {
     expect(() => buildSshExecArgs({ ...target, username: '-oProxyCommand=x' }, 'true', 'linux')).toThrow()

--- a/tests/unit/ssh-tmux-stage.test.ts
+++ b/tests/unit/ssh-tmux-stage.test.ts
@@ -69,9 +69,14 @@ describe('buildTmuxStageScript', () => {
     // Second wget leg (busybox-safe): -T but NO -t -- busybox wget (Alpine,
     // OpenWrt) has no -t flag at all and usage-errors out of the GNU form.
     expect(cmd).toMatch(/wget -q -T \d+ -O "\$_tmp" "\$_url"/)
+    // Round-2 adversarial pass (MAJOR): that busybox-safe leg MUST be gated on
+    // the wget actually being busybox. Ungated it also runs after a GENUINE
+    // failure of the GNU leg, re-running GNU wget without -t -- 20 retries,
+    // ~100s, right back outside the budget on a curl-less DROP-egress host.
+    expect(cmd).toMatch(/wget --help 2>&1 \| head -n 1 \| grep -qi busybox\s*&&\s*wget -q -T \d+ -O "\$_tmp"/)
     // The three are chained with || in exactly that order: curl, GNU wget,
-    // busybox-safe wget -- each only runs if the previous fetcher failed.
-    expect(cmd).toMatch(/curl [^|]*\|\|\s*wget -q -T \d+ -t 1 [^|]*\|\|\s*wget -q -T \d+ -O /)
+    // busybox-gated wget -- each only runs if the previous fetcher failed.
+    expect(cmd).toMatch(/curl [^|]*\|\|\s*wget -q -T \d+ -t 1 [^|]*\|\|\s*\{ wget --help/)
     // Every timeout number any leg carries stays inside the 20s stage budget.
     const timeouts = [...cmd.matchAll(/--connect-timeout (\d+)|--max-time (\d+)|-T (\d+)/g)]
       .map((m) => Number(m[1] ?? m[2] ?? m[3]))
@@ -94,7 +99,10 @@ describe('buildTmuxStageScript', () => {
     // Command separators in this fragment: ||, |, ;, and subshell parens.
     const fragments = cmd.split(/\|\||[|;()]/)
     const curlFragments = fragments.filter((f) => /\bcurl\b/.test(f))
-    const wgetFragments = fragments.filter((f) => /\bwget\b/.test(f))
+    // `wget --help` is an implementation PROBE, not a fetch: it touches no
+    // network, cannot hang on a dead route, and carrying a -T on it would be
+    // meaningless. Everything else calling wget is a fetch and must be bounded.
+    const wgetFragments = fragments.filter((f) => /\bwget\b/.test(f) && !/wget --help/.test(f))
     // Guard the guard: the script must actually contain both fetchers, so an
     // accidental tokenizer change cannot turn this test into a vacuous pass.
     expect(curlFragments.length).toBeGreaterThanOrEqual(1)

--- a/tests/unit/ssh-tmux-stage.test.ts
+++ b/tests/unit/ssh-tmux-stage.test.ts
@@ -49,13 +49,62 @@ describe('buildTmuxStageScript', () => {
     expect(cmd).toMatch(/_sfx=""[\s\S]*fail=arch/)
   })
 
-  it('downloads with curl -fsSL, falling back to wget -qO-, into a temp file', () => {
+  // Follow-up adversarial pass (fail-posture MAJOR): both fetchers must be
+  // time-bounded well inside the host's 20s STAGE_TIMEOUT_MS (a function-local
+  // const in pty-manager.ts, not exported -- the literal 20 below mirrors it).
+  // Unbounded, a DROP-egress host blocks curl for ~127s of SYN retries and GNU
+  // wget then retries 20 times: the host-side timer fires at 20s and queues the
+  // claude launch into a tty that is still mid-download with echo off, and the
+  // fail=download sentinel (the thing that unlocks tier 4) is never printed.
+  it('downloads with a bounded curl, then bounded wget, then a busybox-safe bounded wget, all inside the 20s stage budget', () => {
     const cmd = buildTmuxStageScript(NONCE)
-    expect(cmd).toMatch(/curl -fsSL "\$_url" -o "\$_tmp"/)
-    expect(cmd).toMatch(/wget -qO- "\$_url" > "\$_tmp"/)
-    // The two are chained with || so wget only runs if curl failed.
-    expect(cmd).toMatch(/curl -fsSL[^|]*\|\|\s*wget -qO-/)
+    // curl leg: BOTH a connect bound and a total-time bound, into the temp file.
+    const curlLeg = cmd.match(/curl [^|;]*"\$_tmp"/)?.[0] ?? ''
+    expect(curlLeg).toMatch(/--connect-timeout \d+/)
+    expect(curlLeg).toMatch(/--max-time \d+/)
+    expect(curlLeg).toMatch(/-o "\$_tmp"/)
+    // First wget leg (GNU): -T (network timeout) AND -t 1 (GNU defaults to
+    // --tries=20, which alone blows the budget).
+    expect(cmd).toMatch(/wget -q -T \d+ -t 1 -O "\$_tmp" "\$_url"/)
+    // Second wget leg (busybox-safe): -T but NO -t -- busybox wget (Alpine,
+    // OpenWrt) has no -t flag at all and usage-errors out of the GNU form.
+    expect(cmd).toMatch(/wget -q -T \d+ -O "\$_tmp" "\$_url"/)
+    // The three are chained with || in exactly that order: curl, GNU wget,
+    // busybox-safe wget -- each only runs if the previous fetcher failed.
+    expect(cmd).toMatch(/curl [^|]*\|\|\s*wget -q -T \d+ -t 1 [^|]*\|\|\s*wget -q -T \d+ -O /)
+    // Every timeout number any leg carries stays inside the 20s stage budget.
+    const timeouts = [...cmd.matchAll(/--connect-timeout (\d+)|--max-time (\d+)|-T (\d+)/g)]
+      .map((m) => Number(m[1] ?? m[2] ?? m[3]))
+    expect(timeouts.length).toBeGreaterThanOrEqual(4) // curl x2 + one -T per wget leg
+    for (const t of timeouts) {
+      expect(t).toBeGreaterThan(0)
+      expect(t).toBeLessThanOrEqual(20)
+    }
     expect(cmd).toMatch(/_tmp=\$\(mktemp/)
+  })
+
+  // Invariant form of the same fix, deliberately NOT pinned to today's literal
+  // flags: split the fragment into individual commands and require that EVERY
+  // curl invocation carries --max-time and EVERY wget invocation carries -T.
+  // This is the test that must fail if someone later adds a new, unbounded
+  // fetcher (or drops the bound from an existing one) anywhere in the script,
+  // even if the shape-pinning test above is updated to match the new layout.
+  it('contains no unbounded fetch: every curl has --max-time and every wget has -T', () => {
+    const cmd = buildTmuxStageScript(NONCE)
+    // Command separators in this fragment: ||, |, ;, and subshell parens.
+    const fragments = cmd.split(/\|\||[|;()]/)
+    const curlFragments = fragments.filter((f) => /\bcurl\b/.test(f))
+    const wgetFragments = fragments.filter((f) => /\bwget\b/.test(f))
+    // Guard the guard: the script must actually contain both fetchers, so an
+    // accidental tokenizer change cannot turn this test into a vacuous pass.
+    expect(curlFragments.length).toBeGreaterThanOrEqual(1)
+    expect(wgetFragments.length).toBeGreaterThanOrEqual(2)
+    for (const f of curlFragments) {
+      expect(f, `unbounded curl invocation: ${f}`).toMatch(/--max-time \d+/)
+    }
+    for (const f of wgetFragments) {
+      expect(f, `unbounded wget invocation: ${f}`).toMatch(/-T \d+/)
+    }
   })
 
   // Adversarial review round 2, MINOR: a predictable /tmp path fallback on

--- a/tests/unit/ssh-tmux.test.ts
+++ b/tests/unit/ssh-tmux.test.ts
@@ -152,6 +152,55 @@ describe('buildTmuxLaunchCommand never reads a caller-supplied tmux path (#242 f
   })
 })
 
+// Follow-up adversarial pass (fail-posture MAJOR): the tier-1 launch token
+// must be the alias- AND function-proof form `command tmux`, never the old
+// `"$(command -v tmux)"`. The detection probe runs `command -v tmux` through
+// execSync (non-interactive `sh -c`, alias-blind), but the launch token is
+// expanded by the remote's INTERACTIVE login shell -- where `command -v tmux`
+// prints an alias DEFINITION (`alias tmux='tmux -2'`) for anyone who aliases
+// tmux in their rc file, quoted into one word that exits 127: no claude, on
+// every connect. `command` is a POSIX special builtin that bypasses shell
+// functions, and `tmux` sits in argument position where alias expansion never
+// applies.
+//
+// WHY THE LITERAL TEXT IS ASSERTED, NOT THE IMPORTED CONSTANT: every other
+// test in this file compares buildTmuxLaunchCommand's output against
+// ON_PATH_TMUX_BIN_EXPR / STAGED_TMUX_BIN_EXPR themselves, so a regression
+// INSIDE the constant (e.g. back to `"$(command -v tmux)"`) changes both
+// sides of the comparison at once and every such test stays green -- proven:
+// NO existing test failed when the constant's value changed for this very
+// fix. A self-referential expectation cannot catch a change to the value it
+// re-derives; only the literal can.
+describe('launch-token literals are alias/function-proof (fail-posture follow-up)', () => {
+  it('ON_PATH_TMUX_BIN_EXPR is literally `command tmux` (not a $(command -v) substitution)', () => {
+    expect(ON_PATH_TMUX_BIN_EXPR).toBe('command tmux')
+  })
+
+  it('STAGED_TMUX_BIN_EXPR is literally `"$HOME"/.claude/bin/tmux`', () => {
+    expect(STAGED_TMUX_BIN_EXPR).toBe('"$HOME"/.claude/bin/tmux')
+  })
+
+  it('a tier-1 (staged: false) launch command uses exactly `command tmux` as every tmux token and contains no `$(command -v` anywhere', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, staged: false })
+    // All three invocation sites carry the literal token (has-session guard,
+    // live attach, and the fresh create used by both the attach fallback and
+    // the else branch).
+    expect(cmd.startsWith('if command tmux has-session -t ccc-sid-1 ')).toBe(true)
+    expect(cmd).toContain('then command tmux attach -t ccc-sid-1 || command tmux new-session -s ccc-sid-1 ')
+    expect(cmd).toContain('else command tmux new-session -s ccc-sid-1 ')
+    // The alias-expandable substitution form must never come back, anywhere
+    // in the command.
+    expect(cmd).not.toContain('$(command -v')
+    expect(cmd).not.toContain('command -v tmux')
+  })
+
+  it('the staged (tier-2/3/4) launch command carries the literal `"$HOME"/.claude/bin/tmux` token and no `$(command -v` either', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, staged: true })
+    expect(cmd.startsWith('if "$HOME"/.claude/bin/tmux has-session -t ccc-sid-1 ')).toBe(true)
+    expect(cmd).not.toContain('$(command -v')
+  })
+})
+
 // #242 tier 5: `--continue` on the BARE (non-tmux) launch on a reconnect,
 // gated OFF whenever tmux is in play -- there the has-session wrapper owns
 // the --continue decision itself (fresh branch only), so this flag going ON

--- a/tests/unit/ssh-tmux.test.ts
+++ b/tests/unit/ssh-tmux.test.ts
@@ -25,19 +25,21 @@ const base = {
 }
 
 describe('buildTmuxLaunchCommand', () => {
-  it('builds the has-session wrapper (attach live, else fresh) using ON_PATH_TMUX_BIN_EXPR for staged: false', () => {
+  it('builds the has-session wrapper (attach live, else fresh; attach falls through to fresh on a lost race) using ON_PATH_TMUX_BIN_EXPR for staged: false', () => {
     const cmd = buildTmuxLaunchCommand(base)
     const t = ON_PATH_TMUX_BIN_EXPR
+    const fresh = `${t} new-session -s ccc-sid-1 '${base.innerCmd}'`
     expect(cmd).toBe(
-      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1; else ${t} new-session -s ccc-sid-1 '${base.innerCmd}'; fi`,
+      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1 || ${fresh}; else ${fresh}; fi`,
     )
   })
 
   it('uses STAGED_TMUX_BIN_EXPR for staged: true', () => {
     const cmd = buildTmuxLaunchCommand({ ...base, staged: true })
     const t = STAGED_TMUX_BIN_EXPR
+    const fresh = `${t} new-session -s ccc-sid-1 '${base.innerCmd}'`
     expect(cmd).toBe(
-      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1; else ${t} new-session -s ccc-sid-1 '${base.innerCmd}'; fi`,
+      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1 || ${fresh}; else ${fresh}; fi`,
     )
   })
 
@@ -49,16 +51,31 @@ describe('buildTmuxLaunchCommand', () => {
     expect(cmd).toMatch(/else\s+.*new-session\s+-s\s+ccc-sid-1/)
   })
 
-  // Item 6 (silent-blank-chat fix): --continue rides the FRESH-create branch
-  // only, and only on a reconnect. Mutation to prove this can fail: append
-  // --continue to innerCmd unconditionally, or to the attach branch -- the
-  // attach-branch assertion (no --continue) then fails.
-  it('adds --continue to the fresh-create branch only, on a reconnect', () => {
+  // The attach is NOT atomic with has-session; a lost race (session dies in the
+  // ~10ms gap) must self-heal, not strand the user (adversarial review,
+  // 2026-08-18). Mutation to prove this can fail: drop the `|| <fresh>` from the
+  // attach branch.
+  it('falls the attach THROUGH to a fresh create when the reattach fails', () => {
+    const cmd = buildTmuxLaunchCommand(base)
+    // The live-reattach `attach -t X` is immediately backstopped by `|| <fresh>`.
+    expect(cmd).toContain('attach -t ccc-sid-1 || ')
+    // Two identical create paths: the attach fallback and the else branch.
+    const creates = cmd.split('new-session -s ccc-sid-1 ').length - 1
+    expect(creates).toBe(2)
+  })
+
+  // Item 6 (silent-blank-chat fix): --continue rides every FRESH-create (the
+  // attach fallback AND the else), and only on a reconnect; a LIVE reattach
+  // (`attach -t X` before the `||`) never gets it -- relaunching a running
+  // claude would be wrong. Mutation to prove this can fail: append --continue to
+  // innerCmd unconditionally, or to the attach op -- the assertions below fail.
+  it('adds --continue to every fresh-create branch, never to a live attach, on a reconnect', () => {
     const cmd = buildTmuxLaunchCommand({ ...base, reconnect: true })
-    const attachBranch = cmd.slice(cmd.indexOf('then'), cmd.indexOf('else'))
-    const freshBranch = cmd.slice(cmd.indexOf('else'))
-    expect(attachBranch).not.toContain('--continue')
-    expect(freshBranch).toContain(`${base.innerCmd} --continue`)
+    expect(cmd).toContain('attach -t ccc-sid-1 || ')
+    expect(cmd).not.toMatch(/attach -t ccc-sid-1 --continue/)
+    const creates = cmd.split('new-session -s ccc-sid-1 ').slice(1)
+    expect(creates.length).toBe(2)
+    for (const c of creates) expect(c.startsWith(`'${base.innerCmd} --continue'`)).toBe(true)
   })
 
   it('never adds --continue on a first connect (reconnect: false)', () => {
@@ -93,11 +110,12 @@ describe('buildTmuxLaunchCommand', () => {
   it('single-quotes an innerCmd containing a single quote without breaking out of the argument', () => {
     const innerCmd = `echo 'hi' && say "done"`
     const cmd = buildTmuxLaunchCommand({ ...base, innerCmd })
-    // The fresh-create branch's quoted command argument (after the LAST
-    // '-s ccc-sid-1 ' -- has-session's -t uses a different flag, so this
-    // uniquely lands on new-session's operand).
+    // The else-branch fresh-create quoted argument (after the LAST
+    // '-s ccc-sid-1 ' -- the attach fallback also creates fresh, so use
+    // lastIndexOf to land uniquely on the else branch's operand, terminated
+    // only by '; fi').
     const marker = 'new-session -s ccc-sid-1 '
-    const quotedArg = cmd.slice(cmd.indexOf(marker) + marker.length).replace(/; fi$/, '')
+    const quotedArg = cmd.slice(cmd.lastIndexOf(marker) + marker.length).replace(/; fi$/, '')
     expect(quotedArg.startsWith("'")).toBe(true)
     expect(quotedArg.endsWith("'")).toBe(true)
     // Reverse the POSIX single-quote escaping (strip outer quotes, undo

--- a/tests/unit/ssh-tmux.test.ts
+++ b/tests/unit/ssh-tmux.test.ts
@@ -1,9 +1,11 @@
 // tests/unit/ssh-tmux.test.ts
 //
-// #242: tmux persistence wrapper. `-A` makes reconnect the IDENTICAL code
-// path (attach if the session exists, else create it) — dropping it would
-// make every reconnect spawn a SECOND claude inside a brand-new session
-// instead of resuming the live one.
+// #242 + SSH tmux enhancement (item 6): tmux persistence wrapper. The
+// wrapper is a has-session conditional (attach if the session is alive,
+// else create a fresh one) so a reconnect after the remote rebooted can
+// resume the conversation (`--continue` on the fresh branch) instead of
+// launching a blank chat -- the silent-blank-chat bug the old `new-session
+// -A` one-liner could not fix, because -A cannot tell attach from create.
 //
 // #242 round-3 correction (I3): buildTmuxLaunchCommand no longer takes a
 // wire-reported `tmuxBin` at all -- it picks ONE of two fixed, host-authored
@@ -19,22 +21,49 @@ const base = {
   sessionId: 'sid-1',
   innerCmd: 'CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1 claude --settings ~/.claude/settings-sid-1.json',
   staged: false,
+  reconnect: false,
 }
 
 describe('buildTmuxLaunchCommand', () => {
-  it('builds new-session -A -s ccc-<sid> <cmd>, using ON_PATH_TMUX_BIN_EXPR for staged: false', () => {
+  it('builds the has-session wrapper (attach live, else fresh) using ON_PATH_TMUX_BIN_EXPR for staged: false', () => {
     const cmd = buildTmuxLaunchCommand(base)
-    expect(cmd).toBe(`${ON_PATH_TMUX_BIN_EXPR} new-session -A -s ccc-sid-1 '${base.innerCmd}'`)
+    const t = ON_PATH_TMUX_BIN_EXPR
+    expect(cmd).toBe(
+      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1; else ${t} new-session -s ccc-sid-1 '${base.innerCmd}'; fi`,
+    )
   })
 
   it('uses STAGED_TMUX_BIN_EXPR for staged: true', () => {
     const cmd = buildTmuxLaunchCommand({ ...base, staged: true })
-    expect(cmd).toBe(`${STAGED_TMUX_BIN_EXPR} new-session -A -s ccc-sid-1 '${base.innerCmd}'`)
+    const t = STAGED_TMUX_BIN_EXPR
+    expect(cmd).toBe(
+      `if ${t} has-session -t ccc-sid-1 2>/dev/null; then ${t} attach -t ccc-sid-1; else ${t} new-session -s ccc-sid-1 '${base.innerCmd}'; fi`,
+    )
   })
 
-  it('carries -A so reconnect attaches instead of creating a second session', () => {
+  it('attaches an existing session and only creates fresh when it is gone', () => {
     const cmd = buildTmuxLaunchCommand(base)
-    expect(cmd).toMatch(/new-session\s+-A\s+-s\s+ccc-/)
+    // Attach branch first (reattach a still-running claude), create second.
+    expect(cmd).toMatch(/has-session\s+-t\s+ccc-sid-1/)
+    expect(cmd).toMatch(/then\s+.*attach\s+-t\s+ccc-sid-1/)
+    expect(cmd).toMatch(/else\s+.*new-session\s+-s\s+ccc-sid-1/)
+  })
+
+  // Item 6 (silent-blank-chat fix): --continue rides the FRESH-create branch
+  // only, and only on a reconnect. Mutation to prove this can fail: append
+  // --continue to innerCmd unconditionally, or to the attach branch -- the
+  // attach-branch assertion (no --continue) then fails.
+  it('adds --continue to the fresh-create branch only, on a reconnect', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, reconnect: true })
+    const attachBranch = cmd.slice(cmd.indexOf('then'), cmd.indexOf('else'))
+    const freshBranch = cmd.slice(cmd.indexOf('else'))
+    expect(attachBranch).not.toContain('--continue')
+    expect(freshBranch).toContain(`${base.innerCmd} --continue`)
+  })
+
+  it('never adds --continue on a first connect (reconnect: false)', () => {
+    const cmd = buildTmuxLaunchCommand({ ...base, reconnect: false })
+    expect(cmd).not.toContain('--continue')
   })
 
   it('sanitizes a session id containing spaces/quotes into the tmux session name', () => {
@@ -58,14 +87,17 @@ describe('buildTmuxLaunchCommand', () => {
     // Nothing before the tmux binary token, and the env var itself only
     // appears inside the quoted argument (never as a bare leading token).
     expect(cmd.indexOf('CLAUDE_CODE_DISABLE_MOUSE_CLICKS')).toBe(idx + 1)
-    expect(cmd.startsWith(ON_PATH_TMUX_BIN_EXPR)).toBe(true)
+    expect(cmd.startsWith(`if ${ON_PATH_TMUX_BIN_EXPR} has-session`)).toBe(true)
   })
 
   it('single-quotes an innerCmd containing a single quote without breaking out of the argument', () => {
     const innerCmd = `echo 'hi' && say "done"`
     const cmd = buildTmuxLaunchCommand({ ...base, innerCmd })
-    const marker = '-s ccc-sid-1 '
-    const quotedArg = cmd.slice(cmd.indexOf(marker) + marker.length)
+    // The fresh-create branch's quoted command argument (after the LAST
+    // '-s ccc-sid-1 ' -- has-session's -t uses a different flag, so this
+    // uniquely lands on new-session's operand).
+    const marker = 'new-session -s ccc-sid-1 '
+    const quotedArg = cmd.slice(cmd.indexOf(marker) + marker.length).replace(/; fi$/, '')
     expect(quotedArg.startsWith("'")).toBe(true)
     expect(quotedArg.endsWith("'")).toBe(true)
     // Reverse the POSIX single-quote escaping (strip outer quotes, undo
@@ -92,20 +124,20 @@ describe('buildTmuxLaunchCommand never reads a caller-supplied tmux path (#242 f
   it('ignores anything extra on the input object -- staged: false always emits ON_PATH_TMUX_BIN_EXPR', () => {
     const cmd = buildTmuxLaunchCommand({ ...base, staged: false, tmuxBin: '/tmp/.x/tmux' } as never)
     expect(cmd).not.toContain('/tmp/.x/tmux')
-    expect(cmd.startsWith(ON_PATH_TMUX_BIN_EXPR)).toBe(true)
+    expect(cmd.startsWith(`if ${ON_PATH_TMUX_BIN_EXPR} has-session`)).toBe(true)
   })
 
   it('ignores anything extra on the input object -- staged: true always emits STAGED_TMUX_BIN_EXPR', () => {
     const cmd = buildTmuxLaunchCommand({ ...base, staged: true, tmuxBin: '/tmp/.claude/bin/tmux' } as never)
     expect(cmd).not.toContain('/tmp/.claude/bin/tmux')
-    expect(cmd.startsWith(STAGED_TMUX_BIN_EXPR)).toBe(true)
+    expect(cmd.startsWith(`if ${STAGED_TMUX_BIN_EXPR} has-session`)).toBe(true)
   })
 })
 
-// #242 tier 5: `--continue` on a reconnect, gated OFF whenever tmux is in
-// play (the `-A` reattach already IS the reconnect path in that case; see
-// buildSshClaudeFlags's doc comment for why a second claude inside the same
-// attached pane would be wrong). Both directions are separate mutations a
+// #242 tier 5: `--continue` on the BARE (non-tmux) launch on a reconnect,
+// gated OFF whenever tmux is in play -- there the has-session wrapper owns
+// the --continue decision itself (fresh branch only), so this flag going ON
+// too would double it. Both directions are separate mutations a
 // single test cannot catch: dropping the `!tmuxInPlay` gate only shows up
 // with tmux present, and dropping the `reconnect` gate only shows up with
 // tmux absent -- hence two dedicated tests rather than one table-driven one.
@@ -116,9 +148,9 @@ describe('buildSshClaudeFlags / shouldAddContinueFlag (#242 tier 5)', () => {
   })
 
   // Mutation this catches: dropping `!input.tmuxInPlay` from the gate (e.g.
-  // `return input.reconnect`) would make this fail -- tmux's own `-A` already
-  // reattaches to the live claude process, so a SECOND `--continue` would
-  // start a second claude inside that same attached pane.
+  // `return input.reconnect`) would make this fail -- the tmux wrapper's
+  // fresh-create branch already carries --continue on a reconnect, so this
+  // bare-launch flag going ON too would append a second one.
   it('does NOT add --continue on a reconnect when tmux IS in play', () => {
     expect(shouldAddContinueFlag({ reconnect: true, tmuxInPlay: true })).toBe(false)
     expect(buildSshClaudeFlags({ reconnect: true, tmuxInPlay: true })).toBe('')


### PR DESCRIPTION
Follow-up to #295 (SSH tmux persistence), in two parts.

## 1. The agreed enhancement batch

The backlog worked out on #295 and confirmed with @nubbymong, built and **real-host tested** before
this branch existed — x86_64 Linux, an aarch64 Pi, Hyper-V as both remote and client, and macOS as
both:

- a **Detachable** toggle on the session config (default on) — and it never silently installs tmux
- **Windows client** support (PowerShell delivery, staging gate)
- a true **End vs Leave running** close path, with a dialog rather than a guess
- the **reconnect cascade**: no host → fail intact; live remote → reattach; gone → resume or fresh
- the **silent blank chat** fix (`--continue` behind a `has-session` wrapper)
- resume-outcome messaging, a persistence pill, and the **remote account** surfaced in the header

One bug came out of that host testing and is fixed here: the close path missed a Homebrew tmux on
macOS, because a non-login shell does not carry Homebrew's PATH.

The header pills render through #291's shared `HeaderPill` component rather than carrying their own
copy of the chrome.

## 2. Remediation of the #295 pre-merge adversarial pass

The pass on #295 recorded **PASS on the injection / command-sink / argv lens** — empirically: a
spoofed valid-nonce stage sentinel still produced the fixed staged token, `singleQuote()` survived
quote/`$()`/backtick/20k/unicode payloads through a real shell as exactly one argv element, and a
write-only attacker could not latch completion. Download integrity and the allowlist held too.

It also recorded **five majors**, none of them a boundary bypass and all of them the same shape —
the ladder makes `claude` fail to launch, or misreports what it did. Fixed here:

| | Finding | Fix |
|---|---|---|
| 1 | The terminfo smoke test never tested terminfo: `tmux new-session -d` never opens a client tty, so a terminfo-less remote reported `ok`, the attached launch died, and tier 2 re-selected the same binary forever with no recovery | A short **watchdog** after a wrapped launch falls back to the bare launch the moment the remote refuses (`open terminal failed`, `sessions should be nested`, `exec format error`, …). Safe because a failed wrap means nothing is running; the window closes the instant claude latches, so it can never fire against claude's own output. Covers wrong-arch and truncated binaries too |
| 2 | `"$(command -v tmux)"` is expanded by the *interactive* shell, where `command -v` prints an **alias definition** — exit 127, no claude, every connect. Nested tmux is likewise refused | `ON_PATH_TMUX_BIN_EXPR` → `command tmux` (alias- and function-proof, still a compile-time literal with no wire-reported operand); probe reports `none` when `$TMUX` is already set |
| 3 | The tier-3 fetch was **unbounded** against a 20 s deadline: a DROP-egress host blocked for minutes, the claude line was queued into a busy echo-less tty, and tier 4 — the tier for exactly that host — was never reached | curl `--connect-timeout 5 --max-time 15`; wget `-T 5 -t 1` with a **busybox-safe** second form that drops `-t` (Alpine/OpenWrt have no `-t`) |
| 4 | `destroyed` gated the writes but not the **emits**: a torn-down flow wrote into the dead PTY and emitted onto `ssh:flowState:<id>` — a channel a respawned session with the same id is already subscribed to | Bail at the top of `setFlowState`, `armIdleFallback`, `writeClaudeCmd`, and in `onData` right after the renderer data forward (terminal bytes still reach xterm; no flow logic below runs) |
| 5 | The tier-4 downloader's guards had **no failing test** — raising the 8 MiB cap to `MAX_SAFE_INTEGER` or deleting the https-only redirect refusal left the suite green | Exported for tests, with coverage for the cap (destroy on the wire), the redirect rules, the hop budget, the digest gate, both request timeouts and the cache-write path |

Also fixed: the tier-2 probe now **executes** its candidate (`-V`, bounded) instead of trusting
`access(X_OK)`, which accepted a zero-byte file, a half-written download, a wrong-arch binary and
even a directory named `tmux`.

## Testing

Every fix carries a **mutation-proven** regression test — the fix was reverted and the test watched
to fail, then restored. That mattered here: the existing tier-1 token tests compared the generated
command against the *imported constant*, so changing the constant changed both sides and every test
stayed green. The new tests pin the literal text.

- `npm run typecheck` clean across all three projects
- full suite **5744 passing** (+22 tests here, +15 in a new downloader test file)
- the watchdog's live behaviour against a genuinely terminfo-less remote is unit-simulated, not
  host-confirmed — that joins the standing acceptance check this ladder has carried since #242

`CONTEXT.d/2026-08-18-ssh-tmux-enhancements-and-hardening.md` carries the running-log entry.
