### PR TITLE
feat(canvas): x-ray hover has three modes -- Off / Stealth / On (#367)

### DIFF
--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -1,0 +1,79 @@
+## 2026-08-22 -- Canvas x-ray hover: three modes (Off / Stealth / On), #367
+
+Book item 52. The canvas pane painted an outline and a label chip over the
+content on every mouse move, with no way to stop it, so the one thing the pane
+could not do was show you the artifact plainly. Owner: "switch the canvas x-ray
+hover functionality off via toggle easily so I can view it as a normal browser."
+
+Three modes, a segmented control beside the existing Browse/Draw/Region switch
+in the pane header:
+
+- **Off** -- no hover work at all. The page is a browser tab.
+- **Stealth** -- the hit is still resolved, but nothing is drawn on the page:
+  the element's identity and its box are read out beside the stage instead.
+- **On** -- what shipped (outline + chip). Still the default.
+
+### Where the mode lives
+
+Per USER, not per canvas (owner). So it is `AppSettings.canvasXrayMode` in the
+renderer settings store -- the same path `savedConfigsView` (#362) takes:
+optional field, absent means the shipped behaviour, every reader goes through
+`resolveCanvasXrayMode` rather than comparing the field, and it rides the
+existing `settings` config save. No new IPC channel, no preload change, no
+main-process store. Deliberately NOT `canvasStore.interactionMode`, which is
+per-session UI state that is never persisted.
+
+### Off is enforced in two places, and only one of them is the gate
+
+The content bridge gets one new request, `hoverReporting: { enabled }`, and
+while it is false it emits no `pointer` and no `contentClick`. That is the half
+the host cannot do for itself: only the content can decline to hit-test,
+measure and postMessage on every mouse move, and "behaves like a normal browser
+tab" is a claim about the PAGE's work.
+
+It is not the gate. The bridge shares a realm with the page it reports on and
+may ignore anything, so the pane gates on the mode again in `onPointer` and
+`onContentClick` -- and that is what decides what reaches the review store. The
+request is fire-and-forget with a short timeout; a frame that never answers
+changes nothing about the mode the user chose.
+
+Worth being explicit that this does not breach D8 ("content is never commanded
+to draw"): `hoverReporting` can only make the bridge quieter. No value of it
+makes the page report more than it already would, draw anything, or change what
+it renders. Sent only when the frame's belief disagrees with the mode, so the
+default case (x-ray on, the bridge's own default) costs no round-trip, and the
+belief resets when the frame reloads.
+
+### Decisions
+
+- **A click in Off does nothing** -- the issue left this open ("nothing, or
+  temporarily arms a note"). A browser tab does not turn a click into a
+  selection, and arming a note on click would make Off a fourth hidden mode
+  rather than the absence of one. Pinned by a test (`xrayClickSelects`) so a
+  later change is deliberate. Raised as an owner question on the PR.
+- **The stealth readout is a SIBLING of the notes panel**, not a section inside
+  it: it belongs to the stage's pointer, not to the review. It also keeps this
+  change clear of `CanvasNotesPanel.tsx`, which is under concurrent change on
+  #403.
+- **The readout carries the page-reported marker**, like the on-page chip, the
+  locked label and the checklist. Moving a page-authored identity off the page
+  does not make the page a more reliable narrator of it (the 2026-08-15
+  adversarial finding applies wherever the identity is printed, not just on the
+  stage).
+- **An unparseable stored mode reads as On**, not Off: a preference that fails
+  to parse must not silently disable a feature the user then cannot see the
+  switch working on.
+- **The Browse mode strip now says what x-ray is doing.** A user who switched
+  x-ray off and still read "hover to inspect, click to select" would reasonably
+  conclude the pane was broken.
+- An existing locked focus is NOT cleared when switching to Off -- it is a
+  selection the user made and may be mid-note on. Esc still clears it.
+
+### Verification
+
+`npm run typecheck` clean; full `npx vitest run` 7118 passed / 15 skipped /
+2 todo across 666 files. Guard mutation run: deleting the pointer gate, the
+click gate or the draw gate in the pane fails 3 pane tests; deleting the
+bridge's on-frame re-check fails the queued-move test. The bridge tests drive
+the BUNDLED script (`virtual:canvas-bridge`), so they cannot pass while the
+shipped artifact is broken.

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -42,7 +42,8 @@ makes the page report more than it already would, draw anything, or change what
 it renders. Sent only when the frame's belief disagrees with the mode, so the
 default case (x-ray on, the bridge's own default) costs no round-trip, and the
 belief resets on every `ready` -- every new document, in-frame navigation
-included (see the Copilot round below).
+included -- and an answer is believed only about the document it was asked of
+(see the review rounds below).
 
 ### Decisions
 
@@ -84,17 +85,50 @@ Second round, also real: the frame's believed state was recorded on the SEND.
 canvas-frame-rpc caps requests in flight at four, and a snapshot, an inspect
 and a resolveAnchors can already be outstanding when the user reaches for the
 switch -- so a refused request left the host permanently certain it had quieted
-a frame that was never told. Belief is now recorded on the ANSWER, and the
-repair is driven by the symptom: a pointer or click report arriving in a mode
-that wants none IS the evidence the frame never heard, so it re-asks. One
-request at a time, or a page that declines to go quiet would be choosing the
-host's call rate.
+a frame that was never told. Belief moved to the ANSWER, and the repair was
+driven by the symptom: a report arriving in a mode that wants none.
+
+### Independent review round (SPEC PASS conditional / QUALITY NEEDS-WORK)
+
+Symptom-driven repair was the wrong instinct, and the review found the two
+failures it cannot see. Both hide in the window where a request is parked (up
+to `HOVER_REPORTING_TIMEOUT_MS`), and in both the frame ends up QUIET -- which
+is indistinguishable from a page nobody is pointing at. **Silence is not a
+symptom, so nothing may wait for one.**
+
+- **BLOCKER-1.** Flip the mode while a request is parked: the flip is dropped by
+  the in-flight guard, the parked answer lands recording "quiet", and nothing
+  re-runs. The frame stays quiet for the life of the document -- x-ray On draws
+  nothing, Stealth reads out nothing, clicks stop selecting. Fixed by
+  reconciling when the request SETTLES rather than when the page next speaks.
+- **MAJOR-2.** Document A's late answer landing after document B's `ready`
+  overwrote the reset, and the reconcile then short-circuited -- re-opening,
+  through the other door, the in-frame-navigation bug the Copilot round closed.
+  Fixed by generation-tagging: an answer is believed only about the document it
+  was asked of. The in-flight slot is released for every generation, or one
+  navigation mid-request would wedge the switch for the life of the pane.
+- **MINOR-3.** The state is read from `CanvasHoverReportingResult` -- the
+  frame's own account of what it is doing -- not from the send-time capture. The
+  reply is page-authored, so a non-boolean is no answer at all and changes
+  nothing.
+- **SPEC-MINOR-1.** In Draw or Region the glass owns the pointer, so the
+  stealth readout's "Hover the page" was an instruction the user could follow
+  for a while before working out why nothing appeared. It now names who has the
+  pointer instead.
+
+Because the reconcile retries on every unsatisfying settle, a futile-retry
+budget replaced the old "one at a time" reasoning: three attempts per intent,
+where an intent is `<document generation>:<wanted>`. Keying that AFTER the
+nothing-to-do check turned out to be a flaw of its own -- "Off (gave up) -> On
+-> Off" read as the same intent and the second Off got no attempts, when the
+user asking again is the clearest signal there is that they want it to work.
 
 ### Verification
 
-`npm run typecheck` clean; full `npx vitest run` 7122 passed / 15 skipped /
+`npm run typecheck` clean; full `npx vitest run` 7127 passed / 15 skipped /
 2 todo across 666 files. Guard mutation run: deleting the pointer gate, the
 click gate or the draw gate in the pane fails 3 pane tests; deleting the
-bridge's on-frame re-check fails the queued-move test. The bridge tests drive
+bridge's on-frame re-check fails the queued-move test; and each of the five
+review fixes above fails a test of its own when reverted. The bridge tests drive
 the BUNDLED script (`virtual:canvas-bridge`), so they cannot pass while the
 shipped artifact is broken.

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -81,9 +81,19 @@ came back was the page's own per-mousemove work, which is the whole point of
 Off. Fixed by resetting the frame's believed state on every `ready` (the only
 signal that the document has been replaced) and syncing there.
 
+Second round, also real: the frame's believed state was recorded on the SEND.
+canvas-frame-rpc caps requests in flight at four, and a snapshot, an inspect
+and a resolveAnchors can already be outstanding when the user reaches for the
+switch -- so a refused request left the host permanently certain it had quieted
+a frame that was never told. Belief is now recorded on the ANSWER, and the
+repair is driven by the symptom: a pointer or click report arriving in a mode
+that wants none IS the evidence the frame never heard, so it re-asks. One
+request at a time, or a page that declines to go quiet would be choosing the
+host'''s call rate.
+
 ### Verification
 
-`npm run typecheck` clean; full `npx vitest run` 7120 passed / 15 skipped /
+`npm run typecheck` clean; full `npx vitest run` 7122 passed / 15 skipped /
 2 todo across 666 files. Guard mutation run: deleting the pointer gate, the
 click gate or the draw gate in the pane fails 3 pane tests; deleting the
 bridge's on-frame re-check fails the queued-move test. The bridge tests drive

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -135,9 +135,52 @@ silence is now PAIRED with a control that switches reporting back on and proves
 the bridge, the fixture and the listener were all alive. Without the controls,
 deleting the hover surface outright would have passed every silence assertion.
 
+### The fix-delta round: what the host does NOT know
+
+A verification pass confirmed those fixes and found the same class still open,
+one door along. The bridge APPLIES `hoverReporting` and only THEN replies, so a
+request that does not come back is not a request that did not happen: an Off
+whose ack is dropped (or lands after the 3s timeout) has quieted a frame the
+host still believes is loud. Flip to On and desire matched belief, the reconcile
+short-circuited, and the frame stayed quiet for the life of the document --
+x-ray On drawing nothing, clicks selecting nothing, and no report left to repair
+from.
+
+- **MAJOR-A.** The belief is now a third state. Only a boolean the frame says
+  about itself is believed; a refusal, a timeout and a malformed reply all
+  record `unknown`, which is never equal to what is wanted and so always
+  re-sends. The cost is one round-trip after a frame that would not answer --
+  the correct price for not knowing.
+- **MINOR-B.** The attempt budget is no longer spent on conditions inside the
+  HOST. Over the RPC's in-flight cap the request is refused before a listener
+  exists, and that synchronous rejection fed the post-settle reconcile: all
+  three attempts went in three microtasks, on a condition that clears in
+  milliseconds, after which the intent was wedged. (Reachable: the resolution
+  pass has no in-flight guard of its own, so a few note edits inside its
+  ten-second window saturate the cap.) The cap is checked before the dispatch
+  and re-checked on a bounded timer instead.
+- **MINOR-C.** A rolling send window is the ceiling on requests actually posted.
+  `ready` is page-authored and every one of them is a new document with a fresh
+  budget, so a page that simply re-emits it multiplied the send rate by that
+  budget -- three requests became eighteen after five extra readys.
+- **NIT.** The reload reset bumps the frame generation, as `ready` already did.
+  It was the one place the reset and the bump were not kept together, so a
+  parked answer could land on the document that replaced it and undo it.
+
+The host-side gate is untouched and still the thing that enforces the mode: a
+frame that never answers still leaves Off with no outline, no label and no
+click-select.
+
 ### Verification
 
-`npm run typecheck` clean; full `npx vitest run` 7127 passed / 15 skipped /
+Fix-delta round: `npm run typecheck` clean; full suite 7131 passed / 15 skipped
+/ 2 todo across 666 files (4 new pane tests). Mutation run, one fix at a time:
+dropping the `unknown` write on a rejected request fails the dropped-ack test;
+dropping the in-flight pre-check fails the never-asked test; dropping the send
+window fails the ready-flood test; dropping the generation bump fails the
+replaced-document test -- each exactly one test, and no others.
+
+Earlier round: 7127 passed / 15 skipped /
 2 todo across 666 files. Guard mutation run: deleting the pointer gate, the
 click gate or the draw gate in the pane fails 3 pane tests; deleting the
 bridge's on-frame re-check fails the queued-move test; and each of the five

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -42,7 +42,8 @@ to draw"): `hoverReporting` can only make the bridge quieter. No value of it
 makes the page report more than it already would, draw anything, or change what
 it renders. Sent only when the frame's belief disagrees with the mode, so the
 default case (x-ray on, the bridge's own default) costs no round-trip, and the
-belief resets when the frame reloads.
+belief resets on every `ready` -- every new document, in-frame navigation
+included (see the Copilot round below).
 
 ### Decisions
 
@@ -69,9 +70,20 @@ belief resets when the frame reloads.
 - An existing locked focus is NOT cleared when switching to Off -- it is a
   selection the user made and may be mid-note on. Esc still clears it.
 
+### Copilot round
+
+One real finding, fixed in the same PR: the mode sync was keyed on the pane's
+`contentUrl`/reload nonce, but an IN-FRAME navigation (a link inside the
+content) replaces the document -- and its bridge, which starts at its reporting
+default -- without changing either. So x-ray Off quieted only the first page the
+canvas ever loaded. The host gate hid it: nothing was drawn either way, and what
+came back was the page's own per-mousemove work, which is the whole point of
+Off. Fixed by resetting the frame's believed state on every `ready` (the only
+signal that the document has been replaced) and syncing there.
+
 ### Verification
 
-`npm run typecheck` clean; full `npx vitest run` 7118 passed / 15 skipped /
+`npm run typecheck` clean; full `npx vitest run` 7120 passed / 15 skipped /
 2 todo across 666 files. Guard mutation run: deleting the pointer gate, the
 click gate or the draw gate in the pane fails 3 pane tests; deleting the
 bridge's on-frame re-check fails the queued-move test. The bridge tests drive

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -123,6 +123,18 @@ nothing-to-do check turned out to be a flaw of its own -- "Off (gave up) -> On
 -> Off" read as the same intent and the second Off got no attempts, when the
 user asking again is the clearest signal there is that they want it to work.
 
+### A test of my own that was load-sensitive
+
+The first CI run after the review fixes went red on windows-2025 (macOS and
+local both green) in `canvas-bridge-hover-reporting`: the POSITIVE assertions
+collected events for a fixed 300ms, and the bridge reports on a rAF, so that
+window is a claim about the machine rather than about the bridge. Positives now
+resolve the moment the event lands (5s ceiling, only ever paid when something
+is actually wrong); the fixed window is kept only for the negatives, where each
+silence is now PAIRED with a control that switches reporting back on and proves
+the bridge, the fixture and the listener were all alive. Without the controls,
+deleting the hover surface outright would have passed every silence assertion.
+
 ### Verification
 
 `npm run typecheck` clean; full `npx vitest run` 7127 passed / 15 skipped /

--- a/CONTEXT.d/2026-08-22-n367.md
+++ b/CONTEXT.d/2026-08-22-n367.md
@@ -33,9 +33,8 @@ tab" is a claim about the PAGE's work.
 
 It is not the gate. The bridge shares a realm with the page it reports on and
 may ignore anything, so the pane gates on the mode again in `onPointer` and
-`onContentClick` -- and that is what decides what reaches the review store. The
-request is fire-and-forget with a short timeout; a frame that never answers
-changes nothing about the mode the user chose.
+`onContentClick` -- and that is what decides what reaches the review store. A
+frame that never answers changes nothing about the mode the user chose.
 
 Worth being explicit that this does not breach D8 ("content is never commanded
 to draw"): `hoverReporting` can only make the bridge quieter. No value of it
@@ -89,7 +88,7 @@ a frame that was never told. Belief is now recorded on the ANSWER, and the
 repair is driven by the symptom: a pointer or click report arriving in a mode
 that wants none IS the evidence the frame never heard, so it re-asks. One
 request at a time, or a page that declines to go quiet would be choosing the
-host'''s call rate.
+host's call rate.
 
 ### Verification
 

--- a/src/main/canvas/bridge/index.ts
+++ b/src/main/canvas/bridge/index.ts
@@ -13,6 +13,11 @@
 // and its contrast rule may briefly toggle inline styles while probing a hit
 // stack. Nothing the page RENDERS is changed; page globals are.
 //
+// The one request that is not a question is `hoverReporting` (x-ray Off, #367),
+// and it only ever makes this script quieter: with it false the bridge does no
+// per-mousemove work and emits no pointer/click events. There is no value of it
+// that makes the bridge report more, draw, or touch the document.
+//
 // Trust model: requests are accepted ONLY from the direct parent window
 // (event.source === window.parent). The parent's origin cannot be pinned —
 // the packaged app renderer is a file:// document whose origin serializes to
@@ -62,6 +67,23 @@ declare global {
 
 const NS = CANVAS_BRIDGE_NS
 const MAX_BOXMAP_NODES = 2000
+
+/**
+ * Whether the unsolicited hover surface is live — x-ray Off (#367).
+ *
+ * The host flips this with a `hoverReporting` request. While it is false the
+ * bridge emits no `pointer` and no `contentClick`, so a page under review does
+ * ZERO per-mousemove work: no hit test, no measurement, no structured clone
+ * across postMessage. That is what "view it as a normal browser tab" costs to
+ * mean, and it cannot be had host-side — the host can drop what it hears, but
+ * only the content can decline to do the work.
+ *
+ * True by default: a frame that loads before the host has said anything behaves
+ * exactly as it always did, and the host tells it otherwise on `ready`.
+ * Viewport, ready and the RPC replies are unaffected — the pane still needs to
+ * know where the page is scrolled to in every mode.
+ */
+let hoverReporting = true
 
 // Real browsers always have rAF; the setTimeout fallback keeps the script
 // inert-safe in DOM-less harnesses.
@@ -207,6 +229,7 @@ interface IncomingRequest {
   scope?: unknown
   analysis?: unknown
   anchors?: unknown
+  enabled?: unknown
 }
 
 function handle(msg: IncomingRequest): Promise<unknown> {
@@ -220,6 +243,12 @@ function handle(msg: IncomingRequest): Promise<unknown> {
   if (msg.type === 'resolveAnchors') {
     const anchors = Array.isArray(msg.anchors) ? (msg.anchors.slice(0, MAX_RESOLVE_ANCHORS) as AnchorRef[]) : []
     return Promise.resolve({ results: resolveAnchors(anchors) })
+  }
+  if (msg.type === 'hoverReporting') {
+    // Anything that is not an explicit `false` leaves the hover surface live:
+    // a malformed request must not be able to silently blind the pane.
+    hoverReporting = msg.enabled !== false
+    return Promise.resolve({ enabled: hoverReporting })
   }
   return Promise.reject(new Error('unknown request: ' + String(msg.type)))
 }
@@ -259,11 +288,23 @@ function install(): void {
   }
 
   function queuePointer(pageX: number, pageY: number): void {
+    // x-ray Off. Two checks, and they do different jobs: this one avoids the
+    // WORK (no bookkeeping, no frame scheduled per mouse move — the point of
+    // Off is that the page does nothing, and only the content can decline to),
+    // the one on the frame below decides what is SENT. Only the second is
+    // separately observable from outside, which is why only it has a test of
+    // its own; deleting this one costs a scheduled frame per move, not a
+    // leaked report. Checked in queuePointer rather than at the listener so
+    // the mouseleave path goes through the same gate.
+    if (!hoverReporting) return
     lastPointer = { x: pageX, y: pageY }
     if (rafPending.pointer) return
     rafPending.pointer = true
     raf(() => {
       rafPending.pointer = false
+      // Re-checked on the frame: a move queued a moment before the host
+      // switched x-ray off must not land after it.
+      if (!hoverReporting) return
       if (!lastPointer) {
         send({ ns: NS, type: 'pointer', pageX: 0, pageY: 0, hit: null })
         return
@@ -299,9 +340,15 @@ function install(): void {
   // the bridge REPORTS them. Capture phase, so a page handler that stops
   // propagation cannot make a click invisible to review; nothing is prevented
   // or retargeted — the page's own behaviour is untouched (D8).
+  //
+  // Silent under x-ray Off (#367): a click in a browser tab selects nothing, so
+  // there is nothing for the host to be told about. The listener stays attached
+  // — it never prevented or retargeted anything, and re-adding it on a mode
+  // change would move it later in the capture order than the page's own.
   document.addEventListener(
     'click',
     (event: MouseEvent) => {
+      if (!hoverReporting) return
       send({ ns: NS, type: 'contentClick', pageX: event.pageX, pageY: event.pageY, hit: hitAt(event.pageX, event.pageY) })
     },
     { capture: true, passive: true },

--- a/src/renderer/canvas/xray-mode.ts
+++ b/src/renderer/canvas/xray-mode.ts
@@ -1,0 +1,96 @@
+// X-ray hover modes (#367) — the pure half, so the rules can be unit-tested flat.
+//
+// The canvas pane's hover readout ("x-ray") is the thing that made the pane
+// unusable as a plain browser: every mousemove over the content painted an
+// outline and a label chip over the page, which is exactly what you do NOT want
+// when you are trying to look at the artifact itself. Owner (book item 52):
+// "switch the canvas x-ray hover functionality off via toggle easily so I can
+// view it as a normal browser."
+//
+// Three modes, one click apart:
+//
+//   off      no hover actions at all. The content frame is asked to stop
+//            reporting pointer moves and clicks, the host ignores them if it
+//            hears them anyway, and nothing is drawn. The page is a browser tab.
+//   stealth  hovers still RESOLVE — the element is identified — but nothing is
+//            drawn over the page; the identity and its box are read out in the
+//            side panel instead.
+//   on       what shipped: outline + label chip on the stage.
+//
+// `on` is the default, and absent settings resolve to it, so no existing
+// install changes behaviour on upgrade.
+
+/** The three x-ray hover modes. `on` is what shipped before #367. */
+export type CanvasXrayMode = 'off' | 'stealth' | 'on'
+
+export const CANVAS_XRAY_MODES: readonly CanvasXrayMode[] = ['off', 'stealth', 'on'] as const
+
+export interface CanvasXrayModeOption {
+  value: CanvasXrayMode
+  /** Segment label — one word, this sits in a 38px pane header. */
+  label: string
+  /** Tooltip: what this mode actually does to the page. */
+  title: string
+}
+
+export const CANVAS_XRAY_MODE_OPTIONS: readonly CanvasXrayModeOption[] = [
+  {
+    value: 'off',
+    label: 'Off',
+    title: 'X-ray off — the page behaves like a normal browser tab. Hover resolves nothing and draws nothing, and a click selects nothing.',
+  },
+  {
+    value: 'stealth',
+    label: 'Stealth',
+    title: 'Stealth — hovering still identifies the element, but nothing is drawn on the page: the identity and its box are read out in the panel on the right.',
+  },
+  {
+    value: 'on',
+    label: 'On',
+    title: 'X-ray on — hovering outlines the element on the page and labels it (the default).',
+  },
+] as const
+
+/**
+ * Absent or unknown (an older settings file, a hand edit) => `on`, the
+ * behaviour that shipped. A preference that fails to parse must never silently
+ * disable a feature the user can no longer find the switch for.
+ */
+export function resolveCanvasXrayMode(value: unknown): CanvasXrayMode {
+  return value === 'off' || value === 'stealth' ? value : 'on'
+}
+
+/**
+ * Does anything resolve the hovered element at all?
+ *
+ * This is the ONE fact the content frame is told (canvas-frame-rpc
+ * `hoverReporting`): in `off` the bridge stops emitting `pointer` and
+ * `contentClick`, so the page does no per-mousemove work whatsoever. The bridge
+ * is page-controlled code and may ignore that, which is why the host gates on
+ * the same predicate — see xrayHoverIsLive's use in AgentCanvasPane.
+ */
+export function xrayHoverIsLive(mode: CanvasXrayMode): boolean {
+  return mode !== 'off'
+}
+
+/** Does the host paint the hover outline + label chip over the content? */
+export function xrayDrawsOnPage(mode: CanvasXrayMode): boolean {
+  return mode === 'on'
+}
+
+/** Is the hovered element read out in the side panel instead of on the page? */
+export function xrayReadsOutInPanel(mode: CanvasXrayMode): boolean {
+  return mode === 'stealth'
+}
+
+/**
+ * Does a click inside the content select (lock focus on) what was clicked?
+ *
+ * The issue left this open for `off` — "nothing, or temporarily arms a note".
+ * Nothing: `off` is asked for as "view it as a normal browser", and a browser
+ * tab does not turn a click into a selection. Arming a note on click would make
+ * `off` a fourth, hidden mode rather than the absence of one.
+ */
+export function xrayClickSelects(mode: CanvasXrayMode): boolean {
+  return mode !== 'off'
+}

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -23,7 +23,7 @@ import {
 import { contentPageRectToStage, stageToContentPagePoint, glassNeedsRepin, glassScrollForContent } from '../utils/canvas-coords'
 import { safeAnchorResolutions, safeInspectResult } from '../utils/canvas-geometry-guard'
 import { registerCanvasFrame } from '../canvas/canvas-snapshot-host'
-import { askCanvasFrame } from '../canvas/canvas-frame-rpc'
+import { askCanvasFrame, framesInFlight, MAX_FRAME_REQUESTS_IN_FLIGHT } from '../canvas/canvas-frame-rpc'
 import { createCanvasInboundChannel } from '../canvas/canvas-inbound-channel'
 import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
 import {
@@ -59,6 +59,32 @@ const HOVER_REPORTING_TIMEOUT_MS = 3000
  *  cap) would set the host's call rate. A new document and a new intent each
  *  reset it, so this bounds futile retries, never the feature. */
 const MAX_HOVER_REPORTING_ATTEMPTS = 3
+
+/** How long the reconcile waits before looking again when the request could not
+ *  be SENT at all — the frame's request channel was full, or the send window
+ *  below was spent. Both conditions clear on their own in well under a second,
+ *  so this is a pause, not a backoff. */
+const HOVER_REPORTING_RETRY_MS = 250
+
+/** How many times one attempt may be deferred that way before the pane stops
+ *  looking. Bounded because the timer is the HOST's own loop: without a cap a
+ *  frame that stays saturated would be polled for the life of the document. */
+const MAX_HOVER_REPORTING_DEFERRALS = 12
+
+/**
+ * The ceiling on hoverReporting requests actually posted to a frame in one
+ * rolling window — the flood budget for this channel.
+ *
+ * The per-intent attempt budget bounds futile RETRIES; it cannot bound a page
+ * that manufactures new intents. `ready` is a page-authored message and every
+ * `ready` is a new document with a fresh budget, so a page that simply re-emits
+ * it multiplied the host's send rate by the attempt budget — three requests
+ * became eighteen after five extra readys (independent review of #405). This
+ * bounds the rate whatever drives it; over the ceiling the reconcile waits for
+ * the window rather than spending an attempt.
+ */
+const MAX_HOVER_REPORTING_SENDS_PER_WINDOW = 12
+const HOVER_REPORTING_SEND_WINDOW_MS = 1000
 
 /** Wall-clock of a render, or null when the stored stamp will not parse. */
 function versionClock(iso: string): string | null {
@@ -258,11 +284,25 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const modeRef = useRef(mode)
   const xrayModeRef = useRef(xrayMode)
   const versionIdRef = useRef(version.id)
-  /** What the CURRENT document says it is doing about hover reporting. A bridge
-   *  starts reporting, so a freshly loaded frame is `true` and only a mode that
-   *  disagrees costs a round-trip. Written from the frame's ANSWER, never from
-   *  the send. */
-  const frameHoverReportingRef = useRef(true)
+  /**
+   * What the CURRENT document says it is doing about hover reporting. A bridge
+   * starts reporting, so a freshly loaded frame is `true` and only a mode that
+   * disagrees costs a round-trip. Written from the frame's ANSWER, never from
+   * the send.
+   *
+   * `'unknown'` is a real third state, not a spelling of `true`. A request that
+   * settles without a boolean — refused, timed out, answered with something the
+   * frame did not have to mean — leaves the host with NO account of what the
+   * frame is doing, and leaving the last belief standing there is a lie the
+   * reconcile then acts on: the bridge applies hoverReporting and only then
+   * replies (canvas/bridge), so an Off whose ack is dropped has quieted a frame
+   * the host still believes is loud. Flip to On and desire (true) matched
+   * belief (true), the reconcile short-circuited, and the frame stayed quiet for
+   * the life of the document — x-ray On drawing nothing and clicks selecting
+   * nothing, with no report left to repair from (fix-delta verification, #405).
+   * Unknown never equals what is wanted, so it always re-sends.
+   */
+  const frameHoverReportingRef = useRef<boolean | 'unknown'>(true)
   /** One hoverReporting request in flight at a time. */
   const hoverReportingPendingRef = useRef(false)
   /**
@@ -289,6 +329,14 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
    *  than a reset at each call site — `ready` and the effect that follows it
    *  are the same intent, and resetting in both handed it a double budget. */
   const hoverReportingIntentRef = useRef('')
+  /** How many times the CURRENT attempt has been deferred because the request
+   *  could not be posted at all. Reset when one is actually dispatched, and
+   *  with the intent. */
+  const hoverReportingDeferralsRef = useRef(0)
+  /** The one outstanding deferral timer, so a deferral cannot fan out. */
+  const hoverReportingRetryTimerRef = useRef<number | null>(null)
+  /** The rolling send window: requests posted since `start`. */
+  const hoverReportingWindowRef = useRef({ start: 0, sent: 0 })
   /** Self-reference for the post-settle reconcile, held in a ref so the
    *  recursion does not depend on which render's binding was captured. */
   const syncHoverReportingRef = useRef<() => void>(() => {})
@@ -367,6 +415,46 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   )
 
   /**
+   * Look again shortly, because the request could not be POSTED — not because
+   * the frame said anything. Deliberately not an attempt: an attempt is a thing
+   * the frame was actually asked, and spending the budget on a condition inside
+   * the HOST clears it in three microtasks and wedges the intent (see the
+   * dispatch checks below).
+   */
+  const deferHoverReconcile = useCallback(() => {
+    if (hoverReportingRetryTimerRef.current !== null) return
+    if (hoverReportingDeferralsRef.current >= MAX_HOVER_REPORTING_DEFERRALS) return
+    hoverReportingDeferralsRef.current += 1
+    hoverReportingRetryTimerRef.current = window.setTimeout(() => {
+      hoverReportingRetryTimerRef.current = null
+      syncHoverReportingRef.current()
+    }, HOVER_REPORTING_RETRY_MS)
+  }, [])
+
+  /** Requests still postable in the current send window, rolling it over when
+   *  it has expired. Reading it is what advances the window; posting is what
+   *  spends it. */
+  const hoverReportingSendBudget = useCallback((now: number) => {
+    const w = hoverReportingWindowRef.current
+    if (now - w.start >= HOVER_REPORTING_SEND_WINDOW_MS) {
+      w.start = now
+      w.sent = 0
+    }
+    return MAX_HOVER_REPORTING_SENDS_PER_WINDOW - w.sent
+  }, [])
+
+  // A deferral timer must not outlive the pane: it holds the reconcile, which
+  // would post into a frame the user has closed.
+  useEffect(() => {
+    return () => {
+      if (hoverReportingRetryTimerRef.current !== null) {
+        window.clearTimeout(hoverReportingRetryTimerRef.current)
+        hoverReportingRetryTimerRef.current = null
+      }
+    }
+  }, [])
+
+  /**
    * Bring the frame's belief about hover reporting in line with the x-ray mode
    * (#367).
    *
@@ -402,30 +490,57 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     if (hoverReportingIntentRef.current !== intent) {
       hoverReportingIntentRef.current = intent
       hoverReportingAttemptsRef.current = 0
+      hoverReportingDeferralsRef.current = 0
     }
+    // Unknown is never equal to what is wanted, so a frame the host has no
+    // account of is always asked again rather than short-circuited here.
     if (frameHoverReportingRef.current === enabled) return
     if (hoverReportingPendingRef.current) return
     if (hoverReportingAttemptsRef.current >= MAX_HOVER_REPORTING_ATTEMPTS) return
     const target = iframeRef.current?.contentWindow
     if (!target) return
+    // ── Two ways the request cannot be posted AT ALL, neither of which is the
+    //    frame's doing, and neither of which spends an attempt.
+    //
+    // The first is the RPC's in-flight cap: over it the request is refused
+    // before a listener exists, and that refusal is a synchronous rejection —
+    // which the post-settle reconcile below then fires on, spending the whole
+    // budget in three microtasks on a condition that clears in milliseconds.
+    // (Reachable: the resolution pass has no in-flight guard of its own, so a
+    // few note edits inside its ten-second window saturate the cap.) The
+    // second is this channel's own send window. Both clear on their own, so the
+    // reconcile waits for them instead of counting them against the frame
+    // (fix-delta verification, #405).
+    if (framesInFlight(target) >= MAX_FRAME_REQUESTS_IN_FLIGHT || hoverReportingSendBudget(Date.now()) <= 0) {
+      deferHoverReconcile()
+      return
+    }
     const generation = frameGenerationRef.current
     hoverReportingPendingRef.current = true
     hoverReportingAttemptsRef.current += 1
+    hoverReportingDeferralsRef.current = 0
+    hoverReportingWindowRef.current.sent += 1
     askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS)
       .then(
         (raw) => {
           // Believed only about the document it was asked of, and only as the
           // frame's own account of itself — the reply is page-authored, so a
-          // non-boolean is no answer at all and leaves the state alone.
+          // non-boolean is no answer at all and the host is left not knowing.
           if (generation !== frameGenerationRef.current) return
           const answered = (raw as CanvasHoverReportingResult | null | undefined)?.enabled
-          if (typeof answered === 'boolean') frameHoverReportingRef.current = answered
+          frameHoverReportingRef.current = typeof answered === 'boolean' ? answered : 'unknown'
         },
         () => {
           /* Never landed: refused by the in-flight cap, a frame mid-navigation,
-             a page that answers nothing. Nothing is believed — and the mode
-             still holds meanwhile, because the host-side gate is what enforces
-             it, not this request. */
+             a page that answers nothing, an ack lost or too late. The bridge
+             APPLIES the change and only then replies, so a request that does
+             not come back leaves the host with no account of the frame at all —
+             recorded as exactly that, because carrying the old belief forward is
+             what let a dropped ack strand the frame quiet for the life of the
+             document. The mode still holds meanwhile: the host-side gate is what
+             enforces it, not this request. */
+          if (generation !== frameGenerationRef.current) return
+          frameHoverReportingRef.current = 'unknown'
         },
       )
       .finally(() => {
@@ -435,7 +550,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         hoverReportingPendingRef.current = false
         syncHoverReportingRef.current()
       })
-  }, [canvasId])
+  }, [canvasId, deferHoverReconcile, hoverReportingSendBudget])
   syncHoverReportingRef.current = syncHoverReporting
 
   const handleReportedKey = useCallback(
@@ -549,6 +664,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   // New version (or a retry) → the frame reloads; bridge state starts over.
   useEffect(() => {
     bridgeReadyRef.current = false
+    // Bumped for the same reason `ready` bumps it: this is a NEW document, and
+    // the request parked against the old one must not land on the reset below
+    // and undo it. (The reset without the bump was the one place the two were
+    // not kept together — fix-delta verification, #405.)
+    frameGenerationRef.current += 1
     frameHoverReportingRef.current = true
     setBridgeReady(false)
     setViewport(null)

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -255,6 +255,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
    *  mode that disagrees costs a round-trip. Reset when the frame reloads —
    *  the new document has a new bridge with the default back on. */
   const frameHoverReportingRef = useRef(true)
+  /** One hoverReporting request at a time. The repair path is driven by the
+   *  page's own reports, so without this a page that declines to go quiet would
+   *  be choosing the host's call rate. */
+  const hoverReportingPendingRef = useRef(false)
   /** One outstanding inspect per frame — a page-driven click cannot open a
    *  second one while the first is unanswered. */
   const inspectPendingRef = useRef(false)
@@ -338,19 +342,37 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
    * test, no measurement and no postMessage per mousemove. Sent only when the
    * frame's belief disagrees, so the common case (x-ray on, the bridge's own
    * default) costs no round-trip at all.
+   *
+   * The belief is recorded on the ANSWER, never on the send. A request can be
+   * refused before it is posted — canvas-frame-rpc caps requests in flight at
+   * four, and a snapshot, an inspect and a resolveAnchors can already be
+   * outstanding when the user reaches for the switch — and marking it sent
+   * anyway left the host permanently certain it had quieted a frame that was
+   * never told, with the page doing per-mousemove work for the rest of that
+   * document's life (Copilot review, #405). Nothing is drawn either way, so the
+   * only symptom is the work itself.
    */
   const syncHoverReporting = useCallback(() => {
     const enabled = xrayHoverIsLive(xrayModeRef.current)
-    if (frameHoverReportingRef.current === enabled) return
+    if (frameHoverReportingRef.current === enabled || hoverReportingPendingRef.current) return
     const target = iframeRef.current?.contentWindow
     if (!target) return
-    frameHoverReportingRef.current = enabled
-    void askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS).catch(() => {
-      /* An old bridge, a frame mid-navigation, a page that answers nothing: the
-         mode still holds, because the host-side gate is what enforces it. Left
-         marked as sent — a retry loop over an unanswerable frame would be the
-         page choosing the host's call rate. */
-    })
+    hoverReportingPendingRef.current = true
+    askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS)
+      .then(
+        () => {
+          frameHoverReportingRef.current = enabled
+        },
+        () => {
+          /* Never landed: refused by the in-flight cap, a frame mid-navigation,
+             a page that answers nothing. The belief stays where it was, so the
+             next report, mode change or `ready` asks again — and the mode still
+             holds meanwhile, because the host-side gate is what enforces it. */
+        },
+      )
+      .finally(() => {
+        hoverReportingPendingRef.current = false
+      })
   }, [canvasId])
 
   const handleReportedKey = useCallback(
@@ -408,6 +430,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         onPointer: (hit) => {
           if (!xrayHoverIsLive(xrayModeRef.current)) {
             setHover(null)
+            // A report arriving in a mode that wants none IS the evidence that
+            // the frame was never told — the request was refused, lost, or this
+            // is a document that has not been asked yet. So the symptom drives
+            // the repair; the pending guard keeps it to one request at a time
+            // however fast the reports come.
+            syncHoverReporting()
             return
           }
           setHover(hit ? { hit } : null)
@@ -418,7 +446,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           // Under x-ray Off a click selects nothing: the page was asked for as a
           // normal browser tab, and a tab does not turn a click into a selection
           // (#367 left this open; see xrayClickSelects).
-          if (!xrayClickSelects(xrayModeRef.current)) return
+          if (!xrayClickSelects(xrayModeRef.current)) {
+            // Same evidence as an unwanted pointer report: this frame is still
+            // reporting and should not be.
+            syncHoverReporting()
+            return
+          }
           if (modeRef.current === 'browse') void inspectAndLock(pageX, pageY)
         },
         onContentKey: handleReportedKey,

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -329,6 +329,30 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     [canvasId, sessionId],
   )
 
+  /**
+   * Bring the frame's belief about hover reporting in line with the x-ray mode
+   * (#367).
+   *
+   * The host already ignores what it does not want, so this is not the gate —
+   * it is what makes Off free for the PAGE: a bridge told to stop does no hit
+   * test, no measurement and no postMessage per mousemove. Sent only when the
+   * frame's belief disagrees, so the common case (x-ray on, the bridge's own
+   * default) costs no round-trip at all.
+   */
+  const syncHoverReporting = useCallback(() => {
+    const enabled = xrayHoverIsLive(xrayModeRef.current)
+    if (frameHoverReportingRef.current === enabled) return
+    const target = iframeRef.current?.contentWindow
+    if (!target) return
+    frameHoverReportingRef.current = enabled
+    void askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS).catch(() => {
+      /* An old bridge, a frame mid-navigation, a page that answers nothing: the
+         mode still holds, because the host-side gate is what enforces it. Left
+         marked as sent — a retry loop over an unanswerable frame would be the
+         page choosing the host's call rate. */
+    })
+  }, [canvasId])
+
   const handleReportedKey = useCallback(
     (key: string) => {
       const store = useCanvasReviewStore.getState()
@@ -360,6 +384,16 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         onReady: () => {
           bridgeReadyRef.current = true
           setBridgeReady(true)
+          // Every `ready` is a NEW document with a NEW bridge, and a new bridge
+          // reports by default. An in-frame navigation (a link inside the
+          // content) replaces the document without changing `contentUrl` or the
+          // reload nonce, so this is the ONLY signal that the frame has
+          // forgotten what it was told — without the reset, x-ray Off stopped
+          // quieting the page after the first link click, and the pane looked
+          // right only because the host gate was still dropping the reports
+          // (Copilot review, #405).
+          frameHoverReportingRef.current = true
+          syncHoverReporting()
         },
         onViewport: (vp) => {
           setViewport(vp)
@@ -391,7 +425,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         onFlood: () => setBridgeFlooded(true),
       },
     })
-  }, [repinGlass, canvasId, inspectAndLock, handleReportedKey])
+  }, [repinGlass, canvasId, inspectAndLock, handleReportedKey, syncHoverReporting])
 
   // The same two keys, host-side, for when the HOST document has keyboard
   // focus (after touching the panel or the chrome). Never while typing.
@@ -410,27 +444,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     return () => window.removeEventListener('keydown', onKey)
   }, [sessionId, handleReportedKey])
 
-  // Tell the frame whether the hover surface is wanted at all (#367).
-  //
-  // The host already ignores what it does not want, so this is not the gate —
-  // it is what makes Off free for the PAGE: a bridge told to stop does no hit
-  // test, no measurement and no postMessage per mousemove. Sent only when the
-  // frame's belief disagrees with the mode, so the common case (x-ray on, the
-  // bridge's own default) costs no round-trip at all.
+  // The user changed the mode: bring the frame in line with it. (A frame that
+  // is not ready yet is told on its `ready` instead — see the channel above.)
   useEffect(() => {
     if (!bridgeReady) return
-    const enabled = xrayHoverIsLive(xrayMode)
-    if (frameHoverReportingRef.current === enabled) return
-    const target = iframeRef.current?.contentWindow
-    if (!target) return
-    frameHoverReportingRef.current = enabled
-    void askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS).catch(() => {
-      /* An old bridge, a frame mid-navigation, a page that answers nothing: the
-         mode still holds, because the host-side gate above is what enforces it.
-         Left marked as sent — a retry loop over an unanswerable frame would be
-         the page choosing the host's call rate. */
-    })
-  }, [xrayMode, bridgeReady, canvasId])
+    syncHoverReporting()
+  }, [xrayMode, bridgeReady, syncHoverReporting])
 
   // Switching x-ray off drops whatever was hovered at that instant, so nothing
   // is left painted over a page the user just asked to see plainly.

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -18,6 +18,7 @@ import {
   CanvasVersion,
   canvasContentUrl,
   type AnchorRef,
+  type CanvasHoverReportingResult,
 } from '../../shared/canvas'
 import { contentPageRectToStage, stageToContentPagePoint, glassNeedsRepin, glassScrollForContent } from '../utils/canvas-coords'
 import { safeAnchorResolutions, safeInspectResult } from '../utils/canvas-geometry-guard'
