### PR TITLE
fix(footer): lay the account strip out by measured width, not by count (#378)

### DIFF
--- a/CONTEXT.d/2026-08-22-n378.md
+++ b/CONTEXT.d/2026-08-22-n378.md
@@ -1,0 +1,67 @@
+## 2026-08-22 -- #378 footer account strip: rows by measured width, not by count
+
+Owner, beta.16: "Account summary at bottom of app not showing on one row even
+when there is room." Four accounts at 1900px laid out 2 x 2 with empty footer
+either side of them.
+
+### Why it wrapped early
+
+`splitAccountRows()` in `MultiAccountStatusline.tsx` decided the rows by COUNT
+(<=3 one row, 4..6 two rows balanced 2+2 / 3+2 / 3+3, >6 overflow). It never
+looked at the width. The `flex-wrap` that beta.16 added only wrapped a row that
+was ALREADY over-wide; it could not un-split a row the count rule had split. And
+the strip itself was shrink-to-fit inside its centre zone, so even if it had
+measured itself it would have measured its own cluster, not the free footer
+width between the runtime band and the disclaimer.
+
+### What changed (`src/renderer/components/MultiAccountStatusline.tsx`)
+
+- `splitAccountRows` / `FOOTER_MAX_PER_ROW` / `FOOTER_MAX_VISIBLE` are gone.
+  `layoutFooterRows(items, widths, { available, gap, maxRows, overflowReserve })`
+  replaces them: pure and generic, fill-first. One row whenever every pill fits
+  the free width; wrap only when it truly does not; never more than
+  `FOOTER_MAX_ROWS` (still 2), the tail behind "+N". The last row holds
+  `FOOTER_OVERFLOW_RESERVE_PX` (40) back for the control when anything
+  overflows, moving pills into the overflow until it fits, never emptying the
+  row. An unmeasured pill (never painted, e.g. straight into the overflow) is
+  estimated at the WIDEST measured pill, which wraps early rather than spills.
+  No `available` (first frame, jsdom) -> one row of everything, and the row's
+  `flex-wrap` is the safety net until the effect has run.
+- `useMeasuredFooterRows()` feeds it: the strip is now `w-full` in its zone so
+  `getBoundingClientRect().width` IS the free width; each pill carries a
+  callback ref; a `useLayoutEffect` measures synchronously when the set of
+  accounts, what the pills show (`hidden` / minimal / pending), or the row
+  assignment changes (a pill that moves rows is a new DOM node), and a
+  `ResizeObserver` on the strip + the pills covers window resize, font scale
+  and meters appearing. `reconcileFooterMetrics()` returns the previous object
+  when nothing moved by more than 0.5px, which is what ends the
+  measure -> set -> render -> measure cycle. Widths are cached by account so a
+  pill behind "+N" keeps its last measurement.
+- The inter-pill gap is an INLINE px value (`FOOTER_PILL_GAP_PX = 12`) rather
+  than `gap-x-3` / `gap-x-2`: the layout is computed with that number and rem
+  utilities scale with the global UI font size, so the two would drift. One
+  gap for both the single- and multi-row looks (the multi-row `gap-x-2` was a
+  squeeze to get three pills into 1280px, which measurement makes moot).
+- Single-row pills stay `shrink-0` with the full email; multi-row pills keep
+  `min-w-0` + `truncate` and the `py-1` bar padding, as before. The "+N"
+  popover is untouched.
+
+### Verified
+
+`tests/unit/renderer/multi-account-statusline.test.ts` (layout + cache
+boundaries: exact fit, half-pixel slack, fill-first 3+1, no per-row cap,
+per-pill widths, max rows, control reserve, lone over-wide pill, unmeasured
+estimate, first-paint fallback, nothing dropped 1..25 x 5 widths) and
+`tests/unit/renderer/multi-account-statusline-render.test.tsx` (mocked
+`getBoundingClientRect` by testid + a hand-fired ResizeObserver: four 300px
+pills in 1400px -> ONE row; 1200px -> 3+1; resize narrow/wide re-lays out
+without a remount; the overflow control cases at 1000px / 940px). The eight
+`#378` render tests were run against the old component (src stashed) and fail
+there -- 2 x 2 rows -- and pass on the new one. Full `npx vitest run` and
+`npm run typecheck` results are in the PR.
+
+### Left
+
+VM proof at 1900px with four accounts (the conductor's integration pass). The
+"+N" control's width is a 40px reserve, not a measurement -- fine to two
+digits; a three-digit count would crowd the last row by a few px.

--- a/src/renderer/components/MultiAccountStatusline.tsx
+++ b/src/renderer/components/MultiAccountStatusline.tsx
@@ -103,42 +103,223 @@ export function liveAccountUsage(
   })
 }
 
-/** Never more than 3 account pills side by side -- three full pills (dot + email
- *  + two meters) is already the most that fits to the right of the runtime band
- *  at the 1280px minimum window width (src/main/index.ts minWidth). */
-export const FOOTER_MAX_PER_ROW = 3
 /** The footer grows to at most two rows; past that the tail goes behind the
- *  overflow control rather than eating more of the terminal's height. */
+ *  "+N" overflow control rather than eating more of the terminal's height. */
 export const FOOTER_MAX_ROWS = 2
-export const FOOTER_MAX_VISIBLE = FOOTER_MAX_PER_ROW * FOOTER_MAX_ROWS
+/** Horizontal gap between pills, in px. Applied as an INLINE style (not a
+ *  Tailwind `gap-x-*` class) so the number the layout is computed with and the
+ *  number the browser lays out with are the same one -- rem-based utilities
+ *  scale with the global UI font size, a px constant does not. */
+export const FOOTER_PILL_GAP_PX = 12
+/** Room held back on the last row for the "+N" control when anything
+ *  overflows, so the control never pushes the row past the zone. Generous for
+ *  a two-digit count at 10px text; the popover itself is position: fixed. */
+export const FOOTER_OVERFLOW_RESERVE_PX = 40
+/** Sub-pixel slack on the fit test: getBoundingClientRect() returns fractional
+ *  widths and a pill that is 0.3px "too wide" still paints on the row. */
+const FIT_EPSILON_PX = 0.5
 
 export interface FooterRowLayout<T> {
-  /** Rendered rows, in order. 1 row for <=3 accounts, else 2. */
+  /** Rendered rows, in order, each filled before the next starts. */
   rows: T[][]
-  /** Everything past FOOTER_MAX_VISIBLE -- shown via the "+N" overflow control. */
+  /** Everything that does not fit in FOOTER_MAX_ROWS rows -- shown via the
+   *  "+N" overflow control on the last row. */
   overflow: T[]
 }
 
