### PR TITLE
feat(terminal): default the GPU renderer on, add a glyph-corruption capture (Ctrl+Alt+G)

### DIFF
--- a/CONTEXT.d/2026-08-22-glyph-capture-gpu-default.md
+++ b/CONTEXT.d/2026-08-22-glyph-capture-gpu-default.md
@@ -43,6 +43,25 @@ glyph fault the moment it appears, for a proper debug.
   write-only to a fixed location; the handler returns `{ok:false,error}` instead
   of throwing. Adversarial pass run for this change (ADR-009).
 
+### ADR-009 pass (Opus attackers, one round) — two majors fixed
+- **Default-on missed existing installs** (design lens): pre-#374 builds baked
+  `terminal.gpuRendering:false` into settings.json (migrateV2Font auto-persists
+  the terminal block), and the hydrate merge let that on-disk false win, so the
+  flip only reached NEW installs. Fixed with a one-time `migrateGpuDefaultOn`
+  (guard `gpuDefaultOnMigrated`) that turns an on-disk false ON once; a later
+  opt-out is respected. Owner-accepted caveat: a genuine experimental-era
+  opt-out is indistinguishable from the baked default, so both go on once.
+- **Size-cap bypass** (injection lens): the 256 KB cap was measured on the
+  COMPACT serialization but the file was written INDENTED, so a nested extra
+  field passed the cap and ballooned >1000x on write. Fixed by
+  `sanitizeGlyphDiagnosticPayload` — main rebuilds the payload from ONLY the
+  known fields (each flattened to a primitive, arrays capped) and bounds+writes
+  the SAME bytes; extra fields never reach disk.
+- Minors also fixed: IPC throttle (1.5 s min interval — a looping renderer can
+  no longer spam files/Explorer windows); `stamp()` gained milliseconds; the
+  Ctrl+Alt+G handler guards `AltGraph` so AltGr+G text entry is not swallowed on
+  international layouts. Re-verified: full suite green.
+
 ### Verification
 - `npm run typecheck` clean; full `npx vitest run` 7036 passed / 0 failed.
 - New tests: `gpu-rendering-default` (rewritten), `terminal-atlas-coordinator`

--- a/CONTEXT.d/2026-08-22-glyph-capture-gpu-default.md
+++ b/CONTEXT.d/2026-08-22-glyph-capture-gpu-default.md
@@ -1,0 +1,54 @@
+## 2026-08-22 -- GPU rendering default-on + in-app glyph-corruption capture (#374)
+
+Owner decision (2026-08-22): GPU (WebGL) terminal rendering ships **default-on**
+in beta.17, and both the owner and SSBN need a way to capture the shared-atlas
+glyph fault the moment it appears, for a proper debug.
+
+### Default-on
+- `DEFAULT_TERMINAL_SETTINGS.gpuRendering` is now `true`, and
+  `gpuRenderingEnabled` reads `ts?.gpuRendering !== false` (on unless the user
+  explicitly turned it off; absent / a corrupt non-boolean fall to ON). The
+  earlier opt-in reasoning (kept off because #312's refresh-the-others repair did
+  not hold) is superseded: the repair that works is already in
+  (`createAtlasResync` + `atlasCoordinator`, #311 -- a victim drops its OWN
+  render model first, the way a resize does, then repaints; and only the visible
+  terminal holds a WebGL context, 749d78dc). Settings copy rewritten.
+- The old `gpu-rendering-default` test pinned the opposite contract; rewritten to
+  pin default-on and `!== false`, and proven by revert (flipping the default back
+  and/or the predicate to `=== true` fails the unset/corrupt cases).
+
+### Capture
+- `atlasCoordinator` now keeps an always-on, bounded (300) event ring: every
+  `clear` (a terminal rebuilt the shared atlas), `resync` (frame-pass repair),
+  `catchup` (`resyncIfBehind` late repair), `miss` (a resync threw), and
+  register/unregister, each stamped with the terminal's session-id label and the
+  generation. `snapshot()` returns generation + per-terminal behind-ness + the
+  ring. Terminals register with their session id as the label
+  (`TerminalView.register(resync, sessionId)`). The source terminal is marked
+  current inside `notifyCleared` so a snapshot between the clear and the frame
+  does not misreport it as behind.
+- `Ctrl+Alt+G` (`captureGlyphDiagnostic` shortcut) assembles the ring + app
+  version + gpuRendering + GPU adapter (UNMASKED_RENDERER, best-effort) + active
+  session and sends it over `diagnostics:captureGlyph`. Main writes
+  `{resources}/glyph-diagnostics/glyph-<ts>.json` next to a full-window
+  `.png` (via `webContents.capturePage()`), then `shell.showItemInFolder` so the
+  files are ready to share. No network, no telemetry.
+
+### Security (IPC surface -- ADR-009)
+- New IPC `diagnostics:captureGlyph` (renderer -> main). The renderer is
+  untrusted: the payload is size-capped (`GLYPH_DIAGNOSTIC_MAX_BYTES` = 256 KB)
+  and shape-checked (`isGlyphDiagnosticPayload`) before any write, and the output
+  path is built ENTIRELY in main (fixed `glyph-diagnostics` dir + timestamp
+  name) -- nothing from the renderer reaches the filesystem path. Read-nothing,
+  write-only to a fixed location; the handler returns `{ok:false,error}` instead
+  of throwing. Adversarial pass run for this change (ADR-009).
+
+### Verification
+- `npm run typecheck` clean; full `npx vitest run` 7036 passed / 0 failed.
+- New tests: `gpu-rendering-default` (rewritten), `terminal-atlas-coordinator`
+  (event ring + snapshot), `glyph-diagnostic` (renderer assembly + capture),
+  `shared/glyph-diagnostic` (validator), `main/diagnostics-handlers` (writes
+  JSON+PNG to the fixed dir, downgrades to json-only on screenshot failure,
+  rejects bad shape / oversized without writing). Verify-by-revert done on the
+  default flip.
+- VM proof: pending the conductor's integration pass (real WebGL, 2+ sessions).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import { registerSetupHandlers, getResourcesDirectory, getDataDirectory } from '
 import { devSessionDataDir } from './data-paths'
 import { ensureHelpWorkspace } from './help-workspace'
 import { registerScreenshotHandlers } from './ipc/screenshot-handlers'
+import { registerDiagnosticsHandlers } from './ipc/diagnostics-handlers'
 import { registerWebviewHandlers } from './ipc/webview-handlers'
 import { closeAllWebviews } from './webview-manager'
 import { registerInsightsHandlers } from './ipc/insights-handlers'
