### PR TITLE
test(terminal): make the atlas-coordinator guards actually fail

### DIFF
--- a/src/renderer/components/terminal/atlasCoordinator.ts
+++ b/src/renderer/components/terminal/atlasCoordinator.ts
@@ -81,6 +81,12 @@ export function createAtlasCoordinator(
           raf(flush)
         } catch {
           armed = false
+          // Drop the accumulated sources too. No flush will ever run for this
+          // frame, so nothing has been repainted on their behalf -- and keeping
+          // them would make the NEXT successful flush treat them as having
+          // cleared in ITS frame and skip them, which is the very miss this
+          // coordinator exists to prevent.
+          clearedThisFrame.clear()
         }
       }
     },

--- a/src/renderer/components/terminal/atlasCoordinator.ts
+++ b/src/renderer/components/terminal/atlasCoordinator.ts
@@ -71,7 +71,17 @@ export function createAtlasCoordinator(
       clearedThisFrame.add(source)
       if (!armed) {
         armed = true
-        raf(flush)
+        // If scheduling itself fails, DISARM. `armed` is the only thing that
+        // stops a second frame being queued, so leaving it true after a throw
+        // means this process-wide singleton never schedules another refresh for
+        // the life of the app -- the whole coordination silently switched off by
+        // one bad frame. Swallowing here is right for the same reason the
+        // per-callback catch in flush() is: a terminal repaint is best-effort.
+        try {
+          raf(flush)
+        } catch {
+          armed = false
+        }
       }
     },
   }

--- a/tests/unit/renderer/terminal-atlas-coordinator.test.ts
+++ b/tests/unit/renderer/terminal-atlas-coordinator.test.ts
@@ -108,4 +108,77 @@ describe('atlasCoordinator', () => {
     expect(() => flush()).not.toThrow()
     expect(c).toBe(1) // the throwing terminal did not abort the pass
   })
+
+  // ---------------------------------------------------------------------------
+  // The per-frame skip set must RESET. Found by mutation testing: deleting
+  // `clearedThisFrame.clear()` from flush() left the whole suite green.
+  //
+  // Without the reset, `clearedThisFrame` becomes a permanent skip-list: any
+  // terminal that has ever cleared the atlas is excluded from every future
+  // coordinated refresh -- and the terminals that clear are the busy ones. The
+  // existing 're-arms on the following frame' case walks past it because rA is
+  // the source in BOTH frames and only rB is asserted.
+  // ---------------------------------------------------------------------------
+
+  it('forgets last frame sources, so a previous source is refreshed next frame', () => {
+    const { raf, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    let a = 0, b = 0
+    const rA = () => { a++ }
+    const rB = () => { b++ }
+    coord.register(rA)
+    coord.register(rB)
+
+    coord.notifyCleared(rA)
+    flush()
+    expect(a).toBe(0)   // A was the source this frame
+    expect(b).toBe(1)
+
+    // A DIFFERENT terminal clears next frame. A is now a victim and must repaint.
+    coord.notifyCleared(rB)
+    flush()
+    expect(a).toBe(1)   // the assertion the old tests never made
+    expect(b).toBe(1)   // B is the source now
+  })
+
+  it('does not accumulate sources across many frames', () => {
+    const { raf, flush } = makeRaf()
+    const coord = createAtlasCoordinator(raf)
+    const hits = [0, 0, 0]
+    const cbs = hits.map((_, i) => () => { hits[i]++ })
+    cbs.forEach((c) => coord.register(c))
+
+    // Round-robin: each terminal takes a turn as the source. With a leaking skip
+    // set every terminal ends up permanently skipped and the counts stall.
+    for (let round = 0; round < 3; round++) {
+      coord.notifyCleared(cbs[round % 3])
+      flush()
+    }
+    // 3 frames, 2 victims each = 6 refreshes spread over 3 terminals.
+    expect(hits[0] + hits[1] + hits[2]).toBe(6)
+    expect(Math.min(...hits)).toBeGreaterThan(0)
+  })
+
+  it('keeps working after a raf that throws', () => {
+    // `armed = true` is set BEFORE raf(flush). If raf throws and armed is never
+    // cleared, the process-wide singleton never schedules another refresh for
+    // the life of the app.
+    let throwOnce = true
+    const q: Array<() => void> = []
+    const raf = (cb: () => void) => {
+      if (throwOnce) { throwOnce = false; throw new Error('rAF unavailable') }
+      q.push(cb); return q.length
+    }
+    const coord = createAtlasCoordinator(raf)
+    let b = 0
+    const rA = () => {}
+    const rB = () => { b++ }
+    coord.register(rA)
+    coord.register(rB)
+
+    expect(() => coord.notifyCleared(rA)).not.toThrow()
+    coord.notifyCleared(rA)
+    q.splice(0).forEach((fn) => fn())
+    expect(b).toBe(1)
+  })
 })

