### PR TITLE
docs(context): record the single ADR-009 pass over the beta.16 substrate

### DIFF
--- a/CONTEXT.d/2026-08-21-adr009-beta16-pass.md
+++ b/CONTEXT.d/2026-08-21-adr009-beta16-pass.md
@@ -1,0 +1,100 @@
+# 2026-08-21 — the single ADR-009 pass over the beta.16 substrate
+
+Owner's call, matching the #295/#298 precedent: **no per-PR adversarial passes — one pass
+over the MERGED substrate before beta.16 is cut, fix everything it finds before any
+version bump.** This fragment is the public record of that pass. A pre-existing finding
+it surfaced is embargoed (see the last section) and is written up here only as *that it
+exists and was routed privately*; its public record is written with the release.
+
+## What was attacked, and how
+
+- **Round 1** — `integration/beta16-pass` (beta + #348 browser pane/command kinds,
+  #349 cross-canvas count, #350 COLORFGBG everywhere, #351 README), a local tree never
+  pushed. Ten independent attackers, one per surface × lens (injection/evasion,
+  allowlist bypass, blast-radius/correctness, design & coverage, platform parity), each
+  told to run the code and return repros, not opinions. Desktop proofs ran on the VM
+  (throwaway Playwright specs, never the owner's session), mutation tests on every
+  guard (`mutate*.py`).
+- **Round 2 — the re-attack, bounded to ONE round and scoped before dispatch** to the
+  five fixes round 1 produced (the browser hardening on #348, #352, #353, #354, and the
+  private fix), against a local integration tree of beta + all seven PRs + the private
+  fix. Five fresh attackers, one per fix, same rules.
+- Round bound + file scope were stated in chat before each dispatch (the owner's rule:
+  too much attacking and not enough building is its own failure mode).
+
+## Round 1 → the fix PRs
+
+| Finding | Severity | Where it went |
+| --- | --- | --- |
+| Browser pane ingress: session id not path-safe before it named a partition; handlers passed the raw URL not the normalised href; renderer store accepted non-http(s) watch/home URLs | MAJOR | #348 (`f8934b06`) |
+| #307 tokenomics re-index wiped EVERY event and rewound every cursor, so life-to-date Claude spend whose transcript was gone would be lost on first launch | BLOCKER-class correctness (pre-ship) | #352 |
+| A failed config read was still an "absence" on three paths: unreachable CONFIG dir → fresh install; a single unreadable file → never existed; the Agent Library saved straight to disk past the latch | MAJOR | #353 |
+| Secret values: the "stays one argument" contract on PowerShell 5.1 was measured false (`"`, trailing `\`, `&|^<>%` via a .cmd shim) | MAJOR → verified MINOR (own value, own field) but a false contract | #354 |
+| One unrelated, pre-existing finding | — | **private advisory** (see below) |
+
+## Round 2 → fixed in the same PRs, each with a mutation-checked regression test
+
+- **Browser pane (#348):** 2 MAJOR, both pre-existing view behaviours the pane widened
+  from "the command's watch URL" to "any URL you type": Electron's `safeDialogs` default
+  is OFF, so a page looping `alert()` blocked the whole app (fixed: on, with message);
+  `setWindowOpenHandler` → `shell.openExternal` with no gesture flag and no popup blocker
+  = a page could fire the toolbar's "open in your real browser" primitive in a loop
+  (fixed: popups load in the pane, never `openExternal`). Minors: will-navigate/redirect
+  scheme-only (the 4096 cap must not cancel an OAuth hop; measured on the href at the
+  app doors), `will-prevent-unload` overridden, downloads refused, http/https decided on
+  the CANONICAL host, embedded credentials refused, store ids/titles bounded and cleaned
+  (titles are rendered), `homeFor` own-property. `webview-manager-guards.test.ts` asserts
+  the view's guards through a fake `WebContentsView` — round 2 found two missing
+  precisely because nothing exercised the view.
+- **Tokenomics re-index (#352):** PASS on every replay oracle (12 345 / 5 000 / 5 001 /
+  10 000 mixed events byte-identical, Claude rows untouched, idempotent). Three minors
+  fixed: `firstIndexComplete` cleared in the transaction; `tk_daily` rebuilt from the
+  STORED day; the handle closed on a failed re-index. Design call recorded: pruned-Codex
+  spend is gone after the re-index.
+- **Config latch (#353):** the latch held every attack; beside it, the pre-existing
+  MAJOR: `session:save` bypassed the latch and `loadSessionState()` answered null for a
+  read FAILURE as for an absent file → the empty session list overwrote the saved one at
+  close. Fixed in `session-state.ts` (remember the last load's outcome; refuse
+  save/clear while it was a failure; an unparseable file is moved aside). Minors: an
+  unlistable CONFIG dir is a read failure, not "empty → re-migrate the v1 snapshot"; the
+  v1 localStorage keys are cleared after a migration; the notice renders the lock
+  reason. Left noted: the same null-vs-failed shape in five other main-side persisters
+  (one shared fix later, not five copies); the notice is invisible with the sidebar
+  collapsed.
+- **Secrets (#354):** PASS — 41 accepted values measured intact through powershell.exe
+  5.1 → native / .cmd shim / raw command line, and bash; every refused value shown to
+  break. Gaps closed: `!NAME!` pairs on Windows, NUL everywhere. Noted: >8191 chars fail
+  through a .cmd shim; `--token=$env:X` adjacency is handed over literally.
+- **The private fix:** held (PASS).
+
+Every round-2 fix: regression test added, the guard mutated, the test watched to fail,
+restored. Full suite on the stacked head (`75c72f4e` = all seven PRs merged in order):
+6536 passed, 15 skipped; typecheck clean. The seven PRs were stacked afterwards (each
+merges the previous, changelog conflicts resolved once) so they merge cleanly
+#348 → #354, the private fix last. Verdict comments with the content-addressed marker
+are on each PR.
+
+## What is deliberately NOT here
+
+The pass surfaced one **pre-existing, unfixed** finding outside every PR's scope. Per
+`SECURITY.md` ("Embargo") and ADR-011 it went into a private GitHub Security Advisory with
+a temporary private fork, the fix was developed and reviewed there (round 2 included it),
+and it is merged from the advisory page and **published with the beta.16 release**,
+together with GHSA-266h-8fw5-h75c. Nothing about the component, mechanism or repro is in
+any tracked file, PR, commit message or branch name until then.
+
+## Process notes worth keeping
+
+- The maintainer-account `gh` cannot file via private vulnerability reporting on its own
+  repo (403 from `/security-advisories/reports`); the maintainer endpoint
+  (`POST /security-advisories`, Path B in the runbook) with the script's validated
+  payload worked first time and created the fork. The runbook's "403 = wrong endpoint"
+  line is right in both directions.
+- Stacking by merging `origin/<prev>` instead of the LOCAL stacked branch silently
+  builds a chain that does not accumulate — every branch looks coherent, tests pass, and
+  the final head is missing most of the stack. Verify with `merge-base --is-ancestor`
+  for every branch before trusting a "full substrate" run.
+- A keep-both conflict resolver is for changelog entries only; two code hunks kept
+  side by side compile (two loops, two `canSubmit`s) and hand the last one the win.
+  Read the merged region. And the resolver must be CRLF-aware or it resolves nothing
+  and the markers get committed.


### PR DESCRIPTION
The public record of the one adversarial pass over the merged beta.16 substrate (two bounded rounds; findings, fixes, tests, the embargo split, process notes). Docs-only: no code. Merge any time; it does not depend on the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)