### PR TITLE
fix(terminal): coordinate shared glyph-atlas clears + cap WebGL recreates

### DIFF
--- a/CONTEXT.d/2026-08-20-311-gpu-renderer-multisession.md
+++ b/CONTEXT.d/2026-08-20-311-gpu-renderer-multisession.md
@@ -1,0 +1,36 @@
+## 2026-08-20 -- #311 make the GPU (WebGL) renderer multi-session-safe
+
+The opt-in GPU renderer (`gpuRendering`, off by default since #308 / beta.16)
+corrupts multi-session use: `@xterm/addon-webgl@0.19` shares one `TextureAtlas`
+across every terminal whose render config matches (see `acquireTextureAtlas`),
+so a `clearTextureAtlas()` from one terminal empties the shared texture and only
+the caller repaints. The other live terminals then render against the emptied
+atlas and lose their glyphs until they happen to repaint. This is the beta.16
+"characters gone, backgrounds intact" report.
+
+Fix (renderer-only):
+
+- New `terminal/atlasCoordinator.ts`: live WebGL terminals register a `refresh`
+  callback; when one rebuilds the shared atlas it calls `notifyCleared`, and
+  every OTHER terminal is repainted on the next animation frame. Calls coalesce
+  to one pass per frame; a terminal that cleared this frame is skipped (it
+  already repainted itself). Process-wide singleton, because the atlas is
+  process-global. `createAtlasCoordinator(raf)` is injectable for tests.
+- `terminalWebgl.ts`: cap consecutive context-loss recreations
+  (`DEFAULT_MAX_RECREATES = 3`). A flapping GPU context (driver reset / Windows
+  TDR) previously recreated the addon every frame -- the garbled-glyph / white
+  / renderer-crash storm the original report described. After the cap we stay on
+  the DOM renderer and repaint the garbled viewport.
+- `TerminalView.tsx`: registers each WebGL terminal with the coordinator and
+  routes the repainter's `clearAtlas` through `notifyCleared`; unregisters on
+  teardown.
+
+Tests: `terminal-atlas-coordinator.test.ts` (5) and new cap cases in
+`terminal-webgl-recovery.test.ts` (2). Full suite for the two files: 15 passed;
+`tsc --noEmit` clean.
+
+`gpuRendering` stays OFF by default until this is verified on the desktop with
+several busy sessions (render-structure behavior cannot be unit-tested). Flip
+the default in a follow-up once it holds. Fallback if coordination proves
+insufficient: per-terminal atlas isolation via `patch-package` (recorded on the
+issue, not implemented).

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { installWebglWithRecovery, type WebglHandle } from './terminal/terminalWebgl'
+import { atlasCoordinator } from './terminal/atlasCoordinator'
 import {
   createStaleGlyphRepainter,
   shouldRepaintOnOutput,
@@ -346,6 +347,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     // term.refresh) on the triggers that correlate with the ghosting — scroll and
     // streaming output — throttled so a firehose costs at most a few repaints/sec.
     let webglHandle: WebglHandle | null = null
+    let unregisterAtlas: (() => void) | null = null
     let repainter: StaleGlyphRepainter | null = null
     let lastWheelAt = Number.NEGATIVE_INFINITY
 
@@ -473,27 +475,37 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // and so cannot show the fault at all. Read once at mount — changing it
       // applies to terminals opened afterwards, which keeps a live session from
       // having its renderer swapped underneath it.
+      // Repaint this terminal's viewport from the (shared) glyph atlas.
+      const domRefresh = () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } }
       if (ts.gpuRendering === true) {
         webglHandle = installWebglWithRecovery(term, {
           WebglAddonCtor: WebglAddon,
           raf: requestAnimationFrame,
           isDisposed: () => disposed,
         })
+        // Register with the process-wide coordinator so a clearTextureAtlas()
+        // from ANY terminal repaints this one on the next frame (#311).
+        unregisterAtlas = atlasCoordinator.register(domRefresh)
       }