@@ -51,6 +52,13 @@ const FRAME_READY_TIMEOUT_MS = 8000
  *  nothing waits on the answer — the host's own gate is what enforces the mode,
  *  and this request only asks the page to stop doing work it need not do. */
 const HOVER_REPORTING_TIMEOUT_MS = 3000
+
+/** How many times one intent may be re-sent to a frame that will not confirm
+ *  it. The reconcile retries whenever a request settles without the frame
+ *  agreeing, so without a cap a page that answers wrongly (or a saturated RPC
+ *  cap) would set the host's call rate. A new document and a new intent each
+ *  reset it, so this bounds futile retries, never the feature. */
+const MAX_HOVER_REPORTING_ATTEMPTS = 3
 
 /** Wall-clock of a render, or null when the stored stamp will not parse. */
 function versionClock(iso: string): string | null {
@@ -250,15 +258,40 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const modeRef = useRef(mode)
   const xrayModeRef = useRef(xrayMode)
   const versionIdRef = useRef(version.id)
-  /** What the CURRENT frame was last told about hover reporting. The bridge
-   *  starts reporting, so a freshly loaded frame believes `true` and only a
-   *  mode that disagrees costs a round-trip. Reset when the frame reloads —
-   *  the new document has a new bridge with the default back on. */
+  /** What the CURRENT document says it is doing about hover reporting. A bridge
+   *  starts reporting, so a freshly loaded frame is `true` and only a mode that
+   *  disagrees costs a round-trip. Written from the frame's ANSWER, never from
+   *  the send. */
   const frameHoverReportingRef = useRef(true)
-  /** One hoverReporting request at a time. The repair path is driven by the
-   *  page's own reports, so without this a page that declines to go quiet would
-   *  be choosing the host's call rate. */
+  /** One hoverReporting request in flight at a time. */
   const hoverReportingPendingRef = useRef(false)
+  /**
+   * Which document the in-flight request is about.
+   *
+   * Bumped on every `ready`. An answer is only believed about the document it
+   * was asked of: an in-frame navigation replaces the bridge while a request is
+   * parked, and letting the old document's answer land on the new one's state
+   * re-opened the exact bug e608cf32 closed, through the other door (independent
+   * review of #405).
+   */
+  const frameGenerationRef = useRef(0)
+  /**
+   * Attempts spent on the current intent. A frame can refuse (the RPC's
+   * in-flight cap), time out, or answer something other than what it was asked
+   * — and the reconcile below retries — so something has to stop a page that
+   * will never comply from choosing the host's call rate. The budget belongs to
+   * one intent, so it bounds futile retries rather than the feature.
+   */
+  const hoverReportingAttemptsRef = useRef(0)
+  /** Which intent that budget belongs to: `<document generation>:<wanted>`. A
+   *  new document or a new answer to want is a new intent and a fresh budget.
+   *  Kept as one derived key so there is a single place that decides, rather
+   *  than a reset at each call site — `ready` and the effect that follows it
+   *  are the same intent, and resetting in both handed it a double budget. */
+  const hoverReportingIntentRef = useRef('')
+  /** Self-reference for the post-settle reconcile, held in a ref so the
+   *  recursion does not depend on which render's binding was captured. */
+  const syncHoverReportingRef = useRef<() => void>(() => {})
   /** One outstanding inspect per frame — a page-driven click cannot open a
    *  second one while the first is unanswered. */
   const inspectPendingRef = useRef(false)
@@ -343,37 +376,67 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
    * frame's belief disagrees, so the common case (x-ray on, the bridge's own
    * default) costs no round-trip at all.
    *