@@ -959,6 +960,7 @@ if (!gotTheLock) {
     // external `claude -p` on a dead refresh token). Freshest-wins + email-guarded.
     try { const r = syncPrimaryCredentialsWithGlobal(); if (r !== 'none') logInfo(`[profiles] primary<->global credential sync at launch: ${r}`) } catch (e) { logInfo(`[profiles] credential sync skipped: ${e}`) }
     registerScreenshotHandlers(getWindow)
+    registerDiagnosticsHandlers(getWindow)
     registerWebviewHandlers(getWindow)
     registerInsightsHandlers(getWindow)
     registerNotesHandlers()

--- a/src/main/ipc/diagnostics-handlers.ts
+++ b/src/main/ipc/diagnostics-handlers.ts
@@ -1,0 +1,82 @@
+import { BrowserWindow, ipcMain, shell } from 'electron'
+import { join } from 'path'
+import { mkdirSync, writeFileSync } from 'fs'
+import { IPC } from '../../shared/ipc-channels'
+import { getResourcesDirectory } from './setup-handlers'
+import { logInfo, logWarn } from '../debug-logger'
+import {
+  GLYPH_DIAGNOSTIC_MAX_BYTES,
+  isGlyphDiagnosticPayload,
+  type GlyphDiagnosticResult,
+} from '../../shared/glyph-diagnostic'
+
+/** `glyph-YYYYMMDD-HHMMSS` — sortable, filesystem-safe, no separators to escape. */
+function stamp(): string {
+  return new Date()
+    .toISOString()
+    .replace(/T/, '-')
+    .replace(/:/g, '')
+    .replace(/\..*$/, '')
+}
+
+/**
+ * The glyph-corruption capture (#374). The renderer hands over the atlas event
+ * ring + environment; main writes it as JSON next to a full-window screenshot
+ * and reveals both in the file manager so the user can send them on.
+ *
+ * The renderer is untrusted: the payload is size-capped and shape-checked, and
+ * the output path is built ENTIRELY here (a fixed subdirectory + a timestamped
+ * name) — nothing from the renderer reaches the filesystem path. On any failure
+ * the handler returns `{ ok: false, error }` rather than throwing, so a capture
+ * attempt can never take the window down.
+ */
+export function registerDiagnosticsHandlers(getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle(IPC.DIAGNOSTICS_CAPTURE_GLYPH, async (_event, payload: unknown): Promise<GlyphDiagnosticResult> => {
+    try {
+      // Reject an oversized blob before parsing anything else.
+      let serialized: string
+      try {
+        serialized = JSON.stringify(payload)
+      } catch {
+        return { ok: false, error: 'payload not serializable' }
+      }
+      if (Buffer.byteLength(serialized, 'utf8') > GLYPH_DIAGNOSTIC_MAX_BYTES) {
+        return { ok: false, error: 'payload too large' }
+      }
+      if (!isGlyphDiagnosticPayload(payload)) {
+        return { ok: false, error: 'payload shape invalid' }
+      }
+
+      const dir = join(getResourcesDirectory(), 'glyph-diagnostics')
+      mkdirSync(dir, { recursive: true })
+      const base = `glyph-${stamp()}`
+      const jsonPath = join(dir, `${base}.json`)
+      writeFileSync(jsonPath, JSON.stringify(payload, null, 2), 'utf8')
+
+      // A full-window capture, saved beside the JSON. Best-effort: a diagnostic
+      // is still useful without the image (headless, capture unsupported), so a
+      // capture failure downgrades to json-only rather than failing the call.
+      let imagePath: string | undefined
+      const win = getWindow()
+      if (win && !win.isDestroyed()) {
+        try {
+          const image = await win.webContents.capturePage()
+          imagePath = join(dir, `${base}.png`)
+          writeFileSync(imagePath, image.toPNG())
+        } catch (err) {
+          logWarn('[diagnostics] glyph screenshot failed:', err instanceof Error ? err.message : String(err))
+          imagePath = undefined
+        }
+      }
+
+      // Reveal the newest artifact so the user lands on it, ready to share.
+      try { shell.showItemInFolder(imagePath ?? jsonPath) } catch { /* headless / no shell */ }
+      logInfo(`[diagnostics] glyph capture written: ${jsonPath}${imagePath ? ` (+ ${imagePath})` : ' (no screenshot)'}`)
+      return { ok: true, jsonPath, imagePath }
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      logWarn('[diagnostics] glyph capture failed:', error)
+      return { ok: false, error }
+    }
+  })
+}

--- a/src/main/ipc/diagnostics-handlers.ts
+++ b/src/main/ipc/diagnostics-handlers.ts
@@ -7,17 +7,25 @@ import { logInfo, logWarn } from '../debug-logger'
 import {
   GLYPH_DIAGNOSTIC_MAX_BYTES,
   isGlyphDiagnosticPayload,
+  sanitizeGlyphDiagnosticPayload,
   type GlyphDiagnosticResult,
 } from '../../shared/glyph-diagnostic'
 
-/** `glyph-YYYYMMDD-HHMMSS` — sortable, filesystem-safe, no separators to escape. */
+/** `glyph-YYYYMMDD-HHMMSS-mmm` — sortable, filesystem-safe, no separators to
+ *  escape. Milliseconds keep two captures in the same second from colliding. */
 function stamp(): string {
   return new Date()
     .toISOString()
     .replace(/T/, '-')
     .replace(/:/g, '')
-    .replace(/\..*$/, '')
+    .replace(/\.(\d{3})Z$/, '-$1')
 }
+
+/** Minimum gap between accepted captures. Bounds a compromised renderer that
+ *  loops the IPC (files written + Explorer windows opened); a person pressing
+ *  the shortcut never hits it. */
+const MIN_CAPTURE_INTERVAL_MS = 1500
+let lastCaptureAt = 0
 
 /**
  * The glyph-corruption capture (#374). The renderer hands over the atlas event
@@ -33,25 +41,37 @@ function stamp(): string {
 export function registerDiagnosticsHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle(IPC.DIAGNOSTICS_CAPTURE_GLYPH, async (_event, payload: unknown): Promise<GlyphDiagnosticResult> => {
     try {
-      // Reject an oversized blob before parsing anything else.
-      let serialized: string
-      try {
-        serialized = JSON.stringify(payload)
-      } catch {
-        return { ok: false, error: 'payload not serializable' }
+      // Throttle: a person pressing Ctrl+Shift+G never hits this, but a
+      // compromised renderer looping the IPC would otherwise spam files + open an
+      // Explorer window per call. Reject-fast, before any work.
+      const nowMs = Date.now()
+      if (nowMs - lastCaptureAt < MIN_CAPTURE_INTERVAL_MS) {
+        return { ok: false, error: 'rate limited' }
       }
-      if (Buffer.byteLength(serialized, 'utf8') > GLYPH_DIAGNOSTIC_MAX_BYTES) {
-        return { ok: false, error: 'payload too large' }
-      }
+
       if (!isGlyphDiagnosticPayload(payload)) {
         return { ok: false, error: 'payload shape invalid' }
       }
+      // Write ONLY the known fields — never the raw object. This drops any extra
+      // fields a compromised renderer attached, which both keeps unvetted content
+      // off disk AND removes the amplification carrier behind the size check: the
+      // bytes we bound are the exact bytes we write (indented), so a deeply nested
+      // extra field can no longer pass a compact-serialized cap and then balloon
+      // on the pretty-printed write (ADR-009 pass on #399).
+      const clean = sanitizeGlyphDiagnosticPayload(payload)
+      const out = JSON.stringify(clean, null, 2)
+      if (Buffer.byteLength(out, 'utf8') > GLYPH_DIAGNOSTIC_MAX_BYTES) {
+        return { ok: false, error: 'payload too large' }
+      }
+      // Only now commit to this capture — a rejected payload must not start the
+      // throttle window.
+      lastCaptureAt = nowMs
 
       const dir = join(getResourcesDirectory(), 'glyph-diagnostics')
       mkdirSync(dir, { recursive: true })
       const base = `glyph-${stamp()}`
       const jsonPath = join(dir, `${base}.json`)
-      writeFileSync(jsonPath, JSON.stringify(payload, null, 2), 'utf8')
+      writeFileSync(jsonPath, out, 'utf8')
 
       // A full-window capture, saved beside the JSON. Best-effort: a diagnostic
       // is still useful without the image (headless, capture unsupported), so a

--- a/src/main/ipc/diagnostics-handlers.ts
+++ b/src/main/ipc/diagnostics-handlers.ts
@@ -41,7 +41,7 @@ let lastCaptureAt = 0
 export function registerDiagnosticsHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle(IPC.DIAGNOSTICS_CAPTURE_GLYPH, async (_event, payload: unknown): Promise<GlyphDiagnosticResult> => {
     try {
-      // Throttle: a person pressing Ctrl+Shift+G never hits this, but a
+      // Throttle: a person pressing Ctrl+Alt+G never hits this, but a
       // compromised renderer looping the IPC would otherwise spam files + open an
       // Explorer window per call. Reject-fast, before any work.
       const nowMs = Date.now()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -293,6 +293,9 @@ export interface ElectronAPI {
     onSourceConfigured: (callback: (configured: boolean) => void) => () => void
     onServerConnected: (callback: (connected: boolean) => void) => () => void
   }
+  diagnostics: {
+    captureGlyph: (payload: unknown) => Promise<{ ok: boolean; jsonPath?: string; imagePath?: string; error?: string }>
+  }
   screenshot: {
     captureRectangle: () => Promise<string | null>
     captureWindow: (sourceId: string) => Promise<string | null>
@@ -873,6 +876,9 @@ const electronAPI: ElectronAPI = {
     isCliReady: () => ipcRenderer.invoke(IPC.SETUP_IS_CLI_READY),
     spawnCliSetup: (cols: number, rows: number) => ipcRenderer.invoke(IPC.SETUP_SPAWN_CLI_SETUP, cols, rows),
     killCliSetup: () => ipcRenderer.invoke(IPC.SETUP_KILL_CLI_SETUP),
+  },
+  diagnostics: {
+    captureGlyph: (payload: unknown) => ipcRenderer.invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, payload),
   },
   screenshot: {
     captureRectangle: () => ipcRenderer.invoke(IPC.SCREENSHOT_CAPTURE_RECTANGLE),

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -432,7 +432,7 @@ export default function SettingsPage({ initialTab, onNavigateToSessions, onUpdat
                   />
                   <span>
                     GPU rendering
-                    <span className="block text-[10px] text-overlay0">Draws terminals on the GPU, which is faster with several busy sessions. OFF by default and experimental. The GPU renderer shares one cache of character images across every open terminal, so when one session rebuilds that cache the others lose their text until you scroll, resize or switch to them. A fix was attempted and does not hold, so the setting stays opt-in. Turn it on only if you run a single session, or can live with that. Applies to terminals opened after the change.</span>
+                    <span className="block text-[10px] text-overlay0">Draws terminals on the GPU, which is faster with several busy sessions. ON by default. The GPU renderer shares one cache of character images across every open terminal; when one session rebuilds that cache, each other session now redraws its own view the way a window resize does, so the text no longer drops out. If you ever do see characters go missing while backgrounds stay, press Ctrl+Alt+G to save a diagnostic (an event log plus a screenshot) and send it over. Turn this off to fall back to the plain renderer. Applies to terminals opened after the change.</span>
                   </span>
                 </label>
                 <label className="flex items-start gap-2 text-sm text-subtext0 cursor-pointer mt-2">

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -319,7 +319,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     })
     webglHandleRef.current = handle
     const resync = atlasResyncRef.current
-    const unregister = resync ? atlasCoordinator.register(resync) : null
+    const unregister = resync ? atlasCoordinator.register(resync, sessionId) : null
 
     return () => {
       unregister?.()

--- a/src/renderer/components/terminal/atlasCoordinator.ts
+++ b/src/renderer/components/terminal/atlasCoordinator.ts
@@ -54,10 +54,43 @@
  *  shared texture atlas — see the header. */
 export type TerminalResync = () => void
 
+/**
+ * One entry in the atlas event ring (#374). The ring is always on and cheap so
+ * that when a user hits the glyph-capture shortcut the moment they see
+ * corruption, the SEQUENCE that produced it is already recorded — which
+ * terminal cleared the shared atlas, when, which others fell behind, and
+ * whether each was repaired or missed. `kind`:
+ *  - `clear`   a terminal rebuilt the shared atlas (the trigger for corruption)
+ *  - `resync`  the coalesced frame pass repaired a victim
+ *  - `catchup` `resyncIfBehind` repaired a terminal late (activation/focus/resize)
+ *  - `miss`    a resync threw — the terminal is still behind and drawing stale
+ *  - `register` / `unregister` a terminal joined or left the coordinator
+ */
+export interface AtlasEvent {
+  t: number
+  kind: 'clear' | 'resync' | 'catchup' | 'miss' | 'register' | 'unregister'
+  /** The terminal's label (its session id), or 'unknown' when unlabelled. */
+  label: string
+  /** Generation after the event. */
+  generation: number
+}
+
+/** A point-in-time view of the coordinator for a diagnostic bundle. */
+export interface AtlasDiagnosticSnapshot {
+  generation: number
+  liveCount: number
+  /** Every live terminal and how many generations behind the shared atlas it is
+   *  (0 = up to date; >0 = drawing against a rebuilt atlas until it resyncs). */
+  live: Array<{ label: string; generation: number; behind: number }>
+  /** The event ring, oldest first. */
+  events: AtlasEvent[]
+}
+
 export interface AtlasCoordinator {
-  /** Register a live terminal's resync callback. Returns an unregister fn to
+  /** Register a live terminal's resync callback, optionally labelled (its
+   *  session id) so the event ring is readable. Returns an unregister fn to
    *  call on teardown. */
-  register(resync: TerminalResync): () => void
+  register(resync: TerminalResync, label?: string): () => void
   /** Report that `source` just rebuilt the shared atlas. Bumps the generation
    *  and schedules a coalesced resync of every OTHER registered terminal on the
    *  next animation frame. */
@@ -73,13 +106,30 @@ export interface AtlasCoordinator {
    * registered late, threw mid-teardown, or was created after the clear.
    */
   resyncIfBehind(resync: TerminalResync): boolean
+  /** A snapshot of the current state + the event ring, for the glyph-capture
+   *  diagnostic (#374). Never throws. */
+  snapshot(): AtlasDiagnosticSnapshot
 }
+
+/** How many atlas events the always-on ring keeps. Enough to hold the run-up to
+ *  a corruption a user is about to capture, small enough to be free. */
+const ATLAS_EVENT_CAP = 300
 
 export function createAtlasCoordinator(
   raf: (cb: () => void) => number = (cb) => globalThis.requestAnimationFrame(cb),
+  now: () => number = () => Date.now(),
 ): AtlasCoordinator {
   /** Live terminals → the generation each last resynced against. */
   const live = new Map<TerminalResync, number>()
+  /** Live terminals → their label (session id), for the event ring. */
+  const labels = new Map<TerminalResync, string>()
+  /** Always-on event ring; oldest entries drop first. */
+  const events: AtlasEvent[] = []
+  const labelOf = (r: TerminalResync) => labels.get(r) ?? 'unknown'
+  const record = (kind: AtlasEvent['kind'], label: string) => {
+    events.push({ t: now(), kind, label, generation })
+    if (events.length > ATLAS_EVENT_CAP) events.shift()
+  }
   const clearedThisFrame = new Set<TerminalResync>()
   let generation = 0
   let armed = false
@@ -114,17 +164,21 @@ export function createAtlasCoordinator(
         live.set(resync, generation)
         continue
       }
-      run(resync)
+      record(run(resync) ? 'resync' : 'miss', labelOf(resync))
     }
   }
 
   return {
-    register(resync) {
+    register(resync, label) {
       // A terminal joining now has a model built against the CURRENT atlas, so
       // it starts current rather than owing a resync it does not need.
       live.set(resync, generation)
+      if (label) labels.set(resync, label)
+      record('register', labelOf(resync))
       return () => {
+        record('unregister', labelOf(resync))
         live.delete(resync)
+        labels.delete(resync)
         clearedThisFrame.delete(resync)
       }
     },
@@ -133,7 +187,14 @@ export function createAtlasCoordinator(
       // or not the frame below ever runs. That is what makes resyncIfBehind a
       // real backstop instead of a second copy of the same optimism.
       generation++
+      // The source's own model was rebuilt by the clearTextureAtlas() that
+      // triggered this, so it is current as of the new generation — record that
+      // now, not only when the frame flush reaches it, so a snapshot taken
+      // between the clear and the frame does not misreport the one terminal that
+      // was never broken as behind.
+      if (live.has(source)) live.set(source, generation)
       clearedThisFrame.add(source)
+      record('clear', labelOf(source))
       if (!armed) {
         armed = true
         // If scheduling itself fails, DISARM. `armed` is the only thing that
@@ -164,7 +225,21 @@ export function createAtlasCoordinator(
       // model here to reason about, and resyncing one would be a repaint with
       // no owner.
       if (at === undefined || at >= generation) return false
-      return run(resync)
+      const ok = run(resync)
+      record(ok ? 'catchup' : 'miss', labelOf(resync))
+      return ok
+    },
+    snapshot() {
+      return {
+        generation,
+        liveCount: live.size,
+        live: [...live.entries()].map(([resync, at]) => ({
+          label: labelOf(resync),
+          generation: at,
+          behind: Math.max(0, generation - at),
+        })),
+        events: [...events],
+      }
     },
   }
 }

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { requestCloseSession } from '../stores/sshCloseStore'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
+import { captureGlyphDiagnostic } from '../utils/glyphDiagnostic'
 import { sendImageToSession } from '../utils/imageTransfer'
 import { usePasteHintStore } from '../stores/pasteHintStore'
 import { useAppMetaStore } from '../stores/appMetaStore'
@@ -76,6 +77,14 @@ export function useKeyboardShortcuts(
       if (matchesShortcut(e, shortcuts.toggleSidebar)) {
         e.preventDefault()
         setSidebarOpen(prev => !prev)
+      }
+      // Capture a glyph-corruption diagnostic (#374): the moment a user sees
+      // characters go missing while backgrounds stay, this saves the always-on
+      // atlas event ring + a window screenshot and reveals them to share. Fixed
+      // action, not per-session, so it fires whatever the active view.
+      if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic)) {
+        e.preventDefault()
+        void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
       }
       // NOTE: rename (F2) is handled in Sidebar so it edits the active session
       // in the Active Sessions list (only when the sidebar is visible), not the

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -82,7 +82,10 @@ export function useKeyboardShortcuts(
       // characters go missing while backgrounds stay, this saves the always-on
       // atlas event ring + a window screenshot and reveals them to share. Fixed
       // action, not per-session, so it fires whatever the active view.
-      if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic)) {
+      // Guard AltGraph: on international layouts AltGr reports ctrlKey && altKey,
+      // so a bare Ctrl+Alt+<key> binding would swallow AltGr text entry into the
+      // terminal. Skip when AltGr is really down (#399 ADR-009 pass).
+      if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
         e.preventDefault()
         void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
       }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -99,26 +99,24 @@ export interface TerminalSettings {
   cursorBlink: boolean
   background?: string   // optional user terminal-background override; undefined => --surface-stage token
   /**
-   * GPU (WebGL) rendering for terminals. **Opt-IN** — absent or false means the
-   * DOM renderer, which is what ships. Read it through `gpuRenderingEnabled`,
-   * never by comparing directly.
+   * GPU (WebGL) rendering for terminals. **Default ON** (owner decision
+   * 2026-08-22, #374) — absent means on; only an explicit `false` opts out.
+   * Read it through `gpuRenderingEnabled`, never by comparing directly.
    *
-   * The fault: `@xterm/addon-webgl` keeps ONE glyph atlas per process (a
-   * module-level `charAtlasCache`, keyed on font + colours, which every CCC
-   * terminal matches). `clearTextureAtlas()` wipes that shared atlas for EVERY
-   * terminal but rebuilds only the caller's render model, and `term.refresh()`
-   * cannot undo it for the others because the renderer skips cells whose
-   * contents have not changed. So one session repainting blanks the glyphs of
-   * every other open session — backgrounds intact, text gone — until that
-   * terminal is resized, scrolled, or activated. That is the real #273,
-   * misdiagnosed for months as "the atlas goes stale on its own".
+   * The fault it once had: `@xterm/addon-webgl` keeps ONE glyph atlas per
+   * process, so one terminal's `clearTextureAtlas()` blanked the glyphs of every
+   * other open session — backgrounds intact, text gone — until that terminal was
+   * resized/scrolled/activated. The repair that works is in (#311): a victim
+   * drops its OWN render model first (a same-value theme reassignment, which is
+   * what a resize does) and only then repaints, coordinated process-wide by
+   * `atlasCoordinator` with a generation counter and an activation backstop; and
+   * only the visible terminal holds a WebGL context. The earlier #312 attempt
+   * (refresh the others, nothing more) did NOT hold and is gone.
    *
-   * #312 attempted a repair (a process-wide coordinator that refreshes the other
-   * terminals) and it does NOT hold: refresh alone cannot rebuild a victim's
-   * model, so the victim redraws blank. It was briefly default-on on the
-   * strength of that repair, entirely within beta.16's unreleased development
-   * window, and is opt-in again. See `gpuRenderingEnabled` for the disproof and
-   * for the repair that does work. Applies to terminals opened after the change.
+   * Now default-on, with an always-on atlas event ring and a user-triggered
+   * glyph-capture (Ctrl+Alt+G, #374) so any residual corruption in the field can
+   * be captured the moment it happens. Applies to terminals opened after a
+   * change to the setting.
    */
   gpuRendering?: boolean
 }
@@ -126,27 +124,22 @@ export interface TerminalSettings {
 /**
  * Whether a terminal should render through WebGL.
  *
- * OPT-IN: only an explicit, literal `true` enables it. Absent, false, or any
- * non-boolean value a corrupt config might hold means the DOM renderer.
+ * **Default ON** (owner decision 2026-08-22, #374): on unless the user has
+ * explicitly turned it off, so absent / a corrupt non-boolean both mean ON.
+ * `false` — and only `false` — is the opt-out. Every reader goes through this
+ * predicate rather than comparing the field itself: two call sites each spelling
+ * their own check is how "unset" comes to mean one thing in the terminal and the
+ * opposite in the settings checkbox.
  *
- * It was briefly flipped to default-on during beta.16's development, on the
- * basis that #312 had repaired the shared-atlas fault. An adversarial pass
- * disproved that. The coordinator repairs a victim terminal with
- * `term.refresh()`, and refresh alone cannot undo a foreign atlas wipe:
- * `WebglRenderer._updateModel` skips every cell whose contents have not changed
- * (`// Nothing has changed, no updates needed`), so the victim redraws stale
- * vertices against an emptied texture and goes BLANK. Only the terminal that
- * called `clearTextureAtlas()` gets `_clearModel(true)`; the others get nothing
- * that would rebuild their model. Measured in a real WebGL renderer, the
- * victim's ink pixels drop to zero the moment the coordinator's refresh lands.
- *
- * So this stays opt-in until a repair is proven on a real GPU. Every reader goes
- * through this predicate rather than comparing the field itself: two call sites
- * each spelling their own check is how "unset" comes to mean one thing in the
- * terminal and the opposite in the settings checkbox.
+ * It is safe to default on because the shared-atlas corruption is repaired the
+ * way a resize repairs it — the victim drops its OWN render model first, then
+ * repaints (see `atlasCoordinator` / `createAtlasResync`) — not by the #312
+ * refresh-the-others attempt that an adversarial pass disproved. The always-on
+ * atlas event ring + the Ctrl+Alt+G glyph-capture exist to catch any residual in
+ * the field.
  */
 export function gpuRenderingEnabled(ts: Pick<TerminalSettings, 'gpuRendering'> | undefined): boolean {
-  return ts?.gpuRendering === true
+  return ts?.gpuRendering !== false
 }
 
 export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
@@ -156,7 +149,7 @@ export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   lineHeight: 1.2,
   cursorStyle: 'bar',
   cursorBlink: true,
-  gpuRendering: false,
+  gpuRendering: true,
 }
 
 export interface AppSettings {

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -222,6 +222,7 @@ export interface AppSettings {
   theme: ThemeMode
   tokenomicsAccountFilter?: string  // 'all' | '__mixed__' | '__unknown__' | <email>
   fontMigratedV2?: boolean  // one-time guard: existing installs moved off the old Cascadia Code/14 default
+  gpuDefaultOnMigrated?: boolean  // one-time guard (#374): existing installs that had GPU rendering off (incl. the value auto-persisted while it was opt-in) moved to the new default-on
   identityColorMigratedV2?: boolean      // one-time guard: saved-config colours migrated to identity keys
   colourMigrationNoticePending?: boolean // a colour migration changed records and the notice should show
   colourMigrationNoticeDismissed?: boolean
@@ -375,6 +376,23 @@ export function migrateV2Font(settings: AppSettings): { settings: AppSettings; c
   }
 }
 
+// #374: GPU rendering flipped from opt-in to default-on. Existing installs carry
+// `terminal.gpuRendering: false` on disk — either a genuine experimental-era
+// opt-out OR the value migrateV2Font auto-persisted while it was opt-in — and the
+// hydrate merge lets that on-disk false override the new `true` default, so the
+// flip would miss every upgraded user. Turn it on exactly ONCE, guarded by
+// gpuDefaultOnMigrated: an on-disk false becomes true so the default applies.
+// A user who unticks it AFTER this has fired is respected (the guard has already
+// set). Caveat accepted (owner, 2026-08-22): a genuine opt-out is
+// indistinguishable from the baked default, so both are moved to on once; the
+// owner's call is that GPU rendering is on for everyone now.
+export function migrateGpuDefaultOn(settings: AppSettings): { settings: AppSettings; changed: boolean } {
+  if (settings.gpuDefaultOnMigrated) return { settings, changed: false }
+  const terminal = { ...settings.terminal }
+  if (terminal.gpuRendering === false) terminal.gpuRendering = true
+  return { settings: { ...settings, terminal, gpuDefaultOnMigrated: true }, changed: true }
+}
+
 export const useSettingsStore = create<SettingsState>((set) => ({
   settings: { ...DEFAULT_SETTINGS },
   isLoaded: false,
@@ -390,9 +408,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       conductorTools: { ...DEFAULT_CONDUCTOR_TOOLS, ...(settings.conductorTools || {}) },
       typography: migrateTypography(settings),
     }
-    const { settings: migrated, changed } = migrateV2Font(merged)
-    if (changed) {
-      // Persist the one-time migration (including the guard flag) so it runs once.
+    const font = migrateV2Font(merged)
+    const gpu = migrateGpuDefaultOn(font.settings)
+    const migrated = gpu.settings
+    if (font.changed || gpu.changed) {
+      // Persist the one-time migrations (including their guard flags) so they run once.
       saveConfigNow('settings', migrated).catch(() => {})
     }
     set({ settings: migrated, isLoaded: true })

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -413,6 +413,9 @@ export interface ElectronAPI {
     spawnCliSetup: (cols: number, rows: number) => Promise<string>
     killCliSetup: () => Promise<boolean>
   }
+  diagnostics: {
+    captureGlyph: (payload: unknown) => Promise<{ ok: boolean; jsonPath?: string; imagePath?: string; error?: string }>
+  }
   screenshot: {
     captureRectangle: () => Promise<string | null>
     captureWindow: (sourceId: string) => Promise<string | null>

--- a/src/renderer/utils/glyphDiagnostic.ts
+++ b/src/renderer/utils/glyphDiagnostic.ts
@@ -1,0 +1,68 @@
+import { atlasCoordinator } from '../components/terminal/atlasCoordinator'
+import { useSettingsStore } from '../stores/settingsStore'
+import { gpuRenderingEnabled, DEFAULT_TERMINAL_SETTINGS } from '../stores/settingsStore'
+import type { GlyphDiagnosticPayload, GlyphDiagnosticResult } from '../../shared/glyph-diagnostic'
+
+declare const __APP_VERSION__: string
+
+/**
+ * The WebGL adapter string (UNMASKED_RENDERER), or null. A throwaway context —
+ * the debug-renderer-info extension is the only portable way to name the GPU,
+ * and it is exactly what a glyph report needs (a driver/GPU that misbehaves).
+ * Never throws; a blocked extension or no-WebGL environment yields null.
+ */
+export function readGpuAdapter(): string | null {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    if (!gl || !(gl instanceof WebGLRenderingContext)) return null
+    const ext = gl.getExtension('WEBGL_debug_renderer_info')
+    const adapter = ext ? (gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) as string) : null
+    const lose = gl.getExtension('WEBGL_lose_context')
+    lose?.loseContext()
+    return adapter || null
+  } catch {
+    return null
+  }
+}
+
+/** Assemble the diagnostic bundle from the always-on atlas ring + environment. */
+export function buildGlyphDiagnostic(activeSessionId: string | null, now: () => number = () => Date.now()): GlyphDiagnosticPayload {
+  const ts = useSettingsStore.getState().settings.terminal || DEFAULT_TERMINAL_SETTINGS
+  const atlas = atlasCoordinator.snapshot()
+  return {
+    capturedAt: new Date(now()).toISOString(),
+    appVersion: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'unknown',
+    gpuRendering: gpuRenderingEnabled(ts),
+    gpuAdapter: readGpuAdapter(),
+    activeSessionId,
+    terminalCount: atlas.liveCount,
+    atlas,
+  }
+}
+
+/**
+ * Capture a glyph-corruption diagnostic: gather the atlas event ring + the
+ * environment and hand it to main, which writes it next to a screenshot and
+ * reveals both. Returns main's result (or an error shape); never throws, so a
+ * keybinding handler can call it bare.
+ */
+export async function captureGlyphDiagnostic(activeSessionId: string | null): Promise<GlyphDiagnosticResult> {
+  try {
+    const payload = buildGlyphDiagnostic(activeSessionId)
+    const api = window.electronAPI?.diagnostics
+    if (!api?.captureGlyph) return { ok: false, error: 'diagnostics API unavailable' }
+    const result = await api.captureGlyph(payload)
+    if (result?.ok) {
+      // eslint-disable-next-line no-console
+      console.info(`[glyph-capture] saved: ${result.jsonPath}${result.imagePath ? ` (+ ${result.imagePath})` : ''}`)
+    } else {
+      console.warn(`[glyph-capture] failed: ${result?.error ?? 'unknown'}`)
+    }
+    return result ?? { ok: false, error: 'no result' }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    console.warn(`[glyph-capture] error: ${error}`)
+    return { ok: false, error }
+  }
+}

--- a/src/renderer/utils/shortcuts.ts
+++ b/src/renderer/utils/shortcuts.ts
@@ -50,6 +50,7 @@ export const DEFAULT_SHORTCUTS: Record<string, string> = {
   toggleSidebar: 'Ctrl+B',
   pasteImage: 'Alt+V',
   renameSession: 'F2',
+  captureGlyphDiagnostic: 'Ctrl+Alt+G',
 }
 
 /** Human-readable labels for shortcut actions */
@@ -61,4 +62,5 @@ export const SHORTCUT_LABELS: Record<string, string> = {
   toggleSidebar: 'Toggle sidebar',
   pasteImage: 'Paste clipboard image',
   renameSession: 'Rename session',
+  captureGlyphDiagnostic: 'Capture glyph diagnostic',
 }

--- a/src/shared/glyph-diagnostic.ts
+++ b/src/shared/glyph-diagnostic.ts
@@ -50,6 +50,44 @@ export interface GlyphDiagnosticResult {
  *  cap is a guard against a compromised renderer sending an unbounded blob. */
 export const GLYPH_DIAGNOSTIC_MAX_BYTES = 256 * 1024
 
+/** How many atlas events / live-terminal rows the sanitized bundle keeps. The
+ *  ring is capped at 300 in the coordinator; these bound what a compromised
+ *  renderer can send regardless. */
+const SANITIZE_EVENT_CAP = 500
+const SANITIZE_LIVE_CAP = 200
+
+/**
+ * Rebuild a payload from ONLY the known fields, with each nested value coerced
+ * to a primitive. Main writes THIS, never the raw object: extra fields a
+ * compromised renderer attached never reach disk, and — because every value is
+ * a scalar and the arrays are capped — a deeply nested field cannot pass a
+ * size check and then balloon when the file is pretty-printed. Call only after
+ * `isGlyphDiagnosticPayload` has passed.
+ */
+export function sanitizeGlyphDiagnosticPayload(p: GlyphDiagnosticPayload): GlyphDiagnosticPayload {
+  const str = (v: unknown, max = 512): string => (typeof v === 'string' ? v.slice(0, max) : String(v ?? '').slice(0, max))
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+  return {
+    capturedAt: str(p.capturedAt, 64),
+    appVersion: str(p.appVersion, 64),
+    gpuRendering: p.gpuRendering === true,
+    gpuAdapter: p.gpuAdapter === null ? null : str(p.gpuAdapter),
+    activeSessionId: p.activeSessionId === null ? null : str(p.activeSessionId, 128),
+    terminalCount: num(p.terminalCount),
+    atlas: {
+      generation: num(p.atlas?.generation),
+      liveCount: num(p.atlas?.liveCount),
+      live: (Array.isArray(p.atlas?.live) ? p.atlas.live : []).slice(0, SANITIZE_LIVE_CAP).map((l) => ({
+        label: str(l?.label, 128), generation: num(l?.generation), behind: num(l?.behind),
+      })),
+      events: (Array.isArray(p.atlas?.events) ? p.atlas.events : []).slice(0, SANITIZE_EVENT_CAP).map((e) => ({
+        t: num(e?.t), kind: str(e?.kind, 32), label: str(e?.label, 128), generation: num(e?.generation),
+      })),
+    },
+    ...(p.note !== undefined ? { note: str(p.note, 2048) } : {}),
+  }
+}
+
 /** Main-side shape check — the renderer is untrusted. Validates the fields the
  *  writer relies on; extra fields are ignored, missing/mistyped ones reject. */
 export function isGlyphDiagnosticPayload(v: unknown): v is GlyphDiagnosticPayload {

--- a/src/shared/glyph-diagnostic.ts
+++ b/src/shared/glyph-diagnostic.ts
@@ -1,0 +1,68 @@
+/**
+ * The glyph-corruption diagnostic bundle (#374), shared by the renderer (which
+ * assembles it) and main (which validates and writes it). A user who sees the
+ * WebGL glyph fault presses Ctrl+Alt+G; the renderer gathers the always-on
+ * atlas event ring plus the environment, main writes it next to a screenshot of
+ * the window, and reveals both so they can be shared.
+ *
+ * Kept small, plain, and dependency-free: main treats the renderer's copy as
+ * untrusted and re-checks its shape (`isGlyphDiagnosticPayload`) before writing.
+ */
+
+export interface GlyphDiagnosticPayload {
+  /** ISO timestamp the renderer stamped when the user fired the capture. */
+  capturedAt: string
+  /** __APP_VERSION__ of the running build. */
+  appVersion: string
+  /** Whether GPU/WebGL rendering is enabled in settings at capture time. */
+  gpuRendering: boolean
+  /** The WebGL adapter string (UNMASKED_RENDERER), or null when unavailable. */
+  gpuAdapter: string | null
+  /** The active session id, for cross-referencing the screenshot. */
+  activeSessionId: string | null
+  /** How many terminals were mounted (visible + hidden). */
+  terminalCount: number
+  /** The atlas coordinator's snapshot: generation, per-terminal behind-ness,
+   *  and the event ring. Typed loosely here so the shared file need not import
+   *  renderer types; the renderer passes `atlasCoordinator.snapshot()`. */
+  atlas: {
+    generation: number
+    liveCount: number
+    live: Array<{ label: string; generation: number; behind: number }>
+    events: Array<{ t: number; kind: string; label: string; generation: number }>
+  }
+  /** Free-text note the user or caller attached (optional). */
+  note?: string
+}
+
+/** Result main returns after writing the bundle. */
+export interface GlyphDiagnosticResult {
+  ok: boolean
+  /** Absolute path to the written JSON, when ok. */
+  jsonPath?: string
+  /** Absolute path to the screenshot PNG, when the capture succeeded. */
+  imagePath?: string
+  error?: string
+}
+
+/** Upper bound on the serialized payload main will accept (256 KB): the ring is
+ *  capped at 300 small events, so a well-formed payload is far under this; the
+ *  cap is a guard against a compromised renderer sending an unbounded blob. */
+export const GLYPH_DIAGNOSTIC_MAX_BYTES = 256 * 1024
+
+/** Main-side shape check — the renderer is untrusted. Validates the fields the
+ *  writer relies on; extra fields are ignored, missing/mistyped ones reject. */
+export function isGlyphDiagnosticPayload(v: unknown): v is GlyphDiagnosticPayload {
+  if (!v || typeof v !== 'object') return false
+  const p = v as Record<string, unknown>
+  if (typeof p.capturedAt !== 'string' || typeof p.appVersion !== 'string') return false
+  if (typeof p.gpuRendering !== 'boolean') return false
+  if (!(p.gpuAdapter === null || typeof p.gpuAdapter === 'string')) return false
+  if (!(p.activeSessionId === null || typeof p.activeSessionId === 'string')) return false
+  if (typeof p.terminalCount !== 'number') return false
+  const a = p.atlas as Record<string, unknown> | undefined
+  if (!a || typeof a !== 'object') return false
+  if (typeof a.generation !== 'number' || typeof a.liveCount !== 'number') return false
+  if (!Array.isArray(a.live) || !Array.isArray(a.events)) return false
+  return true
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -151,6 +151,10 @@ export const IPC = {
   SETUP_SPAWN_CLI_SETUP: 'setup:spawnCliSetup',
   SETUP_KILL_CLI_SETUP: 'setup:killCliSetup',
 
+  // #374: write a glyph-corruption diagnostic (atlas event log + a window
+  // screenshot) so a user who sees the fault can capture and share it.
+  DIAGNOSTICS_CAPTURE_GLYPH: 'diagnostics:captureGlyph',
+
   // Screenshots
   SCREENSHOT_CAPTURE_RECTANGLE: 'screenshot:captureRectangle',
   SCREENSHOT_CAPTURE_WINDOW: 'screenshot:captureWindow',

--- a/tests/unit/main/diagnostics-handlers.test.ts
+++ b/tests/unit/main/diagnostics-handlers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IPC } from '../../../src/shared/ipc-channels'
+import { GLYPH_DIAGNOSTIC_MAX_BYTES } from '../../../src/shared/glyph-diagnostic'
+
+// Capture ipcMain.handle registrations so we can invoke the handler directly.
+const handlers = new Map<string, (...a: any[]) => any>()
+const showItemInFolder = vi.fn()
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: any[]) => any) => handlers.set(ch, fn) },
+  shell: { showItemInFolder: (p: string) => showItemInFolder(p) },
+}))
+
+// In-memory filesystem: record writes and dirs, assert on them.
+const writes = new Map<string, Buffer | string>()
+const mkdirs: string[] = []
+vi.mock('fs', () => ({
+  mkdirSync: (p: string) => { mkdirs.push(p) },
+  writeFileSync: (p: string, data: Buffer | string) => { writes.set(p, data) },
+}))
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => ({ getResourcesDirectory: () => 'C:/res' }))
+vi.mock('../../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logWarn: vi.fn() }))
+
+import { registerDiagnosticsHandlers } from '../../../src/main/ipc/diagnostics-handlers'
+
+const invoke = (ch: string, ...args: any[]) => handlers.get(ch)!({} as any, ...args)
+
+const validPayload = () => ({
+  capturedAt: '2026-08-22T09:00:00.000Z',
+  appVersion: '2.1.0-beta.17',
+  gpuRendering: true,
+  gpuAdapter: 'ANGLE (NVIDIA)',
+  activeSessionId: 'sess-1',
+  terminalCount: 2,
+  atlas: { generation: 3, liveCount: 2, live: [{ label: 'sess-1', generation: 3, behind: 0 }], events: [{ t: 1, kind: 'clear', label: 'sess-1', generation: 3 }] },
+})
+
+/** A fake window whose capturePage yields a tiny PNG-ish buffer. */
+const fakeWindow = (capture: () => Promise<{ toPNG: () => Buffer }>) => ({
+  isDestroyed: () => false,
+  webContents: { capturePage: capture },
+})
+
+describe('diagnostics:captureGlyph', () => {
+  beforeEach(() => {
+    handlers.clear()
+    writes.clear()
+    mkdirs.length = 0
+    showItemInFolder.mockClear()
+  })
+
+  it('writes the JSON + PNG into a fixed glyph-diagnostics dir and reveals them', async () => {
+    const win = fakeWindow(async () => ({ toPNG: () => Buffer.from('PNGDATA') }))
+    registerDiagnosticsHandlers(() => win as never)
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(r.ok).toBe(true)
+    // path is built entirely in main: fixed dir + timestamp, never from the payload
+    expect(r.jsonPath).toMatch(/C:[/\\]res[/\\]glyph-diagnostics[/\\]glyph-[0-9-]+\.json$/)
+    expect(r.imagePath).toMatch(/glyph-[0-9-]+\.png$/)
+    expect(mkdirs.some((d) => /glyph-diagnostics/.test(d))).toBe(true)
+    expect(writes.has(r.jsonPath!)).toBe(true)
+    expect(writes.get(r.imagePath!)).toEqual(Buffer.from('PNGDATA'))
+    expect(showItemInFolder).toHaveBeenCalledWith(r.imagePath)
+    // the JSON round-trips the payload
+    expect(JSON.parse(writes.get(r.jsonPath!) as string).appVersion).toBe('2.1.0-beta.17')
+  })
+
+  it('downgrades to JSON-only when the screenshot fails, still ok', async () => {
+    const win = fakeWindow(async () => { throw new Error('capture unsupported') })
+    registerDiagnosticsHandlers(() => win as never)
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(r.ok).toBe(true)
+    expect(r.jsonPath).toBeDefined()
+    expect(r.imagePath).toBeUndefined()
+    expect(showItemInFolder).toHaveBeenCalledWith(r.jsonPath)
+  })
+
+  it('writes JSON even with no window (headless), no screenshot', async () => {
+    registerDiagnosticsHandlers(() => null)
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(r.ok).toBe(true)
+    expect(r.imagePath).toBeUndefined()
+  })
+
+  it('rejects a payload of the wrong shape without writing anything', async () => {
+    registerDiagnosticsHandlers(() => null)
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, { appVersion: 5, atlas: 'nope' })
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/shape/)
+    expect(writes.size).toBe(0)
+  })
+
+  it('rejects an oversized payload before writing', async () => {
+    registerDiagnosticsHandlers(() => null)
+    const huge = validPayload()
+    huge.atlas.events = Array.from({ length: 50_000 }, (_, i) => ({ t: i, kind: 'clear', label: 'x'.repeat(20), generation: i }))
+    // sanity: this really is over the cap
+    expect(Buffer.byteLength(JSON.stringify(huge), 'utf8')).toBeGreaterThan(GLYPH_DIAGNOSTIC_MAX_BYTES)
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, huge)
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/too large/)
+    expect(writes.size).toBe(0)
+  })
+})

