### PR TITLE
fix(canvas): stop the project-scoped library stranding a session's own canvases

### DIFF
--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -1255,6 +1255,36 @@ function clampToNow(iso: string): string {
   return Number.isFinite(ms) && ms <= now ? iso : new Date(now).toISOString()
 }
 
+/**
+ * Do two recorded working directories name the same project?
+ *
+ * The library's project scope compares a canvas record's stamped `cwd` against
+ * the cwd of the session ASKING, and those two strings come from different
+ * places at different times: the record is stamped once at first render and
+ * never drifts, while the asking side is whatever the latest spawn recorded.
+ * On the app-relaunch path that is a different SOURCE entirely -- `pty-handlers`
+ * records `options?.resume?.cwd ?? options?.cwd`, and `resume.cwd` is the first
+ * cwd string in the conversation JSONL, trimmed verbatim. So one tile's key can
+ * alternate between two independent spellings across its life.
+ *
+ * A raw `!==` therefore fails on differences that are not differences: a
+ * trailing separator, a case difference on a case-insensitive filesystem,
+ * forward vs back slashes on Windows. Normalise the way the filesystem itself
+ * would, matching `sameFsPath`. Deliberately LEXICAL: realpath would be
+ * stronger but throws on a directory that no longer exists, which is exactly
+ * the case where someone most needs to find their old canvases.
+ */
+function sameProjectDir(a: string, b: string): boolean {
+  const clean = (p: string) => {
+    const stripped = p.replace(FORMAT_CONTROLS_RE, '')
+    // path.resolve normalises separators and `.` segments, but only makes sense
+    // on an absolute path -- a relative one would be resolved against the main
+    // process's cwd, which has nothing to do with either session.
+    return path.isAbsolute(stripped) ? path.resolve(stripped) : stripped
+  }
+  return sameFsPath(clean(a), clean(b))
+}
+
 /** Canvases this session could reclaim, for the user to choose from. Pure read
  *  — nothing moves until the user names one. */
 export function listOrphanCandidateCanvases(sessionId: string, query: CanvasAdoptionQuery): ReclaimableCanvas[] {
@@ -1335,12 +1365,25 @@ export function listAllCanvases(
   const activeForAsking = asking ? sessionIndex.get(asking) : undefined
   const out: CanvasLibraryEntry[] = []
   for (const record of canvases.values()) {
-    if (projectCwd && record.cwd && record.cwd !== projectCwd) continue
-    const latest = record.versions[record.versions.length - 1]
-    const cwd = record.cwd?.replace(FORMAT_CONTROLS_RE, '')
     // The same question adoptCanvasForSession answers, so the badge and the
     // action can never disagree: did THIS session author it.
     const mine = asking !== undefined && record.sessionId === asking
+    // Project scope NEVER hides a session's own canvas.
+    //
+    // ADR-017 scopes the library to the project, and justifies it by saying the
+    // reclaim list stays unfiltered so a canvas whose project you never open
+    // again still has a route back. It does not: listOrphanCandidateCanvases
+    // returns [] the moment the asking session owns a canvas, and excludes the
+    // session's own regardless. So for any session that has ever rendered, the
+    // scoped library is the ONLY route to its own work -- and a project key that
+    // merely RESPELLS (a trailing separator, a relaunch reading cwd from the
+    // transcript instead of the config) would strand every canvas it authored,
+    // including the one currently active. Filtering by relevance is right;
+    // foreclosing is not, so own rows are always kept and the picker sorts them
+    // to the top.
+    if (!mine && projectCwd && record.cwd && !sameProjectDir(record.cwd, projectCwd)) continue
+    const latest = record.versions[record.versions.length - 1]
+    const cwd = record.cwd?.replace(FORMAT_CONTROLS_RE, '')
     out.push({
       canvasId: record.canvasId,
       versionCount: record.versions.length,

--- a/tests/unit/main/canvas-library-open-own.test.ts
+++ b/tests/unit/main/canvas-library-open-own.test.ts
@@ -182,3 +182,84 @@ describe('the library is scoped to the project', () => {
     expect(ids).toContain(unstamped.canvasId)
   })
 })
+
+describe('project scope does not strand a session on a respelling', () => {
+  // The record's cwd is stamped once at first render and never drifts. The
+  // asking side is whatever the LATEST spawn recorded, and on the relaunch path
+  // that is a different source entirely (the transcript JSONL, not the config).
+  // So the two keys can differ by spelling alone, for one unchanged project.
+
+  it('matches through a trailing separator', () => {
+    const c = renderAs(MINE, PROJECT, 'trailing')
+    const ids = store.listAllCanvases([], PROJECT + path.sep, THEIRS).map((e) => e.canvasId)
+    expect(ids).toContain(c.canvasId)
+  })
+
+  it('matches through mixed separators', () => {
+    const c = renderAs(MINE, PROJECT, 'slashes')
+    const swapped = PROJECT.split(path.sep).join('/')
+    const ids = store.listAllCanvases([], swapped, THEIRS).map((e) => e.canvasId)
+    // On win32 path.resolve normalises the separator; elsewhere the two spellings
+    // are genuinely different paths and staying strict is correct.
+    if (process.platform === 'win32') expect(ids).toContain(c.canvasId)
+    else expect(swapped).toBe(PROJECT)
+  })
+
+  it('matches through a case difference where the filesystem is case-insensitive', () => {
+    const c = renderAs(MINE, PROJECT, 'case')
+    const ids = store.listAllCanvases([], PROJECT.toUpperCase(), THEIRS).map((e) => e.canvasId)
+    if (process.platform === 'win32' || process.platform === 'darwin') {
+      expect(ids).toContain(c.canvasId)
+    } else {
+      expect(ids).not.toContain(c.canvasId)
+    }
+  })
+
+  it('still scopes out another project', () => {
+    // The normalisation must not turn the filter off. Authored by MINE and asked
+    // by THEIRS, so the own-canvas exemption is deliberately not in play here.
+    const here = renderAs(MINE, PROJECT, 'here')
+    const elsewhere = renderAs(MINE, OTHER, 'elsewhere')
+    const ids = store.listAllCanvases([], PROJECT, THEIRS).map((e) => e.canvasId)
+    expect(ids).toContain(here.canvasId)
+    expect(ids).not.toContain(elsewhere.canvasId)
+  })
+})
+
+describe('project scope never hides a session OWN canvas', () => {
+  it('keeps every canvas the asking session authored, whatever project it asks from', () => {
+    // The foreclosing case. ADR-017 says the reclaim list is the route back for
+    // a canvas outside the current project; it is not — listOrphanCandidateCanvases
+    // returns nothing once the session owns a canvas, and excludes its own anyway.
+    // So the library is the only route and it must not drop these.
+    const first = renderAs(MINE, OTHER, 'authored elsewhere')
+    const active = renderAs(MINE, OTHER, 'still elsewhere')
+
+    const ids = store.listAllCanvases([], PROJECT, MINE).map((e) => e.canvasId)
+    expect(ids).toContain(first.canvasId)
+    expect(ids).toContain(active.canvasId)
+  })
+
+  it('keeps the ACTIVE canvas visible after the project key respells', () => {
+    // The worst version of the bug: the canvas currently on screen disappears
+    // from the subject picker, which filters to ownedByThisSession || active.
+    const active = renderAs(MINE, OTHER, 'the open one')
+    const ids = store.listAllCanvases([], PROJECT, MINE).map((e) => e.canvasId)
+    expect(ids).toContain(active.canvasId)
+  })
+
+  it('does not extend the exemption to another session', () => {
+    // Own-canvas only. A different session's out-of-project canvas stays scoped
+    // out, so this is a relevance fix and not a widening.
+    const theirs = renderAs(THEIRS, OTHER, 'not mine')
+    const ids = store.listAllCanvases([], PROJECT, MINE).map((e) => e.canvasId)
+    expect(ids).not.toContain(theirs.canvasId)
+  })
+
+  it('reclaim really is closed as a route back, which is why the above matters', () => {
+    // Pins the premise rather than asserting it in a comment: once MINE holds a
+    // canvas, the reclaim list is empty, so the library is all there is.
+    renderAs(MINE, OTHER, 'owned')
+    expect(store.listOrphanCandidateCanvases(MINE, { isSessionCurrent: allCurrent })).toEqual([])
+  })
+})


### PR DESCRIPTION
From the ADR-009 pass over the unreleased beta.16 delta. **MAJOR**, needs no attacker, and it forecloses permanently.

## The bug

The library's project filter was an exact `!==` on two **raw** strings:

```ts
if (projectCwd && record.cwd && record.cwd !== projectCwd) continue
```

Those two strings come from different places at different times:

- the **record's** `cwd` is stamped once at first render and never drifts;
- the **asking** side is whatever the latest spawn recorded — and on the app-relaunch path that is a different *source* entirely, because `pty-handlers` records `options?.resume?.cwd ?? options?.cwd`, and `resume.cwd` is the first cwd string in the conversation JSONL, trimmed verbatim.

So one tile's project key alternates between two independent spellings across its life. Proven — each of these returns **zero** rows for a project that has not moved:

```
cwd="...\atk-P1"    -> 4 rows
cwd="...\atk-P1\"   -> 0 rows
cwd="...\ATK-P1"    -> 0 rows
cwd="...\atk-P1/"   -> 0 rows
```

Even the **active** canvas disappears, so `CanvasSubjectPicker` (which filters to `ownedByThisSession || canvasId === active`) shows nothing.

## Why there is no way back

ADR-017 justifies the filter by saying the reclaim list stays unfiltered, so a canvas whose project you never open again still has a route back. It does not: `listOrphanCandidateCanvases` returns `[]` the moment the asking session owns a canvas (`canvas-store.ts:1263`) and excludes the session's own regardless (`:1217`).

For every session that has ever rendered, the scoped library is therefore the **only** route to its own work — and it was foreclosing.

## Two changes, because either alone leaves the hole open

1. **`sameProjectDir()`** normalises both sides the way the filesystem would, matching the existing `sameFsPath`: strip format controls, `path.resolve` when absolute (folding separators and `.` segments), case-fold on win32/darwin. Deliberately **lexical** — realpath would be stronger but throws on a directory that no longer exists, which is exactly when someone most needs to find their old canvases.
2. **The filter never drops a row the asking session authored.** Scoping is relevance, not authorization. An own canvas outside the current project is banded, not hidden. The exemption does **not** extend to another session, so nothing widens — there is a test for that.

## Tests

9 added, including one that pins the *premise* rather than leaving it in a comment: that reclaim really is closed as a route back, so the library carrying own rows is load-bearing.

Mutation-checked, and the two halves are independently guarded:

| Mutation | Result |
| --- | --- |
| revert the normalisation (`record.cwd !== projectCwd`) | **3 failed** |
| drop the own-canvas exemption (`!mine &&`) | **2 failed** |

Suite **6100 passed / 15 skipped**, typecheck clean.
