### PR TITLE
fix(terminal): stop rebuilding the glyph atlas on every output chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-beta.14] - 2026-08-18
+
+> Fixes severe terminal flashing and unreadable, broken text introduced in 2.1.0-beta.13. If you are on beta.13, update.
+
+### Fixed
+- The terminal no longer flashes constantly and drops most of its text while Claude is working. A repaint added in 2.1.0-beta.13 to clear leftover "ghost" characters was rebuilding the entire font atlas on every burst of output — and because Claude Code draws in the normal scrollback, that ran for the whole life of every session, so characters were being redrawn faster than they could be prepared. The repaint now rebuilds the font atlas only when scrolling, which is where the ghosting actually comes from, and does the cheap redraw everywhere else. 2.1.0-beta.13 is the only affected release.
+
 ## [2.1.0-beta.13] - 2026-08-18
 
 > Remote sessions survive a dropped connection: SSH sessions now run inside tmux on the remote, so closing the lid, losing wifi or switching networks no longer kills the work — reconnecting picks it back up where it was. Signing in to claude.ai now happens inside the app, which is what finally gets past Cloudflare's "verify you are human" loop.
@@ -1101,6 +1108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-beta.14]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.14
 [2.1.0-beta.13]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.13
 [2.1.0-beta.12]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.12
 [2.1.0-beta.11]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-beta.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.13",
+  "version": "2.1.0-beta.14",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,6 +21,14 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-beta.14',
+    date: '2026-08-18',
+    highlights: 'Fixes severe terminal flashing and unreadable, broken text introduced in 2.1.0-beta.13. If you are on beta.13, update.',
+    changes: [
+      { type: 'fix', description: 'The terminal no longer flashes constantly and drops most of its text while Claude is working. A repaint added in 2.1.0-beta.13 to clear leftover "ghost" characters was rebuilding the entire font atlas on every burst of output — and because Claude Code draws in the normal scrollback, that ran for the whole life of every session, so characters were being redrawn faster than they could be prepared. The repaint now rebuilds the font atlas only when scrolling, which is where the ghosting actually comes from, and does the cheap redraw everywhere else. 2.1.0-beta.13 is the only affected release.' }
+    ]
+  },
+  {
     version: '2.1.0-beta.13',
     date: '2026-08-18',
     highlights: 'Remote sessions survive a dropped connection: SSH sessions now run inside tmux on the remote, so closing the lid, losing wifi or switching networks no longer kills the work — reconnecting picks it back up where it was. Signing in to claude.ai now happens inside the app, which is what finally gets past Cloudflare\'s "verify you are human" loop.',

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -8,6 +8,7 @@ import { installWebglWithRecovery, type WebglHandle } from './terminal/terminalW
 import {
   createStaleGlyphRepainter,
   shouldRepaintOnOutput,
+  shouldSoftRepaintOnOutput,
   outputRepaintIntervalMs,
   WHEEL_ACTIVE_MS,
   type StaleGlyphRepainter,
@@ -449,6 +450,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // wasn't (DOM-renderer fallback / unrecovered context loss) the repainter
         // skips the refresh — a DOM-renderer session has no atlas ghost to bust.
         clearAtlas: () => webglHandle?.clearTextureAtlas() ?? false,
+        atlasActive: () => webglHandle?.isActive() ?? false,
         refresh: () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } },
         now: Date.now,
         setTimer: (cb, ms) => setTimeout(cb, ms),
@@ -828,6 +830,12 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // scrolled up / wheel-active and 1/sec for steady at-bottom streaming,
         // and one settle repaint clears the last chunk's ghost once the stream
         // goes quiet. The repainter skips the refresh when WebGL isn't active.