+export interface FooterLayoutOptions {
+  /** Free width of the footer's centre zone, in px. <= 0 means "not measured
+   *  yet" and yields one row of everything (CSS flex-wrap then wraps it). */
+  available: number
+  gap?: number
+  maxRows?: number
+  overflowReserve?: number
+}
+
 /**
- * Split the live accounts into footer rows.
+ * Lay the account pills out in rows by MEASURED width (#378).
  *
- *   <=3  -> a single row (byte-identical layout to the pre-two-row footer)
- *   4..6 -> two rows, BALANCED (4 -> 2+2, 5 -> 3+2, 6 -> 3+3). Balanced rather
- *           than fill-first (3+1) so the centred cluster stays symmetric; both
- *           satisfy the "max 3 per row" rule.
- *   >6   -> the first 6 in two rows of 3, the rest returned as `overflow`.
+ * The previous split was by count (<=3 one row, 4..6 two rows balanced 2+2 /
+ * 3+2 / 3+3, >6 overflow) and so put four accounts on two rows at 1900px with
+ * empty footer either side of them. This one answers the owner's actual rule:
+ * one row whenever everything fits in the free width; wrap only when it truly
+ * does not, filling each row before starting the next; never more than
+ * FOOTER_MAX_ROWS rows, the rest behind "+N".
  *
- * Pure and generic so the boundaries are unit-testable without a DOM.
+ *   - `widths[i]` is item i's measured width. An item with no measurement yet
+ *     (never painted -- e.g. it appeared straight into the overflow) is
+ *     estimated at the WIDEST measured pill, which errs towards wrapping
+ *     earlier rather than spilling out of the zone; it is corrected the first
+ *     time the pill is painted and measured.
+ *   - With no `available` width, or no measurement at all, the answer is a
+ *     single row: the first frame before the layout effect has run, and jsdom.
+ *   - A pill wider than the whole zone sits alone on a row (it can ellipsise).
+ *   - When anything overflows, the last row keeps `overflowReserve` px free for
+ *     the control, moving pills into the overflow until it fits.
+ *
+ * Pure and generic so the fit boundaries are unit-testable without a DOM.
  */
