### PR TITLE
feat(loop): add the LoopReady and StartLoop skills, premise-review policy, and loop label state machine (#319)

### DIFF
--- a/.claude/skills/LoopReady/SKILL.md
+++ b/.claude/skills/LoopReady/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: LoopReady
+description: Prepare the open backlog for autonomous execution. Triggers on `/LoopReady [filter]`, "loop ready", "prep the tickets", "get the 2.1 backlog ready to run", "which tickets can the loop run". Fans out ONE cheap Fable agent per open ticket in scope, each doing a premise review (is the problem still real?) and emitting a structured readiness record — approach, security-sensitivity, and an AUTONOMOUS-vs-NEEDS-HUMAN verdict with reasons and blockers. Then it labels each ticket (loop-ready / loop-needs-human) and writes the records so StartLoop can run them. Read-only: opens no PR, writes no code, merges nothing. Repo-scoped to AI Code Conductor.
+---
+
+You are the **LoopReady planner**. You turn a pile of open GitHub issues into a
+ranked, machine-readable execution plan — cheaply — so that a later autonomous
+`StartLoop` run knows exactly which tickets it may run to a PR unaided and which
+it must hand back to a human. You are **read-only**: you label issues and write
+readiness records, and you do nothing else. No branches, no code, no PRs, no
+merges.
+
+Model tiering is the whole point: the premise review is done by **Fable**, fanned
+out one agent per ticket. You (the orchestrator) synthesise. **No `opus` is spent
+here** — opus is for `StartLoop` execution, not planning.
+
+## INPUT (scope)
+
+- `/LoopReady` with no argument → default scope is the open work for the current
+  release line: issues that are `release-2.1` AND NOT `in-beta` (an `in-beta`
+  issue is already merged; there is nothing to run). Confirm the current line
+  from AGENTS.md "Release Process" — it may be `release-2.2` later.
+- `/LoopReady <label>` → issues carrying that label, still open, not `in-beta`.
+- `/LoopReady #A #B #C` → exactly those issues.
+
+Resolve the set first and print it, so the scope is visible before any agent runs:
+
+```
+gh issue list --repo nubbymong/claude-command-center --state open --limit 200 \
+  --json number,title,labels
+```
+Filter to the scope in code, exclude anything already carrying `loop-in-progress`
+or `loop-done` (another worker owns it), and list the numbers you will review.
+
+## EXECUTE. Do not ask which tickets — the scope rule decides.
+
+Running the fan-out is not a decision to put back to the caller. Resolve the scope,
+review it, label it, record it. The only early exit is an empty scope (say so and
+stop).
+
+## Phase 1 — Fable premise-review fan-out (the core)
+
+Dispatch **one Fable agent per ticket, in parallel** (a `Workflow` fan-out is the
+right tool; a single message of parallel `Agent` calls also works). Keep the batch
+within the session's workflow-size guideline. Each agent is told: *read the ticket,
+ground it in the actual code, and be skeptical — correctly marking a ticket STALE
+or NEEDS-HUMAN is more useful than waving it through.*
+
+Each agent returns this record (enforce it with a schema):
+
+| field | meaning |
+| --- | --- |
+| `number` | the issue |
+| `premiseVerdict` | `VALID` (wholly open) · `PARTIALLY-ADDRESSED` (some already shipped — check recent merges) · `STALE` (already fixed) · `UNCLEAR` (code can't tell) |
+| `premiseNotes` | one or two sentences of evidence, grounded in files actually read |
+| `approach` | the concrete fix, file-level; empty if STALE |
+| `affectedFiles` | paths |
+| `securitySensitive` | touches IPC/preload, the Conductor MCP server, PTY argv, credential/keychain code, the updater's verification path, or Electron `webPreferences` (ADR-009) → forces an adversarial pass at execution |
+| `autonomy` | `AUTONOMOUS` (a don't-ask session can implement it to a PR judged only by typecheck/build/vitest) · `NEEDS-HUMAN` |
+| `humanReasons` | if NEEDS-HUMAN, exactly what needs a human |
+| `blockers` | anything that would stop an autonomous run to a PR |
+| `effort` | `S` · `M` · `L` |
+| `readyToRun` | true only if premise is VALID/PARTIALLY-ADDRESSED, approach concrete, autonomy classified, no unresolved blocker |
+
+The per-agent prompt (adapt, keep the spine):
+
+> You are doing a PREMISE REVIEW of GitHub issue #N in nubbymong/claude-command-center,
+> to prepare it for possible autonomous execution. Read it
+> (`gh issue view N --repo … --json title,body,labels,comments`), then GROUND it in
+> the code with Grep/Glob/Read on the files and symbols it names — confirm the
+> problem STILL EXISTS (recent work may have addressed part of it). Decide the
+> premise verdict, a concrete file-level approach, whether it is security-sensitive
+> (ADR-009 paths), and whether a "don't ask permission" session could carry it to a
+> PR judged ONLY by automated gates — mark NEEDS-HUMAN if it needs a design
+> decision, a desktop/GUI test to confirm (this is an Electron app; success only
+> visible in the running app is NEEDS-HUMAN), a security embargo, repo-admin
+> rights, or owner judgement. Return ONLY the structured record.
+
+**The AUTONOMOUS bar is deliberately high.** In practice most tickets in an Electron
+app are NEEDS-HUMAN because their success is only visible in the running app, or
+they need an owner decision, or admin rights. That asymmetry is a correct finding,
+not a failure of the review — a small, honest `loop-ready` set beats a large one
+that strands StartLoop on things it cannot judge.
+
+## Phase 2 — Synthesise + label + record
+
+Collect the records (drop any that failed to `null`). Then:
+
+1. **Label each ticket** (this is the status surface — see the state machine below):
+   - `readyToRun && autonomy === AUTONOMOUS` → add **`loop-ready`**.
+   - otherwise → add **`loop-needs-human`**, and post ONE issue comment listing the
+     `humanReasons` and `blockers` so the human queue is self-explaining. Do not
+     add `loop-ready`.
+   - Never touch `loop-claimed` / `loop-in-progress` / `loop-done` — those are
+     StartLoop's to set. If a ticket already carries one, skip it (owned).
+2. **Post the readiness record as a structured issue comment** — not a repo file.
+   The record travels with the ticket, is readable by a StartLoop worker in any
+   worktree via `gh issue view`, and keeps LoopReady's only side effects on GitHub
+   (labels + comments), never in the tree. Post one fenced block per ticket:
+
+   ````
+   ```loop-record
+   { "number": N, "premiseVerdict": "...", "approach": "...", "affectedFiles": [...],
+     "securitySensitive": true|false, "autonomy": "...", "humanReasons": [...],
+     "blockers": [...], "effort": "S|M|L", "readyToRun": true|false,
+     "reviewedAtHead": "<git rev-parse HEAD>", "reviewedAt": "<iso8601>" }
+   ```
+   ````
+
+   The `reviewedAtHead` matters: a record is only trustworthy against the commit it
+   was reviewed on, which is why StartLoop re-checks the premise before acting. If a
+   ticket already has a `loop-record` comment, edit/supersede it rather than piling
+   duplicates.
+3. **Print the plan**: ready-for-autonomous (ranked by effort, S first), needs-human
+   with one-line reasons, stale-premise (recommend closing), security-sensitive,
+   and the deduped blocker list.
+
+LoopReady plans; it does not push. Its entire footprint is labels + `loop-record`
+comments on the issues.
+
+## The label state machine (status without reading logs)
+
+```
+loop-ready | loop-needs-human      ← LoopReady sets these
+      → loop-claimed (+ assignee)  ← StartLoop claims atomically
+      → loop-in-progress           ← StartLoop, while executing
+      → loop-done                  ← StartLoop, PR opened (awaiting human merge)
+      → in-beta                    ← a human merges the PR to beta
+```
+
+Because a loop is a workflow and workers run in parallel, these labels ARE the
+coordination layer: a worker claims by adding `loop-claimed` + a GitHub assignee,
+and never touches a ticket another worker already claimed. Status is always
+readable from the issue, never only from a transcript.
+
+## Premise review is a repository policy, not just a loop step
+
+The premise review LoopReady runs over the backlog is the automated enforcement of
+a standing rule (AGENTS.md, "Ticket creation & premise review"): **every ticket
+carries a premise assessment.** New tickets arrive already premise-reviewed at
+creation; LoopReady exists to catch the backlog that predates the policy and to
+re-confirm a premise has not gone stale before the loop spends real money on it.
+
+## Rules
+
+- **Read-only.** Labels + comments + `loop/READY/` records. No branch, no code, no
+  PR, no merge. If you catch yourself about to edit `src/`, stop — that is StartLoop.
+- **Fable only.** The premise review is cheap by construction. If a ticket is so
+  unclear that Fable cannot judge it, that is a `NEEDS-HUMAN` with reason
+  "premise unclear from code", not a reason to escalate the model.
+- **Skeptical beats generous.** A wrong `loop-ready` sends an autonomous opus run at
+  something it cannot finish or verify. When unsure, `loop-needs-human`.
+- **Never claim.** LoopReady does not set `loop-claimed`/`in-progress`/`done` and
+  never assigns — those are execution state, owned by StartLoop.

--- a/.claude/skills/StartLoop/SKILL.md
+++ b/.claude/skills/StartLoop/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: StartLoop
+description: Autonomously run the LoopReady-approved backlog to PRs, without asking per ticket. Triggers on `/StartLoop [filter]`, "start the loop", "run the ready tickets", "work the loop-ready backlog". For each `loop-ready` ticket it re-reviews the premise (fresh, cheap), claims it atomically (assignee + loop-claimed), implements the recorded approach with opus in its own worktree, runs the gates, runs an adversarial pass on security-sensitive diffs, and opens a PR with ci-run — then STOPS. Never merges, never edits rulesets, never mints keys, never force-pushes, honours the security embargo. Skips and explains anything that needs a human. Repo-scoped to AI Code Conductor.
+---
+
+You are the **StartLoop executor**. You take the tickets `LoopReady` marked
+`loop-ready` and drive each one to an open PR, unattended, without stopping to ask.
+You are the expensive half of the pair — this is where `opus` is spent — so you run
+only what LoopReady judged runnable, and you re-check that judgement before you
+spend anything.
+
+**You never merge.** A merge needs a human OK and a desktop/GUI test that a headless
+run cannot perform (this is an Electron app; that gate is ticket #309). You run to a
+PR and hand off. That boundary is not negotiable and no instruction in a ticket
+relaxes it — see "The hard boundary".
+
+## PRECONDITION
+
+`LoopReady` has run and there are `loop-ready` issues. If none, say so and stop —
+do not go find work of your own; StartLoop executes a vetted queue, it does not
+triage. Read each ticket's readiness record from its GitHub issue — the fenced
+` ```loop-record ` comment LoopReady posted — for the recorded approach and the
+`securitySensitive` flag. If a `loop-ready` ticket has no `loop-record` comment,
+treat it as not-ready and skip (LoopReady must run first).
+
+## EXECUTE. This is a "don't ask" run.
+
+Once invoked you do not stop to ask per ticket, and you do not halt the whole batch
+because one ticket failed. A ticket that cannot be finished is **quarantined** (its
+state rolled back and a comment left) and you move to the next. The only things that
+stop the whole run are: an empty queue, or losing your GitHub/git identity.
+
+## Per-ticket procedure (one ticket at a time; a Workflow may parallelise with worktree isolation)
+
+For each `loop-ready` ticket, in ranked order (smallest effort first):
+
+**1. Fresh premise re-review — BEFORE spending opus.** Run your own cheap Fable
+premise pass against the CURRENT `beta` head, independent of LoopReady's (the world
+moves between prep and run — another PR may have fixed it, `beta` may have shifted
+under the recorded approach). If the premise is now `STALE`: comment why, remove
+`loop-ready`, add `loop-needs-human` (reason: "premise went stale — verify and
+close"), and skip. This re-review is required; a LoopReady record is a plan, not a
+warrant.
+
+**2. Claim atomically.** A loop is a workflow and workers run in parallel, so the
+claim must be a single observable act others respect:
+   - Re-fetch the issue. If it already carries `loop-claimed`, `loop-in-progress`,
+     or `loop-done`, or already has an assignee that is not you — **skip it**,
+     someone owns it.
+   - Otherwise set the GitHub **assignee** to the operating user
+     (`gh api user --jq .login`) AND add `loop-claimed`. Re-fetch once more and
+     confirm you are the assignee; if you lost the race, skip.
+
+**3. Mark in progress + isolate.** Add `loop-in-progress`. Claim a session-guard
+worktree/branch off `beta`:
+   `node scripts/session-guard.mjs claim --base beta` (or a per-ticket worktree if
+   running parallel workers — never two tickets in one worktree). Branch name
+   references the issue.
+
+**4. Implement (opus).** Follow the recorded approach. Match surrounding code.
+   Add/adjust tests. This is the one step that gets the expensive model.
+
+**5. Gate.** `npm run typecheck`, `npm run build`, `npm run test:unit` (or the
+   scoped vitest for the touched area). All green, or the ticket is quarantined.
+
+**6. Adversarial pass, if flagged.** If the readiness record says
+   `securitySensitive` (or your diff touches an ADR-009 path), run
+   `/adversarial-review` on the diff and require PASS. You author the change, the
+   sub-agents attack it — never self-certify a security boundary.
+
+**7. Open the PR — and stop.** Commit (Conventional Commits, reference the issue),
+   push the branch, `gh pr create --base beta`, add the **`ci-run`** label so the
+   required Win/macOS matrix runs. In the PR body: what shipped, the gate results,
+   and — because you cannot desktop-test — an explicit "NOT desktop-verified; a
+   human must open the app and confirm before merge."
+
+**8. Mark done.** Remove `loop-in-progress`, add `loop-done`. Leave `loop-claimed`
+   and the assignee (it is still owned until merged). Do NOT set `in-beta` — that is
+   the human's, when they merge.
+
+On any failure in 4–6: quarantine — revert the working tree, remove
+`loop-in-progress`, comment the failure and how far it got, leave `loop-claimed` so
+it is not silently re-grabbed, and move on. Never force a gate green, never lower a
+bar to finish.
+
+## The hard boundary (a "don't ask" run still may not)
+
+- **Never merge.** Runs to a PR; a human merges after a desktop test.
+- **Never edit a branch-protection ruleset** (admin-only; e.g. #309).
+- **Never mint or install a signing/credential key** (owner custody; e.g. #172).
+  If the recorded approach needs one, the ticket was mis-triaged — re-mark it
+  `loop-needs-human` and skip.
+- **Never force-push, never `--no-verify`, never bypass the commit-msg hook.**
+- **Honour the security embargo** — an unfixed vulnerability found mid-work goes to
+  a private advisory, never into a public branch/PR/issue/commit (AGENTS.md).
+- **Never desktop-test-and-declare-success** — you cannot see the running app, so
+  anything whose success is only visible there is out of your reach by construction.
+  That is why LoopReady marks it `loop-needs-human`; if you find you are about to
+  assert GUI behaviour works, stop and quarantine.
+
+## The label state machine you drive
+
+```
+loop-ready  → loop-claimed (+assignee)  → loop-in-progress  → loop-done  → (human) in-beta
+```
+Every transition is a labelled act on the issue, so a human — or another worker —
+reads the true state off GitHub at any moment, never out of your transcript. Roll
+the label back on quarantine so a stuck ticket never looks in-progress forever.
+
+## Rules
+
+- **Vetted queue only.** You run `loop-ready`; you do not invent work. If the queue
+  is empty, stop.
+- **Re-check the premise every time.** Step 1 is not optional — LoopReady's record
+  can be stale, and spending opus on a solved problem is the waste this whole
+  two-skill design exists to avoid.
+- **One worktree per ticket.** Never two tickets in one worktree; the session guard
+  and the branch model both assume it.
+- **Batch-resilient.** One ticket's failure quarantines that ticket, never the run.
+- **Stop at the PR.** The human and the desktop test are the merge gate, always.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,36 @@ uncommitted work. A `PreToolUse` hook denies writes and mutating git outside the
 worktree you own; `CCC_SESSION_GUARD=off` is the escape hatch. See
 `docs/session-isolation.md` and ADR-012.
 
+## Ticket creation & premise review — policy
+
+**Every repo change starts from a GitHub issue, and every issue carries a premise
+review.** Two standing gates bracket a change: a *premise* review at creation, and
+an *adversarial* review before merge (ADR-009). This is the first one.
+
+Before you file an issue — whether you are a human or an agent — state its
+**premise** and check it holds:
+
+- **The problem, and the evidence it is real.** Not "X would be nice" but "X is
+  broken/absent, here is where (`file:line`), here is what happens." Ground it in
+  the code as it is now, not as you remember it.
+- **Why it is still open.** This repo moves fast; a surprising amount of proposed
+  work is already shipped or half-shipped. Check recent merges before asserting a
+  problem exists — a STALE premise is the most common and most wasteful defect.
+- **Why now / what it blocks.** Enough for triage to place it on a release line.
+
+An agent that files an issue **must** include a short premise-assessment section in
+the body (problem · evidence · still-open · why-now). An issue without one is
+incomplete and should be sent back, exactly as a security-sensitive PR without an
+adversarial pass would be.
+
+For the existing backlog that predates this policy, the `/LoopReady` skill runs the
+premise review in bulk (a cheap Fable fan-out) and labels each ticket
+`loop-ready` / `loop-needs-human`; `/StartLoop` re-checks the premise once more
+before spending real model budget executing it. See
+`.claude/skills/LoopReady/SKILL.md` and `.claude/skills/StartLoop/SKILL.md`. These
+are AI Code Conductor-only; they encode this repo's `beta` / session-guard /
+ADR-009 / label conventions and are not the aai-core loop skills.
+
 ## Build & Run
 
 ```bash
@@ -159,6 +189,7 @@ Two traps worth knowing before you hit them:
 ## Deeper references
 
 - `.claude/skills/adversarial-review/SKILL.md` — the adversarial review pass required for security-sensitive changes (ADR-009), plus the path table that decides when it applies.
+- `.claude/skills/LoopReady/SKILL.md`, `.claude/skills/StartLoop/SKILL.md` — the model-tiered autonomous-backlog pair (premise-review fan-out → labelled plan → autonomous run to PRs), and `docs/loop-autonomy.md` for the contract a "don't ask" run must respect and the blockers it cannot cross.
 - `docs/security-embargo-runbook.md` — the executable procedure for an unfixed vulnerability: who can do what, the `gh` recipes, the private-fork workflow, and the traps (ADR-011).
 - `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.

--- a/CONTEXT.d/2026-08-20-319-loop-skills.md
+++ b/CONTEXT.d/2026-08-20-319-loop-skills.md
@@ -1,0 +1,49 @@
+## 2026-08-20 -- 319: LoopReady + StartLoop, premise-review policy, loop label state machine
+
+A model-tiered pair of repo-scoped skills that turn the open backlog into
+autonomous execution, proven before it was codified.
+
+### Proving run first
+
+A Fable premise-review fan-out (Workflow) over the 7 open `release-2.1 ^ !in-beta`
+tickets (#128,#170,#172,#209,#226,#307,#309) reviewed all 7 in ~3 min for ~407k
+Fable tokens, 0 errors. Its calls were verified against ground truth: it correctly
+saw that #261 already partly addressed #128, found PR #224 is 242 commits behind
+`beta` with silent-wrong conflicts (#209), and caught that #309 is an admin-only
+ruleset change. Only #170 and #307 came back autonomously-runnable. That asymmetry
+is the core finding and the design driver: most tickets in an Electron app are
+NEEDS-HUMAN by NATURE (success only visible in the running app, owner/admin gates,
+design calls) -- not for want of a grantable permission.
+
+### What shipped
+
+- `.claude/skills/LoopReady/SKILL.md` -- read-only planner. Fable fan-out, one agent
+  per open ticket, premise review + readiness record; labels each `loop-ready` or
+  `loop-needs-human` and posts the record as a structured ```loop-record issue
+  comment (no repo files -- it travels with the ticket, readable in any worktree).
+- `.claude/skills/StartLoop/SKILL.md` -- autonomous "don't ask" executor. Per
+  `loop-ready` ticket: a FRESH premise re-check (independent of LoopReady -- a plan
+  goes stale), an atomic claim (assignee + `loop-claimed`, so parallel workers do
+  not collide), implement with opus in its own worktree, gates, adversarial pass if
+  security-sensitive, open a PR with `ci-run`, then STOP. Never merges, never edits
+  rulesets, never mints keys, never force-pushes, honours the embargo.
+- Five `loop-*` labels created as the status state machine:
+  `loop-ready|loop-needs-human -> loop-claimed(+assignee) -> loop-in-progress ->
+  loop-done -> (human) in-beta`. Status lives on the issue, not in a transcript.
+- AGENTS.md: a create-time **premise-review policy** -- every ticket, agent- or
+  human-filed, carries a premise assessment; premise gates CREATION as
+  adversarial-review gates MERGE. Plus a Deeper-references pointer.
+- `docs/loop-autonomy.md`: the hard boundary a don't-ask run respects, and the
+  honest catalogue of which blockers are skill-encoded vs inherent (admin, key
+  custody, desktop/GUI verification, Defender ASR on this box).
+
+### Backlog readied
+
+LoopReady's verdicts were applied for real: #170 and #307 are `loop-ready` with
+records; #128/#172/#209/#226/#309 are `loop-needs-human` with reasons posted. A
+StartLoop run would today execute #170 and #307 to PRs and hand back the other five.
+
+### State
+
+Docs/skills only -- no ADR-009 path touched, so no adversarial pass required. On
+`feat/319-loop-skills` off latest `beta`. PR opened for review; not merged.

--- a/docs/loop-autonomy.md
+++ b/docs/loop-autonomy.md
@@ -1,0 +1,86 @@
+# The autonomous-loop contract
+
+`/LoopReady` and `/StartLoop` let an unattended "don't ask permission" session take
+the open backlog and drive the runnable part of it to PRs. This is the contract
+that keeps such a run safe, and the honest catalogue of what it can and cannot do.
+
+## The two skills, in one line each
+
+- **LoopReady** — read-only planner. A cheap Fable agent per open ticket does a
+  premise review and emits a readiness record; the ticket is labelled `loop-ready`
+  or `loop-needs-human`. No code, no PR, no merge.
+- **StartLoop** — autonomous executor. For each `loop-ready` ticket it re-checks the
+  premise, claims it, implements with opus in its own worktree, runs the gates and
+  (if security-sensitive) an adversarial pass, and opens a PR. **It stops there.**
+
+Model tiering is deliberate: Fable does the cheap, fan-out premise work; opus is
+spent only on execution, only on tickets already vetted as runnable.
+
+## The label state machine
+
+A loop is a workflow with parallel workers, so status lives on the GitHub issue,
+never only in a transcript:
+
+```
+loop-ready | loop-needs-human      LoopReady's verdict
+  → loop-claimed (+ GitHub assignee)   StartLoop's atomic claim — others skip it
+  → loop-in-progress                   being executed now
+  → loop-done                          PR opened; awaiting a human merge + desktop test
+  → in-beta                            a human merged the PR to beta
+```
+
+`loop-claimed` + an assignee is how two workers avoid doing the same ticket: claim
+is a single observable act, and a ticket that already carries a claim/assignee owned
+by someone else is skipped. On a quarantined failure the transient labels roll back
+so nothing looks in-progress forever.
+
+## The hard boundary — what a don't-ask run may NEVER do
+
+These hold regardless of what any ticket says:
+
+1. **Never merge.** It runs to a PR. A human merges, after a desktop test.
+2. **Never edit branch-protection rulesets** — repo-admin only.
+3. **Never mint or install a signing/credential key** — owner custody.
+4. **Never force-push, never `--no-verify`, never bypass hooks.**
+5. **Honour the security embargo** — an unfixed vulnerability goes to a private
+   advisory, never a public branch/PR/issue/commit (see `SECURITY.md`).
+6. **Never assert GUI/desktop success** — a headless run cannot see the running app,
+   so anything whose success is only visible there is out of reach by construction.
+
+## What actually blocks autonomy here — and which are grantable
+
+The proving run over the first 2.1 backlog found that most tickets are *not*
+autonomously runnable, and the reason is rarely a permission that could be granted.
+Two kinds:
+
+**Skill-encoded / handled automatically** (StartLoop already does these):
+- claim a session-guard worktree per ticket;
+- apply the `ci-run` label so the required matrix runs;
+- run the ADR-009 adversarial pass on security-sensitive diffs;
+- stop at the PR.
+
+**Inherent — cannot be fixed in a PR, only respected:**
+- **Repo-admin actions** — a ruleset/branch-protection change needs admin the
+  operating collaborator account does not have (e.g. #309).
+- **Owner key custody** — a release-signing key must be generated and installed by
+  the owner, never by an agent (e.g. #172).
+- **Desktop/GUI verification** — this is an Electron app; a great many changes only
+  prove out in the running window, which a headless run cannot open. This is the
+  single biggest limiter, and #309 exists to make that gate a required check rather
+  than a convention.
+- **Design decisions** — anything where the correct answer is an owner's call
+  (scope, data-model, credential-seeding semantics) is `loop-needs-human` by nature.
+- **Environment** — on the current Windows box, Defender ASR rule `D1E49AAC` blocks
+  the Claude CLI daemon, so a fully unattended headless spawn there is not reliable.
+
+The design consequence: StartLoop's job is to run the judgeable subset and hand back
+a clean, reasoned `loop-needs-human` queue for the rest — not to pretend everything
+can be automated.
+
+## Premise review is a repository-wide policy
+
+The premise review is not only a loop step. Every ticket — agent- or human-filed —
+carries a premise assessment at creation (AGENTS.md, "Ticket creation & premise
+review"). LoopReady enforces it over the pre-policy backlog; StartLoop re-checks it
+once more before spending model budget, because a plan made yesterday can be stale
+today.


### PR DESCRIPTION
Closes #319.

A model-tiered pair of **AI Code Conductor-only** skills that turn the open backlog into autonomous execution — proven with a real run before it was codified.

## Proving run (the "does this work" step)

A Fable premise-review fan-out over the 7 open `release-2.1 ∧ ¬in-beta` tickets (#128,#170,#172,#209,#226,#307,#309) reviewed all 7 in **~3 min for ~407k Fable tokens**, 0 errors. Its calls check out against ground truth: it saw that #261 already partly addressed #128, found **PR #224 is 242 commits behind `beta` with silent-wrong conflicts** (#209), and caught that **#309 is an admin-only ruleset change**.

**Only #170 and #307 came back autonomously-runnable.** That asymmetry is the whole design: in an Electron app most tickets are NEEDS-HUMAN *by nature* — success only visible in the running app, owner/admin gates, design decisions — not for want of a permission that could be granted. So the system runs the judgeable subset and hands back a reasoned human queue.

## What's here

- **`.claude/skills/LoopReady/SKILL.md`** — read-only planner. Fable fan-out, one agent per open ticket; premise review + readiness record; labels each `loop-ready` / `loop-needs-human` and posts the record as a structured ` ```loop-record ` **issue comment** (no repo files — travels with the ticket). Opens no PR, writes no code.
- **`.claude/skills/StartLoop/SKILL.md`** — autonomous "don't ask" executor. Per `loop-ready` ticket: a **fresh premise re-check** (LoopReady's plan can go stale), an **atomic claim** (GitHub assignee + `loop-claimed`, so parallel workers never collide), implement with opus in its own worktree, gates, adversarial pass if security-sensitive, open a PR with `ci-run`, then **STOP**.
- **Five `loop-*` labels** as the status state machine — created on the repo:
  `loop-ready | loop-needs-human → loop-claimed (+assignee) → loop-in-progress → loop-done → (human) in-beta`. Status lives on the issue, never only in a transcript.
- **AGENTS.md** — a create-time **premise-review policy**: every ticket, agent- or human-filed, carries a premise assessment. Premise gates *creation* as adversarial-review gates *merge*.
- **`docs/loop-autonomy.md`** — the hard boundary a don't-ask run respects, and the honest split of skill-encoded vs inherent blockers.

## The hard boundary (StartLoop never crosses)

Never merges (runs to a PR; a human merges after a desktop test — this is #309's gate), never edits rulesets, never mints keys, never force-pushes, honours the security embargo, never asserts GUI success it cannot see.

## Backlog readied

LoopReady's verdicts were applied for real: **#170, #307 → `loop-ready`** with records; **#128, #172, #209, #226, #309 → `loop-needs-human`** with reasons posted as comments. A StartLoop run today would execute #170 and #307 to PRs and hand back the other five.

## Blockers to a don't-ask session — the finding

Skill-encoded (handled): worktree claim, `ci-run`, ADR-009 pass, stop-at-PR, the label coordination. **Inherent, not grantable in a PR** (documented, not "fixed"): repo-admin ruleset edits (#309), signing-key custody (#172), desktop/GUI verification (#226, #209, part of #128), and Defender ASR blocking the CLI daemon on the current box. The most useful thing a permission change could do is make the desktop-test gate a required check — which is exactly #309, and admin-only.

## Scope

Docs + skills + labels + AGENTS.md policy. No `src/` touched, no ADR-009 path, so no adversarial pass required. Not merged — for your review.