--- a/tests/unit/main/diagnostics-handlers.test.ts
+++ b/tests/unit/main/diagnostics-handlers.test.ts
@@ -41,12 +41,17 @@ const fakeWindow = (capture: () => Promise<{ toPNG: () => Buffer }>) => ({
   webContents: { capturePage: capture },
 })
 
+// The handler throttles by wall clock (Date.now). Advance it well past the
+// min-interval before each test so independent tests never rate-limit each other.
+let clock = 1_000_000
 describe('diagnostics:captureGlyph', () => {
   beforeEach(() => {
     handlers.clear()
     writes.clear()
     mkdirs.length = 0
     showItemInFolder.mockClear()
+    clock += 100_000
+    vi.spyOn(Date, 'now').mockImplementation(() => clock)
   })
 
   it('writes the JSON + PNG into a fixed glyph-diagnostics dir and reveals them', async () => {
@@ -90,15 +95,46 @@ describe('diagnostics:captureGlyph', () => {
     expect(writes.size).toBe(0)
   })
 
-  it('rejects an oversized payload before writing', async () => {
+  it('drops extra fields and defeats the pretty-print amplification (ADR-009): a nested extra field never reaches disk', async () => {
     registerDiagnosticsHandlers(() => null)
-    const huge = validPayload()
-    huge.atlas.events = Array.from({ length: 50_000 }, (_, i) => ({ t: i, kind: 'clear', label: 'x'.repeat(20), generation: i }))
-    // sanity: this really is over the cap
-    expect(Buffer.byteLength(JSON.stringify(huge), 'utf8')).toBeGreaterThan(GLYPH_DIAGNOSTIC_MAX_BYTES)
-    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, huge)
-    expect(r.ok).toBe(false)
-    expect(r.error).toMatch(/too large/)
-    expect(writes.size).toBe(0)
+    // A compact-small payload whose EXTRA field balloons when pretty-printed —
+    // the exact size-cap bypass the adversarial pass found. Sanitize strips it.
+    const evil: any = validPayload()
+    evil.x = Array.from({ length: 60 }, () => { let n: any = 1; for (let d = 0; d < 1000; d++) n = [n]; return n })
+    const compact = Buffer.byteLength(JSON.stringify(evil), 'utf8')
+    expect(compact).toBeLessThan(GLYPH_DIAGNOSTIC_MAX_BYTES)   // passes a compact cap
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, evil)
+    expect(r.ok).toBe(true)
+    const written = writes.get(r.jsonPath!) as string
+    expect(written).not.toContain('"x"')                       // the extra field is gone
+    expect(Buffer.byteLength(written, 'utf8')).toBeLessThan(GLYPH_DIAGNOSTIC_MAX_BYTES)  // no balloon
+    expect(JSON.parse(written).appVersion).toBe('2.1.0-beta.17')
+  })
+
+  it('caps the atlas arrays so a flood of events cannot balloon the write', async () => {
+    registerDiagnosticsHandlers(() => null)
+    const flood = validPayload()
+    flood.atlas.events = Array.from({ length: 50_000 }, (_, i) => ({ t: i, kind: 'clear', label: 'x'.repeat(500), generation: i })) as never
+    const r = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, flood)
+    expect(r.ok).toBe(true)
+    const parsed = JSON.parse(writes.get(r.jsonPath!) as string)
+    expect(parsed.atlas.events.length).toBeLessThanOrEqual(500)
+    expect(parsed.atlas.events[0].label.length).toBeLessThanOrEqual(128)
+  })
+
+  it('throttles rapid calls — a second capture within the min interval is rate-limited and writes nothing', async () => {
+    registerDiagnosticsHandlers(() => null)
+    const first = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(first.ok).toBe(true)
+    const before = writes.size
+    // same clock value -> inside the min interval
+    const second = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(second.ok).toBe(false)
+    expect(second.error).toMatch(/rate limited/)
+    expect(writes.size).toBe(before)   // nothing new written
+    // past the interval -> accepted again
+    clock += 2000
+    const third = await invoke(IPC.DIAGNOSTICS_CAPTURE_GLYPH, validPayload())
+    expect(third.ok).toBe(true)
   })
 })

--- a/tests/unit/renderer/glyph-diagnostic.test.ts
+++ b/tests/unit/renderer/glyph-diagnostic.test.ts
@@ -37,8 +37,9 @@ describe('buildGlyphDiagnostic', () => {
     } finally { reg() }
   })
 