-   * The belief is recorded on the ANSWER, never on the send. A request can be
-   * refused before it is posted — canvas-frame-rpc caps requests in flight at
-   * four, and a snapshot, an inspect and a resolveAnchors can already be
-   * outstanding when the user reaches for the switch — and marking it sent
-   * anyway left the host permanently certain it had quieted a frame that was
-   * never told, with the page doing per-mousemove work for the rest of that
-   * document's life (Copilot review, #405). Nothing is drawn either way, so the
-   * only symptom is the work itself.
+   * What the frame is doing is recorded from its ANSWER, never from the send. A
+   * request can be refused before it is ever posted — canvas-frame-rpc caps
+   * requests in flight at four, and a snapshot, an inspect and a resolveAnchors
+   * can already be outstanding when the user reaches for the switch — and
+   * marking it sent anyway left the host permanently certain it had quieted a
+   * frame that was never told (Copilot review, #405).
+   *
+   * And the reconcile happens when the request SETTLES, not when the page next
+   * reports. An earlier revision repaired from the symptom — a report arriving
+   * in a mode that wants none — which cannot see the failure that matters:
+   * flip the mode while a request is parked and the flip is dropped by the
+   * in-flight guard, the parked answer lands, and the frame stays quiet for the
+   * life of the document with x-ray showing nothing at all. Silence is not a
+   * symptom, so nothing is allowed to wait for one (independent review, #405).
    */
   const syncHoverReporting = useCallback(() => {
     const enabled = xrayHoverIsLive(xrayModeRef.current)
-    if (frameHoverReportingRef.current === enabled || hoverReportingPendingRef.current) return
+    // Recorded BEFORE the nothing-to-do check, so that passing through a mode
+    // the frame already agrees with still counts as changing the intent. Keyed
+    // after it, "Off (gave up) -> On -> Off" read as the same intent as the
+    // first Off and the second one got no attempts at all — the user asking
+    // again is the clearest signal there is that they want it to work.
+    const intent = `${frameGenerationRef.current}:${enabled}`
+    if (hoverReportingIntentRef.current !== intent) {
+      hoverReportingIntentRef.current = intent
+      hoverReportingAttemptsRef.current = 0
+    }
+    if (frameHoverReportingRef.current === enabled) return
+    if (hoverReportingPendingRef.current) return
+    if (hoverReportingAttemptsRef.current >= MAX_HOVER_REPORTING_ATTEMPTS) return
     const target = iframeRef.current?.contentWindow
     if (!target) return
+    const generation = frameGenerationRef.current
     hoverReportingPendingRef.current = true
+    hoverReportingAttemptsRef.current += 1
     askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS)
       .then(
-        () => {
-          frameHoverReportingRef.current = enabled
+        (raw) => {
+          // Believed only about the document it was asked of, and only as the
+          // frame's own account of itself — the reply is page-authored, so a
+          // non-boolean is no answer at all and leaves the state alone.
+          if (generation !== frameGenerationRef.current) return
+          const answered = (raw as CanvasHoverReportingResult | null | undefined)?.enabled
+          if (typeof answered === 'boolean') frameHoverReportingRef.current = answered
         },
         () => {
           /* Never landed: refused by the in-flight cap, a frame mid-navigation,
-             a page that answers nothing. The belief stays where it was, so the
-             next report, mode change or `ready` asks again — and the mode still
-             holds meanwhile, because the host-side gate is what enforces it. */
+             a page that answers nothing. Nothing is believed — and the mode
+             still holds meanwhile, because the host-side gate is what enforces
+             it, not this request. */
         },
       )
       .finally(() => {
+        // Cleared for EVERY generation: a stale answer that is no longer
+        // believed must still release the in-flight slot, or one navigation
+        // mid-request would wedge the switch for the life of the pane.
         hoverReportingPendingRef.current = false
+        syncHoverReportingRef.current()
       })
   }, [canvasId])
+  syncHoverReportingRef.current = syncHoverReporting
 
   const handleReportedKey = useCallback(
     (key: string) => {
@@ -414,6 +477,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           // quieting the page after the first link click, and the pane looked
           // right only because the host gate was still dropping the reports
           // (Copilot review, #405).
+          //
+          // The generation bump is what stops the PREVIOUS document's parked
+          // answer from landing on this one's state and undoing this reset.
+          frameGenerationRef.current += 1
           frameHoverReportingRef.current = true
           syncHoverReporting()
         },
@@ -430,12 +497,6 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         onPointer: (hit) => {
           if (!xrayHoverIsLive(xrayModeRef.current)) {
             setHover(null)
-            // A report arriving in a mode that wants none IS the evidence that
-            // the frame was never told — the request was refused, lost, or this
-            // is a document that has not been asked yet. So the symptom drives
-            // the repair; the pending guard keeps it to one request at a time
-            // however fast the reports come.
-            syncHoverReporting()
             return
           }
           setHover(hit ? { hit } : null)
@@ -446,12 +507,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           // Under x-ray Off a click selects nothing: the page was asked for as a
           // normal browser tab, and a tab does not turn a click into a selection
           // (#367 left this open; see xrayClickSelects).
-          if (!xrayClickSelects(xrayModeRef.current)) {
-            // Same evidence as an unwanted pointer report: this frame is still
-            // reporting and should not be.
-            syncHoverReporting()
-            return
-          }
+          if (!xrayClickSelects(xrayModeRef.current)) return
           if (modeRef.current === 'browse') void inspectAndLock(pageX, pageY)
         },
         onContentKey: handleReportedKey,
@@ -648,6 +704,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     if (!hover || !viewport) return null
     return contentPageRectToStage(hover.hit.box, viewport)
   }, [hover, viewport])
+
+  /** Which layer the pointer is on — the same three-way the glass and marquee
+   *  layers are wired from, named once so the stealth readout can tell the user
+   *  why hovering the content is doing nothing. */
+  const pointerOwner = marqueeArmed ? 'marquee' : mode === 'draw' ? 'glass' : 'content'
 
   /** The hover box AS PAINTED on the stage. Null in every posture that must
    *  leave the content alone — the glass owning the pointer, a marquee being
@@ -1152,7 +1213,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             />
           </div>
           {xrayReadsOutInPanel(xrayMode) && (
-            <CanvasXrayReadout hit={mode === 'browse' && !marqueeArmed ? (hover?.hit ?? null) : null} label={hoverLabel} />
+            <CanvasXrayReadout
+              hit={pointerOwner === 'content' ? (hover?.hit ?? null) : null}
+              label={hoverLabel}
+              pointerOwner={pointerOwner}
+            />
           )}
         </div>
       </div>

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -7,7 +7,9 @@ import { CanvasLibrary } from './CanvasLibrary'
 import CanvasSubjectPicker from './CanvasSubjectPicker'
 import CanvasFiledStrip from './CanvasFiledStrip'
 import CanvasNotesPanel from './CanvasNotesPanel'
+import CanvasXrayReadout from './CanvasXrayReadout'
 import { useCanvasStore } from '../stores/canvasStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { useExcalidrawStore } from '../stores/excalidrawStore'
 import {
   MAX_RESOLVE_ANCHORS,
@@ -23,6 +25,15 @@ import { registerCanvasFrame } from '../canvas/canvas-snapshot-host'
 import { askCanvasFrame } from '../canvas/canvas-frame-rpc'
 import { createCanvasInboundChannel } from '../canvas/canvas-inbound-channel'
 import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
+import {
+  CANVAS_XRAY_MODE_OPTIONS,
+  resolveCanvasXrayMode,
+  xrayClickSelects,
+  xrayDrawsOnPage,
+  xrayHoverIsLive,
+  xrayReadsOutInPanel,
+  type CanvasXrayMode,
+} from '../canvas/xray-mode'
 import { openReviewsOf, openSubmittedNotesOf, useCanvasReviewStore } from '../stores/canvasReviewStore'
 import { useCanvasTotalsStore } from '../stores/canvasTotalsStore'
 import { relativeTime } from '../utils/relativeTime'
@@ -35,6 +46,11 @@ const MONO = "'JetBrains Mono', ui-monospace, monospace"
  *  loading. A 404, a CSP-blocked bridge script and a crashed page otherwise
  *  look exactly like a slow one — forever. */
 const FRAME_READY_TIMEOUT_MS = 8000
+
+/** How long the frame gets to acknowledge an x-ray mode change (#367). Short:
+ *  nothing waits on the answer — the host's own gate is what enforces the mode,
+ *  and this request only asks the page to stop doing work it need not do. */
+const HOVER_REPORTING_TIMEOUT_MS = 3000
 
 /** Wall-clock of a render, or null when the stored stamp will not parse. */
 function versionClock(iso: string): string | null {
@@ -216,6 +232,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const setInteractionMode = useCanvasStore((s) => s.setInteractionMode)
   const setActiveVersion = useCanvasStore((s) => s.setActiveVersion)
 
+  // X-ray hover mode (#367) — PER USER, so it comes from settings rather than
+  // from the canvas store where the per-canvas interaction mode lives. Every
+  // read goes through the resolver: an absent or hand-edited value is 'on'.
+  const xrayMode = resolveCanvasXrayMode(useSettingsStore((s) => s.settings.canvasXrayMode))
+
   const focus = useCanvasReviewStore((s) => s.bySessionId[sessionId]?.focus ?? null)
   const marqueeArmed = useCanvasReviewStore((s) => s.bySessionId[sessionId]?.marqueeArmed ?? false)
   const panelHighlight = useCanvasReviewStore((s) => s.bySessionId[sessionId]?.panelHighlight ?? null)
@@ -227,7 +248,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const repinPendingRef = useRef(false)
   const viewportRef = useRef<CanvasViewportInfo | null>(null)
   const modeRef = useRef(mode)
+  const xrayModeRef = useRef(xrayMode)
   const versionIdRef = useRef(version.id)
+  /** What the CURRENT frame was last told about hover reporting. The bridge
+   *  starts reporting, so a freshly loaded frame believes `true` and only a
+   *  mode that disagrees costs a round-trip. Reset when the frame reloads —
+   *  the new document has a new bridge with the default back on. */
+  const frameHoverReportingRef = useRef(true)
   /** One outstanding inspect per frame — a page-driven click cannot open a
    *  second one while the first is unanswered. */
   const inspectPendingRef = useRef(false)
@@ -256,6 +283,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
 
   viewportRef.current = viewport
   modeRef.current = mode
+  xrayModeRef.current = xrayMode
   versionIdRef.current = version.id
 
   // Keep the glass pinned to the content: scene scroll ≡ −content scroll at
@@ -339,10 +367,24 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           viewportRef.current = vp
           repinGlass()
         },
-        onPointer: (hit) => setHover(hit ? { hit } : null),
+        // X-ray Off is enforced HERE, not only by the request that asked the
+        // bridge to go quiet (#367). The bridge shares a realm with the page it
+        // reports on and may ignore that request — or never have received it —
+        // so the mode the user chose is applied to what actually arrives.
+        onPointer: (hit) => {
+          if (!xrayHoverIsLive(xrayModeRef.current)) {
+            setHover(null)
+            return
+          }
+          setHover(hit ? { hit } : null)
+        },
         onContentClick: (pageX, pageY) => {
           // Click-to-lock (spec §6 step 3) — browse mode only; in draw mode the
           // glass owns the pointer and a frame click cannot happen anyway.
+          // Under x-ray Off a click selects nothing: the page was asked for as a
+          // normal browser tab, and a tab does not turn a click into a selection
+          // (#367 left this open; see xrayClickSelects).
+          if (!xrayClickSelects(xrayModeRef.current)) return
           if (modeRef.current === 'browse') void inspectAndLock(pageX, pageY)
         },
         onContentKey: handleReportedKey,
@@ -368,9 +410,38 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     return () => window.removeEventListener('keydown', onKey)
   }, [sessionId, handleReportedKey])
 
