### PR TITLE
build(release): 2.1.0-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
-## [2.1.0-beta.16] - 2026-08-20
+## [2.1.0-beta.16] - 2026-08-21
 
 > The terminal corruption is understood and the setting that causes it is off by default. GPU rendering shares one cache of character images across every open session, so one session rebuilding that cache wipes the text out of all the others, which is why it looked random, why it got worse the more sessions you had, and why resizing the window brought it back. Leave GPU rendering off and you will not see it.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.15",
+  "version": "2.1.0-beta.16",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -22,7 +22,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   {
     version: '2.1.0-beta.16',
-    date: '2026-08-20',
+    date: '2026-08-21',
     highlights: 'The terminal corruption is understood and the setting that causes it is off by default. GPU rendering shares one cache of character images across every open session, so one session rebuilding that cache wipes the text out of all the others, which is why it looked random, why it got worse the more sessions you had, and why resizing the window brought it back. Leave GPU rendering off and you will not see it.',
     changes: [
       { type: 'fix', description: 'On Windows, a secret argument — for a terminal config or a command button — that PowerShell cannot hand to a command intact is now refused when you type it, with the reason under the field, instead of being saved and then silently corrupting the command line. The app starts Windows PowerShell 5.1, which rebuilds a command\'s arguments into one line and never escapes a double quote inside a value; a value containing one, or ending in a backslash, or (for tools installed by npm) containing & | ^ < > %, would arrive split, truncated, or in the worst case re-parsed by cmd.exe. The app cannot rewrite a secret, so it says no up front. Secrets without those characters are unaffected; macOS and Linux are unaffected because the reference there is quoted.' },


### PR DESCRIPTION
Version bump + changelog date for the beta.16 cut. Everything in the entry is already merged to beta (#348–#355 + the advisory fix). Merge last, then the release workflow runs from beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)