### PR TITLE
ci: enforce the desktop-test merge gate via a required label check (#309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # `unlabeled` added alongside `labeled` (#309): the desktop-test gate below
+    # keys on a label, so removing `desktop-tested` must re-run the check and
+    # turn it red again, not leave a stale green.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, beta, 'release/**']
   push:
     branches: [main]
@@ -24,6 +27,42 @@ jobs:
           node-version: '20'
       - name: Verify CHANGELOG.md matches changelog.ts
         run: node scripts/gen-changelog.js --check
+
+  # Desktop-test merge gate (#309). Headless CI can pass while the packaged app
+  # fails to run usefully on a real desktop (it has), so "did a human open it?"
+  # is the real acceptance gate — and it should be enforced by the merge button,
+  # not left to a reviewer's memory or a PR-body note.
+  #
+  # This is the INVERSE of the `ci-run` label below: `ci-run` is opt-in (present
+  # => run the matrix); this one is required-to-allow (the check FAILS unless the
+  # PR carries `desktop-tested` or `skip-desktop-test`). Only PRs are gated;
+  # direct pushes to `main` have no label and are exempt by the event guard.
+  #
+  # The job ALWAYS runs (no `if` that could skip it) and decides pass/fail from
+  # the labels internally — a required check that is "skipped" is treated as
+  # pending and blocks forever, so skipping is not an option once @nubbymong marks
+  # this required in branch protection (the step that turns this from an advisory
+  # red X into an actual merge block; admin-only, tracked in #309).
+  desktop-gate:
+    name: Desktop test gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require desktop-tested (or skip-desktop-test) label
+        env:
+          HAS_TESTED: ${{ contains(github.event.pull_request.labels.*.name, 'desktop-tested') }}
+          HAS_SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-desktop-test') }}
+        run: |
+          if [ "$HAS_TESTED" = "true" ]; then
+            echo "PR carries 'desktop-tested' — the app was exercised on a real desktop. Gate open."
+            exit 0
+          fi
+          if [ "$HAS_SKIP" = "true" ]; then
+            echo "PR carries 'skip-desktop-test' — no desktop test required (docs/deps/CI/changelog-only). Gate open."
+            exit 0
+          fi
+          echo "::error::Desktop-test merge gate: this PR must carry the 'desktop-tested' label (app launched and exercised on a real desktop) or 'skip-desktop-test' (docs/deps/CI/changelog-only) before it can merge. See CONTRIBUTING.md > Desktop-test gate."
+          exit 1
 
   test:
     # Gate the test matrix on a `ci-run` label for PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,16 @@ jobs:
   # PR carries `desktop-tested` or `skip-desktop-test`). Only PRs are gated;
   # direct pushes to `main` have no label and are exempt by the event guard.
   #
-  # The job ALWAYS runs (no `if` that could skip it) and decides pass/fail from
-  # the labels internally — a required check that is "skipped" is treated as
-  # pending and blocks forever, so skipping is not an option once @nubbymong marks
-  # this required in branch protection (the step that turns this from an advisory
-  # red X into an actual merge block; admin-only, tracked in #309).
+  # The job's only `if` is event-scoped (`pull_request`), and that is the whole
+  # design: on every PR it ALWAYS runs, then decides pass/fail from the labels
+  # INTERNALLY. Do not "optimise" this into a label-based `if:`. A required check
+  # that is *skipped* never reports, so GitHub treats it as pending and the PR
+  # blocks forever — a label-gated skip would deadlock exactly the PRs it was
+  # meant to wave through. Decide inside the job; never skip it.
+  #
+  # That matters once @nubbymong marks this a required status check in branch
+  # protection — the step that turns it from an advisory red X into an actual
+  # merge block (admin-only, tracked in #309).
   desktop-gate:
     name: Desktop test gate
     if: github.event_name == 'pull_request'

--- a/CONTEXT.d/2026-08-17-309-desktop-test-gate.md
+++ b/CONTEXT.d/2026-08-17-309-desktop-test-gate.md
@@ -1,0 +1,33 @@
+## 2026-08-17 -- Desktop-test merge gate moved to a required label check (#309)
+
+The "a human must open the app on a real desktop before this ships" rule had no teeth: it
+lived in a reviewer's head and a PR-body note. Headless CI has gone green while the packaged
+app failed to run usefully on a real desktop (the Conductor Proxy MVP: vision crash-loop +
+main-loop stalls), so green CI is not proof the app works.
+
+Converted it to a GitHub gate, mirroring the `ci-run` pattern but inverted:
+
+- `ci-run` is OPT-IN -- present => run the Win/macOS matrix.
+- `desktop-tested` / `skip-desktop-test` are REQUIRED-TO-ALLOW -- the new `Desktop test gate`
+  job FAILS unless the PR carries one of them, so absence blocks merge.
+
+Implementation is a single job in `.github/workflows/ci.yml`. Two design points that are load
+-bearing:
+
+- The job ALWAYS runs (guarded only on `event_name == 'pull_request'`, decides pass/fail from
+  the labels internally). A required check that is *skipped* is treated as pending and blocks
+  forever -- so an `if:` that skips the job when the label is present would deadlock the merge
+  once branch protection requires it. Decide inside, never skip.
+- `on.pull_request.types` gained `unlabeled` next to `labeled`, so removing `desktop-tested`
+  re-runs the check and turns it red again instead of leaving a stale green.
+
+Scope: ALL PRs into beta/main/release; docs/deps/CI/changelog-only PRs clear it with
+`skip-desktop-test` (chosen over a path-filter that auto-passes "non-runtime" PRs, to avoid a
+"what counts as runtime" maintenance surface).
+
+The check is advisory until @nubbymong marks `Desktop test gate` a **required status check** in
+branch protection for beta (and main) -- that is the admin-only step that turns the red X into
+an actual merge block, and the one piece of #309 an agent cannot do.
+
+Docs: CONTRIBUTING.md gains a "Desktop-test gate" subsection next to the ci-run / in-beta /
+release-line label docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,29 @@ a `release-2.2` issue later gets a fix merged to `beta`, drop `release-2.2` and
 add `in-beta`. This invariant is cheap to enforce in CI alongside the changelog
 gate.
 
+### Desktop-test gate (`desktop-tested` / `skip-desktop-test`)
+
+Headless CI (typecheck, unit tests, build) can pass while the packaged app fails
+to run usefully on a real desktop — that has happened. So a PR does not merge on
+green CI alone: **a human must open the app and exercise the change**, and that
+fact is recorded as a label, enforced by the `Desktop test gate` check.
+
+- **`desktop-tested`** — the app was launched and exercised on a real desktop for
+  this change. Apply it once you (or the tester) have actually driven the feature
+  in the running app, not just watched CI go green.
+- **`skip-desktop-test`** — this PR needs no desktop test: docs-, deps-, CI- or
+  changelog-only changes with no runtime surface. Apply it instead of
+  `desktop-tested` for those.
+
+The `Desktop test gate` check **fails until one of these two labels is present**,
+so it is the inverse of `ci-run` (which is opt-in — apply it to *run* the matrix;
+this one must be present to *allow* the merge). Removing the label turns the check
+red again.
+
+Maintainer note: the check only becomes a hard merge block once it is marked a
+**required status check** in branch protection for `beta` (and `main`) — that step
+is admin-only. Until then the check is advisory (a red X, not a stop).
+
 ## Commit Messages
 
 This project follows [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
Closes #309.

## What

Adds a `Desktop test gate` job to `.github/workflows/ci.yml` that **fails unless the PR carries
`desktop-tested` or `skip-desktop-test`**. This turns the "a human opened the app on a real
desktop" acceptance gate — previously a reviewer-memory / PR-body convention — into a check the
merge button honours.

It is the inverse of `ci-run`:
- `ci-run` is **opt-in** — present ⇒ run the Win/macOS matrix.
- the desktop gate is **required-to-allow** — absent ⇒ the check fails ⇒ merge blocked.

## Labels (already created on the repo)

- `desktop-tested` — the app was launched and exercised on a real desktop for this change.
- `skip-desktop-test` — no desktop test needed (docs/deps/CI/changelog-only).

## Design notes worth a look in review

- **The job always runs** (guarded only on `event_name == 'pull_request'`) and decides pass/fail
  from the labels internally. A *skipped* required check is treated as pending and blocks a merge
  forever, so an `if:` that skips when the label is present would deadlock — hence decide inside,
  never skip.
- `on.pull_request.types` gains `unlabeled` next to `labeled`, so removing `desktop-tested`
  re-runs the check and turns it red again rather than leaving a stale green.
- Scope: all PRs into `beta`/`main`/`release/**`; docs/deps/CI-only PRs clear it with
  `skip-desktop-test` (chosen over a path filter that auto-passes "non-runtime" PRs, to avoid a
  "what counts as runtime code" maintenance surface).

## The one step this PR cannot do — @nubbymong

The check is **advisory until it is marked a required status check** in branch protection for
`beta` (and `main`). That is admin-only. Until you enable it, `Desktop test gate` shows red/green
on PRs but does not hard-block merge. Enabling it is what gives the gate teeth.

Note this PR itself will show the gate **red** until it is labeled — apply `skip-desktop-test`
(it is CI + docs only, no runtime surface) to see it go green.

## Gate

- `Changelog in sync` — unaffected (no changelog.ts change)
- Docs + workflow only; no runtime code, no unit-test surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
