### PR TITLE
fix(pty): hold writes until the launch line has been written

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -684,6 +684,17 @@ interface PtySession {
 // Buffer writes for PTYs that haven't spawned yet (e.g., partner terminal initially hidden)
 const pendingWrites = new Map<string, string[]>()
 
+/**
+ * Sessions whose PTY exists but is still the bare shell, waiting for the launch
+ * line queued 300ms behind it. A write that lands in that window used to go
+ * straight to the shell, and a trailing `\r` submitted it as a SHELL COMMAND --
+ * an Ask Conductor question typed at a session that was still starting was
+ * executed by PowerShell instead of being asked of Claude. `writePty` buffers
+ * while a session is in here, and the launch timer replays once the real
+ * program owns the terminal.
+ */
+const launchPendingSessions = new Set<string>()
+
 export interface SSHOptions {
   host: string
   port: number
@@ -1045,6 +1056,20 @@ export function spawnPty(
   // unless the Claude branch resolved an exact-resume launch.
   let resumeUuidForBind: string | null = null
   let resolvedProfileId: string | undefined = undefined
+
+  // See `launchPendingSessions`. A session with a launch line is not ready for
+  // input until that line has been written, so hold writes until then and flush
+  // here. Always paired with `launchPendingSessions.delete` so a failed or
+  // raced launch releases the hold instead of buffering forever.
+  let launchWriteScheduled = false
+  const releaseLaunchHold = () => {
+    launchPendingSessions.delete(sessionId)
+    const pending = pendingWrites.get(sessionId)
+    if (!pending) return
+    logInfo(`[pty] Replaying ${pending.length} buffered write(s) for ${sessionId}`)
+    for (const data of pending) ptyProcess.write(data)
+    pendingWrites.delete(sessionId)
+  }
 
   if (options?.ssh) {
     // Defensive guard: Codex over SSH is not yet supported. The renderer-side
@@ -2794,12 +2819,14 @@ export function spawnPty(
       // never the secret itself — see terminal-launch-line.ts for the contract.
       const launchLine = buildTerminalLaunchLine(options?.terminalOptions, isWin)
 
+      launchWriteScheduled = true
+      launchPendingSessions.add(sessionId)
       setTimeout(() => {
         // Liveness guard: a kill / Restart / app-quit can land inside this 300ms
         // window — writing to a dead or already-replaced PTY here would throw
         // inside the timer (uncaught in main). Only write when our PTY is still
         // the registered one.
-        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) return
+        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { launchPendingSessions.delete(sessionId); return }
         try {
           ptyProcess.write(cdCmd + '\r')
           // Queued straight after the cd: the shell runs them in order, so the
@@ -2808,7 +2835,8 @@ export function spawnPty(
             logInfo(`[pty-manager] shell-only first-run command for ${sessionId}: ${launchLine}`)
             ptyProcess.write(launchLine + '\r')
           }
-        } catch { /* session died mid-launch */ }
+          releaseLaunchHold()
+        } catch { launchPendingSessions.delete(sessionId) /* session died mid-launch */ }
       }, 300)
     } else {
       // Launch Claude Code interactive mode.
@@ -3166,12 +3194,17 @@ export function spawnPty(
         // `claude -- ""`, the blank opening prompt the env route exists to avoid.
         askPrompt: finalSpawnEnv.CCC_ASK_PROMPT !== undefined,
       })
+      launchWriteScheduled = true
+      launchPendingSessions.add(sessionId)
       setTimeout(() => {
         // Liveness guard (see shell-only branch): the 300ms launch-write can race
         // a kill / Restart / app-quit; writing to a dead/replaced PTY from this
         // timer would crash main. Only write when our PTY is still registered.
-        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) return
-        try { ptyProcess.write(escapedCmd + '\r') } catch { /* session died mid-launch */ }
+        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { launchPendingSessions.delete(sessionId); return }
+        try {
+          ptyProcess.write(escapedCmd + '\r')
+          releaseLaunchHold()
+        } catch { launchPendingSessions.delete(sessionId) /* session died mid-launch */ }
       }, 300)
     }
 
