### PR TITLE
fix(ask): stop a double-click making a second, unreachable Ask session

### DIFF
--- a/src/renderer/lib/askConductor.ts
+++ b/src/renderer/lib/askConductor.ts
@@ -92,7 +92,43 @@ const WORKSPACE_FAILED =
  * is typed into that running session instead. Returns the session id, or '' if
  * the help workspace could not be staged (the reason lands in useAskErrorStore).
  */
-export async function launchAskConductor(question?: string): Promise<string> {
+/**
+ * In-flight launch, so a second click while the first is still staging the help
+ * workspace joins it instead of starting a second session.
+ *
+ * The guard below reads the session list BEFORE `await help.workspace()`, which
+ * does an mkdir and two file writes in the main process -- comfortably wider
+ * than a double-click. Two clicks therefore both saw "no ask session" and both
+ * called addSession. That is not a cosmetic duplicate: `Sidebar` filters
+ * `kind !== 'ask'` out of the session list and `AskConductorDock` binds to the
+ * FIRST ask session, so the second is unreachable from either -- while still
+ * being persisted by `buildSessionState` and restored on every launch. The only
+ * way to reach it was the tab bar.
+ */
+let inFlightLaunch: Promise<string> | null = null
+
+export function launchAskConductor(question?: string): Promise<string> {
+  if (inFlightLaunch) {
+    // Join the launch already running. A question typed on the second click
+    // still has to land, and the session it belongs to is the one being staged,
+    // so hand it over once that resolves -- the same PTY write the
+    // already-running branch does.
+    const askPrompt = normaliseQuestion(question)
+    return inFlightLaunch.then((id) => {
+      if (id && askPrompt) window.electronAPI.pty.write(id, askPrompt + '\r')
+      return id
+    })
+  }
+  inFlightLaunch = doLaunchAskConductor(question).finally(() => { inFlightLaunch = null })
+  return inFlightLaunch
+}
+
+/** Reset the in-flight latch. Tests only. */
+export function _resetAskLaunchForTest(): void {
+  inFlightLaunch = null
+}
+
+async function doLaunchAskConductor(question?: string): Promise<string> {
   const askPrompt = normaliseQuestion(question)
   const store = useSessionStore.getState()
 
@@ -116,6 +152,17 @@ export async function launchAskConductor(question?: string): Promise<string> {
     return ''
   }
   useAskErrorStore.getState().setError(null)
+
+  // Re-read AFTER the await. The latch above covers the ordinary double-click,
+  // but the store is a live singleton and this function is not the only thing
+  // that can add a session while an mkdir is in flight. Cheap, and it makes the
+  // "one ask session" claim true by construction rather than by timing.
+  const raced = findAskSession(useSessionStore.getState().sessions)
+  if (raced) {
+    store.setActiveSession(raced.id)
+    if (askPrompt) window.electronAPI.pty.write(raced.id, askPrompt + '\r')
+    return raced.id
+  }
 
   const id = generateId()
   store.addSession({

--- a/tests/unit/renderer/ask-conductor-launch.test.ts
+++ b/tests/unit/renderer/ask-conductor-launch.test.ts
@@ -34,6 +34,7 @@ import {
   findAskSession,
   useAskErrorStore,
   ASK_LABEL,
+  _resetAskLaunchForTest,
 } from '../../../src/renderer/lib/askConductor'
 
 const ptyWrite = vi.fn()
@@ -55,6 +56,7 @@ describe('launchAskConductor', () => {
     markSessionForResumePicker.mockClear()
     addConfig.mockClear()
     ptyWrite.mockClear()
+    _resetAskLaunchForTest()
     setApi('C:/res/help')
   })
 
@@ -137,6 +139,86 @@ describe('launchAskConductor', () => {
     setApi('C:/res/help')
     await launchAskConductor('q')
     expect(useAskErrorStore.getState().error).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // ONE session, even when two clicks land inside one help.workspace() call.
+  //
+  // The reuse guard reads the session list BEFORE `await help.workspace()`, and
+  // that IPC does an mkdir plus two file writes in main -- comfortably wider than
+  // a double-click. Both clicks saw "no ask session" and both called addSession.
+  // Two ask sessions is not a cosmetic duplicate: Sidebar filters kind !== 'ask'
+  // out of the session list and AskConductorDock binds to the FIRST one, so the
+  // second is unreachable from either surface, while buildSessionState still
+  // persists it and it comes back on every launch.
+  // ---------------------------------------------------------------------------
+
+  it('makes ONE session when two launches race inside help.workspace()', async () => {
+    let release: (d: string) => void = () => {}
+    setApi(() => new Promise<never>((res) => { release = res as unknown as (d: string) => void }) as never)
+
+    const a = launchAskConductor('first question')
+    const b = launchAskConductor('second question')
+    release('C:/res/help')
+    const [idA, idB] = await Promise.all([a, b])
+
+    const ask = useSessionStore.getState().sessions.filter((x) => x.kind === 'ask')
+    expect(ask).toHaveLength(1)
+    // Both callers get the SAME session, so neither is left holding a dead id.
+    expect(idA).toBeTruthy()
+    expect(idB).toBe(idA)
+  })
+
+  it('still delivers the second question to the one session', async () => {
+    let release: (d: string) => void = () => {}
+    setApi(() => new Promise<never>((res) => { release = res as unknown as (d: string) => void }) as never)
+
+    const a = launchAskConductor('first question')
+    const b = launchAskConductor('second question')
+    release('C:/res/help')
+    const [id] = await Promise.all([a, b])
+
+    // The first question rides the spawn env (askPrompt); the second cannot,
+    // because the spawn already happened -- so it goes over the PTY, exactly as
+    // it would for a click that arrived a second later.
+    expect(useSessionStore.getState().sessions[0].askPrompt).toBe('first question')
+    expect(ptyWrite).toHaveBeenCalledWith(id, 'second question' + '\r')
+  })
+
+  it('yields to an ask session added by anything else during the await', async () => {
+    // The latch only covers re-entry through this function. The session store is
+    // a live singleton, so a restore or another code path can add an ask session
+    // while help.workspace() is still doing its mkdir. Without the post-await
+    // re-read this launch would add a second one on top of it.
+    let release: (d: string) => void = () => {}
+    setApi(() => new Promise<never>((res) => { release = res as unknown as (d: string) => void }) as never)
+
+    const p = launchAskConductor('mine')
+    useSessionStore.setState({
+      sessions: [{
+        id: 'other-ask-session', kind: 'ask', label: ASK_LABEL, workingDirectory: 'C:/res/help',
+        model: '', status: 'idle', createdAt: Date.now(), sessionType: 'local', provider: 'claude',
+      } as never],
+    })
+    release('C:/res/help')
+    const id = await p
+
+    expect(useSessionStore.getState().sessions.filter((x) => x.kind === 'ask')).toHaveLength(1)
+    expect(id).toBe('other-ask-session')
+    expect(ptyWrite).toHaveBeenCalledWith('other-ask-session', 'mine' + '\r')
+  })
+
+  it('does not latch a failure: a later click can still launch', async () => {
+    setApi(null)
+    expect(await launchAskConductor('q')).toBe('')
+    expect(useSessionStore.getState().sessions).toHaveLength(0)
+
+    // The in-flight latch must clear on the failure path too, or the button is
+    // dead for the rest of the app's life after one bad staging.
+    setApi('C:/res/help')
+    const id = await launchAskConductor('q2')
+    expect(id).toBeTruthy()
+    expect(useSessionStore.getState().sessions).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
From the ADR-009 pass over the unreleased beta.16 delta. **MAJOR.**

## The race

`launchAskConductor` checked for an existing Ask session **before** the await:

```ts
const existing = findAskSession(store.sessions)   // snapshot taken here
if (existing) { ...focus and return... }
dir = await window.electronAPI.help.workspace()   // mkdir + two file writes in main
store.addSession({ ... })                          // ...acted on here
```

`help.workspace()` does an `mkdirSync` and two `writeFileSync` calls in the main process — comfortably wider than a double-click. Both clicks saw "no ask session"; both called `addSession`.

## Why the duplicate is unreachable, not just untidy

- `Sidebar.tsx:90` filters `kind !== 'ask'` out of the session list, so **neither** appears there.
- `AskConductorDock` binds to `sessions.find(s => s.kind === 'ask')` — the **first** one only, so the dock can never focus or reveal the second.
- `buildSessionState()` persists it (`kind` is in the allowlist) and `App.tsx` restores it, so **it comes back on every launch**.
- The only way to close it is to notice a second "Ask Conductor" tab in the tab bar and work out why it exists.

Both spawn real interactive Claude PTYs against the user's account. The function's own docstring already promised *"focused rather than duplicated — the docked pill is a single affordance, not a session factory"*; it was not.

## Two guards

1. **A module-level in-flight promise.** A second call while a launch is staging *joins* it and gets the same session id back, so no caller is left holding a dead id. A question typed on the second click still lands — it goes over the PTY once the launch resolves, exactly as it would for a click a second later (the spawn-env route is spawn-time only). The latch clears in a `finally`, so a failed staging does not leave the button dead for the rest of the app's life.
2. **A re-read of the store after the await.** The latch only covers re-entry through this function, and the session store is a live singleton — a restore or another path can add an ask session while the mkdir is in flight. This makes "one ask session" true by construction rather than by timing.

## Tests

4 added, and the two guards are **independently** guarded:

| Mutation | Result |
| --- | --- |
| disable the in-flight latch (the original bug) | **2 failed** |
| remove the post-await re-read | **1 failed** |

Neither mutation is caught by the other's test — the second guard was added only after mutation-testing showed it had no coverage at all.

Suite **6096 passed / 15 skipped**, typecheck clean.