-      // #273: reproduces the window-resize repaint (clearTextureAtlas + refresh)
-      // against whichever addon is currently live. Its premise — that a
-      // terminal's OWN atlas goes stale and needs rebuilding — was wrong: the
-      // atlas is process-global and these clears were themselves what blanked
-      // the other terminals. It is inert on the default path (clearAtlas()
-      // returns false with no WebGL addon) and is kept only for the opt-in
-      // renderer until that path is either repaired or removed.
+      // #273 / #311: reproduces the window-resize repaint (clearTextureAtlas +
+      // refresh) against whichever addon is currently live. The glyph atlas is
+      // shared across every terminal, so a clear here empties it for all of them
+      // — the coordinator repaints the others (#311) so the clear is now
+      // multi-session-safe rather than blanking their glyphs. Inert on the DOM
+      // path (clearAtlas() returns false — no WebGL addon, nothing to clear).
       repainter = createStaleGlyphRepainter({
-        // Return whether the atlas was actually cleared (WebGL active). When it
-        // wasn't (DOM-renderer fallback / unrecovered context loss) the repainter
-        // skips the refresh — a DOM-renderer session has no atlas ghost to bust.
-        clearAtlas: () => webglHandle?.clearTextureAtlas() ?? false,
+        // Rebuild the shared atlas; when it actually happened (WebGL live), tell
+        // the coordinator so every OTHER terminal repaints — otherwise they
+        // render against the atlas this clear just emptied (#311). Returns
+        // whether the atlas was cleared; false on the DOM fallback / unrecovered
+        // context loss, so the repainter skips its own refresh too.
+        clearAtlas: () => {
+          const cleared = webglHandle?.clearTextureAtlas() ?? false
+          if (cleared) atlasCoordinator.notifyCleared(domRefresh)
+          return cleared
+        },
         atlasActive: () => webglHandle?.isActive() ?? false,
-        refresh: () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } },
+        refresh: domRefresh,
         now: Date.now,
         setTimer: (cb, ms) => setTimeout(cb, ms),
         clearTimer: (h) => clearTimeout(h),
@@ -1122,6 +1134,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       if (handlePaste) container.removeEventListener('paste', handlePaste, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       repainter?.dispose()
+      unregisterAtlas?.()
       if (repainterRef.current === repainter) repainterRef.current = null
       resizeObserver?.disconnect()
       unsubData?.()

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -4,7 +4,7 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
-import { installWebglWithRecovery, type WebglHandle } from './terminal/terminalWebgl'
+import { installWebglWithRecovery, createAtlasRefresh, type WebglHandle } from './terminal/terminalWebgl'
 import { atlasCoordinator } from './terminal/atlasCoordinator'
 import {
   createStaleGlyphRepainter,
@@ -477,6 +477,12 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // having its renderer swapped underneath it.
       // Repaint this terminal's viewport from the (shared) glyph atlas.
       const domRefresh = () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } }
+      // The coordinator's view of this terminal: repaint, but only while WebGL
+      // is actually live here. The SAME reference must go to both register() and
+      // notifyCleared() below — the coordinator skips the terminal that cleared
+      // by callback identity, so two different closures would repaint the source
+      // twice (once via the repainter's clear-then-refresh, once via the frame).
+      const atlasRefresh = createAtlasRefresh(() => webglHandle, domRefresh)
       if (ts.gpuRendering === true) {
         webglHandle = installWebglWithRecovery(term, {
           WebglAddonCtor: WebglAddon,
@@ -485,7 +491,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         })
         // Register with the process-wide coordinator so a clearTextureAtlas()
         // from ANY terminal repaints this one on the next frame (#311).
-        unregisterAtlas = atlasCoordinator.register(domRefresh)
+        unregisterAtlas = atlasCoordinator.register(atlasRefresh)
       }
       // #273 / #311: reproduces the window-resize repaint (clearTextureAtlas +
       // refresh) against whichever addon is currently live. The glyph atlas is
@@ -501,7 +507,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // context loss, so the repainter skips its own refresh too.
         clearAtlas: () => {
           const cleared = webglHandle?.clearTextureAtlas() ?? false
-          if (cleared) atlasCoordinator.notifyCleared(domRefresh)
+          if (cleared) atlasCoordinator.notifyCleared(atlasRefresh)
           return cleared
         },
         atlasActive: () => webglHandle?.isActive() ?? false,