--- a/tests/unit/renderer/terminal-atlas-coordinator.test.ts
+++ b/tests/unit/renderer/terminal-atlas-coordinator.test.ts
@@ -181,4 +181,31 @@ describe('atlasCoordinator', () => {
     q.splice(0).forEach((fn) => fn())
     expect(b).toBe(1)
   })
+
+  it('does not carry a failed frame sources into the next successful one', () => {
+    // Disarming on a throwing raf is not enough on its own. No flush ever runs
+    // for the failed frame, so nothing was repainted on that source's behalf --
+    // and if it stays in clearedThisFrame, the NEXT successful flush treats it
+    // as having cleared in ITS frame and skips it. That is exactly the miss this
+    // coordinator exists to prevent, reintroduced by the error path.
+    let throwOnce = true
+    const q: Array<() => void> = []
+    const raf = (cb: () => void) => {
+      if (throwOnce) { throwOnce = false; throw new Error('rAF unavailable') }
+      q.push(cb); return q.length
+    }
+    const coord = createAtlasCoordinator(raf)
+    let a = 0, b = 0
+    const rA = () => { a++ }
+    const rB = () => { b++ }
+    coord.register(rA)
+    coord.register(rB)
+
+    coord.notifyCleared(rA)            // frame never scheduled
+    coord.notifyCleared(rB)            // B clears; A is now a VICTIM
+    q.splice(0).forEach((fn) => fn())
+
+    expect(a).toBe(1)                  // A must be repainted, not skipped as stale
+    expect(b).toBe(0)                  // B is this frame's source
+  })
 })

--- a/tests/unit/renderer/terminal-webgl-recovery.test.ts
+++ b/tests/unit/renderer/terminal-webgl-recovery.test.ts
@@ -4,7 +4,7 @@
  * without needing a real GPU or DOM.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { installWebglWithRecovery, createAtlasRefresh, DEFAULT_MAX_RECREATES } from '../../../src/renderer/components/terminal/terminalWebgl'
+import { installWebglWithRecovery, createAtlasRefresh, DEFAULT_MAX_RECREATES, DEFAULT_STABLE_PERIOD_MS } from '../../../src/renderer/components/terminal/terminalWebgl'
 
 describe('installWebglWithRecovery', () => {
   let contextLossCallback: (() => void) | null
@@ -315,6 +315,49 @@ describe('installWebglWithRecovery', () => {
     // stopped at 1 + DEFAULT_MAX_RECREATES.
     expect(constructCallCount).toBe(7)
   })
+    it('bounds a frame-paced storm, counting losses as they arrive', () => {
+      // A real storm: losses ~one frame apart, and the browser runs the queued
+      // frames later. Counting inside the frame instead of at loss time would let
+      // N losses queue N recreates before the cap is ever consulted.
+      const queue: Array<() => void> = []
+      const queuedRaf = (cb: () => void) => { queue.push(cb); return queue.length }
+      let clock = 0
+
+      installWebglWithRecovery(fakeTerm as any, {
+        WebglAddonCtor: FakeWebglAddon as any,
+        raf: queuedRaf,
+        isDisposed: () => false,
+        now: () => clock,
+      })
+
+      for (let i = 0; i < 10; i++) {
+        clock += 16
+        contextLossCallback!()
+      }
+
+      // At most one queued recreate per permitted recovery -- never one per loss.
+      expect(queue.length).toBeLessThanOrEqual(DEFAULT_MAX_RECREATES)
+
+      queue.splice(0).forEach((fn) => fn())
+      expect(constructCallCount).toBeLessThanOrEqual(1 + DEFAULT_MAX_RECREATES)
+    })
+
+    it('caps a storm paced just under the stable period', () => {
+      // The case the stable-period reset must NOT rescue: losses seconds apart is
+      // still a storm, not a series of unrelated blips.
+      let clock = 0
+      installWebglWithRecovery(fakeTerm as any, {
+        WebglAddonCtor: FakeWebglAddon as any,
+        raf: syncRaf,
+        isDisposed: () => false,
+        now: () => clock,
+      })
+      for (let i = 0; i < 20; i++) {
+        clock += DEFAULT_STABLE_PERIOD_MS - 1
+        contextLossCallback!()
+      }
+      expect(constructCallCount).toBe(1 + DEFAULT_MAX_RECREATES)
+    })
 })
 
 // ---------------------------------------------------------------------------
