### PR TITLE
feat(release): release gate — refuse a cut with open milestone issues or a stale model registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,37 @@ permissions:
   contents: write
 
 jobs:
+  # ── Release gate (#375, #385) ──
+  # Refuse the cut before a single installer is built: the GitHub milestone
+  # titled after package.json's version must have no open issue without the
+  # `excluded` label (a missing milestone fails closed), and
+  # resources/model-registry.json must cover every model in Anthropic's Claude
+  # Code model configuration article (scripts/fixtures/ holds the expected set).
+  # Every build job `needs` this one. Read-only: GITHUB_TOKEN with issues:read.
+  # No `npm ci` here on purpose — the script is dependency-free plain node, so
+  # the verdict arrives in seconds, not after a native toolchain install.
+  # A dry run is not a release, so it sees the verdict but is not blocked by it.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Refuse to cut with open milestone issues or a stale model registry
+        continue-on-error: ${{ inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/release-gate.mjs
+
   # ── Build Windows installer ──
   build-windows:
+    needs: gate
     # Pinned off windows-latest: the new vs2026 image breaks @electron/node-gyp
     # (no supported Visual Studio). Same pin as ci.yml — unpin together.
     runs-on: windows-2025
@@ -269,6 +298,7 @@ jobs:
 
   # ── Build macOS app ──
   build-macos:
+    needs: gate
     if: ${{ !inputs.dry_run }}
     runs-on: macos-latest
     steps:
@@ -372,6 +402,7 @@ jobs:
   # in the run (visible to the maintainer), and release.js flags the missing
   # AppImage asset — but the release proceeds with the platforms that built.
   build-linux:
+    needs: gate
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,33 @@ jobs:
         with:
           node-version: '20'
 
+      # The milestone the gate checks is the one for the tag actually being cut,
+      # not the bare package.json version. Same tag logic as the build job's
+      # "Determine version" step, so on a rolling re-release (bare version +
+      # channel) the gate checks the channel-suffixed milestone rather than a
+      # different one — kept in lockstep with that step (#375 review).
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          CHANNEL="${{ inputs.channel }}"
+          if [[ "$VERSION" == *-* ]]; then
+            TAG="v${VERSION}"
+          else
+            case "$CHANNEL" in
+              beta) TAG="v${VERSION}-beta" ;;
+              dev)  TAG="v${VERSION}-dev"  ;;
+              *)    TAG="v${VERSION}"      ;;
+            esac
+          fi
+          echo "milestone=${TAG#v}" >> $GITHUB_OUTPUT
+
       - name: Refuse to cut with open milestone issues or a stale model registry
         continue-on-error: ${{ inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/release-gate.mjs
+        run: node scripts/release-gate.mjs --version ${{ steps.version.outputs.milestone }}
 
   # ── Build Windows installer ──
   build-windows:

--- a/CONTEXT.d/2026-08-22-n375.md
+++ b/CONTEXT.d/2026-08-22-n375.md
@@ -1,0 +1,79 @@
+## 2026-08-22 -- Release gate: no cut with open milestone issues or a stale model registry (#375, #385)
+
+beta.16 was cut with book-of-work items still open. The owner's rule -- no beta
+is cut with anything outstanding except what the owner has explicitly excluded
+-- is now a machine check, and the model options the app offers are held to
+Anthropic's Claude Code model configuration article on the same path.
+
+### What changed
+
+- `scripts/release-gate.mjs` (plain ESM, no dependencies). Two checks:
+  1. MILESTONE: the GitHub milestone titled exactly the version being cut must
+     exist and carry no open issue without the `excluded` label. PRs on the
+     milestone are ignored. Missing milestone = fail closed. Offending issues
+     are printed by number and title.
+  2. MODELS: every id in the article's "Supported models" table (hard-coded in
+     `scripts/fixtures/claude-code-model-configuration.json` with the fetch
+     date and refresh instructions) must be covered by
+     `resources/model-registry.json`. A dated article id is covered by the
+     undated registry entry (the app resolves by prefix). Missing = FAIL with a
+     diff; a registry Claude model the article no longer lists = WARN only.
+  Exit 0 pass, 1 refused, 2 could not evaluate (also a refusal). GitHub is read
+  through the REST API with GITHUB_TOKEN/GH_TOKEN, else `gh auth token`. The
+  repo comes from `--repo`, `$GITHUB_REPOSITORY`, package.json `repository`, or
+  the origin remote.
+- `scripts/release.js`: runs the gate right after the next version is computed
+  and BEFORE package.json / changelog are written, so a refused cut leaves the
+  tree clean. No `--skip` flag on purpose: the workflow runs the same gate, so a
+  local bypass would only move the refusal to CI. The pre-release checklist box
+  names the article.
+- `.github/workflows/release.yml`: new first job `gate` (ubuntu, node 20, no
+  `npm ci`, `permissions: contents: read, issues: read`); `build-windows`,
+  `build-macos`, `build-linux` all `needs: gate`. `continue-on-error:
+  ${{ inputs.dry_run }}` so a dry run sees the verdict without being blocked.
+- Docs: `docs/versioning.md` "Release gate" section; one bullet in
+  CONTRIBUTING's release process.
+
+### Why these shapes
+
+- Fail closed on a missing milestone: the gate cannot distinguish "nothing
+  outstanding" from "nobody made the list", and beta.16 is exactly what
+  trusting the absence of a list produces.
+- Extras are a warning, not a failure: `claude-opus-4-8-fast` is in the
+  registry and not in the article; whether it retired is the owner's call, and
+  a gate that fails on Anthropic adding or dropping a line nobody asked about
+  would be bypassed in a week.
+- The fixture is JSON with a `$comment` array (not .mjs) so the Sentinel half
+  of #385 can read the same expected set without importing script code.
+
+### How verified
+
+- `tests/unit/scripts/release-gate.test.ts` (26 tests, mocked GitHub): clean
+  milestone passes; open issue fails and is listed; `excluded` ignored; PRs and
+  closed items ignored; missing milestone fails closed and never queries issues;
+  exact-title match; model check pass / fail-with-diff / extra-as-warning;
+  dated-id coverage rule and its negatives; exit 2 on an unreachable GitHub;
+  pagination + bearer token; token precedence; repo parsing; the shipped fixture
+  is well-formed and the real registry is evaluable.
+- Live dry run against the real repo: `node scripts/release-gate.mjs --version
+  2.1.0-beta.17` REFUSED and listed the 27 open milestone issues plus four
+  article models the registry lacks (`claude-opus-5`, `claude-sonnet-5`,
+  `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`), WARN on
+  `claude-opus-4-8-fast`. A made-up version fails closed on the missing
+  milestone. That is the acceptance in #375 ("a dry run against this milestone
+  fails today and lists the open issues").
+- `release.js` still loads under require() (its pure-helper tests pass);
+  full `npx vitest run` and `npm run typecheck` green at PR time (see the PR).
+
+### What is left
+
+- The gate will REFUSE 2.1.0-beta.17 today on the model check as well as the
+  milestone: the registry has no Opus 5 / Sonnet 5 / Opus 4.5 / Sonnet 4.5
+  entries. Adding them (pricing, efforts, dropdown rows) is the #385 picker fix,
+  not this PR -- the owner decides the rows. Until then `node
+  scripts/release-gate.mjs` prints the exact diff to close.
+- The Sentinel runtime comparison in #385 (flag a removed/renamed/added model
+  from inside the app) is not part of this gate; the fixture is shaped so it can
+  share the expected set.
+- `scripts/release.js` Step 4 still runs `npx tsc --noEmit` (pre-existing; the
+  real check is `npm run typecheck`). Not touched here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ We cut a dedicated RC branch for every release cycle so that `beta` stays open f
 - **`release/vX.Y.Z`:** bug fixes and stabilization only — **no features**. The RC branch is the proposed stable release; merging a feature into it invalidates the candidate.
 - Fixes made on the RC branch are back-ported to `beta` so the next cycle keeps them.
 - When the RC is accepted, merge `release/vX.Y.Z` → `main`, then delete the RC branch.