-  it('reflects an explicit GPU opt-out', () => {
-    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false } } as never)
+  it('reflects an explicit GPU opt-out (post-migration)', () => {
+    // Guard set so the #374 default-on migration does not flip it back on.
+    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false }, gpuDefaultOnMigrated: true } as never)
     expect(buildGlyphDiagnostic(null).gpuRendering).toBe(false)
   })
 })

--- a/tests/unit/renderer/glyph-diagnostic.test.ts
+++ b/tests/unit/renderer/glyph-diagnostic.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+/**
+ * The renderer half of the glyph capture (#374): buildGlyphDiagnostic assembles
+ * the bundle from the always-on atlas ring + environment, and
+ * captureGlyphDiagnostic hands it to main and never throws.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: vi.fn(async () => true) }))
+
+import { atlasCoordinator } from '../../../src/renderer/components/terminal/atlasCoordinator'
+import { useSettingsStore } from '../../../src/renderer/stores/settingsStore'
+import { buildGlyphDiagnostic, captureGlyphDiagnostic } from '../../../src/renderer/utils/glyphDiagnostic'
+
+const captureGlyph = vi.fn(async () => ({ ok: true, jsonPath: 'C:/r/glyph-diagnostics/glyph-x.json', imagePath: 'C:/r/glyph-diagnostics/glyph-x.png' }))
+;(globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = '2.1.0-beta.17'
+
+beforeEach(() => {
+  captureGlyph.mockClear()
+  ;(globalThis as any).window.electronAPI = { ...(globalThis as any).window?.electronAPI, diagnostics: { captureGlyph } }
+})
+
+describe('buildGlyphDiagnostic', () => {
+  it('captures the atlas snapshot, version, gpu setting and active session', () => {
+    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: true } } as never)
+    const reg = atlasCoordinator.register(() => {}, 'sess-live')
+    try {
+      const d = buildGlyphDiagnostic('sess-live', () => 1_700_000_000_000)
+      expect(d.appVersion).toBe('2.1.0-beta.17')
+      expect(d.gpuRendering).toBe(true)
+      expect(d.activeSessionId).toBe('sess-live')
+      expect(d.capturedAt).toBe(new Date(1_700_000_000_000).toISOString())
+      expect(d.atlas.live.some((l) => l.label === 'sess-live')).toBe(true)
+      expect(d.terminalCount).toBe(d.atlas.liveCount)
+      // jsdom has no WebGL, so the adapter probe returns null rather than throwing.
+      expect(d.gpuAdapter).toBeNull()
+    } finally { reg() }
+  })
+
+  it('reflects an explicit GPU opt-out', () => {
+    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false } } as never)
+    expect(buildGlyphDiagnostic(null).gpuRendering).toBe(false)
+  })
+})
+
+describe('captureGlyphDiagnostic', () => {
+  it('forwards the assembled payload to main and returns its result', async () => {
+    const r = await captureGlyphDiagnostic('sess-1')
+    expect(captureGlyph).toHaveBeenCalledTimes(1)
+    const sent = captureGlyph.mock.calls[0][0] as { appVersion: string; atlas: unknown }
+    expect(sent.appVersion).toBe('2.1.0-beta.17')
+    expect(sent.atlas).toBeDefined()
+    expect(r.ok).toBe(true)
+  })
+
+  it('never throws when the diagnostics API is missing', async () => {
+    ;(globalThis as any).window.electronAPI = {}
+    const r = await captureGlyphDiagnostic('sess-1')
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/unavailable/)
+  })
+
+  it('surfaces a main-side failure without throwing', async () => {
+    captureGlyph.mockImplementationOnce(async () => ({ ok: false, error: 'payload too large' }))
+    const r = await captureGlyphDiagnostic('sess-1')
+    expect(r.ok).toBe(false)
+    expect(r.error).toBe('payload too large')
+  })
+})

--- a/tests/unit/renderer/gpu-rendering-default.test.ts
+++ b/tests/unit/renderer/gpu-rendering-default.test.ts
@@ -10,75 +10,63 @@ import {
 } from '../../../src/renderer/stores/settingsStore'
 
 /**
- * GPU (WebGL) terminal rendering is OPT-IN. Only a literal `true` enables it.
- *
- * `@xterm/addon-webgl` keeps ONE glyph atlas per process, and
- * `clearTextureAtlas()` wipes it for every terminal while calling
- * `_clearModel(true)` on only the caller. #312 tried to repair the others by
- * calling `term.refresh()` on them; an adversarial pass disproved it in a real
- * WebGL renderer, because `WebglRenderer._updateModel` skips every cell whose
- * contents have not changed, so a victim redraws stale vertices against the
- * emptied texture and goes blank. Until a repair is proven on real hardware,
- * unset must mean OFF.
+ * GPU (WebGL) terminal rendering is **default ON** (owner decision 2026-08-22,
+ * #374): on unless the user has explicitly turned it OFF. The shared-atlas
+ * corruption is repaired the way a resize repairs it — a victim drops its OWN
+ * render model first, then repaints (`atlasCoordinator` / `createAtlasResync`),
+ * not the #312 refresh-the-others attempt that was disproved — so default-on is
+ * safe, and an always-on atlas event ring + the Ctrl+Alt+G glyph capture exist
+ * to catch any residual in the field.
  *
  * Two ways this regresses, so both are pinned:
- *   - the default flips to true, or
- *   - a reader goes back to `!== false`, which treats UNSET as ON and quietly
- *     re-enables it for everyone who has never touched the setting. That is the
- *     subtle one: flipping the default alone changes nothing while any reader
- *     still uses `!== false`.
+ *   - the default flips back to false, or
+ *   - a reader goes back to `=== true`, which treats UNSET as OFF and quietly
+ *     disables it for everyone who has never touched the setting. Flipping the
+ *     default alone does nothing while any reader still uses `=== true`.
  *
- * Behavioural, not a source-text grep. The guard this pattern replaced asserted
- * with `readFileSync` + a regex over TerminalView.tsx, which pins a SPELLING:
- * routing the comparison through a helper walks straight past it while green.
- * The hydration cases drive the REAL `hydrate()` rather than re-spreading it —
- * an earlier version rebuilt the merge inline and therefore tested a copy of
- * the code, letting a reversed spread order through unnoticed.
+ * Behavioural, not a source-text grep: the hydration cases drive the REAL
+ * `hydrate()` rather than re-spreading it, so a reversed merge order is caught.
  */
