### PR TITLE
feat(sidebar): saved configs cards and find views, chosen in settings (#362)

### DIFF
--- a/CONTEXT.d/2026-08-22-n362.md
+++ b/CONTEXT.d/2026-08-22-n362.md
@@ -1,0 +1,61 @@
+## 2026-08-22 -- #362 Saved Configs panel: cards and find + categories views, chosen in Settings
+
+**What changed**
+
+- Two alternative layouts for the sidebar's Saved Configs panel, built to the
+  owner's decision on the "Saved Configs design pass" canvas (book item 40):
+  - `SavedConfigsCards` (option B): one card per config -- identity colour as a
+    30px swatch carrying the type glyph, a second line in words (kind, directory
+    or user@host, model/effort), stacks per group with a count chip and
+    "launch all", pinned pulled out first, sections as a rule above their stacks.
+  - `SavedConfigsFind` (option C): a find box on top, groups/sections/Pinned as
+    filter chips instead of nested headers, one flat list of 30px rows with a
+    colour bar and type badge, hover launch/edit/delete on a flat panel, and
+    "Launch all N" on the active group or section chip.
+- Both views: a search box with INLINE auto-complete (the first label that
+  starts with the typed text is ghosted; Tab or right-arrow-at-end accepts),
+  every whitespace token must match label/group/section/directory/host, and
+  the same keyboard flow -- type, arrow, Enter launches (Enter with nothing
+  selected launches the first match). Escape clears, then blurs.
+- Both views EXCLUDE configs with a live session (the Ask session never counts)
+  and say "N running, not listed" so the shorter list is explained; when every
+  config is running they say so instead of rendering nothing. Launch-all goes
+  through `launchAllTargets`, which re-checks running and Codex-off at click
+  time, so a stack or chip built a moment earlier can never double-launch.
+- Settings -> General: ONE select, "Saved Configs layout", next to the other
+  sidebar settings (`savedConfigsView`: list | cards | find). Absent = list, so
+  no existing install changes shape; the list view itself is untouched.
+- The panel focuses the find box only when opened DELIBERATELY (header click),
+  never on hover, so a mouse passing over the sidebar cannot steal the keyboard
+  from the terminal.
+
+**Why**
+
+The owner chose both new views rather than one (issue #362 body), with the
+choice in Settings. The pure half (`savedConfigsView.ts`: running ids, search,
+completion, stacks, categories, launch-all targets) is separate from the two
+components so every rule is unit-tested flat.
+
+**How verified**
+
+- `tests/unit/renderer/saved-configs-view-helpers.test.ts` -- the pure helpers.
+- `tests/unit/renderer/saved-configs-cards.test.tsx`,
+  `saved-configs-find.test.tsx` -- component tests: running excluded, launch-all
+  never launches a running or Codex-blocked config, completion, type/arrow/Enter,
+  click, context menu, chip filtering, fallback when a chip empties.
+- `tests/unit/renderer/sidebar-saved-configs-view.test.tsx` -- the setting
+  switches the panel body; absent/unknown = the list; running ids wired.
+- `tests/unit/renderer/settings-saved-configs-view.test.ts` -- the Settings
+  select is wired through `save`.
+- Full `npx vitest run` and `npm run typecheck` green (see the PR).
+- VM proof pending (the conductor's integration pass).
+
+**Left / open for the owner**
+
+- No "Recent" section in the find view (option C drew one): it needs a new
+  persisted last-launched field per config; the decision named "find +
+  categories", so it is left out rather than guessed.
+- The list view's own group/section launch-all still launches running configs
+  (unchanged behaviour); only the two new views apply the rule.
+- Clicking a card or row launches it (they are launchers); the list view's rows
+  still launch only via the play button.

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { CustomCommandsTab } from './settings/CustomCommandsTab'
 import HooksGatewaySection from './github/config/HooksGatewaySection'
 import PageFrame from './PageFrame'
 import { SectionLabel } from './ui/SectionLabel'
+import { SAVED_CONFIGS_VIEW_OPTIONS, resolveSavedConfigsView, type SavedConfigsView } from './sidebar/savedConfigsView'
 import { Kbd } from './ui/Kbd'
 import { trackUsage } from '../stores/tipsStore'
 import { useAddAccount } from '../hooks/useAddAccount'
@@ -232,6 +233,20 @@ export default function SettingsPage({ initialTab, onNavigateToSessions, onUpdat
                   Show Ask Conductor
                   <span className="text-[10px] text-overlay0">(The button at the bottom of the sidebar)</span>
                 </label>
+                {/* #362: the Saved Configs panel's layout. One choice, next to
+                    the other sidebar settings; the list stays the default. */}
+                <Field label="Saved Configs layout">
+                  <select
+                    value={resolveSavedConfigsView(settings.savedConfigsView)}
+                    onChange={(e) => save({ savedConfigsView: e.target.value as SavedConfigsView })}
+                    className="bg-crust/60 border border-surface0/80 rounded-lg px-3 py-2 text-sm text-text w-full focus:outline-none focus:border-blue/50 transition-colors"
+                    data-ux-id="settings-saved-configs-view"
+                  >
+                    {SAVED_CONFIGS_VIEW_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                </Field>
               </Section>
 
               <Section title="Security" icon={<path d="M8 2L3 5v4c0 3.5 2.1 6.4 5 7.5 2.9-1.1 5-4 5-7.5V5L8 2z" stroke="currentColor" strokeWidth="1.2" fill="none" />}>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -31,6 +31,9 @@ import SessionSectionHeader from './sidebar/SessionSectionHeader'
 import SessionGroupHeader from './sidebar/SessionGroupHeader'
 import UngroupedSessionsHeader from './sidebar/UngroupedSessionsHeader'
 import PinnedConfigsPanel from './sidebar/PinnedConfigsPanel'
+import SavedConfigsCards from './sidebar/SavedConfigsCards'
+import SavedConfigsFind from './sidebar/SavedConfigsFind'
+import { resolveSavedConfigsView, runningConfigIds } from './sidebar/savedConfigsView'
 import AskConductorDock from './sidebar/AskConductorDock'
 import { resolveConfigPanelExpanded, toggleConfigPanel, overrideAfterPinChange, type ConfigPanelOverride } from './sidebar/configPanelState'
 import FirstRunCard from './FirstRunCard'
@@ -174,6 +177,16 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
     updateSettings({ configPanelPinned: newVal })
   }
   const [configSearchQuery, setConfigSearchQuery] = useState('')
+  // #362: which layout the panel body uses. The list is the default and is
+  // untouched; cards and find are the two views from the design pass.
+  const savedConfigsView = resolveSavedConfigsView(useSettingsStore((s) => s.settings.savedConfigsView))
+  // Configs with a live session: the cards and find views never list them and
+  // launch-all never starts them. `sessions` already excludes the Ask session.
+  const runningIds = useMemo(() => runningConfigIds(sessions), [sessions])
+  // Bumped when the panel is opened DELIBERATELY (header click), so the find
+  // box takes focus. Never on hover: a mouse passing over the sidebar must not
+  // steal the keyboard from the terminal.
+  const [configPanelFocusRequest, setConfigPanelFocusRequest] = useState(0)
   // The panel used to cap itself at a flat 60vh, which cut the list off partway
   // down a row while empty sidebar sat underneath it. Measure what is actually
   // free below the panel's top edge instead, keeping SESSION_RESERVE px for the
@@ -343,6 +356,15 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const launchFromConfig = async (config: TerminalConfig) => {
     launchConfig(config)
     onViewChange('sessions')
+  }
+
+  // #362: launch-all from the cards / find views. They hand over an already
+  // filtered list (running and Codex-blocked configs removed) -- see
+  // launchAllTargets -- so this is just the loop.
+  const launchMany = async (targets: TerminalConfig[]) => {
+    for (const config of targets) {
+      await launchFromConfig(config)
+    }
   }
 
   const launchGroup = async (groupId: string) => {
@@ -732,7 +754,11 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
             type="button"
             /* Works while pinned too: a pinned panel stays collapsible. This used
                to be blocked when pinned, so "pinned" also meant "stuck open". */
-            onClick={() => setConfigPanelOpen((o) => toggleConfigPanel(o, configPanelPinned))}
+            onClick={() => {
+              const next = toggleConfigPanel(configPanelOpen, configPanelPinned)
+              setConfigPanelOpen(next)
+              if (next) setConfigPanelFocusRequest((n) => n + 1)
+            }}
             aria-expanded={configPanelExpanded}
             className="flex items-center gap-1.5 rounded focus-ring"
             title={configPanelExpanded ? 'Collapse saved configs' : 'Show all saved configs'}
@@ -861,7 +887,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
             }
         }
       >
-        {/* Search input */}
+        {/* Search input (list view) */}
+        {savedConfigsView === 'list' && (
         <div className="px-2 pt-2 pb-1 shrink-0">
           <input
             value={configSearchQuery}
@@ -870,11 +897,14 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
             className="w-full bg-base border border-surface1 rounded px-2 py-1 text-xs text-text placeholder:text-overlay0 outline-none focus:border-blue"
           />
         </div>
+        )}
 
         {/* Fills whatever height the panel got. Previously a second hard-coded
             `calc(60vh - 40px)`, which had to be kept in step with the panel cap
-            AND with the search box's real height by hand. */}
-        <div className="px-2 space-y-0.5 overflow-y-auto pb-2 flex-1 min-h-0">
+            AND with the search box's real height by hand. In the cards / find
+            views this holds only the empty state and the new-section input;
+            the view below owns the scrolling list. */}
+        <div className={savedConfigsView === 'list' ? 'px-2 space-y-0.5 overflow-y-auto pb-2 flex-1 min-h-0' : 'px-2 space-y-0.5 shrink-0'}>
         {configs.length === 0 && !showNewSectionInput && (
           <div className="text-xs text-overlay0 text-center py-4">
             No saved configs.<br />Click + to create one.
@@ -905,6 +935,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           </div>
         )}
 
+        {savedConfigsView === 'list' && (<>
         {/* Sectioned configs */}
         {sectionData.map(({ section, groups: sectionGroups, looseConfigs }) => (
           <div key={section.id} className="mb-1">
@@ -990,7 +1021,38 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           />
         )}
         {unsectionedUngroupedConfigs.map(renderConfigRow)}
+        </>)}
       </div>
+        {/* #362: the two alternative layouts, chosen in Settings -> General.
+            Both own their search box; the inline new-section input and the
+            empty state below stay with the panel. */}
+        {savedConfigsView === 'cards' && (
+          <SavedConfigsCards
+            configs={configs}
+            groups={groups}
+            sections={sections}
+            runningIds={runningIds}
+            onLaunch={launchFromConfig}
+            onLaunchMany={launchMany}
+            onContextMenu={handleConfigContextMenu}
+            focusRequest={configPanelFocusRequest}
+          />
+        )}
+        {savedConfigsView === 'find' && (
+          <SavedConfigsFind
+            configs={configs}
+            groups={groups}
+            sections={sections}
+            runningIds={runningIds}
+            onLaunch={launchFromConfig}
+            onLaunchMany={launchMany}
+            onEdit={setEditingConfig}
+            onDelete={(c) => handleDeleteConfig(c.id)}
+            onContextMenu={handleConfigContextMenu}
+            focusRequest={configPanelFocusRequest}
+          />
+        )}
+
       </div>{/* end overlay */}
       </div>{/* end relative hover wrapper */}
 

--- a/src/renderer/components/sidebar/SavedConfigsCards.tsx
+++ b/src/renderer/components/sidebar/SavedConfigsCards.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo, useRef, useState } from 'react'
+import type { TerminalConfig, ConfigGroup, ConfigSection } from '../../stores/configStore'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { CODEX_OFF_LAUNCH_REASON } from '../../hooks/useLaunchConfig'
+import {
+  buildCardStacks,
+  completeQuery,
+  describeConfig,
+  excludeRunning,
+  launchAllTargets,
+  makeNameLookup,
+  searchConfigs,
+  type CardStack,
+} from './savedConfigsView'
+import {
+  ConfigGlyphIcon,
+  RunningFootnote,
+  SavedConfigsEmpty,
+  SavedConfigsSearch,
+  useLaunchSelection,
+  useScrollSelectedIntoView,
+} from './SavedConfigsSearch'
+
+// The CARDS view of the Saved Configs panel (#362, option B on the canvas):
+// one card per config, the identity colour a solid swatch carrying the type
+// glyph, a second line saying what the config is, stacks per group with a
+// count chip and launch-all. Running configs are not listed. A search box with
+// inline completion sits on top; type -> arrow -> Enter launches.
+
+interface Props {
+  configs: TerminalConfig[]
+  groups: ConfigGroup[]
+  sections: ConfigSection[]
+  /** Ids of configs with a live session -- never shown, never launched by launch-all. */
+  runningIds: ReadonlySet<string>
+  onLaunch: (config: TerminalConfig) => void
+  onLaunchMany: (configs: TerminalConfig[]) => void
+  onContextMenu: (e: React.MouseEvent, configId: string) => void
+  focusRequest?: number
+}
+
+export default function SavedConfigsCards({ configs, groups, sections, runningIds, onLaunch, onLaunchMany, onContextMenu, focusRequest }: Props) {
+  const [query, setQuery] = useState('')
+  const theme = useResolvedTheme()
+  const codexOff = useSettingsStore((s) => s.settings.codexEnabled === false)
+  const isBlocked = (c: TerminalConfig) => codexOff && c.provider === 'codex'
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const lookup = useMemo(() => makeNameLookup(groups, sections), [groups, sections])
+  const launchable = useMemo(() => excludeRunning(configs, runningIds), [configs, runningIds])
+  const visible = useMemo(() => searchConfigs(launchable, query, lookup), [launchable, query, lookup])
+  const stacks = useMemo(() => buildCardStacks(visible, groups, sections), [visible, groups, sections])
+  const flat = useMemo(() => stacks.flatMap((s) => s.configs), [stacks])
+  const completion = completeQuery(query, visible.map((c) => c.label))
+
+  const launch = (c: TerminalConfig) => { if (!isBlocked(c)) onLaunch(c) }
+  const sel = useLaunchSelection(flat, launch)
+  useScrollSelectedIntoView(listRef, sel.selected)
+
+  const launchStack = (stack: CardStack) => {
+    const targets = launchAllTargets(stack.configs, runningIds, isBlocked)
+    if (targets.length > 0) onLaunchMany(targets)
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0" data-ux-id="saved-configs-cards">
+      <SavedConfigsSearch
+        value={query}
+        onChange={(v) => { setQuery(v); sel.setSelected(-1) }}
+        completion={completion}
+        onMove={sel.move}
+        onEnter={sel.enter}
+        focusRequest={focusRequest}
+        hint={query ? `${visible.length} of ${launchable.length}` : undefined}
+      />
+      <div ref={listRef} role="listbox" aria-label="Saved configs" className="overflow-y-auto pb-2 flex-1 min-h-0">
+        <SavedConfigsEmpty total={configs.length} launchable={launchable.length} visible={visible.length} query={query} />
+        {stacks.map((stack) => (
+          <div key={stack.id} className="mb-1" data-ux-id="saved-configs-stack" data-stack-kind={stack.kind}>
+            {stack.sectionTitle && (
+              <div className="flex items-center gap-2 px-3 pt-2 pb-0.5 text-[10px] font-semibold uppercase tracking-widest" style={{ color: 'var(--text-muted)' }}>
+                {stack.sectionTitle}
+                <span className="flex-1 h-px" style={{ background: 'var(--border-subtle)' }} />
+              </div>
+            )}
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 pb-1 text-[11px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
+              {stack.kind === 'pinned' && (
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden className="text-blue">
+                  <path d="M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+                </svg>
+              )}
+              <span className="truncate">{stack.title}</span>
+              <span
+                className="ml-auto inline-flex items-center gap-1 rounded-full border px-1.5 py-px text-[10px] font-medium"
+                style={{ borderColor: 'var(--border-subtle)', color: 'var(--text-muted)' }}
+              >
+                {stack.configs.length}
+                {stack.launchAll && (
+                  <>
+                    <span aria-hidden>&middot;</span>
+                    <button
+                      type="button"
+                      onClick={() => launchStack(stack)}
+                      className="hover:underline focus-ring rounded"
+                      style={{ color: 'var(--status-success)' }}
+                      title={`Launch every config in ${stack.title} that is not already running`}
+                      data-ux-id="saved-configs-launch-all"
+                    >
+                      launch all
+                    </button>
+                  </>
+                )}
+              </span>
+            </div>
+            {stack.configs.map((config) => {
+              const index = flat.indexOf(config)
+              const selected = index === sel.selected
+              const blocked = isBlocked(config)
+              const d = describeConfig(config)
+              const swatch = resolveIdentityColor(config.identityColorKey ?? bucketLegacyColorToKey(config.color), theme)
+              const second = [d.kind, d.where, d.detail].filter(Boolean).join(' · ')
+              return (
+                <div
+                  key={config.id}
+                  role="option"
+                  aria-selected={selected}
+                  aria-disabled={blocked || undefined}
+                  data-ux-id="saved-config-card"
+                  data-config-id={config.id}
+                  tabIndex={-1}
+                  onClick={() => launch(config)}
+                  onMouseEnter={() => sel.setSelected(index)}
+                  onContextMenu={(e) => onContextMenu(e, config.id)}
+                  className={`group relative grid grid-cols-[30px_1fr] items-center gap-2.5 mx-2 my-1 rounded-lg border px-2 py-1.5 min-h-[46px] transition-colors ${blocked ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                  style={{
+                    borderColor: selected ? 'color-mix(in srgb, var(--brand) 55%, transparent)' : 'var(--border-subtle)',
+                    background: selected ? 'color-mix(in srgb, var(--brand) 10%, var(--surface-raised))' : 'var(--surface-raised)',
+                    opacity: blocked ? 0.6 : 1,
+                  }}
+                  title={blocked ? CODEX_OFF_LAUNCH_REASON : second}
+                >
+                  <span
+                    className="w-[30px] h-[30px] rounded-md grid place-items-center shrink-0"
+                    style={{ background: swatch, color: 'var(--color-crust)' }}
+                    aria-hidden
+                  >
+                    <ConfigGlyphIcon glyph={d.glyph} size={13} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-xs font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{config.label}</span>
+                    <span className="block text-[10px] truncate mt-px" style={{ color: 'var(--text-muted)' }}>
+                      <span style={{ color: 'var(--text-secondary)' }}>{d.kind}</span>
+                      {d.where && <> &middot; {d.where}</>}
+                      {d.detail && <> &middot; {d.detail}</>}
+                      {blocked && <> &middot; Codex off</>}
+                    </span>
+                  </span>
+                  {config.pinned && stack.kind !== 'pinned' && (
+                    <span className="absolute top-1 right-1.5 text-blue" aria-hidden>
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" /></svg>
+                    </span>
+                  )}
+                  {!blocked && (
+                    <span
+                      className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md grid place-items-center opacity-0 group-hover:opacity-100 transition-opacity"
+                      style={{ background: 'color-mix(in srgb, var(--status-success) 16%, transparent)', color: 'var(--status-success)' }}
+                      aria-hidden
+                      title="Launch"
+                    >
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="2,1 8,5 2,9" /></svg>
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        ))}
+        <RunningFootnote hidden={configs.length - launchable.length} />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/sidebar/SavedConfigsFind.tsx
+++ b/src/renderer/components/sidebar/SavedConfigsFind.tsx
@@ -1,0 +1,190 @@
+import React, { useMemo, useRef, useState } from 'react'
+import type { TerminalConfig, ConfigGroup, ConfigSection } from '../../stores/configStore'
+import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/identity-colors'
+import { useResolvedTheme } from '../../hooks/useThemeController'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { CODEX_OFF_LAUNCH_REASON } from '../../hooks/useLaunchConfig'
+import { SessionTypeBadge, SshBadge } from './Badges'
+import {
+  ALL_CATEGORY_ID,
+  buildCategories,
+  completeQuery,
+  configsInCategory,
+  excludeRunning,
+  launchAllTargets,
+  makeNameLookup,
+  searchConfigs,
+} from './savedConfigsView'
+import {
+  RunningFootnote,
+  SavedConfigsEmpty,
+  SavedConfigsSearch,
+  useLaunchSelection,
+  useScrollSelectedIntoView,
+} from './SavedConfigsSearch'
+
+// The FIND + CATEGORIES view of the Saved Configs panel (#362, option C on the
+// canvas): a find box with inline completion on top, groups and sections as
+// filter chips instead of nested headers, and one flat list of rows beneath.
+// Running configs are not listed. Launch-all lives on the active group or
+// section chip. Type -> arrow -> Enter launches.
+
+interface Props {
+  configs: TerminalConfig[]
+  groups: ConfigGroup[]
+  sections: ConfigSection[]
+  runningIds: ReadonlySet<string>
+  onLaunch: (config: TerminalConfig) => void
+  onLaunchMany: (configs: TerminalConfig[]) => void
+  onEdit: (config: TerminalConfig) => void
+  onDelete: (config: TerminalConfig) => void
+  onContextMenu: (e: React.MouseEvent, configId: string) => void
+  focusRequest?: number
+}
+
+export default function SavedConfigsFind({ configs, groups, sections, runningIds, onLaunch, onLaunchMany, onEdit, onDelete, onContextMenu, focusRequest }: Props) {
+  const [query, setQuery] = useState('')
+  const [categoryId, setCategoryId] = useState(ALL_CATEGORY_ID)
+  const theme = useResolvedTheme()
+  const codexOff = useSettingsStore((s) => s.settings.codexEnabled === false)
+  const isBlocked = (c: TerminalConfig) => codexOff && c.provider === 'codex'
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const lookup = useMemo(() => makeNameLookup(groups, sections), [groups, sections])
+  const launchable = useMemo(() => excludeRunning(configs, runningIds), [configs, runningIds])
+  const categories = useMemo(() => buildCategories(launchable, groups, sections), [launchable, groups, sections])
+  // A chip can vanish under the selection (its last config started running, the
+  // group was deleted): fall back to All rather than filtering on a ghost.
+  const category = categories.find((c) => c.id === categoryId) ?? categories[0]
+  const inCategory = useMemo(() => configsInCategory(launchable, category, groups), [launchable, category, groups])
+  const visible = useMemo(() => searchConfigs(inCategory, query, lookup), [inCategory, query, lookup])
+  const completion = completeQuery(query, visible.map((c) => c.label))
+
+  const launch = (c: TerminalConfig) => { if (!isBlocked(c)) onLaunch(c) }
+  const sel = useLaunchSelection(visible, launch)
+  useScrollSelectedIntoView(listRef, sel.selected)
+
+  const launchAllCount = (category.kind === 'group' || category.kind === 'section')
+    ? launchAllTargets(visible, runningIds, isBlocked).length
+    : 0
+  const launchAll = () => {
+    const targets = launchAllTargets(visible, runningIds, isBlocked)
+    if (targets.length > 0) onLaunchMany(targets)
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0" data-ux-id="saved-configs-find">
+      <SavedConfigsSearch
+        value={query}
+        onChange={(v) => { setQuery(v); sel.setSelected(-1) }}
+        completion={completion}
+        onMove={sel.move}
+        onEnter={sel.enter}
+        focusRequest={focusRequest}
+        hint={query ? `${visible.length} of ${inCategory.length}` : undefined}
+      />
+      {categories.length > 1 && (
+        <div className="flex flex-wrap items-center gap-1 px-2 pb-1.5 shrink-0" role="group" aria-label="Filter by category" data-ux-id="saved-configs-categories">
+          {categories.map((cat) => {
+            const active = cat.id === category.id
+            return (
+              <button
+                key={cat.id}
+                type="button"
+                aria-pressed={active}
+                onClick={() => { setCategoryId(cat.id); sel.setSelected(-1) }}
+                className="rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-4 focus-ring transition-colors"
+                style={active
+                  ? { background: 'color-mix(in srgb, var(--brand) 16%, transparent)', borderColor: 'color-mix(in srgb, var(--brand) 60%, transparent)', color: 'var(--brand)' }
+                  : { borderColor: 'var(--border-subtle)', color: 'var(--text-secondary)' }}
+                data-ux-id="saved-configs-category"
+                data-category-kind={cat.kind}
+              >
+                {cat.label}
+                <span className="ml-1 font-medium opacity-80">{cat.count}</span>
+              </button>
+            )
+          })}
+          {launchAllCount > 1 && (
+            <button
+              type="button"
+              onClick={launchAll}
+              className="ml-auto rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-4 focus-ring"
+              style={{ borderColor: 'color-mix(in srgb, var(--status-success) 50%, transparent)', color: 'var(--status-success)' }}
+              title={`Launch every listed config in ${category.label} that is not already running`}
+              data-ux-id="saved-configs-launch-all"
+            >
+              Launch all {launchAllCount}
+            </button>
+          )}
+        </div>
+      )}
+      <div ref={listRef} role="listbox" aria-label="Saved configs" className="overflow-y-auto px-2 pb-2 flex-1 min-h-0">
+        <SavedConfigsEmpty total={configs.length} launchable={launchable.length} visible={visible.length} query={query} />
+        {visible.map((config, index) => {
+          const selected = index === sel.selected
+          const blocked = isBlocked(config)
+          const names = lookup(config)
+          const where = category.kind === 'group' ? names.sectionName : (names.groupName ?? names.sectionName)
+          const bar = resolveIdentityColor(config.identityColorKey ?? bucketLegacyColorToKey(config.color), theme)
+          return (
+            <div
+              key={config.id}
+              role="option"
+              aria-selected={selected}
+              aria-disabled={blocked || undefined}
+              data-ux-id="saved-config-row"
+              data-config-id={config.id}
+              tabIndex={-1}
+              onClick={() => launch(config)}
+              onMouseEnter={() => sel.setSelected(index)}
+              onContextMenu={(e) => onContextMenu(e, config.id)}
+              className={`group relative flex items-center gap-2 rounded-md pl-3 pr-2 h-[30px] transition-colors ${blocked ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+              style={{
+                background: selected ? 'color-mix(in srgb, var(--brand) 10%, var(--surface-raised))' : undefined,
+                boxShadow: selected ? 'inset 2px 0 0 var(--brand)' : undefined,
+                opacity: blocked ? 0.6 : 1,
+              }}
+              title={blocked ? CODEX_OFF_LAUNCH_REASON : config.label}
+            >
+              <span className="absolute left-0 top-[7px] bottom-[7px] w-[3px] rounded-r" style={{ background: bar }} aria-hidden />
+              {config.sessionType === 'ssh'
+                ? <SshBadge />
+                : <SessionTypeBadge kind={config.shellOnly ? 'shell' : config.provider === 'codex' ? 'codex' : 'claude'} />}
+              <span className="min-w-0 flex-1 truncate text-xs" style={{ color: 'var(--text-primary)' }}>
+                {config.label}
+                {where && <span className="ml-1.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>{where}</span>}
+                {blocked && <span className="ml-1.5 text-[9px]" style={{ color: 'var(--text-muted)' }}>Codex off</span>}
+              </span>
+              {config.pinned && (
+                <span className="text-blue shrink-0" aria-hidden title="Pinned">
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" /></svg>
+                </span>
+              )}
+              {/* Hover actions on a flat panel at the row's tail (the canvas's
+                  "same as A"). Stop propagation so edit/delete never also launch. */}
+              <span
+                className="absolute right-1.5 flex items-center gap-0.5 rounded pl-3 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity"
+                style={{ background: 'linear-gradient(to left, var(--surface-overlay) 70%, transparent)' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {!blocked && (
+                  <button type="button" onClick={() => launch(config)} className="p-1 rounded hover:bg-surface1 focus-ring" style={{ color: 'var(--status-success)' }} title="Launch">
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor"><polygon points="2,1 8,5 2,9" /></svg>
+                  </button>
+                )}
+                <button type="button" onClick={() => onEdit(config)} className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-text focus-ring" title="Edit">
+                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M8.5 1.5l2 2-7 7H1.5v-2z" /></svg>
+                </button>
+                <button type="button" onClick={() => onDelete(config)} className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-red focus-ring" title="Delete">
+                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="10" y2="10" /><line x1="10" y1="2" x2="2" y2="10" /></svg>
+                </button>
+              </span>
+            </div>
+          )
+        })}
+        <RunningFootnote hidden={configs.length - launchable.length} />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/sidebar/SavedConfigsSearch.tsx
+++ b/src/renderer/components/sidebar/SavedConfigsSearch.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useRef, useState } from 'react'
+import type { TerminalConfig } from '../../stores/configStore'
+import { stepIndex, type ConfigGlyph } from './savedConfigsView'
+
+// The pieces the cards view and the find view share (#362): the search box
+// with inline auto-complete, the arrow/Enter selection over a flat list, and
+// the type glyph drawn into an identity-colour swatch.
+
+// ---------------------------------------------------------------------------
+// Selection: type -> arrow -> Enter launches
+
+export interface LaunchSelection {
+  selected: number
+  setSelected: (i: number) => void
+  move: (delta: number) => void
+  /** Launch the selected item, or the first one when nothing is selected yet. */
+  enter: () => void
+}
+
+export function useLaunchSelection(flat: ReadonlyArray<TerminalConfig>, launch: (config: TerminalConfig) => void): LaunchSelection {
+  const [selected, setSelected] = useState(-1)
+  // The list can shrink under the selection (a config starts running, the
+  // query narrows): clamp rather than point past the end.
+  const clamped = selected >= flat.length ? flat.length - 1 : selected
+  return {
+    selected: clamped,
+    setSelected,
+    move: (delta) => setSelected(stepIndex(clamped, delta, flat.length)),
+    enter: () => {
+      const target = flat[clamped >= 0 ? clamped : 0]
+      if (target) launch(target)
+    },
+  }
+}
+
+/** Scrolls the selected row/card into view whenever the selection moves. */
+export function useScrollSelectedIntoView(container: React.RefObject<HTMLElement | null>, selected: number) {
+  useEffect(() => {
+    if (selected < 0) return
+    const el = container.current?.querySelector<HTMLElement>('[aria-selected="true"]')
+    el?.scrollIntoView?.({ block: 'nearest' })
+  }, [container, selected])
+}
+
+// ---------------------------------------------------------------------------
+// Search box with inline completion
+
+interface SearchProps {
+  value: string
+  onChange: (value: string) => void
+  /** Full completed text (typed prefix + tail), or null when nothing completes. */
+  completion: string | null
+  onMove: (delta: number) => void
+  onEnter: () => void
+  placeholder?: string
+  /** Bumped by the parent when the panel is opened deliberately; the box takes focus. */
+  focusRequest?: number
+  /** Announced count, e.g. "4 of 9". */
+  hint?: string
+}
+
+export function SavedConfigsSearch({ value, onChange, completion, onMove, onEnter, placeholder = 'Find a config...', focusRequest, hint }: SearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (focusRequest) inputRef.current?.focus()
+  }, [focusRequest])
+
+  const accept = () => { if (completion) onChange(completion) }
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); onMove(1); return }
+    if (e.key === 'ArrowUp') { e.preventDefault(); onMove(-1); return }
+    if (e.key === 'Enter') { e.preventDefault(); onEnter(); return }
+    if (e.key === 'Tab' && !e.shiftKey && completion) { e.preventDefault(); accept(); return }
+    if (e.key === 'ArrowRight' && completion) {
+      const el = e.currentTarget
+      if (el.selectionStart === value.length && el.selectionEnd === value.length) { e.preventDefault(); accept() }
+      return
+    }
+    if (e.key === 'Escape') {
+      if (value) { e.preventDefault(); onChange('') } else { e.currentTarget.blur() }
+    }
+  }
+
+  const tail = completion && completion.length > value.length ? completion.slice(value.length) : ''
+  return (
+    <div className="px-2 pt-2 pb-1 shrink-0">
+      <div
+        className="relative rounded border text-xs"
+        style={{ background: 'var(--surface-base)', borderColor: 'var(--border-subtle)' }}
+        data-ux-id="saved-configs-search"
+      >
+        {/* Ghost completion: the typed text invisibly, then the tail in muted
+            ink, in the SAME box and padding as the input so it sits exactly
+            under the caret. */}
+        <span aria-hidden className="absolute inset-0 px-2 py-1 whitespace-pre overflow-hidden pointer-events-none">
+          <span className="invisible">{value}</span>
+          <span data-ux-id="saved-configs-completion" style={{ color: 'var(--text-muted)' }}>{tail}</span>
+        </span>
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          aria-label="Find a saved config"
+          aria-autocomplete="inline"
+          autoComplete="off"
+          spellCheck={false}
+          className="relative w-full bg-transparent px-2 py-1 text-xs outline-none focus-ring placeholder:text-overlay0"
+          style={{ color: 'var(--text-primary)' }}
+        />
+        {hint && (
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] pointer-events-none" style={{ color: 'var(--text-muted)' }}>
+            {hint}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Glyph
+
+/** The type mark: Claude asterisk, Codex rosette, shell prompt, or SSH arrows. */
+export function ConfigGlyphIcon({ glyph, size = 12 }: { glyph: ConfigGlyph; size?: number }) {
+  const common = { width: size, height: size, viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', strokeWidth: 2.5, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const, 'aria-hidden': true }
+  switch (glyph) {
+    case 'codex':
+      return (
+        <svg {...common} strokeWidth={2}>
+          <path d="M12 2C9 2 6.5 4 6 7c-2.5 1-4 3.5-4 6.5C2 17 5 20 8.5 20c1.5 0 3-.5 4-1.5 1 1 2.5 1.5 4 1.5 3.5 0 6.5-3 6.5-6.5 0-3-1.5-5.5-4-6.5C18.5 4 15.5 2 12 2z" />
+          <path d="M12 8v8M8 12h8" />
+        </svg>
+      )
+    case 'shell':
+      return (
+        <svg {...common} strokeWidth={2.4}>
+          <polyline points="4 6 10 12 4 18" />
+          <rect x="12.5" y="14.5" width="8" height="4" rx="1" fill="currentColor" stroke="none" />
+        </svg>
+      )
+    case 'ssh':
+      return (
+        <svg {...common}>
+          <path d="M8 3v18M8 3L4 7M8 3l4 4M16 21V3M16 21l4-4M16 21l-4-4" />
+        </svg>
+      )
+    default:
+      return (
+        <svg {...common}>
+          <path d="M12 2v8.5M12 13.5V22M2 12h8.5M13.5 12H22M4.93 4.93l6.01 6.01M13.06 13.06l6.01 6.01M19.07 4.93l-6.01 6.01M10.94 13.06l-6.01 6.01" />
+        </svg>
+      )
+  }
+}
+
+/** The empty-list lines both views share. */
+export function SavedConfigsEmpty({ total, launchable, visible, query }: { total: number; launchable: number; visible: number; query: string }) {
+  if (total === 0) return null // the panel's own "No saved configs" message covers this
+  if (launchable === 0) {
+    return (
+      <div className="text-xs text-center py-4" style={{ color: 'var(--text-muted)' }} data-ux-id="saved-configs-all-running">
+        All {total} saved {total === 1 ? 'config is' : 'configs are'} running.
+      </div>
+    )
+  }
+  if (visible === 0) {
+    return (
+      <div className="text-xs text-center py-4" style={{ color: 'var(--text-muted)' }} data-ux-id="saved-configs-no-match">
+        Nothing matches {query ? `"${query}"` : 'this filter'}.
+      </div>
+    )
+  }
+  return null
+}
+
+/** "2 running, not listed" -- why the list is shorter than the header count. */
+export function RunningFootnote({ hidden }: { hidden: number }) {
+  if (hidden <= 0) return null
+  return (
+    <div className="px-2 pt-1.5 pb-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }} data-ux-id="saved-configs-running-note">
+      {hidden} running, not listed
+    </div>
+  )
+}

--- a/src/renderer/components/sidebar/savedConfigsView.ts
+++ b/src/renderer/components/sidebar/savedConfigsView.ts
@@ -1,0 +1,312 @@
+// Saved Configs panel — the pure half of the two alternative views (#362).
+//
+// The owner's decision (book item 40): build BOTH the "cards" view and the
+// "find + categories" view from the design-pass canvas, chosen in Settings;
+// both get a search box with auto-complete; both EXCLUDE configs whose
+// session is already running; launch-all stays for a group. The existing
+// hierarchical list stays the default, untouched.
+//
+// Everything that can be reasoned about without a DOM lives here so it can be
+// unit-tested flat: which configs are running, what a query matches, what the
+// inline completion says, how cards stack, what the category chips are, and
+// which configs a "launch all" may actually start.
+
+import type { TerminalConfig, ConfigGroup, ConfigSection } from '../../stores/configStore'
+import type { Session } from '../../stores/sessionStore'
+
+/** The three ways the panel can lay out saved configs. `list` is today's view. */
+export type SavedConfigsView = 'list' | 'cards' | 'find'
+
+export const SAVED_CONFIGS_VIEW_OPTIONS: ReadonlyArray<{ value: SavedConfigsView; label: string }> = [
+  { value: 'list', label: 'List -- sections and groups (default)' },
+  { value: 'cards', label: 'Cards -- one card per config, stacked by group' },
+  { value: 'find', label: 'Find -- search box with category chips' },
+]
+
+/** Absent or unknown (an older settings file, a hand edit) => the default list. */
+export function resolveSavedConfigsView(value: unknown): SavedConfigsView {
+  return value === 'cards' || value === 'find' ? value : 'list'
+}
+
+// ---------------------------------------------------------------------------
+// Running sessions
+
+/**
+ * Ids of the saved configs that currently have a live session. The Ask
+ * Conductor session is deliberately config-less (see sessionStore.Session.kind)
+ * and is skipped here too, so it can never hide a config.
+ */
+export function runningConfigIds(sessions: ReadonlyArray<Pick<Session, 'configId' | 'kind'>>): Set<string> {
+  const ids = new Set<string>()
+  for (const s of sessions) {
+    if (s.kind === 'ask') continue
+    if (s.configId) ids.add(s.configId)
+  }
+  return ids
+}
+
+/** The configs that may appear in a launch list: those without a running session. */
+export function excludeRunning<T extends { id: string }>(configs: ReadonlyArray<T>, running: ReadonlySet<string>): T[] {
+  return configs.filter((c) => !running.has(c.id))
+}
+
+// ---------------------------------------------------------------------------
+// Names and search
+
+export interface ConfigNames {
+  groupName?: string
+  /** The EFFECTIVE section: the group's section when grouped, else the config's own. */
+  sectionName?: string
+}
+
+/** A lookup from config to its (effective) group and section names. */
+export function makeNameLookup(
+  groups: ReadonlyArray<ConfigGroup>,
+  sections: ReadonlyArray<ConfigSection>,
+): (config: TerminalConfig) => ConfigNames {
+  const groupById = new Map(groups.map((g) => [g.id, g]))
+  const sectionById = new Map(sections.map((s) => [s.id, s]))
+  return (config) => {
+    const group = config.groupId ? groupById.get(config.groupId) : undefined
+    const sectionId = group ? group.sectionId : config.sectionId
+    const section = sectionId ? sectionById.get(sectionId) : undefined
+    return { groupName: group?.name, sectionName: section?.name }
+  }
+}
+
+/** The text a query is matched against: label, group, section, directory, SSH host. */
+export function configSearchFields(config: TerminalConfig, names: ConfigNames): string[] {
+  const fields = [config.label, names.groupName, names.sectionName, config.workingDirectory]
+  if (config.sshConfig) fields.push(config.sshConfig.host, `${config.sshConfig.username}@${config.sshConfig.host}`)
+  return fields.filter((f): f is string => !!f)
+}
+
+/**
+ * Every whitespace-separated token of the query must appear (case-insensitively)
+ * in at least one field. "work check" therefore finds "Checkout service" in the
+ * Work group, while a single unbroken substring still behaves as before.
+ */
+export function matchesQuery(config: TerminalConfig, query: string, names: ConfigNames): boolean {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return true
+  const fields = configSearchFields(config, names).map((f) => f.toLowerCase())
+  return tokens.every((t) => fields.some((f) => f.includes(t)))
+}
+
+export function searchConfigs(
+  configs: ReadonlyArray<TerminalConfig>,
+  query: string,
+  lookup: (config: TerminalConfig) => ConfigNames,
+): TerminalConfig[] {
+  if (!query.trim()) return [...configs]
+  return configs.filter((c) => matchesQuery(c, query, lookup(c)))
+}
+
+/**
+ * Inline auto-complete: the first label that begins with what was typed,
+ * returned with the TYPED prefix kept verbatim so the ghost text lines up under
+ * the caret regardless of case. `null` when nothing completes (empty query, no
+ * prefix match, or the typed text already IS the label).
+ */
+export function completeQuery(query: string, labels: ReadonlyArray<string>): string | null {
+  if (!query) return null
+  const q = query.toLowerCase()
+  for (const label of labels) {
+    if (label.length > query.length && label.toLowerCase().startsWith(q)) {
+      return query + label.slice(query.length)
+    }
+  }
+  return null
+}
+
+/** Arrow-key movement over a flat list: clamps at both ends, never wraps. */
+export function stepIndex(current: number, delta: number, length: number): number {
+  if (length <= 0) return -1
+  const base = current < 0 ? (delta > 0 ? -1 : length) : current
+  return Math.min(length - 1, Math.max(0, base + delta))
+}
+
+// ---------------------------------------------------------------------------
+// Describing a config in words (the second line on a card)
+
+export type ConfigGlyph = 'claude' | 'codex' | 'shell' | 'ssh'
+
+export interface ConfigDescription {
+  /** "Claude", "Codex", "Terminal only", "Claude over SSH", ... */
+  kind: string
+  /** Directory tail for local configs, user@host for SSH. */
+  where: string
+  /** Model / effort / command, when the config names one. */
+  detail?: string
+  glyph: ConfigGlyph
+}
+
+/** The last two path segments, so "F:\ccc-wt\46d46697" reads as "ccc-wt\46d46697". */
+export function shortPath(p: string): string {
+  const parts = p.split(/[\\/]+/).filter(Boolean)
+  if (parts.length <= 2) return parts.join('/') || p
+  const sep = p.includes('\\') ? '\\' : '/'
+  return parts.slice(-2).join(sep)
+}
+
+export function describeConfig(config: TerminalConfig): ConfigDescription {
+  const isSsh = config.sessionType === 'ssh'
+  const base = config.shellOnly ? 'Terminal only' : config.provider === 'codex' ? 'Codex' : 'Claude'
+  const kind = isSsh ? `${base} over SSH` : base
+  const where = isSsh && config.sshConfig
+    ? `${config.sshConfig.username}@${config.sshConfig.host}`
+    : shortPath(config.workingDirectory || '')
+  let detail: string | undefined
+  if (config.shellOnly) detail = config.terminalOptions?.command || undefined
+  else if (config.provider === 'codex') detail = config.codexOptions?.reasoningEffort || config.codexOptions?.model || undefined
+  else detail = config.claudeOptions?.effortLevel || config.claudeOptions?.model || config.effortLevel || config.model || undefined
+  const glyph: ConfigGlyph = isSsh ? 'ssh' : config.shellOnly ? 'shell' : config.provider === 'codex' ? 'codex' : 'claude'
+  return { kind, where, detail, glyph }
+}
+
+// ---------------------------------------------------------------------------
+// Cards: stacks
+
+export interface CardStack {
+  id: string
+  kind: 'pinned' | 'section' | 'group' | 'loose'
+  title: string
+  /** Shown once above the first stack of each section (groups inside it carry their own title). */
+  sectionTitle?: string
+  configs: TerminalConfig[]
+  /** Only group and section stacks launch-all, and only when there is more than one to launch. */
+  launchAll: boolean
+}
+
+/**
+ * Order: Pinned (pulled out of their groups, as on the canvas), then each
+ * section's groups and its loose configs, then unsectioned groups, then the
+ * loose ungrouped rest as "Ungrouped". Empty stacks are dropped. A stale
+ * groupId/sectionId (pointing at something deleted) counts as loose, which is
+ * how the list view renders it too.
+ */
+export function buildCardStacks(
+  configs: ReadonlyArray<TerminalConfig>,
+  groups: ReadonlyArray<ConfigGroup>,
+  sections: ReadonlyArray<ConfigSection>,
+): CardStack[] {
+  const stacks: CardStack[] = []
+  const groupById = new Map(groups.map((g) => [g.id, g]))
+  const sectionIds = new Set(sections.map((s) => s.id))
+  const pinned = configs.filter((c) => c.pinned)
+  const rest = configs.filter((c) => !c.pinned)
+  if (pinned.length > 0) stacks.push({ id: 'pinned', kind: 'pinned', title: 'Pinned', configs: pinned, launchAll: false })
+
+  const groupStack = (g: ConfigGroup, sectionTitle?: string): CardStack | null => {
+    const inGroup = rest.filter((c) => c.groupId === g.id)
+    if (inGroup.length === 0) return null
+    return { id: `group:${g.id}`, kind: 'group', title: g.name, sectionTitle, configs: inGroup, launchAll: inGroup.length > 1 }
+  }
+
+  for (const section of sections) {
+    let first = true
+    const take = (s: CardStack | null) => {
+      if (!s) return
+      if (first) { s.sectionTitle = section.name; first = false } else { delete s.sectionTitle }
+      stacks.push(s)
+    }
+    for (const g of groups.filter((g) => g.sectionId === section.id)) take(groupStack(g, section.name))
+    const loose = rest.filter((c) => !(c.groupId && groupById.has(c.groupId)) && c.sectionId === section.id)
+    if (loose.length > 0) take({ id: `section:${section.id}`, kind: 'section', title: section.name, configs: loose, launchAll: loose.length > 1 })
+  }
+
+  for (const g of groups.filter((g) => !g.sectionId || !sectionIds.has(g.sectionId))) {
+    const s = groupStack(g)
+    if (s) stacks.push(s)
+  }
+
+  const ungrouped = rest.filter((c) =>
+    !(c.groupId && groupById.has(c.groupId)) && !(c.sectionId && sectionIds.has(c.sectionId)),
+  )
+  if (ungrouped.length > 0) stacks.push({ id: 'loose', kind: 'loose', title: 'Ungrouped', configs: ungrouped, launchAll: false })
+  return stacks
+}
+
+// ---------------------------------------------------------------------------
+// Find: categories
+
+export interface Category {
+  id: string
+  kind: 'all' | 'pinned' | 'section' | 'group'
+  label: string
+  count: number
+}
+
+export const ALL_CATEGORY_ID = 'all'
+export const PINNED_CATEGORY_ID = 'pinned'
+
+/** The configs a category chip stands for. Sections include their groups' configs. */
+export function configsInCategory(
+  configs: ReadonlyArray<TerminalConfig>,
+  category: Pick<Category, 'id' | 'kind'>,
+  groups: ReadonlyArray<ConfigGroup>,
+): TerminalConfig[] {
+  switch (category.kind) {
+    case 'all': return [...configs]
+    case 'pinned': return configs.filter((c) => !!c.pinned)
+    case 'group': {
+      const gid = category.id.slice('group:'.length)
+      return configs.filter((c) => c.groupId === gid)
+    }
+    case 'section': {
+      const sid = category.id.slice('section:'.length)
+      const groupIds = new Set(groups.filter((g) => g.sectionId === sid).map((g) => g.id))
+      return configs.filter((c) => (c.groupId ? groupIds.has(c.groupId) : c.sectionId === sid))
+    }
+  }
+}
+
+/**
+ * Chips: All, Pinned (when any), then each section, then each group -- only
+ * those with at least one config in the list handed in, so counts agree with
+ * what the rows show (pass the already running-excluded set).
+ */
+export function buildCategories(
+  configs: ReadonlyArray<TerminalConfig>,
+  groups: ReadonlyArray<ConfigGroup>,
+  sections: ReadonlyArray<ConfigSection>,
+): Category[] {
+  const out: Category[] = [{ id: ALL_CATEGORY_ID, kind: 'all', label: 'All', count: configs.length }]
+  const pinned = configs.filter((c) => c.pinned).length
+  if (pinned > 0) out.push({ id: PINNED_CATEGORY_ID, kind: 'pinned', label: 'Pinned', count: pinned })
+  for (const s of sections) {
+    const cat: Category = { id: `section:${s.id}`, kind: 'section', label: s.name, count: 0 }
+    cat.count = configsInCategory(configs, cat, groups).length
+    if (cat.count > 0) out.push(cat)
+  }
+  for (const g of groups) {
+    const cat: Category = { id: `group:${g.id}`, kind: 'group', label: g.name, count: 0 }
+    cat.count = configsInCategory(configs, cat, groups).length
+    if (cat.count > 0) out.push(cat)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Launch all
+
+/**
+ * What "launch all" may start: the candidates minus anything already running
+ * and anything the caller says is blocked (the Codex master off). Running is
+ * re-checked here rather than trusted from the list, so a stack or chip built
+ * a moment ago can never double-launch a config that has since started.
+ */
+export function launchAllTargets<T extends { id: string }>(
+  candidates: ReadonlyArray<T>,
+  running: ReadonlySet<string>,
+  isBlocked: (config: T) => boolean = () => false,
+): T[] {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const c of candidates) {
+    if (seen.has(c.id) || running.has(c.id) || isBlocked(c)) continue
+    seen.add(c.id)
+    out.push(c)
+  }
+  return out
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -215,6 +215,12 @@ export interface AppSettings {
    *  an Ask session that is already open, because a display toggle must not
    *  destroy a running session. */
   showAskConductor: boolean
+  /** #362: how the sidebar's Saved Configs panel lays configs out. 'list' is
+   *  the sections-and-groups list that shipped first; 'cards' and 'find' are
+   *  the two views from the design pass (both search with auto-complete, both
+   *  hide running configs). Absent = 'list', so no existing install changes
+   *  shape on upgrade. */
+  savedConfigsView?: 'list' | 'cards' | 'find'
   // Agent Hub first-run "How it works" banner: true once the user dismisses it.
   // Optional/absent = not yet dismissed (banner shows).
   agentHubExplainerDismissed?: boolean

--- a/tests/unit/renderer/saved-configs-cards.test.tsx
+++ b/tests/unit/renderer/saved-configs-cards.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+/**
+ * Saved Configs -- the CARDS view (#362).
+ *
+ * Pins: running configs are not listed; launch-all on a stack never launches
+ * a running config (even one that started after the stack was built); the
+ * find box completes inline and type -> arrow -> Enter launches; a click on a
+ * card launches it; a Codex config is inert while Codex is off.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const SETTINGS: any = { settings: { theme: 'dark', codexEnabled: true } }
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const useSettingsStore: any = (sel: (s: any) => unknown) => sel(SETTINGS)
+  useSettingsStore.getState = () => SETTINGS
+  return { useSettingsStore }
+})
+
+const { default: SavedConfigsCards } = await import('../../../src/renderer/components/sidebar/SavedConfigsCards')
+type Props = React.ComponentProps<typeof SavedConfigsCards>
+
+const cfg = (id: string, over: Record<string, unknown> = {}) => ({
+  id, label: id, workingDirectory: `/w/${id}`, color: '', sessionType: 'local' as const, provider: 'claude' as const, identityColorKey: 'blue' as const, ...over,
+})
+const groups = [{ id: 'g1', name: 'Work' }]
+const configs: any[] = [
+  cfg('alpha', { groupId: 'g1' }),
+  cfg('beta', { groupId: 'g1' }),
+  cfg('gamma', { groupId: 'g1', provider: 'codex' }),
+  cfg('delta'),
+  cfg('Checkout', { pinned: true }),
+]
+
+let container: HTMLDivElement; let root: Root
+beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container); SETTINGS.settings.codexEnabled = true })
+afterEach(() => { act(() => root.unmount()); container.remove() })
+
+function render(over: Partial<Props> = {}) {
+  const props: Props = {
+    configs, groups, sections: [], runningIds: new Set(),
+    onLaunch: vi.fn(), onLaunchMany: vi.fn(), onContextMenu: vi.fn(),
+    ...over,
+  }
+  act(() => root.render(<SavedConfigsCards {...props} />))
+  return props
+}
+const cards = () => Array.from(container.querySelectorAll<HTMLElement>('[data-ux-id="saved-config-card"]'))
+const cardIds = () => cards().map((c) => c.dataset.configId)
+const input = () => container.querySelector<HTMLInputElement>('input[aria-label="Find a saved config"]')!
+const type = (text: string) => act(() => {
+  const el = input()
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(el, text)
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+})
+const key = (k: string) => act(() => { input().dispatchEvent(new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true })) })
+const click = (el: Element) => act(() => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+
+describe('SavedConfigsCards', () => {
+  it('lists every config as a card, pinned pulled out first, and never a running one', () => {
+    render({ runningIds: new Set(['beta']) })
+    expect(cardIds()).toEqual(['Checkout', 'alpha', 'gamma', 'delta'])
+    expect(container.querySelector('[data-ux-id="saved-configs-running-note"]')!.textContent).toContain('1 running')
+  })
+
+  it('says so when every config is running instead of rendering an empty list', () => {
+    render({ runningIds: new Set(configs.map((c) => c.id)) })
+    expect(cards()).toHaveLength(0)
+    expect(container.querySelector('[data-ux-id="saved-configs-all-running"]')).toBeTruthy()
+  })
+
+  it('launch-all on a stack launches only the configs that are not running', () => {
+    const p = render({ runningIds: new Set(['alpha']) })
+    const btn = container.querySelector<HTMLButtonElement>('[data-ux-id="saved-configs-launch-all"]')!
+    expect(btn).toBeTruthy()
+    click(btn)
+    expect(p.onLaunchMany).toHaveBeenCalledTimes(1)
+    const launched = (p.onLaunchMany as any).mock.calls[0][0].map((c: any) => c.id)
+    expect(launched).toEqual(['beta', 'gamma'])
+    expect(launched).not.toContain('alpha')
+  })
+
+  it('launch-all skips a Codex config while Codex is off', () => {
+    SETTINGS.settings.codexEnabled = false
+    const p = render()
+    click(container.querySelector('[data-ux-id="saved-configs-launch-all"]')!)
+    expect((p.onLaunchMany as any).mock.calls[0][0].map((c: any) => c.id)).toEqual(['alpha', 'beta'])
+  })
+
+  it('offers no launch-all on the pinned or ungrouped stacks', () => {
+    render()
+    const stacks = Array.from(container.querySelectorAll<HTMLElement>('[data-ux-id="saved-configs-stack"]'))
+    for (const s of stacks) {
+      const has = !!s.querySelector('[data-ux-id="saved-configs-launch-all"]')
+      expect(has).toBe(s.dataset.stackKind === 'group')
+    }
+  })
+
+  it('typing narrows the cards and shows the inline completion', () => {
+    render()
+    type('che')
+    expect(cardIds()).toEqual(['Checkout'])
+    expect(container.querySelector('[data-ux-id="saved-configs-completion"]')!.textContent).toBe('ckout')
+    key('Tab')
+    expect(input().value).toBe('checkout')
+  })
+
+  it('type -> arrow -> Enter launches the selected card', () => {
+    const p = render()
+    type('a')                       // alpha, beta, gamma, delta all contain "a"
+    key('ArrowDown'); key('ArrowDown')
+    const selected = container.querySelector<HTMLElement>('[aria-selected="true"]')!
+    expect(selected.dataset.configId).toBe('beta')
+    key('Enter')
+    expect(p.onLaunch).toHaveBeenCalledTimes(1)
+    expect((p.onLaunch as any).mock.calls[0][0].id).toBe('beta')
+  })
+
+  it('Enter with nothing selected launches the first match', () => {
+    const p = render()
+    type('del')
+    key('Enter')
+    expect((p.onLaunch as any).mock.calls[0][0].id).toBe('delta')
+  })
+
+  it('a click on a card launches it; a Codex card is inert while Codex is off', () => {
+    SETTINGS.settings.codexEnabled = false
+    const p = render()
+    click(cards().find((c) => c.dataset.configId === 'alpha')!)
+    click(cards().find((c) => c.dataset.configId === 'gamma')!)
+    expect((p.onLaunch as any).mock.calls.map((c: any[]) => c[0].id)).toEqual(['alpha'])
+    expect(cards().find((c) => c.dataset.configId === 'gamma')!.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('right-click hands the config to the context menu', () => {
+    const p = render()
+    act(() => { cards()[1].dispatchEvent(new MouseEvent('contextmenu', { bubbles: true })) })
+    expect(p.onContextMenu).toHaveBeenCalledWith(expect.anything(), 'alpha')
+  })
+})

--- a/tests/unit/renderer/saved-configs-find.test.tsx
+++ b/tests/unit/renderer/saved-configs-find.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+/**
+ * Saved Configs -- the FIND + CATEGORIES view (#362).
+ *
+ * Pins: chips for All / Pinned / sections / groups with counts over the
+ * launchable set; a chip filters the flat list; launch-all on a group chip
+ * never launches a running config; type -> arrow -> Enter launches; the hover
+ * edit/delete actions do not also launch the row; running configs are hidden.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const SETTINGS: any = { settings: { theme: 'dark', codexEnabled: true } }
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const useSettingsStore: any = (sel: (s: any) => unknown) => sel(SETTINGS)
+  useSettingsStore.getState = () => SETTINGS
+  return { useSettingsStore }
+})
+
+const { default: SavedConfigsFind } = await import('../../../src/renderer/components/sidebar/SavedConfigsFind')
+type Props = React.ComponentProps<typeof SavedConfigsFind>
+
+const cfg = (id: string, over: Record<string, unknown> = {}) => ({
+  id, label: id, workingDirectory: `/w/${id}`, color: '', sessionType: 'local' as const, provider: 'claude' as const, identityColorKey: 'blue' as const, ...over,
+})
+const groups = [{ id: 'g1', name: 'Work', sectionId: 's1' }, { id: 'g2', name: 'Personal' }]
+const sections = [{ id: 's1', name: 'Day job' }]
+const configs: any[] = [
+  cfg('alpha', { groupId: 'g1', pinned: true }),
+  cfg('beta', { groupId: 'g1' }),
+  cfg('gamma', { groupId: 'g1', provider: 'codex' }),
+  cfg('blog', { groupId: 'g2' }),
+  cfg('delta'),
+  cfg('notes', { sectionId: 's1' }),
+]
+
+let container: HTMLDivElement; let root: Root
+beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container); SETTINGS.settings.codexEnabled = true })
+afterEach(() => { act(() => root.unmount()); container.remove() })
+
+function render(over: Partial<Props> = {}) {
+  const props: Props = {
+    configs, groups, sections, runningIds: new Set(),
+    onLaunch: vi.fn(), onLaunchMany: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn(), onContextMenu: vi.fn(),
+    ...over,
+  }
+  act(() => root.render(<SavedConfigsFind {...props} />))
+  return props
+}
+const rows = () => Array.from(container.querySelectorAll<HTMLElement>('[data-ux-id="saved-config-row"]'))
+const rowIds = () => rows().map((r) => r.dataset.configId)
+const chips = () => Array.from(container.querySelectorAll<HTMLButtonElement>('[data-ux-id="saved-configs-category"]'))
+const chipByLabel = (label: string) => chips().find((c) => c.textContent!.startsWith(label))!
+const input = () => container.querySelector<HTMLInputElement>('input[aria-label="Find a saved config"]')!
+const type = (text: string) => act(() => {
+  const el = input()
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(el, text)
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+})
+const key = (k: string) => act(() => { input().dispatchEvent(new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true })) })
+const click = (el: Element) => act(() => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+
+describe('SavedConfigsFind', () => {
+  it('renders the chips with counts over the launchable set, and a flat list', () => {
+    render({ runningIds: new Set(['beta']) })
+    expect(chips().map((c) => c.textContent)).toEqual(['All5', 'Pinned1', 'Day job3', 'Work2', 'Personal1'])
+    expect(rowIds()).toEqual(['alpha', 'gamma', 'blog', 'delta', 'notes'])
+    expect(container.querySelector('[data-ux-id="saved-configs-running-note"]')!.textContent).toContain('1 running')
+  })
+
+  it('a chip filters the list; a section chip covers its groups and loose configs', () => {
+    render()
+    click(chipByLabel('Work'))
+    expect(rowIds()).toEqual(['alpha', 'beta', 'gamma'])
+    expect(chipByLabel('Work').getAttribute('aria-pressed')).toBe('true')
+    click(chipByLabel('Day job'))
+    expect(rowIds()).toEqual(['alpha', 'beta', 'gamma', 'notes'])
+    click(chipByLabel('Pinned'))
+    expect(rowIds()).toEqual(['alpha'])
+  })
+
+  it('shows launch-all only on a group/section chip and never launches a running config', () => {
+    const p = render({ runningIds: new Set(['alpha']) })
+    expect(container.querySelector('[data-ux-id="saved-configs-launch-all"]')).toBeNull() // All: no launch-all
+    click(chipByLabel('Work'))
+    const btn = container.querySelector<HTMLButtonElement>('[data-ux-id="saved-configs-launch-all"]')!
+    expect(btn.textContent).toBe('Launch all 2')
+    click(btn)
+    const launched = (p.onLaunchMany as any).mock.calls[0][0].map((c: any) => c.id)
+    expect(launched).toEqual(['beta', 'gamma'])
+    expect(launched).not.toContain('alpha')
+  })
+
+  it('launch-all skips a Codex config while Codex is off', () => {
+    SETTINGS.settings.codexEnabled = false
+    const p = render()
+    click(chipByLabel('Work'))
+    click(container.querySelector('[data-ux-id="saved-configs-launch-all"]')!)
+    expect((p.onLaunchMany as any).mock.calls[0][0].map((c: any) => c.id)).toEqual(['alpha', 'beta'])
+  })
+
+  it('type -> arrow -> Enter launches the selected row, with inline completion', () => {
+    const p = render()
+    type('bl')
+    expect(rowIds()).toEqual(['blog'])
+    expect(container.querySelector('[data-ux-id="saved-configs-completion"]')!.textContent).toBe('og')
+    type('ta')
+    expect(rowIds()).toEqual(['beta', 'delta'])
+    key('ArrowDown'); key('ArrowDown')
+    expect(container.querySelector<HTMLElement>('[aria-selected="true"]')!.dataset.configId).toBe('delta')
+    key('Enter')
+    expect((p.onLaunch as any).mock.calls[0][0].id).toBe('delta')
+  })
+
+  it('Enter with nothing selected launches the first match, and a chip resets the selection', () => {
+    const p = render()
+    click(chipByLabel('Personal'))
+    key('Enter')
+    expect((p.onLaunch as any).mock.calls[0][0].id).toBe('blog')
+  })
+
+  it('the hover edit and delete actions do not also launch the row', () => {
+    const p = render()
+    const row = rows()[0]
+    click(row.querySelector('[title="Edit"]')!)
+    click(row.querySelector('[title="Delete"]')!)
+    expect(p.onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'alpha' }))
+    expect(p.onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'alpha' }))
+    expect(p.onLaunch).not.toHaveBeenCalled()
+    click(row)
+    expect((p.onLaunch as any).mock.calls[0][0].id).toBe('alpha')
+  })
+
+  it('falls back to All when the active chip loses its last config to a running session', () => {
+    const p = render()
+    click(chipByLabel('Personal'))
+    expect(rowIds()).toEqual(['blog'])
+    act(() => root.render(<SavedConfigsFind {...p} runningIds={new Set(['blog'])} />))
+    expect(chipByLabel('All').getAttribute('aria-pressed')).toBe('true')
+    expect(rowIds()).toEqual(['alpha', 'beta', 'gamma', 'delta', 'notes'])
+  })
+
+  it('says "Nothing matches" for a query with no hits', () => {
+    render()
+    type('zzz')
+    expect(rows()).toHaveLength(0)
+    expect(container.querySelector('[data-ux-id="saved-configs-no-match"]')!.textContent).toContain('zzz')
+  })
+})

--- a/tests/unit/renderer/saved-configs-view-helpers.test.ts
+++ b/tests/unit/renderer/saved-configs-view-helpers.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Saved Configs panel (#362): the pure helpers behind the cards and the
+ * find + categories views. Running configs never appear in a launch list,
+ * launch-all never double-launches, the search matches every token, and the
+ * inline completion keeps the typed prefix verbatim.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  resolveSavedConfigsView,
+  runningConfigIds,
+  excludeRunning,
+  makeNameLookup,
+  matchesQuery,
+  searchConfigs,
+  completeQuery,
+  stepIndex,
+  shortPath,
+  describeConfig,
+  buildCardStacks,
+  buildCategories,
+  configsInCategory,
+  launchAllTargets,
+} from '../../../src/renderer/components/sidebar/savedConfigsView'
+import type { TerminalConfig, ConfigGroup, ConfigSection } from '../../../src/renderer/stores/configStore'
+
+const cfg = (id: string, over: Partial<TerminalConfig> = {}): TerminalConfig => ({
+  id,
+  label: id,
+  workingDirectory: `/home/nick/${id}`,
+  color: '',
+  sessionType: 'local',
+  provider: 'claude',
+  ...over,
+})
+
+const groups: ConfigGroup[] = [
+  { id: 'gWork', name: 'Work', sectionId: 'sDay' },
+  { id: 'gPersonal', name: 'Personal' },
+]
+const sections: ConfigSection[] = [{ id: 'sDay', name: 'Day job' }]
+
+const configs: TerminalConfig[] = [
+  cfg('conductor', { label: 'Conductor beta', pinned: true, groupId: 'gWork', claudeOptions: { effortLevel: 'xhigh' } }),
+  cfg('rune', { label: 'rune-dsl', pinned: true }),
+  cfg('checkout', { label: 'Checkout service', groupId: 'gWork' }),
+  cfg('billing', { label: 'Billing (Codex)', groupId: 'gWork', provider: 'codex', codexOptions: { model: 'gpt-5.5' } }),
+  cfg('buildbox', { label: 'build-box', groupId: 'gWork', sessionType: 'ssh', sshConfig: { host: 'build-box', port: 22, username: 'nick', remotePath: '~' } }),
+  cfg('blog', { label: 'Blog', groupId: 'gPersonal' }),
+  cfg('scratch', { label: 'Scratch shell', groupId: 'gPersonal', shellOnly: true, terminalOptions: { command: 'pwsh' } }),
+  cfg('pi', { label: 'pi-server', sessionType: 'ssh', sshConfig: { host: '10.0.0.12', port: 22, username: 'pi', remotePath: '~' } }),
+  cfg('notes', { label: 'Notes', sectionId: 'sDay' }),
+]
+
+describe('resolveSavedConfigsView', () => {
+  it('defaults to the list for absent or unknown values', () => {
+    expect(resolveSavedConfigsView(undefined)).toBe('list')
+    expect(resolveSavedConfigsView('grid')).toBe('list')
+    expect(resolveSavedConfigsView(3)).toBe('list')
+  })
+  it('round-trips the two new views', () => {
+    expect(resolveSavedConfigsView('cards')).toBe('cards')
+    expect(resolveSavedConfigsView('find')).toBe('find')
+  })
+})
+
+describe('running configs', () => {
+  it('collects the configIds of live sessions and skips the Ask session', () => {
+    const running = runningConfigIds([
+      { configId: 'checkout' },
+      { configId: 'blog', kind: undefined },
+      { configId: 'conductor', kind: 'ask' },
+      { configId: undefined },
+    ])
+    expect([...running].sort()).toEqual(['blog', 'checkout'])
+  })
+  it('excludeRunning drops exactly those', () => {
+    const running = new Set(['checkout', 'pi'])
+    expect(excludeRunning(configs, running).map((c) => c.id)).not.toContain('checkout')
+    expect(excludeRunning(configs, running).map((c) => c.id)).not.toContain('pi')
+    expect(excludeRunning(configs, running)).toHaveLength(configs.length - 2)
+  })
+})
+
+describe('search', () => {
+  const lookup = makeNameLookup(groups, sections)
+  it('matches label, group, effective section, directory and ssh host', () => {
+    expect(matchesQuery(configs[2], 'check', lookup(configs[2]))).toBe(true)
+    expect(matchesQuery(configs[2], 'work', lookup(configs[2]))).toBe(true)
+    expect(matchesQuery(configs[2], 'day job', lookup(configs[2]))).toBe(true) // group's section
+    expect(matchesQuery(configs[2], 'home/nick', lookup(configs[2]))).toBe(true)
+    expect(matchesQuery(configs[4], 'nick@build', lookup(configs[4]))).toBe(true)
+    expect(matchesQuery(configs[5], 'work', lookup(configs[5]))).toBe(false)
+  })
+  it('requires every token to match somewhere', () => {
+    expect(matchesQuery(configs[2], 'work check', lookup(configs[2]))).toBe(true)
+    expect(matchesQuery(configs[2], 'work zzz', lookup(configs[2]))).toBe(false)
+  })
+  it('an empty or blank query keeps everything', () => {
+    expect(searchConfigs(configs, '', lookup)).toHaveLength(configs.length)
+    expect(searchConfigs(configs, '   ', lookup)).toHaveLength(configs.length)
+  })
+  it('searchConfigs narrows to the matches in list order', () => {
+    expect(searchConfigs(configs, 'work', lookup).map((c) => c.id)).toEqual(['conductor', 'checkout', 'billing', 'buildbox'])
+    expect(searchConfigs(configs, 'blog', lookup).map((c) => c.id)).toEqual(['blog'])
+  })
+})
+
+describe('completeQuery (inline auto-complete)', () => {
+  const labels = configs.map((c) => c.label)
+  it('returns null for an empty query', () => {
+    expect(completeQuery('', labels)).toBeNull()
+  })
+  it('completes the first prefix match, keeping the typed casing', () => {
+    expect(completeQuery('che', labels)).toBe('checkout service')
+    expect(completeQuery('CHE', labels)).toBe('CHEckout service')
+  })
+  it('does not complete when nothing starts with the query, or it is already complete', () => {
+    expect(completeQuery('zzz', labels)).toBeNull()
+    expect(completeQuery('out', labels)).toBeNull() // substring, not prefix
+    expect(completeQuery('Blog', labels)).toBeNull()
+  })
+})
+
+describe('stepIndex', () => {
+  it('clamps at both ends and never wraps', () => {
+    expect(stepIndex(0, -1, 5)).toBe(0)
+    expect(stepIndex(4, 1, 5)).toBe(4)
+    expect(stepIndex(2, 1, 5)).toBe(3)
+  })
+  it('enters the list from nothing selected', () => {
+    expect(stepIndex(-1, 1, 5)).toBe(0)
+    expect(stepIndex(-1, -1, 5)).toBe(4)
+    expect(stepIndex(-1, 1, 0)).toBe(-1)
+  })
+})
+
+describe('describeConfig', () => {
+  it('names the kind, the place and the detail', () => {
+    expect(describeConfig(configs[0])).toEqual({ kind: 'Claude', where: 'nick/conductor', detail: 'xhigh', glyph: 'claude' })
+    expect(describeConfig(configs[3])).toEqual({ kind: 'Codex', where: 'nick/billing', detail: 'gpt-5.5', glyph: 'codex' })
+    expect(describeConfig(configs[4])).toEqual({ kind: 'Claude over SSH', where: 'nick@build-box', detail: undefined, glyph: 'ssh' })
+    expect(describeConfig(configs[6])).toEqual({ kind: 'Terminal only', where: 'nick/scratch', detail: 'pwsh', glyph: 'shell' })
+  })
+  it('shortPath keeps the last two segments and the native separator', () => {
+    expect(shortPath('F:\\ccc-wt\\46d46697')).toBe('ccc-wt\\46d46697')
+    expect(shortPath('/home/nick/blog')).toBe('nick/blog')
+    expect(shortPath('~/blog')).toBe('~/blog')
+    expect(shortPath('')).toBe('')
+  })
+})
+
+describe('buildCardStacks', () => {
+  it('pulls pinned out first, then sections (groups, then loose), unsectioned groups, then Ungrouped', () => {
+    const stacks = buildCardStacks(configs, groups, sections)
+    expect(stacks.map((s) => [s.kind, s.title, s.configs.map((c) => c.id)])).toEqual([
+      ['pinned', 'Pinned', ['conductor', 'rune']],
+      ['group', 'Work', ['checkout', 'billing', 'buildbox']],
+      ['section', 'Day job', ['notes']],
+      ['group', 'Personal', ['blog', 'scratch']],
+      ['loose', 'Ungrouped', ['pi']],
+    ])
+  })
+  it('titles the section once, on its first stack', () => {
+    const stacks = buildCardStacks(configs, groups, sections)
+    expect(stacks[1].sectionTitle).toBe('Day job')
+    expect(stacks[2].sectionTitle).toBeUndefined()
+    expect(stacks[3].sectionTitle).toBeUndefined()
+  })
+  it('offers launch-all only on group/section stacks with more than one config', () => {
+    const stacks = buildCardStacks(configs, groups, sections)
+    expect(stacks.find((s) => s.title === 'Work')!.launchAll).toBe(true)
+    expect(stacks.find((s) => s.title === 'Day job')!.launchAll).toBe(false) // one config
+    expect(stacks.find((s) => s.kind === 'pinned')!.launchAll).toBe(false)
+    expect(stacks.find((s) => s.kind === 'loose')!.launchAll).toBe(false)
+  })
+  it('drops empty stacks and treats a stale groupId as loose', () => {
+    const stale = [cfg('ghost', { groupId: 'gone' })]
+    expect(buildCardStacks(stale, groups, sections)).toEqual([
+      expect.objectContaining({ kind: 'loose', configs: stale }),
+    ])
+  })
+})
+
+describe('categories', () => {
+  it('builds All, Pinned, sections, groups with counts over the list handed in', () => {
+    const cats = buildCategories(configs, groups, sections)
+    expect(cats.map((c) => [c.label, c.count])).toEqual([
+      ['All', 9], ['Pinned', 2], ['Day job', 5], ['Work', 4], ['Personal', 2],
+    ])
+  })
+  it('omits Pinned and empty groups when the list has none of them', () => {
+    const none = configs.filter((c) => !c.pinned && c.groupId !== 'gPersonal')
+    expect(buildCategories(none, groups, sections).map((c) => c.label)).toEqual(['All', 'Day job', 'Work'])
+  })
+  it('a section chip covers its groups and its loose configs', () => {
+    const cat = buildCategories(configs, groups, sections).find((c) => c.label === 'Day job')!
+    expect(configsInCategory(configs, cat, groups).map((c) => c.id).sort()).toEqual(['billing', 'buildbox', 'checkout', 'conductor', 'notes'])
+  })
+})
+
+describe('launchAllTargets', () => {
+  it('never includes a running config, a blocked one, or a duplicate', () => {
+    const running = new Set(['checkout'])
+    const work = configs.filter((c) => c.groupId === 'gWork')
+    const targets = launchAllTargets([...work, work[0]], running, (c) => c.provider === 'codex')
+    expect(targets.map((c) => c.id)).toEqual(['conductor', 'buildbox'])
+  })
+  it('returns nothing when everything is running', () => {
+    expect(launchAllTargets(configs, new Set(configs.map((c) => c.id)))).toEqual([])
+  })
+})

--- a/tests/unit/renderer/settings-saved-configs-view.test.ts
+++ b/tests/unit/renderer/settings-saved-configs-view.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Settings -> General carries the ONE Saved Configs layout choice (#362) and
+ * writes it through the same `save` path as its neighbours, so it round-trips
+ * like every other setting. Source-level: SettingsPage needs the whole app
+ * shell to mount, and the behaviour under test is the wiring, not the markup.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { SAVED_CONFIGS_VIEW_OPTIONS } from '../../../src/renderer/components/sidebar/savedConfigsView'
+
+const src = readFileSync(resolve(__dirname, '../../../src/renderer/components/SettingsPage.tsx'), 'utf8')
+
+describe('Settings: Saved Configs layout', () => {
+  it('offers the three layouts from one list, list first', () => {
+    expect(SAVED_CONFIGS_VIEW_OPTIONS.map((o) => o.value)).toEqual(['list', 'cards', 'find'])
+    expect(src).toContain('SAVED_CONFIGS_VIEW_OPTIONS.map')
+  })
+  it('reads through resolveSavedConfigsView and saves savedConfigsView', () => {
+    expect(src).toMatch(/value=\{resolveSavedConfigsView\(settings\.savedConfigsView\)\}/)
+    expect(src).toMatch(/save\(\{ savedConfigsView: e\.target\.value as SavedConfigsView \}\)/)
+  })
+  it('sits in the General section next to the other sidebar settings', () => {
+    const ask = src.indexOf('Show Ask Conductor')
+    const select = src.indexOf('data-ux-id="settings-saved-configs-view"')
+    const security = src.indexOf('<Section title="Security"')
+    expect(ask).toBeGreaterThan(-1)
+    expect(select).toBeGreaterThan(ask)
+    expect(select).toBeLessThan(security)
+  })
+})

--- a/tests/unit/renderer/sidebar-saved-configs-view.test.tsx
+++ b/tests/unit/renderer/sidebar-saved-configs-view.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+/**
+ * Saved Configs panel -- the Settings choice actually switches the panel (#362).
+ *
+ * Absent setting => today's list (its own "Search configs..." box, no cards,
+ * no chips); 'cards' => the cards view; 'find' => the find view. And the
+ * running-session rule is wired: a config with a live session is not listed
+ * in either new view.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const settings: any = { configPanelPinned: true, theme: 'dark', keyboardShortcuts: undefined, codexEnabled: true }
+vi.mock('../../../src/renderer/stores/settingsStore', () => {
+  const STATE = { settings, updateSettings: () => {} }
+  const useSettingsStore: any = (sel: any) => sel(STATE)
+  useSettingsStore.getState = () => STATE
+  return { useSettingsStore }
+})
+const SESSIONS: any = { sessions: [] as any[], activeSessionId: null, setActiveSession: () => {}, removeSession: () => {}, addSession: () => {}, updateSession: () => {} }
+vi.mock('../../../src/renderer/stores/sessionStore', () => {
+  const useSessionStore: any = (sel?: any) => (sel ? sel(SESSIONS) : SESSIONS)
+  useSessionStore.getState = () => SESSIONS
+  return { useSessionStore }
+})
+const CONFIGS: any = {
+  configs: [
+    { id: 'c1', label: 'Alpha', workingDirectory: '/w/a', color: '', sessionType: 'local', provider: 'claude', identityColorKey: 'blue', groupId: 'g1' },
+    { id: 'c2', label: 'Beta', workingDirectory: '/w/b', color: '', sessionType: 'local', provider: 'claude', identityColorKey: 'blue', groupId: 'g1' },
+  ],
+  groups: [{ id: 'g1', name: 'Work' }],
+  sections: [],
+}
+vi.mock('../../../src/renderer/stores/configStore', () => {
+  ;['addConfig','updateConfig','removeConfig','addGroup','renameGroup','removeGroup','toggleGroupCollapsed','moveConfigToGroup','addSection','renameSection','removeSection','toggleSectionCollapsed','moveGroupToSection','moveConfigToSection','togglePinned','duplicateConfig','reorderConfigs'].forEach(k => CONFIGS[k] = () => {})
+  const useConfigStore: any = (sel?: any) => (sel ? sel(CONFIGS) : CONFIGS)
+  useConfigStore.getState = () => CONFIGS
+  return { useConfigStore }
+})
+vi.mock('../../../src/renderer/stores/insightsStore', () => ({ useInsightsStore: (sel: any) => sel({ status: null, statusMessage: null }) }))
+vi.mock('../../../src/renderer/stores/cloudAgentStore', () => ({ useCloudAgentStore: (sel: any) => sel({ agents: [] }) }))
+vi.mock('../../../src/renderer/stores/conductorMcpStore', () => ({ useConductorMcpStore: (sel: any) => sel({ browserRunning: false, serverRunning: true }) }))
+vi.mock('../../../src/renderer/stores/appMetaStore', () => ({ useAppMetaStore: (sel: any) => sel({ meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }) }))
+;(globalThis as any).window.electronAPI = { update: { check: () => Promise.resolve(false), onAvailable: () => () => {}, getVersion: () => Promise.resolve('') } }
+
+const { default: Sidebar } = await import('../../../src/renderer/components/Sidebar')
+
+describe('Sidebar: Saved Configs layout setting (#362)', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container); SESSIONS.sessions = []; delete settings.savedConfigsView })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+  const render = () => act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {} } as any)))
+  const legacySearch = () => container.querySelector('input[placeholder="Search configs..."]')
+
+  it('absent setting renders today\'s list untouched', () => {
+    render()
+    expect(legacySearch()).toBeTruthy()
+    expect(container.querySelector('[data-ux-id="saved-configs-cards"]')).toBeNull()
+    expect(container.querySelector('[data-ux-id="saved-configs-find"]')).toBeNull()
+  })
+
+  it('"cards" renders the cards view in place of the list', () => {
+    settings.savedConfigsView = 'cards'
+    render()
+    expect(legacySearch()).toBeNull()
+    expect(container.querySelector('[data-ux-id="saved-configs-cards"]')).toBeTruthy()
+    expect(container.querySelectorAll('[data-ux-id="saved-config-card"]')).toHaveLength(2)
+  })
+
+  it('"find" renders the find view in place of the list', () => {
+    settings.savedConfigsView = 'find'
+    render()
+    expect(legacySearch()).toBeNull()
+    expect(container.querySelector('[data-ux-id="saved-configs-find"]')).toBeTruthy()
+    expect(container.querySelectorAll('[data-ux-id="saved-config-row"]')).toHaveLength(2)
+  })
+
+  it('a config with a live session is not listed in the new views (the Ask session never counts)', () => {
+    settings.savedConfigsView = 'cards'
+    SESSIONS.sessions = [
+      { id: 's1', configId: 'c1', label: 'Alpha', status: 'idle', createdAt: 1, sessionType: 'local', workingDirectory: '/w/a', model: '', color: '' },
+      { id: 'ask', configId: 'c2', kind: 'ask', label: 'Ask', status: 'idle', createdAt: 1, sessionType: 'local', workingDirectory: '/w/b', model: '', color: '' },
+    ]
+    render()
+    const ids = Array.from(container.querySelectorAll<HTMLElement>('[data-ux-id="saved-config-card"]')).map((c) => c.dataset.configId)
+    expect(ids).toEqual(['c2'])
+  })
+
+  it('an unknown value falls back to the list', () => {
+    settings.savedConfigsView = 'grid'
+    render()
+    expect(legacySearch()).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What and why

#362 (book item 40): the owner decided to build BOTH the **cards** view and the **find + categories** view from the Saved Configs design-pass canvas, with a Settings option to choose. This PR does exactly that; the existing sections-and-groups list stays the default and is untouched.

- **Settings -> General -> "Saved Configs layout"**: one select (List / Cards / Find), next to the other sidebar settings. Absent = list, so no existing install changes shape.
- **Cards view**: one card per config -- identity colour as a swatch carrying the type glyph, a second line in words (Claude / Codex / Terminal only / ... over SSH, directory or user@host, model/effort), stacks per group with a count chip and **launch all**, pinned pulled out first, sections as a rule above their stacks.
- **Find + categories view**: a find box on top, groups/sections/Pinned as **filter chips** with counts, one flat list of rows (colour bar, type badge, group name inline), hover launch/edit/delete, **Launch all N** on the active group or section chip.
- **Both views**: search box with **inline auto-complete** (the first label that starts with what you typed is ghosted; Tab or right-arrow-at-end accepts), every token must match label/group/section/directory/host, and the same keyboard flow -- type, arrow, Enter launches (Enter with nothing selected launches the first match). Escape clears, then blurs.
- **Running sessions excluded**: both views never list a config with a live session (the Ask session never counts) and say "N running, not listed"; when every config is running they say so. Launch-all goes through `launchAllTargets`, which re-checks running and Codex-off at click time, so it can never double-launch.
- The find box takes focus only when the panel is opened deliberately (header click), never on hover, so a mouse passing over the sidebar cannot steal the keyboard from the terminal.

Pure helpers (`src/renderer/components/sidebar/savedConfigsView.ts`) hold every rule -- running ids, token search, completion, card stacks, category chips, launch-all targets -- so they are tested flat; the two components and the shared search box are thin over them.

Issue: #362

## How it was tested

- `tests/unit/renderer/saved-configs-view-helpers.test.ts` -- the pure helpers (24 tests).
- `tests/unit/renderer/saved-configs-cards.test.tsx` -- cards: running excluded, launch-all launches only non-running / non-Codex-off, inline completion + Tab accept, type -> arrow -> Enter, click launches, Codex-off card inert, context menu.
- `tests/unit/renderer/saved-configs-find.test.tsx` -- find: chips with counts, chip filtering (section covers its groups), Launch all on a chip never launches a running config, completion, keyboard, hover edit/delete do not launch, fallback to All when a chip empties, no-match message.
- `tests/unit/renderer/sidebar-saved-configs-view.test.tsx` -- the setting switches the panel body; absent/unknown = today's list; running ids wired through the Sidebar.
- `tests/unit/renderer/settings-saved-configs-view.test.ts` -- the Settings select is wired through `save` in General (source-level; SettingsPage needs the whole shell to mount).
- Full suite: `npx vitest run` -- **632 files passed, 2 skipped (634); 6593 tests passed, 15 skipped**.
- `npm run typecheck` -- clean.
- VM proof: **pending -- the conductor's integration pass**.

Not security-sensitive (renderer UI + a settings key; no IPC/preload/PTY/credential/MCP/updater/webPreferences changes). Changelog deliberately not touched (the conductor writes one consolidated entry).

## Not done / open questions for the owner

- **No "Recent" section** in the find view (option C on the canvas drew one). It needs a new persisted last-launched-per-config field; the decision named "find + categories", so it is left out rather than guessed. Say the word and it is a small follow-up.
- **The list view's own group/section launch-all still launches running configs** (unchanged). Only the two new views apply the running-excluded rule. Should the list view get it too?
- **Clicking a card or row launches it** (they are launchers, and the keyboard flow needs a single primary action). The list view's rows still launch only via the play button. Edit/delete live in the right-click menu (cards) and the hover actions + right-click menu (find).
- Running configs are hidden rather than shown greyed ("exclude or mark -- decide on the canvas"); the work package said excluded, so excluded, with the "N running, not listed" footnote as the explanation.
