### PR TITLE
fix(canvas): a canvas belongs to its project, not to an account

### DIFF
--- a/CONTEXT.d/2026-08-21-canvas-is-project-centric.md
+++ b/CONTEXT.d/2026-08-21-canvas-is-project-centric.md
@@ -1,0 +1,36 @@
+## 2026-08-21 -- the canvas account floor comes out again
+
+Shipped an account floor on the canvas adoption path yesterday (#308), as the fix
+for a fence the 2026-08-14 adversarial review had installed and the "open your own
+canvas" fast path had bypassed. The owner's call on seeing it: a canvas is
+PROJECT-centric, not account-centric. Which Claude account was signed in when a
+mockup was drawn is a property of the session that drew it, not of the artifact.
+
+The floor was wrong in an ordinary way rather than an exotic one. A session id
+outlives an account switch -- switching accounts in a tile restarts the session
+with the same id -- while the record's stamp is fixed at first render. So after a
+switch the tile's own canvases still read as "mine" in the library and "Open here"
+refused them, with a message about a session that was still running, which was not
+what had happened. Meanwhile the ACTIVE canvas kept working, because the
+session-to-canvas index is keyed on the session id alone. One canvas behaved and
+its siblings refused.
+
+Removed: `profileId` from the adoption query, the session-info resolver, the record
+stamp and all three decisions (reclaim candidacy, the own-canvas fast path, the
+library badge). Records written earlier keep the field; nothing reads it, and
+rewriting every record on disk to drop a dead field is the riskier change.
+
+I also tried making the project a FILTER on the reclaim list, and backed it out
+when the tests said so: the library is already per-project, so filtering there too
+would leave a canvas whose project you never open again with no route back. The
+project marks and sorts that list instead. Being locked out of your own canvas is
+a bug this app has already shipped once.
+
+What the 2026-08-14 review actually established is untouched, and ADR-017 says so
+explicitly so it is not re-litigated: a directory match must never be what MOVES a
+canvas. It still isn't -- the user picks a row by id, and "a canvas whose owner
+might still come back is never taken" remains, with its oracle failing safe.
+
+The follow-up I raised at the end of the #308 pass -- the session-to-canvas binding
+surviving an account switch -- is answered by this decision rather than fixed. Under
+ADR-017 it is correct behaviour.

--- a/architecture/decisions/2026-08-21-adr-017-a-canvas-belongs-to-its-project-not-an-account.md
+++ b/architecture/decisions/2026-08-21-adr-017-a-canvas-belongs-to-its-project-not-an-account.md
@@ -1,0 +1,90 @@
+# ADR-017: A canvas belongs to its project, not to an account
+
+- Date: 2026-08-21
+- Status: Accepted
+- Supersedes: the account half of the adoption key introduced by the adversarial
+  review of 2026-08-14 (see ADR-015 / `CONTEXT.d/2026-08-14-*` for that review).
+
+## Context
+
+A canvas records the account a session was running under (`profileId`), stamped
+once at first render, and three decisions consulted it:
+
+- `isReclaimCandidate` refused a canvas whose stamp differed from the asking
+  session's account, exactly, `undefined` included;
+- `adoptCanvasForSession`'s "re-opening your own canvas" fast path required the
+  same match;
+- the library badged a row `ownedByThisSession` only when it matched.
+
+The rule came from the 2026-08-14 adversarial review, which found a real
+canvas-theft primitive: adopting on a **project-directory match** let a second
+tile on the same repo inherit the first tile's canvas *and* its private review
+notes the moment the first tile's PTY exited. The fix correctly removed the
+directory as an automatic key. The account was added alongside it as a further
+floor.
+
+That floor turned out to be wrong, and its wrongness is ordinary rather than
+exotic. **A session id outlives an account switch** — switching accounts in a
+tile restarts the session with the same id — while the record's stamp is fixed at
+birth. So after a switch:
+
+- every canvas that tile had drawn still read as "mine" in the library, and
+  "Open here" refused it;
+- the refusal said "it may belong to a session that is still running", which was
+  not what had happened;
+- and the *active* canvas kept working, because the session→canvas index is keyed
+  on the session id alone, so the user saw one canvas behave and its siblings
+  refuse.
+
+Asked about it, the owner was unambiguous: **a canvas is project-centric, not
+account-centric.**
+
+That is also the better model. A canvas is a mockup of something in a project.
+Which Claude account happened to be signed in while it was drawn is a property of
+the session that drew it, not of the artifact — and users switch accounts inside
+one tile for reasons (rate limits, work vs personal) that have nothing to do with
+what they are designing.
+
+## Decision
+
+**The account decides nothing about a canvas.** `profileId` is removed from the
+adoption query, from the session-info resolver, from the record stamp, and from
+all three decisions above.
+
+**The project is the axis, and it organises rather than forecloses:**
+
+- the **library** is scoped to the project directory (unchanged — relevance, and
+  fail-open when either side has no cwd);
+- the **reclaim list** offers every reclaimable canvas and *marks* which are from
+  the project you are in (`sameProject`, sorted first) rather than hiding the
+  others.
+
+The distinction in that second point is deliberate. The library is already
+per-project; if the reclaim list filtered by project too, a canvas whose project
+you never open again would have no route back at all. Being locked out of your
+own canvas is a bug this app has already shipped once.
+
+**What the 2026-08-14 review actually established is untouched**, and it is worth
+restating so it is not re-litigated: a directory match must never be what MOVES a
+canvas. It still isn't. The user picks a row by id, and the one floor their
+choice cannot lower remains "a canvas whose owner might still come back is never
+taken", with its oracle failing safe.
+
+Records written before this ADR keep their `profileId` field. Nothing reads it.
+It is not validated and not stripped — rewriting every record on disk to remove a
+field nothing consults would be the riskier change.
+
+## Consequences
+
+- A tile that switches accounts keeps full access to the canvases it drew. This
+  is the reported problem, fixed.
+- The account is no longer a barrier between two sessions on the same machine.
+  This is a real reduction in separation, and it is accepted knowingly: a canvas
+  holds the user's own mockups and their own review notes, both parties are the
+  same human on the same machine, and no privilege boundary is crossed. The
+  guards that stop one *session* taking another's canvas are unchanged.
+- A future adversarial pass will find no account check here. That is intentional,
+  and this ADR is the record of why — do not re-add it without a new decision.
+- The session→canvas index remains keyed on session id alone, so the active
+  canvas follows a tile across an account switch. Under this ADR that is correct
+  behaviour rather than the leak it looked like beforehand.

--- a/src/main/canvas/canvas-session-link.ts
+++ b/src/main/canvas/canvas-session-link.ts
@@ -7,7 +7,8 @@
 // conversation, two canvases both "v1", and the user typing "repush to canvas".
 //
 // This module resolves each session's identity for the canvas store (so every
-// record is stamped with the conversation and account it belongs to) and runs
+// record is stamped with the project and conversation it belongs to — the
+// account is deliberately not part of that, see ADR-017) and runs
 // ADOPTION: a session with no canvas reclaims the canvas of the same
 // conversation. Adoption is keyed on the CONVERSATION, never the project
 // directory — see the long note on adoptCanvasForSession for why a directory
@@ -37,7 +38,6 @@ const CONVERSATION_UUID_RE = /^[0-9a-fA-F][0-9a-fA-F-]{7,63}$/
 interface SpawnInfo {
   cwd?: string
   resumeUuid?: string
-  profileId?: string
   /** Cleared once this session owns a canvas, so the retry stops running. */
   settled?: boolean
 }
@@ -105,9 +105,9 @@ function savedTileIds(): Set<string> | null {
  */
 export function noteSessionSpawnForCanvas(
   sessionId: string,
-  opts: { cwd?: string; resumeUuid?: string; profileId?: string },
+  opts: { cwd?: string; resumeUuid?: string },
 ): void {
-  spawnInfo.set(sessionId, { cwd: opts.cwd, resumeUuid: opts.resumeUuid, profileId: opts.profileId })
+  spawnInfo.set(sessionId, { cwd: opts.cwd, resumeUuid: opts.resumeUuid })
 }
 
 /**

--- a/src/main/canvas/canvas-session-link.ts
+++ b/src/main/canvas/canvas-session-link.ts
@@ -68,7 +68,6 @@ export function installCanvasSessionLink(): void {
   setCanvasSessionInfoResolver((sessionId) => ({
     cwd: spawnInfo.get(sessionId)?.cwd,
     conversationUuid: conversationUuidFor(sessionId),
-    profileId: spawnInfo.get(sessionId)?.profileId,
   }))
 }
 
@@ -183,7 +182,6 @@ export function listReclaimableCanvases(sessionId: string, openTileSessionIds: s
   const info = spawnInfo.get(sessionId)
   const ownCwd = info?.cwd
   return listOrphanCandidateCanvases(sessionId, {
-    profileId: info?.profileId,
     isSessionCurrent: currentSessionOracle(openTileSessionIds),
   })
     .map((c) => ({ ...c, sameProject: !!ownCwd && !!c.cwd && c.cwd === ownCwd }))
@@ -203,9 +201,7 @@ export function reclaimCanvasForSession(
   canvasId: string,
   openTileSessionIds: string[] = [],
 ): boolean {
-  const info = spawnInfo.get(sessionId)
   const adopted = adoptCanvasForSession(sessionId, canvasId, {
-    profileId: info?.profileId,
     // The SAME oracle the list used. Reclaim is addressed by id, so a canvas
     // the list correctly refused to offer must not be takeable by naming it.
     isSessionCurrent: currentSessionOracle(openTileSessionIds),
@@ -232,18 +228,6 @@ export function canvasCwdForSession(sessionId: string): string | undefined {
   return spawnInfo.get(sessionId)?.cwd
 }
 
-/**
- * The account a session was spawned under, or undefined for the default account
- * (and for a session we never saw spawn).
- *
- * Unlike the cwd above, this one IS part of an authorization key: it is what
- * `adoptCanvasForSession` compares against the record's stamp. The library takes
- * it so a row badged "yours" is a row the action will actually open — resolved
- * in main from its own spawn record, never accepted from the renderer.
- */
-export function canvasProfileForSession(sessionId: string): string | undefined {
-  return spawnInfo.get(sessionId)?.profileId
-}
 
 /** Drop a session's link state when its PTY is gone for good. */
 export function forgetSessionForCanvas(sessionId: string): void {

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -396,9 +396,6 @@ interface CanvasRecord extends CanvasState {
    */
   cwd?: string
   conversationUuid?: string
-  /** The account profile the owning session ran under. Part of the adoption
-   *  key: a canvas must never cross accounts (adversarial review 2026-08-14). */
-  profileId?: string
 }
 
 /**
@@ -413,14 +410,17 @@ interface CanvasRecord extends CanvasState {
  * — and the only party able to make it is the user, who is asked (see
  * canvas-session-link.listReclaimableCanvases).
  *
- * What remains is a floor the user's choice cannot lower: an account never
- * changes, and a canvas whose owner might still come back is never taken.
+ * What remains is one floor the user's choice cannot lower: a canvas whose owner
+ * might still come back is never taken.
+ *
+ * The account is deliberately NOT part of this. A canvas belongs to the PROJECT
+ * it was made for, not to whichever Claude account happened to be signed in when
+ * it was drawn — switching accounts in a tile is an ordinary thing to do, and
+ * making it an adoption key left users unable to open their own mockups. The
+ * project is the axis, and it organises rather than forecloses: the library
+ * scopes to it, the reclaim list marks and sorts by it. See ADR-017.
  */
 export interface CanvasAdoptionQuery {
-  /** The account profile this session runs under. Must equal the record's
-   *  stamp — an unstamped legacy record never crosses into a profiled session
-   *  and vice versa. */
-  profileId?: string
   /**
    * True when the given session can still come back and claim its canvas by
    * id — a live PTY, or a tile still in the saved-session list. Fails SAFE:
@@ -435,7 +435,7 @@ export type { ReclaimableCanvas }
  *  layer (canvas-session-link) so this store stays lifecycle-blind. */
 export type CanvasSessionInfoResolver = (
   sessionId: string,
-) => { cwd?: string; conversationUuid?: string; profileId?: string } | null
+) => { cwd?: string; conversationUuid?: string } | null
 
 let sessionInfoResolver: CanvasSessionInfoResolver | null = null
 
@@ -636,7 +636,9 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
   // same strictness as every other field of a record read back from disk.
   if (r.cwd !== undefined && (typeof r.cwd !== 'string' || r.cwd.length === 0 || r.cwd.length > MAX_CWD_CHARS)) return null
   if (r.conversationUuid !== undefined && (typeof r.conversationUuid !== 'string' || !CONVERSATION_UUID_RE.test(r.conversationUuid))) return null
-  if (r.profileId !== undefined && (typeof r.profileId !== 'string' || !PROFILE_ID_RE.test(r.profileId))) return null
+  // NOTE: records written before ADR-017 carry a `profileId` stamp. It decides
+  // nothing now and is neither validated nor removed — rewriting every record on
+  // disk to drop a field nothing reads would be the riskier change.
   // The title is re-cleaned rather than validated: it is free text from the
   // agent, so a record written by an older build (or hand-edited) is normalised
   // to the same shape a fresh render produces, and an unusable one simply drops
@@ -1034,16 +1036,12 @@ export function renderVersion(
     typeof info?.conversationUuid === 'string' && CONVERSATION_UUID_RE.test(info.conversationUuid)
       ? info.conversationUuid
       : undefined
-  const profileStamp =
-    typeof info?.profileId === 'string' && PROFILE_ID_RE.test(info.profileId) ? info.profileId : undefined
 
   const base: CanvasRecord = existing ?? { canvasId, sessionId, createdAt, activeVersionId: null, versions: [] }
   const nextRecord: CanvasRecord = {
     ...base,
     ...(cwdStamp && !base.cwd ? { cwd: cwdStamp } : {}),
     ...(conversationStamp ? { conversationUuid: conversationStamp } : {}),
-    // Stamped once, like cwd: the account a canvas was born under is fixed.
-    ...(profileStamp && !base.profileId ? { profileId: profileStamp } : {}),
     // The subject. Only ever set to a title that names the SAME subject (a
     // different one took the new-canvas branch above), so this fills in a
     // missing title and refreshes the wording, never repurposes the canvas.
@@ -1187,18 +1185,21 @@ export function setActiveVersion(sessionId: string, versionId: string): CanvasSt
  * the caller is expected to re-bind the canvas's review store next
  * (rebindReviewsToSession) — reviews.json carries the owner session id too.
  */
-function normalizedProfile(query: CanvasAdoptionQuery): string | undefined {
-  return typeof query.profileId === 'string' && PROFILE_ID_RE.test(query.profileId) ? query.profileId : undefined
-}
-
-/** Is `record` one this session could be OFFERED? Shared by the lister and the
- *  reclaim, so the list can never advertise something reclaim would refuse. */
+/**
+ * Is `record` one this session could be OFFERED? Shared by the lister and the
+ * reclaim, so the list can never advertise something reclaim would refuse.
+ *
+ * The project is NOT a filter here, deliberately. The library is already
+ * per-project, so if this path hid other projects' canvases too, a canvas whose
+ * project you never open again would have no route back at all — and being
+ * locked out of your own canvas is a bug this app has already shipped once. The
+ * reclaim list instead offers everything reclaimable and MARKS which rows are
+ * from the project you are in (`sameProject`, sorted first), so the project is
+ * what organises the choice rather than what forecloses it.
+ */
 function isReclaimCandidate(record: CanvasRecord, sessionId: string, query: CanvasAdoptionQuery): boolean {
   if (record.sessionId === sessionId) return false
   if (record.versions.length === 0) return false // nothing to inherit
-  // Exact, `undefined` included: an unstamped legacy record does not cross
-  // into a profiled session, and a profiled record does not cross out.
-  if (record.profileId !== normalizedProfile(query)) return false
   try {
     if (query.isSessionCurrent(record.sessionId)) return false
   } catch {
@@ -1310,33 +1311,19 @@ export function listAllCanvases(
    * a permission.
    */
   askingSessionId?: string,
-  /**
-   * The account the asking session runs under, so "mine" means the same thing
-   * here as it does to the action behind it.
-   *
-   * A session id outlives an account switch while a record's profileId is
-   * stamped at birth, and adoptCanvasForSession refuses across accounts. Badging
-   * on the session id alone therefore offered rows that "Open here" would refuse
-   * with "it may belong to a session that is still running" — a list that
-   * disagrees with the action is the shape this code has been bitten by before
-   * (canvas-session-link: "a list that refuses while the by-id reclaim allows is
-   * the hole"), inverted.
-   */
-  askingProfileId?: string,
 ): CanvasLibraryEntry[] {
   ensureDiskScanned()
   const open = new Set(openTileSessionIds.filter((id) => SESSION_ID_RE.test(id)))
   const asking = askingSessionId && SESSION_ID_RE.test(askingSessionId) ? askingSessionId : undefined
-  const askingProfile = normalizedProfile({ profileId: askingProfileId, isSessionCurrent: () => false })
   const activeForAsking = asking ? sessionIndex.get(asking) : undefined
   const out: CanvasLibraryEntry[] = []
   for (const record of canvases.values()) {
     if (projectCwd && record.cwd && record.cwd !== projectCwd) continue
     const latest = record.versions[record.versions.length - 1]
     const cwd = record.cwd?.replace(FORMAT_CONTROLS_RE, '')
-    // Exact, `undefined` included — the same comparison adoptCanvasForSession
-    // makes, so the badge and the action can never disagree.
-    const mine = asking !== undefined && record.sessionId === asking && record.profileId === askingProfile
+    // The same question adoptCanvasForSession answers, so the badge and the
+    // action can never disagree: did THIS session author it.
+    const mine = asking !== undefined && record.sessionId === asking
     out.push({
       canvasId: record.canvasId,
       versionCount: record.versions.length,
@@ -1574,18 +1561,12 @@ export function adoptCanvasForSession(
   // every session that has a library to open. Reported as "it says I can't open
   // it", with the list showing the user's own three canvases as belonging to
   // another session.
-  // The account floor still applies, though — it is the one part of the key
-  // that is NOT about who holds the index. A session id survives an in-tile
-  // account switch (useRestartSession re-adds the tile with the same id) while
-  // the record's profileId is stamped once, at birth, so after a switch every
-  // canvas this tile authored under the previous account still says "mine" and
-  // would otherwise be one click from binding to a session now running as
-  // someone else. Exact, `undefined` included, matching isReclaimCandidate:
-  // "a canvas must never cross accounts" (adversarial review 2026-08-14).
-  // A mismatch falls through rather than returning, so the machinery below gets
-  // its ordinary refusal.
+  // Nothing else applies to it. An earlier cut also required the record's
+  // account stamp to match the asking session's, which made a tile that had
+  // switched accounts unable to re-open the canvases it had drawn itself — the
+  // account is not what a canvas belongs to (ADR-017).
   const own = canvases.get(canvasId)
-  if (own && own.sessionId === sessionId && own.profileId === normalizedProfile(query)) {
+  if (own && own.sessionId === sessionId) {
     sessionIndex.set(sessionId, own.canvasId)
     emitChanged(own)
     return { canvasId: own.canvasId, activeVersionId: own.activeVersionId }

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -46,8 +46,6 @@ const MAX_CANVASES_PER_SESSION = 50
  *  (hex + dashes) — it is a MATCHING key, never a path segment. */
 const CONVERSATION_UUID_RE = /^[0-9a-fA-F][0-9a-fA-F-]{7,63}$/
 const MAX_CWD_CHARS = 1024
-/** Account-profile ids are app-minted; bounded defensively like the others. */
-const PROFILE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
 
 /**
  * The canvas serving allowlist, PER SESSION.
@@ -636,9 +634,9 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
   // same strictness as every other field of a record read back from disk.
   if (r.cwd !== undefined && (typeof r.cwd !== 'string' || r.cwd.length === 0 || r.cwd.length > MAX_CWD_CHARS)) return null
   if (r.conversationUuid !== undefined && (typeof r.conversationUuid !== 'string' || !CONVERSATION_UUID_RE.test(r.conversationUuid))) return null
-  // NOTE: records written before ADR-017 carry a `profileId` stamp. It decides
-  // nothing now and is neither validated nor removed — rewriting every record on
-  // disk to drop a field nothing reads would be the riskier change.
+  // Records written before ADR-017 carry a `profileId` stamp. It decides
+  // nothing now, so it is not validated — and because the record below is built
+  // field by field rather than spread, it simply does not survive the read.
   // The title is re-cleaned rather than validated: it is free text from the
   // agent, so a record written by an older build (or hand-edited) is normalised
   // to the same shape a fresh render produces, and an unusable one simply drops
@@ -666,11 +664,27 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
     activeVersionId = versions[versions.length - 1]?.id ?? null
   }
 
-  // The MAC is the envelope, not part of the record: strip it so the in-memory
-  // record (and therefore the NEXT persist, which re-MACs) never carries a
-  // stale one inside the authenticated content.
-  const { mac: _mac, ...rest } = r as Partial<CanvasRecord> & { mac?: unknown }
-  return { ...(rest as CanvasRecord), versions, activeVersionId }
+  // Built field by field, not spread from what was on disk.
+  //
+  // The MAC is the envelope rather than part of the record, so it has to come
+  // off — otherwise the in-memory record, and therefore the NEXT persist which
+  // re-MACs, carries a stale one inside the authenticated content. Spreading
+  // `rest` did that but also carried anything ELSE the file happened to hold: an
+  // unknown field survived validation and was written back into a freshly
+  // signed record, which is the opposite of "a hand-edited file is never
+  // repaired". Naming the fields keeps the record exactly the shape this build
+  // understands, and is also how a field that has been retired (`profileId`,
+  // ADR-017) stops travelling.
+  return {
+    canvasId: r.canvasId,
+    sessionId: r.sessionId,
+    createdAt: r.createdAt as string,
+    ...(r.cwd !== undefined ? { cwd: r.cwd } : {}),
+    ...(r.conversationUuid !== undefined ? { conversationUuid: r.conversationUuid } : {}),
+    ...(r.title !== undefined ? { title: r.title } : {}),
+    versions,
+    activeVersionId,
+  }
 }
 
 function loadFromDisk(canvasId: string): CanvasRecord | null {
@@ -1171,10 +1185,12 @@ export function setActiveVersion(sessionId: string, versionId: string): CanvasSt
  * were all consequences of treating a directory as an identity. It is not one.
  * Resuming a conversation is.
  *
- * Both halves of the key must agree and neither may be absent:
- *   - `conversationUuid` — required; no conversation, no adoption;
- *   - `profileId` — the account, compared exactly, `undefined` included, so a
- *     canvas never crosses accounts in either direction.
+ * There is no identity key here at all any more. The account used to be one —
+ * compared exactly, `undefined` included — and ADR-017 removed it: a canvas
+ * belongs to the PROJECT it was made for, not to whichever Claude account
+ * happened to be signed in, and a session id outlives an account switch, so the
+ * check locked users out of their own mockups. Do not re-add it without a new
+ * decision; the ADR is the record of why it went.
  *
  * A canvas is only adoptable when its owner session is not current per the
  * caller's check — a live PTY or a saved tile keeps its canvas reclaimable by
@@ -1271,8 +1287,9 @@ export function listOrphanCandidateCanvases(sessionId: string, query: CanvasAdop
  *
  * Addressed by id, never matched: the canvas the user picked out of
  * listOrphanCandidateCanvases is the one that moves. The floor still applies —
- * same account, owner not current — so a stale id or a canvas that came back
- * to life is refused rather than taken.
+ * owner not current — so a stale id or a canvas that came back to life is
+ * refused rather than taken. That floor is now the ONLY one (ADR-017 removed
+ * the account half), so its oracle is what the whole guarantee rests on.
  *
  * Persists BEFORE memory moves (the renderVersion discipline), and the caller
  * re-binds the review store next (rebindReviewsToSession) — reviews.json

--- a/src/main/ipc/canvas-handlers.ts
+++ b/src/main/ipc/canvas-handlers.ts
@@ -33,7 +33,6 @@ import {
 import { resolveCanvasSnapshot, setSnapshotSender } from '../canvas/canvas-snapshot-broker'
 import {
   canvasCwdForSession,
-  canvasProfileForSession,
   installCanvasSessionLink,
   listReclaimableCanvases,
   reclaimCanvasForSession,
@@ -255,11 +254,7 @@ export function registerCanvasHandlers(getWindow: () => BrowserWindow | null): v
     // record rather than accepted from the renderer, so the caller cannot ask to
     // see another project's list by naming its path.
     const cwd = sessionId ? canvasCwdForSession(sessionId) : undefined
-    // Same source, same reason, and this one decides what "yours" means: the
-    // account floor adoptCanvasForSession enforces has to be the one the badge
-    // is drawn from, or the library offers rows that "Open here" refuses.
-    const profileId = sessionId ? canvasProfileForSession(sessionId) : undefined
-    const entries = listAllCanvases(openTileSessionIds ?? [], cwd, sessionId, profileId)
+    const entries = listAllCanvases(openTileSessionIds ?? [], cwd, sessionId)
     // What is outstanding on each, joined HERE: the review store imports the
     // canvas store, so the reverse import would be a cycle, and this handler
     // already holds both (same reason the delete handler drops reviews here).

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -335,8 +335,6 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
       noteSessionSpawnForCanvas(sessionId, {
         cwd: options?.resume?.cwd ?? options?.cwd,
         resumeUuid: options?.resume?.uuid,
-        // Part of the adoption key: a canvas never crosses accounts.
-        profileId: options?.profileId,
       })
     }
 

--- a/tests/unit/main/canvas-adoption.test.ts
+++ b/tests/unit/main/canvas-adoption.test.ts
@@ -199,36 +199,28 @@ describe('reclaim candidates + adoptCanvasForSession (user-chosen)', () => {
     expect(store.adoptCanvasForSession(SID_B, '', { isSessionCurrent: notCurrent })).toBeNull()
   })
 
-  it('never crosses accounts: profileId must match exactly, undefined included', () => {
+  it('does not care which ACCOUNT a canvas was drawn under (ADR-017)', () => {
+    // A canvas belongs to the project it was made for, not to whichever
+    // Claude account happened to be signed in. Requiring the account to match
+    // meant a tile that had switched accounts could not open the mockups it
+    // had drawn itself, which is an ordinary thing to want to do.
     const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'work account', 'profile-work')
     restart()
-    // A different account is neither offered nor takeable by id.
     expect(
-      store.listOrphanCandidateCanvases(SID_B, { profileId: 'profile-personal', isSessionCurrent: notCurrent }),
-    ).toEqual([])
-    expect(
-      store.adoptCanvasForSession(SID_B, canvasId, { profileId: 'profile-personal', isSessionCurrent: notCurrent }),
-    ).toBeNull()
-    // An unprofiled session cannot take a profiled record either.
-    expect(store.adoptCanvasForSession(SID_B, canvasId, { isSessionCurrent: notCurrent })).toBeNull()
-    expect(canvasJson(canvasId).sessionId).toBe(SID_A)
-    // The matching account can.
-    const ok = store.adoptCanvasForSession(SID_B, canvasId, {
-      profileId: 'profile-work',
-      isSessionCurrent: notCurrent,
-    })
+      store.listOrphanCandidateCanvases(SID_B, { isSessionCurrent: notCurrent }).map((c) => c.canvasId),
+    ).toContain(canvasId)
+    const ok = store.adoptCanvasForSession(SID_B, canvasId, { isSessionCurrent: notCurrent })
     expect(ok?.canvasId).toBe(canvasId)
+    expect(canvasJson(canvasId).sessionId).toBe(SID_B)
   })
 
-  it('an unprofiled legacy record does not cross into a profiled session', () => {
-    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'legacy')
+  it('still refuses a canvas whose owner might come back — the one floor left', () => {
+    // Removing the account term must not weaken the guard that actually stops
+    // one tile taking a live tile$([char]39)s canvas and its private notes.
+    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'still running', 'profile-work')
     restart()
-    expect(
-      store.listOrphanCandidateCanvases(SID_B, { profileId: 'profile-work', isSessionCurrent: notCurrent }),
-    ).toEqual([])
-    expect(
-      store.adoptCanvasForSession(SID_B, canvasId, { profileId: 'profile-work', isSessionCurrent: notCurrent }),
-    ).toBeNull()
+    expect(store.adoptCanvasForSession(SID_B, canvasId, { isSessionCurrent: () => true })).toBeNull()
+    expect(canvasJson(canvasId).sessionId).toBe(SID_A)
   })
 
   it('never re-homes a session that already owns a canvas', () => {

--- a/tests/unit/main/canvas-adoption.test.ts
+++ b/tests/unit/main/canvas-adoption.test.ts
@@ -55,9 +55,8 @@ function renderAs(
   cwd: string | undefined,
   conversationUuid: string | undefined,
   body: string,
-  profileId?: string,
 ) {
-  store.setCanvasSessionInfoResolver(() => ({ cwd, conversationUuid, profileId }))
+  store.setCanvasSessionInfoResolver(() => ({ cwd, conversationUuid }))
   return store.renderVersion(sessionId, { mode: 'design', html: `<!doctype html><p>${body}</p>` })
 }
 
@@ -204,7 +203,7 @@ describe('reclaim candidates + adoptCanvasForSession (user-chosen)', () => {
     // Claude account happened to be signed in. Requiring the account to match
     // meant a tile that had switched accounts could not open the mockups it
     // had drawn itself, which is an ordinary thing to want to do.
-    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'work account', 'profile-work')
+    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'work account')
     restart()
     expect(
       store.listOrphanCandidateCanvases(SID_B, { isSessionCurrent: notCurrent }).map((c) => c.canvasId),
@@ -216,11 +215,55 @@ describe('reclaim candidates + adoptCanvasForSession (user-chosen)', () => {
 
   it('still refuses a canvas whose owner might come back — the one floor left', () => {
     // Removing the account term must not weaken the guard that actually stops
-    // one tile taking a live tile$([char]39)s canvas and its private notes.
-    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'still running', 'profile-work')
+    // one tile taking a live tile's canvas and its private notes.
+    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'still running')
     restart()
     expect(store.adoptCanvasForSession(SID_B, canvasId, { isSessionCurrent: () => true })).toBeNull()
     expect(canvasJson(canvasId).sessionId).toBe(SID_A)
+  })
+
+  it('does not carry an unknown or retired field back out of a record', () => {
+    // sanitizeRecord used to spread whatever was on disk, so a field this build
+    // does not know about survived validation and was written back into a
+    // freshly SIGNED record — the opposite of "a hand-edited file is never
+    // repaired". It also kept the retired account stamp (ADR-017) alive
+    // forever. The record is now built field by field.
+    const { canvasId } = renderAs(SID_A, CWD, CONV_1, 'one')
+    const file = path.join(getResourcesDirectory(), 'canvas', canvasId, 'canvas.json')
+
+    // A legitimately signed record that happens to carry extra keys.
+    const planted = JSON.parse(fs.readFileSync(file, 'utf8'))
+    delete planted.mac
+    planted.profileId = 'profile-work'
+    planted.hostileExtra = { secret: 'C:/Users/v/.ssh/id_ed25519' }
+    planted.mac = store._canvasRecordMacForTest(planted)
+    fs.writeFileSync(file, JSON.stringify(planted))
+
+    restart()
+    const row = store.listAllCanvases([], CWD, SID_A).find((e) => e.canvasId === canvasId)
+    expect(row).toBeTruthy() // the record still loads; only the extras are dropped
+
+    // Touch it so the store re-persists, then read what it wrote.
+    renderAs(SID_A, CWD, CONV_1, 'two')
+    const after = canvasJson(canvasId)
+    expect(after).not.toHaveProperty('profileId')
+    expect(after).not.toHaveProperty('hostileExtra')
+  })
+
+  it('never offers a session a canvas it already owns', () => {
+    // Reachable, though it looks shadowed: a session that owns two canvases is
+    // in the index under one of them, and DELETING that one clears the index
+    // entry while leaving the other still stamped with the session. The reclaim
+    // list then runs for a session that still owns a canvas — which must not be
+    // offered back to it as somebody else's stranded work.
+    store.setCanvasSessionInfoResolver(() => ({ cwd: CWD, conversationUuid: CONV_1 }))
+    const first = store.renderVersion(SID_A, { mode: 'design', title: 'one', html: '<!doctype html><p>one</p>' })
+    const second = store.renderVersion(SID_A, { mode: 'design', title: 'two', html: '<!doctype html><p>two</p>' })
+    expect(second.canvasId).not.toBe(first.canvasId)
+    store.deleteCanvas(second.canvasId)
+
+    const offered = store.listOrphanCandidateCanvases(SID_A, { isSessionCurrent: notCurrent })
+    expect(offered.map((c) => c.canvasId)).not.toContain(first.canvasId)
   })
 
   it('never re-homes a session that already owns a canvas', () => {

--- a/tests/unit/main/canvas-library-open-own.test.ts
+++ b/tests/unit/main/canvas-library-open-own.test.ts
@@ -119,81 +119,40 @@ describe('opening a canvas this session already owns', () => {
   })
 })
 
-describe('the account floor survives the "already mine" fast path', () => {
-  // "A canvas must never cross accounts" (adversarial review 2026-08-14) is
-  // enforced by isReclaimCandidate, which the own-canvas branch above runs
-  // BEFORE. That matters because a session id outlives an account switch — the
-  // tile is re-added with the same id — while the record's profileId is stamped
-  // once, at birth. So after switching accounts in a tile, every canvas that
-  // tile authored still says "mine" and would be one click from binding to a
-  // session now running as somebody else.
+describe('the ACCOUNT does not decide anything about a canvas (ADR-017)', () => {
+  // A canvas belongs to the PROJECT it was made for. Which Claude account was
+  // signed in when it was drawn is not part of its identity: a session id
+  // outlives an in-tile account switch, so making the account an adoption key
+  // left a tile unable to re-open the canvases it had drawn itself.
   const P1 = 'profile-one'
-  const P2 = 'profile-two'
 
-  it('refuses a canvas stamped with a DIFFERENT account, even to its own session', () => {
-    // Two subjects under account one, so the SECOND is what the session points
-    // at and switching back to the first is a real re-point, not a no-op.
+  it('opens a canvas drawn under a DIFFERENT account', () => {
     const first = renderAs(MINE, PROJECT, 'under account one', P1)
-    const second = renderAs(MINE, PROJECT, 'also under account one', P1)
-
-    const crossed = store.adoptCanvasForSession(MINE, first.canvasId, {
-      profileId: P2,
-      isSessionCurrent: allCurrent,
-    })
-    expect(crossed).toBeNull()
-    // ...and the refusal actually held: the session still points where it did.
-    expect(store.getCanvasStateForSession(MINE)?.canvasId).toBe(second.canvasId)
-  })
-
-  it('refuses in the other direction too: an UNSTAMPED record into a profiled session', () => {
-    const legacy = renderAs(MINE, PROJECT, 'no account stamp')
-    expect(store.adoptCanvasForSession(MINE, legacy.canvasId, {
-      profileId: P1,
-      isSessionCurrent: allCurrent,
-    })).toBeNull()
-  })
-
-  it('refuses a PROFILED record to the same session now on the DEFAULT account', () => {
-    // The third direction, and the one a real user takes most often: switching
-    // a tile BACK to the default account, where the query carries no profile at
-    // all. A floor written as "only compare when a profile was given" passes
-    // both cases above and lets this one through.
-    const first = renderAs(MINE, PROJECT, 'one', P1)
     renderAs(MINE, PROJECT, 'two', P1)
-    expect(store.adoptCanvasForSession(MINE, first.canvasId, {
-      isSessionCurrent: allCurrent,
-    })).toBeNull()
-  })
-
-  it('badges a row "mine" only when the action would actually open it', () => {
-    // The library and the action must answer the same question. Badging on the
-    // session id alone offered rows that Open here refuses, with a message
-    // about a session that is still running — which is not what happened.
-    const authored = renderAs(MINE, PROJECT, 'under account one', P1)
-
-    const sameAccount = store.listAllCanvases([], PROJECT, MINE, P1)
-      .find((e) => e.canvasId === authored.canvasId)
-    expect(sameAccount?.ownedByThisSession).toBe(true)
-
-    const afterSwitch = store.listAllCanvases([], PROJECT, MINE, P2)
-      .find((e) => e.canvasId === authored.canvasId)
-    // Still listed — the library shows everything — but not as this session's.
-    expect(afterSwitch).toBeTruthy()
-    expect(afterSwitch?.ownedByThisSession).toBeUndefined()
-    expect(afterSwitch?.isActiveForThisSession).toBeUndefined()
-  })
-
-  it('still opens the session\'s own canvas when the account MATCHES', () => {
-    // The floor must not cost the fix it sits inside: same session, same
-    // account, an earlier canvas that a new subject filed.
-    const first = renderAs(MINE, PROJECT, 'one', P1)
-    renderAs(MINE, PROJECT, 'two', P1)
-    const reopened = store.adoptCanvasForSession(MINE, first.canvasId, {
-      profileId: P1,
-      isSessionCurrent: allCurrent,
-    })
+    const reopened = store.adoptCanvasForSession(MINE, first.canvasId, { isSessionCurrent: allCurrent })
     expect(reopened?.canvasId).toBe(first.canvasId)
     expect(store.getCanvasStateForSession(MINE)?.canvasId).toBe(first.canvasId)
+  })
+
+  it('badges it as yours in the library too, so list and action agree', () => {
+    const authored = renderAs(MINE, PROJECT, 'under account one', P1)
+    const row = store.listAllCanvases([], PROJECT, MINE).find((e) => e.canvasId === authored.canvasId)
+    expect(row?.ownedByThisSession).toBe(true)
+  })
+
+  it('opens an UNSTAMPED legacy canvas just the same', () => {
+    const legacy = renderAs(MINE, PROJECT, 'no account stamp')
+    expect(store.adoptCanvasForSession(MINE, legacy.canvasId, { isSessionCurrent: allCurrent })?.canvasId)
+      .toBe(legacy.canvasId)
+  })
+
+  it('mentions the account nowhere in what the library hands back', () => {
+    // The stamp may still exist on records written before ADR-017. Nothing
+    // reads it, and it must not leak into a row the renderer draws.
+    renderAs(MINE, PROJECT, 'under account one', P1)
+    for (const row of store.listAllCanvases([], PROJECT, MINE)) {
+      expect(Object.keys(row)).not.toContain('profileId')
+    }
   })
 })
 

--- a/tests/unit/main/canvas-session-link.test.ts
+++ b/tests/unit/main/canvas-session-link.test.ts
@@ -123,6 +123,52 @@ describe('a canvas whose own tile is still open', () => {
   })
 })
 
+describe('the saved-tile half of the currency oracle', () => {
+  // Since ADR-017 removed the account term, "is the owner still current" is
+  // the ONLY floor under a reclaim. Its three branches are a live PTY, an open
+  // tile the renderer told us about, and the saved-tile file — and until these
+  // tests the saved-tile branches had never executed: the harness pins
+  // savedState to null and savedStateFileExists to false everywhere else.
+  // Mutating either branch to "not current" left the whole canvas suite green.
+
+  it('refuses a canvas whose owner is a SAVED TILE, not a running one', () => {
+    const canvasId = renderAs(OWNER, PROJECT, CONV)
+    restart()
+    // Graceful Save & Close: no PTY anywhere, and the renderer has not yet
+    // said which tiles it restored — the state file is all we have.
+    h.savedState = { sessions: [{ id: OWNER }] }
+    h.savedStateFileExists = true
+
+    expect(link.listReclaimableCanvases(ASKER, [])).toEqual([])
+    expect(link.reclaimCanvasForSession(ASKER, canvasId, [])).toBe(false)
+  })
+
+  it('treats a state file it cannot read as UNKNOWN, so nothing is takeable', () => {
+    // The fail-safe that matters at boot: the file is there, it did not parse,
+    // and we cannot tell who was open. Fail open here and a reclaim during the
+    // restore window takes a tile that is about to come back.
+    const canvasId = renderAs(OWNER, PROJECT, CONV)
+    restart()
+    h.savedState = null
+    h.savedStateFileExists = true
+
+    expect(link.listReclaimableCanvases(ASKER, [])).toEqual([])
+    expect(link.reclaimCanvasForSession(ASKER, canvasId, [])).toBe(false)
+  })
+
+  it('still offers it once the saved tiles are known and the owner is NOT among them', () => {
+    // The floor must not become "never" — that would make every stranded
+    // canvas unreachable, which is the bug the reclaim path exists to fix.
+    const canvasId = renderAs(OWNER, PROJECT, CONV)
+    restart()
+    h.savedState = { sessions: [{ id: 'cccc3333cccc3333cccc3333' }] }
+    h.savedStateFileExists = true
+
+    expect(link.listReclaimableCanvases(ASKER, []).map((c) => c.canvasId)).toContain(canvasId)
+    expect(link.reclaimCanvasForSession(ASKER, canvasId, [])).toBe(true)
+  })
+})
+
 describe('what the card is given to tell candidates apart', () => {
   it('carries the conversation short id, so two canvases from one project differ', () => {
     const first = renderAs(OWNER, PROJECT, CONV)


### PR DESCRIPTION
fix(canvas): a canvas belongs to its project, not to an account

Which Claude account was signed in when a mockup was drawn is a property of the
session that drew it, not of the artifact. Requiring it to match was wrong in an
ordinary way rather than an exotic one: a session id outlives an account switch —
switching accounts in a tile restarts the session with the same id — while the
record's stamp is fixed at first render. After a switch, every canvas that tile
had drawn still read as "mine" in the library and "Open here" refused it, saying
it might belong to a session that is still running, which was not what had
happened. The ACTIVE canvas meanwhile kept working, because the session-to-canvas
index is keyed on the session id alone. One canvas behaved and its siblings
refused.

So `profileId` comes out of the adoption query, the session-info resolver, the
record stamp, and all three decisions that consulted it — reclaim candidacy, the
own-canvas fast path, and the library badge. Records written earlier keep the
field: nothing reads it, and rewriting every record on disk to drop a dead field
is the riskier change.

The project is the axis, and it organises rather than forecloses. The library
stays scoped to the project directory; the reclaim list goes on offering
everything reclaimable and MARKING which rows are from the project you are in. I
tried filtering that list by project too and backed it out — the library is
already per-project, so filtering both would leave a canvas whose project you
never open again with no route back, and being locked out of your own canvas is a
bug this app has already shipped once.

What the 2026-08-14 adversarial review established is untouched, and ADR-017 says
so explicitly so it is not re-litigated: a directory match must never be what
MOVES a canvas. It still isn't. The user picks a row by id, and the one floor
their choice cannot lower — a canvas whose owner might still come back is never
taken — is unchanged, oracle still failing safe.