+- **Every cut is gated** (`scripts/release-gate.mjs`, run by `release.js` and as the first job of `release.yml`): the GitHub milestone titled after the version must have no open issue without the `excluded` label, and the model registry must cover every model in Anthropic's Claude Code model configuration article. No bypass — see [`docs/versioning.md`](docs/versioning.md#release-gate-the-cut-is-refused-until-it-passes).
 
 For the versioning scheme, prerelease suffixes (`-beta.N`/`-rc.N`), update channels, and when a rebuild ships to users vs. requires a version bump, see [`docs/versioning.md`](docs/versioning.md).
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -70,6 +70,34 @@ leaving the hand-written notes untouched — a *rolling re-release*.
 - Shipping stable: drop the suffix (`2.1.0`) and release from `main` with
   `channel=stable`.
 
+## Release gate (the cut is refused until it passes)
+
+`scripts/release-gate.mjs` runs before any release is made — as the first step
+of `scripts/release.js` (before `package.json` is touched) and as the first job
+of `release.yml` on every dispatch (`gate`; every build job `needs` it). It has
+no bypass. Two checks, both must pass:
+
+1. **Milestone (#375).** A GitHub milestone titled exactly the version being cut
+   (e.g. `2.1.0-beta.17`) must exist and have **no open issue** without the
+   `excluded` label. Open issues are printed by number; pull requests on the
+   milestone are ignored. A missing milestone **fails closed** — the gate cannot
+   tell "nothing outstanding" from "nobody made the list". To clear it: close
+   the issues, move them to a later milestone, or have the owner label them
+   `excluded` (owner-excluded from the current milestone gate).
+2. **Model registry (#385).** `resources/model-registry.json` must cover every
+   model in Anthropic's [Claude Code model configuration](https://support.claude.com/en/articles/11940350-claude-code-model-configuration)
+   article. The expected set is hard-coded in
+   `scripts/fixtures/claude-code-model-configuration.json` with its fetch date
+   and refresh instructions; a dated article id (`claude-opus-4-5-20251101`) is
+   covered by the undated registry entry (`claude-opus-4-5`). A missing model
+   **fails** with a diff; a registry Claude model the article no longer lists is
+   a **warning** (flagged for the owner, not fatal). That article is the
+   reference whenever the model/effort options are set for a release: registry
+   `dropdown` rows, aliases, `--model` values, 1M variants, effort levels.
+
+Run it by hand at any time: `node scripts/release-gate.mjs [--version X]`
+(exit 0 pass, 1 refused, 2 could not evaluate — also a refusal).
+
 ## End-to-end flow
 
 1. Bump `package.json` `version` and add the matching `src/renderer/changelog.ts`

--- a/scripts/fixtures/claude-code-model-configuration.json
+++ b/scripts/fixtures/claude-code-model-configuration.json
@@ -1,0 +1,25 @@
+{
+  "$comment": [
+    "Expected model set for the release gate's MODEL REGISTRY check (scripts/release-gate.mjs, #385).",
+    "This is the 'Supported models' table of Anthropic's Claude Code model configuration support article,",
+    "copied verbatim (label, id) on fetchedAt. resources/model-registry.json must cover every id here",
+    "or a release is refused.",
+    "How to refresh: open `source` in a browser (or `curl -sL <source> | grep -o 'claude-[a-z0-9-]*' | sort -u`),",
+    "rewrite `models` from the Supported models table in the article's order, set fetchedAt to today,",
+    "then run `node scripts/release-gate.mjs` and update resources/model-registry.json until the model check passes."
+  ],
+  "source": "https://support.claude.com/en/articles/11940350-claude-code-model-configuration",
+  "fetchedAt": "2026-08-22",
+  "models": [
+    { "label": "Opus 5", "id": "claude-opus-5" },
+    { "label": "Sonnet 5", "id": "claude-sonnet-5" },
+    { "label": "Fable 5", "id": "claude-fable-5" },
+    { "label": "Opus 4.8", "id": "claude-opus-4-8" },
+    { "label": "Opus 4.7", "id": "claude-opus-4-7" },
+    { "label": "Sonnet 4.6", "id": "claude-sonnet-4-6" },
+    { "label": "Opus 4.6", "id": "claude-opus-4-6" },
+    { "label": "Opus 4.5", "id": "claude-opus-4-5-20251101" },
+    { "label": "Haiku 4.5", "id": "claude-haiku-4-5-20251001" },
+    { "label": "Sonnet 4.5", "id": "claude-sonnet-4-5-20250929" }
+  ]
+}

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -120,6 +120,17 @@ export function registryIdCovers(registryId, expectedId) {
 export function evaluateModels({ registry, expected }) {
   const registryModels = (registry && registry.models) || []
   const expectedModels = (expected && expected.models) || []
+  // Fail closed: an empty or missing expected-models fixture (a truncated file
+  // from a bad merge, say) must NOT vacuously pass -- with nothing to check the
+  // loop below would leave `missing` empty and report ok. A safety gate that
+  // passes because it had nothing to compare is worse than no gate.
+  if (expectedModels.length === 0) {
+    return {
+      ok: false,
+      reason: 'the expected-models fixture is empty or missing — cannot verify the registry (fail closed)',
+      missing: [], extra: [], covered: [],
+    }
+  }
   const missing = []
   const covered = []
   const usedRegistryIds = new Set()

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+// Release gate (#375, #385): refuse to cut a release while its milestone still
+// has open issues, or while the model registry disagrees with Anthropic's
+// published Claude Code model configuration.
+//
+// Why: 2.1.0-beta.16 was cut with book-of-work items still open after an agent
+// answered "no pending work on my side". The owner's rule is that no beta is
+// cut with anything outstanding except what the owner has EXPLICITLY excluded,
+// and that the models the app offers follow Anthropic's support article. Both
+// are now machine-checked, and the check runs where a release is actually made:
+//   - scripts/release.js, before anything is written or pushed, and
+//   - .github/workflows/release.yml, as the first job of every dispatch, so the
+//     workflow-dispatch path (where release.js never runs) is gated too.
+//
+// Checks
+//   1. MILESTONE  The GitHub milestone titled exactly <version> (e.g.
+//      "2.1.0-beta.17") must exist and have no open issue without the
+//      `excluded` label. Pull requests on the milestone are ignored (they are
+//      not book-of-work items). A MISSING milestone fails closed: the gate
+//      cannot tell "nothing outstanding" from "nobody made the list".
+//   2. MODELS  Every id in the support article's "Supported models" table
+//      (scripts/fixtures/claude-code-model-configuration.json, refreshed by
+//      hand — the fixture says how) must be covered by resources/model-registry.json.
+//      A registry id covers an article id when it is equal, or when the article
+//      id is that id plus a `-YYYYMMDD` date suffix (the app resolves dated ids
+//      to the undated entry by prefix; the CLI accepts both). Missing = FAIL,
+//      printed as a diff. A registry Claude model the article no longer lists
+//      is a WARNING (flagged, not fatal): the owner decides whether it retired.
+//
+// Usage
+//   node scripts/release-gate.mjs                      # version from package.json
+//   node scripts/release-gate.mjs --version 2.1.0-beta.17
+//   node scripts/release-gate.mjs --repo owner/name    # default: $GITHUB_REPOSITORY, else package.json repository, else the origin remote
+//   node scripts/release-gate.mjs --registry <path> --expected <path>
+//
+// Auth: GITHUB_TOKEN or GH_TOKEN (read access is enough), else `gh auth token`.
+//
+// Exit codes: 0 = pass; 1 = REFUSED (a check failed); 2 = could not evaluate
+// (network/auth/config) — also refuses, because an unevaluated gate is not a
+// passed gate.
+//
+// Plain ESM, no dependencies: it runs on a bare CI runner before `npm ci`.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+export const EXIT_OK = 0
+export const EXIT_REFUSED = 1
+export const EXIT_CANNOT_EVALUATE = 2
+
+export const EXCLUDED_LABEL = 'excluded'
+export const DEFAULT_REGISTRY_PATH = path.join(ROOT, 'resources', 'model-registry.json')
+export const DEFAULT_EXPECTED_PATH = path.join(ROOT, 'scripts', 'fixtures', 'claude-code-model-configuration.json')
+
+// ── pure helpers (unit-tested) ──────────────────────────────────────
+
+/** Label names from the REST `labels` shape ([{name}] or [string]). */
+function labelNames(labels) {
+  return (labels || []).map((l) => (typeof l === 'string' ? l : l && l.name)).filter(Boolean)
+}
+
+/**
+ * Milestone verdict for one version.
+ *
+ * @param {object} input
+ * @param {string} input.version          e.g. "2.1.0-beta.17" — must equal the milestone title
+ * @param {Array<{number:number,title:string,state?:string}>|null} input.milestones
+ * @param {Array<{number:number,title:string,labels?:any[],pull_request?:object,state?:string}>} input.issues
+ *        open issues ON that milestone (already filtered by the API; re-filtered here defensively)
+ * @param {string} [input.excludedLabel]
+ * @returns {{ ok: boolean, reason: string|null, milestone: object|null, blocking: Array<{number:number,title:string,labels:string[]}>, excluded: Array<{number:number,title:string}> }}
+ */
+export function evaluateMilestone({ version, milestones, issues, excludedLabel = EXCLUDED_LABEL }) {
+  const title = String(version || '').trim()
+  const milestone = (milestones || []).find((m) => m && String(m.title).trim() === title) || null
+  if (!milestone) {
+    return {
+      ok: false,
+      reason: `no GitHub milestone titled "${title}" — create it (and put the release's issues on it) before cutting; the gate fails closed on a missing milestone`,
+      milestone: null, blocking: [], excluded: [],
+    }
+  }
+  const blocking = []
+  const excluded = []
+  for (const it of issues || []) {
+    if (!it || it.pull_request) continue          // PRs are not book-of-work items
+    if (it.state && it.state !== 'open') continue
+    const labels = labelNames(it.labels)
+    if (labels.includes(excludedLabel)) excluded.push({ number: it.number, title: it.title })
+    else blocking.push({ number: it.number, title: it.title, labels })
+  }
+  blocking.sort((a, b) => a.number - b.number)
+  excluded.sort((a, b) => a.number - b.number)
+  return {
+    ok: blocking.length === 0,
+    reason: blocking.length === 0 ? null : `${blocking.length} open issue(s) on milestone "${title}" without the "${excludedLabel}" label`,
+    milestone, blocking, excluded,
+  }
+}
+
+/** An article id is covered by a registry id when equal, or equal minus a -YYYYMMDD suffix. */
+export function registryIdCovers(registryId, expectedId) {
+  if (registryId === expectedId) return true
+  const m = /^(.*)-(\d{8})$/.exec(expectedId)
+  return !!m && m[1] === registryId
+}
+
+/**
+ * Model-registry verdict.
+ *
+ * @param {object} input
+ * @param {{models:Array<{id:string,family?:string,label?:string}>}} input.registry   resources/model-registry.json
+ * @param {{models:Array<{id:string,label?:string}>,source?:string,fetchedAt?:string}} input.expected   the fixture
+ * @returns {{ ok: boolean, reason: string|null, missing: Array<{id:string,label?:string}>, extra: Array<{id:string,label?:string}>, covered: Array<{id:string,by:string}> }}
+ */
+export function evaluateModels({ registry, expected }) {
+  const registryModels = (registry && registry.models) || []
+  const expectedModels = (expected && expected.models) || []
+  const missing = []
+  const covered = []
+  const usedRegistryIds = new Set()
+  for (const exp of expectedModels) {
+    const hit = registryModels.find((m) => registryIdCovers(m.id, exp.id))
+    if (hit) { covered.push({ id: exp.id, by: hit.id }); usedRegistryIds.add(hit.id) }
+    else missing.push({ id: exp.id, label: exp.label })
+  }
+  // Claude models we carry that the article no longer names — flagged, not fatal.
+  // Non-Claude entries (the codex family) are not the article's business.
+  const extra = registryModels
+    .filter((m) => typeof m.id === 'string' && m.id.startsWith('claude-') && !usedRegistryIds.has(m.id))
+    .map((m) => ({ id: m.id, label: m.label }))
+  return {
+    ok: missing.length === 0,
+    reason: missing.length === 0 ? null : `${missing.length} model(s) from the Claude Code model configuration article are not in the registry`,
+    missing, extra, covered,
+  }
+}
+
+/** Render both verdicts as the lines the gate prints. */
+export function formatReport({ version, repo, milestoneResult, modelsResult, expectedMeta }) {
+  const out = []
+  out.push(`Release gate for v${version}${repo ? ` (${repo})` : ''}`)
+  out.push('')
+  // ── milestone
+  if (milestoneResult) {
+    const mr = milestoneResult
+    if (mr.ok) {
+      out.push(`  OK    milestone "${version}" (#${mr.milestone.number}) has no open issues left` +
+        (mr.excluded.length ? ` (${mr.excluded.length} excluded by the owner: ${mr.excluded.map((i) => `#${i.number}`).join(' ')})` : ''))
+    } else {
+      out.push(`  FAIL  milestone: ${mr.reason}`)
+      for (const i of mr.blocking) out.push(`          #${i.number}  ${i.title}${i.labels.length ? `  [${i.labels.join(', ')}]` : ''}`)
+      if (mr.excluded.length) out.push(`          (excluded, not counted: ${mr.excluded.map((i) => `#${i.number}`).join(' ')})`)
+      if (mr.milestone) out.push(`          Close them, move them to a later milestone, or have the owner label them "${EXCLUDED_LABEL}".`)
+    }
+  }
+  // ── models
+  if (modelsResult) {
+    const r = modelsResult
+    const src = expectedMeta && expectedMeta.source ? ` per ${expectedMeta.source}` : ''
+    const at = expectedMeta && expectedMeta.fetchedAt ? ` (fixture fetched ${expectedMeta.fetchedAt})` : ''
+    if (r.ok) out.push(`  OK    model registry covers all ${r.covered.length} supported Claude Code models${at}`)
+    else {
+      out.push(`  FAIL  model registry: ${r.reason}${src}${at}`)
+      for (const m of r.missing) out.push(`          - ${m.id}${m.label ? `  (${m.label})` : ''}   article lists it, resources/model-registry.json does not`)
+      out.push('          Add the missing entries to resources/model-registry.json (models + dropdown) or refresh the fixture if the article changed.')
+    }
+    for (const m of r.extra) out.push(`  WARN  ${m.id}${m.label ? ` (${m.label})` : ''} is in the registry but the article no longer lists it — retired? (not fatal)`)
+  }
+  return out
+}
+
+// ── GitHub access ───────────────────────────────────────────────────
+
+export function resolveToken(env = process.env, runGh = (args) => execFileSync('gh', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })) {
+  const fromEnv = env.GITHUB_TOKEN || env.GH_TOKEN
+  if (fromEnv) return fromEnv
+  try { return String(runGh(['auth', 'token'])).trim() || null } catch { return null }
+}
+
+/** Minimal paginated GET against api.github.com. Throws on non-2xx. */
+export async function githubListAll(pathAndQuery, { token, fetchImpl = globalThis.fetch, perPage = 100, maxPages = 20 } = {}) {
+  const all = []
+  for (let page = 1; page <= maxPages; page++) {
+    const sep = pathAndQuery.includes('?') ? '&' : '?'
+    const url = `https://api.github.com${pathAndQuery}${sep}per_page=${perPage}&page=${page}`
+    const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'ccc-release-gate', 'X-GitHub-Api-Version': '2022-11-28' }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const res = await fetchImpl(url, { headers })
+    if (!res.ok) throw new Error(`GitHub API ${res.status} for ${pathAndQuery}`)
+    const chunk = await res.json()
+    if (!Array.isArray(chunk)) throw new Error(`GitHub API returned a non-array for ${pathAndQuery}`)
+    all.push(...chunk)
+    if (chunk.length < perPage) break
+  }
+  return all
+}
+
+/** `owner/name` from a GitHub URL (https, ssh, or git+https), else null. */
+export function repoFromUrl(url) {
+  const m = /github\.com[/:]([^/\s]+)\/([^/\s.]+?)(?:\.git)?(?:\/|$)/.exec(String(url || '').trim())
+  return m ? `${m[1]}/${m[2]}` : null
+}
+
+export function repoFromPackageJson(pkg) {
+  const r = pkg && pkg.repository
+  return repoFromUrl(typeof r === 'string' ? r : r && r.url)
+}
+
+/** Local fallback: the checkout's origin remote (release.js runs from a clone; CI has $GITHUB_REPOSITORY). */
+export function repoFromGitRemote(runGit = (args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })) {
+  try { return repoFromUrl(runGit(['remote', 'get-url', 'origin'])) } catch { return null }
+}
+
+// ── the gate ────────────────────────────────────────────────────────
+
+/**
+ * Run both checks. Everything external is injectable so the verdict logic is
+ * testable with no network: `listAll(path)` must return the parsed JSON array
+ * for a GitHub REST list endpoint.
+ *
+ * @returns {Promise<{ exitCode: number, lines: string[], milestoneResult: object|null, modelsResult: object|null }>}
+ */
+export async function runGate({
+  version,
+  repo,
+  listAll,
+  registry,
+  expected,
+  log = (s) => console.log(s),
+} = {}) {
+  const lines = []
+  let milestoneResult = null
+  let modelsResult = null
+  let cannotEvaluate = null
+
+  if (!version) cannotEvaluate = 'no version given and none readable from package.json'
+  else if (!repo) cannotEvaluate = 'cannot determine the GitHub repo (set GITHUB_REPOSITORY, pass --repo, or run from a clone with an origin remote)'
+
+  if (!cannotEvaluate) {
+    try {
+      const milestones = await listAll(`/repos/${repo}/milestones?state=all`)
+      const ms = milestones.find((m) => m && String(m.title).trim() === String(version).trim())
+      const issues = ms ? await listAll(`/repos/${repo}/issues?milestone=${ms.number}&state=open`) : []
+      milestoneResult = evaluateMilestone({ version, milestones, issues })
+    } catch (err) {
+      cannotEvaluate = `could not read the milestone from GitHub: ${err && err.message ? err.message : err}`
+    }
+  }
+
+  if (!cannotEvaluate) {
+    try {
+      modelsResult = evaluateModels({ registry, expected })
+    } catch (err) {
+      cannotEvaluate = `could not evaluate the model registry: ${err && err.message ? err.message : err}`
+    }
+  }
+
+  if (cannotEvaluate) {
+    lines.push(`Release gate for v${version || '?'}: CANNOT EVALUATE — ${cannotEvaluate}`)
+    lines.push('An unevaluated gate is a refused gate. Fix the cause and re-run.')
+    for (const l of lines) log(l)
+    return { exitCode: EXIT_CANNOT_EVALUATE, lines, milestoneResult, modelsResult }
+  }
+
+  lines.push(...formatReport({ version, repo, milestoneResult, modelsResult, expectedMeta: expected }))
+  const ok = milestoneResult.ok && modelsResult.ok
+  lines.push('')
+  lines.push(ok ? `PASS  v${version} may be cut.` : `REFUSED  v${version} must not be cut until the FAIL lines above are cleared.`)
+  for (const l of lines) log(l)
+  return { exitCode: ok ? EXIT_OK : EXIT_REFUSED, lines, milestoneResult, modelsResult }
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────
+
+function argValue(argv, flag) {
+  const i = argv.indexOf(flag)
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null
+}
+
+function readJson(p) { return JSON.parse(fs.readFileSync(p, 'utf-8')) }
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const pkg = readJson(path.join(ROOT, 'package.json'))
+  const version = argValue(argv, '--version') || pkg.version
+  const repo = argValue(argv, '--repo') || env.GITHUB_REPOSITORY || repoFromPackageJson(pkg) || repoFromGitRemote()
+  const registryPath = argValue(argv, '--registry') || DEFAULT_REGISTRY_PATH
+  const expectedPath = argValue(argv, '--expected') || DEFAULT_EXPECTED_PATH
+
+  let registry, expected
+  try {
+    registry = readJson(registryPath)
+    expected = readJson(expectedPath)
+  } catch (err) {
+    console.error(`Release gate: CANNOT EVALUATE — ${err.message}`)
+    return EXIT_CANNOT_EVALUATE
+  }
+
+  const token = resolveToken(env)
+  if (!token) console.error('Release gate: no GITHUB_TOKEN/GH_TOKEN and `gh auth token` gave nothing — trying unauthenticated (public repo, rate-limited)')
+  const listAll = (p) => githubListAll(p, { token })
+  const { exitCode } = await runGate({ version, repo, listAll, registry, expected })
+  return exitCode
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+if (invokedDirectly) {
+  // exitCode, not process.exit(): a hard exit while undici's keep-alive handle is
+  // still closing trips a libuv assertion on Windows (exit 127, noisy, and it
+  // hides the real code). Nothing else keeps the loop alive, so draining is safe.
+  main().then(
+    (code) => { process.exitCode = code },
+    (err) => { console.error(`Release gate: CANNOT EVALUATE — ${err && err.stack ? err.stack : err}`); process.exitCode = EXIT_CANNOT_EVALUATE },
+  )
+}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -622,6 +622,19 @@ step(6, TOTAL_STEPS, 'Checking for stale GitHub release...')
 try {
   const existing = run(`gh release view ${tag} --json tagName -q .tagName 2>&1 || echo ""`)
   if (existing.trim() === tag) {
+    // Re-run the gate IMMEDIATELY before the destructive delete. The gate ran at
+    // Step 2, but commit/tag/push happened since; a milestone issue opened in
+    // that window would let us delete the last good release for this tag and
+    // then have CI's own gate refuse to build a replacement, leaving no release
+    // at all (#375 review). Re-checking here closes that window to ~zero — and
+    // CI's gate job is still the authoritative backstop before any build.
+    console.log(`      Re-checking the release gate before deleting ${tag}...`)
+    try {
+      runInherit(`node scripts/release-gate.mjs --version ${version}`)
+    } catch {
+      fail(`RELEASE GATE REFUSED v${version} before the stale-release delete — the existing ${tag} release is left intact.\n      ` +
+        'Resolve the open milestone issues (or label them "excluded") and re-run.')
+    }
     warn(`A release for ${tag} already exists — deleting so the workflow can recreate cleanly`)
     run(`gh release delete ${tag} --yes`)
     ok('Stale release deleted (tag preserved)')

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -10,7 +10,9 @@
  * Local steps (fast feedback before pushing):
  *   1. Pre-flight checks (gh auth, npm audit, git status)
  *   2. Channel selection (stable / beta / dev)
- *   3. Version bump
+ *   3. Version bump — gated by scripts/release-gate.mjs (#375/#385): the
+ *      milestone named after the new version must have no open issues (bar
+ *      `excluded`) and the model registry must match Anthropic's article
  *   4. Update changelog.ts version + date of the newest entry, regenerate CHANGELOG.md
  *   5. Typecheck + unit tests + build smoke test
  *   6. Git commit + tag + push
@@ -367,6 +369,9 @@ console.log('  │    new features were added this release      │')
 console.log('  │  □ Added trackUsage() calls for new features │')
 console.log('  │  □ Updated changelog.ts with release notes   │')
 console.log('  │  □ Tested new features visually in dev mode  │')
+console.log('  │  □ Model options follow the Claude Code      │')
+console.log('  │    model configuration article (#385) —      │')
+console.log('  │    the release gate below checks it          │')
 console.log('  │                                              │')
 console.log('  └─────────────────────────────────────────────┘')
 console.log('')
@@ -466,6 +471,28 @@ if (NO_BUMP) {
   } catch (err) {
     fail(err.message)
   }
+}
+
+// --- Release gate (#375, #385) — BEFORE anything is written ---
+// Refuses the cut while the milestone titled `version` has open issues without
+// the `excluded` label, or while resources/model-registry.json lacks a model
+// Anthropic's Claude Code model configuration article lists. Runs here, before
+// package.json / changelog are touched, so a refused cut leaves the tree clean.
+// There is deliberately NO --skip flag: release.yml runs the same gate on every
+// dispatch, so a local bypass would only move the refusal to CI.
+console.log(`      Release gate for v${version}...`)
+try {
+  // `version` came from parseVersion/nextVersion (or package.json), so it is a
+  // plain semver string — safe to place on the command line.
+  runInherit(`node scripts/release-gate.mjs --version ${version}`)
+  ok(`Release gate passed for v${version}`)
+} catch {
+  fail(`RELEASE GATE REFUSED v${version} — see the FAIL lines above.\n      ` +
+    'Close or move the open milestone issues (or have the owner label them "excluded"),\n      ' +
+    'and align resources/model-registry.json with the Claude Code model configuration article.')
+}
+
+if (!NO_BUMP) {
   pkg.version = version
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8')
 

--- a/tests/unit/scripts/release-gate.test.ts
+++ b/tests/unit/scripts/release-gate.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// release-gate.mjs is plain ESM and guards main() behind an argv[1] check, so
+// importing it here pulls in the pure verdict logic without touching GitHub.
+// Everything external (the REST list calls) is injected through `listAll`.
+import {
+  evaluateMilestone,
+  evaluateModels,
+  registryIdCovers,
+  repoFromUrl,
+  repoFromPackageJson,
+  runGate,
+  githubListAll,
+  resolveToken,
+  EXIT_OK,
+  EXIT_REFUSED,
+  EXIT_CANNOT_EVALUATE,
+  EXCLUDED_LABEL,
+  DEFAULT_REGISTRY_PATH,
+  DEFAULT_EXPECTED_PATH,
+} from '../../../scripts/release-gate.mjs'
+
+type Issue = { number: number; title: string; labels?: Array<{ name: string } | string>; pull_request?: object; state?: string }
+type Milestone = { number: number; title: string; state?: string }
+
+const EXPECTED = {
+  source: 'https://example.test/article',
+  fetchedAt: '2026-08-22',
+  models: [
+    { label: 'Opus 4.8', id: 'claude-opus-4-8' },
+    { label: 'Sonnet 4.6', id: 'claude-sonnet-4-6' },
+    { label: 'Haiku 4.5', id: 'claude-haiku-4-5-20251001' },
+  ],
+}
+
+const REGISTRY_OK = {
+  models: [
+    { id: 'claude-opus-4-8', family: 'opus', label: 'Opus 4.8' },
+    { id: 'claude-sonnet-4-6', family: 'sonnet', label: 'Sonnet 4.6' },
+    { id: 'claude-haiku-4-5', family: 'haiku', label: 'Haiku 4.5' },
+    { id: 'codex-family', family: 'codex', label: 'Codex' },
+  ],
+}
+
+/** A fake GitHub: one milestone list, issues keyed by milestone number. */
+function fakeGitHub(milestones: Milestone[], issuesByMilestone: Record<number, Issue[]>) {
+  const calls: string[] = []
+  const listAll = async (p: string): Promise<unknown[]> => {
+    calls.push(p)
+    if (p.startsWith('/repos/o/r/milestones')) return milestones
+    const m = /\/repos\/o\/r\/issues\?milestone=(\d+)&state=open/.exec(p)
+    if (m) return issuesByMilestone[Number(m[1])] ?? []
+    throw new Error(`unexpected path ${p}`)
+  }
+  return { listAll, calls }
+}
+
+const silent = () => {}
+
+// ── evaluateMilestone ──────────────────────────────────────────────
+describe('release-gate evaluateMilestone', () => {
+  const milestones: Milestone[] = [{ number: 7, title: '2.1.0-beta.17' }, { number: 8, title: '2.2' }]
+
+  it('passes a milestone with no open issues', () => {
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues: [] })
+    expect(r.ok).toBe(true)
+    expect(r.milestone?.number).toBe(7)
+    expect(r.blocking).toEqual([])
+  })
+
+  it('fails and lists every open issue that is not excluded, ascending', () => {
+    const issues: Issue[] = [
+      { number: 385, title: 'Model picker', labels: [{ name: 'bug' }] },
+      { number: 358, title: 'Command bar', labels: [{ name: 'enhancement' }, { name: 'ux' }] },
+    ]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(false)
+    expect(r.blocking.map((i) => i.number)).toEqual([358, 385])
+    expect(r.blocking[0].labels).toEqual(['enhancement', 'ux'])
+    expect(r.reason).toContain('2 open issue(s)')
+  })
+
+  it('ignores issues carrying the excluded label (owner-excluded from the gate)', () => {
+    const issues: Issue[] = [
+      { number: 374, title: 'GPU rendering', labels: [{ name: EXCLUDED_LABEL }, { name: 'enhancement' }] },
+    ]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(true)
+    expect(r.excluded.map((i) => i.number)).toEqual([374])
+  })
+
+  it('accepts labels as plain strings too', () => {
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues: [{ number: 1, title: 'x', labels: ['excluded'] }] })
+    expect(r.ok).toBe(true)
+  })
+
+  it('ignores pull requests and non-open items on the milestone', () => {
+    const issues: Issue[] = [
+      { number: 390, title: 'feat: something', pull_request: { url: 'x' } },
+      { number: 391, title: 'closed already', state: 'closed' },
+    ]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(true)
+  })
+
+  it('fails CLOSED when no milestone carries the version as its title', () => {
+    const r = evaluateMilestone({ version: '2.1.0-beta.18', milestones, issues: [] })
+    expect(r.ok).toBe(false)
+    expect(r.milestone).toBeNull()
+    expect(r.reason).toMatch(/no GitHub milestone titled "2.1.0-beta.18"/)
+  })
+
+  it('matches the milestone title exactly — "2.2" is not "2.2.0"', () => {
+    expect(evaluateMilestone({ version: '2.2.0', milestones, issues: [] }).ok).toBe(false)
+    expect(evaluateMilestone({ version: ' 2.2 ', milestones, issues: [] }).ok).toBe(true)
+  })
+})
+
+// ── evaluateModels ─────────────────────────────────────────────────
+describe('release-gate evaluateModels', () => {
+  it('passes when every article model is covered (dated article ids resolve to the undated registry entry)', () => {
+    const r = evaluateModels({ registry: REGISTRY_OK, expected: EXPECTED })
+    expect(r.ok).toBe(true)
+    expect(r.missing).toEqual([])
+    expect(r.covered).toContainEqual({ id: 'claude-haiku-4-5-20251001', by: 'claude-haiku-4-5' })
+    expect(r.extra).toEqual([])   // codex-family is not a Claude model
+  })
+
+  it('fails with the missing ids when the article names a model the registry lacks', () => {
+    const registry = { models: REGISTRY_OK.models.filter((m) => m.id !== 'claude-sonnet-4-6') }
+    const r = evaluateModels({ registry, expected: EXPECTED })
+    expect(r.ok).toBe(false)
+    expect(r.missing).toEqual([{ id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' }])
+  })
+
+  it('flags (but does not fail on) a registry Claude model the article no longer lists', () => {
+    const registry = { models: [...REGISTRY_OK.models, { id: 'claude-opus-4-8-fast', family: 'opus', label: 'Opus 4.8 Fast' }] }
+    const r = evaluateModels({ registry, expected: EXPECTED })
+    expect(r.ok).toBe(true)
+    expect(r.extra).toEqual([{ id: 'claude-opus-4-8-fast', label: 'Opus 4.8 Fast' }])
+  })
+
+  it('registryIdCovers: equal, or equal minus a -YYYYMMDD suffix — nothing looser', () => {
+    expect(registryIdCovers('claude-opus-4-5', 'claude-opus-4-5-20251101')).toBe(true)
+    expect(registryIdCovers('claude-opus-4-5', 'claude-opus-4-5')).toBe(true)
+    // a bare family id must NOT cover a versioned one — that is the #385 bug shape
+    expect(registryIdCovers('claude-opus', 'claude-opus-4-5-20251101')).toBe(false)
+    expect(registryIdCovers('claude-opus-4', 'claude-opus-4-5')).toBe(false)
+    expect(registryIdCovers('claude-opus-4-5', 'claude-opus-4-5-fast')).toBe(false)
+  })
+})
+
+// ── runGate (mocked GitHub) ────────────────────────────────────────
+describe('release-gate runGate', () => {
+  it('clean milestone + covered registry → exit 0 with a PASS line', async () => {
+    const gh = fakeGitHub([{ number: 7, title: '2.1.0-beta.17' }], { 7: [] })
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_OK)
+    expect(r.lines.at(-1)).toMatch(/^PASS/)
+    expect(gh.calls).toEqual(['/repos/o/r/milestones?state=all', '/repos/o/r/issues?milestone=7&state=open'])
+  })
+
+  it('open issue → exit 1 and the issue is printed by number and title', async () => {
+    const gh = fakeGitHub([{ number: 7, title: '2.1.0-beta.17' }], { 7: [{ number: 377, title: 'Tips re-review', labels: [{ name: 'ux' }] }] })
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_REFUSED)
+    expect(r.lines.join('\n')).toMatch(/#377\s+Tips re-review\s+\[ux\]/)
+    expect(r.lines.at(-1)).toMatch(/^REFUSED/)
+  })
+
+  it('excluded label ignored → exit 0, and the excluded issue is named in the OK line', async () => {
+    const gh = fakeGitHub([{ number: 7, title: '2.1.0-beta.17' }], { 7: [{ number: 374, title: 'GPU', labels: [{ name: 'excluded' }] }] })
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_OK)
+    expect(r.lines.join('\n')).toMatch(/excluded by the owner: #374/)
+  })
+
+  it('missing milestone → exit 1 (fails closed) and never queries issues', async () => {
+    const gh = fakeGitHub([{ number: 8, title: '2.2' }], {})
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_REFUSED)
+    expect(r.lines.join('\n')).toMatch(/no GitHub milestone titled "2.1.0-beta.17"/)
+    expect(gh.calls).toEqual(['/repos/o/r/milestones?state=all'])
+  })
+
+  it('model check fails → exit 1 even when the milestone is clean, with a diff of the missing ids', async () => {
+    const gh = fakeGitHub([{ number: 7, title: '2.1.0-beta.17' }], { 7: [] })
+    const registry = { models: REGISTRY_OK.models.filter((m) => m.id !== 'claude-opus-4-8') }
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_REFUSED)
+    const text = r.lines.join('\n')
+    expect(text).toMatch(/OK\s+milestone/)
+    expect(text).toMatch(/FAIL\s+model registry/)
+    expect(text).toMatch(/- claude-opus-4-8\s+\(Opus 4.8\)/)
+  })
+
+  it('model check passes → the OK line says how many models are covered', async () => {
+    const gh = fakeGitHub([{ number: 7, title: '2.1.0-beta.17' }], { 7: [] })
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.lines.join('\n')).toMatch(/OK\s+model registry covers all 3 supported Claude Code models/)
+  })
+
+  it('GitHub unreachable → exit 2 (cannot evaluate), not a pass', async () => {
+    const listAll = async () => { throw new Error('GitHub API 503 for /repos/o/r/milestones?state=all') }
+    const r = await runGate({ version: '2.1.0-beta.17', repo: 'o/r', listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE)
+    expect(r.lines[0]).toMatch(/CANNOT EVALUATE/)
+  })
+
+  it('no version / no repo → exit 2', async () => {
+    const gh = fakeGitHub([], {})
+    expect((await runGate({ version: '', repo: 'o/r', listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })).exitCode).toBe(EXIT_CANNOT_EVALUATE)
+    expect((await runGate({ version: '1.0.0', repo: null, listAll: gh.listAll, registry: REGISTRY_OK, expected: EXPECTED, log: silent })).exitCode).toBe(EXIT_CANNOT_EVALUATE)
+  })
+})
+
+// ── plumbing ───────────────────────────────────────────────────────
+describe('release-gate plumbing', () => {
+  it('githubListAll paginates until a short page and sends the bearer token', async () => {
+    const seen: Array<{ url: string; auth: string | undefined }> = []
+    const pages: Record<string, unknown[]> = { '1': Array.from({ length: 2 }, (_, i) => ({ n: i })), '2': [{ n: 2 }] }
+    const fetchImpl = async (url: string, init: { headers: Record<string, string> }) => {
+      seen.push({ url, auth: init.headers.Authorization })
+      const page = new URL(url).searchParams.get('page') ?? '1'
+      return { ok: true, status: 200, json: async () => pages[page] ?? [] }
+    }
+    const all = await githubListAll('/repos/o/r/milestones?state=all', { token: 't0k', fetchImpl: fetchImpl as unknown as typeof fetch, perPage: 2 })
+    expect(all).toHaveLength(3)
+    expect(seen.map((s) => s.url)).toEqual([
+      'https://api.github.com/repos/o/r/milestones?state=all&per_page=2&page=1',
+      'https://api.github.com/repos/o/r/milestones?state=all&per_page=2&page=2',
+    ])
+    expect(seen[0].auth).toBe('Bearer t0k')
+  })
+
+  it('githubListAll throws on a non-2xx (so the gate reports CANNOT EVALUATE, never pass)', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 401, json: async () => ({}) })
+    await expect(githubListAll('/repos/o/r/milestones', { token: null, fetchImpl: fetchImpl as unknown as typeof fetch })).rejects.toThrow(/401/)
+  })
+
+  it('resolveToken prefers GITHUB_TOKEN, then GH_TOKEN, then `gh auth token`', () => {
+    expect(resolveToken({ GITHUB_TOKEN: 'a', GH_TOKEN: 'b' }, () => 'c')).toBe('a')
+    expect(resolveToken({ GH_TOKEN: 'b' }, () => 'c')).toBe('b')
+    expect(resolveToken({}, () => 'c\n')).toBe('c')
+    expect(resolveToken({}, () => { throw new Error('no gh') })).toBeNull()
+  })
+
+  it('repoFromUrl handles https, ssh and git+https forms', () => {
+    expect(repoFromUrl('https://github.com/nubbymong/claude-command-center.git')).toBe('nubbymong/claude-command-center')
+    expect(repoFromUrl('git@github.com:nubbymong/claude-command-center.git\n')).toBe('nubbymong/claude-command-center')
+    expect(repoFromUrl('git+https://github.com/o/r')).toBe('o/r')
+    expect(repoFromUrl('')).toBeNull()
+    expect(repoFromPackageJson({ repository: { type: 'git', url: 'https://github.com/o/r.git' } })).toBe('o/r')
+    expect(repoFromPackageJson({})).toBeNull()
+  })
+})
+
+// ── the real fixture and the real registry ─────────────────────────
+describe('release-gate shipped fixture', () => {
+  const expected = JSON.parse(readFileSync(DEFAULT_EXPECTED_PATH, 'utf-8'))
+  const registry = JSON.parse(readFileSync(DEFAULT_REGISTRY_PATH, 'utf-8'))
+
+  it('the fixture is well-formed: source, fetch date, and unique claude-* ids', () => {
+    expect(expected.source).toMatch(/^https:\/\/support\.claude\.com\//)
+    expect(expected.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    const ids = expected.models.map((m: { id: string }) => m.id)
+    expect(ids.length).toBeGreaterThan(0)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const id of ids) expect(id).toMatch(/^claude-[a-z0-9-]+$/)
+  })
+
+  it('evaluates the shipped registry without throwing (the verdict itself is the gate\'s business, not this test\'s)', () => {
+    // Deliberately NOT asserting ok here: the registry is edited under #385 and
+    // the article changes under Anthropic's hand. The release gate is where the
+    // verdict bites; this test only proves the real inputs are readable.
+    const r = evaluateModels({ registry, expected })
+    expect(Array.isArray(r.missing)).toBe(true)
+    expect(r.covered.length + r.missing.length).toBe(expected.models.length)
+  })
+
+  it('resolves DEFAULT paths to files that exist in the repo', () => {
+    expect(resolve(DEFAULT_REGISTRY_PATH)).toMatch(/resources[\\/]model-registry\.json$/)
+    expect(resolve(DEFAULT_EXPECTED_PATH)).toMatch(/scripts[\\/]fixtures[\\/]claude-code-model-configuration\.json$/)
+  })
+})

--- a/tests/unit/scripts/release-gate.test.ts
+++ b/tests/unit/scripts/release-gate.test.ts
@@ -142,6 +142,14 @@ describe('release-gate evaluateModels', () => {
     expect(r.extra).toEqual([{ id: 'claude-opus-4-8-fast', label: 'Opus 4.8 Fast' }])
   })
 
+  it('FAILS CLOSED when the expected-models fixture is empty or missing — a truncated fixture must not vacuously pass', () => {
+    for (const expected of [{ models: [] }, {}, null, undefined]) {
+      const r = evaluateModels({ registry: REGISTRY_OK, expected })
+      expect(r.ok, JSON.stringify(expected)).toBe(false)
+      expect(r.reason).toMatch(/empty or missing|cannot verify|fail closed/i)
+    }
+  })
+
   it('registryIdCovers: equal, or equal minus a -YYYYMMDD suffix — nothing looser', () => {
     expect(registryIdCovers('claude-opus-4-5', 'claude-opus-4-5-20251101')).toBe(true)
     expect(registryIdCovers('claude-opus-4-5', 'claude-opus-4-5')).toBe(true)


### PR DESCRIPTION
## What and why

A release is now **refused** until two checks pass — `scripts/release-gate.mjs`, run by `scripts/release.js` (before `package.json` is touched) and as the first job of `release.yml` on every dispatch (every build job `needs: gate`). No bypass.

1. **Milestone (#375).** The GitHub milestone titled exactly the version being cut (`2.1.0-beta.17`) must exist and have no open issue without the `excluded` label. Open issues are printed by number and title; PRs on the milestone are ignored. A **missing milestone fails closed** — the gate cannot tell "nothing outstanding" from "nobody made the list".
2. **Model registry (#385, owner comment 2026-08-22).** `resources/model-registry.json` must cover every model in Anthropic's [Claude Code model configuration](https://support.claude.com/en/articles/11940350-claude-code-model-configuration) article. The expected set is hard-coded in `scripts/fixtures/claude-code-model-configuration.json` (fetched 2026-08-22, with refresh instructions). A dated article id (`claude-opus-4-5-20251101`) is covered by the undated registry entry (`claude-opus-4-5`). Missing → **FAIL with a diff**; a registry Claude model the article no longer lists → **WARN** (flagged for the owner, not fatal).

Why: beta.16 was cut with book-of-work items still open after an agent said nothing was pending. The owner's rule is now a machine check, in both places a release is actually made.

Exit codes: 0 pass, 1 refused, 2 could not evaluate (also a refusal). Plain ESM, no dependencies; reads GitHub via REST with `GITHUB_TOKEN`/`GH_TOKEN`, else `gh auth token`. Docs: `docs/versioning.md` "Release gate" section + one CONTRIBUTING bullet; running log in `CONTEXT.d/2026-08-22-n375.md`.

Issues: #375, #385 (the pre-release-check half; the picker fix and the Sentinel runtime comparison are not in this PR).

## Live dry run (the #375 acceptance)

`node scripts/release-gate.mjs --version 2.1.0-beta.17` today → **REFUSED**: lists all 27 open milestone issues (#358–#385 minus #376), and the model check reports four article models the registry lacks — `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929` — plus a WARN on `claude-opus-4-8-fast` (in the registry, not in the article). A made-up version fails closed on the missing milestone.

## How it was tested

- `tests/unit/scripts/release-gate.test.ts` — 26 tests with a mocked GitHub: clean milestone passes; open issue fails and is listed; `excluded` ignored; PRs/closed items ignored; missing milestone fails closed and never queries issues; exact title match; model check pass / fail-with-diff / extra-as-warning; dated-id coverage rule and its negatives (a bare family id does NOT cover a versioned one); GitHub unreachable → exit 2; pagination + bearer token; token precedence; repo-url parsing; the shipped fixture is well-formed and the real registry is evaluable.
- `tests/unit/scripts/release.test.ts` still green (release.js loads under `require()` without dispatching).
- Full suite `npx vitest run`: **628 files passed | 2 skipped (630); 6568 tests passed | 15 skipped**.
- `npm run typecheck`: **green** (node + web + bridge projects).
- Workflow YAML parses; the `gate` job has `permissions: contents: read, issues: read` and `continue-on-error: ${{ inputs.dry_run }}` so a dry run sees the verdict without being blocked.

VM proof: pending — the conductor's integration pass.

## Not done / open questions for the owner

- **The gate will refuse beta.17 on the model check until the registry gains Opus 5 / Sonnet 5 / Opus 4.5 / Sonnet 4.5** (pricing, efforts, dropdown rows). That is the #385 picker fix, which needs the owner's decision on the rows — deliberately not touched here. `node scripts/release-gate.mjs` prints the exact diff to close.
- `claude-opus-4-8-fast` is in the registry but not in the article — a WARN today. Owner call: keep (real CLI id) or retire.
- Coverage rule: a registry id covers an article id when equal or equal-minus-`-YYYYMMDD`. If you would rather the registry carry the dated ids verbatim, flip `registryIdCovers` to equality only.
- The workflow gate has no bypass by design. If an emergency re-release of an already-published tag must go through while the next milestone is open, the milestone title is the knob (the gate reads the milestone named after `package.json`'s version).
- Not security-sensitive (no IPC/preload/PTY/credentials/MCP/updater/webPreferences touched): a new script, a fixture, release.js/release.yml wiring, docs.
