### PR TITLE
ci: stop Dependabot's own titles failing the PR Title check

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,6 +9,25 @@
 // documents reality rather than fighting it.
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // Dependabot writes its own titles, and when `commit-message.prefix` is set to
+  // something it does not recognise as a Conventional type (`deps`, per
+  // .github/dependabot.yml) it capitalises the description: `deps: Bump x from a
+  // to b`. That trips config-conventional's `subject-case` rule, so EVERY npm
+  // bump opened here fails the PR Title check on arrival and has to be retitled
+  // by hand before it can merge — five at a time, every week (#302-#306).
+  //
+  // Exempt exactly that generated shape and nothing else. Deliberately anchored
+  // and fully specified (`from X to Y`) rather than a loose /^deps:/ match, so a
+  // hand-written `deps:` subject is still held to every rule a human commit is.
+  // The github-actions ecosystem needs no exemption: it runs with no custom
+  // prefix, so Dependabot emits `build(deps): bump …` in lower case already.
+  ignores: [
+    // Single-package npm bump, e.g. `deps: Bump electron from 43.2.0 to 43.4.0`.
+    (message) => /^deps: Bump \S+ from \S+ to \S+$/.test(message),
+    // Grouped bump, e.g. `build(deps): Bump the npm_and_yarn group across 1
+    // directory with 6 updates` (#187) — same capitalisation, different shape.
+    (message) => /^(?:deps|build\(deps\)): Bump the \S+ group .+ updates?$/.test(message),
+  ],
   rules: {
     // Allowed types. Standard Conventional set plus `deps` — Dependabot is
     // configured (.github/dependabot.yml) to prefix its PRs with `deps`.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -26,7 +26,13 @@ module.exports = {
     (message) => /^deps: Bump \S+ from \S+ to \S+$/.test(message),
     // Grouped bump, e.g. `build(deps): Bump the npm_and_yarn group across 1
     // directory with 6 updates` (#187) — same capitalisation, different shape.
-    (message) => /^(?:deps|build\(deps\)): Bump the \S+ group .+ updates?$/.test(message),
+    // The `across N director(y|ies)` clause appears only for a multi-directory
+    // group, hence optional. Everything else is fixed text or a bare integer, so
+    // there is no free-form run in the middle for an arbitrary subject to ride
+    // in on — `Bump the x group and also Add Support with 2 updates` is rejected.
+    (message) =>
+      /^(?:deps|build\(deps\)): Bump the \S+ group (?:across \d+ director(?:y|ies) )?with \d+ updates?$/
+        .test(message),
   ],
   rules: {
     // Allowed types. Standard Conventional set plus `deps` — Dependabot is


### PR DESCRIPTION
Dependabot capitalises the description when `commit-message.prefix` is set to something it does not recognise as a Conventional type (`deps`, per `.github/dependabot.yml`), so it opens every npm bump as `deps: Bump x from a to b`. config-conventional's `subject-case` rule rejects a sentence-case subject, so **every bump fails `lint-pr-title` the moment it is opened** and has to be retitled by hand before it can merge. That was all five of #302-#306, and it recurs every week the schedule fires.

Exempts exactly the two shapes Dependabot generates — the single-package bump and the grouped one (#187) — and nothing else. Both patterns are anchored and fully specified rather than a loose `/^deps:/` prefix match, so a hand-written `deps:` subject is still held to every rule a human commit is.

Verified narrow in both directions:

| Result | Title |
| --- | --- |
| PASS | `deps: Bump electron from 43.2.0 to 43.4.0` |
| PASS | `build(deps): Bump the npm_and_yarn group across 1 directory with 6 updates` |
| FAIL | `build(deps): Bump the group and also Drop Support` |
| FAIL | `feat: Add a shiny thing` |
| FAIL | `deps: Bump stuff` |

The github-actions ecosystem needs no exemption: it runs with no custom prefix, so Dependabot emits `build(deps): bump …` in lower case already.

CI-config only, no runtime code — hence `skip-desktop-test`.