+  // Tell the frame whether the hover surface is wanted at all (#367).
+  //
+  // The host already ignores what it does not want, so this is not the gate —
+  // it is what makes Off free for the PAGE: a bridge told to stop does no hit
+  // test, no measurement and no postMessage per mousemove. Sent only when the
+  // frame's belief disagrees with the mode, so the common case (x-ray on, the
+  // bridge's own default) costs no round-trip at all.
+  useEffect(() => {
+    if (!bridgeReady) return
+    const enabled = xrayHoverIsLive(xrayMode)
+    if (frameHoverReportingRef.current === enabled) return
+    const target = iframeRef.current?.contentWindow
+    if (!target) return
+    frameHoverReportingRef.current = enabled
+    void askCanvasFrame(target, canvasId, { type: 'hoverReporting', enabled }, HOVER_REPORTING_TIMEOUT_MS).catch(() => {
+      /* An old bridge, a frame mid-navigation, a page that answers nothing: the
+         mode still holds, because the host-side gate above is what enforces it.
+         Left marked as sent — a retry loop over an unanswerable frame would be
+         the page choosing the host's call rate. */
+    })
+  }, [xrayMode, bridgeReady, canvasId])
+
+  // Switching x-ray off drops whatever was hovered at that instant, so nothing
+  // is left painted over a page the user just asked to see plainly.
+  useEffect(() => {
+    if (!xrayHoverIsLive(xrayMode)) setHover(null)
+  }, [xrayMode])
+
   // New version (or a retry) → the frame reloads; bridge state starts over.
   useEffect(() => {
     bridgeReadyRef.current = false
+    frameHoverReportingRef.current = true
     setBridgeReady(false)
     setViewport(null)
     setHover(null)
@@ -526,6 +597,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     return contentPageRectToStage(hover.hit.box, viewport)
   }, [hover, viewport])
 