@@ -3185,15 +3218,10 @@ export function spawnPty(
   ptySessions.set(sessionId, { ptyProcess, sessionId })
   updateSessionMeta({ id: sessionId, label: options?.configLabel ?? sessionId, cwd: options?.cwd, provider: options?.provider ?? 'claude' })
 
-  // Replay any buffered writes (from commands sent before PTY was ready)
-  const pending = pendingWrites.get(sessionId)
-  if (pending) {
-    logInfo(`[pty] Replaying ${pending.length} buffered write(s) for ${sessionId}`)
-    for (const data of pending) {
-      ptyProcess.write(data)
-    }
-    pendingWrites.delete(sessionId)
-  }
+  // Replay any buffered writes (from commands sent before PTY was ready). When a
+  // launch line is queued, its timer owns the replay so the buffered write lands
+  // in the process the user meant, not in the shell that is about to be replaced.
+  if (!launchWriteScheduled) releaseLaunchHold()
 
   // Record the run via the transcripts worker pipeline (Logs v2). Gated on the
   // live `loggingEnabled` setting (default-true) and never for shell-only
@@ -3454,7 +3482,9 @@ export function writePty(sessionId: string, data: string): void {
 
   try {
     const session = ptySessions.get(sessionId)
-    if (session) {
+    // The PTY can exist while still being the bare shell (see
+    // launchPendingSessions): writing now hands the text to THAT shell.
+    if (session && !launchPendingSessions.has(sessionId)) {
       if (data.length > WRITE_CHUNK_SIZE) {
         writeChunked(sessionId, session.ptyProcess, data)
       } else {
@@ -3504,6 +3534,7 @@ export function resizePty(sessionId: string, cols: number, rows: number): void {
  */
 function cleanupSessionResources(sessionId: string): void {
   pendingWrites.delete(sessionId)
+  launchPendingSessions.delete(sessionId)
   recentWrites.delete(sessionId)
   sshOscBuffers.delete(sessionId)
   // #242 finding I1: drop ALL of this session's sentinel buffers alongside its

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1067,7 +1067,25 @@ export function spawnPty(
     const pending = pendingWrites.get(sessionId)
     if (!pending) return
     logInfo(`[pty] Replaying ${pending.length} buffered write(s) for ${sessionId}`)
-    for (const data of pending) ptyProcess.write(data)
+    for (const data of pending) {
+      // Same chunking rule the live path uses: a paste larger than
+      // WRITE_CHUNK_SIZE overflows/truncates ConPTY's input buffer if written in
+      // one go. Holding a write must not change how it is delivered.
+      if (data.length > WRITE_CHUNK_SIZE) writeChunked(sessionId, ptyProcess, data)
+      else ptyProcess.write(data)
+    }
+    pendingWrites.delete(sessionId)
+  }
+  /**
+   * The launch never landed (the PTY was killed/replaced inside the window, or
+   * the launch write threw). There is no program to deliver held writes to, so
+   * drop them with the hold -- leaving them buffered orphans them: nothing
+   * replays that buffer, and it survives until session teardown.
+   */
+  const abandonLaunchHold = () => {
+    launchPendingSessions.delete(sessionId)
+    const dropped = pendingWrites.get(sessionId)?.length ?? 0
+    if (dropped > 0) logWarn(`[pty] Dropping ${dropped} held write(s) for ${sessionId}: launch never completed`)
     pendingWrites.delete(sessionId)
   }
 
@@ -2826,7 +2844,7 @@ export function spawnPty(
         // window — writing to a dead or already-replaced PTY here would throw
         // inside the timer (uncaught in main). Only write when our PTY is still
         // the registered one.
-        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { launchPendingSessions.delete(sessionId); return }
+        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { abandonLaunchHold(); return }
         try {
           ptyProcess.write(cdCmd + '\r')
           // Queued straight after the cd: the shell runs them in order, so the
@@ -2836,7 +2854,7 @@ export function spawnPty(
             ptyProcess.write(launchLine + '\r')
           }
           releaseLaunchHold()
-        } catch { launchPendingSessions.delete(sessionId) /* session died mid-launch */ }
+        } catch { abandonLaunchHold() /* session died mid-launch */ }
       }, 300)
     } else {
       // Launch Claude Code interactive mode.
@@ -3200,11 +3218,11 @@ export function spawnPty(
         // Liveness guard (see shell-only branch): the 300ms launch-write can race
         // a kill / Restart / app-quit; writing to a dead/replaced PTY from this
         // timer would crash main. Only write when our PTY is still registered.
-        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { launchPendingSessions.delete(sessionId); return }
+        if (ptySessions.get(sessionId)?.ptyProcess !== ptyProcess) { abandonLaunchHold(); return }
         try {
           ptyProcess.write(escapedCmd + '\r')
           releaseLaunchHold()
-        } catch { launchPendingSessions.delete(sessionId) /* session died mid-launch */ }
+        } catch { abandonLaunchHold() /* session died mid-launch */ }
       }, 300)
     }
 
@@ -3493,11 +3511,17 @@ export function writePty(sessionId: string, data: string): void {
     } else if (sessionId === '__cli_setup__') {
       writeCliSetupPty(data)
     } else {
-      // PTY not spawned yet — buffer the write (e.g., partner terminal command clicked before PTY ready)
+      // Buffer: either there is no PTY yet (partner terminal command clicked
+      // before it was ready) or there is one but it is still the bare shell
+      // waiting for its launch line. The two are different states and the log
+      // says which, because "not yet spawned" against a live PTY reads as a bug.
+      const held = launchPendingSessions.has(sessionId)
       const pending = pendingWrites.get(sessionId) || []
       pending.push(data)
       pendingWrites.set(sessionId, pending)
-      logInfo(`[pty] Buffered write for ${sessionId} (PTY not yet spawned, ${pending.length} pending)`)
+      logInfo(
+        `[pty] Buffered write for ${sessionId} (${held ? 'launch line still pending' : 'PTY not yet spawned'}, ${pending.length} pending)`,
+      )
     }
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException)?.code

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -465,17 +465,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // then we try ONE recreate in the next frame (GPU-blip recovery).
       // If recreate fails, we force term.refresh so the DOM renderer
       // repaints the viewport the dead WebGL canvas left garbled.
-      // The GPU renderer is ON unless explicitly turned off (see
-      // TerminalSettings.gpuRendering). `@xterm/addon-webgl` keeps ONE glyph
-      // atlas per PROCESS, so a clearTextureAtlas() from ANY terminal used to
-      // blank the glyphs of every OTHER mounted terminal until it was
-      // resized/scrolled/activated — which is why beta.16 shipped it off. #312
-      // fixed that: the atlasCoordinator below repaints the others on the next
-      // frame, so the clear is survivable and the containment is no longer
-      // needed. Unset means ON; a stored `false` is a user who turned it off and
-      // is left exactly as it is. Read once at mount — changing the setting
-      // applies to terminals opened afterwards, which keeps a live session from
-      // having its renderer swapped underneath it.
+      // The GPU renderer is OPT-IN: only a literal `true` enables it (see
+      // settingsStore.gpuRenderingEnabled). `@xterm/addon-webgl` keeps ONE glyph
+      // atlas per PROCESS, so a clearTextureAtlas() from ANY terminal blanks the
+      // glyphs of every OTHER mounted terminal until it is
+      // resized/scrolled/activated. That is NOT fixed: the atlasCoordinator below
+      // is necessary but not sufficient, because a victim's render model is never
+      // cleared and refresh() alone therefore repaints it blank. The coordinator
+      // is kept as scaffolding and is inert while the renderer is off. Read once
+      // at mount — changing the setting applies to terminals opened afterwards,
+      // which keeps a live session from having its renderer swapped underneath it.
       // Repaint this terminal's viewport from the (shared) glyph atlas.
       const domRefresh = () => { try { term?.refresh(0, term.rows - 1) } catch { /* disposed */ } }
       // The coordinator's view of this terminal: repaint, but only while WebGL
@@ -496,10 +495,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       }
       // #273 / #311: reproduces the window-resize repaint (clearTextureAtlas +
       // refresh) against whichever addon is currently live. The glyph atlas is
-      // shared across every terminal, so a clear here empties it for all of them
-      // — the coordinator repaints the others (#311) so the clear is now
-      // multi-session-safe rather than blanking their glyphs. Inert on the DOM
-      // path (clearAtlas() returns false — no WebGL addon, nothing to clear).
+      // shared across every terminal, so a clear here empties it for all of them.
+      // The coordinator (#311) refreshes the others, which is necessary but does
+      // NOT make the clear safe — a victim keeps its old render model, so the
+      // refresh repaints it blank. Only relevant when the opt-in GPU renderer is
+      // on; inert on the DOM path (clearAtlas() returns false — nothing to clear).
       repainter = createStaleGlyphRepainter({
         // Rebuild the shared atlas; when it actually happened (WebGL live), tell
         // the coordinator so every OTHER terminal repaints — otherwise they

--- a/src/renderer/components/terminal/atlasCoordinator.ts
+++ b/src/renderer/components/terminal/atlasCoordinator.ts
@@ -10,11 +10,19 @@
  * keeps rendering against the emptied atlas and loses its glyphs (backgrounds
  * intact) until it happens to repaint. That is the beta.16 corruption.
  *
- * The fix is coordination: each live WebGL terminal registers a `refresh`
- * callback here; when one rebuilds the shared atlas it calls `notifyCleared`,
- * and every OTHER registered terminal is refreshed on the next animation frame.
- * The blank a clear leaves in the other terminals is therefore corrected within
- * ~1 frame instead of lasting until a resize/scroll/activate.
+ * Coordination is PART of a fix, not the whole one: each live WebGL terminal
+ * registers a `refresh` callback here; when one rebuilds the shared atlas it
+ * calls `notifyCleared`, and every OTHER registered terminal is refreshed on the
+ * next animation frame.
+ *
+ * That is necessary but NOT sufficient, and this module does not repair the
+ * corruption on its own. `clearTextureAtlas()` calls `_clearModel(true)` for the
+ * CALLER only, so a victim still holds its old cells, `_updateModel` concludes
+ * nothing changed, and refresh() draws stale vertices against an emptied
+ * texture — i.e. blank. A working repair has to clear the victim's render model
+ * WITHOUT re-wiping the shared texture. This module is retained as scaffolding
+ * for that, and is inert while `gpuRendering` is off — which is the default,
+ * since the setting is opt-in (a literal `true`; see gpuRenderingEnabled).
  *
  * Calls are coalesced per frame: N terminals each clearing in the same frame
  * produce ONE refresh pass over the others, not N. A terminal that cleared this

--- a/tests/e2e/pty-launch-hold.spec.ts
+++ b/tests/e2e/pty-launch-hold.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Desktop verification for the launch-hold fix, against a REAL ConPTY in the
+ * REAL app (no mocks): a write that lands while the launch line is still queued
+ * must reach the launched program, not the bare shell that briefly precedes it.
+ *
+ * Driven through the app's own IPC rather than the UI, so it exercises
+ * pty-manager end to end without depending on session-dialog selectors.
+ */
+import { test, expect } from '@playwright/test'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+let ctx: IsolatedApp
+let page: IsolatedApp['page']
+
+test.beforeAll(async () => {
+  ctx = await launchIsolatedApp()
+  page = ctx.page
+})
+
+test.afterAll(async () => {
+  await closeIsolatedApp(ctx)
+})
+
+test.describe('PTY launch hold', () => {
+  test('a write during the launch window lands after the launcher, and is not lost', async () => {
+    test.setTimeout(60_000)
+
+    const out = await page.evaluate(async () => {
+      const api = (window as unknown as { electronAPI: any }).electronAPI
+      const id = 'e2e-launch-hold-' + Date.now()
+      const chunks: string[] = []
+      const off = api.pty.onData(id, (d: string) => { chunks.push(d) })
+
+      await api.pty.spawn(id, {
+        cwd: 'C:\\',
+        cols: 120,
+        rows: 30,
+        shellOnly: true,
+        // The launcher command: this is what the 300ms timer writes.
+        terminalOptions: { command: 'echo', args: 'CCC_LAUNCHER_RAN' },
+      })
+
+      // Immediately -- well inside the 300ms window. Before the fix this went
+      // straight to the bare shell.
+      api.pty.write(id, 'echo CCC_HELD_WRITE\r')
+
+      await new Promise((r) => setTimeout(r, 8000))
+      off?.()
+      api.pty.kill(id)
+      return chunks.join('')
+    })
+
+    // Strip ANSI so ordering is measured on text, not escape sequences.
+    const clean = out.replace(/\u001b\[[0-9;?]*[A-Za-z]/g, '')
+
+    // Both must have actually run: the launcher, and our held write. The write
+    // being DELIVERED is half the fix -- holding it must not drop it.
+    const launcherAt = clean.indexOf('CCC_LAUNCHER_RAN')
+    const heldAt = clean.indexOf('CCC_HELD_WRITE')
+
+    expect(launcherAt, `launcher never ran. Output:\n${clean.slice(0, 2000)}`).toBeGreaterThanOrEqual(0)
+    expect(heldAt, `held write was LOST. Output:\n${clean.slice(0, 2000)}`).toBeGreaterThanOrEqual(0)
+    expect(heldAt, `held write reached the shell BEFORE the launcher. Output:\n${clean.slice(0, 2000)}`)
+      .toBeGreaterThan(launcherAt)
+  })
+})

--- a/tests/unit/pty-buffered-write-ordering.test.ts
+++ b/tests/unit/pty-buffered-write-ordering.test.ts
@@ -1,0 +1,128 @@
+// A PTY exists ~300ms before its launch line is written, so for that window the
+// terminal is a bare interactive shell that has not yet become Claude. A write
+// landing there went straight to that shell, and its trailing `\r` submitted it
+// as a SHELL COMMAND -- an Ask Conductor question typed at a session that was
+// still starting got executed by PowerShell instead of asked of Claude.
+//
+// Note the window that matters is AFTER spawn, not before it: spawnPty calls
+// killPty(sessionId) on entry, which drops any pre-spawn `pendingWrites`, so a
+// write buffered before the spawn is discarded rather than replayed.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const writeMock = vi.fn()
+const spawnMock = vi.fn(() => ({
+  onData: () => {},
+  onExit: () => {},
+  write: writeMock,
+  kill: () => {},
+  pid: 4321,
+}))
+
+vi.mock('node-pty', () => ({ spawn: spawnMock }))
+vi.mock('electron', () => ({
+  // getAllWindows is a STATIC, and pushAccountIdentity calls it during spawn --
+  // a bare `class {}` throws there and the spawn never reaches its launch timer.
+  BrowserWindow: Object.assign(class {}, { getAllWindows: () => [] }),
+  nativeTheme: { shouldUseDarkColors: false, on: () => {} },
+  app: { getPath: () => '/tmp' },
+}))
+
+const { spawnPty, writePty, killPty } = await import('../../src/main/pty-manager')
+const { registerProvider } = await import('../../src/main/providers')
+const { ClaudeProvider } = await import('../../src/main/providers/claude')
+registerProvider(new ClaudeProvider())
+
+const fakeWin = { webContents: { send: () => {} }, isDestroyed: () => false } as never
+
+/** Index of the first write containing `needle`, or -1. */
+function indexOfWrite(needle: string): number {
+  return writeMock.mock.calls.findIndex(
+    (c) => typeof c[0] === 'string' && c[0].includes(needle),
+  )
+}
+
+beforeEach(() => {
+  writeMock.mockClear()
+  spawnMock.mockClear()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('a write that lands while the launch line is still queued', () => {
+  it('is held until claude owns the terminal, not given to the bare shell', () => {
+    const id = 'ask-window-1'
+    spawnPty(fakeWin, id, { cwd: process.cwd(), cols: 80, rows: 24 })
+
+    // Mid-window: the PTY is registered, the launch line has NOT been written.
+    vi.advanceTimersByTime(100)
+    expect(indexOfWrite('claude')).toBe(-1)
+
+    writePty(id, 'what is the canvas for?\r')
+    // Nothing may reach the shell yet -- this is the whole defect.
+    expect(indexOfWrite('what is the canvas for?')).toBe(-1)
+
+    vi.advanceTimersByTime(400)
+
+    const launch = indexOfWrite('claude')
+    const question = indexOfWrite('what is the canvas for?')
+    expect(launch).toBeGreaterThanOrEqual(0)
+    expect(question).toBeGreaterThanOrEqual(0) // delivered, not dropped
+    expect(question).toBeGreaterThan(launch) // and only once claude is running
+
+    killPty(id)
+  })
+
+  it('writes straight through once the launch line has been written', () => {
+    const id = 'ask-window-2'
+    spawnPty(fakeWin, id, { cwd: process.cwd(), cols: 80, rows: 24 })
+    vi.advanceTimersByTime(400) // launch line written, hold released
+
+    const before = writeMock.mock.calls.length
+    writePty(id, 'a later question\r')
+    // No buffering after the window: the write is immediate.
+    expect(writeMock.mock.calls.length).toBe(before + 1)
+    expect(indexOfWrite('a later question')).toBeGreaterThanOrEqual(0)
+
+    killPty(id)
+  })
+
+  it('holds for a shell-only session too, until its launcher command is written', () => {
+    const id = 'ask-window-shellonly'
+    spawnPty(fakeWin, id, {
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      shellOnly: true,
+      terminalOptions: { command: 'my-launcher' },
+    })
+
+    vi.advanceTimersByTime(100)
+    writePty(id, 'typed too early\r')
+    expect(indexOfWrite('typed too early')).toBe(-1)
+
+    vi.advanceTimersByTime(400)
+    const launcher = indexOfWrite('my-launcher')
+    const typed = indexOfWrite('typed too early')
+    expect(launcher).toBeGreaterThanOrEqual(0)
+    expect(typed).toBeGreaterThan(launcher)
+
+    killPty(id)
+  })
+
+  it('releases the hold when the session dies inside the window', () => {
+    const id = 'ask-window-3'
+    spawnPty(fakeWin, id, { cwd: process.cwd(), cols: 80, rows: 24 })
+    vi.advanceTimersByTime(100)
+    writePty(id, 'never delivered\r')
+
+    killPty(id) // PTY gone; the launch timer's liveness guard will bail
+    vi.advanceTimersByTime(400)
+
+    // The point is that nothing is stuck holding writes for a dead session, and
+    // the text was never handed to the shell that briefly existed.
+    expect(indexOfWrite('never delivered')).toBe(-1)
+  })
+})

--- a/tests/unit/pty-buffered-write-ordering.test.ts
+++ b/tests/unit/pty-buffered-write-ordering.test.ts
@@ -112,6 +112,29 @@ describe('a write that lands while the launch line is still queued', () => {
     killPty(id)
   })
 
+  it('replays a large held paste in chunks, not as one oversized write', () => {
+    const id = 'ask-window-chunked'
+    spawnPty(fakeWin, id, { cwd: process.cwd(), cols: 80, rows: 24 })
+    vi.advanceTimersByTime(100)
+
+    // Well over WRITE_CHUNK_SIZE (256B). Written in one go this overflows or
+    // truncates ConPTY's input buffer -- the reason writePty chunks at all.
+    const big = 'X'.repeat(4096)
+    writePty(id, big)
+
+    vi.advanceTimersByTime(400) // launch line lands, hold releases
+    vi.advanceTimersByTime(5000) // let the chunked writer drain its interval
+
+    const payloads = writeMock.mock.calls
+      .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
+      .filter((s) => s.includes('X'))
+    expect(payloads.length).toBeGreaterThan(1) // chunked, not one write
+    expect(Math.max(...payloads.map((p) => p.length))).toBeLessThanOrEqual(256)
+    expect(payloads.join('').length).toBe(big.length) // and nothing lost
+
+    killPty(id)
+  })
+
   it('releases the hold when the session dies inside the window', () => {
     const id = 'ask-window-3'
     spawnPty(fakeWin, id, { cwd: process.cwd(), cols: 80, rows: 24 })


### PR DESCRIPTION
Found by the second ADR-009 adversarial pass over the unreleased beta.16 delta.

### The defect

A PTY exists for ~300ms before its launch line is written, so for that window the
terminal is a bare interactive shell that has not yet become Claude. A write landing
there went straight to that shell, and the trailing CR submitted it — so an **Ask
Conductor question typed at a session that was still starting was executed by
PowerShell instead of being asked of Claude**.

That is exactly what the `askPrompt` env route exists to prevent: `providers/claude/spawn.ts`
passes the question *by reference* (`CCC_ASK_PROMPT`) so the shell never parses the user's
words, and `terminal-launch-line.ts` documents that as the injection boundary for the field.
The `pty:write` path bypassed all of it — `normaliseQuestion` strips control characters and
deliberately leaves shell metacharacters alone, which is correct for keystrokes into a TUI
and wrong for a shell.

Nothing shipped: beta.16 is unreleased.

### The fix

Sessions with a launch line are marked launch-pending. `writePty` buffers while the mark is
set, and the launch timer flushes once the real program owns the terminal. Every exit from
the window clears the mark — the liveness-guard return, a throw, and `cleanupSessionResources`
— so a failed launch can't leave writes buffered forever.

Worth recording: the reachable window is **after** spawn, not before it. `spawnPty` calls
`killPty(sessionId)` on entry, which drops any pre-spawn `pendingWrites`, so a write buffered
before the spawn was already discarded rather than replayed. The first version of this fix
reordered that replay and would have changed nothing.

### Also

Two comments corrected. Both documented the reverted #318 default (`Unset means ON`) and
claimed #312 repaired the shared-atlas fault. They sit at the exact site a reader decides
whether to re-enable the GPU renderer, and acting on them re-ships the blank-terminal fault —
the #318 → #322 round trip, again. The coordinator is now described as necessary but not
sufficient, and inert while the opt-in setting is off.

### Verification

- `tests/unit/pty-buffered-write-ordering.test.ts` — 4 guards.
- Mutation-tested, each restored byte-for-byte:

  | mutation | result |
  | --- | --- |
  | drop the `writePty` launch-hold check (the original bug) | 3 failed |
  | never mark the session launch-pending | 2 failed |
  | never release the mark | 1 failed |

- Full suite 6133 passed / 15 skipped; `npm run typecheck` clean.

### Not fixed here

`findAskSession` still matches on `kind` alone, so a question handed to an Ask session whose
PTY already exited is silently swallowed while the dock still paints a live dot. Separate
change — it needs a liveness test rather than an existence test.