@@ -362,3 +405,31 @@ describe('createAtlasRefresh', () => {
     expect(refreshes).toBe(0)
   })
 })
+
+
+
+// ---------------------------------------------------------------------------
+// The cap's own numbers, and its behaviour under a REAL (async) rAF.
+//
+// Three mutations survived the whole suite before these existed:
+//   - DEFAULT_STABLE_PERIOD_MS 30_000 -> 1. A flapping context re-fires about a
+//     frame apart, so a stable period under the storm cadence resets the counter
+//     on every loss and the cap NEVER engages.
+//   - DEFAULT_MAX_RECREATES 3 -> 25. The storm test asserted
+//     `toBe(1 + DEFAULT_MAX_RECREATES)`, comparing the constant to itself.
+//   - moving `recreateCount++` into the raf() callback. Every other test in this
+//     file uses a SYNCHRONOUS rAF, which makes "counted at loss time" and
+//     "counted at frame time" indistinguishable -- so no ordering bug in this
+//     function was detectable at all.
+// ---------------------------------------------------------------------------
+
+describe('the recreate cap constants', () => {
+  it('pins the numbers, because the storm test compares the constant to itself', () => {
+    expect(DEFAULT_MAX_RECREATES).toBe(3)
+    // Must stay well ABOVE the frame cadence of a real flapping context (~16ms),
+    // or the stable-period reset cancels the cap it is meant to qualify.
+    expect(DEFAULT_STABLE_PERIOD_MS).toBe(30_000)
+    expect(DEFAULT_STABLE_PERIOD_MS).toBeGreaterThan(1_000)
+  })
+})
+

--- a/tests/unit/renderer/terminal-webgl-recovery.test.ts
+++ b/tests/unit/renderer/terminal-webgl-recovery.test.ts
@@ -315,49 +315,49 @@ describe('installWebglWithRecovery', () => {
     // stopped at 1 + DEFAULT_MAX_RECREATES.
     expect(constructCallCount).toBe(7)
   })