+        //
+        // beta.14: only the scrolled-up / wheel-active case rebuilds the glyph
+        // ATLAS. At-bottom streaming gets a refresh-only repaint, because Claude
+        // Code renders in the normal buffer, so a rebuild-per-chunk ran for the
+        // entire life of every session — continuous flashing and frames drawn
+        // against a half-rebuilt atlas (the beta.13 regression).
         if (term && repainter) {
           const repaintState = {
             alternateBuffer: term.buffer.active.type === 'alternate',
@@ -835,14 +843,15 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
             msSinceWheel: Date.now() - lastWheelAt,
             wheelActiveMs: WHEEL_ACTIVE_MS,
           }
-          if (shouldRepaintOnOutput(repaintState)) {
+          const strong = shouldRepaintOnOutput(repaintState)
+          if (strong || shouldSoftRepaintOnOutput(repaintState)) {
             const paceMs = outputRepaintIntervalMs(repaintState)
-            repainter.schedule(paceMs)
+            repainter.schedule(paceMs, strong)
             // Settle at the SAME pace: a between-chunks settle on a steady
             // at-bottom stream must not repaint faster than the stream (it would
             // defeat the 1/sec bound); when output truly stops it still clears
             // the final ghost within one interval.
-            repainter.settle(undefined, paceMs)
+            repainter.settle(undefined, paceMs, strong)
           }
         }
 

--- a/src/renderer/components/terminal/staleGlyphRepaint.ts
+++ b/src/renderer/components/terminal/staleGlyphRepaint.ts
@@ -65,15 +65,37 @@ export interface OutputRepaintState {
 }
 
 /**
- * Should arriving output trigger a stale-glyph repaint?
+ * Should arriving output trigger the STRONG repaint (atlas rebuild + refresh)?
  *
- * Every NORMAL-buffer chunk qualifies — at the bottom too, since the ghost also
+ * beta.14 regression fix: #292 widened this to every normal-buffer chunk, so an
+ * atlas rebuild ran 1-4 times a second for as long as output flowed. Claude Code
+ * renders in the NORMAL buffer, not the alternate screen, so the exemption below
+ * never applied to this app's main use case: sessions flashed continuously and
+ * drew frames against a half-rebuilt atlas. The strong repaint is back to the
+ * conditions that actually corrupt the atlas (scrolled up, or wheeling); steady
+ * at-bottom streaming takes the cheap path instead (shouldSoftRepaintOnOutput).
+ *
+ * Superseded text kept for context: every NORMAL-buffer chunk qualified — at the bottom too, since the ghost also
  * forms under steady at-bottom streaming with no scroll (#273 follow-up). The
  * alternate screen (a TUI, Claude's own UI) owns its full repaints and does not
  * accumulate these stale cells, so it is left alone. How OFTEN a qualifying
  * stream repaints is `outputRepaintIntervalMs`.
  */
 export function shouldRepaintOnOutput(s: OutputRepaintState): boolean {
+  if (s.alternateBuffer) return false
+  return s.scrolledUp || s.msSinceWheel < s.wheelActiveMs
+}
+
+/**
+ * Should arriving output trigger the CHEAP repaint (refresh only, no atlas
+ * rebuild)?
+ *
+ * This is the at-bottom coverage #292 added, minus the part that made beta.13
+ * unusable. A merely-stale viewport is fixed by marking it dirty and
+ * re-rendering from the atlas already in memory; rebuilding the atlas was never
+ * what fixed that, and doing so on a schedule is what caused the flashing.
+ */
+export function shouldSoftRepaintOnOutput(s: OutputRepaintState): boolean {
   return !s.alternateBuffer
 }
 
@@ -92,6 +114,11 @@ export interface RepainterDeps {
    *  atlas was actually cleared; false on the DOM-renderer fallback (or an
    *  unrecovered context loss) — nothing to clear, so nothing to repaint. */
   clearAtlas: () => boolean
+  /** True when the WebGL renderer is live, WITHOUT rebuilding anything. Gates
+   *  the cheap repaint so a DOM-renderer session (which never had the artifact)
+   *  pays nothing — the same reasoning that gates the strong path on
+   *  clearAtlas()'s return value. */
+  atlasActive: () => boolean
   /** Mark the viewport dirty so it re-renders (term.refresh(0, rows-1)). */
   refresh: () => void
   now: () => number
@@ -102,16 +129,19 @@ export interface RepainterDeps {
 }
 
 export interface StaleGlyphRepainter {
-  /** Request a strong repaint soon. Leading-edge immediate, then coalesced into
-   *  at most one repaint per interval for the rest of a burst. `intervalMs`
-   *  overrides the pace for this request (defaults to the repainter's). */
-  schedule(intervalMs?: number): void
+  /** Request a repaint soon. Leading-edge immediate, then coalesced into at most
+   *  one repaint per interval for the rest of a burst. `intervalMs` overrides
+   *  the pace for this request (defaults to the repainter's). `strong` (default
+   *  true) rebuilds the glyph atlas; pass false for the cheap refresh-only
+   *  repaint. If ANY request coalesced into a window was strong, the single
+   *  repaint that window produces is strong. */
+  schedule(intervalMs?: number, strong?: boolean): void
   /** Arm (or re-arm) ONE repaint for when requests go quiet: fires `quietMs`
    *  after the last settle() call, through the normal throttle at `intervalMs`
    *  (default the repainter's). A continuous stream keeps pushing it out; the
    *  moment it stops, the last chunk's ghost is cleared. Pass the stream's own
    *  pace so a settle firing mid-stream cannot repaint faster than the stream. */
-  settle(quietMs?: number, intervalMs?: number): void
+  settle(quietMs?: number, intervalMs?: number, strong?: boolean): void
   /** Cancel any pending repaint and refuse further ones. */
   dispose(): void
 }
@@ -128,6 +158,8 @@ export interface StaleGlyphRepainter {
 export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepainter {
   const minInterval = deps.minIntervalMs ?? REPAINT_MIN_INTERVAL_MS
   let lastPaintAt = Number.NEGATIVE_INFINITY
+  /** Whether the repaint this throttle window will produce must rebuild the atlas. */
+  let pendingStrong = false
   let timer: ReturnType<typeof setTimeout> | null = null
   /** When the armed trailing timer is due (deps.now() clock), so a faster-paced
    *  request can tell whether it would fire sooner and bring it forward. */
@@ -135,8 +167,16 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
   let settleTimer: ReturnType<typeof setTimeout> | null = null
   let disposed = false
 
-  const paint = () => {
+  const paint = (strong: boolean) => {
     lastPaintAt = deps.now()
+    if (!strong) {
+      // Cheap path (#292 at-bottom coverage): re-render the viewport from the
+      // atlas ALREADY in memory. Fixes a stale painted cell without the rebuild
+      // that made beta.13 flash. Gated on WebGL being live for the same reason
+      // the strong path is.
+      if (deps.atlasActive()) deps.refresh()
+      return
+    }
     // clearAtlas() rebuilds the WebGL glyph atlas; refresh() then re-rasters
     // against it (the programmatic equivalent of the window-move full repaint).
     // When WebGL isn't active clearAtlas() returns false — there is no atlas
@@ -146,14 +186,20 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
     if (deps.clearAtlas()) deps.refresh()
   }
 
-  const schedule = (intervalMs: number = minInterval) => {
+  const schedule = (intervalMs: number = minInterval, strong: boolean = true) => {
     if (disposed) return
     const since = deps.now() - lastPaintAt
     if (since >= intervalMs) {
       if (timer) { deps.clearTimer(timer); timer = null; timerDueAt = Number.POSITIVE_INFINITY }
-      paint()
+      const wasStrong = strong || pendingStrong
+      pendingStrong = false
+      paint(wasStrong)
       return
     }
+    // A strong request anywhere in the window wins: a wheel landing mid at-bottom
+    // stream must still get its atlas rebuild, not be swallowed by the cheap
+    // repaint that happened to be scheduled first.
+    pendingStrong = pendingStrong || strong
     // Inside the window: one trailing repaint at the edge of THIS request's
     // window (lastPaintAt + intervalMs). An armed timer that is due no later
     // stands (never push a repaint out — that would starve a steady stream); a
@@ -171,11 +217,13 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
       timer = null
       timerDueAt = Number.POSITIVE_INFINITY
       if (disposed) return
-      paint()
+      const wasStrong = pendingStrong
+      pendingStrong = false
+      paint(wasStrong)
     }, intervalMs - since)
   }
 
-  const settle = (quietMs: number = SETTLE_QUIET_MS, intervalMs: number = minInterval) => {
+  const settle = (quietMs: number = SETTLE_QUIET_MS, intervalMs: number = minInterval, strong: boolean = true) => {
     if (disposed) return
     // Debounce: every call pushes the settle repaint out to quietMs from NOW.
     if (settleTimer) deps.clearTimer(settleTimer)
@@ -189,7 +237,7 @@ export function createStaleGlyphRepainter(deps: RepainterDeps): StaleGlyphRepain
       // at-bottom stream stays at its 1/sec pace instead of the settle dragging
       // it up to the chunk rate; when the stream truly stops, the final ghost is
       // still cleared within one interval. See BOTTOM_STREAM_INTERVAL_MS.
-      schedule(intervalMs)
+      schedule(intervalMs, strong)
     }, quietMs)
   }
 

--- a/src/renderer/components/terminal/terminalWebgl.ts
+++ b/src/renderer/components/terminal/terminalWebgl.ts
@@ -28,8 +28,22 @@ export interface WebglHandle {
    * true if it ran, false when WebGL isn't active (initial load failed, or a
    * context loss dropped us to the DOM renderer) — in which case the caller's
    * `term.refresh()` is the repaint that matters.
+   *
+   * EXPENSIVE: every glyph on screen must be re-rasterized afterwards. Calling
+   * it on a schedule during continuous output makes the terminal flash and
+   * renders frames against a half-rebuilt atlas (beta.13 regression, #292).
+   * Reserve it for the cases that actually corrupt the atlas; use `isActive()`
+   * plus a plain `term.refresh()` for a merely-stale viewport.
    */
   clearTextureAtlas(): boolean
+  /**
+   * True when the WebGL renderer is currently live. Lets a caller do the cheap
+   * half of a repaint (mark the viewport dirty, re-render from the EXISTING
+   * atlas) without paying for an atlas rebuild, while still skipping the work
+   * entirely on a DOM-renderer session that never had the artifact (#273
+   * adversarial review).
+   */
+  isActive(): boolean
 }
 
 /**
@@ -101,6 +115,9 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
         // active" so the caller falls back to a plain refresh.
         return false
       }
+    },
+    isActive() {
+      return currentAddon !== null
     },
   }
 }

--- a/tests/unit/renderer/stale-glyph-repaint.test.ts
+++ b/tests/unit/renderer/stale-glyph-repaint.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   shouldRepaintOnOutput,
+  shouldSoftRepaintOnOutput,
   outputRepaintIntervalMs,
   createStaleGlyphRepainter,
   REPAINT_MIN_INTERVAL_MS,
@@ -31,11 +32,31 @@ describe('shouldRepaintOnOutput', () => {
     expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS - 1 })).toBe(true)
   })
 
-  // #273 follow-up: the ghost also forms under steady at-bottom streaming with
-  // no scroll at all (a slicer's stderr) — and stayed, because nothing repainted.
-  it('repaints at the bottom with no recent scroll too (ghost-at-bottom follow-up)', () => {
-    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(true)
-    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(true)
+  // beta.14 regression fix. #292 made this return true for EVERY normal-buffer
+  // chunk, which meant an atlas rebuild 1-4 times a second for as long as output
+  // flowed. Claude Code renders in the normal buffer, so that ran for the whole
+  // life of every session: continuous flashing, and frames drawn against a
+  // half-rebuilt atlas. The STRONG (atlas-rebuilding) repaint is only for the
+  // conditions that corrupt the atlas; at-bottom streaming takes the cheap path.
+  it('does NOT force an atlas rebuild for steady at-bottom streaming', () => {
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(false)
+    expect(shouldRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(false)
+  })
+})
+
+// #273 follow-up: the ghost also forms under steady at-bottom streaming with no
+// scroll at all (a slicer's stderr) — and stayed, because nothing repainted. That
+// coverage is kept, as a refresh-only repaint.
+describe('shouldSoftRepaintOnOutput', () => {
+  const base = { alternateBuffer: false, scrolledUp: false, msSinceWheel: Infinity, wheelActiveMs: WHEEL_ACTIVE_MS }
+
+  it('covers steady at-bottom streaming (the case the strong repaint no longer takes)', () => {
+    expect(shouldSoftRepaintOnOutput({ ...base, msSinceWheel: WHEEL_ACTIVE_MS })).toBe(true)
+    expect(shouldSoftRepaintOnOutput({ ...base, msSinceWheel: Infinity })).toBe(true)
+  })
+
+  it('still leaves the alternate screen alone', () => {
+    expect(shouldSoftRepaintOnOutput({ ...base, alternateBuffer: true })).toBe(false)
   })
 })
 
@@ -66,6 +87,7 @@ function makeHarness({ webglActive = true }: { webglActive?: boolean } = {}) {
 
   const deps = {
     clearAtlas: () => { clearAtlas++; return webglActive },
+    atlasActive: () => webglActive,
     refresh: () => { refresh++ },
     now: () => time,
     setTimer: (cb: () => void, ms: number) => {
@@ -98,6 +120,61 @@ function makeHarness({ webglActive = true }: { webglActive?: boolean } = {}) {
     pendingTimers: () => timers.length,
   }
 }
+
+describe('createStaleGlyphRepainter — the cheap (soft) repaint, beta.14', () => {
+  // The beta.13 regression: every chunk of normal-buffer output rebuilt the
+  // glyph atlas, so a Claude Code session (normal buffer, output essentially
+  // continuous) flashed nonstop and drew frames against a half-rebuilt atlas.
+  // A stale painted cell only needs the viewport re-rendered from the atlas
+  // already in memory.
+  it('refreshes WITHOUT rebuilding the atlas when strong=false', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(1000, false)
+    expect(h.counts()).toEqual({ clearAtlas: 0, refresh: 1 })
+  })
+
+  it('never rebuilds the atlas across a long at-bottom stream', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    // 30 seconds of steady output at the at-bottom pace.
+    for (let i = 0; i < 300; i++) {
+      r.schedule(1000, false)
+      r.settle(300, 1000, false)
+      h.advance(100)
+    }
+    h.advance(2000)
+    expect(h.counts().clearAtlas).toBe(0)
+  })
+
+  it('skips even the refresh when WebGL is inactive (nothing to repaint)', () => {
+    const h = makeHarness({ webglActive: false })
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(1000, false)
+    expect(h.counts()).toEqual({ clearAtlas: 0, refresh: 0 })
+  })
+
+  // A wheel landing mid-stream must still get the atlas rebuild it asked for,
+  // rather than being swallowed by a cheap repaint that coalesced first.
+  it('upgrades a coalesced window to strong when any request in it was strong', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(1000, false)            // leading edge: cheap repaint
+    expect(h.counts()).toEqual({ clearAtlas: 0, refresh: 1 })
+    h.advance(50)
+    r.schedule(1000, false)            // coalesced, cheap
+    r.schedule(1000, true)             // ...then a wheel arrives: strong
+    h.advance(1000)
+    expect(h.counts().clearAtlas).toBe(1)
+  })
+
+  it('defaults to a strong repaint when no flag is passed', () => {
+    const h = makeHarness()
+    const r = createStaleGlyphRepainter(h.deps)
+    r.schedule(1000)
+    expect(h.counts()).toEqual({ clearAtlas: 1, refresh: 1 })
+  })
+})
 
 describe('createStaleGlyphRepainter', () => {
   it('exposes the documented throttle interval default', () => {


### PR DESCRIPTION
**Hotfix for the beta.13 regression that makes the terminal unusable.** Bumps to `2.1.0-beta.14`.

The terminal flashes continuously and most text renders as missing or fragmented glyphs, while typing as well as while Claude streams.

## Cause

#292 widened `shouldRepaintOnOutput` to **every** normal-buffer chunk, and each repaint calls `clearTextureAtlas()` + `refresh()`. Claude Code renders in the **normal buffer**, not the alternate screen, so the alternate-buffer exemption never applied to this app's main use case: the glyph atlas was rebuilt 1×/sec for the entire life of every session, and 4×/sec for 3s after any wheel. Frames then draw against a half-rebuilt atlas.

```
beta.12:  !alternateBuffer && (scrolledUp || wheelActive)
beta.13:  !alternateBuffer                                 <-- every chunk
```

## Fix

The atlas rebuild returns to the conditions that actually corrupt it (scrolled up, or wheeling). #292's at-bottom coverage is kept as a **refresh-only** repaint — a stale painted cell is fixed by re-rendering the viewport from the atlas already in memory; the rebuild was never the part that fixed it.

- `WebglHandle` gains `isActive()`, so the cheap path can skip a DOM-renderer session without clearing anything to find out.
- `schedule()`/`settle()` take a `strong` flag. If any request coalesced into a throttle window was strong, that window's single repaint is strong — so a wheel landing mid-stream still gets its rebuild.

## Testing

Regression tests are mutation-proven: disabling the soft path fails 4 of them, including `never rebuilds the atlas across a long at-bottom stream` (30s of simulated streaming, asserts `clearAtlas` count is 0).

- `npm run typecheck` clean
- full suite **5755 passing**