### PR TITLE
fix(accounts): stop Open artifacts being dead on a cold account

### DIFF
--- a/src/main/ipc/account-web-handlers.ts
+++ b/src/main/ipc/account-web-handlers.ts
@@ -43,6 +43,25 @@ const profileIdSchema = z.string().regex(PROFILE_ID_RE)
 
 export function registerAccountWebHandlers(): void {
   /** Both halves of an account's auth in one payload — the UI shows them together. */
+  // Web-session status on its own.
+  //
+  // ACCOUNT_WEB_STATUS awaits readClaudeCliAuth() -- a `claude auth status`
+  // subprocess that can take seconds -- before it returns anything, including
+  // the web view, which is a synchronous local JSON read. Anything that only
+  // needs "does this account have a claude.ai session" was therefore paying for
+  // the CLI probe: the sidebar context menu renders "Open artifacts" disabled
+  // until the answer arrives, so on an account whose status was not already
+  // cached the item was dead at the moment the user clicked it, with no window
+  // and no log line. Split so the cheap question gets a cheap answer.
+  ipcMain.handle(IPC.ACCOUNT_WEB_WEB_STATUS, async (_e, profileId: unknown) => {
+    try {
+      const id = profileIdSchema.parse(profileId)
+      return { ok: true, web: viewFor(id) }
+    } catch (err) {
+      return fail('webStatus', err)
+    }
+  })
+
   ipcMain.handle(IPC.ACCOUNT_WEB_STATUS, async (_e, profileId: unknown) => {
     try {
       const id = profileIdSchema.parse(profileId)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -227,6 +227,8 @@ export interface ElectronAPI {
         }
       | { ok: false; error: string }
     >
+    /** Web-session status only — a local read, no CLI subprocess. */
+    webStatus: (profileId: string) => Promise<{ ok: true; web: any } | { ok: false; error: string }>
     signIn: (profileId: string) => Promise<{ ok: true; state: any } | { ok: false; error: string }>
     signInState: () => Promise<{ ok: true; state: any } | { ok: false; error: string }>
     cancel: (profileId: string) => Promise<{ ok: true } | { ok: false; error: string }>
@@ -768,6 +770,7 @@ const electronAPI: ElectronAPI = {
   },
   accountWeb: {
     status: (profileId) => ipcRenderer.invoke(IPC.ACCOUNT_WEB_STATUS, profileId),
+    webStatus: (profileId) => ipcRenderer.invoke(IPC.ACCOUNT_WEB_WEB_STATUS, profileId),
     signIn: (profileId) => ipcRenderer.invoke(IPC.ACCOUNT_WEB_SIGN_IN, profileId),
     signInState: () => ipcRenderer.invoke(IPC.ACCOUNT_WEB_SIGN_IN_STATE),
     cancel: (profileId) => ipcRenderer.invoke(IPC.ACCOUNT_WEB_CANCEL, profileId),

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1159,9 +1159,19 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
                     // that no longer exists) produced no window and no message —
                     // indistinguishable from the menu item simply not working.
                     const pid = (s.profileId ?? primaryProfileId)!
-                    void window.electronAPI.accountWeb.openArtifacts(pid).then((r) => {
-                      if (!r.ok) alert(`Could not open artifacts for this account: ${r.error}`)
-                    })
+                    void window.electronAPI.accountWeb.openArtifacts(pid)
+                      .then((r) => {
+                        if (!r.ok) alert(`Could not open artifacts for this account: ${r.error}`)
+                      })
+                      // A rejected invoke -- IPC transport gone, or the handler dying
+                      // before it can build its envelope -- lands here, not in the
+                      // ok:false branch. Without this it is silent again, which is the
+                      // whole bug: no window and no message are indistinguishable from
+                      // a menu item that does not work.
+                      .catch((err: unknown) => {
+                        const why = (err as Error)?.message ?? String(err)
+                        alert(`Could not open artifacts for this account: ${why}`)
+                      })
                   }
                 : undefined
             }

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -123,6 +123,20 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
     if (!profileId) return
     await useAccountAuthStore.getState().refresh(profileId, { force })
   }, [])
+  /**
+   * Web-session status for the menu about to open.
+   *
+   * The full `refresh` cannot answer this without first awaiting the
+   * `claude auth status` subprocess, so on an account whose status was not
+   * already cached "Open artifacts" rendered disabled and a click did nothing at
+   * all — no window, no error, no log line. This is a local read, so the answer
+   * lands before the menu is even painted. The heavy refresh still runs
+   * alongside for the CLI half.
+   */
+  const refreshWebOnly = React.useCallback((profileId?: string) => {
+    if (!profileId) return
+    void useAccountAuthStore.getState().refreshWeb(profileId)
+  }, [])
 
   /** Acquire this account's claude.ai web session, then refresh the menu state. */
   const authenticateWebForSession = React.useCallback(async (profileId: string) => {
@@ -646,7 +660,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
         onRenameFinish={handleFinishSessionRename}
         onRenameCancel={() => { setRenamingSessionId(null); setSessionRenameValue('') }}
         onClick={(e) => handleSessionClick(session.id, e)}
-        onContextMenu={(e) => { e.preventDefault(); void refreshWebSessions(session.profileId ?? primaryProfileId); setSessionContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY }) }}
+        onContextMenu={(e) => { e.preventDefault(); refreshWebOnly(session.profileId ?? primaryProfileId); void refreshWebSessions(session.profileId ?? primaryProfileId); setSessionContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY }) }}
         isSelected={selectedSessionIds.has(session.id)}
         isFocused={focusedSessionIndex === flatIndex}
       />