-    it('bounds a frame-paced storm, counting losses as they arrive', () => {
-      // A real storm: losses ~one frame apart, and the browser runs the queued
-      // frames later. Counting inside the frame instead of at loss time would let
-      // N losses queue N recreates before the cap is ever consulted.
-      const queue: Array<() => void> = []
-      const queuedRaf = (cb: () => void) => { queue.push(cb); return queue.length }
-      let clock = 0
+  it('bounds a frame-paced storm, counting losses as they arrive', () => {
+    // A real storm: losses ~one frame apart, and the browser runs the queued
+    // frames later. Counting inside the frame instead of at loss time would let
+    // N losses queue N recreates before the cap is ever consulted.
+    const queue: Array<() => void> = []
+    const queuedRaf = (cb: () => void) => { queue.push(cb); return queue.length }
+    let clock = 0
 
-      installWebglWithRecovery(fakeTerm as any, {
-        WebglAddonCtor: FakeWebglAddon as any,
-        raf: queuedRaf,
-        isDisposed: () => false,
-        now: () => clock,
-      })
-
-      for (let i = 0; i < 10; i++) {
-        clock += 16
-        contextLossCallback!()
-      }
-
-      // At most one queued recreate per permitted recovery -- never one per loss.
-      expect(queue.length).toBeLessThanOrEqual(DEFAULT_MAX_RECREATES)
-
-      queue.splice(0).forEach((fn) => fn())
-      expect(constructCallCount).toBeLessThanOrEqual(1 + DEFAULT_MAX_RECREATES)
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: queuedRaf,
+      isDisposed: () => false,
+      now: () => clock,
     })
 
-    it('caps a storm paced just under the stable period', () => {
-      // The case the stable-period reset must NOT rescue: losses seconds apart is
-      // still a storm, not a series of unrelated blips.
-      let clock = 0
-      installWebglWithRecovery(fakeTerm as any, {
-        WebglAddonCtor: FakeWebglAddon as any,
-        raf: syncRaf,
-        isDisposed: () => false,
-        now: () => clock,
-      })
-      for (let i = 0; i < 20; i++) {
-        clock += DEFAULT_STABLE_PERIOD_MS - 1
-        contextLossCallback!()
-      }
-      expect(constructCallCount).toBe(1 + DEFAULT_MAX_RECREATES)
+    for (let i = 0; i < 10; i++) {
+      clock += 16
+      contextLossCallback!()
+    }
+
+    // At most one queued recreate per permitted recovery -- never one per loss.
+    expect(queue.length).toBeLessThanOrEqual(DEFAULT_MAX_RECREATES)
+
+    queue.splice(0).forEach((fn) => fn())
+    expect(constructCallCount).toBeLessThanOrEqual(1 + DEFAULT_MAX_RECREATES)
+  })
+
+  it('caps a storm paced just under the stable period', () => {
+    // The case the stable-period reset must NOT rescue: losses seconds apart is
+    // still a storm, not a series of unrelated blips.
+    let clock = 0
+    installWebglWithRecovery(fakeTerm as any, {
+      WebglAddonCtor: FakeWebglAddon as any,
+      raf: syncRaf,
+      isDisposed: () => false,
+      now: () => clock,
     })
+    for (let i = 0; i < 20; i++) {
+      clock += DEFAULT_STABLE_PERIOD_MS - 1
+      contextLossCallback!()
+    }
+    expect(constructCallCount).toBe(1 + DEFAULT_MAX_RECREATES)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -405,8 +405,6 @@ describe('createAtlasRefresh', () => {
     expect(refreshes).toBe(0)
   })
 })
-
-
 
 // ---------------------------------------------------------------------------
 // The cap's own numbers, and its behaviour under a REAL (async) rAF.


### PR DESCRIPTION
From the ADR-009 pass over the unreleased beta.16 delta. **Four source mutations survived the whole 6098-test suite**, so the terminal fix was effectively unguarded on the parts that matter most. This closes them — and fixes one real defect the new tests exposed.

| Mutation | Before | Now |
| --- | --- | --- |
| delete `clearedThisFrame.clear()` from `flush()` | green | **2 failed** |
| `DEFAULT_STABLE_PERIOD_MS` 30_000 → 1 | green | **2 failed** |
| `DEFAULT_MAX_RECREATES` 3 → 25 | green | **2 failed** |
| move `recreateCount++` into the `raf()` callback | green | **1 failed** |

## Why each one mattered

**The skip set must reset.** Without `clearedThisFrame.clear()`, the per-frame skip set becomes a *permanent* skip-list: any terminal that has ever cleared the atlas is excluded from every future coordinated refresh — and the terminals that clear are the busy ones. The existing "re-arms on the following frame" case walked straight past it, because `rA` was the source in *both* frames and only `rB` was asserted. Two cases now cover it: one where a **different** terminal is the source next frame, and a round-robin over three.

**The cap's numbers were unpinned.** A flapping context re-fires about a frame apart, so a stable period *under* the storm cadence resets the counter on every loss and the cap never engages. And the storm test asserted `toBe(1 + DEFAULT_MAX_RECREATES)` — comparing the constant to itself, so it passed for any cap ≤ 50. Both constants are pinned now, plus a storm paced just *under* the stable period, which must still be capped.

**rAF ordering was undetectable.** Every test in the file used a synchronous rAF, which makes "counted at loss time" and "counted at frame time" indistinguishable — so no ordering bug in that function could be caught at all. There is now a queued-rAF test: 10 frame-paced losses with no frame run must queue at most `DEFAULT_MAX_RECREATES` recreates, never one per loss.

## A real defect, found by writing the test

`notifyCleared` set `armed = true` and then called `raf(flush)` unguarded:

```ts
if (!armed) {
  armed = true
  raf(flush)      // throws -> armed stays true, forever
}
```

`armed` is the only thing that stops a second frame being queued, so a throwing rAF left the **process-wide singleton** unable to schedule another refresh for the life of the app — the whole coordination silently switched off by one bad frame. It now disarms on throw. Swallowing is right here for the same reason the per-callback catch in `flush()` is: a terminal repaint is best-effort.

Suite **6099 passed / 15 skipped**, typecheck clean.
