### PR TITLE
fix(config): stop the colour migration mangling a corrupt settings section

### DIFF
--- a/src/renderer/utils/configHydration.ts
+++ b/src/renderer/utils/configHydration.ts
@@ -115,7 +115,7 @@ export async function retireAskConfig(
   try {
     if (removed > 0) {
       const saved = await window.electronAPI.config.save('configs', kept)
-      if (saved === false) {
+      if (!saved) {
         // The row is still on disk. Leaving the flag unset is the whole point:
         // it retries next launch instead of recording a deletion that never
         // happened. The in-memory value stays as read, so the session the user
@@ -134,7 +134,7 @@ export async function retireAskConfig(
     if (!metaIsWritable) return removed > 0 ? { ...configData, configs: kept } : configData
     const newMeta = { ...meta, askConfigRetired: true }
     const metaSaved = await window.electronAPI.config.save('appMeta', newMeta)
-    if (metaSaved === false) return removed > 0 ? { ...configData, configs: kept } : configData
+    if (!metaSaved) return removed > 0 ? { ...configData, configs: kept } : configData
     return { ...configData, configs: kept, appMeta: newMeta }
   } catch (e) {
     // Never block boot on this. Without the flag it simply runs again next launch.
@@ -407,7 +407,22 @@ export function hydrateStores(configData: Record<string, unknown>): void {
 export async function applyConfigColourMigration(
   configData: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  const rawSettings = { ...((configData.settings as any) || {}) }
+  // A settings section that is present but NOT a plain object is left exactly
+  // as it is, the same way the configs section below is. `|| {}` rejects only
+  // FALSY values, so a string or an array is truthy and spreads into
+  // character/index keys -- and this function writes that back, replacing the
+  // user's file with a mangled derivative of itself and setting
+  // identityColorMigratedV2 on it, so it never revisits. Worse, the result is
+  // a genuine plain object, so hydrateStores' coerceObject passes it WITHOUT
+  // setting configHydrationNoticePending: a corruption that would have been
+  // detected and reported becomes silent and permanent. The sibling migration
+  // in this file already guards exactly this via metaIsWritable.
+  const rawSettingsValue = configData.settings
+  const settingsAbsent = rawSettingsValue === undefined || rawSettingsValue === null
+  const settingsIsWritable =
+    settingsAbsent || (typeof rawSettingsValue === 'object' && !Array.isArray(rawSettingsValue))
+  if (!settingsIsWritable) return configData
+  const rawSettings = { ...((rawSettingsValue as any) || {}) }
   if (rawSettings.identityColorMigratedV2) return configData            // guard set: fast path
 
   // `|| []` accepted anything truthy, so a configs section that is present but
@@ -434,7 +449,7 @@ export async function applyConfigColourMigration(
       const newSettings = { ...rawSettings, identityColorMigratedV2: true }
       // Boolean, not a rejection: config.save catches its own write errors and
       // resolves false, so the catch below never sees a failed write.
-      if ((await window.electronAPI.config.save('settings', newSettings)) === false) return configData
+      if (!(await window.electronAPI.config.save('settings', newSettings))) return configData
       return { ...configData, settings: newSettings }
     } catch (e) {
       console.error('[colourMigration] guard persist failed (no-op case); will retry', e)
@@ -449,7 +464,7 @@ export async function applyConfigColourMigration(
       // the guard must not be written either — otherwise the migration records
       // itself as done and the notice invites the user to review colours that
       // were never saved.
-      if ((await window.electronAPI.config.save('configs', records)) === false) {
+      if (!(await window.electronAPI.config.save('configs', records))) {
         console.error('[colourMigration] configs did not persist; guard NOT set, will retry')
         return configData
       }
@@ -461,7 +476,7 @@ export async function applyConfigColourMigration(
       colourMigrationNoticePending: dismissed ? rawSettings.colourMigrationNoticePending : true,
     }
     // 2) guard + pending SECOND
-    if ((await window.electronAPI.config.save('settings', newSettings)) === false) {
+    if (!(await window.electronAPI.config.save('settings', newSettings))) {
       // The configs ARE on disk; only the guard is not. Hydrate from what was
       // written so memory matches, and let the next launch retry the guard.
       return { ...configData, configs: changedNow ? records : configs }

--- a/tests/unit/renderer/colour-migration-hydration.test.ts
+++ b/tests/unit/renderer/colour-migration-hydration.test.ts
@@ -48,7 +48,7 @@ describe('applyConfigColourMigration', () => {
 
   it('config save rejects: guard NOT set, returns original', async () => {
     const data = { settings: {}, configs: [{ color: '#FF3366' }] }
-    setupSave((key) => key === 'configs' ? Promise.reject(new Error('disk')) : Promise.resolve())
+    setupSave((key) => key === 'configs' ? Promise.reject(new Error('disk')) : Promise.resolve(true))
     const out: any = await applyConfigColourMigration(data)
     expect(out).toBe(data)
   })
@@ -131,9 +131,13 @@ describe('applyConfigColourMigration', () => {
 
   it('config save ok but settings save rejects: returns original (retry next launch)', async () => {
     const data = { settings: {}, configs: [{ color: '#FF3366' }] }
-    setupSave((key) => key === 'settings' ? Promise.reject(new Error('disk')) : Promise.resolve())
+    const { calls } = setupSave((key) => key === 'settings' ? Promise.reject(new Error('disk')) : Promise.resolve(true))
     const out: any = await applyConfigColourMigration(data)
     expect(out).toBe(data)
+    // The configs write must actually have SUCCEEDED and the settings write
+    // must actually have been attempted, or this is passing on the wrong path.
+    expect(calls.map((c) => c.key)).toContain('configs')
+    expect(calls.map((c) => c.key)).toContain('settings')
   })
 
   it('partial-success recovery: guard false, changed 0, records already keyed+legacy -> guard + pending', async () => {

--- a/tests/unit/renderer/colour-migration-hydration.test.ts
+++ b/tests/unit/renderer/colour-migration-hydration.test.ts
@@ -5,7 +5,12 @@ function setupSave(impl?: (key: string, data: any) => Promise<unknown>) {
   const calls: Array<{ key: string; data: any }> = []
   const save = vi.fn((key: string, data: any) => {
     calls.push({ key, data })
-    return impl ? impl(key, data) : Promise.resolve()
+    // `true`, not `undefined`. config.save resolves a BOOLEAN -- it reports
+    // failure by resolving FALSE, never by rejecting. A default of undefined
+    // encodes "undefined counts as a successful save", a value the real API
+    // never produces, so hardening the source from `saved === false` to the
+    // safer `!saved` would turn these tests red for the wrong reason.
+    return impl ? impl(key, data) : Promise.resolve(true)
   })
   ;(globalThis as any).window = { electronAPI: { config: { save } } }
   return { calls, save }
@@ -85,6 +90,43 @@ describe('applyConfigColourMigration', () => {
     const out = await applyConfigColourMigration(data)
     expect(out).toBe(data)
     expect(save).not.toHaveBeenCalled()
+  })
+
+
+  it('stands aside for a corrupt settings section instead of mangling it', async () => {
+    // The mirror of the configs case above, and worse in one way. `|| {}` rejects
+    // only FALSY values, so a string is truthy and spreads into character keys:
+    // {"0":"t","1":"h",...}. Writing that back destroys the user's only forensic
+    // copy AND sets identityColorMigratedV2 on it, so it never revisits -- and
+    // because the result is a genuine plain object, hydrateStores' coerceObject
+    // passes it without raising configHydrationNoticePending. A detected,
+    // reportable corruption becomes a silent permanent one.
+    const { save } = setupSave()
+    const data = { settings: 'theme=dark', configs: [{ color: '#FF3366' }] }
+    const out = await applyConfigColourMigration(data)
+    expect(out).toBe(data)
+    expect(data.settings).toBe('theme=dark')
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('stands aside for a settings section that is an array', async () => {
+    const { save } = setupSave()
+    const data = { settings: [{ a: 1 }], configs: [{ color: '#FF3366' }] }
+    const out = await applyConfigColourMigration(data)
+    expect(out).toBe(data)
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('still migrates when settings is absent or null', async () => {
+    // Absent must stay writable: that is an ordinary first-run config, not a
+    // corrupt one, and refusing it would strand the migration forever.
+    for (const settings of [undefined, null]) {
+      const { save } = setupSave()
+      const data: any = { settings, configs: [{ color: '#FF3366' }] }
+      const out: any = await applyConfigColourMigration(data)
+      expect(out).not.toBe(data)
+      expect(save).toHaveBeenCalled()
+    }
   })
 
   it('config save ok but settings save rejects: returns original (retry next launch)', async () => {


### PR DESCRIPTION
From the ADR-009 pass over the unreleased beta.16 delta.

## The bug

`applyConfigColourMigration` opened with:

```ts
const rawSettings = { ...((configData.settings as any) || {}) }
```

`|| {}` rejects only **falsy** values, so a settings section that is a string or an array is truthy and spreads into character/index keys. Observed against the real module:

```
wrote to settings.json: {"0":"t","1":"h","2":"e","3":"m","4":"e","5":"=", ... ,"identityColorMigratedV2":true}
```

Three things compound:

1. that derivative is **written back**, so the original bytes — the user's only forensic copy — are gone;
2. `identityColorMigratedV2: true` goes into the same object, **burning the guard**, so it never revisits;
3. the result is a genuine plain object, so `hydrateStores`' `coerceObject` passes it **without** setting `configHydrationNoticePending`. Without the migration, `coerceObject` would have reset to `{}` *and told the user*.

So the migration converts a detected, reportable corruption into a silent, permanent one.

## The fix already existed, one function away

The sibling migration in this same file guards exactly this via `metaIsWritable`, with the reasoning spelled out in a comment: *"spreading a string into `{...}` yields character indices, and writing that back replaces the user's file with a mangled derivative of itself."* That reasoning was applied to `appMeta` and to the `configs` section — and not to `settings`. Now it is.

Absent and `null` stay writable: that is an ordinary first-run config, not a corrupt one, and refusing it would strand the migration forever.

## Bonus: the persist checks

Hardened from `saved === false` to `!saved`. `config.save` reports failure by **resolving false**, never by rejecting, and a strict `=== false` reads a future `undefined`/`null` as *success* — which would set the guard and never retry.

This could not be tightened before: `setupSave`'s default mock resolved `undefined`, so the tests encoded "undefined counts as a successful save" — a value the real API never produces — and the hardening would have turned three tests red for the wrong reason. The mock now resolves `true`, which is what the API actually does, and the hardening is green.

## Tests

3 added (corrupt string, array, and absent/null still migrating). Mutation-checked: removing the writability guard fails 2.

Suite **6095 passed / 15 skipped**, typecheck clean.