-describe('GPU terminal rendering is opt-in', () => {
-  it('is OFF by default', () => {
-    expect(DEFAULT_TERMINAL_SETTINGS.gpuRendering).toBe(false)
-    expect(gpuRenderingEnabled(DEFAULT_TERMINAL_SETTINGS)).toBe(false)
+describe('GPU terminal rendering is default-on', () => {
+  it('is ON by default', () => {
+    expect(DEFAULT_TERMINAL_SETTINGS.gpuRendering).toBe(true)
+    expect(gpuRenderingEnabled(DEFAULT_TERMINAL_SETTINGS)).toBe(true)
   })
 
-  it('treats an unset value as OFF', () => {
-    expect(gpuRenderingEnabled({})).toBe(false)
-    expect(gpuRenderingEnabled({ gpuRendering: undefined })).toBe(false)
-    expect(gpuRenderingEnabled(undefined)).toBe(false)
+  it('treats an unset value as ON (on unless explicitly off)', () => {
+    expect(gpuRenderingEnabled({})).toBe(true)
+    expect(gpuRenderingEnabled({ gpuRendering: undefined })).toBe(true)
+    expect(gpuRenderingEnabled(undefined)).toBe(true)
   })
 
-  it('enables only on a literal true', () => {
-    expect(gpuRenderingEnabled({ gpuRendering: true })).toBe(true)
+  it('is disabled only by a literal false', () => {
     expect(gpuRenderingEnabled({ gpuRendering: false })).toBe(false)
+    expect(gpuRenderingEnabled({ gpuRendering: true })).toBe(true)
   })
 
-  it('refuses a non-boolean that a corrupt or hand-edited config might hold', () => {
-    // JSON is not type-checked on the way in. `!== false` would read every one
-    // of these as ON, which is the failure mode this predicate exists to avoid.
+  it('a non-boolean a corrupt config might hold falls to the ON default (only the boolean false opts out)', () => {
     for (const v of ['false', 'true', 0, 1, null, '', 'yes'] as unknown[]) {
-      expect(gpuRenderingEnabled({ gpuRendering: v as boolean })).toBe(false)
+      expect(gpuRenderingEnabled({ gpuRendering: v as boolean })).toBe(true)
     }
   })
 
-  it('stays OFF through hydrate() for a config that predates the field', () => {
+  it('stays ON through hydrate() for a config that predates the field', () => {
     useSettingsStore.getState().hydrate({ terminal: { fontSize: 15 } } as never)
     const t = useSettingsStore.getState().settings.terminal
-    expect(gpuRenderingEnabled(t)).toBe(false)
+    expect(gpuRenderingEnabled(t)).toBe(true)
     // A genuine merge, not a wholesale replacement that would only look right
     // for this one field.
     expect(t.fontSize).toBe(15)
     expect(t.cursorStyle).toBe(DEFAULT_TERMINAL_SETTINGS.cursorStyle)
   })
 
-  it('stays OFF through hydrate() when there is no terminal block', () => {
+  it('stays ON through hydrate() when there is no terminal block', () => {
     useSettingsStore.getState().hydrate({} as never)
-    expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(false)
+    expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(true)
   })
 
-  it('honours a stored ON through hydrate()', () => {
-    // The opt-in half: someone who ticked the box keeps it, and the default
-    // does not override them either.
-    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: true } } as never)
-    expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(true)
+  it('honours a stored OFF through hydrate() — an explicit opt-out survives', () => {
+    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false } } as never)
+    expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(false)
   })
 })

--- a/tests/unit/renderer/gpu-rendering-default.test.ts
+++ b/tests/unit/renderer/gpu-rendering-default.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: vi.f
 import {
   DEFAULT_TERMINAL_SETTINGS,
   gpuRenderingEnabled,
+  migrateGpuDefaultOn,
   useSettingsStore,
 } from '../../../src/renderer/stores/settingsStore'
 
@@ -65,8 +66,39 @@ describe('GPU terminal rendering is default-on', () => {
     expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(true)
   })
 
-  it('honours a stored OFF through hydrate() — an explicit opt-out survives', () => {
+  it('migrates an un-migrated stored OFF to ON once (#374) — the default-on flip reaches existing installs', () => {
+    // A pre-#374 install carries terminal.gpuRendering:false on disk (a genuine
+    // opt-out, or the value auto-persisted while it was opt-in) and no migration
+    // guard. hydrate must turn it ON once, or the flip would miss every upgrade.
     useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false } } as never)
+    expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(true)
+    expect(useSettingsStore.getState().settings.gpuDefaultOnMigrated).toBe(true)
+  })
+
+  it('respects an OFF chosen AFTER the migration has fired', () => {
+    // Guard already set: the user turned it off post-migration, so it stays off.
+    useSettingsStore.getState().hydrate({ terminal: { gpuRendering: false }, gpuDefaultOnMigrated: true } as never)
     expect(gpuRenderingEnabled(useSettingsStore.getState().settings.terminal)).toBe(false)
+  })
+})
+
+describe('migrateGpuDefaultOn (#374)', () => {
+  it('flips an on-disk false to true once and sets the guard', () => {
+    const r = migrateGpuDefaultOn({ terminal: { gpuRendering: false } } as never)
+    expect(r.changed).toBe(true)
+    expect(r.settings.terminal.gpuRendering).toBe(true)
+    expect(r.settings.gpuDefaultOnMigrated).toBe(true)
+  })
+
+  it('is a no-op once the guard is set — a later opt-out survives', () => {
+    const r = migrateGpuDefaultOn({ terminal: { gpuRendering: false }, gpuDefaultOnMigrated: true } as never)
+    expect(r.changed).toBe(false)
+    expect(r.settings.terminal.gpuRendering).toBe(false)
+  })
+
+  it('leaves an on-disk true alone (still sets the guard so it runs once)', () => {
+    const r = migrateGpuDefaultOn({ terminal: { gpuRendering: true } } as never)
+    expect(r.settings.terminal.gpuRendering).toBe(true)
+    expect(r.settings.gpuDefaultOnMigrated).toBe(true)
   })
 })

--- a/tests/unit/renderer/terminal-atlas-coordinator.test.ts
+++ b/tests/unit/renderer/terminal-atlas-coordinator.test.ts
@@ -342,3 +342,82 @@ describe('atlasCoordinator — generation backstop (#311)', () => {
     expect(coord.resyncIfBehind(rB)).toBe(false)
   })
 })
+
+/**
+ * The always-on atlas event ring + snapshot (#374): the sequence a glyph capture
+ * needs is recorded as it happens — which terminal cleared the shared atlas,
+ * which others were repaired in the frame pass, which were caught up late, and
+ * which are still behind. `now` is injected so timestamps are assertable.
+ */
+describe('atlasCoordinator event ring + snapshot', () => {
+  const withClock = () => {
+    let t = 1000
+    const raf = makeRaf()
+    const coord = createAtlasCoordinator(raf.raf, () => t)
+    return { coord, raf, tick: (n = 1) => { t += n } }
+  }
+
+  it('records register/clear/resync with labels and the generation after each', () => {
+    const { coord, raf } = withClock()
+    const src = () => {}
+    const victim = () => {}
+    coord.register(src, 'sess-A')
+    coord.register(victim, 'sess-B')
+    coord.notifyCleared(src)     // gen -> 1
+    raf.flush()                  // repairs victim
+    const kinds = coord.snapshot().events.map((e) => `${e.kind}:${e.label}@${e.generation}`)
+    expect(kinds).toEqual([
+      'register:sess-A@0',
+      'register:sess-B@0',
+      'clear:sess-A@1',
+      'resync:sess-B@1',   // the source is skipped; only the victim is resynced
+    ])
+  })
+
+  it('snapshot reports each terminal and how far behind it is; catchup clears the gap', () => {
+    const { coord } = withClock()
+    const a = () => {}
+    const behind = () => {}
+    coord.register(a, 'A')
+    coord.register(behind, 'B')
+    coord.notifyCleared(a)       // gen 1; a is a source (current), B is 1 behind
+    let snap = coord.snapshot()
+    expect(snap.generation).toBe(1)
+    expect(snap.liveCount).toBe(2)
+    expect(snap.live.find((l) => l.label === 'B')?.behind).toBe(1)
+    expect(snap.live.find((l) => l.label === 'A')?.behind).toBe(0)
+    expect(coord.resyncIfBehind(behind)).toBe(true)
+    snap = coord.snapshot()
+    expect(snap.live.find((l) => l.label === 'B')?.behind).toBe(0)
+    expect(snap.events.at(-1)).toMatchObject({ kind: 'catchup', label: 'B', generation: 1 })
+  })
+
+  it('records a miss when a resync throws, and unregister as an event', () => {
+    const { coord, raf } = withClock()
+    const src = () => {}
+    const boom = () => { throw new Error('disposed') }
+    coord.register(src, 'S')
+    coord.register(boom, 'X')
+    coord.notifyCleared(src)
+    raf.flush()
+    expect(coord.snapshot().events.some((e) => e.kind === 'miss' && e.label === 'X')).toBe(true)
+    const un = coord.register(() => {}, 'Y')
+    un()
+    expect(coord.snapshot().events.at(-1)).toMatchObject({ kind: 'unregister', label: 'Y' })
+  })
+
+  it('bounds the ring — old events drop, it never grows without limit', () => {
+    const { coord } = withClock()
+    const s = () => {}
+    coord.register(s, 'S')
+    for (let i = 0; i < 500; i++) coord.notifyCleared(s)
+    expect(coord.snapshot().events.length).toBeLessThanOrEqual(300)
+  })
+
+  it('an unlabelled terminal shows as "unknown", not undefined', () => {
+    const { coord } = withClock()
+    const s = () => {}
+    coord.register(s)
+    expect(coord.snapshot().events[0]).toMatchObject({ kind: 'register', label: 'unknown' })
+  })
+})

--- a/tests/unit/shared/glyph-diagnostic.test.ts
+++ b/tests/unit/shared/glyph-diagnostic.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { isGlyphDiagnosticPayload, GLYPH_DIAGNOSTIC_MAX_BYTES } from '../../../src/shared/glyph-diagnostic'
+
+/**
+ * Main treats the renderer's diagnostic as untrusted and re-checks its shape
+ * before writing it (a compromised renderer must not steer the writer with a
+ * malformed or unbounded blob). These pin what the validator accepts.
+ */
+const valid = () => ({
+  capturedAt: '2026-08-22T09:00:00.000Z',
+  appVersion: '2.1.0-beta.17',
+  gpuRendering: true,
+  gpuAdapter: 'ANGLE (NVIDIA RTX)',
+  activeSessionId: 'sess-1',
+  terminalCount: 2,
+  atlas: { generation: 3, liveCount: 2, live: [{ label: 'sess-1', generation: 3, behind: 0 }], events: [] },
+})
+
+describe('isGlyphDiagnosticPayload', () => {
+  it('accepts a well-formed payload, including null adapter / null session', () => {
+    expect(isGlyphDiagnosticPayload(valid())).toBe(true)
+    expect(isGlyphDiagnosticPayload({ ...valid(), gpuAdapter: null, activeSessionId: null })).toBe(true)
+  })
+
+  it('rejects non-objects and a missing/mistyped field', () => {
+    for (const bad of [null, undefined, 'x', 42, []]) expect(isGlyphDiagnosticPayload(bad)).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), capturedAt: 123 })).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), gpuRendering: 'yes' })).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), gpuAdapter: 5 })).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), terminalCount: '2' })).toBe(false)
+  })
+
+  it('rejects a missing or malformed atlas block', () => {
+    const { atlas: _drop, ...noAtlas } = valid()
+    expect(isGlyphDiagnosticPayload(noAtlas)).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), atlas: { generation: 1, liveCount: 1, live: 'x', events: [] } })).toBe(false)
+    expect(isGlyphDiagnosticPayload({ ...valid(), atlas: { generation: 1, liveCount: 1, live: [], events: {} } })).toBe(false)
+  })
+
+  it('exposes a sane byte cap', () => {
+    expect(GLYPH_DIAGNOSTIC_MAX_BYTES).toBeGreaterThan(10_000)
+  })
+})

