### PR TITLE
fix(sidebar): show the config-load-failed state in the collapsed rail

### DIFF
--- a/CONTEXT.d/2026-08-22-n370.md
+++ b/CONTEXT.d/2026-08-22-n370.md
@@ -1,0 +1,52 @@
+## 2026-08-22 -- #370: config-load-failed notice visible in the collapsed rail
+
+### What changed
+
+`ConfigLoadFailedNotice` ("your configuration could not be loaded -- saving is
+paused") renders inside the expanded sidebar's session list. The collapsed rail
+never mounts that list, so with the sidebar collapsed nothing on screen said the
+app was running on defaults with writes latched off, and every save silently did
+nothing. The notice is deliberately not dismissible for exactly this reason;
+collapsing the sidebar was a dismiss in all but name (ADR-009 re-attack
+follow-up, noted-not-fixed in the beta.16 pass).
+
+New: `src/renderer/components/sidebar/ConfigLoadFailedRailIndicator.tsx`.
+Mounted in `Sidebar.tsx`'s collapsed branch, between `SidebarNav` and the dock.
+
+- Renders nothing while `useConfigWriteLockStore.lockedReason` is null, so the
+  rail is unchanged in the normal case.
+- While locked: a 32px glyph (the notice's own circle-exclamation) in
+  `--status-danger`, the same footprint as the dock pills, so the rail's width
+  does not change. `aria-label` + the rail's instant inline tooltip (the
+  `SidebarNav` pattern) name the state: "Your configuration could not be loaded
+  -- saving is paused. Click for details."
+- Click toggles a popover beside the rail containing the SAME
+  `ConfigLoadFailedNotice` component -- reason line and "start fresh anyway"
+  button included -- so the two surfaces cannot drift apart and the way out is
+  reachable without expanding the sidebar.
+- The popover closes on Escape (capture phase, stopPropagation) or a backdrop
+  MOUSEDOWN (the `TerminalContextMenu` pattern; a synthetic click never
+  dismisses). The glyph itself cannot be dismissed: it goes when the lock clears
+  (start fresh from either surface, or a relaunch with the file readable).
+
+Expanded behaviour is untouched; the glyph is a collapsed-rail affordance only.
+
+Not done: no toast over the window. The issue asked for glyph + tooltip + click
+opens the notice; a toast would duplicate the notice and is the one thing the
+owner may still want (open question on the PR).
+
+### How verified
+
+`tests/unit/renderer/config-load-failed-rail-indicator.test.tsx` (10 cases):
+indicator alone (nothing when unlocked, labelled glyph when locked, click opens
+the notice with the reason verbatim, Escape / backdrop mousedown close it while
+a synthetic click does not, "start fresh" unlocks and removes the glyph, lock
+clearing elsewhere removes it) and the full `Sidebar` collapsed (glyph present,
+reason reachable by click), collapsed with no failure (no glyph), expanded
+(notice as before, no glyph).
+
+The Sidebar-collapsed case was run before wiring the indicator into
+`Sidebar.tsx` and failed (`expected null not to be null` on the glyph); it
+passes after. Full suite and typecheck results are on the PR.
+
+ADR-009 does not apply: renderer UI only, nothing on the sensitive-path table.

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -34,6 +34,7 @@ import FirstRunCard from './FirstRunCard'
 import ColourMigrationNotice from './ColourMigrationNotice'
 import ConfigHydrationNotice from './ConfigHydrationNotice'
 import ConfigLoadFailedNotice from './ConfigLoadFailedNotice'
+import ConfigLoadFailedRailIndicator from './sidebar/ConfigLoadFailedRailIndicator'
 import { useAppMetaStore } from '../stores/appMetaStore'
 import { deriveOnboarding } from '../onboarding/gate'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
@@ -610,6 +611,11 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           collapsed
           onShowAccountUsage={onShowAccountUsage}
         />
+        {/* #370: the config-load-failed notice below is in the EXPANDED list
+            only, so the rail carries a danger glyph (tooltip + click opens the
+            same notice in a popover) while writes are latched. Renders nothing
+            otherwise. */}
+        <ConfigLoadFailedRailIndicator />
         {/* `mt-auto` because the collapsed rail has no flex-1 child to push
             against — the nav is content-height. */}
         <AskConductorDock

--- a/src/renderer/components/sidebar/ConfigLoadFailedRailIndicator.tsx
+++ b/src/renderer/components/sidebar/ConfigLoadFailedRailIndicator.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useConfigWriteLockStore } from '../../stores/configWriteLockStore'
+import ConfigLoadFailedNotice from '../ConfigLoadFailedNotice'
+
+/**
+ * The collapsed rail's window onto ConfigLoadFailedNotice (#370).
+ *
+ * The notice itself lives in the expanded sidebar's session list, which is the
+ * one place the collapsed rail does not render -- so with the sidebar
+ * collapsed nothing on screen said the app was running on defaults with saving
+ * latched off, and every save silently did nothing. The notice is deliberately
+ * not dismissible for exactly that reason, and collapsing the sidebar was a
+ * dismiss in all but name.
+ *
+ * This is a 32px danger glyph in the rail, the same footprint as the dock
+ * pills so the rail does not grow. It has a tooltip naming the state, and a
+ * click opens the SAME notice (reason text, "start fresh anyway") in a popover
+ * beside the rail, so the failure text and the way out are reachable without
+ * expanding the sidebar. The popover can be closed -- the glyph cannot: it
+ * stays until the lock clears (start fresh, or a relaunch with the file
+ * readable), which is the non-dismissibility the notice relies on.
+ *
+ * Popover dismissal is Escape or a backdrop MOUSEDOWN (the TerminalContextMenu
+ * pattern), never click: Ctrl+C in a terminal fires click events.
+ */
+
+const POPOVER_W = 304
+
+const TOOLTIP = 'Your configuration could not be loaded -- saving is paused. Click for details.'
+
+export default function ConfigLoadFailedRailIndicator() {
+  const locked = useConfigWriteLockStore((s) => s.lockedReason !== null)
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  // Anchor beside the glyph after first paint, clamped into the window (the
+  // rail can be taller than the notice, or the glyph near the bottom edge).
+  useLayoutEffect(() => {
+    if (!open) return
+    const el = popoverRef.current
+    const anchor = buttonRef.current?.getBoundingClientRect()
+    if (!el || !anchor) return
+    const rect = el.getBoundingClientRect()
+    let left = anchor.right + 8
+    let top = anchor.top
+    if (top + rect.height > window.innerHeight - 8) top = window.innerHeight - rect.height - 8
+    if (left + rect.width > window.innerWidth - 8) left = window.innerWidth - rect.width - 8
+    if (top < 8) top = 8
+    if (left < 8) left = 8
+    el.style.left = `${left}px`
+    el.style.top = `${top}px`
+    el.style.opacity = '1'
+  }, [open])
+
+  // Escape closes the popover only. Capture phase + stopPropagation so a
+  // keybinding behind it does not also act on the same keystroke.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      e.preventDefault()
+      setOpen(false)
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [open])
+
+  // Lock cleared (start fresh, from here or anywhere): nothing to show, and
+  // nothing to keep open.
+  useEffect(() => {
+    if (!locked) setOpen(false)
+  }, [locked])
+
+  if (!locked) return null
+
+  return (
+    <div className="flex flex-col items-center py-1.5 shrink-0">
+      <button
+        ref={buttonRef}
+        type="button"
+        data-ux-id="config-load-failed-rail-indicator"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={TOOLTIP}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="group w-8 h-8 flex items-center justify-center rounded-lg transition-colors focus-ring relative"
+        style={{
+          color: 'var(--status-danger)',
+          background: 'color-mix(in srgb, var(--status-danger) 14%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--status-danger) 48%, transparent)',
+        }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+        {/* Instant inline tooltip, the rail's own pattern (SidebarNav); sits to
+            the right of the glyph so it never clips off the window edge. */}
+        <span
+          className="pointer-events-none absolute z-40 left-full ml-2 top-1/2 -translate-y-1/2 px-2 py-0.5 text-[11px] rounded bg-surface1 text-text border border-surface2 shadow-md whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-100"
+          aria-hidden="true"
+        >
+          {TOOLTIP}
+        </span>
+      </button>
+
+      {open && (
+        // mousedown (not click) dismisses: a synthetic click must not close it,
+        // and the popover is gone before any mouseup reaches a terminal.
+        <div
+          data-ux-id="config-load-failed-popover-backdrop"
+          className="fixed inset-0 z-50"
+          onMouseDown={() => setOpen(false)}
+          onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setOpen(false) }}
+        >
+          <div
+            ref={popoverRef}
+            role="dialog"
+            aria-label="Configuration could not be loaded"
+            data-ux-id="config-load-failed-popover"
+            className="fixed rounded-xl border shadow-xl pt-2"
+            style={{
+              width: POPOVER_W,
+              opacity: 0,
+              background: 'var(--surface-overlay)',
+              borderColor: 'var(--border-strong)',
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            {/* The notice, unchanged: same copy, same reason line, same "start
+                fresh" button -- so the two surfaces can never drift apart. */}
+            <ConfigLoadFailedNotice />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tests/unit/renderer/config-load-failed-rail-indicator.test.tsx
+++ b/tests/unit/renderer/config-load-failed-rail-indicator.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+/**
+ * #370 -- the config-load-failed notice lives in the sidebar's session list,
+ * so with the sidebar COLLAPSED nothing on screen said the app was running on
+ * defaults with saving paused. The collapsed rail now carries a danger glyph
+ * whenever writes are latched; it has a tooltip and opens the full notice
+ * (reason text + "start fresh") in a popover beside the rail.
+ *
+ * Pinned here:
+ *  - nothing renders while writes are not locked (no idle glyph in the rail);
+ *  - locked -> a button with the failure named in its accessible label;
+ *  - click -> the notice, with the lock reason verbatim, is on screen;
+ *  - Escape and backdrop MOUSEDOWN close the popover (a synthetic click does
+ *    not -- Ctrl+C in a terminal fires click events); the glyph stays;
+ *  - "start fresh" inside the popover unlocks and the glyph goes with it;
+ *  - the full Sidebar, collapsed, renders the glyph (the regression itself).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// The Sidebar mount needs the same store stand-ins sidebar-config-disclosure
+// uses; they are harmless for the indicator-only cases.
+const settings = { configPanelPinned: false, theme: 'dark', keyboardShortcuts: undefined }
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings, updateSettings: () => {} }
+  const useSettingsStore: any = (sel: any) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+vi.mock('../../../src/renderer/stores/sessionStore', () => {
+  const STATE = { sessions: [], activeSessionId: null, setActiveSession: () => {}, removeSession: () => {}, addSession: () => {}, updateSession: () => {} }
+  const useSessionStore: any = (sel?: any) => (sel ? sel(STATE) : STATE)
+  useSessionStore.getState = () => STATE
+  return { useSessionStore }
+})
+vi.mock('../../../src/renderer/stores/configStore', () => {
+  const STATE: any = { configs: [], groups: [], sections: [] }
+  ;['addConfig','updateConfig','removeConfig','addGroup','renameGroup','removeGroup','toggleGroupCollapsed','moveConfigToGroup','addSection','renameSection','removeSection','toggleSectionCollapsed','moveGroupToSection','moveConfigToSection','togglePinned','duplicateConfig','reorderConfigs'].forEach(k => STATE[k] = () => {})
+  const useConfigStore: any = (sel?: any) => (sel ? sel(STATE) : STATE)
+  useConfigStore.getState = () => STATE
+  return { useConfigStore }
+})
+vi.mock('../../../src/renderer/stores/insightsStore', () => ({ useInsightsStore: (sel: any) => sel({ status: null, statusMessage: null }) }))
+vi.mock('../../../src/renderer/stores/cloudAgentStore', () => ({ useCloudAgentStore: (sel: any) => sel({ agents: [] }) }))
+vi.mock('../../../src/renderer/stores/conductorMcpStore', () => ({ useConductorMcpStore: (sel: any) => sel({ browserRunning: false, serverRunning: true }) }))
+vi.mock('../../../src/renderer/stores/appMetaStore', () => ({ useAppMetaStore: (sel: any) => sel({ meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }) }))
+;(globalThis as any).window.electronAPI = { update: { check: () => Promise.resolve(false), onAvailable: () => () => {}, getVersion: () => Promise.resolve('') } }
+
+const { default: ConfigLoadFailedRailIndicator } = await import('../../../src/renderer/components/sidebar/ConfigLoadFailedRailIndicator')
+const { default: Sidebar } = await import('../../../src/renderer/components/Sidebar')
+const { useConfigWriteLockStore } = await import('../../../src/renderer/stores/configWriteLockStore')
+const { readFailureLockReason } = await import('../../../src/renderer/utils/configHydration')
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useConfigWriteLockStore.getState().unlock()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+  useConfigWriteLockStore.getState().unlock()
+})
+
+const q = (id: string) => container.querySelector<HTMLElement>(`[data-ux-id="${id}"]`)
+const REASON = readFailureLockReason({ readFailed: false, failedKeys: ['settings', 'commands'] })!
+
+const mountIndicator = () => act(() => { root.render(<ConfigLoadFailedRailIndicator />) })
+const lock = () => act(() => { useConfigWriteLockStore.getState().lock(REASON) })
+const click = (el: Element) => act(() => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+const mousedown = (el: Element) => act(() => { el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })) })
+const escape = () => act(() => {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+})
+
+describe('ConfigLoadFailedRailIndicator', () => {
+  it('renders nothing while writes are not locked', () => {
+    mountIndicator()
+    expect(q('config-load-failed-rail-indicator')).toBeNull()
+  })
+
+  it('shows a danger glyph that names the failure in its label once locked', () => {
+    lock()
+    mountIndicator()
+    const btn = q('config-load-failed-rail-indicator')
+    expect(btn).not.toBeNull()
+    expect(btn!.tagName).toBe('BUTTON')
+    expect(btn!.getAttribute('aria-label')).toMatch(/configuration could not be loaded/i)
+    expect(btn!.getAttribute('aria-label')).toMatch(/saving is paused/i)
+    // The tooltip text is in the DOM too, for the hover affordance.
+    expect(btn!.textContent).toMatch(/configuration could not be loaded/i)
+    // Nothing open yet.
+    expect(q('config-load-failed-notice')).toBeNull()
+    expect(btn!.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens the full notice -- reason text included -- on click', () => {
+    lock()
+    mountIndicator()
+    click(q('config-load-failed-rail-indicator')!)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    expect(q('config-load-failed-reason')?.textContent).toBe(REASON)
+    expect(q('config-load-failed-rail-indicator')!.getAttribute('aria-expanded')).toBe('true')
+    // Clicking the glyph again toggles the popover shut; the glyph stays.
+    click(q('config-load-failed-rail-indicator')!)
+    expect(q('config-load-failed-notice')).toBeNull()
+    expect(q('config-load-failed-rail-indicator')).not.toBeNull()
+  })
+
+  it('closes on Escape and keeps the glyph', () => {
+    lock()
+    mountIndicator()
+    click(q('config-load-failed-rail-indicator')!)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    escape()
+    expect(q('config-load-failed-notice')).toBeNull()
+    expect(q('config-load-failed-rail-indicator')).not.toBeNull()
+  })
+
+  it('closes on backdrop MOUSEDOWN, not on a synthetic click', () => {
+    lock()
+    mountIndicator()
+    click(q('config-load-failed-rail-indicator')!)
+    const backdrop = q('config-load-failed-popover-backdrop')!
+    expect(backdrop).not.toBeNull()
+    // A click alone (what Ctrl+C in a terminal can synthesise) must not dismiss.
+    click(backdrop)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    // A mousedown inside the popover must not dismiss either.
+    mousedown(q('config-load-failed-notice')!)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    mousedown(backdrop)
+    expect(q('config-load-failed-notice')).toBeNull()
+    expect(q('config-load-failed-rail-indicator')).not.toBeNull()
+  })
+
+  it('"start fresh" inside the popover unlocks and removes the glyph', () => {
+    lock()
+    mountIndicator()
+    click(q('config-load-failed-rail-indicator')!)
+    click(q('config-load-failed-start-fresh')!)
+    expect(useConfigWriteLockStore.getState().lockedReason).toBeNull()
+    expect(q('config-load-failed-notice')).toBeNull()
+    expect(q('config-load-failed-rail-indicator')).toBeNull()
+  })
+
+  it('disappears when the lock clears from elsewhere', () => {
+    lock()
+    mountIndicator()
+    expect(q('config-load-failed-rail-indicator')).not.toBeNull()
+    act(() => { useConfigWriteLockStore.getState().unlock() })
+    expect(q('config-load-failed-rail-indicator')).toBeNull()
+  })
+})
+
+describe('Sidebar, collapsed, with a config load failure (#370)', () => {
+  const mountSidebar = (collapsed: boolean) => act(() => {
+    root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {}, collapsed } as any))
+  })
+
+  it('shows the failure in the collapsed rail and the reason is reachable by click', () => {
+    lock()
+    mountSidebar(true)
+    // Sanity: this IS the collapsed rail (the expanded notice is not mounted).
+    expect(q('config-load-failed-notice')).toBeNull()
+    const btn = q('config-load-failed-rail-indicator')
+    expect(btn).not.toBeNull()
+    click(btn!)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    expect(q('config-load-failed-reason')?.textContent).toBe(REASON)
+  })
+
+  it('keeps the rail free of the glyph when nothing failed', () => {
+    mountSidebar(true)
+    expect(q('config-load-failed-rail-indicator')).toBeNull()
+  })
+
+  it('keeps the expanded notice as it was', () => {
+    lock()
+    mountSidebar(false)
+    expect(q('config-load-failed-notice')).not.toBeNull()
+    expect(q('config-load-failed-reason')?.textContent).toBe(REASON)
+    // The glyph is a collapsed-rail affordance only.
+    expect(q('config-load-failed-rail-indicator')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What and why

#370 — the "your configuration could not be loaded — saving is paused" notice lives in the expanded sidebar's session list, which the collapsed rail never mounts. With the sidebar collapsed nothing on screen said the app was running on defaults with writes latched off, and every save silently did nothing. The notice is deliberately non-dismissible for exactly that reason; collapsing the sidebar was a dismiss in all but name (ADR-009 re-attack follow-up, noted-not-fixed in the beta.16 pass).

**The fix.** New `src/renderer/components/sidebar/ConfigLoadFailedRailIndicator.tsx`, mounted in `Sidebar.tsx`'s collapsed branch between the nav and the dock:

- Renders nothing unless `useConfigWriteLockStore.lockedReason` is set — the rail is untouched in the normal case.
- While locked: a 32px glyph in `--status-danger` (the notice's own circle-exclamation), the same footprint as the dock pills, so the rail's width does not change. `aria-label` + the rail's inline tooltip read "Your configuration could not be loaded — saving is paused. Click for details."
- Click opens the **same** `ConfigLoadFailedNotice` (reason line naming the failed files + the "Start fresh anyway" button) in a popover beside the rail, so the failure text and the way out are reachable without expanding the sidebar. Popover closes on Escape or backdrop **mousedown** (the TerminalContextMenu pattern — a synthetic click never dismisses it). The glyph itself cannot be dismissed: it clears when the lock clears (start fresh from either surface, or a relaunch with the file readable).
- Expanded sidebar behaviour is unchanged.

Issues: #370

## How it was tested

- `tests/unit/renderer/config-load-failed-rail-indicator.test.tsx` (new, 10 cases): indicator alone (nothing when unlocked; labelled glyph when locked; click opens the notice with the lock reason verbatim; Escape / backdrop mousedown close it while a synthetic click does not; "start fresh" unlocks and removes the glyph; lock clearing elsewhere removes it), plus the full `Sidebar` mounted collapsed with a lock (glyph present, reason reachable by click), collapsed without a failure (no glyph), and expanded (notice as before, no glyph).
- The Sidebar-collapsed regression case was run before the rail was wired and **failed** (`expected null not to be null` on the glyph); it passes after.
- Full suite `npx vitest run`: **628 files passed | 2 skipped — 6552 tests passed | 15 skipped**.
- `npm run typecheck`: clean.

VM proof: pending — the conductor's integration pass.

## Not done / open questions for the owner

- No toast over the window. The issue's acceptance asked for glyph + tooltip + click-opens-notice, which is what shipped; a launch-time toast would duplicate the notice. Say the word if you want one as well.
- "Clears when the file becomes readable" is satisfied on relaunch (the lock is set once at boot); there is no runtime re-read of the config directory, same as before.
- Not security-sensitive: renderer UI only, no IPC/preload/PTY/credential paths touched.