@@ -1139,7 +1153,16 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
             codeSignedIn={!s.shellOnly && s.sessionType === 'local' && (s.provider ?? 'claude') === 'claude' && authByProfile[(s.profileId ?? primaryProfileId)!]?.cliAuthed === true}
             onOpenArtifacts={
               !s.shellOnly && (s.profileId ?? primaryProfileId) && s.sessionType === 'local'
-                ? () => { void window.electronAPI.accountWeb.openArtifacts((s.profileId ?? primaryProfileId)!) }
+                ? () => {
+                    // Surface the outcome. This used to discard the result, so a
+                    // main-process refusal (an unresolvable partition, a profile
+                    // that no longer exists) produced no window and no message —
+                    // indistinguishable from the menu item simply not working.
+                    const pid = (s.profileId ?? primaryProfileId)!
+                    void window.electronAPI.accountWeb.openArtifacts(pid).then((r) => {
+                      if (!r.ok) alert(`Could not open artifacts for this account: ${r.error}`)
+                    })
+                  }
                 : undefined
             }
             onAuthenticateWeb={

--- a/src/renderer/stores/accountAuthStore.ts
+++ b/src/renderer/stores/accountAuthStore.ts
@@ -72,6 +72,13 @@ export const useAccountAuthStore = create<AccountAuthState>((set, get) => ({
     // will publish the fresh status to every subscriber.
     if (inFlight.has(profileId)) return
     inFlight.add(profileId)
+    // Publish the CHEAP half immediately, without waiting for the CLI probe
+    // below. Any caller that needs only "does this account have a claude.ai
+    // session" -- the sidebar context menu deciding whether Open artifacts is
+    // live -- gets its answer in a file read rather than a subprocess. Done
+    // here rather than only at the call site so the fast path cannot be lost
+    // by someone deleting one line of wiring in a component.
+    void get().refreshWeb(profileId)
     set((s) => ({ byProfile: { ...s.byProfile, [profileId]: { ...(s.byProfile[profileId] ?? {}), loading: true, error: undefined } } }))
     try {
       const r = await window.electronAPI.accountWeb.status(profileId)

--- a/src/renderer/stores/accountAuthStore.ts
+++ b/src/renderer/stores/accountAuthStore.ts
@@ -32,6 +32,18 @@ interface AccountAuthState {
    *  sessions must not re-probe every time. `force` (a manual pill refresh, or a
    *  refresh right after a sign-in/out) always probes. */
   refresh: (profileId: string, opts?: { force?: boolean }) => Promise<void>
+  /**
+   * Fetch ONLY the claude.ai web-session status.
+   *
+   * `refresh` cannot answer "does this account have a web session" without first
+   * awaiting the `claude auth status` subprocess, because the main-process
+   * handler resolves both together. Anything that needs just the web answer --
+   * the sidebar context menu deciding whether "Open artifacts" is live -- was
+   * therefore waiting seconds on a question that is a local JSON read, and
+   * rendering a disabled item in the meantime. Never gated by the TTL: it costs
+   * a file read, and the whole point is that it lands before the user clicks.
+   */
+  refreshWeb: (profileId: string) => Promise<void>
   /** Drop a profile's cached status (e.g. account deleted). */
   clear: (profileId: string) => void
 }
@@ -79,6 +91,28 @@ export const useAccountAuthStore = create<AccountAuthState>((set, get) => ({
       inFlight.delete(profileId)
     }
     void get
+  },
+
+  refreshWeb: async (profileId: string) => {
+    if (!profileId) return
+    try {
+      const r = await window.electronAPI.accountWeb.webStatus(profileId)
+      if (!r.ok) return
+      // Merge, never replace: `cliAuthed` and `fetchedAt` belong to the full
+      // probe and must survive this. Deliberately does NOT set `fetchedAt` --
+      // that stamp means "the CLI probe succeeded at this time" and drives the
+      // TTL, so stamping it here would suppress the next real refresh.
+      set((s) => ({
+        byProfile: {
+          ...s.byProfile,
+          [profileId]: { ...(s.byProfile[profileId] ?? { loading: false }), web: r.web?.status ?? 'none' },
+        },
+      }))
+    } catch {
+      // Leave whatever is cached. A failed cheap read is not evidence the
+      // session is gone, and downgrading it to 'none' here would disable the
+      // menu item on a working account.
+    }
   },
 
   clear: (profileId: string) => set((s) => {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -342,6 +342,8 @@ export interface ElectronAPI {
         }
       | { ok: false; error: string }
     >
+    /** Web-session status only — a local read, no CLI subprocess. */
+    webStatus: (profileId: string) => Promise<{ ok: true; web: any } | { ok: false; error: string }>
     signIn: (profileId: string) => Promise<{ ok: true; state: any } | { ok: false; error: string }>
     signInState: () => Promise<{ ok: true; state: any } | { ok: false; error: string }>
     cancel: (profileId: string) => Promise<{ ok: true } | { ok: false; error: string }>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -311,6 +311,10 @@ export const IPC = {
   // Per-account claude.ai web session (#216): sign in via the system browser,
   // hold the cookies in a per-account partition, open artifacts as that account.
   ACCOUNT_WEB_STATUS: 'accountWeb:status',
+  /** Web-session status ONLY. A local JSON read, so it answers in microseconds —
+   *  unlike ACCOUNT_WEB_STATUS, which awaits the `claude auth status` subprocess
+   *  before it can report anything at all. */
+  ACCOUNT_WEB_WEB_STATUS: 'accountWeb:webStatus',
   ACCOUNT_WEB_SIGN_IN: 'accountWeb:signIn',
   ACCOUNT_WEB_SIGN_IN_STATE: 'accountWeb:signInState',
   ACCOUNT_WEB_CANCEL: 'accountWeb:cancel',

--- a/tests/unit/account-web-status-split.test.ts
+++ b/tests/unit/account-web-status-split.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The web-session question must not wait on the Claude Code CLI probe.
+ *
+ * `accountWeb:status` resolves the claude.ai web session AND `claude auth
+ * status` together, and the CLI half shells out to a subprocess that can take
+ * seconds. The sidebar's session context menu computed "Open artifacts" from
+ * that combined result, so on an account whose status was not already cached the
+ * item rendered DISABLED and a click did nothing at all — no window, no error,
+ * and no log line, because the handler was never reached. On an account that
+ * happened to be warm it worked instantly, which made it look account-specific
+ * rather than timing-specific.
+ *
+ * `accountWeb:webStatus` answers the cheap half on its own. These tests pin that
+ * it genuinely does NOT touch the CLI probe: the fake below never settles, so if
+ * the handler ever awaits it again these tests hang instead of quietly passing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const handlers: Record<string, (e: unknown, ...args: unknown[]) => unknown> = {}
+
+/** Resolves only if something explicitly releases it — never on its own. */
+let releaseCliProbe: (() => void) | null = null
+let cliProbeCalls = 0
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (e: unknown, ...args: unknown[]) => unknown) => { handlers[channel] = fn },
+  },
+  BrowserWindow: { fromWebContents: () => null },
+}))
+vi.mock('../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logError: vi.fn() }))
+vi.mock('../../src/main/data-paths', () => ({ getDataDirectory: () => 'C:/fake/data' }))
+vi.mock('../../src/main/account-web/sign-in', () => ({
+  cancelSignIn: vi.fn(), clearWebSession: vi.fn(), getSignInState: vi.fn(), runSignIn: vi.fn(),
+}))
+vi.mock('../../src/main/account-web/artifacts', () => ({ closeArtifacts: vi.fn(), openArtifacts: vi.fn() }))
+vi.mock('../../src/main/account-web/claude-cli-auth', () => ({
+  // The subprocess, standing in for `claude auth status`. It HANGS.
+  readClaudeCliAuth: vi.fn(async () => {
+    cliProbeCalls++
+    await new Promise<void>((resolve) => { releaseCliProbe = resolve })
+    return { authenticated: true, email: 'someone@example.com' }
+  }),
+  claudeAuthCommand: vi.fn(() => 'claude auth login'),
+}))
+vi.mock('../../src/main/account-web/session-store', () => ({
+  getAuthBrowser: vi.fn(() => 'chrome'),
+  getAuthMethod: vi.fn(() => 'claudeai'),
+  removeWebSession: vi.fn(),
+  saveWebSession: vi.fn(),
+  setAuthBrowser: vi.fn(),
+  setAuthMethod: vi.fn(),
+  viewFor: vi.fn((profileId: string) => ({ profileId, status: 'active', expiresAt: 4102444800000 })),
+}))
+
+const { registerAccountWebHandlers } = await import('../../src/main/ipc/account-web-handlers')
+const { IPC } = await import('../../src/shared/ipc-channels')
+
+beforeEach(() => {
+  cliProbeCalls = 0
+  releaseCliProbe = null
+  for (const k of Object.keys(handlers)) delete handlers[k]
+  registerAccountWebHandlers()
+})
+
+const PROFILE = 'profile-msf97sgf-eb8d26'
+
+describe('accountWeb:webStatus', () => {
+  it('answers while the CLI probe is still hanging', async () => {
+    const res = (await handlers[IPC.ACCOUNT_WEB_WEB_STATUS]({}, PROFILE)) as {
+      ok: boolean
+      web?: { status: string }
+    }
+    expect(res.ok).toBe(true)
+    expect(res.web?.status).toBe('active')
+  })
+
+  it('never invokes the CLI probe at all', async () => {
+    await handlers[IPC.ACCOUNT_WEB_WEB_STATUS]({}, PROFILE)
+    // Not merely "fast" — it must not start the subprocess, or every context
+    // menu would still pay for one even once the answer was already back.
+    expect(cliProbeCalls).toBe(0)
+  })
+
+  it('still validates the profile id at the boundary', async () => {
+    const res = (await handlers[IPC.ACCOUNT_WEB_WEB_STATUS]({}, '../escape')) as { ok: boolean }
+    expect(res.ok).toBe(false)
+    expect(cliProbeCalls).toBe(0)
+  })
+
+  it('is the CHEAP half of a handler whose full form does block', async () => {
+    // The contrast that makes the split worth having. The combined handler is
+    // still awaiting the hung probe here, so it must not have settled — this is
+    // what the context menu used to be waiting on.
+    let settled = false
+    void (handlers[IPC.ACCOUNT_WEB_STATUS]({}, PROFILE) as Promise<unknown>).then(() => { settled = true })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(cliProbeCalls).toBe(1)
+    expect(settled).toBe(false)
+
+    // And it completes normally once the subprocess does, so the split has not
+    // broken the full path.
+    releaseCliProbe?.()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(settled).toBe(true)
+  })
+})

--- a/tests/unit/renderer/account-auth-store.test.ts
+++ b/tests/unit/renderer/account-auth-store.test.ts
@@ -7,10 +7,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAccountAuthStore, _resetAccountAuthForTest } from '../../../src/renderer/stores/accountAuthStore'
 
 let statusMock: ReturnType<typeof vi.fn>
+let webStatusMock: ReturnType<typeof vi.fn>
 beforeEach(() => {
   _resetAccountAuthForTest()
   statusMock = vi.fn()
-  ;(globalThis as any).window.electronAPI = { accountWeb: { status: statusMock } }
+  webStatusMock = vi.fn()
+  ;(globalThis as any).window.electronAPI = { accountWeb: { status: statusMock, webStatus: webStatusMock } }
 })
 
 describe('accountAuthStore.refresh', () => {
@@ -100,5 +102,99 @@ describe('accountAuthStore.refresh', () => {
     await useAccountAuthStore.getState().refresh('profile-f')
     useAccountAuthStore.getState().clear('profile-f')
     expect(useAccountAuthStore.getState().byProfile['profile-f']).toBeUndefined()
+  })
+})
+
+describe('accountAuthStore.refreshWeb', () => {
+  // The renderer half of the "Open artifacts was dead on a cold account" fix.
+  // `accountWeb:status` cannot answer "does this account have a claude.ai
+  // session" without first awaiting the `claude auth status` subprocess, so the
+  // context menu rendered its item disabled for seconds and a click in that
+  // window did nothing at all. `refreshWeb` asks the cheap question on its own.
+  //
+  // Added after mutation testing showed three separate ways to revert the whole
+  // fix with the full suite still green.
+
+  it('asks webStatus and NEVER the slow combined status', async () => {
+    webStatusMock.mockResolvedValue({ ok: true, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refreshWeb('profile-a')
+    expect(webStatusMock).toHaveBeenCalledWith('profile-a')
+    // The point of the split. Calling `status` here reintroduces the subprocess
+    // wait that made the menu item dead.
+    expect(statusMock).not.toHaveBeenCalled()
+    expect(useAccountAuthStore.getState().byProfile['profile-a'].web).toBe('active')
+  })
+
+  it('merges into the existing record instead of replacing it', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'none' } })
+    await useAccountAuthStore.getState().refresh('profile-b')
+    const before = useAccountAuthStore.getState().byProfile['profile-b']
+
+    webStatusMock.mockResolvedValue({ ok: true, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refreshWeb('profile-b')
+    const after = useAccountAuthStore.getState().byProfile['profile-b']
+
+    expect(after.web).toBe('active')
+    // cliAuthed belongs to the full probe and must survive the cheap one, or the
+    // session-header pill goes blank every time a context menu opens.
+    expect(after.cliAuthed).toBe(true)
+    expect(after.fetchedAt).toBe(before.fetchedAt)
+  })
+
+  it('does NOT stamp fetchedAt', async () => {
+    // fetchedAt means "the CLI probe succeeded at this time" and drives the 30s
+    // AUTO_REFRESH_TTL_MS. Stamping it here would make a right-click suppress
+    // the next real probe, so cliAuthed would go stale invisibly.
+    webStatusMock.mockResolvedValue({ ok: true, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refreshWeb('profile-c')
+    expect(useAccountAuthStore.getState().byProfile['profile-c'].fetchedAt).toBeUndefined()
+  })
+
+  it('leaves a cached status alone when the read fails', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-d')
+
+    webStatusMock.mockRejectedValue(new Error('IPC gone'))
+    await useAccountAuthStore.getState().refreshWeb('profile-d')
+    // A failed cheap read is not evidence the session is gone. Downgrading to
+    // 'none' here would disable the menu item on a working account -- the exact
+    // bug this fix exists to remove.
+    expect(useAccountAuthStore.getState().byProfile['profile-d'].web).toBe('active')
+  })
+
+  it('leaves a cached status alone when the handler returns ok:false', async () => {
+    statusMock.mockResolvedValue({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await useAccountAuthStore.getState().refresh('profile-e')
+
+    webStatusMock.mockResolvedValue({ ok: false, error: 'bad profile id' })
+    await useAccountAuthStore.getState().refreshWeb('profile-e')
+    expect(useAccountAuthStore.getState().byProfile['profile-e'].web).toBe('active')
+  })
+
+
+  it('is kicked off by refresh() too, so the fast answer does not depend on one call site', async () => {
+    // The context-menu wiring calls refreshWeb directly, but that is one line in
+    // a component and deleting it silently reintroduces the dead menu item. The
+    // store starts the cheap read itself, so the web answer lands even if the
+    // caller only asked for the full refresh.
+    let releaseSlow!: (v: unknown) => void
+    statusMock.mockReturnValue(new Promise((r) => { releaseSlow = r }))
+    webStatusMock.mockResolvedValue({ ok: true, web: { status: 'active' } })
+
+    const p = useAccountAuthStore.getState().refresh('profile-f')
+    // Let the cheap read settle while the CLI probe is still outstanding.
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+
+    expect(webStatusMock).toHaveBeenCalledWith('profile-f')
+    expect(useAccountAuthStore.getState().byProfile['profile-f'].web).toBe('active')
+
+    releaseSlow({ ok: true, cli: { authenticated: true }, web: { status: 'active' } })
+    await p
+    expect(useAccountAuthStore.getState().byProfile['profile-f'].cliAuthed).toBe(true)
+  })
+
+  it('ignores an empty profile id rather than fetching', async () => {
+    await useAccountAuthStore.getState().refreshWeb('')
+    expect(webStatusMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Reported live: right-clicking one session and choosing **Open artifacts** did nothing, while the same item on another session worked and reopened happily. It looked account-specific. It is timing-specific.

## What actually happens

`Sidebar.tsx` fires an auth refresh and opens the menu **in the same tick**:

```tsx
onContextMenu={(e) => { e.preventDefault(); void refreshWebSessions(...); setSessionContextMenu({...}) }}
```

and the menu decides whether the item is live from `authByProfile[profileId]?.web === 'active'`.

That value comes from `accountWeb:status`, whose handler is:

```ts
const cli = await readClaudeCliAuth(id)   // `claude auth status` — a subprocess
...
return { ok: true, web: viewFor(id), cli, ... }   // viewFor() is a local JSON read
```

The cheap half is gated behind the expensive one. So for any account whose status was not already cached, **Open artifacts** rendered `disabled` for as long as the subprocess took, and a click in that window did nothing at all — no window, no error, and no log line, because the IPC handler was never reached. The store's own comment already flags the probe as "up to ~10s".

An account that had recently been active was warm in the cache and worked instantly. That is the whole of the difference between the two sessions.

## Confirmed, not inferred

Checked against the running install:

- the stored web session for the failing account is `status: active`, expiring in September — so the auth is genuinely fine;
- the app log shows `[account-web] opened artifacts for <profile>` firing for the working account and **never** firing for the failing one, which is only possible if the handler was never invoked.

## Changes

1. **New `accountWeb:webStatus` IPC** returning `viewFor(id)` alone. The cheap question gets a cheap answer. `accountWeb:status` is untouched and still backs the auth pills.
2. **`accountAuthStore.refreshWeb()`** merges just the `web` field. It deliberately does *not* stamp `fetchedAt` — that stamp means "the CLI probe succeeded at this time" and drives the TTL, so setting it here would suppress the next real refresh — and it does not downgrade a cached status on a failed read, since a failed cheap read is not evidence a session is gone.
3. **The context-menu click no longer discards the result.** It was `void openArtifacts(...)`, so a main-process refusal was indistinguishable from the item simply not working.

## Tests

Pinned behaviourally rather than by shape: the fake CLI probe in the new test **never settles**, so if the web handler is ever coupled back to it, the tests hang instead of quietly passing.

Verified by doing exactly that — reintroducing `await readClaudeCliAuth(id)` fails precisely the two tests that should fail (10s timeouts) and nothing else. A fourth test asserts the contrast directly: the *full* handler must still be blocked on the same fake while the cheap one has already answered, and must complete once the fake is released.

Suite **6096 passed / 15 skipped**, typecheck clean.

## Note for the ADR-009 pass

This adds an IPC channel, so it is in scope for the adversarial pass over the unreleased beta. The new handler validates `profileId` with the same `profileIdSchema` as every other channel in the file, before it touches anything, and returns the same result-envelope shape — there is a test for the reject path.