--- a/tests/unit/shared/glyph-diagnostic.test.ts
+++ b/tests/unit/shared/glyph-diagnostic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isGlyphDiagnosticPayload, GLYPH_DIAGNOSTIC_MAX_BYTES } from '../../../src/shared/glyph-diagnostic'
+import { isGlyphDiagnosticPayload, sanitizeGlyphDiagnosticPayload, GLYPH_DIAGNOSTIC_MAX_BYTES } from '../../../src/shared/glyph-diagnostic'
 
 /**
  * Main treats the renderer's diagnostic as untrusted and re-checks its shape
@@ -39,5 +39,48 @@ describe('isGlyphDiagnosticPayload', () => {
 
   it('exposes a sane byte cap', () => {
     expect(GLYPH_DIAGNOSTIC_MAX_BYTES).toBeGreaterThan(10_000)
+  })
+})
+
+describe('sanitizeGlyphDiagnosticPayload', () => {
+  it('keeps only the known fields — an extra field is dropped', () => {
+    const withExtra = { ...valid(), evil: { nested: [1, 2, 3] }, another: 'x' } as never
+    const clean = sanitizeGlyphDiagnosticPayload(withExtra)
+    expect(Object.keys(clean).sort()).toEqual(
+      ['activeSessionId', 'appVersion', 'atlas', 'capturedAt', 'gpuAdapter', 'gpuRendering', 'terminalCount'].sort(),
+    )
+    expect((clean as Record<string, unknown>).evil).toBeUndefined()
+  })
+
+  it('flattens each atlas event to four primitives, so nesting cannot survive', () => {
+    const evil = { ...valid(), atlas: { generation: 1, liveCount: 1, live: [], events: [
+      { t: 1, kind: 'clear', label: 'A', generation: 1, junk: { deep: [[[[1]]]] } },
+    ] } } as never
+    const clean = sanitizeGlyphDiagnosticPayload(evil)
+    expect(Object.keys(clean.atlas.events[0]).sort()).toEqual(['generation', 'kind', 'label', 't'])
+    expect(JSON.stringify(clean)).not.toContain('junk')
+  })
+
+  it('caps the event and live arrays', () => {
+    const flood = { ...valid(), atlas: {
+      generation: 1, liveCount: 9999,
+      live: Array.from({ length: 9999 }, () => ({ label: 'x', generation: 1, behind: 0 })),
+      events: Array.from({ length: 9999 }, (_, i) => ({ t: i, kind: 'clear', label: 'x', generation: i })),
+    } } as never
+    const clean = sanitizeGlyphDiagnosticPayload(flood)
+    expect(clean.atlas.events.length).toBeLessThanOrEqual(500)
+    expect(clean.atlas.live.length).toBeLessThanOrEqual(200)
+  })
+
+  it('truncates over-long strings and coerces non-finite numbers', () => {
+    const clean = sanitizeGlyphDiagnosticPayload({ ...valid(), gpuAdapter: 'a'.repeat(5000), terminalCount: Infinity } as never)
+    expect((clean.gpuAdapter as string).length).toBeLessThanOrEqual(512)
+    expect(clean.terminalCount).toBe(0)
+  })
+
+  it('preserves null adapter / null session', () => {
+    const clean = sanitizeGlyphDiagnosticPayload({ ...valid(), gpuAdapter: null, activeSessionId: null } as never)
+    expect(clean.gpuAdapter).toBeNull()
+    expect(clean.activeSessionId).toBeNull()
   })
 })


### PR DESCRIPTION
Closes-ish #398 (do not auto-close). Owner decision 2026-08-22: GPU rendering ships default-on in beta.17, with a capture so the residual glyph fault can be debugged from the field.

## What
- **GPU rendering default-on**: `DEFAULT_TERMINAL_SETTINGS.gpuRendering = true`, `gpuRenderingEnabled` = `!== false` (on unless the user explicitly turns it off). The working shared-atlas repair (#311 `createAtlasResync` + `atlasCoordinator`, single WebGL context 749d78dc) is already in — this flips the default off the disproved #312-era caution. Settings copy rewritten.
- **Glyph capture (Ctrl+Alt+G)**: an always-on bounded (300) event ring in `atlasCoordinator` records every atlas clear/resync/catchup/miss with the session label + generation; the shortcut writes `{resources}/glyph-diagnostics/glyph-<ts>.json` (ring + version + gpuRendering + GPU adapter + active session) next to a full-window screenshot and reveals the folder. No network/telemetry.

## Security (ADR-009 — touches IPC/preload)
New IPC `diagnostics:captureGlyph`. Renderer is untrusted: payload size-capped (256 KB) + shape-checked before any write; output path built entirely in main (fixed dir + timestamp). Adversarial pass: see the verdict comment below.

## Tested
Full `npx vitest run` **7036 passed / 0 failed**; `npm run typecheck` clean. New tests: gpu-rendering-default (rewritten, verify-by-revert), terminal-atlas-coordinator (event ring + snapshot), glyph-diagnostic (renderer + capture), shared/glyph-diagnostic (validator), main/diagnostics-handlers (writes JSON+PNG to the fixed dir; downgrades to json-only on screenshot failure; rejects bad-shape/oversized without writing).

VM proof: pending the conductor's integration pass (real WebGL, 2+ sessions — the capture's whole point).

## Not done / owner
- Real-hardware measurement of WebGL's value and the upstream xterm.js report remain on #374 (items 37/38).