--- a/src/renderer/components/terminal/atlasCoordinator.ts
+++ b/src/renderer/components/terminal/atlasCoordinator.ts
@@ -1,0 +1,81 @@
+/**
+ * Cross-terminal glyph-atlas coordinator (#311).
+ *
+ * `@xterm/addon-webgl` keeps ONE `TextureAtlas` per render config and shares it
+ * across every terminal whose font/size/theme match (see `acquireTextureAtlas`
+ * in the addon). CCC opens terminals with identical settings, so they all share
+ * one atlas. When any one of them rebuilds that atlas — `clearTextureAtlas()`,
+ * which the stale-glyph repainter (#273) calls — the shared texture is emptied
+ * and only the CALLING terminal is asked to redraw. Every OTHER live terminal
+ * keeps rendering against the emptied atlas and loses its glyphs (backgrounds
+ * intact) until it happens to repaint. That is the beta.16 corruption.
+ *
+ * The fix is coordination: each live WebGL terminal registers a `refresh`
+ * callback here; when one rebuilds the shared atlas it calls `notifyCleared`,
+ * and every OTHER registered terminal is refreshed on the next animation frame.
+ * The blank a clear leaves in the other terminals is therefore corrected within
+ * ~1 frame instead of lasting until a resize/scroll/activate.
+ *
+ * Calls are coalesced per frame: N terminals each clearing in the same frame
+ * produce ONE refresh pass over the others, not N. A terminal that cleared this
+ * frame already repainted itself (the repainter does clear-then-refresh), so it
+ * is skipped.
+ *
+ * The atlas it guards is process-global, so the app uses a single shared
+ * `atlasCoordinator`. `createAtlasCoordinator` is exported (with an injectable
+ * `raf`) so the coalescing logic is unit-testable without a real animation frame.
+ */
+
+export type TerminalRefresh = () => void
+
+export interface AtlasCoordinator {
+  /** Register a live terminal's repaint callback. Returns an unregister fn to
+   *  call on teardown. */
+  register(refresh: TerminalRefresh): () => void
+  /** Report that `source` just rebuilt the shared atlas. Schedules a coalesced
+   *  refresh of every OTHER registered terminal on the next animation frame. */
+  notifyCleared(source: TerminalRefresh): void
+}
+
+export function createAtlasCoordinator(
+  raf: (cb: () => void) => number = (cb) => globalThis.requestAnimationFrame(cb),
+): AtlasCoordinator {
+  const live = new Set<TerminalRefresh>()
+  const clearedThisFrame = new Set<TerminalRefresh>()
+  let armed = false
+
+  const flush = () => {
+    armed = false
+    // Snapshot the terminals that cleared this frame, then reset for the next
+    // one. Those terminals already repainted themselves via clear-then-refresh,
+    // so they are skipped.
+    const sources = new Set(clearedThisFrame)
+    clearedThisFrame.clear()
+    // Snapshot `live` so a refresh() that unregisters mid-pass cannot disturb
+    // the iteration.
+    for (const refresh of [...live]) {
+      if (sources.has(refresh)) continue
+      try { refresh() } catch { /* terminal disposed between arming and flush */ }
+    }
+  }
+
+  return {
+    register(refresh) {
+      live.add(refresh)
+      return () => {
+        live.delete(refresh)
+        clearedThisFrame.delete(refresh)
+      }
+    },
+    notifyCleared(source) {
+      clearedThisFrame.add(source)
+      if (!armed) {
+        armed = true
+        raf(flush)
+      }
+    },
+  }
+}
+
+/** Process-wide coordinator — the atlas it guards is process-global. */
+export const atlasCoordinator = createAtlasCoordinator()

--- a/src/renderer/components/terminal/terminalWebgl.ts
+++ b/src/renderer/components/terminal/terminalWebgl.ts
@@ -12,7 +12,20 @@ export interface WebglRecoveryOptions {
   WebglAddonCtor: new () => WebglAddon
   raf: (cb: () => void) => number
   isDisposed: () => boolean
+  /**
+   * How many consecutive context losses to recover from before staying on the
+   * DOM renderer for good. A flapping GPU context (a driver reset / Windows TDR)
+   * fires context loss every frame; without a cap the addon recreates on every
+   * one — the storm that shows as garbled glyphs, a white flash, then a renderer
+   * crash, on repeat (#311). After the cap we stay on the DOM renderer and
+   * repaint the garbled viewport. Defaults to DEFAULT_MAX_RECREATES.
+   */
+  maxRecreates?: number
 }