+  /** The hover box AS PAINTED on the stage. Null in every posture that must
+   *  leave the content alone — the glass owning the pointer, a marquee being
+   *  dragged, and now x-ray Stealth and Off (#367), where the hover is either
+   *  read out beside the stage or not resolved at all. */
+  const stageHoverRect = mode === 'browse' && !marqueeArmed && xrayDrawsOnPage(xrayMode) ? hoverStageRect : null
+
   const focusStageRect = useMemo(() => {
     if (!focus || !viewport) return null
     return contentPageRectToStage(focus.bboxPage, viewport)
@@ -560,11 +637,29 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   // review); the leftover chrome is hidden by the glass-scoped CSS.
   const glassUIOptions = useMemo(() => ({ welcomeScreen: false, tools: { image: false } }), [])
 
+  // What Browse actually does depends on the x-ray mode now, and the strip is
+  // the only thing that says so — a user who switched x-ray off and still read
+  // "hover to inspect, click to select" would reasonably think it had failed.
+  const browseHint =
+    xrayMode === 'off'
+      ? 'the page is live and plain — x-ray is off, so hovering and clicking do nothing here'
+      : xrayMode === 'stealth'
+        ? 'the page is live — hovering names the element in the panel and draws nothing · click to select · ↑ parent · Esc clear'
+        : 'the page is live — hover to inspect, click to select · ↑ parent · Esc clear'
+
   const modeStrip = marqueeArmed
     ? { color: 'text-peach', label: 'Region', hint: 'drag a rectangle over the area — Esc cancels' }
     : mode === 'draw'
       ? { color: 'text-mauve', label: 'Draw', hint: 'sketch on the glass; select strokes, then attach them to a note' }
-      : { color: 'text-blue', label: 'Browse', hint: 'the page is live — hover to inspect, click to select · ↑ parent · Esc clear' }
+      : { color: 'text-blue', label: 'Browse', hint: browseHint }
+
+  /** Per USER, so it is written straight to settings rather than to any canvas
+   *  state (#367). Fire-and-forget: the store applies the change synchronously
+   *  and the persist is the config saver's problem, exactly as every other
+   *  settings toggle in the app does it. */
+  const setXrayMode = (next: CanvasXrayMode) => {
+    void useSettingsStore.getState().updateSettings({ canvasXrayMode: next })
+  }
 
   const segmentClass = (active: boolean) =>
     `px-2.5 py-[5px] rounded text-[11.5px] font-medium leading-none transition-colors focus-ring disabled:opacity-40 ${
@@ -706,6 +801,32 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             Region
           </button>
         </div>
+        {/* X-ray (#367) — whether pointing at the page marks it up, names it
+            quietly beside the stage, or does nothing at all. Beside the mode
+            switch because the two together are the whole answer to "what
+            happens when I move the mouse over this". */}
+        <span className="shrink-0 text-[10px] uppercase tracking-wide text-[var(--text-secondary)]" aria-hidden="true">
+          X-ray
+        </span>
+        <div
+          className="shrink-0 flex items-center gap-[2px] p-[2px] rounded-md bg-[var(--surface-panel)] border border-[var(--border-subtle)]"
+          role="group"
+          aria-label="Canvas x-ray hover"
+          data-testid="canvas-xray-mode"
+        >
+          {CANVAS_XRAY_MODE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setXrayMode(option.value)}
+              aria-pressed={xrayMode === option.value}
+              className={segmentClass(xrayMode === option.value)}
+              title={option.title}
+              data-testid={`canvas-xray-${option.value}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
         <button
           onClick={() => togglePane(sessionId)}
           aria-label="Close Agent Canvas"
@@ -790,14 +911,14 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
               Clipped to the stage so a box for offscreen page coords cannot
               paint over the surrounding chrome. */}
           <div className="absolute inset-0 pointer-events-none overflow-hidden" data-canvas-layer="overlay">
-            {mode === 'browse' && !marqueeArmed && hoverStageRect && (
+            {stageHoverRect && (
               <div
                 className="absolute border-2 border-blue rounded-sm"
                 style={{
-                  left: hoverStageRect.x,
-                  top: hoverStageRect.y,
-                  width: hoverStageRect.width,
-                  height: hoverStageRect.height,
+                  left: stageHoverRect.x,
+                  top: stageHoverRect.y,
+                  width: stageHoverRect.width,
+                  height: stageHoverRect.height,
                   background: 'color-mix(in srgb, var(--color-blue) 12%, transparent)',
                 }}
               />
@@ -862,12 +983,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                 }}
               />
             )}
-            {mode === 'browse' && !marqueeArmed && hoverStageRect && (
+            {stageHoverRect && (
               <div
                 className="absolute px-1.5 py-0.5 text-[10px] rounded bg-crust text-text border border-surface1 whitespace-nowrap max-w-[60%] overflow-hidden text-ellipsis"
                 style={{
-                  left: Math.max(0, hoverStageRect.x),
-                  top: Math.max(0, hoverStageRect.y - 22),
+                  left: Math.max(0, stageHoverRect.x),
+                  top: Math.max(0, stageHoverRect.y - 22),
                 }}
                 // Every word of this chip — role, name, tag, ux-id — is the
                 // frame's `pointer` report about itself, so it is marked like
@@ -962,14 +1083,26 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           </div>
         </div>
 
-        {/* Notes panel — docked (spec D3). */}
-        <CanvasNotesPanel
-          sessionId={sessionId}
-          version={version}
-          getGlassApi={() => glassApiRef.current}
-          onReturnToTerminal={() => togglePane(sessionId)}
-          isActive={isActive}
-        />
+        {/* Notes panel — docked (spec D3) — with the stealth x-ray readout
+            below it when that mode is on (#367). The readout is a SIBLING, not
+            a section of the panel: it belongs to the stage's pointer, not to
+            the review, and keeping it out means the panel's own file is
+            untouched by this change. The panel keeps its own width and left
+            border; this column just stacks the two. */}
+        <div className="shrink-0 flex flex-col min-h-0">
+          <div className="flex-1 min-h-0 flex">
+            <CanvasNotesPanel
+              sessionId={sessionId}
+              version={version}
+              getGlassApi={() => glassApiRef.current}
+              onReturnToTerminal={() => togglePane(sessionId)}
+              isActive={isActive}
+            />
+          </div>
+          {xrayReadsOutInPanel(xrayMode) && (
+            <CanvasXrayReadout hit={mode === 'browse' && !marqueeArmed ? (hover?.hit ?? null) : null} label={hoverLabel} />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/components/CanvasXrayReadout.tsx
+++ b/src/renderer/components/CanvasXrayReadout.tsx
@@ -17,6 +17,19 @@
 import type { CanvasHitInfo } from '../../shared/canvas'
 import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
 
+/**
+ * Who owns the pointer right now — the pane's Browse / Draw / Region switch,
+ * restated for this strip.
+ *
+ * The readout has to say something when it has no element to name, and "hover
+ * the page" is only true when hovering the page is a thing that can happen. In
+ * Draw the glass sits over the content and in Region the marquee layer does, so
+ * the content never sees the pointer: the invitation was an instruction the
+ * user could follow for a while before working out why nothing ever appeared
+ * (independent review of #405).
+ */
+export type CanvasPointerOwner = 'content' | 'glass' | 'marquee'
+
 interface Props {
   /** The hovered element as the CONTENT reported it, or null when the pointer
    *  is off the page (or has not been on it yet). */
@@ -24,6 +37,9 @@ interface Props {
   /** The same one-line identity the On-mode chip prints, assembled by the pane
    *  so the two modes can never drift into naming the same element differently. */
   label: string
+  /** Which layer the pointer is on, so the empty state can be honest about
+   *  whether hovering the content is even possible. */
+  pointerOwner: CanvasPointerOwner
 }
 
 /** Page coordinates, rounded — a sub-pixel box is noise in a readout. */
@@ -32,7 +48,15 @@ function boxText(box: CanvasHitInfo['box']): string {
   return `${r(box.width)} × ${r(box.height)} at ${r(box.x)}, ${r(box.y)}`
 }
 
-export default function CanvasXrayReadout({ hit, label }: Props) {
+/** What to say with no element to name — which depends entirely on whether the
+ *  content could have been hovered at all. */
+function idleText(pointerOwner: CanvasPointerOwner): string {
+  if (pointerOwner === 'glass') return 'Draw has the pointer — switch to Browse to name what you point at.'
+  if (pointerOwner === 'marquee') return 'Region has the pointer — switch to Browse to name what you point at.'
+  return 'Hover the page — what you point at is named here.'
+}
+
+export default function CanvasXrayReadout({ hit, label, pointerOwner }: Props) {
   return (
     <div
       className="w-80 shrink-0 border-l border-t border-surface0 bg-mantle text-[12px] px-3 py-2"
@@ -57,8 +81,8 @@ export default function CanvasXrayReadout({ hit, label }: Props) {
           </div>
         </>
       ) : (
-        <div className="mt-1 text-[11px] text-subtext0">
-          Hover the page — what you point at is named here.
+        <div className="mt-1 text-[11px] text-subtext0" data-testid="canvas-xray-idle">
+          {idleText(pointerOwner)}
         </div>
       )}
     </div>

--- a/src/renderer/components/CanvasXrayReadout.tsx
+++ b/src/renderer/components/CanvasXrayReadout.tsx
@@ -1,0 +1,66 @@
+// The stealth x-ray readout (#367) — where the hovered element goes when
+// nothing may be drawn on the page.
+//
+// Stealth is the mode for looking at the artifact as a user would while still
+// wanting to know what you are pointing at: the hit is resolved exactly as in
+// On, but the outline and the label chip that would sit over the content are
+// replaced by this strip beside the notes panel. The box is stated in numbers
+// instead of being painted, because a rectangle drawn on the page IS the thing
+// stealth exists to avoid.
+//
+// It is a SIBLING of CanvasNotesPanel rather than a section inside it. Two
+// reasons, and the second is the load-bearing one: the panel is the review
+// surface (notes, checklist, composer) and this is a live pointer readout that
+// belongs to the stage, and the panel is under concurrent change on another
+// branch (#403), so a strip that can live outside it should.
+
+import type { CanvasHitInfo } from '../../shared/canvas'
+import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
+
+interface Props {
+  /** The hovered element as the CONTENT reported it, or null when the pointer
+   *  is off the page (or has not been on it yet). */
+  hit: CanvasHitInfo | null
+  /** The same one-line identity the On-mode chip prints, assembled by the pane
+   *  so the two modes can never drift into naming the same element differently. */
+  label: string
+}
+
+/** Page coordinates, rounded — a sub-pixel box is noise in a readout. */
+function boxText(box: CanvasHitInfo['box']): string {
+  const r = (n: number) => Math.round(n)
+  return `${r(box.width)} × ${r(box.height)} at ${r(box.x)}, ${r(box.y)}`
+}
+
+export default function CanvasXrayReadout({ hit, label }: Props) {
+  return (
+    <div
+      className="w-80 shrink-0 border-l border-t border-surface0 bg-mantle text-[12px] px-3 py-2"
+      data-testid="canvas-xray-readout"
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-subtext1">X-ray</span>
+        <span className="text-[11px] text-overlay1">stealth — nothing is drawn on the page</span>
+      </div>
+      {hit ? (
+        <>
+          {/* Every word of the identity is the frame's own report about itself,
+              marked exactly as the On-mode chip and the locked label are. Moving
+              the readout off the page does not make the page a more reliable
+              narrator of it. */}
+          <div className="mt-1 truncate text-text" title={PAGE_REPORTED_TITLE} data-testid="canvas-xray-label">
+            <span className="text-overlay1">{PAGE_REPORTED_MARK} </span>
+            {label}
+          </div>
+          <div className="mt-0.5 text-[11px] text-subtext0" data-testid="canvas-xray-box">
+            {boxText(hit.box)}
+          </div>
+        </>
+      ) : (
+        <div className="mt-1 text-[11px] text-subtext0">
+          Hover the page — what you point at is named here.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -214,6 +214,16 @@ export interface AppSettings {
    *  hide running configs). Absent = 'list', so no existing install changes
    *  shape on upgrade. */
   savedConfigsView?: 'list' | 'cards' | 'find'
+  /** #367: the Agent Canvas x-ray hover mode. 'on' is the outline + label chip
+   *  drawn over the content (what shipped); 'stealth' still resolves the
+   *  hovered element but draws nothing, reading it out in the canvas side panel
+   *  instead; 'off' does no hover work at all, so the content behaves like a
+   *  normal browser tab. PER USER, not per canvas (owner, book item 52) — which
+   *  is why it lives here rather than in the canvas store, where the canvas's
+   *  own interaction mode lives. Absent = 'on', so no existing install changes
+   *  behaviour on upgrade. Every reader goes through resolveCanvasXrayMode
+   *  (src/renderer/canvas/xray-mode.ts) rather than comparing the field. */
+  canvasXrayMode?: 'off' | 'stealth' | 'on'
   // Agent Hub first-run "How it works" banner: true once the user dismisses it.
   // Optional/absent = not yet dismissed (banner shows).
   agentHubExplainerDismissed?: boolean

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -427,6 +427,29 @@ export type CanvasBridgeRequest =
   | { ns: typeof CANVAS_BRIDGE_NS; id: number; type: 'elementAtPoint'; x: number; y: number }
   | { ns: typeof CANVAS_BRIDGE_NS; id: number; type: 'inspect'; x: number; y: number }
   | { ns: typeof CANVAS_BRIDGE_NS; id: number; type: 'resolveAnchors'; anchors: AnchorRef[] }
+  /**
+   * Ask the content to stop (or resume) emitting its unsolicited `pointer` and
+   * `contentClick` events — x-ray Off (#367).
+   *
+   * The only request that is not a question, and it is worth being precise
+   * about why it does not breach D8 ("content is never commanded to draw"): it
+   * can only make the bridge QUIETER. No value of `enabled` makes the page
+   * report more than it already would, draw anything, or change what it
+   * renders. Off means the page does no per-mousemove work at all, which is
+   * what "view it as a normal browser tab" has to mean to be worth having.
+   *
+   * It is not a security boundary in either direction. The bridge shares a
+   * realm with the page and may ignore this, so the HOST gates on the same mode
+   * (AgentCanvasPane's onPointer/onContentClick), and that gate is the one that
+   * decides what reaches the review store.
+   */
+  | { ns: typeof CANVAS_BRIDGE_NS; id: number; type: 'hoverReporting'; enabled: boolean }
+
+/** Reply to 'hoverReporting': what the bridge says it is now doing. Advisory —
+ *  the host enforces the mode itself and never needs this to be true. */
+export interface CanvasHoverReportingResult {
+  enabled: boolean
+}
 
 export interface CanvasSnapshotNode extends CanvasHitInfo {
   children: CanvasSnapshotNode[]

--- a/tests/unit/renderer/canvas-bridge-hover-reporting.test.ts
+++ b/tests/unit/renderer/canvas-bridge-hover-reporting.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+// The content side of x-ray Off (#367): the bridge's hover surface can be
+// switched off, and while it is off the page does no per-mousemove work.
+//
+// This is what the host CANNOT do for itself. The host can drop a report it did
+// not want (and does — see canvas-xray-pane), but only the content can decline
+// to hit-test, measure and structured-clone a message on every mouse move. "The
+// page behaves like a normal browser tab" is a claim about the PAGE's work, so
+// it is pinned here, against the BUNDLED bridge that ccc-ux:// actually serves.
+//
+// What must survive being switched off is pinned too: viewport reporting and
+// the request/response surface. A canvas whose scroll position stopped updating
+// would be a broken pane, not a quiet one.
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest'
+import { bridgeRequest, collectEvents, installBridge, stubLayout } from './canvas-bridge-harness'
+
+/** jsdom has no hit testing; the fixture decides what is "under" the pointer. */
+function pointAt(el: Element | null): void {
+  ;(document as { elementFromPoint?: unknown }).elementFromPoint = () => el
+}
+
+function moveMouse(times = 3): void {
+  for (let i = 0; i < times; i++) document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }))
+}
+
+async function setHoverReporting(enabled: unknown): Promise<{ ok: boolean; result?: unknown }> {
+  return bridgeRequest('hoverReporting', { enabled })
+}
+
+beforeAll(() => {
+  stubLayout({ x: 10, y: 20, width: 100, height: 30 })
+  document.body.innerHTML = `<main><button data-ux-id="save-btn">Save draft</button></main>`
+  pointAt(document.querySelector('[data-ux-id="save-btn"]'))
+  installBridge()
+})
+
+// Module state in the bundled script: every test leaves it as it found it.
+afterEach(async () => {
+  await setHoverReporting(true)
+})
+
+describe('the hover surface is live by default', () => {
+  it('reports pointer moves before the host has said anything', async () => {
+    const events = collectEvents('pointer', 300)
+    moveMouse(5)
+    expect((await events).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('reports clicks before the host has said anything', async () => {
+    const events = collectEvents('contentClick', 300)
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect((await events).length).toBe(1)
+  })
+})
+
+describe('switched off, the page does no hover work at all', () => {
+  it('acknowledges the request with what it is now doing', async () => {
+    const reply = await setHoverReporting(false)
+    expect(reply.ok).toBe(true)
+    expect(reply.result).toEqual({ enabled: false })
+  })
+
+  it('emits no pointer events however much the mouse moves', async () => {
+    await setHoverReporting(false)
+    const events = collectEvents('pointer', 300)
+    moveMouse(25)
+    expect(await events).toEqual([])
+  })
+
+  it('emits nothing on mouseleave either — the same gate covers the clear', async () => {
+    await setHoverReporting(false)
+    const events = collectEvents('pointer', 300)
+    document.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+    expect(await events).toEqual([])
+  })
+
+  it('emits no contentClick — in Off a click selects nothing, so there is nothing to report', async () => {
+    await setHoverReporting(false)
+    const events = collectEvents('contentClick', 300)
+    for (let i = 0; i < 5; i++) document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(await events).toEqual([])
+  })
+
+  it('drops a move that was queued a frame before the switch', async () => {
+    // The rAF the move scheduled is still pending when the host switches off;
+    // without the re-check on the frame it would land after Off took effect.
+    const events = collectEvents('pointer', 300)
+    moveMouse(1)
+    await setHoverReporting(false)
+    expect(await events).toEqual([])
+  })
+})
+
+describe('switching off silences the hover surface and nothing else', () => {
+  it('keeps reporting the viewport — a pane that stopped tracking scroll is broken, not quiet', async () => {
+    await setHoverReporting(false)
+    const events = collectEvents('viewport', 300)
+    window.dispatchEvent(new Event('scroll'))
+    expect((await events).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('still answers requests — snapshots and anchor resolution are not hover', async () => {
+    await setHoverReporting(false)
+    const reply = await bridgeRequest('boxMap')
+    expect(reply.ok).toBe(true)
+    expect(Array.isArray(reply.result)).toBe(true)
+  })
+})
+
+describe('the switch is reversible and fails live', () => {
+  it('resumes reporting when asked to', async () => {
+    await setHoverReporting(false)
+    await setHoverReporting(true)
+    const events = collectEvents('pointer', 300)
+    moveMouse(5)
+    expect((await events).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('takes only a literal false for an answer — a malformed request cannot blind the pane', async () => {
+    for (const value of [undefined, null, 0, '', 'false', 'off'] as unknown[]) {
+      const reply = await setHoverReporting(value)
+      expect(reply.result, String(value)).toEqual({ enabled: true })
+    }
+    const events = collectEvents('pointer', 300)
+    moveMouse(5)
+    expect((await events).length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/tests/unit/renderer/canvas-bridge-hover-reporting.test.ts
+++ b/tests/unit/renderer/canvas-bridge-hover-reporting.test.ts
@@ -13,7 +13,8 @@
 // would be a broken pane, not a quiet one.
 
 import { describe, it, expect, beforeAll, afterEach } from 'vitest'
-import { bridgeRequest, collectEvents, installBridge, stubLayout } from './canvas-bridge-harness'
+import { bridgeRequest, installBridge, stubLayout } from './canvas-bridge-harness'
+import { CANVAS_BRIDGE_NS } from '../../../src/shared/canvas'
 
 /** jsdom has no hit testing; the fixture decides what is "under" the pointer. */
 function pointAt(el: Element | null): void {
@@ -26,6 +27,48 @@ function moveMouse(times = 3): void {
 
 async function setHoverReporting(enabled: unknown): Promise<{ ok: boolean; result?: unknown }> {
   return bridgeRequest('hoverReporting', { enabled })
+}
+
+/** How long a NEGATIVE assertion watches for an event that must not come. */
+const SILENCE_WINDOW_MS = 300
+/** How long a POSITIVE assertion will wait for one that must. Generous because
+ *  it is only ever paid when something is wrong: the wait resolves the moment
+ *  the event lands. A fixed window here is what made the first version of this
+ *  file fail on a loaded CI box while passing everywhere else — the bridge
+ *  reports on a rAF, and 300ms is a claim about the machine, not about the
+ *  bridge. */
+const ARRIVAL_TIMEOUT_MS = 5000
+
+/**
+ * Events of `kind` seen in a window — resolving EARLY once `min` have arrived.
+ * `min: 0` (the default) is the negative form: watch the whole window and
+ * report what came, which must be nothing.
+ */
+function watchEvents(kind: string, { min = 0, ms }: { min?: number; ms: number }): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve) => {
+    const seen: Record<string, unknown>[] = []
+    const done = () => {
+      window.removeEventListener('message', onMessage)
+      clearTimeout(timer)
+      resolve(seen)
+    }
+    const onMessage = (event: MessageEvent) => {
+      const msg = event.data as { ns?: string; type?: string } | undefined
+      if (msg?.ns !== CANVAS_BRIDGE_NS || msg.type !== kind) return
+      seen.push(msg as Record<string, unknown>)
+      if (min > 0 && seen.length >= min) done()
+    }
+    const timer = setTimeout(done, ms)
+    window.addEventListener('message', onMessage)
+  })
+}
+
+/** The bridge is reporting again — the control every silence assertion is
+ *  paired with, so "nothing arrived" can never pass for "the bridge is dead". */
+async function expectStillReports(): Promise<void> {
+  const events = watchEvents('pointer', { min: 1, ms: ARRIVAL_TIMEOUT_MS })
+  moveMouse(5)
+  expect((await events).length, 'the bridge reports once it is switched back on').toBeGreaterThanOrEqual(1)
 }
 
 beforeAll(() => {
@@ -42,15 +85,15 @@ afterEach(async () => {
 
 describe('the hover surface is live by default', () => {
   it('reports pointer moves before the host has said anything', async () => {
-    const events = collectEvents('pointer', 300)
+    const events = watchEvents('pointer', { min: 1, ms: ARRIVAL_TIMEOUT_MS })
     moveMouse(5)
     expect((await events).length).toBeGreaterThanOrEqual(1)
   })
 
   it('reports clicks before the host has said anything', async () => {
-    const events = collectEvents('contentClick', 300)
+    const events = watchEvents('contentClick', { min: 1, ms: ARRIVAL_TIMEOUT_MS })
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    expect((await events).length).toBe(1)
+    expect((await events).length).toBeGreaterThanOrEqual(1)
   })
 })
 
@@ -63,29 +106,39 @@ describe('switched off, the page does no hover work at all', () => {
 
   it('emits no pointer events however much the mouse moves', async () => {
     await setHoverReporting(false)
-    const events = collectEvents('pointer', 300)
+    const events = watchEvents('pointer', { ms: SILENCE_WINDOW_MS })
     moveMouse(25)
     expect(await events).toEqual([])
+    // The control: that silence was the switch, not a dead bridge, a dead
+    // fixture or a window nobody is listening on. Without this, deleting the
+    // whole hover surface would pass every assertion above.
+    await setHoverReporting(true)
+    await expectStillReports()
   })
 
   it('emits nothing on mouseleave either — the same gate covers the clear', async () => {
     await setHoverReporting(false)
-    const events = collectEvents('pointer', 300)
+    const events = watchEvents('pointer', { ms: SILENCE_WINDOW_MS })
     document.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
     expect(await events).toEqual([])
   })
 
   it('emits no contentClick — in Off a click selects nothing, so there is nothing to report', async () => {
     await setHoverReporting(false)
-    const events = collectEvents('contentClick', 300)
+    const events = watchEvents('contentClick', { ms: SILENCE_WINDOW_MS })
     for (let i = 0; i < 5; i++) document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(await events).toEqual([])
+
+    await setHoverReporting(true)
+    const loud = watchEvents('contentClick', { min: 1, ms: ARRIVAL_TIMEOUT_MS })
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect((await loud).length, 'clicks are reported again once switched on').toBeGreaterThanOrEqual(1)
   })
 
   it('drops a move that was queued a frame before the switch', async () => {
     // The rAF the move scheduled is still pending when the host switches off;
     // without the re-check on the frame it would land after Off took effect.
-    const events = collectEvents('pointer', 300)
+    const events = watchEvents('pointer', { ms: SILENCE_WINDOW_MS })
     moveMouse(1)
     await setHoverReporting(false)
     expect(await events).toEqual([])
@@ -95,7 +148,7 @@ describe('switched off, the page does no hover work at all', () => {
 describe('switching off silences the hover surface and nothing else', () => {
   it('keeps reporting the viewport — a pane that stopped tracking scroll is broken, not quiet', async () => {
     await setHoverReporting(false)
-    const events = collectEvents('viewport', 300)
+    const events = watchEvents('viewport', { min: 1, ms: ARRIVAL_TIMEOUT_MS })
     window.dispatchEvent(new Event('scroll'))
     expect((await events).length).toBeGreaterThanOrEqual(1)
   })
@@ -112,9 +165,7 @@ describe('the switch is reversible and fails live', () => {
   it('resumes reporting when asked to', async () => {
     await setHoverReporting(false)
     await setHoverReporting(true)
-    const events = collectEvents('pointer', 300)
-    moveMouse(5)
-    expect((await events).length).toBeGreaterThanOrEqual(1)
+    await expectStillReports()
   })
 
   it('takes only a literal false for an answer — a malformed request cannot blind the pane', async () => {
@@ -122,8 +173,6 @@ describe('the switch is reversible and fails live', () => {
       const reply = await setHoverReporting(value)
       expect(reply.result, String(value)).toEqual({ enabled: true })
     }
-    const events = collectEvents('pointer', 300)
-    moveMouse(5)
-    expect((await events).length).toBeGreaterThanOrEqual(1)
+    await expectStillReports()
   })
 })

--- a/tests/unit/renderer/canvas-xray-mode.test.ts
+++ b/tests/unit/renderer/canvas-xray-mode.test.ts
@@ -1,0 +1,127 @@
+// The x-ray hover mode itself (#367): what each mode means, and that the choice
+// survives as a PER-USER setting rather than as canvas state.
+//
+// The persistence half drives the REAL settings store and the REAL hydrate(),
+// with only the config writer stubbed — the failure this is here to catch is a
+// preference that looks right in the pane and is gone on the next launch, and a
+// re-spread of hydrate() in the test would never catch it.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const saveConfigNow = vi.fn(async () => true)
+vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: (...a: unknown[]) => saveConfigNow(...(a as [])) }))
+
+import {
+  CANVAS_XRAY_MODES,
+  CANVAS_XRAY_MODE_OPTIONS,
+  resolveCanvasXrayMode,
+  xrayClickSelects,
+  xrayDrawsOnPage,
+  xrayHoverIsLive,
+  xrayReadsOutInPanel,
+} from '../../../src/renderer/canvas/xray-mode'
+import { useSettingsStore, DEFAULT_SETTINGS } from '../../../src/renderer/stores/settingsStore'
+
+beforeEach(() => {
+  saveConfigNow.mockClear()
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS } })
+})
+
+describe('resolveCanvasXrayMode', () => {
+  it('round-trips all three modes', () => {
+    for (const mode of CANVAS_XRAY_MODES) expect(resolveCanvasXrayMode(mode)).toBe(mode)
+  })
+
+  it('falls back to ON for an absent value — an install that predates the setting is unchanged', () => {
+    expect(resolveCanvasXrayMode(undefined)).toBe('on')
+    expect(resolveCanvasXrayMode(null)).toBe('on')
+  })
+
+  it('falls back to ON for anything a hand-edited or corrupt config might hold', () => {
+    // Deliberately not "fail closed to off": a mode that silently disables the
+    // feature leaves the user hunting for a switch they cannot see the effect of.
+    for (const v of ['stealthy', 'On', 'OFF', '', 0, 1, true, false, {}, []] as unknown[]) {
+      expect(resolveCanvasXrayMode(v), String(v)).toBe('on')
+    }
+  })
+
+  it('offers exactly the three modes, off first, in the order the header shows them', () => {
+    expect(CANVAS_XRAY_MODE_OPTIONS.map((o) => o.value)).toEqual(['off', 'stealth', 'on'])
+    for (const o of CANVAS_XRAY_MODE_OPTIONS) expect(o.title.length).toBeGreaterThan(20)
+  })
+})
+
+describe('what each mode does', () => {
+  it('OFF resolves nothing, draws nothing, reads out nothing, and selects nothing on click', () => {
+    expect(xrayHoverIsLive('off')).toBe(false)
+    expect(xrayDrawsOnPage('off')).toBe(false)
+    expect(xrayReadsOutInPanel('off')).toBe(false)
+    // The design point the issue left open, pinned so a later "temporarily arms
+    // a note" is a deliberate change and not a drift.
+    expect(xrayClickSelects('off')).toBe(false)
+  })
+
+  it('STEALTH resolves and reads out in the panel, but draws nothing on the page', () => {
+    expect(xrayHoverIsLive('stealth')).toBe(true)
+    expect(xrayDrawsOnPage('stealth')).toBe(false)
+    expect(xrayReadsOutInPanel('stealth')).toBe(true)
+    expect(xrayClickSelects('stealth')).toBe(true)
+  })
+
+  it('ON is what shipped: resolved and drawn on the page, nothing in the panel', () => {
+    expect(xrayHoverIsLive('on')).toBe(true)
+    expect(xrayDrawsOnPage('on')).toBe(true)
+    expect(xrayReadsOutInPanel('on')).toBe(false)
+    expect(xrayClickSelects('on')).toBe(true)
+  })
+
+  it('exactly one mode draws on the page, and only a drawing-free mode reads out', () => {
+    expect(CANVAS_XRAY_MODES.filter(xrayDrawsOnPage)).toEqual(['on'])
+    for (const mode of CANVAS_XRAY_MODES) {
+      if (xrayReadsOutInPanel(mode)) expect(xrayDrawsOnPage(mode)).toBe(false)
+      if (!xrayHoverIsLive(mode)) expect(xrayReadsOutInPanel(mode)).toBe(false)
+    }
+  })
+})
+
+describe('the mode is remembered per USER', () => {
+  it('is unset by default, which reads as ON', () => {
+    expect(DEFAULT_SETTINGS.canvasXrayMode).toBeUndefined()
+    expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe('on')
+  })
+
+  it('writes the chosen mode to the settings config, not to canvas state', async () => {
+    await useSettingsStore.getState().updateSettings({ canvasXrayMode: 'stealth' })
+    expect(useSettingsStore.getState().settings.canvasXrayMode).toBe('stealth')
+    expect(saveConfigNow).toHaveBeenCalledTimes(1)
+    const [key, data] = saveConfigNow.mock.calls[0] as unknown as [string, { canvasXrayMode?: string }]
+    // The `settings` config is the per-user one; a per-canvas store would have
+    // put this somewhere the next canvas could not see it.
+    expect(key).toBe('settings')
+    expect(data.canvasXrayMode).toBe('stealth')
+  })
+
+  it('round-trips every mode through the store', async () => {
+    for (const mode of CANVAS_XRAY_MODES) {
+      await useSettingsStore.getState().updateSettings({ canvasXrayMode: mode })
+      expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe(mode)
+    }
+  })
+
+  it('survives hydrate() — the mode is read back from a stored config on next launch', () => {
+    useSettingsStore.getState().hydrate({ canvasXrayMode: 'off' } as never)
+    expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe('off')
+    // A genuine merge, not a wholesale replacement.
+    expect(useSettingsStore.getState().settings.defaultModel).toBe(DEFAULT_SETTINGS.defaultModel)
+  })
+
+  it('hydrating a config that predates the setting leaves it ON', () => {
+    useSettingsStore.getState().hydrate({} as never)
+    expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe('on')
+  })
+
+  it('hydrating a corrupt stored value reads as ON rather than a broken mode', () => {
+    useSettingsStore.getState().hydrate({ canvasXrayMode: 'x-ray' } as never)
+    expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe('on')
+  })
+})

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -40,9 +40,13 @@ const answerAsARealFrameWould = (_target: unknown, _canvasId: unknown, payload: 
     ? Promise.resolve({ enabled: payload.enabled })
     : new Promise(() => {})
 const askFrame = vi.fn(answerAsARealFrameWould)
+/** How many requests the RPC layer already has outstanding to this frame. The
+ *  pane reads this before it posts, so a test can saturate the cap the way a
+ *  snapshot, an inspect and a resolution pass do. */
+let framesInFlightNow = 0
 vi.mock('../../../src/renderer/canvas/canvas-frame-rpc', () => ({
   askCanvasFrame: (...args: unknown[]) => askFrame(...(args as [])),
-  framesInFlight: () => 0,
+  framesInFlight: () => framesInFlightNow,
   MAX_FRAME_REQUESTS_IN_FLIGHT: 4,
 }))
 
@@ -69,6 +73,14 @@ const STATE: CanvasState = {
   activeVersionId: 'v1',
   versions: [{ id: 'v1', mode: 'design', createdAt: '2026-08-14T10:00:00Z', source: { mode: 'design', entry: 'index.html' } }],
 } as CanvasState
+
+/** A second render on the same canvas — switching to it reloads the frame. */
+const V2 = {
+  id: 'v2',
+  mode: 'design',
+  createdAt: '2026-08-14T10:05:00Z',
+  source: { mode: 'design', entry: 'index.html' },
+} as (typeof STATE.versions)[number]
 
 const SAVE_BUTTON = {
   role: 'button',
@@ -159,6 +171,7 @@ beforeEach(() => {
   // leave it running for the next one.
   askFrame.mockReset()
   askFrame.mockImplementation(answerAsARealFrameWould)
+  framesInFlightNow = 0
   useCanvasStore.getState().reset()
   useCanvasReviewStore.getState().reset()
   useCanvasStore.setState({
@@ -374,7 +387,7 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     // agreeing, so something has to stop a page that never complies from
     // setting the host's call rate. Three attempts per intent. (A non-boolean
     // is no answer at all: the reply is page-authored, so nothing is believed
-    // from it and the state stays where it was.)
+    // from it and the host records that it does not know.)
     askFrame.mockImplementation(() => Promise.resolve({ enabled: 'nope' }))
     await renderPane('off')
     await act(async () => handlers().onReady())
@@ -388,16 +401,20 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     expect(hoverReportingCalls()).toEqual([false, false, false])
 
     // Passing through On and back to Off is the user asking again, which is a
-    // new intent and a fresh budget. On itself sends nothing: the frame is
-    // already reporting, which is what On wants.
+    // new intent and a fresh budget. On costs a round-trip of its own here —
+    // this frame answered nothing the host could believe, so the host does NOT
+    // know whether it is still reporting, and a mode that needs those reports
+    // has to say so rather than assume the default it started from (fix-delta
+    // verification, #405). A frame that answers truthfully still costs nothing:
+    // see the round-trip test below.
     await act(async () => {
       container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
     })
-    expect(hoverReportingCalls()).toEqual([false, false, false])
+    expect(hoverReportingCalls()).toEqual([false, false, false, true, true, true])
     await act(async () => {
       container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-off"]')!.click()
     })
-    expect(hoverReportingCalls()).toEqual([false, false, false, false, false, false])
+    expect(hoverReportingCalls()).toEqual([false, false, false, true, true, true, false, false, false])
 
     // Nothing was ever drawn throughout: the host gate never depended on the
     // frame complying.
@@ -471,6 +488,115 @@ describe('a mode change while a request is in flight', () => {
       container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
     })
     expect(hoverReportingCalls()).toEqual([false, false, true])
+  })
+})
+
+// ── What the host does NOT know (fix-delta verification of #405) ─────────────
+// The bridge applies hoverReporting and only THEN replies, so a request that
+// does not come back is not a request that did not happen. Everything here is
+// about the host being honest that it has no account of the frame, and about
+// not spending its one budget on conditions inside itself.
+describe('a request the frame never acknowledged', () => {
+  it('leaves the host not knowing, so the next mode still asks', async () => {
+    // MAJOR-A. Off is applied by the bridge; the ack is dropped (or lands after
+    // the timeout). Carrying the old belief forward made the flip to On a
+    // no-op — desire(true) matched belief(true), the reconcile short-circuited
+    // — and the frame stayed quiet for the life of the document: x-ray On drew
+    // nothing, clicks selected nothing, and no report was left to repair from.
+    const lost = () => Promise.reject(new Error('The canvas frame did not answer the hoverReporting request in time.'))
+    askFrame.mockImplementationOnce(lost).mockImplementationOnce(lost).mockImplementationOnce(lost)
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+
+    // The user asks for On. The frame may well be quiet — the host cannot say —
+    // so this MUST go out rather than be answered from a stale belief.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
+    })
+    expect(hoverReportingCalls()).toEqual([false, false, false, true])
+
+    // …and once that lands the asking stops: unknown is a state to leave, not a
+    // reason to keep asking.
+    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    expect(hoverReportingCalls()).toEqual([false, false, false, true])
+  })
+
+  it('does not spend the budget on a frame it never managed to ask', async () => {
+    // MINOR-B. Over the RPC's in-flight cap the request is refused BEFORE a
+    // listener exists — a synchronous rejection, which the post-settle
+    // reconcile fires straight back into: all three attempts went in three
+    // microtasks, on a condition that clears in milliseconds. (Reachable: the
+    // resolution pass has no in-flight guard of its own, so a few note edits
+    // inside its ten-second window saturate the cap.) The intent was then
+    // wedged — the cap cleared and nothing ever asked again.
+    askFrame.mockImplementation((target: unknown, canvasId: unknown, payload: { type?: string; enabled?: boolean }) =>
+      framesInFlightNow >= 4
+        ? Promise.reject(new Error('Too many canvas frame requests are already in flight'))
+        : answerAsARealFrameWould(target, canvasId, payload),
+    )
+    framesInFlightNow = 4
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    // Nothing was asked at all, so nothing was held against the frame.
+    expect(hoverReportingCalls()).toEqual([])
+
+    framesInFlightNow = 0
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400))
+    })
+    expect(hoverReportingCalls()).toEqual([false])
+  })
+
+  it('does not let a parked answer land on the document that replaced it', async () => {
+    // The NIT. A new version (or a retry) reloads the frame and resets the
+    // belief to a fresh bridge's default — but the request parked against the
+    // OLD document was still in its generation, so its answer landed on the new
+    // one and undid that reset. The generation bump belongs with every reset,
+    // not only with `ready`.
+    const settleOld = parkNextRequest()
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+
+    await act(async () => {
+      useCanvasStore.setState((s) => ({
+        bySessionId: {
+          ...s.bySessionId,
+          [SID]: {
+            ...s.bySessionId[SID]!,
+            versions: [...STATE.versions, V2],
+            activeVersionId: V2.id,
+          },
+        },
+      }))
+    })
+    await act(async () => settleOld({ enabled: false }))
+    expect(hoverReportingCalls()).toEqual([false, false])
+  })
+
+  it('does not let a flood of `ready` multiply the send rate', async () => {
+    // MINOR-C. `ready` is page-authored, and every one of them is a new
+    // document with a fresh attempt budget — so a page that simply re-emits it
+    // multiplied the host's send rate by that budget (three requests became
+    // eighteen after five extra readys). The rolling send window is the
+    // ceiling, whatever drives it. Time is frozen so this asserts the ceiling
+    // and not the wall clock.
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    try {
+      askFrame.mockImplementation(() => Promise.resolve({ enabled: 'nope' }))
+      await renderPane('off')
+      for (let i = 0; i < 6; i++) await act(async () => handlers().onReady())
+      // Six documents × three attempts is eighteen without a ceiling.
+      expect(hoverReportingCalls().length).toBe(12)
+      expect(hoverReportingCalls().every((enabled) => enabled === false)).toBe(true)
+      // And the mode still holds regardless: the host gate never depended on
+      // any of this landing.
+      await hoverSaveButton()
+      expect(overlay().textContent).not.toContain('button "Save"')
+    } finally {
+      now.mockRestore()
+    }
   })
 })
 

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -32,7 +32,14 @@ vi.mock('../../../src/renderer/components/CanvasNotesPanel', () => ({ default: (
 // preference and the round-trip through it is part of what is under test).
 vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: vi.fn(async () => true) }))
 
-const askFrame = vi.fn(() => new Promise(() => {}))
+// A frame that answers a hoverReporting request (as a real bridge does) and
+// never answers anything else — an inspect left in flight is what the
+// one-inspect-at-a-time rule is about, and is not this file's subject.
+const askFrame = vi.fn((_target: unknown, _canvasId: unknown, payload: { type?: string; enabled?: boolean }) =>
+  payload?.type === 'hoverReporting'
+    ? Promise.resolve({ enabled: payload.enabled })
+    : new Promise(() => {}),
+)
 vi.mock('../../../src/renderer/canvas/canvas-frame-rpc', () => ({
   askCanvasFrame: (...args: unknown[]) => askFrame(...(args as [])),
   framesInFlight: () => 0,
@@ -297,6 +304,48 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     await act(async () => handlers().onPointer(SAVE_BUTTON))
     await act(async () => handlers().onViewport(VIEWPORT))
     expect(hoverReportingCalls()).toEqual([false])
+  })
+
+  it('does not believe a request that was refused before it was posted', async () => {
+    // canvas-frame-rpc caps requests in flight at four, and a snapshot, an
+    // inspect and a resolveAnchors can already be outstanding when the user
+    // reaches for the switch. Marking the frame quiet on the SEND left the host
+    // permanently certain it had told a frame that was never told, and the page
+    // doing per-mousemove work for the rest of that document's life (Copilot
+    // review, #405). Nothing is drawn either way, so the work IS the symptom.
+    const refuse = () => Promise.reject(new Error('Too many canvas frame requests are already in flight'))
+    // `ready` and the mode effect that follows it are two triggers, so two
+    // refusals leave the frame un-told with nothing left to ask on its own.
+    askFrame.mockImplementationOnce(refuse).mockImplementationOnce(refuse)
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false, false])
+
+    // The page is still reporting, which is the evidence that it never heard.
+    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+    // …and nothing was drawn while it was still reporting.
+    expect(overlay().textContent).not.toContain('button "Save"')
+
+    // Once one lands, the asking stops.
+    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+  })
+
+  it('asks once at a time, however fast a page that will not go quiet reports', async () => {
+    // The repair is driven by the page's own reports, so without the in-flight
+    // guard the page would be choosing the host's call rate.
+    let settle: (v: unknown) => void = () => {}
+    askFrame.mockImplementationOnce(() => new Promise((resolve) => { settle = resolve }))
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    await act(async () => {
+      for (let i = 0; i < 50; i++) handlers().onPointer(SAVE_BUTTON)
+      for (let i = 0; i < 50; i++) handlers().onContentClick(1, 1)
+    })
+    expect(hoverReportingCalls()).toEqual([false])
+    await act(async () => settle({ enabled: false }))
   })
 
   it('says in the mode strip that hovering and clicking do nothing', async () => {

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -35,11 +35,11 @@ vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: vi.f
 // A frame that answers a hoverReporting request (as a real bridge does) and
 // never answers anything else — an inspect left in flight is what the
 // one-inspect-at-a-time rule is about, and is not this file's subject.
-const askFrame = vi.fn((_target: unknown, _canvasId: unknown, payload: { type?: string; enabled?: boolean }) =>
+const answerAsARealFrameWould = (_target: unknown, _canvasId: unknown, payload: { type?: string; enabled?: boolean }) =>
   payload?.type === 'hoverReporting'
     ? Promise.resolve({ enabled: payload.enabled })
-    : new Promise(() => {}),
-)
+    : new Promise(() => {})
+const askFrame = vi.fn(answerAsARealFrameWould)
 vi.mock('../../../src/renderer/canvas/canvas-frame-rpc', () => ({
   askCanvasFrame: (...args: unknown[]) => askFrame(...(args as [])),
   framesInFlight: () => 0,
@@ -122,6 +122,18 @@ function readout(): HTMLElement | null {
   return container.querySelector('[data-testid="canvas-xray-readout"]')
 }
 
+/**
+ * Park the NEXT frame request: it stays unanswered until the returned settle is
+ * called. This is the shape both review blockers hide in — a hoverReporting
+ * request is in flight (for up to HOVER_REPORTING_TIMEOUT_MS of real time)
+ * while the world moves under it.
+ */
+function parkNextRequest(): (value: unknown) => void {
+  let settle: (value: unknown) => void = () => {}
+  askFrame.mockImplementationOnce(() => new Promise((resolve) => { settle = resolve }))
+  return (value: unknown) => settle(value)
+}
+
 /** The hoverReporting requests the pane has sent to the frame, in order. */
 function hoverReportingCalls(): boolean[] {
   return askFrame.mock.calls
@@ -143,7 +155,10 @@ async function renderPane(mode?: CanvasXrayMode): Promise<void> {
 beforeEach(() => {
   createChannel.mockClear()
   disposeChannel.mockClear()
-  askFrame.mockClear()
+  // Reset, not clear: a test that installs its own frame behaviour must not
+  // leave it running for the next one.
+  askFrame.mockReset()
+  askFrame.mockImplementation(answerAsARealFrameWould)
   useCanvasStore.getState().reset()
   useCanvasReviewStore.getState().reset()
   useCanvasStore.setState({
@@ -224,6 +239,32 @@ describe('x-ray STEALTH — resolved, but nothing drawn on the page', () => {
     const label = container.querySelector('[data-testid="canvas-xray-label"]')
     expect(label?.textContent).toContain('page-reported')
     expect(label?.getAttribute('title')).toMatch(/cannot verify/i)
+  })
+
+  it('does not invite a hover the glass would swallow', async () => {
+    // In Draw (and Region) the pointer never reaches the content, so "Hover the
+    // page" was an instruction the user could follow for a while before working
+    // out why nothing ever appeared (independent review of #405).
+    await renderPane('stealth')
+    await act(async () => {
+      useCanvasStore.getState().setInteractionMode(SID, 'draw')
+    })
+    const idle = container.querySelector('[data-testid="canvas-xray-idle"]')
+    expect(idle?.textContent).toContain('Draw has the pointer')
+    expect(idle?.textContent).not.toContain('Hover the page')
+  })
+
+  it('says so for Region too, and goes back to the invitation in Browse', async () => {
+    await renderPane('stealth')
+    await act(async () => {
+      useCanvasReviewStore.getState().setMarqueeArmed(SID, true)
+    })
+    expect(container.querySelector('[data-testid="canvas-xray-idle"]')?.textContent).toContain('Region has the pointer')
+
+    await act(async () => {
+      useCanvasReviewStore.getState().setMarqueeArmed(SID, false)
+    })
+    expect(container.querySelector('[data-testid="canvas-xray-idle"]')?.textContent).toContain('Hover the page')
   })
 
   it('empties the readout when the pointer leaves the page', async () => {
@@ -314,43 +355,122 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     // doing per-mousemove work for the rest of that document's life (Copilot
     // review, #405). Nothing is drawn either way, so the work IS the symptom.
     const refuse = () => Promise.reject(new Error('Too many canvas frame requests are already in flight'))
-    // `ready` and the mode effect that follows it are two triggers, so two
-    // refusals leave the frame un-told with nothing left to ask on its own.
     askFrame.mockImplementationOnce(refuse).mockImplementationOnce(refuse)
     await renderPane('off')
+    // Each refusal reconciles when it settles, so the third attempt lands
+    // without waiting for anything the page has to do first.
     await act(async () => handlers().onReady())
-    expect(hoverReportingCalls()).toEqual([false, false])
-
-    // The page is still reporting, which is the evidence that it never heard.
-    await act(async () => handlers().onPointer(SAVE_BUTTON))
     expect(hoverReportingCalls()).toEqual([false, false, false])
-    // …and nothing was drawn while it was still reporting.
     expect(overlay().textContent).not.toContain('button "Save"')
 
     // Once one lands, the asking stops.
     await act(async () => handlers().onPointer(SAVE_BUTTON))
-    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    await act(async () => handlers().onViewport(VIEWPORT))
     expect(hoverReportingCalls()).toEqual([false, false, false])
   })
 
-  it('asks once at a time, however fast a page that will not go quiet reports', async () => {
-    // The repair is driven by the page's own reports, so without the in-flight
-    // guard the page would be choosing the host's call rate.
-    let settle: (v: unknown) => void = () => {}
-    askFrame.mockImplementationOnce(() => new Promise((resolve) => { settle = resolve }))
+  it('gives up on a frame that will never confirm, and tries again when the user asks again', async () => {
+    // The reconcile retries whenever a request settles without the frame
+    // agreeing, so something has to stop a page that never complies from
+    // setting the host's call rate. Three attempts per intent. (A non-boolean
+    // is no answer at all: the reply is page-authored, so nothing is believed
+    // from it and the state stays where it was.)
+    askFrame.mockImplementation(() => Promise.resolve({ enabled: 'nope' }))
     await renderPane('off')
     await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+
+    // Reports from the page do not buy it more attempts.
     await act(async () => {
       for (let i = 0; i < 50; i++) handlers().onPointer(SAVE_BUTTON)
       for (let i = 0; i < 50; i++) handlers().onContentClick(1, 1)
     })
-    expect(hoverReportingCalls()).toEqual([false])
-    await act(async () => settle({ enabled: false }))
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+
+    // Passing through On and back to Off is the user asking again, which is a
+    // new intent and a fresh budget. On itself sends nothing: the frame is
+    // already reporting, which is what On wants.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
+    })
+    expect(hoverReportingCalls()).toEqual([false, false, false])
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-off"]')!.click()
+    })
+    expect(hoverReportingCalls()).toEqual([false, false, false, false, false, false])
+
+    // Nothing was ever drawn throughout: the host gate never depended on the
+    // frame complying.
+    expect(overlay().textContent).not.toContain('button "Save"')
   })
 
   it('says in the mode strip that hovering and clicking do nothing', async () => {
     await renderPane('off')
     expect(container.textContent).toContain('x-ray is off')
+  })
+})
+
+// ── The world moving under a parked request (independent review of #405) ─────
+// A hoverReporting request can sit unanswered for up to HOVER_REPORTING_TIMEOUT_MS.
+// Both findings live in that window, and neither has a symptom to repair from:
+// the frame in both cases goes QUIET, which is indistinguishable from a page
+// nobody is pointing at.
+describe('a mode change while a request is in flight', () => {
+  it('is not lost when the parked answer finally lands', async () => {
+    // BLOCKER-1. Off, request parked; the user flips to On, and the in-flight
+    // guard drops that sync. The parked answer then lands saying "quiet" — and
+    // before the post-settle reconcile, nothing re-ran: the frame stayed quiet
+    // for the life of the document, so x-ray On drew nothing, Stealth read out
+    // nothing, and clicks stopped selecting, with no report to notice it by.
+    const settle = parkNextRequest()
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
+    })
+    expect(hoverReportingCalls()).toEqual([false])
+
+    await act(async () => settle({ enabled: false }))
+    expect(hoverReportingCalls()).toEqual([false, true])
+
+    // …and the pane works again, which is the point.
+    await hoverSaveButton()
+    expect(overlay().textContent).toContain('button "Save"')
+  })
+
+  it('does not let the previous document’s answer land on the new one', async () => {
+    // MAJOR-2. Doc A's parked answer arrives after doc B's `ready`. Believing
+    // it about doc B set the state to "quiet" while doc B was loud, and the
+    // reconcile then short-circuited — re-opening, through the other door, the
+    // in-frame-navigation bug e608cf32 closed.
+    const settleDocA = parkNextRequest()
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+
+    // Doc B: an in-frame navigation, so a new bridge at its reporting default.
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+
+    await act(async () => settleDocA({ enabled: false }))
+    expect(hoverReportingCalls()).toEqual([false, false])
+  })
+
+  it('releases the in-flight slot even for an answer it refuses to believe', async () => {
+    // The generation check must not skip the cleanup: one navigation during one
+    // request would otherwise wedge the switch for the life of the pane.
+    const settleDocA = parkNextRequest()
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    await act(async () => handlers().onReady())
+    await act(async () => settleDocA({ enabled: false }))
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-on"]')!.click()
+    })
+    expect(hoverReportingCalls()).toEqual([false, false, true])
   })
 })
 

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -273,6 +273,32 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     expect(hoverReportingCalls()).toEqual([false])
   })
 
+  it('tells a newly navigated document to stop reporting too', async () => {
+    // A link click inside the content replaces the document — and its bridge,
+    // which starts at its reporting default — without changing the pane's
+    // contentUrl or its reload nonce. `ready` is the only signal that the frame
+    // has forgotten what it was told, so a mode sync keyed on the URL left Off
+    // quieting only the FIRST page the canvas ever loaded (Copilot review,
+    // #405). The host gate hid this: nothing was drawn either way, and only the
+    // page's own per-mousemove work came back.
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false, false])
+  })
+
+  it('does not re-ask a document that is already quiet', async () => {
+    // The reset is on `ready` (a new document), not on every render: a mode the
+    // frame already agrees with must still cost no round-trip.
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    await act(async () => handlers().onPointer(SAVE_BUTTON))
+    await act(async () => handlers().onViewport(VIEWPORT))
+    expect(hoverReportingCalls()).toEqual([false])
+  })
+
   it('says in the mode strip that hovering and clicking do nothing', async () => {
     await renderPane('off')
     expect(container.textContent).toContain('x-ray is off')

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+//
+// The three x-ray hover modes as the PANE actually behaves (#367).
+//
+// Off is the mode the owner asked for — "so I can view it as a normal browser"
+// — and it is the one with two halves that can drift apart: the frame is asked
+// to stop reporting, and the host ignores reports if it hears them anyway. The
+// second half is the one that matters (the bridge shares a realm with the page
+// and may ignore anything), so every mode here is driven through the channel
+// handlers, exactly as a real frame would drive them, rather than by asserting
+// that a request was sent.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import type { CanvasState } from '../../../src/shared/canvas'
+import type { CanvasXrayMode } from '../../../src/renderer/canvas/xray-mode'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@excalidraw/excalidraw', () => ({
+  Excalidraw: () => null,
+  exportToBlob: vi.fn(),
+  sceneCoordsToViewportCoords: () => ({ x: 0, y: 0 }),
+  viewportCoordsToSceneCoords: () => ({ x: 0, y: 0 }),
+}))
+// The notes panel is not under test, and this change deliberately does not
+// touch it — the readout is its sibling.
+vi.mock('../../../src/renderer/components/CanvasNotesPanel', () => ({ default: () => null }))
+// No disk, no IPC: the settings store is REAL (the mode is a real per-user
+// preference and the round-trip through it is part of what is under test).
+vi.mock('../../../src/renderer/utils/config-saver', () => ({ saveConfigNow: vi.fn(async () => true) }))
+
+const askFrame = vi.fn(() => new Promise(() => {}))
+vi.mock('../../../src/renderer/canvas/canvas-frame-rpc', () => ({
+  askCanvasFrame: (...args: unknown[]) => askFrame(...(args as [])),
+  framesInFlight: () => 0,
+  MAX_FRAME_REQUESTS_IN_FLIGHT: 4,
+}))
+
+const disposeChannel = vi.fn()
+const createChannel = vi.fn(() => disposeChannel)
+vi.mock('../../../src/renderer/canvas/canvas-inbound-channel', () => ({
+  createCanvasInboundChannel: createChannel,
+  INBOUND_FLOOD_BUDGET: 600,
+  INBOUND_FLOOD_WINDOW_MS: 1000,
+  reportedKeyIsPlausible: () => true,
+  reportedClickIsPlausible: () => true,
+}))
+
+const AgentCanvasPane = (await import('../../../src/renderer/components/AgentCanvasPane')).default
+const { useCanvasStore } = await import('../../../src/renderer/stores/canvasStore')
+const { useCanvasReviewStore } = await import('../../../src/renderer/stores/canvasReviewStore')
+const { useSettingsStore, DEFAULT_SETTINGS } = await import('../../../src/renderer/stores/settingsStore')
+const { resolveCanvasXrayMode } = await import('../../../src/renderer/canvas/xray-mode')
+
+const SID = 'session-1'
+const STATE: CanvasState = {
+  canvasId: 'canvas-1',
+  sessionId: SID,
+  activeVersionId: 'v1',
+  versions: [{ id: 'v1', mode: 'design', createdAt: '2026-08-14T10:00:00Z', source: { mode: 'design', entry: 'index.html' } }],
+} as CanvasState
+
+const SAVE_BUTTON = {
+  role: 'button',
+  name: 'Save',
+  tag: 'button',
+  uxId: 'save-button',
+  box: { x: 10, y: 40, width: 60, height: 20 },
+}
+const VIEWPORT = { scrollX: 0, scrollY: 0, width: 800, height: 600, dpr: 1, scale: 1 }
+
+;(globalThis as any).window.electronAPI = {
+  ...((globalThis as any).window?.electronAPI ?? {}),
+  pty: { ...((globalThis as any).window?.electronAPI?.pty ?? {}), write: vi.fn() },
+  canvas: {
+    ...((globalThis as any).window?.electronAPI?.canvas ?? {}),
+    getState: vi.fn(async () => STATE),
+    reviewGetState: vi.fn(async () => null),
+    listReclaimable: vi.fn(async () => []),
+  },
+}
+
+interface Handlers {
+  onReady: () => void
+  onViewport: (vp: typeof VIEWPORT) => void
+  onPointer: (hit: typeof SAVE_BUTTON | null) => void
+  onContentClick: (x: number, y: number) => void
+}
+
+let container: HTMLDivElement
+let root: Root
+
+function handlers(): Handlers {
+  return (createChannel.mock.calls[0][0] as { handlers: Handlers }).handlers
+}
+
+/** What the frame would do: report where the page is, then a hover on Save. */
+async function hoverSaveButton(): Promise<void> {
+  await act(async () => {
+    handlers().onViewport(VIEWPORT)
+    handlers().onPointer(SAVE_BUTTON)
+  })
+}
+
+function overlay(): HTMLElement {
+  const el = container.querySelector('[data-canvas-layer="overlay"]')
+  expect(el, 'the stage overlay layer').toBeTruthy()
+  return el as HTMLElement
+}
+
+function readout(): HTMLElement | null {
+  return container.querySelector('[data-testid="canvas-xray-readout"]')
+}
+
+/** The hoverReporting requests the pane has sent to the frame, in order. */
+function hoverReportingCalls(): boolean[] {
+  return askFrame.mock.calls
+    .map((c) => (c as unknown as unknown[])[2] as { type?: string; enabled?: boolean })
+    .filter((p) => p?.type === 'hoverReporting')
+    .map((p) => p.enabled as boolean)
+}
+
+async function renderPane(mode?: CanvasXrayMode): Promise<void> {
+  useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS, canvasXrayMode: mode } })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root.render(<AgentCanvasPane sessionId={SID} />)
+  })
+}
+
+beforeEach(() => {
+  createChannel.mockClear()
+  disposeChannel.mockClear()
+  askFrame.mockClear()
+  useCanvasStore.getState().reset()
+  useCanvasReviewStore.getState().reset()
+  useCanvasStore.setState({
+    bySessionId: {
+      [SID]: {
+        canvasId: STATE.canvasId,
+        versions: STATE.versions,
+        activeVersionId: STATE.activeVersionId,
+        interactionMode: 'browse',
+        emptyView: 'intro',
+        unseenRender: false,
+        loaded: true,
+      },
+    },
+  })
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+describe('x-ray ON — what shipped', () => {
+  it('is the default when nothing was ever chosen', async () => {
+    await renderPane(undefined)
+    expect(resolveCanvasXrayMode(useSettingsStore.getState().settings.canvasXrayMode)).toBe('on')
+  })
+
+  it('outlines and labels the hovered element on the page', async () => {
+    await renderPane('on')
+    await hoverSaveButton()
+    expect(overlay().textContent).toContain('button "Save"')
+    expect(overlay().querySelectorAll('.border-blue').length).toBe(1)
+  })
+
+  it('shows nothing in the side panel — the readout belongs to stealth', async () => {
+    await renderPane('on')
+    await hoverSaveButton()
+    expect(readout()).toBeNull()
+  })
+
+  it('costs the frame no round-trip: the bridge already reports by default', async () => {
+    await renderPane('on')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([])
+  })
+})
+
+describe('x-ray STEALTH — resolved, but nothing drawn on the page', () => {
+  it('draws no outline and no label chip over the content', async () => {
+    await renderPane('stealth')
+    await hoverSaveButton()
+    expect(overlay().textContent).not.toContain('button "Save"')
+    expect(overlay().querySelectorAll('.border-blue').length).toBe(0)
+  })
+
+  it('names the hovered element in the side panel instead', async () => {
+    await renderPane('stealth')
+    await hoverSaveButton()
+    const panel = readout()
+    expect(panel, 'the stealth readout').toBeTruthy()
+    expect(panel!.textContent).toContain('button "Save"')
+    expect(panel!.textContent).toContain('save-button')
+  })
+
+  it('states the box in numbers rather than painting it', async () => {
+    await renderPane('stealth')
+    await hoverSaveButton()
+    expect(container.querySelector('[data-testid="canvas-xray-box"]')?.textContent).toContain('60 × 20')
+    expect(container.querySelector('[data-testid="canvas-xray-box"]')?.textContent).toContain('10, 40')
+  })
+
+  it('still marks the identity as the page’s own account of itself', async () => {
+    // Moving the readout off the page does not make the page a more reliable
+    // narrator of it — the same attribution the on-page chip carries.
+    await renderPane('stealth')
+    await hoverSaveButton()
+    const label = container.querySelector('[data-testid="canvas-xray-label"]')
+    expect(label?.textContent).toContain('page-reported')
+    expect(label?.getAttribute('title')).toMatch(/cannot verify/i)
+  })
+
+  it('empties the readout when the pointer leaves the page', async () => {
+    await renderPane('stealth')
+    await hoverSaveButton()
+    await act(async () => handlers().onPointer(null))
+    expect(readout()!.textContent).not.toContain('button "Save"')
+    expect(readout()!.textContent).toContain('Hover the page')
+  })
+
+  it('keeps the frame reporting — stealth still needs the hit', async () => {
+    await renderPane('stealth')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([])
+  })
+
+  it('still selects on click', async () => {
+    await renderPane('stealth')
+    await act(async () => handlers().onContentClick(12, 44))
+    expect(askFrame).toHaveBeenCalledTimes(1)
+    expect((askFrame.mock.calls[0] as unknown as unknown[])[2]).toMatchObject({ type: 'inspect' })
+  })
+})
+
+describe('x-ray OFF — the page behaves like a normal browser tab', () => {
+  it('draws nothing on the page for a hover the frame reports anyway', async () => {
+    // The frame is asked to stop reporting, but the bridge is page-controlled
+    // code: this is the host refusing a report it did not want.
+    await renderPane('off')
+    await hoverSaveButton()
+    expect(overlay().textContent).not.toContain('button "Save"')
+    expect(overlay().querySelectorAll('.border-blue').length).toBe(0)
+  })
+
+  it('shows nothing in the side panel either', async () => {
+    await renderPane('off')
+    await hoverSaveButton()
+    expect(readout()).toBeNull()
+  })
+
+  it('selects nothing on click — no inspect is issued at all', async () => {
+    await renderPane('off')
+    await act(async () => {
+      handlers().onViewport(VIEWPORT)
+      for (let i = 0; i < 5; i++) handlers().onContentClick(12, 44)
+    })
+    expect(askFrame.mock.calls.filter((c) => ((c as unknown as unknown[])[2] as { type?: string })?.type === 'inspect')).toEqual([])
+    expect(useCanvasReviewStore.getState().bySessionId[SID]?.focus ?? null).toBeNull()
+  })
+
+  it('tells the frame to stop reporting once it is ready', async () => {
+    await renderPane('off')
+    await act(async () => handlers().onReady())
+    expect(hoverReportingCalls()).toEqual([false])
+  })
+
+  it('says in the mode strip that hovering and clicking do nothing', async () => {
+    await renderPane('off')
+    expect(container.textContent).toContain('x-ray is off')
+  })
+})
+
+describe('the header switch', () => {
+  it('offers exactly three segments, with the current one pressed', async () => {
+    await renderPane('stealth')
+    const group = container.querySelector('[data-testid="canvas-xray-mode"]')!
+    const buttons = Array.from(group.querySelectorAll('button'))
+    expect(buttons.map((b) => b.textContent)).toEqual(['Off', 'Stealth', 'On'])
+    expect(buttons.map((b) => b.getAttribute('aria-pressed'))).toEqual(['false', 'true', 'false'])
+  })
+
+  it('switches mode in one click, and the choice is written to the user’s settings', async () => {
+    await renderPane('on')
+    await hoverSaveButton()
+    expect(overlay().textContent).toContain('button "Save"')
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="canvas-xray-off"]')!.click()
+    })
+    // Per user, not per canvas: the value lands in the settings store.
+    expect(useSettingsStore.getState().settings.canvasXrayMode).toBe('off')
+    // …and what was already on screen is dropped, not left painted over a page
+    // the user just asked to see plainly.
+    expect(overlay().textContent).not.toContain('button "Save"')
+  })
+
+  it('round-trips off → stealth → on, telling the frame only when that changes', async () => {
+    await renderPane('on')
+    await act(async () => handlers().onReady())
+
+    const click = async (mode: CanvasXrayMode) => {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>(`[data-testid="canvas-xray-${mode}"]`)!.click()
+      })
+      expect(useSettingsStore.getState().settings.canvasXrayMode).toBe(mode)
+    }
+
+    await click('off')
+    await click('stealth')
+    await click('on')
+    await click('off')
+    // on(default, silent) → off → stealth(live again) → on(no change) → off.
+    expect(hoverReportingCalls()).toEqual([false, true, false])
+  })
+})


### PR DESCRIPTION
Closes #367 (book item 52).

The canvas pane outlined and labelled the hovered element on every mouse move, with no way to stop it — so the one thing the pane could not do was show you the artifact plainly. Owner: *"switch the canvas x-ray hover functionality off via toggle easily so I can view it as a normal browser."*

## Three modes, one click apart

A segmented control in the pane header, beside the existing Browse / Draw / Region switch.

| Mode | Hover resolves? | Drawn on the page | Shown in the panel | Click selects |
|---|---|---|---|---|
| **Off** | no | nothing | nothing | no |
| **Stealth** | yes | nothing | identity + box | yes |
| **On** (default) | yes | outline + label chip | nothing | yes |

The Browse mode strip now says which of these is in force. A user who switched x-ray off and still read *"hover to inspect, click to select"* would reasonably conclude the pane was broken.

## Remembered per user

`AppSettings.canvasXrayMode`, optional, read through `resolveCanvasXrayMode` — the same shape `savedConfigsView` (#362) takes. Absent means `on`, so no existing install changes behaviour on upgrade, and a hand-edited or corrupt value reads as `on` rather than silently disabling a feature the user then cannot see the switch working on. It rides the existing `settings` config save: **no new IPC channel, no preload change, no main-process store**.

Deliberately not `canvasStore.interactionMode` — that is per-session UI state that is never persisted, and the owner asked for per user, not per canvas.

## How the mode reaches the page

```
settings.canvasXrayMode
  -> resolveCanvasXrayMode          (renderer/canvas/xray-mode.ts)
  -> CanvasSurface                  xrayMode + xrayModeRef
       |- host gate    onPointer / onContentClick        <- authoritative
       |- draw gate    stageHoverRect                    <- On only
       |- panel        <CanvasXrayReadout>               <- Stealth only
       `- askCanvasFrame({type:'hoverReporting', enabled})
              -> bridge `hoverReporting` flag
                   -> queuePointer / click listener go silent
```

Off is applied in two places and **only one of them is the gate**. The bridge request is the half the host cannot do for itself: only the content can decline to hit-test, measure and `postMessage` on every mouse move, and "behaves like a normal browser tab" is a claim about the *page's* work. But the bridge shares a realm with the page it reports on and may ignore anything, so the pane gates on the mode again in `onPointer`/`onContentClick` — and that gate is what decides what reaches the review store. The request is fire-and-forget with a 3s timeout; a frame that never answers changes nothing about the mode the user chose.

It does not breach D8 ("content is never commanded to draw"): `hoverReporting` can only make the bridge **quieter**. There is no value of it that makes the page report more than it already would, draw anything, or change what it renders. It is sent only when the frame's belief disagrees with the mode, so the default case (x-ray on, the bridge's own default) costs no round-trip at all, and the belief resets when the frame reloads.

## Owner question — what a click does in Off

The issue left this open: *"decide on the canvas what a click does in Off: nothing, or temporarily arms a note."*

This run implemented **nothing**: Off was asked for as "view it as a normal browser", and a browser tab does not turn a click into a selection. Arming a note on click would make Off a fourth, hidden mode rather than the absence of one.

**The alternative is still open.** If you would rather Off kept a way to capture a note without leaving the mode — click arms a one-shot selection, the next click behaves normally — say so and it is a small change: `xrayClickSelects` in `src/renderer/canvas/xray-mode.ts` is the single decision point, and it is pinned by a test so the current behaviour cannot drift into the other one by accident.

Two smaller calls worth your eye:

- An existing **locked focus is not cleared** when switching to Off — it is a selection you made and may be mid-note on. Esc still clears it. The alternative (Off wipes it) loses work.
- The stealth readout sits **below the notes panel** as a sibling, not inside it. It belongs to the stage's pointer rather than to the review, and it keeps this diff clear of `CanvasNotesPanel.tsx`, which #403 is changing.

## Attribution

The stealth readout carries the `page-reported` marker and the same tooltip the on-page chip does. Moving a page-authored identity off the page does not make the page a more reliable narrator of it — the 2026-08-15 adversarial finding applies wherever that identity is printed, not only on the stage.

## Verification

- `npm run typecheck` — clean
- Full `npx vitest run` — **7118 passed, 15 skipped, 2 todo (7135)**, 664 files passed / 2 skipped (666). No failures.
- New: `canvas-xray-mode.test.ts` (14), `canvas-xray-pane.test.tsx` (19), `canvas-bridge-hover-reporting.test.ts` (11).
- **Guard mutation run** — removing the pointer gate, the click gate or the draw gate fails 3 pane tests; removing the bridge's on-frame re-check fails the queued-move test. The bridge tests drive the BUNDLED script (`virtual:canvas-bridge`), so they cannot pass while the shipped artifact is broken.

No changelog edits (per the task brief). Dated fragment at `CONTEXT.d/2026-08-22-n367.md`.

Branch is based on `origin/beta` @ `8b6b2277`; happy to rebase after #403 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
