### PR TITLE
fix(onboarding): show What's New when the seen stamp is ahead of any build that ran (#369)

### DIFF
--- a/CONTEXT.d/2026-08-22-n369.md
+++ b/CONTEXT.d/2026-08-22-n369.md
@@ -1,0 +1,86 @@
+# 2026-08-22 -- #369: What's New did not appear after installing beta.16 (offline installer)
+
+## What happened
+
+The owner installed beta.16 from the offline .exe and never saw the full-screen
+What's New page. beta.16 had just changed the gate to stamp and compare the
+version the build actually RUNS (`__APP_VERSION__`) instead of the newest
+changelog entry authored, and its changelog promised that an existing "ahead"
+stamp "corrects itself on the next launch".
+
+## Cause (from the code, not reproduced on a VM)
+
+The code that shipped in beta.16 predicted this exact outcome in its own
+header comment (`src/renderer/onboarding/whats-new-gate.ts`): a beta.15-era
+build running with the beta.16 changelog entry already written -- the
+wall-of-text incident of 2026-08-21 -- stamped `lastSeenVersion = 2.1.0-beta.16`
+on dismissal, a version that had not shipped. The real beta.16 then compared
+the stamp to itself, read `same-version`, and showed nothing.
+
+The beta.16 fix stopped NEW bad stamps being written; it did nothing about the
+one already on disk. "Corrects itself on the next launch" is only true for a
+stamp two or more releases ahead (then `lastSeen !== current` and the notes
+show); the stamp the old rule actually wrote is always exactly ONE ahead, the
+one case that reads as "already seen".
+
+Hypothesis ranking, since the VM belongs to the conductor:
+
+1. (most likely, and what the code itself predicted) the ahead stamp above.
+   Consistent with the offline installer mattering only in that nothing about
+   it touches app-meta -- the updater does not either; the state was already
+   on disk before either installer ran.
+2. a beta.15-era preview build that ran the FULL flow (beta channel re-walked
+   every build back then) and whose finish stamped the same ahead value --
+   same root, different surface.
+3. app-meta not readable at the beta.16 launch (the #341 latch hydrates from
+   `{}`) -> read as a fresh install -> tour, no notes. The owner would have
+   seen the read-failure notice and the whole tour; not reported.
+
+A clean beta.15 -> beta.16 offline install will NOT reproduce it: the beta.15
+release build's changelog head is beta.15, so it stamps beta.15 and the
+beta.16 gate reads within-line and shows the page. The reproducing sequence
+needs the intermediate preview build, or the equivalent hand-edit (below).
+
+## Fix
+
+The "seen" stamp is no longer trusted on its own. A new app-meta field,
+`lastRunVersion`, is stamped with `__APP_VERSION__` at every boot (App.tsx
+`postConfigInit`, AFTER the launch decision has read the previous value) and
+acts as the witness: a `lastSeenVersion` newer than the last build that ran
+cannot have been written by the build it names, and is read as the last run
+instead (`seenVersionFor` in `upgrade-flow.ts`). On a meta written before the
+field existed the witness falls back to `setupVersion`, which every build since
+1.x has stamped with its own version -- the only pre-existing record of a
+build having run, and never ahead. `decideUpgradeFlow` gains a `lastRunVersion`
+input and a `stamped-ahead` reason; `shouldShowWhatsNew` supplies the witness;
+the harness diffs `stepsNewSince` against the same clamped origin (`seenVersion()`),
+so a stamp written ahead of its build cannot hide a page new in this one either.
+
+Existing semantics unchanged: fresh install -> tour, no notes; beta-to-beta ->
+notes once; downgrade -> notes once; relaunch after acknowledging -> nothing;
+no witness at all -> the stamp decides, as before.
+
+## Verified
+
+- `tests/unit/renderer/upgrade-flow.test.ts` (+10: the #369 shape, witness
+  precedence, downgrade, legacy no-witness, `seenVersionFor`, `lastRunVersionOf`)
+- `tests/unit/renderer/whats-new-gate.test.ts` (+4: the store-reading wrapper
+  with the owner's meta shape; `seenVersion()`)
+- `tests/unit/renderer/whats-new-exactly-once.test.ts` (new): the owner's
+  asked-for pin, "a version change always shows the page exactly once", as a
+  launch-sequence simulation including the #369 replay with the OLD stamping
+  rule, beta/rc/final ordering, quit-before-ack, downgrade, fresh install.
+- All 13 behavioural assertions were run against the pre-fix code first and
+  failed (the two `expected false to be true` ones are the bug; the rest are
+  the missing helpers).
+- `npm run typecheck` clean; full `npx vitest run` green (see PR).
+
+## Left / for the conductor's VM pass
+
+Exact replay of the owner's state, no intermediate build needed: on a VM that
+has run the real beta.16 and settled, edit `app-meta.json` in CONFIG/ so
+`setupVersion` is `2.1.0-beta.15` and `lastRunVersion` is absent, leaving
+`lastSeenVersion = 2.1.0-beta.16`; launch the PR's preview build (still
+versioned 2.1.0-beta.16). Old code: nothing. New code: the What's New page
+once; relaunch: nothing. No ADR: a field and a clamp, no architectural change.
+Changelog entry left to the conductor's consolidated pass.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -425,13 +425,14 @@ export default function App() {
     async function postConfigInit() {
       const appMeta = useAppMetaStore.getState().meta
 
-      // Re-fire the first-run tour when the VERSION warrants it: every build on
-      // the beta line so testers see the current flow, and on any channel when
-      // the user has crossed a release line (2.0.x → 2.1.x). Clearing
-      // completedSteps + onboardingCompletedVersion flips deriveOnboarding back
-      // to due (the harness re-runs); its finish step re-stamps
-      // onboardingAppVersion so it will not re-fire until the next one that
-      // qualifies. A first install runs through deriveOnboarding already.
+      // Re-fire the first-run tour when the VERSION warrants it: an
+      // ONBOARDING_VERSION bump, or a crossed release line (2.0.x → 2.1.x) on
+      // any channel — see shouldReonboardForVersion; a beta bump alone no
+      // longer does (2026-08-21). Clearing completedSteps +
+      // onboardingCompletedVersion flips deriveOnboarding back to due (the
+      // harness re-runs); its finish step re-stamps onboardingAppVersion so it
+      // will not re-fire until the next one that qualifies. A first install
+      // runs through deriveOnboarding already.
       const reonboard = shouldReonboardForVersion(appMeta, __APP_VERSION__, useSettingsStore.getState().settings.updateChannel)
       if (reonboard) {
         useAppMetaStore.getState().update({ completedSteps: {}, onboardingCompletedVersion: undefined })
@@ -452,6 +453,16 @@ export default function App() {
       // Only arm the notes-only mode when the harness is not already coming up
       // for its own reasons; there, whatsNewV2 is simply its first page.
       if (surface === 'tour' && !alreadyRunning) setWhatsNewOnly(true)
+
+      // Record that THIS build ran — AFTER the decision above has read the
+      // previous value, which is the whole point of it. It is the witness
+      // against a lastSeenVersion that no build of that version ever wrote
+      // (#369): a stamp newer than the last build that ran does not count as
+      // seen. Unconditional, unlike setupVersion below, which waits on config
+      // or the CLI and is only the fallback witness for metas older than this.
+      if (appMeta.lastRunVersion !== __APP_VERSION__) {
+        useAppMetaStore.getState().update({ lastRunVersion: __APP_VERSION__ })
+      }
 
       if (appMeta.setupVersion !== __APP_VERSION__) {
         const hasExistingConfig = useConfigStore.getState().configs.length > 0 ||

--- a/src/renderer/onboarding/OnboardingHarness.tsx
+++ b/src/renderer/onboarding/OnboardingHarness.tsx
@@ -16,6 +16,7 @@ import { CodexSignInStep } from './CodexSignInStep'
 import { TransparencyStep } from './TransparencyStep'
 import { FinishStep } from './FinishStep'
 import { settleOnboardingFinish, settleWhatsNewOnly } from './settle'
+import { seenVersion } from './whats-new-gate'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useAppMetaStore } from '../stores/appMetaStore'
 
@@ -152,7 +153,10 @@ export function OnboardingHarness({
   // is where that reshuffle is wanted.
   const [pages] = useState<BuiltStep[]>(() => {
     if (!whatsNewOnly) return PAGES
-    const lastSeen = useAppMetaStore.getState().meta.lastSeenVersion
+    // The stamp clamped to the last build that ran, not the raw stamp — the
+    // same origin the launch decision used (#369), so a stamp written ahead of
+    // its build cannot hide a page that is new in this one.
+    const lastSeen = seenVersion()
     const settings = { codexEnabled: useSettingsStore.getState().settings.codexEnabled }
     const newIds = new Set(stepsNewSince(lastSeen, settings).map((s) => s.id))
     return PAGES.filter((p) => p.id === 'whatsNewV2' || newIds.has(p.id))

--- a/src/renderer/onboarding/upgrade-flow.ts
+++ b/src/renderer/onboarding/upgrade-flow.ts
@@ -30,10 +30,54 @@ export interface VersionedEntry {
 export interface UpgradeFlowInput {
   /** `lastSeenVersion` from app meta. Absent on a first install. */
   lastSeenVersion?: string
-  /** The version now running (changelog head, i.e. this build). */
+  /**
+   * The version that last actually RAN on this machine — `lastRunVersionOf(meta)`.
+   * The witness against a "seen" stamp that the build it names never wrote
+   * (#369): a stamp NEWER than any build that has run cannot mean the user saw
+   * those notes, so it does not count as seen. Absent means no record, and the
+   * stamp is trusted as it always was.
+   */
+  lastRunVersion?: string
+  /** The version now running (`__APP_VERSION__`, i.e. this build). */
   currentVersion: string
   /** 'beta' testers re-walk the tour on every version; see `showTour`. */
   channel?: string
+}
+
+/**
+ * The last build that actually ran, as well as the stored meta can say.
+ *
+ * `lastRunVersion` is stamped with `__APP_VERSION__` at every boot (App.tsx,
+ * after the launch decision has read the previous value). It did not exist
+ * before the #369 fix, so a meta written by an older build falls back to
+ * `setupVersion`, which every build since 1.x has stamped with its own version
+ * on its first launch — the only pre-existing record of a build having run,
+ * and never ahead, because it too is keyed on `__APP_VERSION__`.
+ */
+export function lastRunVersionOf(meta: { lastRunVersion?: string; setupVersion?: string }): string | undefined {
+  return meta.lastRunVersion ?? meta.setupVersion
+}
+
+/**
+ * The version the user can actually have SEEN the notes for: the stamp,
+ * clamped to the last build that ran.
+ *
+ * This is the #369 repair in one line. Until beta.16 the dismissal stamped the
+ * changelog HEAD, which on any build between two releases is one release ahead
+ * of the build running — so the owner's machine reached the real beta.16
+ * already holding `lastSeenVersion = beta.16`, written by a beta.15 build, and
+ * the gate read "same version" and showed nothing. No build of beta.16 had run
+ * (`setupVersion` still said beta.15), so the stamp could not be true; a stamp
+ * newer than the last run is read as the last run instead.
+ *
+ * Anything that asks "what has this user seen?" — the launch decision, and the
+ * harness working out which pages are new since — goes through this, so the
+ * two never disagree.
+ */
+export function seenVersionFor(input: { lastSeenVersion?: string; lastRunVersion?: string }): string | undefined {
+  const { lastSeenVersion, lastRunVersion } = input
+  if (!lastSeenVersion || !lastRunVersion) return lastSeenVersion
+  return compareVersions(lastSeenVersion, lastRunVersion) > 0 ? lastRunVersion : lastSeenVersion
 }
 
 export interface UpgradeFlowDecision {
@@ -45,7 +89,7 @@ export interface UpgradeFlowDecision {
   showTour: boolean
   /** Why, in a word — for logging and for tests that assert the REASON rather
    *  than just the outcome, so a right answer for a wrong reason still fails. */
-  reason: 'no-stored-version' | 'same-version' | 'crossed-line' | 'beta-channel' | 'within-line'
+  reason: 'no-stored-version' | 'same-version' | 'stamped-ahead' | 'crossed-line' | 'beta-channel' | 'within-line'
 }
 
 export function decideUpgradeFlow(input: UpgradeFlowInput): UpgradeFlowDecision {
@@ -53,6 +97,8 @@ export function decideUpgradeFlow(input: UpgradeFlowInput): UpgradeFlowDecision 
 
   if (!lastSeenVersion) {
     // Nothing is "new" to someone who has never run it. They get the tour.
+    // A record of an earlier RUN does not change that: no stamp means the tour
+    // never finished, and the tour is what that user is owed.
     return { kind: 'first-install', showWhatsNew: false, showTour: true, reason: 'no-stored-version' }
   }
 
@@ -60,7 +106,16 @@ export function decideUpgradeFlow(input: UpgradeFlowInput): UpgradeFlowDecision 
   // release, and a stored version that differs only in formatting must not
   // re-fire the modal on every launch.
   if (compareVersions(lastSeenVersion, currentVersion) === 0) {
-    return { kind: 'nothing', showWhatsNew: false, showTour: false, reason: 'same-version' }
+    // ...unless the stamp is newer than any build that has actually run. Then
+    // it was written by an OLDER build naming a version it had not shipped —
+    // the beta.15 → beta.16 incident behind #369 — and the user has not seen
+    // these notes at all. Show them, once; the acknowledgement re-stamps from
+    // the running build and the next launch reads `same-version` honestly.
+    const seen = seenVersionFor(input)
+    if (seen === lastSeenVersion) {
+      return { kind: 'nothing', showWhatsNew: false, showTour: false, reason: 'same-version' }
+    }
+    return { kind: 'upgrade', showWhatsNew: true, showTour: false, reason: 'stamped-ahead' }
   }
 
   // Deliberately not gated on moving FORWARD. A downgrade — a tester dropping

--- a/src/renderer/onboarding/whats-new-gate.ts
+++ b/src/renderer/onboarding/whats-new-gate.ts
@@ -20,11 +20,23 @@
  * The version a user has "seen" is the version they RAN. Both functions are
  * keyed on `__APP_VERSION__` for that reason, and the changelog is left to do
  * the one job it is good for: supplying the entries themselves.
+ *
+ * That prediction came true (#369). The owner's machine had run exactly such a
+ * build on 2026-08-21 and held `lastSeenVersion = beta.16` when the real
+ * beta.16 was installed from the offline .exe; the gate read `same-version`
+ * and the page never appeared. Stamping the running version stopped NEW bad
+ * stamps being written but did nothing about the one already on disk — the
+ * beta.16 changelog's "corrects itself on the next launch" was true only for a
+ * stamp two or more releases ahead, and the stamp that actually gets written
+ * is always exactly one ahead. So the stamp is no longer trusted on its own:
+ * it is read against the last build that actually RAN (`lastRunVersionOf`),
+ * and a stamp newer than that is a stamp no build of that version wrote. See
+ * `seenVersionFor` in upgrade-flow.ts.
  */
 
 import { useAppMetaStore } from '../stores/appMetaStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { decideUpgradeFlow } from './upgrade-flow'
+import { decideUpgradeFlow, lastRunVersionOf, seenVersionFor } from './upgrade-flow'
 
 declare const __APP_VERSION__: string
 
@@ -42,13 +54,30 @@ export function shouldShowWhatsNew(): boolean {
   try {
     const currentVersion = runningVersion()
     if (!currentVersion) return false
+    const meta = useAppMetaStore.getState().meta
     return decideUpgradeFlow({
-      lastSeenVersion: useAppMetaStore.getState().meta.lastSeenVersion,
+      lastSeenVersion: meta.lastSeenVersion,
+      lastRunVersion: lastRunVersionOf(meta),
       currentVersion,
       channel: useSettingsStore.getState().settings.updateChannel,
     }).showWhatsNew
   } catch {
     return false
+  }
+}
+
+/**
+ * The version this user has actually seen the notes for — the stored stamp,
+ * clamped to the last build that ran (#369). What the harness diffs against
+ * when it works out which pages are new since, so it and `shouldShowWhatsNew`
+ * agree on where the user is coming from.
+ */
+export function seenVersion(): string | undefined {
+  try {
+    const meta = useAppMetaStore.getState().meta
+    return seenVersionFor({ lastSeenVersion: meta.lastSeenVersion, lastRunVersion: lastRunVersionOf(meta) })
+  } catch {
+    return undefined
   }
 }
 

--- a/src/renderer/stores/appMetaStore.ts
+++ b/src/renderer/stores/appMetaStore.ts
@@ -4,6 +4,10 @@ import { saveConfigNow } from '../utils/config-saver'
 export interface AppMeta {
   setupVersion?: string
   lastSeenVersion?: string
+  /** The version that last RAN: stamped with __APP_VERSION__ at every boot, after the launch
+   *  decision has read the previous value. The witness that a "seen" stamp was written by the
+   *  build it names (#369); `lastRunVersionOf` falls back to setupVersion on metas older than it. */
+  lastRunVersion?: string
   lastTrainingVersion?: string
   commandsSeeded?: boolean
   colorMigrated?: boolean

--- a/tests/unit/renderer/upgrade-flow.test.ts
+++ b/tests/unit/renderer/upgrade-flow.test.ts
@@ -6,7 +6,7 @@
 // the fourteen in between.
 
 import { describe, it, expect } from 'vitest'
-import { decideUpgradeFlow, entriesSince, bootWhatsNewSurface } from '../../../src/renderer/onboarding/upgrade-flow'
+import { decideUpgradeFlow, entriesSince, bootWhatsNewSurface, seenVersionFor, lastRunVersionOf } from '../../../src/renderer/onboarding/upgrade-flow'
 import { compareVersions, crossedReleaseLine, releaseLine } from '../../../src/shared/version-order'
 import { sectionsFor } from '../../../src/renderer/onboarding/WhatsNewV2Step'
 
@@ -253,5 +253,100 @@ describe('bootWhatsNewSurface — which surface carries the notes this launch', 
 
   it('nothing shows when nothing changed', () => {
     expect(bootWhatsNewSurface({ tourWillRun: false, whatsNewDue: false })).toBe('none')
+  })
+})
+
+describe('decideUpgradeFlow — a "seen" stamp no build of that version ever wrote (#369)', () => {
+  // The beta.16 incident. A beta.15-era build stamped `lastSeenVersion` from
+  // the changelog head (beta.16, pending) rather than from the version it was
+  // running. The real beta.16 then compared the stamp to itself, read
+  // `same-version`, and never showed the page. Nothing corrected it: the
+  // "corrects itself on the next launch" claim held only for a stamp two or
+  // more releases ahead, and the stamp that actually gets written is always
+  // exactly one ahead.
+  //
+  // The witness is the version that actually RAN last (`lastRunVersion`, or
+  // `setupVersion` on a meta written before that field existed — every build
+  // since 1.x has stamped it with its own version). A stamp newer than any
+  // build that ran cannot have been written on the build it names.
+  it('shows the page when the stamp equals the running build but is NEWER than the last build that ran', () => {
+    const d = decideUpgradeFlow({
+      lastSeenVersion: '2.1.0-beta.16',   // stamped by a beta.15 build, from the changelog head
+      lastRunVersion: '2.1.0-beta.15',    // the last build that actually ran
+      currentVersion: '2.1.0-beta.16',
+      channel: 'beta',
+    })
+    expect(d.showWhatsNew).toBe(true)
+    expect(d.reason).toBe('stamped-ahead')
+  })
+
+  it('still shows nothing when the stamp was written by the running build itself', () => {
+    // The ordinary relaunch: seen on beta.16, ran beta.16, running beta.16.
+    const d = decideUpgradeFlow({
+      lastSeenVersion: '2.1.0-beta.16',
+      lastRunVersion: '2.1.0-beta.16',
+      currentVersion: '2.1.0-beta.16',
+    })
+    expect(d).toMatchObject({ kind: 'nothing', showWhatsNew: false, reason: 'same-version' })
+  })
+
+  it('does not re-show after a downgrade once the notes for that build were acknowledged', () => {
+    // Ran beta.17 without acknowledging, dropped back to beta.16 whose notes
+    // WERE acknowledged on beta.16: the stamp (beta.16) is older than the last
+    // run (beta.17), so it is trusted, and it matches the running build.
+    const d = decideUpgradeFlow({
+      lastSeenVersion: '2.1.0-beta.16',
+      lastRunVersion: '2.1.0-beta.17',
+      currentVersion: '2.1.0-beta.16',
+    })
+    expect(d.showWhatsNew).toBe(false)
+  })
+
+  it('without any witness, trusts the stamp as before', () => {
+    // A meta with no record of what ran (neither field) is the pre-existing
+    // behaviour, and every other test in this file: the stamp decides.
+    const d = decideUpgradeFlow({ lastSeenVersion: '2.1.0-beta.16', currentVersion: '2.1.0-beta.16' })
+    expect(d.reason).toBe('same-version')
+  })
+
+  it('a stamp ahead by MORE than one release already showed (the one case the old rule caught)', () => {
+    const d = decideUpgradeFlow({
+      lastSeenVersion: '2.1.0-beta.17',
+      lastRunVersion: '2.1.0-beta.15',
+      currentVersion: '2.1.0-beta.16',
+    })
+    expect(d.showWhatsNew).toBe(true)
+  })
+
+  it('a fresh install stays a fresh install even if some build ran before', () => {
+    // No stamp at all means the tour never finished; the tour, not the notes,
+    // is what that user gets (deriveOnboarding has them). lastRunVersion must
+    // not turn that into an upgrade.
+    const d = decideUpgradeFlow({ lastRunVersion: '2.1.0-beta.15', currentVersion: '2.1.0-beta.16' })
+    expect(d.kind).toBe('first-install')
+    expect(d.showWhatsNew).toBe(false)
+  })
+})
+
+describe('seenVersionFor — the version the user can actually have seen', () => {
+  it('clamps a stamp that is ahead of the last build that ran', () => {
+    expect(seenVersionFor({ lastSeenVersion: '2.1.0-beta.16', lastRunVersion: '2.1.0-beta.15' })).toBe('2.1.0-beta.15')
+  })
+  it('leaves a stamp at or behind the last run alone', () => {
+    expect(seenVersionFor({ lastSeenVersion: '2.1.0-beta.16', lastRunVersion: '2.1.0-beta.16' })).toBe('2.1.0-beta.16')
+    expect(seenVersionFor({ lastSeenVersion: '2.1.0-beta.15', lastRunVersion: '2.1.0-beta.17' })).toBe('2.1.0-beta.15')
+  })
+  it('passes through when there is no witness, or no stamp', () => {
+    expect(seenVersionFor({ lastSeenVersion: '2.1.0-beta.16' })).toBe('2.1.0-beta.16')
+    expect(seenVersionFor({ lastRunVersion: '2.1.0-beta.16' })).toBeUndefined()
+    expect(seenVersionFor({})).toBeUndefined()
+  })
+})
+
+describe('lastRunVersionOf — which meta field witnesses the last run', () => {
+  it('prefers lastRunVersion, falls back to setupVersion, else undefined', () => {
+    expect(lastRunVersionOf({ lastRunVersion: '2.1.0-beta.16', setupVersion: '2.1.0-beta.15' })).toBe('2.1.0-beta.16')
+    expect(lastRunVersionOf({ setupVersion: '2.1.0-beta.15' })).toBe('2.1.0-beta.15')
+    expect(lastRunVersionOf({})).toBeUndefined()
   })
 })

--- a/tests/unit/renderer/whats-new-exactly-once.test.ts
+++ b/tests/unit/renderer/whats-new-exactly-once.test.ts
@@ -1,0 +1,134 @@
+// A version change shows the What's New page exactly once (#369).
+//
+// The rule the owner asked to have pinned, as a simulation rather than a
+// single assertion: a machine's app-meta carried through a sequence of
+// launches, each launch deciding with the pure rule and stamping the way the
+// real code stamps. "Exactly once" means: the page is shown on the first
+// launch of every build that differs from the one before, is shown again only
+// if that launch ended without the user acknowledging it, and is never shown
+// twice for the same build once acknowledged.
+//
+// The sequence that produced #369 is replayed with the OLD stamping rule —
+// a beta.15-era build stamped the changelog HEAD, not the version it ran —
+// and that is the case the witness field exists for.
+
+import { describe, it, expect } from 'vitest'
+import { decideUpgradeFlow, lastRunVersionOf } from '../../../src/renderer/onboarding/upgrade-flow'
+
+interface Meta {
+  lastSeenVersion?: string
+  setupVersion?: string
+  lastRunVersion?: string
+}
+
+interface Launch {
+  /** The version this build IS (package.json / __APP_VERSION__). */
+  version: string
+  /** Pre-beta.16 build: stamps "seen" from the changelog head, which on any
+   *  build between two releases sits one release AHEAD of `version`. */
+  legacyHead?: string
+  /** The user closed the app before the page's CTA. */
+  quitBeforeAck?: boolean
+}
+
+/** One launch, mutating `meta` the way the renderer does. Returns whether the page showed. */
+function launch(meta: Meta, l: Launch): boolean {
+  let shown: boolean
+  if (l.legacyHead) {
+    // beta.15 and earlier: `lastSeen !== changelog[0].version` decided, and the
+    // dismissal stamped changelog[0].version. No lastRunVersion existed.
+    shown = !!meta.lastSeenVersion && meta.lastSeenVersion !== l.legacyHead
+    if (shown && !l.quitBeforeAck) meta.lastSeenVersion = l.legacyHead
+  } else {
+    shown = decideUpgradeFlow({
+      lastSeenVersion: meta.lastSeenVersion,
+      lastRunVersion: lastRunVersionOf(meta),
+      currentVersion: l.version,
+      channel: 'beta',
+    }).showWhatsNew
+    // postConfigInit: record that this build ran, AFTER the decision read the previous value.
+    meta.lastRunVersion = l.version
+    if (shown && !l.quitBeforeAck) meta.lastSeenVersion = l.version   // markWhatsNewSeen
+  }
+  // Every build since 1.x: setupVersion = its own version, after the decision.
+  meta.setupVersion = l.version
+  return shown
+}
+
+/** Run a sequence from a meta and return the versions whose page was shown, in order. */
+function run(meta: Meta, launches: Launch[]): string[] {
+  const shown: string[] = []
+  for (const l of launches) if (launch(meta, l)) shown.push(l.version)
+  return shown
+}
+
+/** A machine that finished the tour on `v` (the tour's finish stamps lastSeenVersion). */
+const settledOn = (v: string, legacy = false): Meta =>
+  legacy ? { lastSeenVersion: v, setupVersion: v } : { lastSeenVersion: v, setupVersion: v, lastRunVersion: v }
+
+describe('a version change shows the page exactly once', () => {
+  it('beta to beta, with relaunches in between', () => {
+    const meta = settledOn('2.1.0-beta.15')
+    expect(run(meta, [
+      { version: '2.1.0-beta.15' },
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.17' },
+      { version: '2.1.0-beta.17' },
+    ])).toEqual(['2.1.0-beta.16', '2.1.0-beta.17'])
+  })
+
+  it('beta, rc, final: once each, in that order', () => {
+    const meta = settledOn('2.1.0-beta.16')
+    expect(run(meta, [
+      { version: '2.1.0-rc.1' },
+      { version: '2.1.0-rc.1' },
+      { version: '2.1.0' },
+      { version: '2.1.0' },
+    ])).toEqual(['2.1.0-rc.1', '2.1.0'])
+  })
+
+  it('THE #369 SEQUENCE: a beta.15-era build stamped the pending head, then the real beta.16 arrived', () => {
+    // Release beta.15 (head == version): settled. Then a build of the beta
+    // branch still versioned beta.15 whose changelog head was already beta.16
+    // — the wall-of-text incident of 2026-08-21. Dismissing it stamped beta.16.
+    // Then the real beta.16 installed from the offline .exe.
+    const meta = settledOn('2.1.0-beta.15', true)
+    expect(run(meta, [
+      { version: '2.1.0-beta.15', legacyHead: '2.1.0-beta.16' },   // preview: showed (stale rule), stamped beta.16
+      { version: '2.1.0-beta.16' },                                // the real beta.16: MUST show
+      { version: '2.1.0-beta.16' },                                // and then settle
+    ])).toEqual(['2.1.0-beta.15', '2.1.0-beta.16'])
+  })
+
+  it('an unacknowledged page comes back on the next launch, then settles', () => {
+    const meta = settledOn('2.1.0-beta.15')
+    expect(run(meta, [
+      { version: '2.1.0-beta.16', quitBeforeAck: true },
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.16' },
+    ])).toEqual(['2.1.0-beta.16', '2.1.0-beta.16'])
+  })
+
+  it('a downgrade shows once, and going back up shows once', () => {
+    const meta = settledOn('2.1.0-beta.17')
+    expect(run(meta, [
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.16' },
+      { version: '2.1.0-beta.17' },
+      { version: '2.1.0-beta.17' },
+    ])).toEqual(['2.1.0-beta.16', '2.1.0-beta.17'])
+  })
+
+  it('a fresh install never sees the page until its SECOND build', () => {
+    // No stamp: the tour runs instead (its finish stamps lastSeenVersion, which
+    // the simulation models as the tour having settled on the first build).
+    const meta: Meta = {}
+    expect(run(meta, [{ version: '2.1.0-beta.16' }])).toEqual([])
+    // The tour's finish.
+    meta.lastSeenVersion = '2.1.0-beta.16'
+    expect(run(meta, [{ version: '2.1.0-beta.16' }, { version: '2.1.0-beta.17' }, { version: '2.1.0-beta.17' }]))
+      .toEqual(['2.1.0-beta.17'])
+  })
+})

--- a/tests/unit/renderer/whats-new-gate.test.ts
+++ b/tests/unit/renderer/whats-new-gate.test.ts
@@ -44,7 +44,7 @@ vi.mock('../../../src/renderer/stores/settingsStore', () => {
   return { useSettingsStore }
 })
 
-const { shouldShowWhatsNew, markWhatsNewSeen, runningVersion } = await import(
+const { shouldShowWhatsNew, markWhatsNewSeen, runningVersion, seenVersion } = await import(
   '../../../src/renderer/onboarding/whats-new-gate'
 )
 
@@ -85,5 +85,40 @@ describe('whats-new gate is keyed on the RUNNING version', () => {
   it('is idempotent: stamping then re-asking shows nothing', () => {
     markWhatsNewSeen()
     expect(shouldShowWhatsNew()).toBe(false)
+  })
+})
+
+describe('#369 — a stamp no build of that version wrote does not suppress the page', () => {
+  // The owner's machine at the first launch of the real beta.16: a beta.15-era
+  // build had stamped lastSeenVersion = beta.16 from the pending changelog
+  // head, while setupVersion — stamped by every build with its own version —
+  // still said beta.15. The running build here is beta.15 (the file's pin), so
+  // the same shape is: stamp == running build, last run == one older.
+  it('shows the page when the stamp equals the running build but setupVersion says an older build ran last', () => {
+    metaState.meta.lastSeenVersion = '2.1.0-beta.15'
+    metaState.meta.setupVersion = '2.1.0-beta.14'
+    expect(shouldShowWhatsNew()).toBe(true)
+  })
+
+  it('lastRunVersion outranks setupVersion as the witness', () => {
+    metaState.meta.lastSeenVersion = '2.1.0-beta.15'
+    metaState.meta.setupVersion = '2.1.0-beta.14'     // stale: setup never re-stamped
+    metaState.meta.lastRunVersion = '2.1.0-beta.15'   // but this build has run and stamped
+    expect(shouldShowWhatsNew()).toBe(false)
+  })
+
+  it('a relaunch after acknowledging on this build shows nothing', () => {
+    metaState.meta.lastSeenVersion = '2.1.0-beta.15'
+    metaState.meta.setupVersion = '2.1.0-beta.15'
+    metaState.meta.lastRunVersion = '2.1.0-beta.15'
+    expect(shouldShowWhatsNew()).toBe(false)
+  })
+
+  it('seenVersion() is the stamp clamped to what actually ran — what the harness diffs against', () => {
+    metaState.meta.lastSeenVersion = '2.1.0-beta.15'
+    metaState.meta.setupVersion = '2.1.0-beta.14'
+    expect(seenVersion()).toBe('2.1.0-beta.14')
+    metaState.meta.lastRunVersion = '2.1.0-beta.15'
+    expect(seenVersion()).toBe('2.1.0-beta.15')
   })
 })


### PR DESCRIPTION
## What and why

For #369 — the full-screen What's New page did not appear after installing beta.16 from the offline installer.

**Cause.** The beta.16 code predicted this in its own header (`src/renderer/onboarding/whats-new-gate.ts`). A beta.15-era build running with the beta.16 changelog entry already written — the wall-of-text incident of 2026-08-21 — stamped `lastSeenVersion = 2.1.0-beta.16` from the changelog head when dismissed. The real beta.16 then compared the stamp to itself, read `same-version`, and showed nothing. beta.16 stopped NEW bad stamps (it stamps the running version now) but did nothing about the stamp already on disk; the changelog's "corrects itself on the next launch" was true only for a stamp two or more releases ahead, and the stamp the old rule wrote is always exactly one ahead. The installer kind is irrelevant: neither the updater nor the offline .exe touches app-meta; the state was on disk before either ran.

Hypothesis ranking (the VM is the conductor's, so this was established from code, not reproduced): 1) the ahead stamp above (most likely, predicted verbatim by the shipped code); 2) a beta.15-era preview that ran the full flow on the beta channel and whose finish stamped the same ahead value — same root; 3) app-meta unreadable at launch (#341 latch hydrates `{}`) → read as fresh install → tour, no notes — the owner would have seen the read-failure notice and the whole tour, so unlikely.

A clean beta.15 → beta.16 offline install will NOT reproduce it (the beta.15 release build's changelog head is beta.15, so it stamps beta.15 and beta.16 shows the page). The reproducing sequence needs the intermediate preview build, or the app-meta edit under "VM proof".

**Fix.** The "seen" stamp is no longer trusted on its own. A new app-meta field `lastRunVersion` is stamped with `__APP_VERSION__` at every boot (App.tsx `postConfigInit`, AFTER the launch decision has read the previous value) and is the witness: a `lastSeenVersion` newer than the last build that ran cannot have been written by the build it names, and is read as the last run instead (`seenVersionFor`). Metas older than the field fall back to `setupVersion`, which every build since 1.x has stamped with its own version — the only pre-existing record of a build having run, and never ahead. `decideUpgradeFlow` gains the `lastRunVersion` input and a `stamped-ahead` reason; `shouldShowWhatsNew` supplies the witness; the harness diffs `stepsNewSince` against the same clamped origin (`seenVersion()`).

Unchanged semantics: fresh install → tour, no notes; beta-to-beta → notes once; downgrade → notes once; relaunch after acknowledging → nothing; no witness at all → the stamp decides, as before.

Files: `src/renderer/onboarding/upgrade-flow.ts`, `whats-new-gate.ts`, `OnboardingHarness.tsx`, `src/renderer/stores/appMetaStore.ts`, `src/renderer/App.tsx` (stamp + one stale comment), `CONTEXT.d/2026-08-22-n369.md`. No changelog edit (the conductor's consolidated pass). No security-sensitive paths touched.

## How it was tested

- `tests/unit/renderer/upgrade-flow.test.ts` — +10: the #369 shape (`stamp == current, lastRun older → show, reason stamped-ahead`), witness precedence, downgrade unaffected, legacy no-witness unchanged, fresh install unchanged, `seenVersionFor`, `lastRunVersionOf`.
- `tests/unit/renderer/whats-new-gate.test.ts` — +4: the store-reading wrapper with the owner's meta shape (`setupVersion` fallback, `lastRunVersion` precedence, relaunch), `seenVersion()`.
- `tests/unit/renderer/whats-new-exactly-once.test.ts` — NEW: the owner's asked-for pin, "a version change always shows the page exactly once", as a launch-sequence simulation: beta→beta with relaunches, beta→rc→final, THE #369 SEQUENCE replayed with the OLD stamping rule, quit-before-acknowledge, downgrade and back, fresh install.
- All behavioural assertions were run against the pre-fix code first and failed (`expected false to be true` for the two direct #369 assertions; the rest on the missing helpers) — 13 failed / 43 passed before, 95/95 across the six related files after.
- Full suite: `npx vitest run` → **628 files passed, 2 skipped (630); 6562 tests passed, 15 skipped (6577)**.
- `npm run typecheck` → clean (node, web, bridge).

VM proof: pending — the conductor's integration pass. Exact replay of the owner's state without an intermediate build: on a VM that has run the real beta.16 and settled, edit `app-meta.json` in CONFIG/ so `setupVersion` is `2.1.0-beta.15` and `lastRunVersion` is absent (leave `lastSeenVersion = 2.1.0-beta.16`), then launch this PR's preview build (still versioned 2.1.0-beta.16). Old code: nothing. New code: the What's New page once; relaunch: nothing.

## Not done / open questions for the owner

- Not reproduced on the VM before changing (the VM belongs to the conductor; the recipe above is the stand-in). If the owner's machine also showed the full tour at that launch rather than nothing at all, hypothesis 3 (unreadable app-meta) moves up and is worth a look at the log.
- The `App.tsx` boot stamp of `lastRunVersion` is not unit-tested (App.tsx is not renderable in vitest); it is one `update()` call, mirrored in the simulation's launch model.
- No ADR: one field and a clamp, not an architectural change.