+
+/** Consecutive context losses recovered from before we stay on the DOM renderer.
+ *  Enough to ride out a genuine one-off GPU blip, low enough to kill a storm. */
+export const DEFAULT_MAX_RECREATES = 3
 
 /**
  * A handle onto the LIVE WebGL addon, valid across context-loss recreations.
@@ -54,6 +67,9 @@ export interface WebglHandle {
  *   2. In the next animation frame, try to construct + load a fresh addon (GPU-blip recovery).
  *   3. If the recreate throws (GPU genuinely gone), call `term.refresh(0, rows-1)` so the
  *      DOM renderer repaints the viewport that the dead WebGL canvas left garbled.
+ *   4. After `maxRecreates` consecutive losses, stop recreating and stay on the DOM
+ *      renderer — a context that keeps dying would otherwise recreate every frame and
+ *      storm the renderer into a crash (#311).
  *
  * Returns a WebglHandle so the caller can force a full repaint (#273) against
  * whichever addon is currently live. The happy path (WebGL works, no context
@@ -61,6 +77,17 @@ export interface WebglHandle {
  */
 export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOptions): WebglHandle {
   const { WebglAddonCtor, raf, isDisposed } = opts
+  const maxRecreates = opts.maxRecreates ?? DEFAULT_MAX_RECREATES
+  // Consecutive context losses recovered from so far. Shared across every
+  // recreated addon (each re-arms its own onContextLoss), so a flapping context
+  // that keeps recreating is counted across the whole storm, not per addon.
+  let recreateCount = 0
+
+  const forceDomRepaint = () => {
+    // The DOM renderer is already active (dispose() switched to it); repaint the
+    // viewport the dead WebGL canvas left garbled.
+    try { term.refresh(0, term.rows - 1) } catch { /* terminal may have been disposed */ }
+  }
 
   // The addon currently loaded on the terminal, or null when WebGL isn't active
   // (never loaded, or dropped to the DOM renderer after a context loss). Kept in
@@ -82,6 +109,14 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
       // touching a dead addon.
       currentAddon = null
       addon.dispose()
+      if (recreateCount >= maxRecreates) {
+        // Cap reached: the context keeps dying (a flapping GPU / Windows TDR).
+        // Stop recreating and stay on the DOM renderer — recreating again just
+        // feeds the crash loop (#311). Repaint the garbled viewport and give up.
+        forceDomRepaint()
+        return
+      }
+      recreateCount++
       raf(() => {
         if (isDisposed()) return
         try {
@@ -89,7 +124,7 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
         } catch {
           // Recreate failed: DOM renderer is already active (dispose() did
           // that), but the existing viewport rows are garbled. Force a repaint.
-          try { term.refresh(0, term.rows - 1) } catch { /* terminal may have been disposed */ }
+          forceDomRepaint()
         }
       })
     })

--- a/src/renderer/components/terminal/terminalWebgl.ts
+++ b/src/renderer/components/terminal/terminalWebgl.ts
@@ -21,11 +21,37 @@ export interface WebglRecoveryOptions {
    * repaint the garbled viewport. Defaults to DEFAULT_MAX_RECREATES.
    */
   maxRecreates?: number
+  /**
+   * How long the context must survive for the NEXT loss to count as a fresh
+   * incident rather than a continuation of the current storm. See
+   * DEFAULT_STABLE_PERIOD_MS. Defaults to DEFAULT_STABLE_PERIOD_MS.
+   */
+  stablePeriodMs?: number
+  /** Clock, injectable for tests. Defaults to Date.now. */
+  now?: () => number
 }
 
 /** Consecutive context losses recovered from before we stay on the DOM renderer.
  *  Enough to ride out a genuine one-off GPU blip, low enough to kill a storm. */
 export const DEFAULT_MAX_RECREATES = 3