-export function splitAccountRows<T>(accounts: T[]): FooterRowLayout<T> {
-  const visible = accounts.slice(0, FOOTER_MAX_VISIBLE)
-  const overflow = accounts.slice(FOOTER_MAX_VISIBLE)
-  if (visible.length === 0) return { rows: [], overflow }
-  if (visible.length <= FOOTER_MAX_PER_ROW) return { rows: [visible], overflow }
-  const perRow = Math.min(FOOTER_MAX_PER_ROW, Math.ceil(visible.length / FOOTER_MAX_ROWS))
+export function layoutFooterRows<T>(
+  items: T[],
+  widths: ReadonlyArray<number | undefined>,
+  opts: FooterLayoutOptions,
+): FooterRowLayout<T> {
+  if (items.length === 0) return { rows: [], overflow: [] }
+  const gap = opts.gap ?? FOOTER_PILL_GAP_PX
+  const maxRows = Math.max(1, opts.maxRows ?? FOOTER_MAX_ROWS)
+  const reserve = opts.overflowReserve ?? FOOTER_OVERFLOW_RESERVE_PX
+  const available = opts.available
+  const isWidth = (w: number | undefined): w is number => typeof w === 'number' && Number.isFinite(w) && w > 0
+  const measured = widths.filter(isWidth)
+  if (!(available > 0) || measured.length === 0) return { rows: [items], overflow: [] }
+  const estimate = Math.max(...measured)
+  const widthOf = (i: number): number => {
+    const w = widths[i]
+    return isWidth(w) ? w : estimate
+  }
+  const fits = (w: number) => w <= available + FIT_EPSILON_PX
+
   const rows: T[][] = []
-  for (let i = 0; i < visible.length; i += perRow) rows.push(visible.slice(i, i + perRow))
+  let cur: T[] = []
+  let curW = 0
+  let overflowFrom = -1
+  for (let i = 0; i < items.length; i++) {
+    const w = widthOf(i)
+    if (cur.length > 0 && !fits(curW + gap + w)) {
+      if (rows.length === maxRows - 1) {
+        overflowFrom = i
+        break
+      }
+      rows.push(cur)
+      cur = []
+      curW = 0
+    }
+    cur.push(items[i])
+    curW = cur.length === 1 ? w : curW + gap + w
+  }
+  if (cur.length > 0) rows.push(cur)
+  const overflow = overflowFrom >= 0 ? items.slice(overflowFrom) : []
+
+  // The "+N" control lives on the last row: make room for it, pulling pills
+  // into the overflow from the end until it fits (never emptying the row).
+  if (overflow.length > 0) {
+    const last = rows[rows.length - 1]
+    const lastStart = items.length - overflow.length - last.length
+    let lastW = curW
+    while (last.length > 1 && !fits(lastW + gap + reserve)) {
+      overflow.unshift(last.pop() as T)
+      lastW -= gap + widthOf(lastStart + last.length)
+    }
+  }
   return { rows, overflow }
+}
+
+/** Measured geometry the row layout is computed from: the centre zone's free
+ *  width and each painted pill's width, keyed by account. */
+interface FooterMetrics {
+  available: number
+  widths: Record<string, number>
+}
+
+const EMPTY_METRICS: FooterMetrics = { available: 0, widths: {} }
+
+/**
+ * Fold a fresh measurement into the previous one. Returns `prev` itself when
+ * nothing moved by more than the fit epsilon, so the state update is a no-op
+ * and the measure -> set -> render -> measure cycle terminates. Keys no longer
+ * live are dropped; keys live but not currently painted (behind "+N") keep
+ * their last measurement.
+ */
+export function reconcileFooterMetrics(
+  prev: FooterMetrics,
+  available: number,
+  fresh: Record<string, number>,
+  liveKeys: ReadonlySet<string>,
+): FooterMetrics {
+  let changed = Math.abs(prev.available - available) > FIT_EPSILON_PX
+  const widths: Record<string, number> = {}
+  for (const k of liveKeys) {
+    const w = fresh[k] ?? prev.widths[k]
+    if (w === undefined) continue
+    widths[k] = w
+    const before = prev.widths[k]
+    if (before === undefined || Math.abs(before - w) > FIT_EPSILON_PX) changed = true
+  }
+  for (const k of Object.keys(prev.widths)) if (!liveKeys.has(k)) changed = true
+  return changed ? { available, widths } : prev
+}
+
+/**
+ * Rows for the footer from REAL widths. Measures the strip's free width and
+ * every painted pill synchronously in a layout effect when the set of accounts
+ * or what the pills show changes (so the first paint is already laid out), and
+ * via a ResizeObserver on the strip and the pills for everything else --
+ * window resize, font scale, a meter appearing. Widths are cached by account
+ * so a pill currently behind the "+N" control keeps the width it had when it
+ * was last painted.
+ */
+function useMeasuredFooterRows(
+  accounts: LiveAccount[],
+  contentSignature: string,
+): {
+  layout: FooterRowLayout<LiveAccount>
+  rootRef: React.RefObject<HTMLDivElement | null>
+  pillRef: (key: string) => (el: HTMLElement | null) => void
+} {
+  const rootRef = React.useRef<HTMLDivElement | null>(null)
+  const pillEls = React.useRef(new Map<string, HTMLElement>())
+  const [metrics, setMetrics] = React.useState<FooterMetrics>(EMPTY_METRICS)
+  const liveKeys = React.useMemo(() => new Set(accounts.map((a) => a.email)), [accounts])
+  const liveKeysRef = React.useRef(liveKeys)
+  liveKeysRef.current = liveKeys
+
+  const measure = React.useCallback(() => {
+    const root = rootRef.current
+    if (!root) return
+    const available = root.getBoundingClientRect().width
+    const fresh: Record<string, number> = {}
+    for (const [k, el] of pillEls.current) fresh[k] = el.getBoundingClientRect().width
+    setMetrics((prev) => reconcileFooterMetrics(prev, available, fresh, liveKeysRef.current))
+  }, [])
+
+  // Callback refs keep a live key -> element map without a querySelectorAll
+  // sweep per render. One stable function per key, so React does not detach
+  // and re-attach every pill on every render.
+  const refCache = React.useRef(new Map<string, (el: HTMLElement | null) => void>())
+  const pillRef = React.useCallback((key: string) => {
+    let fn = refCache.current.get(key)
+    if (!fn) {
+      fn = (el) => {
+        if (el) pillEls.current.set(key, el)
+        else pillEls.current.delete(key)
+      }
+      refCache.current.set(key, fn)
+    }
+    return fn
+  }, [])
+
+  const layout = React.useMemo(
+    () => layoutFooterRows(accounts, accounts.map((a) => metrics.widths[a.email]), { available: metrics.available }),
+    [accounts, metrics],
+  )
+
+  // Re-run when the set of accounts, what a pill shows, or the row assignment
+  // changes: each can mount/unmount pill ELEMENTS (a pill that moves to another
+  // row is a new node under a new parent) that the observer must (un)watch.
+  // Bounded: a re-measure that changes nothing returns the same metrics object,
+  // so no re-render follows and the cycle ends.
+  const keysSignature = accounts.map((a) => a.email).join(' ')
+  const rowsSignature = layout.rows.map((r) => r.length).join('/') + ':' + layout.overflow.length
+  React.useLayoutEffect(() => {
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => measure())
+    if (rootRef.current) ro.observe(rootRef.current)
+    for (const el of pillEls.current.values()) ro.observe(el)
+    return () => ro.disconnect()
+  }, [measure, keysSignature, contentSignature, rowsSignature])
+
+  return { layout, rootRef, pillRef }
 }
 
 function tooltip(a: LiveAccount, opts?: { withPercent?: boolean }): string {
@@ -317,11 +498,15 @@ function AccountPill({
   compact,
   showPending,
   minimal,
+  pillRef,
 }: {
   account: LiveAccount
   hidden: string[]
   theme: 'dark' | 'light'
   compact: boolean
+  /** Measurement hook-up: the row layout is computed from this element's
+   *  rendered width (#378). */
+  pillRef?: (el: HTMLElement | null) => void
   /** Whether a payload is still expected -- see the gate in the parent. */
   showPending: boolean
   /** Minimal mode: the meters collapse to traffic-light dots and the label
@@ -355,6 +540,7 @@ function AccountPill({
   const reportedNothing = account.buckets.length === 0
   return (
     <span
+      ref={pillRef}
       // Each account sits in its own subtle rounded pill so the boundary between
       // accounts reads at a glance, rather than relying on whitespace alone.
       className={`flex items-center gap-1.5 rounded-full border px-2 py-0.5 ${compact ? 'min-w-0' : 'shrink-0'}`}
@@ -591,11 +777,13 @@ function AccountOverflow({
  * bars appear is curated INDEPENDENTLY of the per-session strip via
  * footerHiddenUsageBuckets (a footer-scoped denylist by bucket label).
  *
- * Layout (owner request): <=3 accounts stay on one row exactly as before; 4-6
- * stretch the footer to two rows of at most 3; past 6 the tail collapses into a
- * "+N" overflow control. The footer is `min-h-7` (a MINIMUM) inside a flex
- * column whose terminal pane re-fits from a ResizeObserver, so growing it is
- * safe -- nothing measures the bar's height.
+ * Layout (owner request, #378): one row whenever every pill fits in the free
+ * footer width; wrap only when they truly do not, filling each row before the
+ * next; at most two rows, the tail behind a "+N" overflow control. The rows are
+ * computed from MEASURED widths (useMeasuredFooterRows), not from a count. The
+ * footer is `min-h-7` (a MINIMUM) inside a flex column whose terminal pane
+ * re-fits from a ResizeObserver, so growing it is safe -- nothing measures the
+ * bar's height.
  */
 export default function MultiAccountStatusline() {
   const sessions = useSessionStore((s) => s.sessions)
@@ -618,7 +806,12 @@ export default function MultiAccountStatusline() {
     [sessions, profiles, aliases, overrides],
   )
 
-  const { rows, overflow } = React.useMemo(() => splitAccountRows(accounts), [accounts])
+  // What a pill SHOWS decides its width: the denylist, minimal mode and the
+  // pending placeholder all change it without changing the set of accounts.
+  // The hook re-measures when this signature changes.
+  const contentSignature = `${hidden.join(',')}|${minimal ? 'dots' : 'meters'}|${statusLineEnabled ? 'p' : '-'}`
+  const { layout, rootRef, pillRef } = useMeasuredFooterRows(accounts, contentSignature)
+  const { rows, overflow } = layout
 
   if (accounts.length < 2) return null
 
@@ -630,25 +823,41 @@ export default function MultiAccountStatusline() {
 
   return (
     <div
-      className={`flex flex-col items-center min-w-0 ${multiRow ? 'gap-1 py-1' : ''}`}
+      ref={rootRef}
+      // w-full: the strip spans its centre zone so its measured width IS the
+      // free width between the runtime band and the disclaimer -- the number
+      // the row layout is computed against. Shrink-to-fit (the old behaviour)
+      // measured the cluster's own width, which is useless for deciding how
+      // much room there is. Rows centre their pills inside it.
+      className={`flex flex-col items-center w-full min-w-0 ${multiRow ? 'gap-1 py-1' : ''}`}
       data-testid="multi-account-statusline"
       data-account-rows={rows.length}
     >
       {rows.map((row, i) => (
         <div
           key={i}
-          // flex-wrap is the occlusion fix. The count-based split above caps a
-          // row at 3 accounts, but 3 pills still overflow a narrow window --
-          // and the centred cluster then spilled equally out of BOTH sides of
-          // its zone and was clipped by the footer's overflow-hidden, cutting
-          // the first pill in half against the CLI band. Wrapping turns that
-          // horizontal overflow into an extra line, which the footer can absorb
-          // because its height is a MINIMUM (min-h-7), not a fixed size.
-          className={`flex flex-wrap items-center justify-center min-w-0 ${multiRow ? 'gap-x-2 gap-y-1' : 'gap-x-3 gap-y-1'}`}
+          // The rows are sized by measurement, so a row never exceeds the zone
+          // once the layout effect has run. flex-wrap stays as the safety net
+          // for the frames before it has (first paint, a resize in flight):
+          // an over-wide row wraps onto an extra line the footer can absorb
+          // (its height is a MINIMUM, min-h-7), instead of spilling out of
+          // BOTH sides of its centred zone and being clipped.
+          className="flex flex-wrap items-center justify-center min-w-0 gap-y-1"
+          // Inline px gap, the same constant the layout was computed with.
+          style={{ columnGap: FOOTER_PILL_GAP_PX }}
           data-testid="multi-account-row"
         >
           {row.map((a) => (
-            <AccountPill key={a.email} account={a} hidden={hidden} theme={theme} compact={multiRow} showPending={statusLineEnabled} minimal={minimal} />
+            <AccountPill
+              key={a.email}
+              account={a}
+              hidden={hidden}
+              theme={theme}
+              compact={multiRow}
+              showPending={statusLineEnabled}
+              minimal={minimal}
+              pillRef={pillRef(a.email)}
+            />
           ))}
           {i === rows.length - 1 && overflow.length > 0 && (
             <AccountOverflow accounts={overflow} hidden={hidden} theme={theme} />

--- a/tests/unit/renderer/multi-account-statusline-render.test.tsx
+++ b/tests/unit/renderer/multi-account-statusline-render.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../../../src/renderer/stores/accountProfilesStore', () => ({ useAccount
 vi.mock('../../../src/renderer/stores/settingsStore', () => ({ useSettingsStore: (sel: any) => sel(settingsState) }))
 vi.mock('../../../src/renderer/hooks/useThemeController', () => ({ useResolvedTheme: () => 'dark' }))
 
-const { default: MultiAccountStatusline } = await import('../../../src/renderer/components/MultiAccountStatusline')
+const { default: MultiAccountStatusline, FOOTER_PILL_GAP_PX } = await import('../../../src/renderer/components/MultiAccountStatusline')
 
 let container: HTMLDivElement
 let root: Root
@@ -35,7 +35,45 @@ beforeEach(() => {
 afterEach(() => {
   act(() => { root.unmount() })
   container.remove()
+  vi.restoreAllMocks()
+  delete (globalThis as any).ResizeObserver
 })
+
+/**
+ * jsdom does no layout: every getBoundingClientRect() is 0 x 0, which the
+ * strip reads as "not measured yet" (one row, CSS wraps it). These tests
+ * give it numbers instead -- a free width for the strip and a width per pill
+ * -- so the row layout has something real to compute from (#378).
+ */
+let measured: { available: number; pill: number | ((email: string) => number) } | null = null
+function measure(available: number, pill: number | ((email: string) => number)) {
+  measured = { available, pill }
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    let width = 0
+    if (measured) {
+      const tid = this.getAttribute('data-testid')
+      if (tid === 'multi-account-statusline') width = measured.available
+      else if (tid === 'multi-account-pill') {
+        const email = this.querySelector('[data-testid="multi-account-pill-label"]')?.textContent ?? ''
+        width = typeof measured.pill === 'function' ? measured.pill(email) : measured.pill
+      }
+    }
+    return { width, height: 0, top: 0, left: 0, right: width, bottom: 0, x: 0, y: 0, toJSON() { return {} } } as DOMRect
+  })
+}
+
+/** A ResizeObserver stand-in that lets a test fire the observer by hand. */
+const roCallbacks: Array<() => void> = []
+function installResizeObserver() {
+  roCallbacks.length = 0
+  ;(globalThis as any).ResizeObserver = class {
+    private cb: () => void
+    constructor(cb: () => void) { this.cb = cb; roCallbacks.push(cb) }
+    observe() {}
+    unobserve() {}
+    disconnect() { const i = roCallbacks.indexOf(this.cb); if (i >= 0) roCallbacks.splice(i, 1) }
+  }
+}
 
 describe('MultiAccountStatusline render (Bug 3)', () => {
   it('renders a 5h and 7d progress BAR per account (not percentage text)', () => {
@@ -74,10 +112,11 @@ describe('MultiAccountStatusline render (Bug 3)', () => {
   })
 })
 
-// Two-row footer (owner request): "if there are more than 3 open accounts the
-// bottom bar stretches to two rows with a max of 3 accounts on each row - if the
-// user has more than 6 then an overflow button they can click for their status".
-describe('MultiAccountStatusline -- two-row footer + overflow', () => {
+// Wrapping footer (owner request, #378): one row whenever every account pill
+// fits in the free footer width; wrap only when they truly do not, filling
+// each row before the next; at most two rows, the tail behind a "+N" overflow
+// control. Rows come from MEASURED widths (see `measure` above), not a count.
+describe('MultiAccountStatusline -- wrapping footer + overflow', () => {
   // n accounts, each with one live session and a 5h tick. Emails sort in the
   // order generated (name falls back to the email), so row contents are stable.
   function useAccounts(n: number): string[] {
@@ -94,13 +133,83 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
   const toggle = () => container.querySelector<HTMLButtonElement>('[data-testid="multi-account-overflow-toggle"]')
   const popover = () => container.querySelector<HTMLElement>('[data-testid="multi-account-overflow-popover"]')
 
+  const rowCounts = () => rows().map((x) => x.querySelectorAll('[data-testid="multi-account-pill"]').length)
+
   it('3 accounts stay on ONE row', () => {
+    measure(1400, 300)
     useAccounts(3)
     render()
     expect(rows()).toHaveLength(1)
     expect(pills()).toHaveLength(3)
-    expect(rows()[0].querySelectorAll('[data-testid="multi-account-pill"]')).toHaveLength(3)
+    expect(rowCounts()).toEqual([3])
     expect(toggle()).toBeNull()
+  })
+
+  it('#378: four pills of known width in a 1400px free span render on ONE row', () => {
+    // The owner's case: four accounts, a 1900px window, the strip 2 x 2 with
+    // empty footer either side. 4 x 300 + 3 x 12 = 1236 fits in 1400.
+    measure(1400, 300)
+    useAccounts(4)
+    render()
+    expect(rows()).toHaveLength(1)
+    expect(rowCounts()).toEqual([4])
+    expect(toggle()).toBeNull()
+    const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
+    expect(strip.getAttribute('data-account-rows')).toBe('1')
+  })
+
+  it('#378: four pills that do NOT fit wrap fill-first (3 + 1), not balanced (2 + 2)', () => {
+    // 3 x 300 + 2 x 12 = 924 fits in 1200; the fourth would make it 1236.
+    measure(1200, 300)
+    useAccounts(4)
+    render()
+    expect(rowCounts()).toEqual([3, 1])
+    expect(toggle()).toBeNull()
+  })
+
+  it('#378: more than three fit on a row when the width is there', () => {
+    measure(1400, 200) // 6 x 200 + 5 x 12 = 1260
+    useAccounts(6)
+    render()
+    expect(rowCounts()).toEqual([6])
+  })
+
+  it('#378: the strip spans its centre zone so it measures the FREE width, not its own content', () => {
+    // Shrink-to-fit (the old `flex flex-col items-center` with no width) would
+    // measure the cluster itself -- useless for deciding how much room there is.
+    useAccounts(2)
+    render()
+    const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
+    expect(strip.className).toContain('w-full')
+    // Rows centre their pills inside it.
+    expect(rows()[0].className).toContain('justify-center')
+  })
+
+  it('#378: re-lays out when the free width changes (ResizeObserver), without a remount', () => {
+    installResizeObserver()
+    measure(1400, 300)
+    useAccounts(4)
+    render()
+    expect(rowCounts()).toEqual([4])
+    expect(roCallbacks.length).toBeGreaterThan(0)
+    // The window narrows: the same four pills no longer fit on one line.
+    measured!.available = 1200
+    act(() => { for (const cb of [...roCallbacks]) cb() })
+    expect(rowCounts()).toEqual([3, 1])
+    // ...and widens again: back to one row.
+    measured!.available = 1400
+    act(() => { for (const cb of [...roCallbacks]) cb() })
+    expect(rowCounts()).toEqual([4])
+  })
+
+  it('#378: with nothing measured yet (first paint) everything is ONE row and nothing overflows', () => {
+    // No `measure(...)`: jsdom's 0 x 0 rects are the pre-layout state. The
+    // row is flex-wrap, so the browser wraps it until the effect has run.
+    useAccounts(9)
+    render()
+    expect(rowCounts()).toEqual([9])
+    expect(toggle()).toBeNull()
+    expect(rows()[0].className).toContain('flex-wrap')
   })
 
   it('a footer pill carries NO identity dot — the rim and fill already say it', () => {
@@ -118,8 +227,9 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
   it('but the overflow list KEEPS its dots — there they are the only identity marking', () => {
     // Those rows carry no pill tint, so removing the dot there would leave
     // nothing at all tying a row to its account.
-    // 8, not 6: six pills fit on the two rows, so the overflow control only
-    // appears from the seventh account.
+    // 1000px free, 300px pills: three per row, six on the two rows, so the
+    // overflow control appears from the seventh account.
+    measure(1000, 300)
     useAccounts(8)
     render()
     act(() => { toggle()!.click() })
@@ -130,20 +240,29 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     }
   })
 
-  it('the one-row layout keeps the tighter gap and no extra vertical padding, no truncation', () => {
+  it('the one-row layout adds no vertical padding and no truncation', () => {
+    measure(1400, 300)
     useAccounts(3)
     render()
     const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
     expect(strip.className).not.toContain('py-1') // the bar does not grow
-    // The boxed-pill design carries the visual boundary, so the inter-pill gap
-    // tightened from gap-6 to gap-3. Split into gap-x/gap-y once rows could
-    // wrap: the horizontal gap is unchanged, the row gap is the new part.
-    expect(rows()[0].className).toContain('gap-x-3')
-    expect(rows()[0].className).not.toContain('gap-6')
     // Pills keep their full width (email un-truncated) exactly as before.
     for (const p of pills()) {
       expect(p.className).toContain('shrink-0')
       expect(p.innerHTML).not.toContain('truncate')
+    }
+  })
+
+  it('#378: the pill gap is an inline px value equal to the layout constant, not a rem utility', () => {
+    // The layout is computed with FOOTER_PILL_GAP_PX; the browser must lay
+    // out with the same number. A `gap-x-*` class is rem-based and scales
+    // with the global UI font size, so the two would drift apart.
+    measure(1400, 300)
+    useAccounts(4)
+    render()
+    for (const r of rows()) {
+      expect(r.style.columnGap).toBe(`${FOOTER_PILL_GAP_PX}px`)
+      expect(r.className).not.toMatch(/\bgap-x-/)
     }
   })
 
@@ -245,14 +364,14 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     }
   })
 
-  it('the two-row layout tightens the gap, pads the taller bar, and lets the email ellipsise', () => {
+  it('the two-row layout pads the taller bar and lets the email ellipsise', () => {
+    measure(1200, 300) // 3 + 1
     useAccounts(4)
     render()
     const strip = container.querySelector<HTMLElement>('[data-testid="multi-account-statusline"]')!
     expect(strip.className).toContain('py-1')
-    expect(rows()[0].className).toContain('gap-x-2')
-    // Pills may shrink and the email ellipsises so three fit at the 1280px
-    // minimum window width; the full address stays in the pill's title.
+    // Pills may shrink and the email ellipsises; the full address stays in
+    // the pill's title.
     for (const p of pills()) {
       expect(p.className).toContain('min-w-0')
       expect(p.innerHTML).toContain('truncate')
@@ -260,27 +379,26 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     }
   })
 
-  it('4 accounts stretch the strip to TWO rows', () => {
+  it('4 accounts that do not fit stretch the strip to TWO rows', () => {
+    measure(1200, 300)
     useAccounts(4)
     render()
-    const r = rows()
-    expect(r).toHaveLength(2)
+    expect(rows()).toHaveLength(2)
     expect(pills()).toHaveLength(4)
-    expect(r.map((x) => x.querySelectorAll('[data-testid="multi-account-pill"]').length)).toEqual([2, 2])
     expect(toggle()).toBeNull()
   })
 
-  it('6 accounts fill two rows of 3 with no overflow control', () => {
+  it('6 accounts at three per row fill two rows of 3 with no overflow control', () => {
+    measure(1000, 300)
     useAccounts(6)
     render()
-    const r = rows()
-    expect(r).toHaveLength(2)
-    expect(r.map((x) => x.querySelectorAll('[data-testid="multi-account-pill"]').length)).toEqual([3, 3])
+    expect(rowCounts()).toEqual([3, 3])
     expect(pills()).toHaveLength(6)
     expect(toggle()).toBeNull()
   })
 
-  it('7 accounts show SIX pills plus a "+1" overflow control', () => {
+  it('7 accounts at three per row show SIX pills plus a "+1" overflow control', () => {
+    measure(1000, 300)
     const emails = useAccounts(7)
     render()
     expect(rows()).toHaveLength(2)
@@ -296,14 +414,27 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
     expect(rows()[1].contains(btn!)).toBe(true)
   })
 
-  it('9 accounts collapse three into the overflow control', () => {
+  it('9 accounts at three per row collapse three into the overflow control', () => {
+    measure(1000, 300)
     useAccounts(9)
     render()
     expect(pills()).toHaveLength(6)
     expect(toggle()!.textContent).toBe('+3')
   })
 
+  it('#378: the last row gives up a pill when the "+N" control would not fit beside it', () => {
+    // 3 x 300 + 2 x 12 = 924 fits in 940, but + 12 + 40 for the control does
+    // not: the second row keeps two pills and the control, the sixth account
+    // joins the seventh behind it.
+    measure(940, 300)
+    useAccounts(7)
+    render()
+    expect(rowCounts()).toEqual([3, 2])
+    expect(toggle()!.textContent).toBe('+2')
+  })
+
   it('clicking the overflow control reveals the hidden accounts, Escape dismisses it', () => {
+    measure(1000, 300)
     const emails = useAccounts(8)
     render()
     expect(popover()).toBeNull()
@@ -324,6 +455,7 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
   })
 
   it('a mousedown outside the overflow popover dismisses it', () => {
+    measure(1000, 300)
     useAccounts(7)
     render()
     act(() => { toggle()!.click() })
@@ -333,6 +465,7 @@ describe('MultiAccountStatusline -- two-row footer + overflow', () => {
   })
 
   it('a mousedown INSIDE the overflow popover keeps it open', () => {
+    measure(1000, 300)
     useAccounts(7)
     render()
     act(() => { toggle()!.click() })

--- a/tests/unit/renderer/multi-account-statusline.test.ts
+++ b/tests/unit/renderer/multi-account-statusline.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   liveAccountUsage,
-  splitAccountRows,
-  FOOTER_MAX_PER_ROW,
+  layoutFooterRows,
+  reconcileFooterMetrics,
   FOOTER_MAX_ROWS,
-  FOOTER_MAX_VISIBLE,
+  FOOTER_PILL_GAP_PX,
+  FOOTER_OVERFLOW_RESERVE_PX,
   type LiveAccount,
 } from '../../../src/renderer/components/MultiAccountStatusline'
 import type { Session } from '../../../src/renderer/stores/sessionStore'
@@ -140,69 +141,147 @@ describe('liveAccountUsage', () => {
   })
 })
 
-// Footer row splitting (owner request): <=3 accounts stay on ONE row exactly as
-// before; 4-6 stretch the footer to two rows of at most 3; past 6 the tail goes
-// behind a "+N" overflow control. Generic + pure, so the boundaries are tested
-// here without a DOM (the rendered counterpart lives in
-// multi-account-statusline-render.test.tsx).
-describe('splitAccountRows -- footer row/overflow boundaries', () => {
+// Footer row layout (#378). The old split was by COUNT (<=3 one row, 4..6 two
+// rows, >6 overflow) and put four accounts on two rows at 1900px with empty
+// footer either side. Rows now come from MEASURED widths: one row whenever
+// everything fits the free width; wrap only when it truly does not, filling
+// each row before the next; at most FOOTER_MAX_ROWS rows, the rest behind "+N".
+// Generic + pure, so the fit boundaries are tested here without a DOM (the
+// rendered counterpart lives in multi-account-statusline-render.test.tsx).
+describe('layoutFooterRows -- measured footer rows (#378)', () => {
   const list = (n: number) => Array.from({ length: n }, (_, i) => `a${i + 1}`)
+  const same = (n: number, w: number) => Array.from({ length: n }, () => w)
+  const gap = FOOTER_PILL_GAP_PX
 
-  it('exposes the layout caps the footer is built around', () => {
-    expect(FOOTER_MAX_PER_ROW).toBe(3)
+  it('exposes the layout constants the footer is built around', () => {
     expect(FOOTER_MAX_ROWS).toBe(2)
-    expect(FOOTER_MAX_VISIBLE).toBe(6)
+    expect(FOOTER_PILL_GAP_PX).toBe(12)
+    expect(FOOTER_OVERFLOW_RESERVE_PX).toBe(40)
   })
 
-  it('keeps 1-3 accounts on a single row (no layout change from before)', () => {
-    expect(splitAccountRows(list(1))).toEqual({ rows: [['a1']], overflow: [] })
-    expect(splitAccountRows(list(2))).toEqual({ rows: [['a1', 'a2']], overflow: [] })
-    expect(splitAccountRows(list(3))).toEqual({ rows: [['a1', 'a2', 'a3']], overflow: [] })
+  it('four pills of known width in a 1400px free span render on ONE row (the owner\'s case)', () => {
+    // 4 x 300 + 3 gaps of 12 = 1236 <= 1400. The count-based split said 2+2.
+    const out = layoutFooterRows(list(4), same(4, 300), { available: 1400 })
+    expect(out).toEqual({ rows: [['a1', 'a2', 'a3', 'a4']], overflow: [] })
   })
 
-  it('stretches to TWO rows at 4 accounts, balanced 2+2', () => {
-    const out = splitAccountRows(list(4))
-    expect(out.rows).toHaveLength(2)
-    expect(out.rows.map((r) => r.length)).toEqual([2, 2])
-    expect(out.rows).toEqual([['a1', 'a2'], ['a3', 'a4']])
+  it('keeps everything on one row right up to the exact free width', () => {
+    const exact = 4 * 300 + 3 * gap
+    expect(layoutFooterRows(list(4), same(4, 300), { available: exact }).rows).toHaveLength(1)
+    // Half a pixel of measurement noise does not wrap a row.
+    expect(layoutFooterRows(list(4), same(4, 300), { available: exact - 0.4 }).rows).toHaveLength(1)
+    // A whole pixel short does.
+    expect(layoutFooterRows(list(4), same(4, 300), { available: exact - 1 }).rows).toHaveLength(2)
+  })
+
+  it('wraps FILL-FIRST, not balanced: 4 pills that do not fit go 3+1, never 2+2', () => {
+    // 3 x 300 + 2 x 12 = 924 fits in 1200; the fourth (1236) does not.
+    const out = layoutFooterRows(list(4), same(4, 300), { available: 1200 })
+    expect(out.rows).toEqual([['a1', 'a2', 'a3'], ['a4']])
     expect(out.overflow).toEqual([])
   })
 
-  it('splits 5 accounts 3+2 (never more than 3 on a row)', () => {
-    const out = splitAccountRows(list(5))
-    expect(out.rows.map((r) => r.length)).toEqual([3, 2])
-    expect(out.overflow).toEqual([])
+  it('more than three fit on a row when the width is there (no per-row cap)', () => {
+    const out = layoutFooterRows(list(6), same(6, 200), { available: 1400 })
+    // 6 x 200 + 5 x 12 = 1260 <= 1400: six on one row.
+    expect(out.rows).toEqual([list(6)])
   })
 
-  it('fills two rows of 3 at 6 accounts with NO overflow', () => {
-    const out = splitAccountRows(list(6))
-    expect(out.rows).toEqual([['a1', 'a2', 'a3'], ['a4', 'a5', 'a6']])
-    expect(out.overflow).toEqual([])
+  it('uses the real per-pill widths, not an average', () => {
+    // 500 + 12 + 500 = 1012 > 1000, so a2 wraps; then 500 + 12 + 100 fits.
+    const out = layoutFooterRows(list(3), [500, 500, 100], { available: 1000 })
+    expect(out.rows).toEqual([['a1'], ['a2', 'a3']])
   })
 
-  it('shows 6 and overflows the rest at 7 accounts', () => {
-    const out = splitAccountRows(list(7))
+  it('never renders more than FOOTER_MAX_ROWS rows: the tail goes to the overflow', () => {
+    // 3 per row at 1000px (924); 7 pills -> 3 + 3 + 1, and the third row is
+    // not allowed, so a7 overflows. The last row then has to make room for
+    // the "+N" control: 924 + 12 + 40 = 976 <= 1000, so it keeps all three.
+    const out = layoutFooterRows(list(7), same(7, 300), { available: 1000 })
     expect(out.rows).toEqual([['a1', 'a2', 'a3'], ['a4', 'a5', 'a6']])
     expect(out.overflow).toEqual(['a7'])
   })
 
-  it('overflows everything past 6, preserving order', () => {
-    const out = splitAccountRows(list(10))
-    expect(out.rows.flat()).toEqual(['a1', 'a2', 'a3', 'a4', 'a5', 'a6'])
-    expect(out.overflow).toEqual(['a7', 'a8', 'a9', 'a10'])
+  it('makes room for the "+N" control on the last row, moving pills into the overflow if it must', () => {
+    // 3 x 300 + 2 x 12 = 924 fits in 940, but 924 + 12 + 40 = 976 does not:
+    // the last row gives up a pill so the control fits beside the rest.
+    const out = layoutFooterRows(list(7), same(7, 300), { available: 940 })
+    expect(out.rows).toEqual([['a1', 'a2', 'a3'], ['a4', 'a5']])
+    expect(out.overflow).toEqual(['a6', 'a7'])
   })
 
-  it('never puts more than 3 on a row and never renders more than 2 rows', () => {
+  it('never empties the last row to fit the control', () => {
+    // One pill per row; the control does not fit beside it either, but the
+    // row keeps its pill -- a row of nothing but "+N" would be worse.
+    const out = layoutFooterRows(list(4), same(4, 300), { available: 310 })
+    expect(out.rows).toEqual([['a1'], ['a2']])
+    expect(out.overflow).toEqual(['a3', 'a4'])
+  })
+
+  it('a pill wider than the whole zone sits alone on a row rather than vanishing', () => {
+    const out = layoutFooterRows(list(2), [900, 100], { available: 500 })
+    expect(out.rows).toEqual([['a1'], ['a2']])
+    expect(out.overflow).toEqual([])
+  })
+
+  it('estimates an unmeasured pill at the WIDEST measured one (wraps early, never spills)', () => {
+    // a3 has never been painted. Estimated at 400: 400 + 12 + 400 = 812 fits
+    // 1000, + 12 + 400 = 1224 does not -> 2 + 1, NOT 3 on one row.
+    const out = layoutFooterRows(list(3), [400, 200, undefined], { available: 1000 })
+    expect(out.rows).toEqual([['a1', 'a2'], ['a3']])
+  })
+
+  it('with no measured free width, everything is one row (first paint / jsdom) and nothing overflows', () => {
+    expect(layoutFooterRows(list(9), same(9, 300), { available: 0 })).toEqual({ rows: [list(9)], overflow: [] })
+    expect(layoutFooterRows(list(9), same(9, 300), { available: NaN })).toEqual({ rows: [list(9)], overflow: [] })
+    // ...and likewise when not a single pill has been measured yet.
+    expect(layoutFooterRows(list(9), same(9, undefined as unknown as number), { available: 1400 })).toEqual({ rows: [list(9)], overflow: [] })
+  })
+
+  it('drops nothing and duplicates nothing: rows + overflow is the input, in order, never more than 2 rows', () => {
     for (let n = 1; n <= 25; n++) {
-      const out = splitAccountRows(list(n))
-      expect(out.rows.length).toBeLessThanOrEqual(FOOTER_MAX_ROWS)
-      for (const row of out.rows) expect(row.length).toBeLessThanOrEqual(FOOTER_MAX_PER_ROW)
-      // Nothing is dropped or duplicated: rows + overflow == the input, in order.
-      expect([...out.rows.flat(), ...out.overflow]).toEqual(list(n))
+      for (const available of [310, 700, 1000, 1400, 3000]) {
+        const out = layoutFooterRows(list(n), same(n, 300), { available })
+        expect(out.rows.length).toBeLessThanOrEqual(FOOTER_MAX_ROWS)
+        expect([...out.rows.flat(), ...out.overflow]).toEqual(list(n))
+        for (const row of out.rows) expect(row.length).toBeGreaterThan(0)
+      }
     }
   })
 
   it('returns no rows for an empty list', () => {
-    expect(splitAccountRows([])).toEqual({ rows: [], overflow: [] })
+    expect(layoutFooterRows([], [], { available: 1400 })).toEqual({ rows: [], overflow: [] })
+  })
+})
+
+// The measurement cache behind the layout: the same object back when nothing
+// moved is what ends the measure -> set -> render -> measure cycle.
+describe('reconcileFooterMetrics -- measurement cache', () => {
+  const live = (...k: string[]) => new Set(k)
+
+  it('returns the SAME object when nothing moved by more than the fit epsilon', () => {
+    const prev = { available: 1400, widths: { a: 300, b: 301 } }
+    expect(reconcileFooterMetrics(prev, 1400.3, { a: 300.2, b: 300.8 }, live('a', 'b'))).toBe(prev)
+  })
+
+  it('returns a new object when the free width or a pill width changes', () => {
+    const prev = { available: 1400, widths: { a: 300 } }
+    expect(reconcileFooterMetrics(prev, 1200, { a: 300 }, live('a'))).toEqual({ available: 1200, widths: { a: 300 } })
+    expect(reconcileFooterMetrics(prev, 1400, { a: 320 }, live('a'))).toEqual({ available: 1400, widths: { a: 320 } })
+  })
+
+  it('keeps the last width of a live pill that is not painted right now (behind "+N")', () => {
+    const prev = { available: 1400, widths: { a: 300, b: 280 } }
+    // b is live but not in the fresh sweep: its cached width survives.
+    const out = reconcileFooterMetrics(prev, 1400, { a: 300 }, live('a', 'b'))
+    expect(out).toBe(prev)
+    expect(out.widths.b).toBe(280)
+  })
+
+  it('forgets an account that is no longer live', () => {
+    const prev = { available: 1400, widths: { a: 300, gone: 280 } }
+    const out = reconcileFooterMetrics(prev, 1400, { a: 300 }, live('a'))
+    expect(out).not.toBe(prev)
+    expect(out.widths).toEqual({ a: 300 })
   })
 })


### PR DESCRIPTION
## What and why

Fixes #378 -- the multi-account strip at the bottom of the app wrapped to two rows when there was room for all the accounts on one (four accounts at 1900px rendered 2 x 2 with empty footer either side).

**Root cause.** The row split in `MultiAccountStatusline.tsx` was decided by *count* (<=3 accounts one row, 4..6 two rows balanced 2+2 / 3+2 / 3+3, >6 overflow). It never looked at the width. The `flex-wrap` added in beta.16 could only wrap a row that was already over-wide; it could not un-split a row the count rule had split. And the strip was shrink-to-fit inside its centre zone, so it could not even see how much room the zone had.

**Fix.** The rows now come from *measured* widths:

- `layoutFooterRows()` replaces `splitAccountRows()`: pure, generic, fill-first. One row whenever every pill fits the free width; wrap only when they truly do not; at most two rows, the tail behind the "+N" control (room is reserved on the last row so the control never pushes it past the zone; the row is never emptied to fit it). An unmeasured pill is estimated at the widest measured one (wraps early rather than spills). No measured width yet (first frame) -> one row of everything, and the row's `flex-wrap` is the safety net until the layout effect has run.
- `useMeasuredFooterRows()` feeds it: the strip is `w-full` in its zone so its rect *is* the free width between the runtime band and the disclaimer; each pill carries a callback ref; a `useLayoutEffect` measures synchronously when the set of accounts, what the pills show, or the row assignment changes (so the first paint is already laid out); a `ResizeObserver` on the strip and the pills covers window resize, font scale and meters appearing. A measurement that changes nothing returns the same state object, which is what ends the measure -> set -> render -> measure cycle. Widths are cached per account so a pill behind "+N" keeps its last measurement.
- The inter-pill gap is an inline px constant (`FOOTER_PILL_GAP_PX = 12`) rather than a rem-based `gap-x-*` class, so the browser lays out with the same number the layout was computed with (rem utilities scale with the global UI font size). One gap for both the single- and multi-row looks.
- Single-row pills stay `shrink-0` with the full email; multi-row pills keep `min-w-0` + `truncate` and the `py-1` bar padding, as before. The "+N" popover is untouched. `BottomBar.tsx` is untouched.

Issue: #378

## How it was tested

- `tests/unit/renderer/multi-account-statusline.test.ts` -- `layoutFooterRows` / `reconcileFooterMetrics` boundaries: four 300px pills in a 1400px span -> one row; exact fit and half-pixel slack; fill-first 3+1 (never 2+2); no per-row cap; per-pill widths; max two rows; the "+N" reserve; a lone over-wide pill; the unmeasured estimate; the first-paint fallback; nothing dropped or duplicated for 1..25 accounts x 5 widths; the cache returning the same object when nothing moved.
- `tests/unit/renderer/multi-account-statusline-render.test.tsx` -- rendered rows with `getBoundingClientRect` mocked by testid and a hand-fired `ResizeObserver`: four 300px pills in 1400px render ONE row; 1200px -> 3+1; resize narrow/wide re-lays out without a remount; the strip is `w-full`; the inline px gap; the overflow-control cases at 1000px / 940px; first paint with nothing measured is one row.
- The eight `#378` render tests were run against the OLD component (src stashed) and fail there (2 x 2 rows), and pass on the new one.
- Full suite: `npx vitest run` -> 627 files passed, 2 skipped; 6559 tests passed, 15 skipped.
- `npm run typecheck` -> clean.

VM proof: pending -- the conductor's integration pass (1900px with four accounts; also worth a glance at 1280px with three, and at >6 accounts for the "+N" control).

## Not done / open questions for the owner

- No hard cap on pills per row any more (the 08-15 "max 3 per row" is superseded by "one row whenever they fit"). At a very wide window with many accounts the strip can show five or six on a row before wrapping. Say if you want a cap back.
- The "+N" control's width is a 40px reserve rather than a measurement: fine to two digits; a three-digit count would crowd the last row by a few px.
- Changelog entry: left to the conductor's consolidated pass.