+
+/**
+ * How long the WebGL context must survive before the next loss is treated as a
+ * NEW incident and the recreate counter resets.
+ *
+ * Without this the cap is a LIFETIME cap, not a consecutive one: a terminal left
+ * open for days would burn its three recoveries on three unrelated blips — a
+ * driver update, a sleep/wake, a monitor replugged — each of which recovered
+ * perfectly, and then permanently drop to the DOM renderer on the fourth. That
+ * is precisely the case the cap is supposed to tolerate.
+ *
+ * A storm is defined by losses arriving back to back (a TDR loop re-fires within
+ * seconds, a flapping context every frame), so it reaches the cap long before
+ * this window elapses and the reset never rescues it. A context that has
+ * rendered for a full 30 seconds has demonstrably recovered, and the loss that
+ * follows is a new event, not the same one.
+ */
+export const DEFAULT_STABLE_PERIOD_MS = 30_000
 
 /**
  * A handle onto the LIVE WebGL addon, valid across context-loss recreations.
@@ -60,6 +86,34 @@ export interface WebglHandle {
 }
 
 /**
+ * Build the callback a terminal registers with the shared atlas coordinator.
+ *
+ * The coordinator repaints every OTHER terminal when one rebuilds the shared
+ * glyph atlas — but only a terminal actually rendering through WebGL has
+ * anything to repaint. Two ways a terminal ends up registered without WebGL:
+ * `installWebglWithRecovery` swallows an initial load failure (WebGL
+ * unavailable in the environment), and a context-loss storm can drop a terminal
+ * to the DOM renderer permanently once the recreate cap is reached. Either way
+ * the viewport is correct already, so the refresh is pure waste.
+ *
+ * Gating here rather than at the registration site covers BOTH cases with one
+ * check — registration happens once at mount, when the second case has not
+ * happened yet.
+ *
+ * Note for callers: register THIS function with the coordinator and pass the
+ * SAME reference to `notifyCleared`. The coordinator skips the terminal that
+ * cleared by callback identity, so passing a different function for the two
+ * would repaint the source twice — once from the repainter's own
+ * clear-then-refresh, once from the coordinator.
+ */
+export function createAtlasRefresh(
+  getHandle: () => WebglHandle | null,
+  refresh: () => void,
+): () => void {
+  return () => { if (getHandle()?.isActive()) refresh() }
+}
+
+/**
  * Loads a WebGL addon onto `term` and wires a self-reloading context-loss handler.
  *
  * On context loss the addon fires its callback; we:
@@ -78,10 +132,15 @@ export interface WebglHandle {
 export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOptions): WebglHandle {
   const { WebglAddonCtor, raf, isDisposed } = opts
   const maxRecreates = opts.maxRecreates ?? DEFAULT_MAX_RECREATES
-  // Consecutive context losses recovered from so far. Shared across every
-  // recreated addon (each re-arms its own onContextLoss), so a flapping context
-  // that keeps recreating is counted across the whole storm, not per addon.
+  const stablePeriodMs = opts.stablePeriodMs ?? DEFAULT_STABLE_PERIOD_MS
+  const now = opts.now ?? Date.now
+  // Consecutive context losses recovered from within the CURRENT storm. Shared
+  // across every recreated addon (each re-arms its own onContextLoss), so a
+  // flapping context that keeps recreating is counted across the whole storm,
+  // not per addon — and reset once the context has held for stablePeriodMs, so
+  // the cap bounds one storm rather than the terminal's whole lifetime.
   let recreateCount = 0
+  let lastLossAt = Number.NEGATIVE_INFINITY
 
   const forceDomRepaint = () => {
     // The DOM renderer is already active (dispose() switched to it); repaint the
@@ -109,6 +168,13 @@ export function installWebglWithRecovery(term: Terminal, opts: WebglRecoveryOpti
       // touching a dead addon.
       currentAddon = null
       addon.dispose()
+      // A loss that arrives after the context has held for stablePeriodMs is a
+      // new incident, not the continuation of a storm — start its count afresh.
+      // Must run BEFORE the cap check, or a terminal that recovered cleanly
+      // hours ago would still be measured against that old count.
+      const lossAt = now()
+      if (lossAt - lastLossAt > stablePeriodMs) recreateCount = 0
+      lastLossAt = lossAt
       if (recreateCount >= maxRecreates) {
         // Cap reached: the context keeps dying (a flapping GPU / Windows TDR).
         // Stop recreating and stay on the DOM renderer — recreating again just

--- a/tests/unit/renderer/terminal-atlas-coordinator.test.ts
+++ b/tests/unit/renderer/terminal-atlas-coordinator.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the cross-terminal glyph-atlas coordinator (#311).
+ * Verifies that a shared-atlas clear repaints the OTHER terminals, that calls
+ * coalesce into one pass per frame, and that unregister/teardown is honored —
+ * all without a real GPU, DOM, or animation frame.
+ */
+import { describe, it, expect } from 'vitest'
+import { createAtlasCoordinator } from '../../../src/renderer/components/terminal/atlasCoordinator'
+
+/** A controllable requestAnimationFrame: callbacks queue until flush() runs
+ *  them, so a test can assert how many frames were scheduled. */
+function makeRaf() {
+  let q: Array<() => void> = []
+  return {
+    raf: (cb: () => void) => { q.push(cb); return q.length },
+    pending: () => q.length,
+    flush: () => { const due = q; q = []; due.forEach((fn) => fn()) },
+  }
+}
+
+describe('atlasCoordinator', () => {
+  it('refreshes other terminals on the next frame, not the source', () => {
+    const { raf, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let a = 0, b = 0
+    const rA = () => { a++ }
+    const rB = () => { b++ }
+    coord.register(rA)
+    coord.register(rB)
+
+    coord.notifyCleared(rA)
+    // Nothing until the frame fires.
+    expect(a).toBe(0)
+    expect(b).toBe(0)
+
+    flush()
+    expect(a).toBe(0) // source skipped — it already repainted itself
+    expect(b).toBe(1) // the other terminal was repainted
+  })
+
+  it('coalesces many clears in one frame into a single pass', () => {
+    const { raf, pending, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let a = 0, b = 0, c = 0
+    const rA = () => { a++ }
+    const rB = () => { b++ }
+    const rC = () => { c++ }
+    coord.register(rA)
+    coord.register(rB)
+    coord.register(rC)
+
+    coord.notifyCleared(rA)
+    coord.notifyCleared(rB)
+    expect(pending()).toBe(1) // ONE frame scheduled, not two
+
+    flush()
+    expect(c).toBe(1)  // idle terminal repainted once
+    expect(a).toBe(0)  // both sources skipped
+    expect(b).toBe(0)
+  })
+
+  it('re-arms on the following frame', () => {
+    const { raf, pending, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let b = 0
+    const rA = () => {}
+    const rB = () => { b++ }
+    coord.register(rA)
+    coord.register(rB)
+
+    coord.notifyCleared(rA)
+    flush()
+    expect(b).toBe(1)
+
+    coord.notifyCleared(rA)
+    expect(pending()).toBe(1) // a fresh frame is scheduled
+    flush()
+    expect(b).toBe(2)
+  })
+
+  it('does not refresh a terminal after it unregisters', () => {
+    const { raf, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let a = 0, b = 0
+    const rA = () => { a++ }
+    const rB = () => { b++ }
+    coord.register(rA)
+    const unregisterB = coord.register(rB)
+
+    unregisterB()
+    coord.notifyCleared(rA)
+    flush()
+    expect(b).toBe(0) // gone from the live set
+  })
+
+  it('keeps refreshing the rest when one refresh throws', () => {
+    const { raf, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let c = 0
+    const rSource = () => {}
+    const rThrows = () => { throw new Error('terminal disposed mid-frame') }
+    const rC = () => { c++ }
+    coord.register(rSource)
+    coord.register(rThrows)
+    coord.register(rC)
+
+    coord.notifyCleared(rSource)
+    expect(() => flush()).not.toThrow()
+    expect(c).toBe(1) // the throwing terminal did not abort the pass
+  })
+})

--- a/tests/unit/renderer/terminal-webgl-recovery.test.ts
+++ b/tests/unit/renderer/terminal-webgl-recovery.test.ts
@@ -4,7 +4,7 @@
  * without needing a real GPU or DOM.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { installWebglWithRecovery, DEFAULT_MAX_RECREATES } from '../../../src/renderer/components/terminal/terminalWebgl'
+import { installWebglWithRecovery, createAtlasRefresh, DEFAULT_MAX_RECREATES } from '../../../src/renderer/components/terminal/terminalWebgl'
 
 describe('installWebglWithRecovery', () => {
   let contextLossCallback: (() => void) | null
@@ -248,5 +248,117 @@ describe('installWebglWithRecovery', () => {
 
     // 1 initial + at most DEFAULT_MAX_RECREATES recreations — never one per loss.
     expect(constructCallCount).toBe(1 + DEFAULT_MAX_RECREATES)
+  })
+
+  // -------------------------------------------------------------------------
+  // The cap counts ONE storm, not the terminal's lifetime (#312 review)
+  // -------------------------------------------------------------------------
+
+  it('does not recreate for a loss still inside the stable period once capped', () => {
+    let clock = 0
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+      maxRecreates: 2,
+      stablePeriodMs: 30_000,
+      now: () => clock,
+    })
+
+    clock = 0; contextLossCallback!()      // recreate -> construct 2
+    clock = 1_000; contextLossCallback!()  // recreate -> construct 3
+    clock = 2_000; contextLossCallback!()  // cap reached -> no recreate
+    expect(constructCallCount).toBe(3)
+
+    // Still inside the stable period: the storm is ongoing, stay capped.
+    clock = 2_000 + 30_000; contextLossCallback!() // gap == stablePeriodMs, NOT >
+    expect(constructCallCount).toBe(3)
+  })
+
+  it('resets the cap for a loss that arrives after the context held stable', () => {
+    let clock = 0
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+      maxRecreates: 2,
+      stablePeriodMs: 30_000,
+      now: () => clock,
+    })
+
+    clock = 0; contextLossCallback!()
+    clock = 1_000; contextLossCallback!()
+    clock = 2_000; contextLossCallback!()  // capped
+    expect(constructCallCount).toBe(3)
+
+    // The context then rendered for well past the stable period. This loss is a
+    // NEW incident — a driver update, a sleep/wake — not the same storm, so the
+    // terminal gets its recoveries back instead of being stuck on the DOM
+    // renderer for the rest of its life.
+    clock = 2_000 + 30_001; contextLossCallback!()
+    expect(constructCallCount).toBe(4)
+  })
+
+  it('survives three unrelated blips a day apart without giving up WebGL', () => {
+    let clock = 0
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+      now: () => clock,
+    })
+
+    const DAY = 24 * 60 * 60 * 1000
+    for (let i = 1; i <= 6; i++) { clock = i * DAY; contextLossCallback!() }
+
+    // Every one recovered: 1 initial + 6 recreations. A lifetime cap would have
+    // stopped at 1 + DEFAULT_MAX_RECREATES.
+    expect(constructCallCount).toBe(7)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createAtlasRefresh: the coordinator callback is inert without live WebGL
+// ---------------------------------------------------------------------------
+
+describe('createAtlasRefresh', () => {
+  it('repaints while WebGL is live on this terminal', () => {
+    let refreshes = 0
+    const handle = { isActive: () => true, clearTextureAtlas: () => true }
+    createAtlasRefresh(() => handle as any, () => { refreshes++ })()
+    expect(refreshes).toBe(1)
+  })
+
+  it('does not repaint a terminal whose WebGL never loaded', () => {
+    let refreshes = 0
+    // installWebglWithRecovery swallows an initial load failure and hands back a
+    // handle that is simply never active — the DOM renderer is doing the work
+    // and its viewport is already correct.
+    const handle = { isActive: () => false, clearTextureAtlas: () => false }
+    createAtlasRefresh(() => handle as any, () => { refreshes++ })()
+    expect(refreshes).toBe(0)
+  })
+
+  it('stops repainting once a terminal falls back to the DOM renderer for good', () => {
+    let refreshes = 0
+    let live = true
+    const handle = { isActive: () => live, clearTextureAtlas: () => live }
+    const cb = createAtlasRefresh(() => handle as any, () => { refreshes++ })
+
+    cb()
+    expect(refreshes).toBe(1)
+
+    // Context-loss storm hit the recreate cap: WebGL is gone for this terminal.
+    // Registration happened at mount, so only a liveness check inside the
+    // callback can notice.
+    live = false
+    cb()
+    expect(refreshes).toBe(1)
+  })
+
+  it('does not repaint before the handle exists', () => {
+    let refreshes = 0
+    createAtlasRefresh(() => null, () => { refreshes++ })()
+    expect(refreshes).toBe(0)
   })
 })

--- a/tests/unit/renderer/terminal-webgl-recovery.test.ts
+++ b/tests/unit/renderer/terminal-webgl-recovery.test.ts
@@ -4,7 +4,7 @@
  * without needing a real GPU or DOM.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { installWebglWithRecovery } from '../../../src/renderer/components/terminal/terminalWebgl'
+import { installWebglWithRecovery, DEFAULT_MAX_RECREATES } from '../../../src/renderer/components/terminal/terminalWebgl'
 
 describe('installWebglWithRecovery', () => {
   let contextLossCallback: (() => void) | null
@@ -209,5 +209,44 @@ describe('installWebglWithRecovery', () => {
 
     // No load attempt either.
     expect(loadAddonCallCount).toBe(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Recreate cap: a flapping context must NOT recreate forever (#311)
+  // -------------------------------------------------------------------------
+
+  it('stops recreating after maxRecreates consecutive context losses', () => {
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+      maxRecreates: 2,
+    })
+
+    // Initial load => 1 construct.
+    contextLossCallback!() // loss 1: under cap -> recreate (construct 2)
+    contextLossCallback!() // loss 2: under cap -> recreate (construct 3)
+    const atCap = constructCallCount
+    expect(atCap).toBe(3)
+
+    contextLossCallback!() // loss 3: cap reached -> NO recreate, repaint instead
+    contextLossCallback!() // loss 4: still capped -> still no recreate
+
+    expect(constructCallCount).toBe(atCap)          // no further addons built
+    expect(refreshCallCount).toBeGreaterThanOrEqual(1) // capped losses repaint the DOM
+    expect(refreshArgs).toEqual([0, 23])
+  })
+
+  it('bounds total recreations under a persistent context-loss storm (default cap)', () => {
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+    })
+
+    for (let i = 0; i < 50; i++) contextLossCallback!()
+
+    // 1 initial + at most DEFAULT_MAX_RECREATES recreations — never one per loss.
+    expect(constructCallCount).toBe(1 + DEFAULT_MAX_RECREATES)
   })
 })


### PR DESCRIPTION
Closes #311.

## Problem

The opt-in GPU (WebGL) renderer corrupts multi-session use. `@xterm/addon-webgl@0.19`
shares one `TextureAtlas` across every terminal whose render config matches
(`acquireTextureAtlas`), so a `clearTextureAtlas()` from one terminal empties the shared
texture and only that terminal repaints — the others keep rendering against the emptied
atlas and lose their glyphs (backgrounds intact) until they happen to repaint. That is the
beta.16 "characters gone" report. Separately, `installWebglWithRecovery` recreated the
addon on every context loss with no cap, so a flapping GPU context (driver reset / Windows
TDR) recreated it every frame — the garbled-glyph → white-screen → renderer-crash loop.

## Fix (renderer-only)

- **`terminal/atlasCoordinator.ts`** (new): live WebGL terminals register a `refresh`
  callback; after any atlas clear, every *other* terminal repaints on the next animation
  frame. Calls coalesce to one pass per frame; the terminal that cleared is skipped (it
  already repainted itself). Process-wide singleton because the atlas is process-global.
- **`terminalWebgl.ts`**: cap consecutive context-loss recreations (`DEFAULT_MAX_RECREATES
  = 3`), then stay on the DOM renderer and repaint the garbled viewport.
- **`TerminalView.tsx`**: register each WebGL terminal, route `clearAtlas` through the
  coordinator, unregister on teardown.

## Tests

- `terminal-atlas-coordinator.test.ts` (5) + new cap cases in `terminal-webgl-recovery.test.ts` (2); full file suite 15 passing.
- `tsc --noEmit` clean (whole project).

## Scope / gates

- Renderer-only (no IPC / preload / PTY / updater / webPreferences) → no adversarial-review
  gate (ADR-009).
- `gpuRendering` stays **OFF by default**. Flip the default in a follow-up only after
  desktop verification with several busy sessions (render-structure behavior cannot be
  unit-tested).

## Desktop verification needed

1. Settings → Terminal → enable GPU rendering (Experimental).
2. Open 4+ sessions; stream output in several at once; scroll one while another streams.
3. Confirm no session loses characters when another repaints, and no white-screen / crash loop.

Fallback if coordination proves insufficient in the field: per-terminal atlas isolation via
`patch-package` (recorded on #311, not implemented here).
