### PR TITLE
fix(main): a failed config read is not an absence in five persisters

### DIFF
--- a/CONTEXT.d/2026-08-22-persisters-null-vs-failed.md
+++ b/CONTEXT.d/2026-08-22-persisters-null-vs-failed.md
@@ -1,0 +1,87 @@
+# 2026-08-22 — one shared null-vs-failed pattern for the main-side persisters
+
+First of the #371 follow-ups the ADR-009 pass before beta.16 left noted rather than
+fixed. That pass fixed the shape for saved sessions (#353) and wrote down where else it
+lived: *"the same null-vs-failed shape in five other main-side persisters (one shared fix
+later, not five copies)"*. This is that fix.
+
+## The shape
+
+A failed READ is not an absence. A file can be there and unreadable for a moment — an AV
+scanner holding a just-written file (EBUSY), a permissions hiccup, a network share that
+blinked — and every one of these loaders answered `null` for that exactly as it answered
+for "no file". The caller then did the ordinary thing with the empty store it was handed
+(added an item, swept a stuck entry, saved the form the user had just opened) and wrote
+it over the file it had never managed to read.
+
+Nothing failed loudly. The user's cloud agents, team library, usage history, vision
+settings or window geometry were simply gone.
+
+## The five, and how each one reached the write
+
+| Persister | The write that lost it |
+| --- | --- |
+| `cloud-agent-manager.ts` | dispatching an agent persisted a one-element array over the history |
+| `team-manager.ts` (teams + runs) | the next `saveTeam()` wrote one team over the whole library; the boot stuck-run sweep wrote over the run history |
+| `usage/usage-snapshots.ts` | every caller rebuilds the whole map and saves it back, so one bad read dropped every OTHER profile's snapshot |
+| `ipc/vision-handlers.ts` | `getConfig` → null → the form rendered defaults → the user touched one control → `saveConfig` wrote defaults over the real config |
+| `index.ts` window geometry | a bare `catch { /* ignore */ }` returned the hardcoded 3200x1800 default, and the close handler wrote it back over the real geometry |
+
+Vision was doubly quiet: the handler discarded `writeConfig`'s boolean and returned
+`{ ok: true }` unconditionally, so a failed save was reported to the user as a
+successful one too. Window state was the only one of the five that bypassed
+`config-manager` entirely, so it also never had the atomic write.
+
+## The pattern
+
+`src/main/persist-latch.ts` — one latch, applied five times, never copied:
+
+- `config-manager.readConfigChecked()` answers with an OUTCOME, not just a value.
+  Three ways to get nothing, not one: **absent** (an empty store is the truth),
+  **unparseable** (content unrecoverable — moved aside to `<name>.corrupt-<ts>`, never
+  silently destroyed, writes stay allowed because there is nothing left to protect), and
+  **failed** (the file could not be read).
+- `createReadFailureLatch(name)` remembers the last load's outcome. While it was
+  `failed`, `saveConfigLatched` refuses and logs why. A later successful load clears it.
+
+The failure signal rides on the latch, never on the return value, so every caller keeps
+its existing shape and only has to consult the latch before it WRITES.
+
+The asymmetry is what makes this safe to apply everywhere: a refused write costs one
+unsaved change, which the next successful load un-refuses. An un-refused write costs the
+file.
+
+Two files means two latches (`team-manager`), never one shared: one file's read failure
+says nothing about the other's, and sharing would latch writes off for a file that read
+perfectly well.
+
+## What was deliberately NOT changed
+
+The renderer's bulk load (`loadAllConfig` → `readConfigDetailed`) keeps its own contract
+from #353: a renderer config file that exists and cannot be read OR parsed latches
+renderer writes, and nothing is moved aside. That path is a separate boundary
+(GHSA-m8p2) and an unparseable renderer config is recoverable by hand — the latch is what
+stops defaults being written over it. `readConfigDetailed` now delegates to the same
+reader with `quarantineUnparseable: false`, so there is one implementation and no
+behaviour change.
+
+Window geometry moved out of `index.ts` into `src/main/window-state.ts`. It is a
+persister like the others and needed the same latch plus a unit test, and it now goes
+through the shared `windowState` config key — which resolves to exactly the path it used
+to build by hand (`<CONFIG>/window-state.json`), so upgrading installs keep their
+geometry with no migration, and it picks up the atomic write it never had.
+
+## Verification
+
+Every latch was mutation-tested: `refuses()` forced to return false, the suites watched
+go red (10 tests across four files), the guard restored byte-for-byte.
+
+That mutation is also what caught a test that could not fail — the first cut of the
+cloud-agent case asserted "nothing was written" after a failed load, which is true
+whatever the latch does, because a failed load leaves an empty list and the boot sweep
+has nothing to change and never reaches `persist()`. Dispatching an agent is the only
+persist path reachable while latched, so that is what the test now drives. The
+unreachable case is kept beside it with a comment saying it is not a latch assertion, so
+the next reader does not mistake it for one.
+
+Full suite on the branch: 7111 passed, 15 skipped, 2 todo (663 files); typecheck clean.

--- a/src/main/cloud-agent-manager.ts
+++ b/src/main/cloud-agent-manager.ts
@@ -7,7 +7,7 @@ import { BrowserWindow } from 'electron'
 import * as os from 'os'
 import * as fs from 'fs'
 import * as path from 'path'
-import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from './persist-latch'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched, mergeById } from './persist-latch'
 import { logInfo, logWarn, logError } from './debug-logger'
 import { resolveVersionBinary, isVersionInstalled, installVersion } from './legacy-version-manager'
 import { isValidLegacyVersion } from '../shared/legacy-version'
@@ -96,8 +96,33 @@ function generateId(): string {
  *  the very next `cleanupStuckAgents()` writes back over the file. */
 const cloudAgentsLatch = createReadFailureLatch('cloud-agent')
 
-function persist(): void {
-  saveConfigLatched('cloudAgents', agents, cloudAgentsLatch)
+/**
+ * Returns false when the agent list did NOT reach disk. Callers must surface
+ * that: `initCloudAgentManager` runs once, at boot, so before the retry inside
+ * `saveConfigLatched` existed a single transient lock at startup silently
+ * discarded every agent dispatched for the rest of the process.
+ */
+function persist(removedIds?: readonly string[]): boolean {
+  return saveConfigLatched('cloudAgents', () => agents, cloudAgentsLatch, {
+    onRecovered: (recovered) => {
+      // The file is readable again: everything that was on disk before the
+      // failed load comes back, and anything dispatched since wins on its id.
+      agents = mergeById(recovered, agents)
+      // …but a REMOVAL must not be undone by the merge — the removed row is
+      // still on disk, so folding disk back in would resurrect it.
+      if (removedIds && removedIds.length > 0) {
+        const gone = new Set(removedIds)
+        agents = agents.filter((a) => !gone.has(a.id))
+      }
+    },
+  })
+}
+
+/** Why the last write did not land, in words a user can act on. */
+function persistFailure(): string {
+  return cloudAgentsLatch.failed()
+    ? 'Your cloud agents could not be saved: the agents file could not be read, so it was left alone rather than overwritten. Nothing on disk was lost — try again once it is readable.'
+    : 'Your cloud agents could not be written to disk.'
 }
 
 function broadcastStatus(agent: CloudAgentData): void {
@@ -373,18 +398,25 @@ export function cancelAgent(id: string): boolean {
   return true
 }
 
-export function removeAgent(id: string): boolean {
+export function removeAgent(id: string): { ok: boolean; removed: boolean; error?: string } {
   const idx = agents.findIndex(a => a.id === id)
-  if (idx < 0) return false
+  if (idx < 0) return { ok: true, removed: false }
 
   // Cancel if running
   if (agents[idx].status === 'running') {
     cancelAgent(id)
   }
 
-  agents.splice(idx, 1)
-  persist()
-  return true
+  const snapshot = agents
+  agents = agents.filter(a => a.id !== id)
+  // #371 BLOCKER-1: a refused write used to return true, so the row vanished
+  // from the UI and came back on restart. Roll the in-memory list back so the
+  // screen keeps matching the disk.
+  if (!persist([id])) {
+    agents = snapshot
+    return { ok: false, removed: false, error: persistFailure() }
+  }
+  return { ok: true, removed: true }
 }
 
 export async function retryAgent(id: string): Promise<CloudAgentData | null> {
@@ -410,12 +442,16 @@ export function getAgentOutput(id: string): string {
   return agent?.output || ''
 }
 
-export function clearCompletedAgents(): number {
-  const before = agents.length
+export function clearCompletedAgents(): { ok: boolean; removed: number; error?: string } {
+  const snapshot = agents
+  const clearedIds = agents.filter(a => a.status !== 'running' && a.status !== 'pending').map(a => a.id)
+  if (clearedIds.length === 0) return { ok: true, removed: 0 }
   agents = agents.filter(a => a.status === 'running' || a.status === 'pending')
-  const removed = before - agents.length
-  if (removed > 0) persist()
-  return removed
+  if (!persist(clearedIds)) {
+    agents = snapshot
+    return { ok: false, removed: 0, error: persistFailure() }
+  }
+  return { ok: true, removed: clearedIds.length }
 }
 
 export function killAllAgents(): void {

--- a/src/main/cloud-agent-manager.ts
+++ b/src/main/cloud-agent-manager.ts
@@ -7,7 +7,7 @@ import { BrowserWindow } from 'electron'
 import * as os from 'os'
 import * as fs from 'fs'
 import * as path from 'path'
-import { readConfig, writeConfig } from './config-manager'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from './persist-latch'
 import { logInfo, logWarn, logError } from './debug-logger'
 import { resolveVersionBinary, isVersionInstalled, installVersion } from './legacy-version-manager'
 import { isValidLegacyVersion } from '../shared/legacy-version'
@@ -92,8 +92,12 @@ function generateId(): string {
   return randomId('ca-')
 }
 
+/** #371: a failed read of cloud-agents.json must not become an empty list that
+ *  the very next `cleanupStuckAgents()` writes back over the file. */
+const cloudAgentsLatch = createReadFailureLatch('cloud-agent')
+
 function persist(): void {
-  writeConfig('cloudAgents', agents)
+  saveConfigLatched('cloudAgents', agents, cloudAgentsLatch)
 }
 
 function broadcastStatus(agent: CloudAgentData): void {
@@ -112,9 +116,15 @@ function broadcastOutputChunk(id: string, chunk: string): void {
 
 export function initCloudAgentManager(windowGetter: () => BrowserWindow | null): void {
   getWindow = windowGetter
-  // Load persisted agents
-  const saved = readConfig<CloudAgentData[]>('cloudAgents')
-  agents = saved || []
+  // Load persisted agents. A read FAILURE latches writes off (see persist-latch)
+  // so the empty list below is never saved over a file we could not read.
+  const saved = loadConfigLatched<CloudAgentData[]>('cloudAgents', cloudAgentsLatch)
+  agents = Array.isArray(saved) ? saved : []
+}
+
+/** Test seam — the latch is module state and outlives a test file otherwise. */
+export function _resetCloudAgentLatchForTest(): void {
+  cloudAgentsLatch.reset()
 }
 
 export function cleanupStuckAgents(): void {

--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import { join } from 'path'
-import { readFileSync, existsSync, readdirSync, copyFileSync, rmSync, statSync } from 'fs'
+import { readFileSync, existsSync, readdirSync, copyFileSync, rmSync, statSync, renameSync } from 'fs'
 import { getResourcesDirectory } from './ipc/setup-handlers'
 import { logInfo, logError, logWarn } from './debug-logger'
 import { atomicWriteSecure, mkdirSecure, hardenCredentialDir, hardenCredentialFile } from './account-profiles'
@@ -228,6 +228,73 @@ export function readConfig<T = unknown>(key: ConfigKey): T | null {
 }
 
 /**
+ * Why a config read returned what it did.
+ *
+ * `readConfig` collapses all four of these into `null`, which is the shape the
+ * main-side persisters were built on and the reason they could overwrite a file
+ * they had failed to read (#371). See `persist-latch.ts` for the pattern that
+ * consumes this.
+ */
+export type ConfigReadOutcome = 'ok' | 'absent' | 'unparseable' | 'failed'
+
+export interface CheckedRead<T> {
+  value: T | null
+  outcome: ConfigReadOutcome
+}
+
+/**
+ * Read a config file and say WHY, distinguishing the three ways to get nothing.
+ *
+ * `quarantineUnparseable` (default true) moves a file whose CONTENT does not
+ * parse aside to `<name>.corrupt-<ts>` rather than leaving it to be silently
+ * overwritten by the next save. It is off for the renderer's bulk load, which
+ * latches on unparseable instead of quarantining — that path is a separate
+ * contract (#353) and is deliberately left exactly as it was.
+ *
+ * An unregistered key is `failed`, not `absent`: `writeConfig` already refuses
+ * one, so answering "absent" would invite a caller to build an empty store for
+ * a key it can never persist.
+ */
+export function readConfigChecked<T = unknown>(
+  key: ConfigKey,
+  opts: { quarantineUnparseable?: boolean } = {},
+): CheckedRead<T> {
+  const quarantine = opts.quarantineUnparseable !== false
+  const fileName = CONFIG_FILES[key]
+  if (!fileName) {
+    logError(`[config-manager] Refusing to read unknown config key: ${String(key)}`)
+    return { value: null, outcome: 'failed' }
+  }
+  const filePath = join(getConfigDir(), fileName)
+  let data: string
+  try {
+    if (!existsSync(filePath)) return { value: null, outcome: 'absent' }
+    data = readFileSync(filePath, 'utf-8')
+  } catch (err) {
+    // The file is (probably) there and could not be read: EBUSY, EACCES,
+    // EPERM, EIO, a junction refusal. This is the case the latch exists for.
+    logError(`[config-manager] Failed to read ${key} (read failure, NOT an absence): ${err}`)
+    return { value: null, outcome: 'failed' }
+  }
+  try {
+    return { value: JSON.parse(data) as T, outcome: 'ok' }
+  } catch (parseErr) {
+    // Unreadable CONTENT, not an unreadable FILE: keep it for forensics, start
+    // clean. Nothing is left to protect, so writes stay allowed.
+    if (quarantine) {
+      const aside = `${filePath}.corrupt-${Date.now()}`
+      try {
+        renameSync(filePath, aside)
+        logError(`[config-manager] ${key} did not parse (${(parseErr as Error)?.message ?? parseErr}); moved aside to ${aside}`)
+      } catch {
+        logError(`[config-manager] ${key} did not parse and could not be moved aside; the next save overwrites it`)
+      }
+    }
+    return { value: null, outcome: 'unparseable' }
+  }
+}
+
+/**
  * Write a config file atomically via the shared helper (#233) — staging,
  * exclusive create, the rename retry and cleanup all live in atomic-write.ts.
  *
@@ -330,18 +397,20 @@ export interface LoadAllResult {
   failedKeys: ConfigKey[]
 }
 
-/** Like readConfig, but says WHY it returned null. */
+/**
+ * Like readConfig, but says WHY it returned null.
+ *
+ * The renderer's bulk load has its own contract (#353): a file that EXISTS and
+ * cannot be read OR parsed latches renderer writes off, and nothing is moved
+ * aside — an unparseable renderer config is recoverable by hand and the latch
+ * is what stops defaults being written over it. So unparseable maps to
+ * `failed: true` here, and quarantine is off. An unregistered key stays
+ * `failed: false` (it is not one of RENDERER_CONFIG_KEYS anyway).
+ */
 function readConfigDetailed(key: ConfigKey): { value: unknown; failed: boolean } {
-  const fileName = CONFIG_FILES[key]
-  if (!fileName) return { value: null, failed: false }
-  const filePath = join(getConfigDir(), fileName)
-  try {
-    if (!existsSync(filePath)) return { value: null, failed: false }
-    return { value: JSON.parse(readFileSync(filePath, 'utf-8')), failed: false }
-  } catch (err) {
-    logError(`[config-manager] Failed to read ${key}: ${err}`)
-    return { value: null, failed: true }
-  }
+  if (!CONFIG_FILES[key]) return { value: null, failed: false }
+  const read = readConfigChecked<unknown>(key, { quarantineUnparseable: false })
+  return { value: read.value, failed: read.outcome === 'failed' || read.outcome === 'unparseable' }
 }
 
 export function loadAllConfig(): LoadAllResult {

--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -262,34 +262,54 @@ export function readConfigChecked<T = unknown>(
   const quarantine = opts.quarantineUnparseable !== false
   const fileName = CONFIG_FILES[key]
   if (!fileName) {
-    logError(`[config-manager] Refusing to read unknown config key: ${String(key)}`)
+    // Not 'absent': `writeConfig` refuses an unregistered key too, so telling a
+    // caller "there is no file" would invite it to build an empty store for a
+    // key it can never persist. Named distinctly in the log — a typo'd key is a
+    // programming error, not an unreadable disk.
+    logError(`[config-manager] Refusing to read UNREGISTERED config key: ${String(key)} (not in CONFIG_FILES — this is a bug, not a disk failure)`)
     return { value: null, outcome: 'failed' }
   }
   const filePath = join(getConfigDir(), fileName)
   let data: string
   try {
-    if (!existsSync(filePath)) return { value: null, outcome: 'absent' }
+    // `existsSync` answers false for ANY stat error, not just ENOENT — a denied
+    // parent, an unmounted resources directory, a share that blinked. Reading
+    // that as "absent" is the exact collapse this function exists to undo, and
+    // it is the case `loadAllConfig` already handles on the renderer side by
+    // latching every key. So: open-and-read, and let only ENOENT mean absent.
     data = readFileSync(filePath, 'utf-8')
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code
+    if (code === 'ENOENT') return { value: null, outcome: 'absent' }
     // The file is (probably) there and could not be read: EBUSY, EACCES,
-    // EPERM, EIO, a junction refusal. This is the case the latch exists for.
-    logError(`[config-manager] Failed to read ${key} (read failure, NOT an absence): ${err}`)
+    // EPERM, EIO, ENOTDIR, a junction refusal. This is the case the latch
+    // exists for.
+    logError(`[config-manager] Failed to read ${key} (read failure, NOT an absence; code=${code ?? 'none'}): ${err}`)
     return { value: null, outcome: 'failed' }
   }
   try {
     return { value: JSON.parse(data) as T, outcome: 'ok' }
   } catch (parseErr) {
+    // Log unconditionally: the renderer bulk-load path passes
+    // `quarantineUnparseable: false`, and it is the path that latches every
+    // renderer write (GHSA-m8p2). Losing its only diagnostic to an `if` was the
+    // wrong direction. Quarantine conditionally; say why always.
+    logError(`[config-manager] ${key} did not parse: ${(parseErr as Error)?.message ?? parseErr}`)
+    if (!quarantine) return { value: null, outcome: 'unparseable' }
     // Unreadable CONTENT, not an unreadable FILE: keep it for forensics, start
-    // clean. Nothing is left to protect, so writes stay allowed.
-    if (quarantine) {
-      const aside = `${filePath}.corrupt-${Date.now()}`
-      try {
-        renameSync(filePath, aside)
-        logError(`[config-manager] ${key} did not parse (${(parseErr as Error)?.message ?? parseErr}); moved aside to ${aside}`)
-      } catch {
-        logError(`[config-manager] ${key} did not parse and could not be moved aside; the next save overwrites it`)
-      }
+    // clean. "Nothing is left to protect" is only true once the move has
+    // actually happened…
+    const aside = `${filePath}.corrupt-${Date.now()}`
+    try {
+      renameSync(filePath, aside)
+    } catch (renameErr) {
+      // …and when it has not, the premise is false: the unparseable file is
+      // still sitting there, possibly hand-recoverable, and allowing writes
+      // would let the next save overwrite it. Latch instead.
+      logError(`[config-manager] ${key} did not parse AND could not be moved aside (${(renameErr as Error)?.message ?? renameErr}); refusing writes rather than letting the next save overwrite it`)
+      return { value: null, outcome: 'failed' }
     }
+    logInfo(`[config-manager] ${key} moved aside to ${aside}; starting clean`)
     return { value: null, outcome: 'unparseable' }
   }
 }

--- a/src/main/config-manager.ts
+++ b/src/main/config-manager.ts
@@ -4,7 +4,7 @@
  * and can live on a network drive for portability.
  */
 
-import { join } from 'path'
+import { join, parse } from 'path'
 import { readFileSync, existsSync, readdirSync, copyFileSync, rmSync, statSync, renameSync } from 'fs'
 import { getResourcesDirectory } from './ipc/setup-handlers'
 import { logInfo, logError, logWarn } from './debug-logger'
@@ -255,6 +255,23 @@ export interface CheckedRead<T> {
  * one, so answering "absent" would invite a caller to build an empty store for
  * a key it can never persist.
  */
+/**
+ * Is the volume the config store lives on actually there?
+ *
+ * Deliberately the ROOT (`F:\`, `\\server\share\`, `/`) and not the CONFIG
+ * directory: a fresh install legitimately has no CONFIG directory yet, and
+ * treating that as a failure would latch writes off before the first save.
+ */
+function configRootReachable(): boolean {
+  try {
+    const root = parse(getConfigDir()).root
+    if (!root) return true // relative/unknown shape — do not invent a failure
+    return existsSync(root)
+  } catch {
+    return true // cannot tell: fall back to the plain ENOENT reading
+  }
+}
+
 export function readConfigChecked<T = unknown>(
   key: ConfigKey,
   opts: { quarantineUnparseable?: boolean } = {},
@@ -280,7 +297,23 @@ export function readConfigChecked<T = unknown>(
     data = readFileSync(filePath, 'utf-8')
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code
-    if (code === 'ENOENT') return { value: null, outcome: 'absent' }
+    if (code === 'ENOENT') {
+      // ENOENT is NOT proof of absence on Windows: a mapped network drive that
+      // has not reconnected, or a removable drive not yet attached at logon,
+      // answers ENOENT for every path on it. The resources directory can live
+      // on either (it is user-selected), so a whole unavailable config store
+      // would read as "fresh install", latch nothing, and the first save would
+      // clobber it once the drive came back (#371, ADR-009 pass).
+      //
+      // So ask whether the ROOT is there. Root missing → the store is
+      // unreachable → failed. Root present but the file is not → genuinely
+      // absent, which is what a real fresh install looks like.
+      if (!configRootReachable()) {
+        logError(`[config-manager] ${key} read ENOENT and the resources root is unreachable — treating as a READ FAILURE, not a fresh install`)
+        return { value: null, outcome: 'failed' }
+      }
+      return { value: null, outcome: 'absent' }
+    }
     // The file is (probably) there and could not be read: EBUSY, EACCES,
     // EPERM, EIO, ENOTDIR, a junction refusal. This is the case the latch
     // exists for.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell } from 'electron'
 import { join } from 'path'
 import { homedir } from 'os'
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
+import { writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { registerPtyHandlers } from './ipc/pty-handlers'
 import { splashBuildQuery } from './splash-info'
@@ -89,10 +89,11 @@ import { startServiceStatusPoller, stopServiceStatusPoller, getLastServiceStatus
 import { initUpdateWatcher, stopUpdateWatcher, getProjectRootPath, isPackagedApp } from './update-watcher'
 import { startUpdateServer, stopUpdateServer } from './update-server'
 import { saveSessionState, loadSessionState, clearSessionState, hasSavedSessionState, SessionState } from './session-state'
-import { getConfigDir, ensureConfigDir, snapshotConfig } from './config-manager'
+import { getConfigDir, snapshotConfig } from './config-manager'
 import { stopGlobalVision, killSpawnedBrowser, cleanupLegacyVisionMarkers } from './vision-manager'
 import { startConductorMcpServer, stopConductorMcpServer, startBrowserAtBoot } from './conductor-mcp-server'
 import { readConfig } from './config-manager'
+import { loadWindowState, saveWindowState, type WindowState } from './window-state'
 import { saveCredential, deleteCredential } from './credential-store'
 import { resolveConductorMcpPort } from '../shared/mcp-ports'
 import { IPC } from '../shared/ipc-channels'
@@ -187,46 +188,17 @@ migrateRegistryKeys()
 // protocol handler is installed inside whenReady, before any window exists.
 registerCccUxSchemePrivileges()
 
-// Lazy getter — can't call getConfigDir() at module load time
-function getWindowStateFile(): string {
-  return join(getConfigDir(), 'window-state.json')
-}
-
-interface WindowState {
-  x?: number
-  y?: number
-  width: number
-  height: number
-  isMaximized: boolean
-}
-
-function loadWindowState(): WindowState {
-  try {
-    const file = getWindowStateFile()
-    if (existsSync(file)) {
-      return JSON.parse(readFileSync(file, 'utf-8'))
-    }
-  } catch {
-    // ignore
-  }
-  return { width: 3200, height: 1800, isMaximized: false }
-}
-
-function saveWindowState(win: BrowserWindow): void {
+/** Geometry lives in `window-state.ts` (#371) — it is a persister like the
+ *  others and needed the same read-failure latch, plus a unit test. */
+function saveWindowStateFor(win: BrowserWindow): void {
   const bounds = win.getBounds()
-  const state: WindowState = {
+  saveWindowState({
     x: bounds.x,
     y: bounds.y,
     width: bounds.width,
     height: bounds.height,
     isMaximized: win.isMaximized()
-  }
-  try {
-    ensureConfigDir()
-    writeFileSync(getWindowStateFile(), JSON.stringify(state))
-  } catch {
-    // ignore
-  }
+  })
 }
 
 let mainWindow: BrowserWindow | null = null
@@ -471,7 +443,7 @@ function createWindow(): void {
   let closeRequestedOnce = false
 
   mainWindow.on('close', (e) => {
-    if (mainWindow) saveWindowState(mainWindow)
+    if (mainWindow) saveWindowStateFor(mainWindow)
 
     // If not yet allowed to close, prevent and notify renderer
     if (!allowClose) {

--- a/src/main/ipc/vision-handlers.ts
+++ b/src/main/ipc/vision-handlers.ts
@@ -23,6 +23,12 @@ export function _resetVisionLatchForTest(): void {
 export function registerVisionHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('vision:start', async () => {
     const config = loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
+    // Say WHICH kind of nothing this is. "Not configured" sends the user to the
+    // settings panel, which — on a read failure — is exactly where they would
+    // overwrite the config they still have (#371 MINOR-5).
+    if (!config && visionLatch.failed()) {
+      return { ok: false, error: 'Vision settings could not be read this time, so vision was not started. They are still on disk — try again in a moment.' }
+    }
     if (!config?.enabled) return { ok: false, error: 'Vision not configured' }
     try {
       await startGlobalVision(config, getWindow)
@@ -70,7 +76,26 @@ export function registerVisionHandlers(getWindow: () => BrowserWindow | null): v
     }
   })
 
-  ipcMain.handle('vision:saveConfig', async (_event, config: GlobalVisionConfig) => {
+  /**
+   * `generation` is the token `vision:getConfig` handed out with the config the
+   * form was built from (#371 MAJOR-5).
+   *
+   * The latch alone is not enough here, because the stale state lives in the
+   * RENDERER: `getConfig` fails, the panel renders defaults, then something
+   * else — `vision:start`, the launch path — reads the file successfully and
+   * clears the latch. A save arriving after that looks perfectly healthy and
+   * writes the defaults over the real config. The token closes that window: it
+   * changes on recovery, so a form built while the file was unreadable can
+   * never save over the file once it is readable again.
+   */
+  ipcMain.handle('vision:saveConfig', async (_event, config: GlobalVisionConfig, generation?: number) => {
+    if (typeof generation === 'number' && generation !== visionLatch.generation()) {
+      return {
+        ok: false,
+        stale: true,
+        error: 'Vision settings were not saved: these settings were shown before the settings file could be read, so saving them would overwrite the real ones. Reopen this panel to see what is actually saved.',
+      }
+    }
     // Report the real outcome. A refused save (the last read FAILED) and a
     // failed write both come back as ok:false rather than a false reassurance.
     const saved = saveConfigLatched('visionGlobal', config, visionLatch)
@@ -84,6 +109,14 @@ export function registerVisionHandlers(getWindow: () => BrowserWindow | null): v
   })
 
   ipcMain.handle('vision:getConfig', async () => {
-    return loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
+    const config = loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
+    return {
+      config,
+      generation: visionLatch.generation(),
+      /** True when `config` is null because the file could not be READ, rather
+       *  than because there is none. The panel must not offer defaults as if
+       *  this were a fresh install. */
+      readFailed: visionLatch.failed(),
+    }
   })
 }

--- a/src/main/ipc/vision-handlers.ts
+++ b/src/main/ipc/vision-handlers.ts
@@ -89,16 +89,32 @@ export function registerVisionHandlers(getWindow: () => BrowserWindow | null): v
    * never save over the file once it is readable again.
    */
   ipcMain.handle('vision:saveConfig', async (_event, config: GlobalVisionConfig, generation?: number) => {
-    if (typeof generation === 'number' && generation !== visionLatch.generation()) {
+    // The token is MANDATORY (#371, ADR-009 pass). Accepting a save without one
+    // left the whole guard opt-in: any caller that omitted it — an older
+    // renderer, a future one, a bug — got the unguarded path back.
+    if (typeof generation !== 'number') {
+      return {
+        ok: false,
+        error: 'Vision settings were not saved: this panel did not say which reading of the settings file it was built from. Reopen it and try again.',
+      }
+    }
+    if (generation !== visionLatch.generation()) {
       return {
         ok: false,
         stale: true,
         error: 'Vision settings were not saved: these settings were shown before the settings file could be read, so saving them would overwrite the real ones. Reopen this panel to see what is actually saved.',
       }
     }
+    // `retry: false`: a vision config is ONE object, so there is nothing to
+    // merge. Letting the shared retry recover the file and then write would put
+    // the renderer's defaults over the settings it had just rescued — the very
+    // clobber the generation token is here to stop (#371, ADR-009 pass). A
+    // latched save refuses, and the user reopens the panel to see what is really
+    // stored.
+    //
     // Report the real outcome. A refused save (the last read FAILED) and a
     // failed write both come back as ok:false rather than a false reassurance.
-    const saved = saveConfigLatched('visionGlobal', config, visionLatch)
+    const saved = saveConfigLatched('visionGlobal', config, visionLatch, { retry: false })
     if (saved) return { ok: true }
     return {
       ok: false,

--- a/src/main/ipc/vision-handlers.ts
+++ b/src/main/ipc/vision-handlers.ts
@@ -1,13 +1,28 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { startGlobalVision, stopGlobalVision, getGlobalVisionStatus, launchBrowser, tryReconnectGlobalVision, resetVisionRelaunchBreaker, isGlobalVisionRunning } from '../vision-manager'
-import { readConfig, writeConfig } from '../config-manager'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from '../persist-latch'
 import { isPackagedApp } from '../update-watcher'
 import { resolveCdpPort } from '../../shared/cdp-ports'
 import type { GlobalVisionConfig } from '../../shared/types'
 
+/**
+ * #371. `vision:getConfig` answering null for a read FAILURE is what makes this
+ * one dangerous: the settings form renders its defaults for "not configured
+ * yet", the user touches one control, and `vision:saveConfig` writes those
+ * defaults over the config it never read. The old handler then returned
+ * `{ ok: true }` unconditionally — it discarded `writeConfig`'s boolean — so a
+ * failed save was reported to the user as a successful one either way.
+ */
+const visionLatch = createReadFailureLatch('vision-config')
+
+/** Test seam — the latch is module state and outlives a test file otherwise. */
+export function _resetVisionLatchForTest(): void {
+  visionLatch.reset()
+}
+
 export function registerVisionHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('vision:start', async () => {
-    const config = readConfig<GlobalVisionConfig>('visionGlobal')
+    const config = loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
     if (!config?.enabled) return { ok: false, error: 'Vision not configured' }
     try {
       await startGlobalVision(config, getWindow)
@@ -46,7 +61,7 @@ export function registerVisionHandlers(getWindow: () => BrowserWindow | null): v
       if (isGlobalVisionRunning()) {
         tryReconnectGlobalVision()
       } else {
-        const saved = readConfig<GlobalVisionConfig>('visionGlobal')
+        const saved = loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
         await startGlobalVision({ ...(saved ?? {}), browser, debugPort, headless } as GlobalVisionConfig, getWindow)
       }
       return { ok: true, ...result }
@@ -56,11 +71,19 @@ export function registerVisionHandlers(getWindow: () => BrowserWindow | null): v
   })
 
   ipcMain.handle('vision:saveConfig', async (_event, config: GlobalVisionConfig) => {
-    writeConfig('visionGlobal', config)
-    return { ok: true }
+    // Report the real outcome. A refused save (the last read FAILED) and a
+    // failed write both come back as ok:false rather than a false reassurance.
+    const saved = saveConfigLatched('visionGlobal', config, visionLatch)
+    if (saved) return { ok: true }
+    return {
+      ok: false,
+      error: visionLatch.failed()
+        ? 'Vision settings were not saved: the existing settings file could not be read, so it was left alone. Try again once it is readable.'
+        : 'Vision settings could not be saved.',
+    }
   })
 
   ipcMain.handle('vision:getConfig', async () => {
-    return readConfig<GlobalVisionConfig>('visionGlobal')
+    return loadConfigLatched<GlobalVisionConfig>('visionGlobal', visionLatch)
   })
 }

--- a/src/main/persist-latch.ts
+++ b/src/main/persist-latch.ts
@@ -126,6 +126,16 @@ export interface LatchedSaveOptions {
   /** Names the refused operation in the log ('save', 'clear', …). */
   action?: string
   /**
+   * Set false to REFUSE outright instead of retrying the read.
+   *
+   * The retry exists for stores that can MERGE (a list keyed by id): recover
+   * the file, fold it in, write the union. A store whose state is a single
+   * object has nothing to merge, so recovering the file only to write the
+   * in-memory fallback over it is the loss, not the fix. `window-state` and the
+   * vision config are both that shape (#371, ADR-009 pass).
+   */
+  retry?: boolean
+  /**
    * Called when the retry read below RECOVERS a file that had previously failed
    * to read. The owner MUST fold the recovered content back into its in-memory
    * state before the write happens — otherwise the empty store built from the
@@ -164,10 +174,15 @@ export function saveConfigLatched(
   opts: LatchedSaveOptions = {},
 ): boolean {
   const action = opts.action ?? 'save'
+  let justRecovered = false
   if (latch.failed()) {
+    if (opts.retry === false) {
+      latch.refuses(action)
+      return false
+    }
     const retry = readConfigChecked(key)
-    latch.note(retry.outcome)
     if (retry.outcome === 'failed') {
+      latch.note(retry.outcome)
       latch.refuses(action)
       return false
     }
@@ -176,8 +191,24 @@ export function saveConfigLatched(
     // it can decide — `recovered` is null in both cases, which is a truthful
     // answer meaning "there is nothing on disk to merge".
     opts.onRecovered?.(retry.value)
+    justRecovered = true
+    latch.note(retry.outcome)
   }
-  return writeConfig(key, typeof value === 'function' ? (value as () => unknown)() : value)
+  const ok = writeConfig(key, typeof value === 'function' ? (value as () => unknown)() : value)
+  if (!ok && justRecovered) {
+    // The latch was cleared by the recovery and the WRITE then failed, so the
+    // caller is about to roll its in-memory state back — to the PRE-recovery
+    // snapshot, which is the small set built from a failed load. With the latch
+    // clear, the next save would write that over the file we just proved is
+    // readable, report {ok:true}, and lose the lot silently (#371, ADR-009
+    // pass). Re-latch: the next save retries the read and merges again.
+    latch.note('failed')
+    logError(
+      `[${latch.name}] ${key} became readable but the write FAILED; re-latching so the next save ` +
+        `re-reads and merges rather than overwriting the file with a state built from the failed load`,
+    )
+  }
+  return ok
 }
 
 /**

--- a/src/main/persist-latch.ts
+++ b/src/main/persist-latch.ts
@@ -42,12 +42,24 @@ export interface ReadFailureLatch {
   readonly name: string
   /** True while the last load was a read FAILURE (not an absence). */
   failed(): boolean
+  /**
+   * The generation of the last SUCCESSFUL load. It changes every time a load
+   * succeeds, so a caller that built some state from a load can prove, later,
+   * that the state it is about to write still comes from the newest reading of
+   * the file. A caller holding generation 0 (or any stale one) is holding state
+   * that never saw the current file.
+   */
+  generation(): number
   /** Record a load outcome. Anything other than `failed` clears the latch. */
   note(outcome: ConfigReadOutcome): void
   /**
    * The write gate. Returns true when the caller must NOT write, and logs why.
    * `action` names what is being refused ('save', 'clear', …) so the log line
    * reads as a sentence.
+   *
+   * Logged once per latch transition rather than per call: `saveSnapshots` runs
+   * on every successful usage fetch, so a latched process used to write an
+   * error line per poll for its whole lifetime.
    */
   refuses(action: string): boolean
   /** Test seam — a module-level latch outlives a test otherwise. */
@@ -56,22 +68,41 @@ export interface ReadFailureLatch {
 
 export function createReadFailureLatch(name: string): ReadFailureLatch {
   let lastLoadFailed = false
+  let generationCounter = 0
+  let refusalLogged = false
   return {
     name,
     failed: () => lastLoadFailed,
+    generation: () => generationCounter,
     note(outcome: ConfigReadOutcome) {
+      const wasFailed = lastLoadFailed
       lastLoadFailed = outcome === 'failed'
+      if (outcome === 'failed') return
+      refusalLogged = false
+      // The generation changes only on RECOVERY — a load that succeeds after a
+      // failure. Bumping on every successful load would refuse an ordinary
+      // save: reading the file twice between opening a form and saving it is
+      // normal, and nothing about the content changed. What a caller needs to
+      // detect is precisely "the file was unreadable when I built this state,
+      // and it is readable now", because that is when its state is stale.
+      if (wasFailed) generationCounter += 1
     },
     refuses(action: string): boolean {
       if (!lastLoadFailed) return false
-      logError(
-        `[${name}] refusing to ${action}: the last load FAILED to read the file (it was not absent), ` +
-          `so what is on disk is kept rather than overwritten by a state that never saw it`,
-      )
+      if (!refusalLogged) {
+        refusalLogged = true
+        logError(
+          `[${name}] refusing to ${action}: the file could not be read (it was not absent), ` +
+            `so what is on disk is kept rather than overwritten by a state that never saw it. ` +
+            `Further refusals for this latch are not logged until a load succeeds.`,
+        )
+      }
       return true
     },
     reset() {
       lastLoadFailed = false
+      generationCounter = 0
+      refusalLogged = false
     },
   }
 }
@@ -91,12 +122,80 @@ export function loadConfigLatched<T = unknown>(key: ConfigKey, latch: ReadFailur
   return read.value
 }
 
+export interface LatchedSaveOptions {
+  /** Names the refused operation in the log ('save', 'clear', …). */
+  action?: string
+  /**
+   * Called when the retry read below RECOVERS a file that had previously failed
+   * to read. The owner MUST fold the recovered content back into its in-memory
+   * state before the write happens — otherwise the empty store built from the
+   * failed load is what lands on the newly readable file, which is the exact
+   * loss this whole module exists to prevent.
+   *
+   * Omit it only when the state being written does not depend on what was on
+   * disk (see `window-state.ts`, which refuses outright instead).
+   */
+  onRecovered?: (recovered: unknown) => void
+}
+
 /**
- * Write a config key through a latch. Refuses while the latch is set, and
- * reports the refusal as a failed write — a caller that surfaces "saved" to the
- * user must not claim success for a write that never happened.
+ * Write a config key through a latch.
+ *
+ * A latched save does NOT simply refuse. It re-reads the file first, because
+ * the failures this guards against are transient by nature — an AV scanner
+ * holding a file for 50 ms, a share that blinked — and five of the six
+ * persisters load exactly once, at boot. Without this retry a single 50 ms lock
+ * at startup would disable persistence for the entire process life, which turns
+ * a momentary read failure into a guaranteed loss of everything the user does
+ * afterwards. Worse than the bug it replaced.
+ *
+ * So: retry the read; if it now succeeds, hand the recovered content to
+ * `onRecovered` so the owner can merge it, then write. A refusal therefore
+ * means the file is STILL unreadable, which is the only case worth refusing
+ * for.
+ *
+ * `value` is a thunk so it is evaluated AFTER any recovery — the merged state,
+ * not the empty one the caller was holding when it called.
  */
-export function saveConfigLatched(key: ConfigKey, value: unknown, latch: ReadFailureLatch, action = 'save'): boolean {
-  if (latch.refuses(action)) return false
-  return writeConfig(key, value)
+export function saveConfigLatched(
+  key: ConfigKey,
+  value: unknown | (() => unknown),
+  latch: ReadFailureLatch,
+  opts: LatchedSaveOptions = {},
+): boolean {
+  const action = opts.action ?? 'save'
+  if (latch.failed()) {
+    const retry = readConfigChecked(key)
+    latch.note(retry.outcome)
+    if (retry.outcome === 'failed') {
+      latch.refuses(action)
+      return false
+    }
+    logInfo(`[${latch.name}] ${key} is readable again; folding it back in before saving`)
+    // Even when the retry says "absent" or "unparseable" the owner is told, so
+    // it can decide — `recovered` is null in both cases, which is a truthful
+    // answer meaning "there is nothing on disk to merge".
+    opts.onRecovered?.(retry.value)
+  }
+  return writeConfig(key, typeof value === 'function' ? (value as () => unknown)() : value)
+}
+
+/**
+ * Fold a recovered on-disk list back into an in-memory one, keyed on `id`.
+ *
+ * The disk copy is the truth for everything that existed before the read
+ * failed; the in-memory copy is the truth for anything created since, and for
+ * any row the user has changed. So: start from disk, then let memory win per
+ * id. Anything unrecognisable on disk is dropped rather than trusted.
+ */
+export function mergeById<T extends { id?: unknown }>(recovered: unknown, inMemory: readonly T[]): T[] {
+  if (!Array.isArray(recovered)) return [...inMemory]
+  const byId = new Map<string, T>()
+  for (const row of recovered as T[]) {
+    if (row && typeof row === 'object' && typeof row.id === 'string') byId.set(row.id, row)
+  }
+  for (const row of inMemory) {
+    if (row && typeof row.id === 'string') byId.set(row.id, row)
+  }
+  return [...byId.values()]
 }

--- a/src/main/persist-latch.ts
+++ b/src/main/persist-latch.ts
@@ -1,0 +1,102 @@
+/**
+ * The shared null-vs-failed pattern for main-side persisters.
+ *
+ * A failed READ is not an absence. A file may be there and unreadable for a
+ * moment — an AV scanner holding a just-written file (EBUSY), a permissions
+ * hiccup, a network share that blinked — and a loader that answers `null` for
+ * that exactly as it answers for "no file" hands its caller an empty store.
+ * The caller then does the ordinary thing with an empty store (adds one item,
+ * cleans up a stuck entry, saves the form the user just opened) and writes it
+ * over the file it never managed to read. The user's cloud agents, team
+ * library, usage history, vision settings or window geometry are gone, and
+ * nothing failed loudly.
+ *
+ * `session-state.ts` fixed this shape for saved sessions in the ADR-009 pass
+ * before beta.16 (#353), and that pass left a note: the same shape is in five
+ * other main-side persisters, and it wanted ONE shared fix rather than five
+ * copies of the same latch. This module is that fix (#371).
+ *
+ * The rule, in one line: **while the last load was a read failure, the file on
+ * disk outranks anything in memory that never saw it.**
+ *
+ * Three outcomes, not two:
+ *
+ *   - **absent** — there is genuinely no file. An empty store is the truth.
+ *     Writes allowed.
+ *   - **unparseable** — the file read fine and its CONTENT is unrecoverable.
+ *     It is moved aside (never silently destroyed) so the store can start
+ *     clean. Writes allowed — there is nothing left to protect.
+ *   - **failed** — the file could not be read. Writes are REFUSED until a
+ *     later load succeeds, which clears the latch.
+ *
+ * Note the asymmetry that makes this safe to apply everywhere: a refused write
+ * costs one unsaved change, which the next successful load un-refuses. An
+ * un-refused write costs the file.
+ */
+
+import { logError, logInfo } from './debug-logger'
+import { readConfigChecked, writeConfig, type ConfigKey, type ConfigReadOutcome } from './config-manager'
+
+export interface ReadFailureLatch {
+  /** Name used in log lines — the persister, not the file. */
+  readonly name: string
+  /** True while the last load was a read FAILURE (not an absence). */
+  failed(): boolean
+  /** Record a load outcome. Anything other than `failed` clears the latch. */
+  note(outcome: ConfigReadOutcome): void
+  /**
+   * The write gate. Returns true when the caller must NOT write, and logs why.
+   * `action` names what is being refused ('save', 'clear', …) so the log line
+   * reads as a sentence.
+   */
+  refuses(action: string): boolean
+  /** Test seam — a module-level latch outlives a test otherwise. */
+  reset(): void
+}
+
+export function createReadFailureLatch(name: string): ReadFailureLatch {
+  let lastLoadFailed = false
+  return {
+    name,
+    failed: () => lastLoadFailed,
+    note(outcome: ConfigReadOutcome) {
+      lastLoadFailed = outcome === 'failed'
+    },
+    refuses(action: string): boolean {
+      if (!lastLoadFailed) return false
+      logError(
+        `[${name}] refusing to ${action}: the last load FAILED to read the file (it was not absent), ` +
+          `so what is on disk is kept rather than overwritten by a state that never saw it`,
+      )
+      return true
+    },
+    reset() {
+      lastLoadFailed = false
+    },
+  }
+}
+
+/**
+ * Read a config key through a latch. Returns the parsed value, or null for
+ * "absent", "unparseable" and "failed" alike — the failure signal rides on the
+ * latch, never on the return value, so callers keep their existing shape and
+ * only have to consult the latch before they WRITE.
+ */
+export function loadConfigLatched<T = unknown>(key: ConfigKey, latch: ReadFailureLatch): T | null {
+  const read = readConfigChecked<T>(key)
+  latch.note(read.outcome)
+  if (read.outcome === 'failed') {
+    logInfo(`[${latch.name}] ${key} could not be read; writes are refused until a load succeeds`)
+  }
+  return read.value
+}
+
+/**
+ * Write a config key through a latch. Refuses while the latch is set, and
+ * reports the refusal as a failed write — a caller that surfaces "saved" to the
+ * user must not claim success for a write that never happened.
+ */
+export function saveConfigLatched(key: ConfigKey, value: unknown, latch: ReadFailureLatch, action = 'save'): boolean {
+  if (latch.refuses(action)) return false
+  return writeConfig(key, value)
+}

--- a/src/main/team-manager.ts
+++ b/src/main/team-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import { BrowserWindow } from 'electron'
-import { readConfig, writeConfig } from './config-manager'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from './persist-latch'
 import { dispatchAgent, cancelAgent, getAgentOutput, onAgentCompletion, CloudAgentData } from './cloud-agent-manager'
 import { logInfo, logError } from './debug-logger'
 import type { TeamTemplate, TeamRun, TeamRunStep, TeamRunStatus, TeamStep } from '../shared/types'
@@ -29,12 +29,25 @@ function generateRunId(): string {
   return randomId('tr-')
 }
 
+// #371: two files, so two latches — a team library that failed to read must not
+// be overwritten by the one team the user saves next, and a failed read of the
+// run history must not be overwritten by the boot-time stuck-run sweep. One
+// file's read failure says nothing about the other's, so they never share.
+const teamsLatch = createReadFailureLatch('team-manager:teams')
+const runsLatch = createReadFailureLatch('team-manager:runs')
+
 function persistTeams(): void {
-  writeConfig('agentTeams', teams)
+  saveConfigLatched('agentTeams', teams, teamsLatch)
 }
 
 function persistRuns(): void {
-  writeConfig('agentTeamRuns', runs)
+  saveConfigLatched('agentTeamRuns', runs, runsLatch)
+}
+
+/** Test seam — the latches are module state and outlive a test file otherwise. */
+export function _resetTeamLatchesForTest(): void {
+  teamsLatch.reset()
+  runsLatch.reset()
 }
 
 function broadcastRunStatus(run: TeamRun): void {
@@ -46,8 +59,10 @@ function broadcastRunStatus(run: TeamRun): void {
 
 export function initTeamManager(windowGetter: () => BrowserWindow | null): void {
   getWindow = windowGetter
-  teams = readConfig<TeamTemplate[]>('agentTeams') || []
-  runs = readConfig<TeamRun[]>('agentTeamRuns') || []
+  const savedTeams = loadConfigLatched<TeamTemplate[]>('agentTeams', teamsLatch)
+  const savedRuns = loadConfigLatched<TeamRun[]>('agentTeamRuns', runsLatch)
+  teams = Array.isArray(savedTeams) ? savedTeams : []
+  runs = Array.isArray(savedRuns) ? savedRuns : []
 
   // Clean up stuck runs from previous app session
   let changed = false

--- a/src/main/team-manager.ts
+++ b/src/main/team-manager.ts
@@ -5,7 +5,7 @@
  */
 
 import { BrowserWindow } from 'electron'
-import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from './persist-latch'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched, mergeById } from './persist-latch'
 import { dispatchAgent, cancelAgent, getAgentOutput, onAgentCompletion, CloudAgentData } from './cloud-agent-manager'
 import { logInfo, logError } from './debug-logger'
 import type { TeamTemplate, TeamRun, TeamRunStep, TeamRunStatus, TeamStep } from '../shared/types'
@@ -36,12 +36,38 @@ function generateRunId(): string {
 const teamsLatch = createReadFailureLatch('team-manager:teams')
 const runsLatch = createReadFailureLatch('team-manager:runs')
 
-function persistTeams(): void {
-  saveConfigLatched('agentTeams', teams, teamsLatch)
+/**
+ * Returns false when the team library did NOT reach disk. `initTeamManager`
+ * runs once, at boot, so a transient lock there used to discard every team the
+ * user built for the rest of the process — while the UI reported each save as
+ * successful. That is #371 BLOCKER-1 and it is why these return a boolean.
+ */
+function persistTeams(removedIds?: readonly string[]): boolean {
+  return saveConfigLatched('agentTeams', () => teams, teamsLatch, {
+    onRecovered: (recovered) => {
+      teams = mergeById(recovered, teams)
+      // A deletion must survive the merge: the row is still on disk.
+      if (removedIds && removedIds.length > 0) {
+        const gone = new Set(removedIds)
+        teams = teams.filter((t) => !gone.has(t.id))
+      }
+    },
+  })
 }
 
-function persistRuns(): void {
-  saveConfigLatched('agentTeamRuns', runs, runsLatch)
+function persistRuns(): boolean {
+  return saveConfigLatched('agentTeamRuns', () => runs, runsLatch, {
+    onRecovered: (recovered) => {
+      runs = mergeById(recovered, runs)
+    },
+  })
+}
+
+/** Why the last team write did not land, in words a user can act on. */
+function teamPersistFailure(): string {
+  return teamsLatch.failed()
+    ? 'Your team library could not be saved: the teams file could not be read, so it was left alone rather than overwritten. Your saved teams are intact — try again once it is readable.'
+    : 'Your team library could not be written to disk.'
 }
 
 /** Test seam — the latches are module state and outlive a test file otherwise. */
@@ -92,26 +118,41 @@ export function listTeams(): TeamTemplate[] {
   return teams
 }
 
-export function saveTeam(team: TeamTemplate): TeamTemplate {
+export function saveTeam(team: TeamTemplate): { ok: boolean; team?: TeamTemplate; error?: string } {
+  const snapshot = teams
   const idx = teams.findIndex(t => t.id === team.id)
+  let saved: TeamTemplate
   if (idx >= 0) {
-    teams[idx] = { ...team, updatedAt: Date.now() }
+    saved = { ...team, updatedAt: Date.now() }
+    teams = teams.map((t, i) => (i === idx ? saved : t))
   } else {
-    team.id = team.id || generateTeamId()
-    team.createdAt = team.createdAt || Date.now()
-    team.updatedAt = Date.now()
-    teams.unshift(team)
+    saved = {
+      ...team,
+      id: team.id || generateTeamId(),
+      createdAt: team.createdAt || Date.now(),
+      updatedAt: Date.now(),
+    }
+    teams = [saved, ...teams]
   }
-  persistTeams()
-  return idx >= 0 ? teams[idx] : team
+  // The user's work stays in the editor if this does not land: roll back so the
+  // in-memory library keeps matching what is actually on disk.
+  if (!persistTeams()) {
+    teams = snapshot
+    return { ok: false, error: teamPersistFailure() }
+  }
+  return { ok: true, team: saved }
 }
 
-export function deleteTeam(id: string): boolean {
+export function deleteTeam(id: string): { ok: boolean; deleted: boolean; error?: string } {
   const idx = teams.findIndex(t => t.id === id)
-  if (idx < 0) return false
-  teams.splice(idx, 1)
-  persistTeams()
-  return true
+  if (idx < 0) return { ok: true, deleted: false }
+  const snapshot = teams
+  teams = teams.filter(t => t.id !== id)
+  if (!persistTeams([id])) {
+    teams = snapshot
+    return { ok: false, deleted: false, error: teamPersistFailure() }
+  }
+  return { ok: true, deleted: true }
 }
 
 export function listRuns(): TeamRun[] {

--- a/src/main/usage/usage-snapshots.ts
+++ b/src/main/usage/usage-snapshots.ts
@@ -88,7 +88,18 @@ export function loadSnapshots(): Map<string, UsageSnapshot> {
  *  not worth failing a usage fetch over, so this never throws. */
 export function saveSnapshots(snapshots: Map<string, UsageSnapshot>): boolean {
   try {
-    return saveConfigLatched('usageSnapshots', Object.fromEntries(snapshots), snapshotsLatch)
+    return saveConfigLatched('usageSnapshots', () => Object.fromEntries(snapshots), snapshotsLatch, {
+      onRecovered: (recovered) => {
+        // `account-usage` hydrates once per process and then saves on every
+        // successful fetch, so without this the first failed read disabled
+        // snapshots until restart. On recovery, every OTHER profile's snapshot
+        // comes back from disk; the live map wins for the profiles it holds,
+        // because those figures are newer than anything on disk.
+        for (const [profileId, snap] of parseSnapshots(recovered)) {
+          if (!snapshots.has(profileId)) snapshots.set(profileId, snap)
+        }
+      },
+    })
   } catch {
     return false
   }

--- a/src/main/usage/usage-snapshots.ts
+++ b/src/main/usage/usage-snapshots.ts
@@ -20,7 +20,7 @@
 // Nothing is shown on a fresh install until one fetch has succeeded and been
 // persisted, so a new user sees this from their second run onward. That is
 // inherent: there is no honest figure to show before there is a figure.
-import { readConfig, writeConfig } from '../config-manager'
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from '../persist-latch'
 import type { UsageBucket, CreditsInfo } from '../../shared/usage-types'
 
 export interface UsageSnapshot {
@@ -66,11 +66,19 @@ export function parseSnapshots(raw: unknown): Map<string, UsageSnapshot> {
   return out
 }
 
-/** Read the persisted snapshots. Never throws: an unreadable file is simply no
- *  snapshots, which is the state every install starts in anyway. */
+/** #371: the old comment here said "an unreadable file is simply no snapshots",
+ *  which is true for an ABSENT file and false for an unreadable one. Every
+ *  caller rebuilds the whole map and saves it back, so one EBUSY read at the
+ *  wrong moment dropped every other profile's snapshot. */
+const snapshotsLatch = createReadFailureLatch('usage-snapshots')
+
+/** Read the persisted snapshots. Never throws: an ABSENT file is no snapshots,
+ *  which is the state every install starts in. A file that could not be READ is
+ *  also no snapshots to show, but it latches saving off until a load succeeds —
+ *  a blank card costs a fetch, an overwritten file costs the history. */
 export function loadSnapshots(): Map<string, UsageSnapshot> {
   try {
-    return parseSnapshots(readConfig<unknown>('usageSnapshots'))
+    return parseSnapshots(loadConfigLatched<unknown>('usageSnapshots', snapshotsLatch))
   } catch {
     return new Map()
   }
@@ -80,8 +88,13 @@ export function loadSnapshots(): Map<string, UsageSnapshot> {
  *  not worth failing a usage fetch over, so this never throws. */
 export function saveSnapshots(snapshots: Map<string, UsageSnapshot>): boolean {
   try {
-    return writeConfig('usageSnapshots', Object.fromEntries(snapshots))
+    return saveConfigLatched('usageSnapshots', Object.fromEntries(snapshots), snapshotsLatch)
   } catch {
     return false
   }
+}
+
+/** Test seam — the latch is module state and outlives a test file otherwise. */
+export function _resetSnapshotsLatchForTest(): void {
+  snapshotsLatch.reset()
 }

--- a/src/main/window-state.ts
+++ b/src/main/window-state.ts
@@ -1,0 +1,60 @@
+/**
+ * The main window's saved geometry.
+ *
+ * Lifted out of `index.ts` by #371. It lived there as two private functions
+ * whose failure handling was a bare `catch { /* ignore *\/ }` returning the
+ * hardcoded default — so an unreadable window-state.json silently resized the
+ * user's window to 3200x1800, and the close handler wrote that default straight
+ * back over their real geometry. It is also the only one of the five persisters
+ * that bypassed `config-manager` entirely, so it never had the atomic write.
+ *
+ * Both are fixed by going through the shared `windowState` config key, which
+ * resolves to exactly the path this used to build by hand
+ * (`<CONFIG>/window-state.json`) — so there is no migration — plus the shared
+ * read-failure latch (see `persist-latch.ts`).
+ */
+
+import { createReadFailureLatch, loadConfigLatched, saveConfigLatched } from './persist-latch'
+
+export interface WindowState {
+  x?: number
+  y?: number
+  width: number
+  height: number
+  isMaximized: boolean
+}
+
+export const DEFAULT_WINDOW_STATE: WindowState = { width: 3200, height: 1800, isMaximized: false }
+
+const windowStateLatch = createReadFailureLatch('window-state')
+
+/**
+ * The saved geometry, or the default.
+ *
+ * A window has to open at SOME size, so a read failure still returns the
+ * default here — what changes is that the latch remembers it was a failure, so
+ * `saveWindowState` will not write that default back over the real file.
+ */
+export function loadWindowState(): WindowState {
+  const saved = loadConfigLatched<WindowState>('windowState', windowStateLatch)
+  if (!saved || typeof saved !== 'object') return { ...DEFAULT_WINDOW_STATE }
+  // width/height are the only fields the window cannot open without; a
+  // hand-edited or truncated file that lost them is not usable geometry.
+  if (typeof saved.width !== 'number' || typeof saved.height !== 'number') return { ...DEFAULT_WINDOW_STATE }
+  return saved
+}
+
+/** Persist the geometry. Refused while the last load was a read FAILURE. */
+export function saveWindowState(state: WindowState): boolean {
+  return saveConfigLatched('windowState', state, windowStateLatch)
+}
+
+/** True while the last load failed to READ the file (rather than not find it). */
+export function windowStateReadFailed(): boolean {
+  return windowStateLatch.failed()
+}
+
+/** Test seam — the latch is module state and outlives a test file otherwise. */
+export function _resetWindowStateLatchForTest(): void {
+  windowStateLatch.reset()
+}

--- a/src/main/window-state.ts
+++ b/src/main/window-state.ts
@@ -57,7 +57,11 @@ export function loadWindowState(): WindowState {
  * ending anyway.
  */
 export function saveWindowState(state: WindowState): boolean {
-  return saveConfigLatched('windowState', state, windowStateLatch)
+  // `retry: false` is what makes the paragraph above TRUE (#371, ADR-009 pass).
+  // Without it the shared retry would recover the file and then write the
+  // fallback 3200x1800 straight over the geometry it had just rescued — the
+  // exact loss this refusal exists to prevent, with the doc claiming otherwise.
+  return saveConfigLatched('windowState', state, windowStateLatch, { retry: false })
 }
 
 /** True while the last load failed to READ the file (rather than not find it). */

--- a/src/main/window-state.ts
+++ b/src/main/window-state.ts
@@ -44,7 +44,18 @@ export function loadWindowState(): WindowState {
   return saved
 }
 
-/** Persist the geometry. Refused while the last load was a read FAILURE. */
+/**
+ * Persist the geometry. Refused while the last load was a read FAILURE.
+ *
+ * Deliberately the ONE latched save with no recovery retry (#371). The others
+ * retry because they load once at boot and save many times, so a refusal that
+ * never lifts would be a session-long outage. This one loads once and saves
+ * once, at window close, and the geometry it would write after a failed load is
+ * the fallback DEFAULT rather than anything the user chose — so recovering the
+ * file only to overwrite it with 3200x1800 would be the loss, not the fix.
+ * Keeping the saved geometry is the right answer here, and the process is
+ * ending anyway.
+ */
 export function saveWindowState(state: WindowState): boolean {
   return saveConfigLatched('windowState', state, windowStateLatch)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -432,8 +432,16 @@ export interface ElectronAPI {
     stop: () => Promise<{ ok: boolean }>
     status: () => Promise<{ running: boolean; connected: boolean; browser: string; mcpPort: number }>
     launch: (browser: string, debugPort: number, url?: string, headless?: boolean) => Promise<{ ok: boolean; pid?: number; command?: string; error?: string }>
-    saveConfig: (config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean }) => Promise<{ ok: boolean }>
-    getConfig: () => Promise<{ enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null>
+    /**
+     * #371. `generation` is the token handed out by `getConfig` alongside the
+     * config the form was built from. Pass it back so main can refuse a save
+     * built from defaults it showed while the settings file was unreadable
+     * (`ok:false, stale:true`). `ok:false` means IT IS NOT ON DISK.
+     */
+    saveConfig: (config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean }, generation?: number) => Promise<{ ok: boolean; stale?: boolean; error?: string }>
+    /** `readFailed` distinguishes "no config yet" from "could not read it" — the
+     *  caller must not present defaults as saved settings in the latter case. */
+    getConfig: () => Promise<{ config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null; generation: number; readFailed: boolean }>
     onStatusChanged: (callback: (data: { connected: boolean; browser: string; mcpPort: number }) => void) => () => void
   }
   legacyVersion: {
@@ -447,18 +455,23 @@ export interface ElectronAPI {
   cloudAgent: {
     dispatch: (agent: { name: string; description: string; projectPath: string; configId?: string; profileId?: string; legacyVersion?: { enabled: boolean; version: string }; skipPermissions?: boolean }) => Promise<import('../shared/types').CloudAgent>
     cancel: (id: string) => Promise<boolean>
-    remove: (id: string) => Promise<boolean>
+    /** #371: `ok:false` means the agent is STILL on disk — do not drop the row. */
+    remove: (id: string) => Promise<{ ok: true; removed: boolean } | { ok: false; error: string }>
     retry: (id: string) => Promise<import('../shared/types').CloudAgent | null>
     list: () => Promise<import('../shared/types').CloudAgent[]>
     getOutput: (id: string) => Promise<string>
-    clearCompleted: () => Promise<number>
+    /** #371: `ok:false` means nothing was cleared — do not filter the list. */
+    clearCompleted: () => Promise<{ ok: true; removed: number } | { ok: false; error: string }>
     onStatusChanged: (callback: (agent: import('../shared/types').CloudAgent) => void) => () => void
     onOutputChunk: (callback: (data: { id: string; chunk: string }) => void) => () => void
   }
   team: {
     list: () => Promise<import('../shared/types').TeamTemplate[]>
-    save: (team: import('../shared/types').TeamTemplate) => Promise<import('../shared/types').TeamTemplate>
-    delete: (id: string) => Promise<boolean>
+    /** #371: `ok:false` means the team is NOT on disk — keep the user's work in
+     *  the editor rather than reporting a save that did not happen. */
+    save: (team: import('../shared/types').TeamTemplate) => Promise<{ ok: true; team: import('../shared/types').TeamTemplate } | { ok: false; error: string }>
+    /** #371: `ok:false` means the team is STILL on disk — do not drop the row. */
+    delete: (id: string) => Promise<{ ok: true; deleted: boolean } | { ok: false; error: string }>
     run: (teamId: string, projectPath?: string) => Promise<import('../shared/types').TeamRun | null>
     cancelRun: (runId: string) => Promise<boolean>
     listRuns: () => Promise<import('../shared/types').TeamRun[]>
@@ -970,7 +983,8 @@ const electronAPI: ElectronAPI = {
     status: () => ipcRenderer.invoke(IPC.VISION_STATUS),
     launch: (browser: string, debugPort: number, url?: string, headless?: boolean) =>
       ipcRenderer.invoke(IPC.VISION_LAUNCH, browser, debugPort, url, headless ?? true),
-    saveConfig: (config: any) => ipcRenderer.invoke(IPC.VISION_SAVE_CONFIG, config),
+    saveConfig: (config: any, generation?: number) =>
+      ipcRenderer.invoke(IPC.VISION_SAVE_CONFIG, config, generation),
     getConfig: () => ipcRenderer.invoke(IPC.VISION_GET_CONFIG),
     onStatusChanged: (callback: (data: { connected: boolean; browser: string; mcpPort: number }) => void) => {
       const handler = (_: unknown, data: any) => callback(data)

--- a/src/renderer/components/CloudAgentsPage.tsx
+++ b/src/renderer/components/CloudAgentsPage.tsx
@@ -568,6 +568,10 @@ export default function CloudAgentsPage() {
   const accountFilter = useCloudAgentStore(s => s.accountFilter)
   const setAccountFilter = useCloudAgentStore(s => s.setAccountFilter)
   const clearCompleted = useCloudAgentStore(s => s.clearCompleted)
+  // #371 BLOCKER-1: a refused remove / clear used to be discarded, so the rows
+  // vanished and came back on restart. They now stay put — say why.
+  const mutationError = useCloudAgentStore(s => s.error)
+  const clearMutationError = useCloudAgentStore(s => s.clearError)
   const [showNewDialog, setShowNewDialog] = useState(false)
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   // First-run example prefill for the New Agent dialog (ephemeral).
@@ -689,6 +693,26 @@ export default function CloudAgentsPage() {
         <div className="flex flex-col flex-1 min-h-0">
         {!explainerDismissed && (
           <AgentHubExplainer onDismiss={() => { void updateSettings({ agentHubExplainerDismissed: true }) }} />
+        )}
+        {mutationError && (
+          <div
+            role="alert"
+            className="mx-4 mt-2 flex items-start gap-2 text-xs leading-snug rounded-lg px-2.5 py-1.5 shrink-0"
+            style={{
+              color: 'var(--status-danger)',
+              background: 'color-mix(in srgb, var(--status-danger) 12%, transparent)',
+              border: '1px solid color-mix(in srgb, var(--status-danger) 30%, transparent)',
+            }}
+          >
+            <span className="flex-1 min-w-0">{mutationError}</span>
+            <button
+              onClick={clearMutationError}
+              className="shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+              title="Dismiss"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>
+            </button>
+          </div>
         )}
         {counts.all === 0 ? (
           <AgentHubExamples

--- a/src/renderer/components/TeamBuilder.tsx
+++ b/src/renderer/components/TeamBuilder.tsx
@@ -42,6 +42,10 @@ export default function TeamBuilder({ onClose }: { onClose: () => void }) {
   const [projectPath, setProjectPath] = useState(editingTeam?.projectPath || '')
   const [steps, setSteps] = useState<TeamStep[]>(editingTeam?.steps || [])
   const [saving, setSaving] = useState(false)
+  // #371 BLOCKER-1: a refused/failed disk write used to close this dialog as if
+  // it had saved, and the pipeline was gone on the next restart. The message
+  // stays here, in front of the work that did not land.
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   // Deliberately NO useDialogEscape: this is a multi-step pipeline with a
   // per-step prompt in each field, and Escape is a reflex when leaving a
@@ -87,6 +91,7 @@ export default function TeamBuilder({ onClose }: { onClose: () => void }) {
   const handleSave = async () => {
     if (!name.trim() || steps.length === 0) return
     setSaving(true)
+    setSaveError(null)
     try {
       const team: TeamTemplate = {
         id: editingTeam?.id || generateTeamId(),
@@ -97,7 +102,13 @@ export default function TeamBuilder({ onClose }: { onClose: () => void }) {
         createdAt: editingTeam?.createdAt || Date.now(),
         updatedAt: Date.now(),
       }
-      await saveTeam(team)
+      const result = await saveTeam(team)
+      if (!result.ok) {
+        // Do NOT close: the pipeline is not on disk, and closing would discard
+        // the only copy of it that exists.
+        setSaveError(result.error || 'Your pipeline could not be saved to disk.')
+        return
+      }
       onClose()
     } finally {
       setSaving(false)
@@ -204,6 +215,21 @@ export default function TeamBuilder({ onClose }: { onClose: () => void }) {
         </DialogBody>
 
         <DialogFooter>
+          {/* #371: a save that did not reach disk keeps the editor open and says
+              why, so the user's work is not lost behind a closed dialog. */}
+          {saveError && (
+            <div
+              role="alert"
+              className="flex-1 min-w-0 text-[11px] leading-snug rounded-lg px-2.5 py-1.5"
+              style={{
+                color: 'var(--status-danger)',
+                background: 'color-mix(in srgb, var(--status-danger) 12%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--status-danger) 30%, transparent)',
+              }}
+            >
+              {saveError}
+            </div>
+          )}
           <DialogButton variant="ghost" onClick={onClose}>Cancel</DialogButton>
           <DialogButton variant="primary" onClick={handleSave} disabled={!isValid || saving}>
             {saving ? 'Saving...' : editingTeam ? 'Save Changes' : 'Create Pipeline'}

--- a/src/renderer/components/TeamsPanel.tsx
+++ b/src/renderer/components/TeamsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTeamStore, setupTeamListener } from '../stores/teamStore'
 import TeamBuilder from './TeamBuilder'
 import TeamRunView from './TeamRunView'
@@ -33,10 +33,26 @@ export default function TeamsPanel() {
   const deleteTeam = useTeamStore(s => s.deleteTeam)
   const runTeam = useTeamStore(s => s.runTeam)
 
+  // #371 BLOCKER-1: a refused delete used to leave the row on screen with no
+  // explanation — indistinguishable from a click that missed. Say what happened.
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const handleDelete = async (id: string) => {
+    setDeleteError(null)
+    const result = await deleteTeam(id)
+    if (!result.ok) {
+      setDeleteError(result.error || 'This pipeline could not be deleted from disk.')
+    }
+  }
+
   useEffect(() => {
     const cleanup = setupTeamListener()
     return cleanup
   }, [])
+
+  // A delete failure belongs to the pipeline it was raised for; moving away
+  // from that pipeline retires the message.
+  useEffect(() => { setDeleteError(null) }, [selectedTeamId])
 
   const selectedTeam = teams.find(t => t.id === selectedTeamId) || null
   const selectedRun = runs.find(r => r.id === selectedRunId) || null
@@ -149,8 +165,9 @@ export default function TeamsPanel() {
         ) : selectedTeam ? (
           <TeamDetail
             team={selectedTeam}
+            deleteError={deleteError}
             onEdit={() => openBuilder(selectedTeam)}
-            onDelete={() => deleteTeam(selectedTeam.id)}
+            onDelete={() => { void handleDelete(selectedTeam.id) }}
             onRun={() => runTeam(selectedTeam.id)}
           />
         ) : (
@@ -212,8 +229,8 @@ function TeamCard({ team, selected, lastStatus, onClick }: {
   )
 }
 
-function TeamDetail({ team, onEdit, onDelete, onRun }: {
-  team: TeamTemplate; onEdit: () => void; onDelete: () => void; onRun: () => void
+function TeamDetail({ team, deleteError, onEdit, onDelete, onRun }: {
+  team: TeamTemplate; deleteError: string | null; onEdit: () => void; onDelete: () => void; onRun: () => void
 }) {
   return (
     <div className="flex-1 flex flex-col min-h-0 p-4">
@@ -244,6 +261,19 @@ function TeamDetail({ team, onEdit, onDelete, onRun }: {
         </div>
         {team.description && (
           <p className="text-xs text-overlay1 mt-1">{team.description}</p>
+        )}
+        {deleteError && (
+          <div
+            role="alert"
+            className="mt-2 text-[11px] leading-snug rounded-lg px-2.5 py-1.5"
+            style={{
+              color: 'var(--status-danger)',
+              background: 'color-mix(in srgb, var(--status-danger) 12%, transparent)',
+              border: '1px solid color-mix(in srgb, var(--status-danger) 30%, transparent)',
+            }}
+          >
+            {deleteError}
+          </div>
         )}
       </div>
 

--- a/src/renderer/components/conductor-mcp/VisionSubTool.tsx
+++ b/src/renderer/components/conductor-mcp/VisionSubTool.tsx
@@ -10,7 +10,7 @@ const visionIcon = (
 )
 
 export default function VisionSubTool() {
-  const { browserRunning, browserConnected, stopBrowser, launchBrowser } = useConductorMcpStore()
+  const { browserRunning, browserConnected, stopBrowser, launchBrowser, error } = useConductorMcpStore()
 
   const statusLabel = browserRunning && browserConnected ? 'Connected'
     : browserRunning ? 'Browser launching...'
@@ -39,6 +39,22 @@ export default function VisionSubTool() {
       description="Headless Chrome via CDP. Auto-starts at app boot; Stop button kills it for the current run."
       toolList={['screenshot', 'navigate', 'click', 'type', 'eval']}
       actions={actions}
-    />
+    >
+      {/* #371: the store's error had no surface at all, so a refused settings
+          read/write — and a failed browser launch before it — were silent. */}
+      {error && (
+        <div
+          role="alert"
+          className="text-xs leading-snug rounded-lg px-2.5 py-1.5"
+          style={{
+            color: 'var(--status-danger)',
+            background: 'color-mix(in srgb, var(--status-danger) 12%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--status-danger) 30%, transparent)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </SubToolCard>
   )
 }

--- a/src/renderer/stores/cloudAgentStore.ts
+++ b/src/renderer/stores/cloudAgentStore.ts
@@ -3,19 +3,32 @@ import type { CloudAgent, CloudAgentStatus } from '../types/electron'
 
 type FilterType = 'all' | 'running' | 'completed' | 'failed'
 
+/**
+ * Outcome of a persisting mutation. `ok:false` means main REFUSED or FAILED the
+ * disk write (#371 BLOCKER-1) — the agent is still on disk, so the row must
+ * stay on screen rather than vanish and reappear on the next restart.
+ */
+export interface CloudAgentMutationResult {
+  ok: boolean
+  error?: string
+}
+
 interface CloudAgentState {
   agents: CloudAgent[]
   selectedAgentId: string | null
   filter: FilterType
   searchQuery: string
   accountFilter: string
+  /** Why the last remove / clear-completed did not land. */
+  error: string | null
 
   hydrate: (agents: CloudAgent[]) => void
   dispatch: (params: { name: string; description: string; projectPath: string; configId?: string; profileId?: string; legacyVersion?: { enabled: boolean; version: string }; skipPermissions?: boolean }) => Promise<void>
   cancel: (id: string) => Promise<void>
-  remove: (id: string) => Promise<void>
+  remove: (id: string) => Promise<CloudAgentMutationResult>
   retry: (id: string) => Promise<void>
-  clearCompleted: () => Promise<void>
+  clearCompleted: () => Promise<CloudAgentMutationResult>
+  clearError: () => void
   selectAgent: (id: string | null) => void
   setFilter: (filter: FilterType) => void
   setSearchQuery: (query: string) => void
@@ -58,6 +71,7 @@ export const useCloudAgentStore = create<CloudAgentState>((set, get) => ({
   filter: 'all',
   searchQuery: '',
   accountFilter: 'all',
+  error: null,
 
   hydrate: (agents: CloudAgent[]) => {
     set({ agents: agents || [] })
@@ -78,13 +92,24 @@ export const useCloudAgentStore = create<CloudAgentState>((set, get) => ({
     await window.electronAPI.cloudAgent.cancel(id)
   },
 
+  // #371 BLOCKER-1. This still writes NOTHING itself (see the note above) — it
+  // only reads main's answer. `ok:false` means main rolled its own list back and
+  // the agent is still in cloud-agents.json, so filtering it out here would show
+  // a removal that did not happen and un-remove itself on the next restart.
   remove: async (id: string) => {
-    await window.electronAPI.cloudAgent.remove(id)
+    set({ error: null })
+    const result = await window.electronAPI.cloudAgent.remove(id)
+    if (!result.ok) {
+      const error = result.error || 'This agent could not be removed from disk.'
+      set({ error })
+      return { ok: false, error }
+    }
     set(state => {
       const agents = state.agents.filter(a => a.id !== id)
       const selectedAgentId = state.selectedAgentId === id ? null : state.selectedAgentId
       return { agents, selectedAgentId }
     })
+    return { ok: true }
   },
 
   retry: async (id: string) => {
@@ -96,7 +121,13 @@ export const useCloudAgentStore = create<CloudAgentState>((set, get) => ({
   },
 
   clearCompleted: async () => {
-    await window.electronAPI.cloudAgent.clearCompleted()
+    set({ error: null })
+    const result = await window.electronAPI.cloudAgent.clearCompleted()
+    if (!result.ok) {
+      const error = result.error || 'The finished agents could not be cleared from disk.'
+      set({ error })
+      return { ok: false, error }
+    }
     set(state => {
       const agents = state.agents.filter(a => a.status === 'running' || a.status === 'pending')
       const selectedAgentId = agents.find(a => a.id === state.selectedAgentId)
@@ -104,7 +135,10 @@ export const useCloudAgentStore = create<CloudAgentState>((set, get) => ({
         : null
       return { agents, selectedAgentId }
     })
+    return { ok: true }
   },
+
+  clearError: () => set({ error: null }),
 
   selectAgent: (id: string | null) => set({ selectedAgentId: id }),
   setFilter: (filter: FilterType) => set({ filter }),

--- a/src/renderer/stores/conductorMcpStore.ts
+++ b/src/renderer/stores/conductorMcpStore.ts
@@ -10,13 +10,24 @@ interface ConductorMcpState {
   visionConfig: GlobalVisionConfig
   browserRunning: boolean
   browserConnected: boolean
+  /**
+   * #371 MAJOR-5. The token main handed out with the config this store is
+   * holding. It goes back with every save so main can refuse a save built from
+   * defaults that were shown while the settings file was unreadable — by then
+   * the read may have recovered elsewhere, so the latch alone cannot tell.
+   * 0 means "never loaded"; the handler treats a mismatch as stale.
+   */
+  visionConfigGeneration: number
+  /** True when the last load could not READ the settings, so `visionConfig`
+   *  holds defaults that are NOT what is on disk. */
+  visionConfigReadFailed: boolean
 
   // Error surface (shared across sub-tools)
   error: string | null
 
   // Actions
   loadConfig: () => Promise<void>
-  saveConfig: (config: GlobalVisionConfig) => Promise<void>
+  saveConfig: (config: GlobalVisionConfig) => Promise<{ ok: boolean; error?: string }>
   launchBrowser: () => Promise<void>
   stopBrowser: () => Promise<void>
   fetchStatus: () => Promise<void>
@@ -40,16 +51,45 @@ export const useConductorMcpStore = create<ConductorMcpState>((set, get) => ({
   visionConfig: { ...DEFAULT_CONFIG },
   browserRunning: false,
   browserConnected: false,
+  visionConfigGeneration: 0,
+  visionConfigReadFailed: false,
   error: null,
 
+  // #371 MINOR-5/MAJOR-5. `config: null` is two different things and they need
+  // opposite handling: "nothing saved yet" (defaults are the honest answer) and
+  // "could not read the file" (defaults are a LIE that the user will then save
+  // over their real settings). Main now says which, so say so too.
   loadConfig: async () => {
-    const config = await window.electronAPI.vision.getConfig()
-    if (config) set({ visionConfig: config })
+    set({ error: null })
+    const result = await window.electronAPI.vision.getConfig()
+    if (result.readFailed) {
+      set({
+        visionConfigGeneration: result.generation,
+        visionConfigReadFailed: true,
+        error: 'Vision settings could not be read, so the values shown are defaults, not your saved settings. Your settings file is untouched — reopen this panel once it is readable.',
+      })
+      return
+    }
+    set({
+      visionConfig: result.config ?? { ...DEFAULT_CONFIG },
+      visionConfigGeneration: result.generation,
+      visionConfigReadFailed: false,
+    })
   },
 
   saveConfig: async (config) => {
-    await window.electronAPI.vision.saveConfig(config)
-    set({ visionConfig: config })
+    set({ error: null })
+    const result = await window.electronAPI.vision.saveConfig(config, get().visionConfigGeneration)
+    if (!result.ok) {
+      // Includes the `stale` case: the form was built from defaults shown while
+      // the file was unreadable, so main refused to write them over the real
+      // settings. Either way the config is NOT on disk — don't commit it here.
+      const error = result.error || 'Vision settings could not be saved.'
+      set({ error })
+      return { ok: false, error }
+    }
+    set({ visionConfig: config, visionConfigReadFailed: false })
+    return { ok: true }
   },
 
   launchBrowser: async () => {

--- a/src/renderer/stores/teamStore.ts
+++ b/src/renderer/stores/teamStore.ts
@@ -2,6 +2,16 @@ import { create } from 'zustand'
 import type { TeamTemplate, TeamRun, TeamRunStatus } from '../types/electron'
 import { trackUsage } from './tipsStore'
 
+/**
+ * Outcome of a persisting mutation. `ok:false` means main REFUSED or FAILED the
+ * disk write (#371 BLOCKER-1) — the change is not on disk, so the store must not
+ * pretend it is. Callers show `error` and keep the user's work where it is.
+ */
+export interface TeamMutationResult {
+  ok: boolean
+  error?: string
+}
+
 interface TeamState {
   teams: TeamTemplate[]
   runs: TeamRun[]
@@ -9,12 +19,15 @@ interface TeamState {
   selectedRunId: string | null
   showBuilder: boolean
   editingTeam: TeamTemplate | null
+  /** Why the last save/delete did not land, in words a user can act on. */
+  error: string | null
 
   hydrate: (teams: TeamTemplate[], runs: TeamRun[]) => void
   loadTeams: () => Promise<void>
   loadRuns: () => Promise<void>
-  saveTeam: (team: TeamTemplate) => Promise<TeamTemplate>
-  deleteTeam: (id: string) => Promise<void>
+  saveTeam: (team: TeamTemplate) => Promise<TeamMutationResult>
+  deleteTeam: (id: string) => Promise<TeamMutationResult>
+  clearError: () => void
   runTeam: (teamId: string, projectPath?: string) => Promise<void>
   cancelRun: (runId: string) => Promise<void>
   selectTeam: (id: string | null) => void
@@ -32,6 +45,7 @@ export const useTeamStore = create<TeamState>((set, get) => ({
   selectedRunId: null,
   showBuilder: false,
   editingTeam: null,
+  error: null,
 
   hydrate: (teams, runs) => {
     set({ teams: teams || [], runs: runs || [] })
@@ -47,8 +61,20 @@ export const useTeamStore = create<TeamState>((set, get) => ({
     set({ runs })
   },
 
+  // #371 BLOCKER-1. Main answers `{ ok:false }` when the write was refused or
+  // failed, and rolls its own in-memory library back, so the ONLY correct
+  // renderer behaviour is to leave local state alone too — otherwise the team
+  // sits on screen until the next restart makes it disappear. The builder also
+  // stays open (showBuilder untouched) so the user's work is not thrown away.
   saveTeam: async (team) => {
-    const saved = await window.electronAPI.team.save(team)
+    set({ error: null })
+    const result = await window.electronAPI.team.save(team)
+    if (!result.ok) {
+      const error = result.error || 'Your team could not be saved to disk.'
+      set({ error })
+      return { ok: false, error }
+    }
+    const saved = result.team
     set(state => {
       const idx = state.teams.findIndex(t => t.id === saved.id)
       const teams = [...state.teams]
@@ -59,16 +85,25 @@ export const useTeamStore = create<TeamState>((set, get) => ({
       }
       return { teams, showBuilder: false, editingTeam: null }
     })
-    return saved
+    return { ok: true }
   },
 
   deleteTeam: async (id) => {
-    await window.electronAPI.team.delete(id)
+    set({ error: null })
+    const result = await window.electronAPI.team.delete(id)
+    if (!result.ok) {
+      const error = result.error || 'Your team could not be deleted from disk.'
+      set({ error })
+      return { ok: false, error }
+    }
     set(state => ({
       teams: state.teams.filter(t => t.id !== id),
       selectedTeamId: state.selectedTeamId === id ? null : state.selectedTeamId,
     }))
+    return { ok: true }
   },
+
+  clearError: () => set({ error: null }),
 
   runTeam: async (teamId, projectPath) => {
     const run = await window.electronAPI.team.run(teamId, projectPath)

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -473,8 +473,16 @@ export interface ElectronAPI {
     stop: () => Promise<{ ok: boolean }>
     status: () => Promise<{ running: boolean; connected: boolean; browser: string; mcpPort: number }>
     launch: (browser: string, debugPort: number, url?: string, headless?: boolean) => Promise<{ ok: boolean; pid?: number; command?: string; error?: string }>
-    saveConfig: (config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean }) => Promise<{ ok: boolean }>
-    getConfig: () => Promise<{ enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null>
+    /**
+     * #371. `generation` is the token handed out by `getConfig` alongside the
+     * config the form was built from. Pass it back so main can refuse a save
+     * built from defaults it showed while the settings file was unreadable
+     * (`ok:false, stale:true`). `ok:false` means IT IS NOT ON DISK.
+     */
+    saveConfig: (config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean }, generation?: number) => Promise<{ ok: boolean; stale?: boolean; error?: string }>
+    /** `readFailed` distinguishes "no config yet" from "could not read it" — the
+     *  caller must not present defaults as saved settings in the latter case. */
+    getConfig: () => Promise<{ config: { enabled?: boolean; browser: 'chrome' | 'edge'; debugPort: number; mcpPort?: number; url?: string; headless?: boolean } | null; generation: number; readFailed: boolean }>
     onStatusChanged: (callback: (data: { connected: boolean; browser: string; mcpPort: number }) => void) => () => void
   }
   legacyVersion: {
@@ -488,18 +496,23 @@ export interface ElectronAPI {
   cloudAgent: {
     dispatch: (agent: { name: string; description: string; projectPath: string; configId?: string; profileId?: string; legacyVersion?: { enabled: boolean; version: string } }) => Promise<CloudAgent>
     cancel: (id: string) => Promise<boolean>
-    remove: (id: string) => Promise<boolean>
+    /** #371: `ok:false` means the agent is STILL on disk — do not drop the row. */
+    remove: (id: string) => Promise<{ ok: true; removed: boolean } | { ok: false; error: string }>
     retry: (id: string) => Promise<CloudAgent | null>
     list: () => Promise<CloudAgent[]>
     getOutput: (id: string) => Promise<string>
-    clearCompleted: () => Promise<number>
+    /** #371: `ok:false` means nothing was cleared — do not filter the list. */
+    clearCompleted: () => Promise<{ ok: true; removed: number } | { ok: false; error: string }>
     onStatusChanged: (callback: (agent: CloudAgent) => void) => () => void
     onOutputChunk: (callback: (data: { id: string; chunk: string }) => void) => () => void
   }
   team: {
     list: () => Promise<TeamTemplate[]>
-    save: (team: TeamTemplate) => Promise<TeamTemplate>
-    delete: (id: string) => Promise<boolean>
+    /** #371: `ok:false` means the team is NOT on disk — keep the user's work in
+     *  the editor rather than reporting a save that did not happen. */
+    save: (team: TeamTemplate) => Promise<{ ok: true; team: TeamTemplate } | { ok: false; error: string }>
+    /** #371: `ok:false` means the team is STILL on disk — do not drop the row. */
+    delete: (id: string) => Promise<{ ok: true; deleted: boolean } | { ok: false; error: string }>
     run: (teamId: string, projectPath?: string) => Promise<TeamRun | null>
     cancelRun: (runId: string) => Promise<boolean>
     listRuns: () => Promise<TeamRun[]>

--- a/tests/unit/cloud-agent-manager.test.ts
+++ b/tests/unit/cloud-agent-manager.test.ts
@@ -15,8 +15,17 @@ vi.mock('child_process', () => ({
 // Mock config-manager
 const mockReadConfig = vi.fn()
 const mockWriteConfig = vi.fn()
+/** #371: when set, cloud-agents.json EXISTS and cannot be read — which is not
+ *  the same as it not being there, and must not become an empty list saved back
+ *  over it by the boot-time stuck-agent sweep. */
+const cfg = { readFails: false }
 vi.mock('../../src/main/config-manager', () => ({
   readConfig: (...args: any[]) => mockReadConfig(...args),
+  readConfigChecked: (key: string) => {
+    if (cfg.readFails) return { value: null, outcome: 'failed' }
+    const v = mockReadConfig(key)
+    return v == null ? { value: null, outcome: 'absent' } : { value: v, outcome: 'ok' }
+  },
   writeConfig: (...args: any[]) => mockWriteConfig(...args),
   getConfigDir: () => '/mock/CONFIG',
   ensureConfigDir: vi.fn(),
@@ -64,6 +73,7 @@ import {
   killAllAgents,
   cleanupStuckAgents,
   onAgentCompletion,
+  _resetCloudAgentLatchForTest,
 } from '../../src/main/cloud-agent-manager'
 
 // Create a mock ChildProcess
@@ -93,6 +103,8 @@ describe('cloud-agent-manager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    cfg.readFails = false
+    _resetCloudAgentLatchForTest()
     // clearAllMocks resets call history but not return values — restore defaults.
     profMocks.getPrimaryProfileId.mockReturnValue(null)
     profMocks.getProfileConfigDir.mockImplementation((id: string) => `/nonexistent/profiles/${id}`)
@@ -463,6 +475,65 @@ describe('cloud-agent-manager', () => {
 
       expect(cb1).toHaveBeenCalled()
       expect(cb2).toHaveBeenCalled()
+    })
+  })
+
+  /**
+   * #371 — a failed read of cloud-agents.json is not an empty agent list.
+   *
+   * This is the worst of the five for timing: `cleanupStuckAgents()` runs at
+   * boot, immediately after the load, and persists whenever it changes
+   * anything. So a read failure went straight to a write of `[]`.
+   */
+  describe('a read failure is not an absence', () => {
+    it('refuses to persist over a file it could not read', async () => {
+      cfg.readFails = true
+      initCloudAgentManager(() => mockWindow)
+
+      expect(listAgents()).toHaveLength(0) // the empty list the failure produced
+
+      // Dispatching is what actually reaches persist() — the boot sweep cannot,
+      // because the failed load left nothing for it to change. This is the
+      // write that used to put a one-element array over the user's history.
+      mockSpawn.mockReturnValue(createMockProcess())
+      await dispatchAgent({ name: 'New', description: 'd', projectPath: '/p' })
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('cloudAgents', expect.anything())
+    })
+
+    it('the boot sweep cannot reach the file either — it has nothing to change', () => {
+      cfg.readFails = true
+      initCloudAgentManager(() => mockWindow)
+      cleanupStuckAgents()
+      clearCompletedAgents()
+      // Not a latch assertion: with the list empty there is nothing to persist.
+      // Recorded so the NEXT reader knows the latch is proved by the dispatch
+      // test above, and does not mistake this for a guard being exercised.
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('cloudAgents', expect.anything())
+    })
+
+    it('an ABSENT file still persists — a fresh install must be able to save its first agent', async () => {
+      mockReadConfig.mockReturnValue(null)
+      initCloudAgentManager(() => mockWindow)
+
+      mockSpawn.mockReturnValue(createMockProcess())
+      await dispatchAgent({ name: 'First', description: 'd', projectPath: '/p' })
+      expect(mockWriteConfig).toHaveBeenCalledWith('cloudAgents', expect.any(Array))
+    })
+
+    it('resumes persisting once a load succeeds', async () => {
+      cfg.readFails = true
+      initCloudAgentManager(() => mockWindow)
+      cleanupStuckAgents()
+      expect(mockWriteConfig).not.toHaveBeenCalled()
+
+      cfg.readFails = false
+      mockReadConfig.mockReturnValue([{ id: 'ca-old', name: 'kept', status: 'completed' }])
+      initCloudAgentManager(() => mockWindow)
+      expect(listAgents()).toHaveLength(1)
+
+      mockSpawn.mockReturnValue(createMockProcess())
+      await dispatchAgent({ name: 'Now', description: 'd', projectPath: '/p' })
+      expect(mockWriteConfig).toHaveBeenCalledWith('cloudAgents', expect.any(Array))
     })
   })
 })

--- a/tests/unit/cloud-agent-manager.test.ts
+++ b/tests/unit/cloud-agent-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock('child_process', () => ({
 
 // Mock config-manager
 const mockReadConfig = vi.fn()
-const mockWriteConfig = vi.fn()
+const mockWriteConfig = vi.fn(() => true)
 /** #371: when set, cloud-agents.json EXISTS and cannot be read — which is not
  *  the same as it not being there, and must not become an empty list saved back
  *  over it by the boot-time stuck-agent sweep. */
@@ -331,13 +331,13 @@ describe('cloud-agent-manager', () => {
       ])
       initCloudAgentManager(() => mockWindow)
       const result = removeAgent('a1')
-      expect(result).toBe(true)
+      expect(result).toEqual({ ok: true, removed: true })
       expect(listAgents()).toHaveLength(1)
       expect(listAgents()[0].id).toBe('a2')
     })
 
     it('returns false for unknown id', () => {
-      expect(removeAgent('nonexistent')).toBe(false)
+      expect(removeAgent('nonexistent')).toEqual({ ok: true, removed: false })
     })
   })
 
@@ -382,7 +382,7 @@ describe('cloud-agent-manager', () => {
       ])
       initCloudAgentManager(() => mockWindow)
       const removed = clearCompletedAgents()
-      expect(removed).toBe(2)
+      expect(removed).toEqual({ ok: true, removed: 2 })
       expect(listAgents()).toHaveLength(1)
       expect(listAgents()[0].id).toBe('a2')
     })
@@ -390,7 +390,7 @@ describe('cloud-agent-manager', () => {
     it('returns 0 when nothing to clear', () => {
       mockReadConfig.mockReturnValue([{ id: 'a1', status: 'running' }])
       initCloudAgentManager(() => mockWindow)
-      expect(clearCompletedAgents()).toBe(0)
+      expect(clearCompletedAgents()).toEqual({ ok: true, removed: 0 })
     })
   })
 
@@ -520,20 +520,59 @@ describe('cloud-agent-manager', () => {
       expect(mockWriteConfig).toHaveBeenCalledWith('cloudAgents', expect.any(Array))
     })
 
-    it('resumes persisting once a load succeeds', async () => {
+    /**
+     * Review MAJOR-1. `initCloudAgentManager` runs once, at boot, so the old
+     * "call init twice" recovery test proved a property at a seam production
+     * never reaches. This drives the real one: init once, the lock lifts, and
+     * the next dispatch recovers by itself.
+     */
+    it('recovers on the next dispatch, with no second load — the production path', async () => {
+      mockReadConfig.mockReturnValue([{ id: 'ca-old', name: 'from last week', status: 'completed' }])
       cfg.readFails = true
       initCloudAgentManager(() => mockWindow)
-      cleanupStuckAgents()
-      expect(mockWriteConfig).not.toHaveBeenCalled()
+      expect(listAgents()).toHaveLength(0)
 
       cfg.readFails = false
-      mockReadConfig.mockReturnValue([{ id: 'ca-old', name: 'kept', status: 'completed' }])
+      mockSpawn.mockReturnValue(createMockProcess())
+      await dispatchAgent({ name: 'Now', description: 'd', projectPath: '/p' })
+
+      const written = mockWriteConfig.mock.calls.filter((c: any[]) => c[0] === 'cloudAgents').at(-1)![1] as any[]
+      // The agent that was on disk is back, alongside the new one.
+      expect(written.some((a) => a.id === 'ca-old')).toBe(true)
+      expect(written.some((a) => a.name === 'Now')).toBe(true)
+    })
+
+    /**
+     * The tombstone case, reachable here (unlike for teams, where a failed load
+     * leaves nothing to delete): once the merge folds the disk copy back in, a
+     * removal must stick rather than being resurrected by the next save.
+     */
+    it('a removal is not resurrected by the recovery merge', async () => {
+      mockReadConfig.mockReturnValue([{ id: 'ca-old', name: 'on disk', status: 'completed' }])
+      cfg.readFails = true
       initCloudAgentManager(() => mockWindow)
-      expect(listAgents()).toHaveLength(1)
+
+      cfg.readFails = false
+      // Nothing in memory yet (the load failed), so there is nothing to remove.
+      expect(removeAgent('ca-old')).toEqual({ ok: true, removed: false })
 
       mockSpawn.mockReturnValue(createMockProcess())
       await dispatchAgent({ name: 'Now', description: 'd', projectPath: '/p' })
-      expect(mockWriteConfig).toHaveBeenCalledWith('cloudAgents', expect.any(Array))
+      expect(listAgents().some((a) => a.id === 'ca-old')).toBe(true)
+
+      expect(removeAgent('ca-old')).toEqual({ ok: true, removed: true })
+      const written = mockWriteConfig.mock.calls.filter((c: any[]) => c[0] === 'cloudAgents').at(-1)![1] as any[]
+      expect(written.some((a) => a.id === 'ca-old')).toBe(false)
+    })
+
+    it('a remove whose WRITE fails is reported, and the agent stays', () => {
+      mockReadConfig.mockReturnValue([{ id: 'ca-1', name: 'x', status: 'completed' }])
+      initCloudAgentManager(() => mockWindow)
+      mockWriteConfig.mockReturnValueOnce(false)
+      const res = removeAgent('ca-1')
+      expect(res.ok).toBe(false)
+      expect(res.error).toBeTruthy()
+      expect(listAgents()).toHaveLength(1)
     })
   })
 })

--- a/tests/unit/main/persist-latch.test.ts
+++ b/tests/unit/main/persist-latch.test.ts
@@ -1,0 +1,253 @@
+/**
+ * The shared null-vs-failed pattern for main-side persisters (#371).
+ *
+ * The ADR-009 pass before beta.16 fixed this shape for saved sessions (#353)
+ * and left a note: five other main-side persisters conflate "no file" with
+ * "could not read the file", and it wanted ONE shared fix rather than five
+ * copies. `persist-latch.ts` is that fix; these tests are its spec.
+ *
+ * The whole point is a distinction, so every test here has to be able to tell
+ * the three outcomes apart on the ONE thing that matters — whether the bytes on
+ * disk survive. A test that only checked a return value would pass against a
+ * latch that never latched.
+ *
+ * Real fs, real config-manager: the failure being modelled is an fs failure, so
+ * mocking the layer under test would prove nothing. Only `readFileSync` is
+ * patched, and only for the file each test names.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync as realReadFileSync, existsSync, readdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const h = vi.hoisted(() => ({ resourcesDir: '', failFor: null as string | null, errno: 'EBUSY' }))
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => ({
+  getResourcesDirectory: () => h.resourcesDir,
+  registerSetupHandlers: () => {},
+}))
+vi.mock('../../../src/main/debug-logger', () => ({
+  logInfo: vi.fn(), logError: vi.fn(), logWarn: vi.fn(), logDebug: vi.fn(), logTrace: vi.fn(),
+}))
+
+// Only the named file fails, and only on READ. Everything else — the atomic
+// write's staging file, the directory hardening — really runs.
+vi.mock('fs', async (importOriginal) => {
+  const real = await importOriginal<typeof import('fs')>()
+  const patched = {
+    ...real,
+    readFileSync: (p: any, o: any) => {
+      if (h.failFor && String(p).endsWith(h.failFor)) {
+        const err = new Error(`${h.errno}: resource busy or locked, open '${String(p)}'`) as NodeJS.ErrnoException
+        err.code = h.errno
+        throw err
+      }
+      return real.readFileSync(p, o)
+    },
+  }
+  return { ...patched, default: patched }
+})
+
+const { readConfigChecked, writeConfig } = await import('../../../src/main/config-manager')
+const { createReadFailureLatch, loadConfigLatched, saveConfigLatched } = await import('../../../src/main/persist-latch')
+const windowState = await import('../../../src/main/window-state')
+
+let configDir = ''
+
+beforeAll(() => {
+  // One dir for the whole file: getConfigDir() caches its answer.
+  h.resourcesDir = mkdtempSync(join(tmpdir(), 'persist-latch-'))
+  configDir = join(h.resourcesDir, 'CONFIG')
+  mkdirSync(configDir, { recursive: true })
+})
+
+afterAll(() => {
+  try { rmSync(h.resourcesDir, { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+beforeEach(() => {
+  h.failFor = null
+  h.errno = 'EBUSY'
+  windowState._resetWindowStateLatchForTest()
+})
+
+// Lazy: `configDir` is only known once beforeAll has made the temp dir.
+const agentsFile = () => join(configDir, 'cloud-agents.json')
+const GOOD = [{ id: 'ca-1', name: 'the user\'s real agent' }]
+const writeGoodAgents = () => writeFileSync(agentsFile(), JSON.stringify(GOOD, null, 2))
+const agentBytes = () => realReadFileSync(agentsFile(), 'utf-8')
+
+describe('readConfigChecked tells the three ways to get nothing apart', () => {
+  it('a file that is not there is ABSENT, not a failure', () => {
+    try { rmSync(agentsFile(), { force: true }) } catch { /* fine */ }
+    const r = readConfigChecked('cloudAgents')
+    expect(r.outcome).toBe('absent')
+    expect(r.value).toBeNull()
+  })
+
+  it('a file that reads and parses is OK', () => {
+    writeGoodAgents()
+    const r = readConfigChecked('cloudAgents')
+    expect(r.outcome).toBe('ok')
+    expect(r.value).toEqual(GOOD)
+  })
+
+  it('a file that cannot be READ is FAILED, and is left exactly as it was', () => {
+    writeGoodAgents()
+    const before = agentBytes()
+    h.failFor = 'cloud-agents.json'
+    const r = readConfigChecked('cloudAgents')
+    expect(r.outcome).toBe('failed')
+    expect(r.value).toBeNull()
+    h.failFor = null
+    expect(agentBytes()).toBe(before)
+  })
+
+  it.each(['EACCES', 'EPERM', 'EIO'])('%s is a read failure too, not an absence', (code) => {
+    writeGoodAgents()
+    h.failFor = 'cloud-agents.json'
+    h.errno = code
+    expect(readConfigChecked('cloudAgents').outcome).toBe('failed')
+  })
+
+  it('a file that reads but does not PARSE is UNPARSEABLE, and is moved aside rather than destroyed', () => {
+    writeFileSync(agentsFile(), '{ this is not json')
+    const r = readConfigChecked('cloudAgents')
+    expect(r.outcome).toBe('unparseable')
+    expect(r.value).toBeNull()
+    expect(existsSync(agentsFile())).toBe(false)
+    const aside = readdirSync(configDir).filter((f) => f.startsWith('cloud-agents.json.corrupt-'))
+    expect(aside).toHaveLength(1)
+    // The original bytes are kept for forensics, not silently dropped.
+    expect(realReadFileSync(join(configDir, aside[0]), 'utf-8')).toBe('{ this is not json')
+    for (const f of aside) rmSync(join(configDir, f), { force: true })
+  })
+
+  it('an unregistered key is FAILED, not absent — writeConfig refuses it, so an empty store could never be saved', () => {
+    const r = readConfigChecked('nope' as never)
+    expect(r.outcome).toBe('failed')
+  })
+})
+
+describe('the latch refuses writes only after a READ failure', () => {
+  it('a read failure latches, and the refused save leaves the file untouched', () => {
+    writeGoodAgents()
+    const before = agentBytes()
+    const latch = createReadFailureLatch('test')
+
+    h.failFor = 'cloud-agents.json'
+    expect(loadConfigLatched('cloudAgents', latch)).toBeNull()
+    expect(latch.failed()).toBe(true)
+
+    // What every one of the five persisters does next: build an empty store and
+    // save it. This is the write that used to destroy the file.
+    expect(saveConfigLatched('cloudAgents', [], latch)).toBe(false)
+
+    h.failFor = null
+    expect(agentBytes()).toBe(before)
+    expect(readConfigChecked('cloudAgents').value).toEqual(GOOD)
+  })
+
+  it('a later successful load clears the latch and writing resumes', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.failed()).toBe(true)
+
+    h.failFor = null
+    expect(loadConfigLatched('cloudAgents', latch)).toEqual(GOOD)
+    expect(latch.failed()).toBe(false)
+    expect(saveConfigLatched('cloudAgents', [{ id: 'ca-2' }], latch)).toBe(true)
+    expect(readConfigChecked('cloudAgents').value).toEqual([{ id: 'ca-2' }])
+  })
+
+  it('an ABSENT file does not latch — an empty store really is the truth, and must be savable', () => {
+    rmSync(agentsFile(), { force: true })
+    const latch = createReadFailureLatch('test')
+    expect(loadConfigLatched('cloudAgents', latch)).toBeNull()
+    expect(latch.failed()).toBe(false)
+    expect(saveConfigLatched('cloudAgents', GOOD, latch)).toBe(true)
+  })
+
+  it('an UNPARSEABLE file does not latch — its content is already unrecoverable and has been kept aside', () => {
+    writeFileSync(agentsFile(), 'not json at all')
+    const latch = createReadFailureLatch('test')
+    expect(loadConfigLatched('cloudAgents', latch)).toBeNull()
+    expect(latch.failed()).toBe(false)
+    expect(saveConfigLatched('cloudAgents', GOOD, latch)).toBe(true)
+    for (const f of readdirSync(configDir).filter((n) => n.includes('.corrupt-'))) rmSync(join(configDir, f), { force: true })
+  })
+
+  it('refuses `clear` for the same reason it refuses `save`', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.refuses('clear')).toBe(true)
+    h.failFor = null
+    expect(readConfigChecked('cloudAgents').value).toEqual(GOOD)
+  })
+
+  it('one persister\'s read failure says nothing about another\'s', () => {
+    writeGoodAgents()
+    writeConfig('agentTeams', [{ id: 't-1' }])
+    const agentsLatch = createReadFailureLatch('agents')
+    const teamsLatch = createReadFailureLatch('teams')
+
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', agentsLatch)
+    loadConfigLatched('agentTeams', teamsLatch)
+
+    expect(agentsLatch.failed()).toBe(true)
+    expect(teamsLatch.failed()).toBe(false)
+    expect(saveConfigLatched('agentTeams', [{ id: 't-2' }], teamsLatch)).toBe(true)
+  })
+})
+
+describe('window geometry (the persister that hid its failure best)', () => {
+  const wsFile = () => join(configDir, 'window-state.json')
+  const REAL = { x: 100, y: 120, width: 1280, height: 800, isMaximized: false }
+
+  it('reads the saved geometry back', () => {
+    writeFileSync(wsFile(), JSON.stringify(REAL))
+    expect(windowState.loadWindowState()).toEqual(REAL)
+    expect(windowState.windowStateReadFailed()).toBe(false)
+  })
+
+  it('still opens a window on a read failure, but never writes the default back over the real geometry', () => {
+    writeFileSync(wsFile(), JSON.stringify(REAL))
+    h.failFor = 'window-state.json'
+
+    // The window must still open at SOME size.
+    expect(windowState.loadWindowState()).toEqual(windowState.DEFAULT_WINDOW_STATE)
+    expect(windowState.windowStateReadFailed()).toBe(true)
+
+    // The close handler fires with the geometry of a window that opened at the
+    // default. Before #371 this is the write that lost the user's layout.
+    expect(windowState.saveWindowState({ x: 0, y: 0, width: 3200, height: 1800, isMaximized: false })).toBe(false)
+
+    h.failFor = null
+    expect(JSON.parse(realReadFileSync(wsFile(), 'utf-8'))).toEqual(REAL)
+  })
+
+  it('a missing file is an absence: the default opens AND is saved', () => {
+    rmSync(wsFile(), { force: true })
+    expect(windowState.loadWindowState()).toEqual(windowState.DEFAULT_WINDOW_STATE)
+    expect(windowState.windowStateReadFailed()).toBe(false)
+    expect(windowState.saveWindowState(REAL)).toBe(true)
+    expect(JSON.parse(realReadFileSync(wsFile(), 'utf-8'))).toEqual(REAL)
+  })
+
+  it('geometry without usable width/height falls back to the default', () => {
+    writeFileSync(wsFile(), JSON.stringify({ isMaximized: true }))
+    expect(windowState.loadWindowState()).toEqual(windowState.DEFAULT_WINDOW_STATE)
+  })
+
+  it('writes to the same path the hand-rolled version used, so upgrading installs keep their geometry', () => {
+    rmSync(wsFile(), { force: true })
+    windowState.saveWindowState(REAL)
+    expect(existsSync(join(configDir, 'window-state.json'))).toBe(true)
+  })
+})

--- a/tests/unit/main/persist-latch.test.ts
+++ b/tests/unit/main/persist-latch.test.ts
@@ -20,7 +20,12 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync as realReadFileSync
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-const h = vi.hoisted(() => ({ resourcesDir: '', failFor: null as string | null, errno: 'EBUSY' }))
+const h = vi.hoisted(() => ({
+  resourcesDir: '',
+  failFor: null as string | null,
+  failRenameFor: null as string | null,
+  errno: 'EBUSY',
+}))
 
 vi.mock('../../../src/main/ipc/setup-handlers', () => ({
   getResourcesDirectory: () => h.resourcesDir,
@@ -44,12 +49,22 @@ vi.mock('fs', async (importOriginal) => {
       }
       return real.readFileSync(p, o)
     },
+    // Lets a test model "the file did not parse AND could not be quarantined".
+    renameSync: (from: any, to: any) => {
+      if (h.failRenameFor && String(from).endsWith(h.failRenameFor)) {
+        const err = new Error(`EACCES: permission denied, rename '${String(from)}'`) as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      return real.renameSync(from, to)
+    },
   }
   return { ...patched, default: patched }
 })
 
+const { logError } = await import('../../../src/main/debug-logger')
 const { readConfigChecked, writeConfig } = await import('../../../src/main/config-manager')
-const { createReadFailureLatch, loadConfigLatched, saveConfigLatched } = await import('../../../src/main/persist-latch')
+const { createReadFailureLatch, loadConfigLatched, saveConfigLatched, mergeById } = await import('../../../src/main/persist-latch')
 const windowState = await import('../../../src/main/window-state')
 
 let configDir = ''
@@ -67,7 +82,9 @@ afterAll(() => {
 
 beforeEach(() => {
   h.failFor = null
+  h.failRenameFor = null
   h.errno = 'EBUSY'
+  vi.mocked(logError).mockClear()
   windowState._resetWindowStateLatchForTest()
 })
 
@@ -126,6 +143,53 @@ describe('readConfigChecked tells the three ways to get nothing apart', () => {
   it('an unregistered key is FAILED, not absent — writeConfig refuses it, so an empty store could never be saved', () => {
     const r = readConfigChecked('nope' as never)
     expect(r.outcome).toBe('failed')
+  })
+
+  /**
+   * Review MAJOR-2. The first cut asked `existsSync` first, and `existsSync`
+   * answers false for ANY stat error — a denied parent, an unmounted resources
+   * directory, a share that blinked — so the one case with the widest blast
+   * radius (the whole CONFIG directory unreachable) read as "fresh install".
+   * Only ENOENT may mean absent.
+   */
+  it.each(['ENOTDIR', 'EACCES', 'EPERM', 'EBUSY', 'EIO', 'ELOOP'])(
+    '%s means the file could not be READ, never that it is absent',
+    (code) => {
+      writeGoodAgents()
+      h.failFor = 'cloud-agents.json'
+      h.errno = code
+      expect(readConfigChecked('cloudAgents').outcome).toBe('failed')
+    },
+  )
+
+  it('ENOENT is the only error that means absent', () => {
+    writeGoodAgents()
+    h.failFor = 'cloud-agents.json'
+    h.errno = 'ENOENT'
+    expect(readConfigChecked('cloudAgents').outcome).toBe('absent')
+  })
+
+  /**
+   * Review MAJOR-3. "Nothing is left to protect" is the entire justification
+   * for letting writes continue after an unparseable read — and it is only true
+   * once the file has ACTUALLY been moved aside. When the rename fails the file
+   * is still sitting there, possibly hand-recoverable, and the next save would
+   * overwrite it.
+   */
+  it('an unparseable file that could NOT be moved aside latches instead of allowing the overwrite', () => {
+    writeFileSync(agentsFile(), '{ truncated by a power cut, 90% recoverable')
+    const before = agentBytes()
+    h.failRenameFor = 'cloud-agents.json'
+
+    const r = readConfigChecked('cloudAgents')
+    expect(r.outcome).toBe('failed')
+
+    const latch = createReadFailureLatch('test')
+    latch.note(r.outcome)
+    expect(saveConfigLatched('cloudAgents', () => [], latch)).toBe(false)
+
+    h.failRenameFor = null
+    expect(agentBytes()).toBe(before)
   })
 })
 
@@ -203,6 +267,107 @@ describe('the latch refuses writes only after a READ failure', () => {
     expect(agentsLatch.failed()).toBe(true)
     expect(teamsLatch.failed()).toBe(false)
     expect(saveConfigLatched('agentTeams', [{ id: 't-2' }], teamsLatch)).toBe(true)
+  })
+})
+
+/**
+ * Review findings on #406. The first cut latched correctly and then never
+ * un-latched: five of the six persisters load exactly once, at boot, so a
+ * single 50 ms lock disabled persistence for the whole process — and every
+ * refused write was reported to the caller as a success. Both halves are worse
+ * than the bug they replaced, so both are pinned here.
+ */
+describe('a latched save retries the read rather than refusing forever', () => {
+  it('recovers, folds the file back in, and writes — no second load needed', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+
+    h.failFor = 'cloud-agents.json'
+    expect(loadConfigLatched('cloudAgents', latch)).toBeNull()
+    expect(latch.failed()).toBe(true)
+
+    // The lock lifts. Nothing re-loads — this is the production shape, where
+    // init ran once at boot and only saves happen from here on.
+    h.failFor = null
+    let recovered: unknown = 'never called'
+    const inMemory = [{ id: 'ca-new', name: 'made while the file was locked' }]
+    expect(
+      saveConfigLatched('cloudAgents', () => inMemory, latch, { onRecovered: (r) => { recovered = r } }),
+    ).toBe(true)
+
+    // The owner was handed the file it never managed to read…
+    expect(recovered).toEqual(GOOD)
+    expect(latch.failed()).toBe(false)
+  })
+
+  it('still refuses while the file is STILL unreadable, and leaves the bytes alone', () => {
+    writeGoodAgents()
+    const before = agentBytes()
+    const latch = createReadFailureLatch('test')
+
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+    expect(saveConfigLatched('cloudAgents', () => [], latch)).toBe(false)
+
+    h.failFor = null
+    expect(agentBytes()).toBe(before)
+  })
+
+  it('evaluates the value AFTER recovery, so the merged state is what lands', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+
+    // Exactly how the persisters use it: the thunk reads module state that
+    // `onRecovered` has just merged into.
+    h.failFor = null
+    let state: unknown[] = [{ id: 'ca-new' }]
+    saveConfigLatched('cloudAgents', () => state, latch, {
+      onRecovered: (r) => { state = mergeById(r, state as { id?: unknown }[]) },
+    })
+
+    const onDisk = readConfigChecked<Array<{ id: string }>>('cloudAgents').value!
+    expect(onDisk.map((a) => a.id).sort()).toEqual(['ca-1', 'ca-new'])
+  })
+
+  it('the refusal is logged once per latch, not once per save', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+
+    // `saveSnapshots` runs on every usage poll; a line per poll for the life of
+    // the process is noise that buries the one that matters.
+    for (let i = 0; i < 5; i++) expect(saveConfigLatched('cloudAgents', () => [], latch)).toBe(false)
+    const refusals = vi.mocked(logError).mock.calls.filter((c) => String(c[0]).includes('refusing to save'))
+    expect(refusals).toHaveLength(1)
+  })
+})
+
+describe('the generation changes only on recovery', () => {
+  it('an ordinary re-read does not invalidate a form built from the last one', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    loadConfigLatched('cloudAgents', latch)
+    const g = latch.generation()
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.generation()).toBe(g)
+  })
+
+  it('a load that succeeds AFTER a failure does invalidate it', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    loadConfigLatched('cloudAgents', latch)
+    const g = latch.generation()
+
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.generation()).toBe(g) // a FAILED read is not a new generation
+
+    h.failFor = null
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.generation()).not.toBe(g)
   })
 })
 

--- a/tests/unit/main/persist-latch.test.ts
+++ b/tests/unit/main/persist-latch.test.ts
@@ -24,6 +24,10 @@ const h = vi.hoisted(() => ({
   resourcesDir: '',
   failFor: null as string | null,
   failRenameFor: null as string | null,
+  failWriteFor: null as string | null,
+  /** Models a mapped/removable drive that is not attached: every path on it
+   *  answers ENOENT, including the volume root. */
+  unreachableRoot: false,
   errno: 'EBUSY',
 }))
 
@@ -47,7 +51,22 @@ vi.mock('fs', async (importOriginal) => {
         err.code = h.errno
         throw err
       }
+      if (h.unreachableRoot) {
+        const err = new Error(`ENOENT: no such file or directory, open '${String(p)}'`) as NodeJS.ErrnoException
+        err.code = 'ENOENT'
+        throw err
+      }
       return real.readFileSync(p, o)
+    },
+    // The volume root itself disappears with the drive.
+    existsSync: (p: any) => (h.unreachableRoot ? false : real.existsSync(p)),
+    writeFileSync: (p: any, d: any, o: any) => {
+      if (h.failWriteFor && String(p).includes(h.failWriteFor.replace(/\.json$/, ''))) {
+        const err = new Error(`EACCES: permission denied, open '${String(p)}'`) as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      return real.writeFileSync(p, d, o)
     },
     // Lets a test model "the file did not parse AND could not be quarantined".
     renameSync: (from: any, to: any) => {
@@ -83,6 +102,8 @@ afterAll(() => {
 beforeEach(() => {
   h.failFor = null
   h.failRenameFor = null
+  h.failWriteFor = null
+  h.unreachableRoot = false
   h.errno = 'EBUSY'
   vi.mocked(logError).mockClear()
   windowState._resetWindowStateLatchForTest()
@@ -342,6 +363,72 @@ describe('a latched save retries the read rather than refusing forever', () => {
     for (let i = 0; i < 5; i++) expect(saveConfigLatched('cloudAgents', () => [], latch)).toBe(false)
     const refusals = vi.mocked(logError).mock.calls.filter((c) => String(c[0]).includes('refusing to save'))
     expect(refusals).toHaveLength(1)
+  })
+})
+
+/**
+ * #371 ADR-009 pass — two clobber paths the RETRY itself introduced.
+ */
+describe('a recovery whose write then fails does not become a silent total loss', () => {
+  it('re-latches, so the next save re-reads instead of overwriting with the failed-load state', () => {
+    writeGoodAgents()
+    const latch = createReadFailureLatch('test')
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+    expect(latch.failed()).toBe(true)
+
+    // The file becomes readable, the recovery runs — and the WRITE fails.
+    h.failFor = null
+    h.failWriteFor = 'cloud-agents.json'
+    let recovered: unknown = null
+    expect(
+      saveConfigLatched('cloudAgents', () => [{ id: 'ca-new' }], latch, { onRecovered: (r) => { recovered = r } }),
+    ).toBe(false)
+    expect(recovered).toEqual(GOOD)
+
+    // The caller now rolls back to its PRE-recovery snapshot (the small set
+    // built from the failed load). If the latch had stayed clear, that would be
+    // written over the good file next time and reported as a success.
+    expect(latch.failed()).toBe(true)
+
+    h.failWriteFor = null
+    expect(saveConfigLatched('cloudAgents', () => [{ id: 'ca-new' }], latch, {
+      onRecovered: (r) => { recovered = r },
+    })).toBe(true)
+    // It re-read and merged again rather than clobbering.
+    expect(recovered).toEqual(GOOD)
+  })
+
+  it('retry:false refuses outright — for a store with nothing to merge', () => {
+    writeGoodAgents()
+    const before = agentBytes()
+    const latch = createReadFailureLatch('test')
+    h.failFor = 'cloud-agents.json'
+    loadConfigLatched('cloudAgents', latch)
+
+    // The file is readable again, but a single-object store must NOT be
+    // recovered-then-overwritten with its in-memory fallback.
+    h.failFor = null
+    expect(saveConfigLatched('cloudAgents', () => [], latch, { retry: false })).toBe(false)
+    expect(agentBytes()).toBe(before)
+  })
+})
+
+describe('an unreachable resources volume is not a fresh install', () => {
+  it('ENOENT with the root gone is a read FAILURE, not an absence', () => {
+    // What a mapped network drive that has not reconnected, or a removable
+    // drive not yet attached at logon, answers for every path on it.
+    h.unreachableRoot = true
+    expect(readConfigChecked('cloudAgents').outcome).toBe('failed')
+  })
+
+  it('ENOENT with the root present is a genuine absence — a fresh install must still write', () => {
+    rmSync(agentsFile(), { force: true })
+    expect(readConfigChecked('cloudAgents').outcome).toBe('absent')
+    const latch = createReadFailureLatch('test')
+    expect(loadConfigLatched('cloudAgents', latch)).toBeNull()
+    expect(latch.failed()).toBe(false)
+    expect(saveConfigLatched('cloudAgents', () => GOOD, latch)).toBe(true)
   })
 })
 

--- a/tests/unit/main/vision-config-persist.test.ts
+++ b/tests/unit/main/vision-config-persist.test.ts
@@ -55,7 +55,10 @@ const REAL: GlobalVisionConfig = { enabled: true, browser: 'edge', debugPort: 93
 const DEFAULTS = { enabled: true, browser: 'chrome', debugPort: 9222, headless: true } as GlobalVisionConfig
 
 const getConfig = () => handlers.get('vision:getConfig')!({})
-const saveConfig = (c: GlobalVisionConfig) => handlers.get('vision:saveConfig')!({}, c)
+const saveConfig = (c: GlobalVisionConfig, generation?: number) =>
+  handlers.get('vision:saveConfig')!({}, c, generation)
+/** The config half of the new `{config, generation, readFailed}` answer. */
+const readConfig = async () => (await getConfig()).config
 
 beforeEach(() => {
   handlers.clear()
@@ -69,7 +72,7 @@ beforeEach(() => {
 describe('vision config persistence', () => {
   it('round-trips a saved config', async () => {
     expect(await saveConfig(REAL)).toEqual({ ok: true })
-    expect(await getConfig()).toEqual(REAL)
+    expect(await readConfig()).toEqual(REAL)
   })
 
   it('refuses to save over a config it could not read, and says so', async () => {
@@ -77,14 +80,14 @@ describe('vision config persistence', () => {
     cfg.readFails = true
 
     // The form renders defaults because getConfig came back null…
-    expect(await getConfig()).toBeNull()
+    expect(await readConfig()).toBeNull()
     // …the user touches a control and it saves. This is the write that lost it.
     const res = await saveConfig(DEFAULTS)
     expect(res.ok).toBe(false)
     expect(res.error).toMatch(/could not be read/i)
 
     cfg.readFails = false
-    expect(await getConfig()).toEqual(REAL)
+    expect(await readConfig()).toEqual(REAL)
   })
 
   it('reports a failed write as a failure rather than {ok:true}', async () => {
@@ -95,7 +98,7 @@ describe('vision config persistence', () => {
   })
 
   it('an ABSENT config still saves — first-run setup must be able to write one', async () => {
-    expect(await getConfig()).toBeNull()
+    expect(await readConfig()).toBeNull()
     expect(await saveConfig(REAL)).toEqual({ ok: true })
     expect(store.visionGlobal).toEqual(REAL)
   })
@@ -107,7 +110,7 @@ describe('vision config persistence', () => {
     expect((await saveConfig(DEFAULTS)).ok).toBe(false)
 
     cfg.readFails = false
-    expect(await getConfig()).toEqual(REAL)
+    expect(await readConfig()).toEqual(REAL)
     expect(await saveConfig(DEFAULTS)).toEqual({ ok: true })
     expect(store.visionGlobal).toEqual(DEFAULTS)
   })
@@ -120,6 +123,6 @@ describe('vision config persistence', () => {
     await handlers.get('vision:start')!({})
     expect((await saveConfig(DEFAULTS)).ok).toBe(false)
     cfg.readFails = false
-    expect(await getConfig()).toEqual(REAL)
+    expect(await readConfig()).toEqual(REAL)
   })
 })

--- a/tests/unit/main/vision-config-persist.test.ts
+++ b/tests/unit/main/vision-config-persist.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Vision settings: a failed read is not "not configured yet" (#371).
+ *
+ * The loss path here is a round trip through the UI rather than a boot sweep:
+ * `vision:getConfig` answered null for a read FAILURE exactly as for an absent
+ * file, so the settings form rendered its defaults, the user touched one
+ * control, and `vision:saveConfig` wrote those defaults over the config it had
+ * never managed to read.
+ *
+ * And it always said it had worked — the old handler discarded `writeConfig`'s
+ * boolean and returned `{ ok: true }` unconditionally, so a failed save was
+ * reported to the user as a successful one too.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { GlobalVisionConfig } from '../../../src/shared/types'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: any[]) => any) => handlers.set(ch, fn) },
+  BrowserWindow: class {},
+}))
+
+const store: Record<string, unknown> = {}
+const cfg = { readFails: false, writeOk: true }
+vi.mock('../../../src/main/config-manager', () => ({
+  readConfig: (key: string) => store[key] ?? null,
+  readConfigChecked: (key: string) => {
+    if (cfg.readFails) return { value: null, outcome: 'failed' }
+    return key in store ? { value: store[key], outcome: 'ok' } : { value: null, outcome: 'absent' }
+  },
+  writeConfig: (key: string, data: unknown) => {
+    if (!cfg.writeOk) return false
+    store[key] = data
+    return true
+  },
+}))
+
+vi.mock('../../../src/main/vision-manager', () => ({
+  startGlobalVision: vi.fn(async () => {}),
+  stopGlobalVision: vi.fn(async () => {}),
+  getGlobalVisionStatus: vi.fn(() => ({ running: false })),
+  launchBrowser: vi.fn(async () => ({})),
+  tryReconnectGlobalVision: vi.fn(),
+  resetVisionRelaunchBreaker: vi.fn(),
+  isGlobalVisionRunning: vi.fn(() => false),
+}))
+vi.mock('../../../src/main/update-watcher', () => ({ isPackagedApp: () => false }))
+vi.mock('../../../src/main/debug-logger', () => ({
+  logInfo: vi.fn(), logError: vi.fn(), logWarn: vi.fn(), logDebug: vi.fn(), logTrace: vi.fn(),
+}))
+
+const { registerVisionHandlers, _resetVisionLatchForTest } = await import('../../../src/main/ipc/vision-handlers')
+
+const REAL: GlobalVisionConfig = { enabled: true, browser: 'edge', debugPort: 9333, headless: false } as GlobalVisionConfig
+const DEFAULTS = { enabled: true, browser: 'chrome', debugPort: 9222, headless: true } as GlobalVisionConfig
+
+const getConfig = () => handlers.get('vision:getConfig')!({})
+const saveConfig = (c: GlobalVisionConfig) => handlers.get('vision:saveConfig')!({}, c)
+
+beforeEach(() => {
+  handlers.clear()
+  for (const k of Object.keys(store)) delete store[k]
+  cfg.readFails = false
+  cfg.writeOk = true
+  _resetVisionLatchForTest()
+  registerVisionHandlers(() => null)
+})
+
+describe('vision config persistence', () => {
+  it('round-trips a saved config', async () => {
+    expect(await saveConfig(REAL)).toEqual({ ok: true })
+    expect(await getConfig()).toEqual(REAL)
+  })
+
+  it('refuses to save over a config it could not read, and says so', async () => {
+    store.visionGlobal = REAL
+    cfg.readFails = true
+
+    // The form renders defaults because getConfig came back null…
+    expect(await getConfig()).toBeNull()
+    // …the user touches a control and it saves. This is the write that lost it.
+    const res = await saveConfig(DEFAULTS)
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/could not be read/i)
+
+    cfg.readFails = false
+    expect(await getConfig()).toEqual(REAL)
+  })
+
+  it('reports a failed write as a failure rather than {ok:true}', async () => {
+    cfg.writeOk = false
+    const res = await saveConfig(REAL)
+    expect(res.ok).toBe(false)
+    expect(res.error).toBeTruthy()
+  })
+
+  it('an ABSENT config still saves — first-run setup must be able to write one', async () => {
+    expect(await getConfig()).toBeNull()
+    expect(await saveConfig(REAL)).toEqual({ ok: true })
+    expect(store.visionGlobal).toEqual(REAL)
+  })
+
+  it('resumes saving once a load succeeds', async () => {
+    store.visionGlobal = REAL
+    cfg.readFails = true
+    await getConfig()
+    expect((await saveConfig(DEFAULTS)).ok).toBe(false)
+
+    cfg.readFails = false
+    expect(await getConfig()).toEqual(REAL)
+    expect(await saveConfig(DEFAULTS)).toEqual({ ok: true })
+    expect(store.visionGlobal).toEqual(DEFAULTS)
+  })
+
+  it('vision:start latches too — it reads the same file', async () => {
+    store.visionGlobal = REAL
+    cfg.readFails = true
+    // A read failure reads as "not configured", which is the pre-existing
+    // behaviour; what must NOT happen is a save on the back of it.
+    await handlers.get('vision:start')!({})
+    expect((await saveConfig(DEFAULTS)).ok).toBe(false)
+    cfg.readFails = false
+    expect(await getConfig()).toEqual(REAL)
+  })
+})

--- a/tests/unit/main/vision-config-persist.test.ts
+++ b/tests/unit/main/vision-config-persist.test.ts
@@ -55,8 +55,10 @@ const REAL: GlobalVisionConfig = { enabled: true, browser: 'edge', debugPort: 93
 const DEFAULTS = { enabled: true, browser: 'chrome', debugPort: 9222, headless: true } as GlobalVisionConfig
 
 const getConfig = () => handlers.get('vision:getConfig')!({})
-const saveConfig = (c: GlobalVisionConfig, generation?: number) =>
-  handlers.get('vision:saveConfig')!({}, c, generation)
+/** The generation is MANDATORY now, so the default mirrors a panel that read
+ *  the config and then saved it. Pass one explicitly to model a stale panel. */
+const saveConfig = async (c: GlobalVisionConfig, generation?: number) =>
+  handlers.get('vision:saveConfig')!({}, c, generation ?? (await getConfig()).generation)
 /** The config half of the new `{config, generation, readFailed}` answer. */
 const readConfig = async () => (await getConfig()).config
 
@@ -113,6 +115,33 @@ describe('vision config persistence', () => {
     expect(await readConfig()).toEqual(REAL)
     expect(await saveConfig(DEFAULTS)).toEqual({ ok: true })
     expect(store.visionGlobal).toEqual(DEFAULTS)
+  })
+
+  /**
+   * #371 ADR-009 pass. Without a mandatory token the whole guard was opt-in:
+   * any caller that omitted it got the unguarded path back.
+   */
+  it('refuses a save that carries no generation at all', async () => {
+    store.visionGlobal = REAL
+    const res = await handlers.get('vision:saveConfig')!({}, DEFAULTS)
+    expect(res.ok).toBe(false)
+    expect(store.visionGlobal).toEqual(REAL)
+  })
+
+  /**
+   * The save's OWN retry used to recover the file and then write the renderer's
+   * defaults over it — no merge is possible for a single-object config, so the
+   * recovery was the loss.
+   */
+  it('a latched save never recovers-then-writes: it refuses and keeps the file', async () => {
+    store.visionGlobal = REAL
+    cfg.readFails = true
+    const stale = (await getConfig()).generation
+    // The file becomes readable again before the save lands.
+    cfg.readFails = false
+    const res = await saveConfig(DEFAULTS, stale)
+    expect(res.ok).toBe(false)
+    expect(store.visionGlobal).toEqual(REAL)
   })
 
   it('vision:start latches too — it reads the same file', async () => {

--- a/tests/unit/renderer/cloud-agent-store-persist-failure.test.ts
+++ b/tests/unit/renderer/cloud-agent-store-persist-failure.test.ts
@@ -1,0 +1,143 @@
+/**
+ * #371 BLOCKER-1 — `cloudAgent:remove` and `cloudAgent:clearCompleted` used to
+ * answer a bare boolean / count that the store discarded, filtering the local
+ * list unconditionally. A refused write (main could not read cloud-agents.json,
+ * so it left the file alone) therefore made rows vanish from the Agent Hub and
+ * reappear at the next restart. Main now rolls its own list back and answers
+ * `{ ok:false, error }`; the renderer must keep its rows.
+ *
+ * The renderer still persists NOTHING for cloudAgents (see the note at the top
+ * of cloudAgentStore.ts) — it only reads main's answer.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useCloudAgentStore } from '../../../src/renderer/stores/cloudAgentStore'
+import type { CloudAgent } from '../../../src/renderer/types/electron'
+
+function makeAgent(overrides: Partial<CloudAgent> = {}): CloudAgent {
+  return {
+    id: 'ca-1',
+    name: 'Test Agent',
+    description: 'Test description',
+    status: 'running',
+    createdAt: 1,
+    updatedAt: 1,
+    projectPath: 'C:\\dev\\project',
+    output: '',
+    ...overrides,
+  }
+}
+
+const api = () => (window as any).electronAPI.cloudAgent
+
+describe('cloudAgentStore persistence failures (#371 BLOCKER-1)', () => {
+  beforeEach(() => {
+    useCloudAgentStore.setState({
+      agents: [],
+      selectedAgentId: null,
+      filter: 'all',
+      searchQuery: '',
+      accountFilter: 'all',
+      error: null,
+    })
+  })
+
+  describe('remove', () => {
+    it('leaves the agent IN the store when the write is refused', async () => {
+      useCloudAgentStore.setState({ agents: [makeAgent({ id: 'a1' }), makeAgent({ id: 'a2' })] })
+      api().remove.mockResolvedValueOnce({ ok: false, error: 'agents file unreadable' })
+
+      const result = await useCloudAgentStore.getState().remove('a1')
+
+      expect(result.ok).toBe(false)
+      expect(useCloudAgentStore.getState().agents.map(a => a.id)).toEqual(['a1', 'a2'])
+      expect(useCloudAgentStore.getState().error).toBe('agents file unreadable')
+    })
+
+    it('keeps the selection on a refused remove', async () => {
+      useCloudAgentStore.setState({ agents: [makeAgent({ id: 'a1' })], selectedAgentId: 'a1' })
+      api().remove.mockResolvedValueOnce({ ok: false, error: 'nope' })
+
+      await useCloudAgentStore.getState().remove('a1')
+
+      expect(useCloudAgentStore.getState().selectedAgentId).toBe('a1')
+    })
+
+    it('writes nothing itself on failure — main owns cloud-agents.json', async () => {
+      const saveSpy = (window as any).electronAPI.config.save as ReturnType<typeof vi.fn>
+      saveSpy.mockClear()
+      useCloudAgentStore.setState({ agents: [makeAgent({ id: 'a1' })] })
+      api().remove.mockResolvedValueOnce({ ok: false, error: 'nope' })
+
+      await useCloudAgentStore.getState().remove('a1')
+
+      expect(saveSpy).not.toHaveBeenCalled()
+    })
+
+    it('drops the row and clears the error on success', async () => {
+      useCloudAgentStore.setState({
+        agents: [makeAgent({ id: 'a1' }), makeAgent({ id: 'a2' })],
+        selectedAgentId: 'a1',
+        error: 'stale failure from a previous attempt',
+      })
+      api().remove.mockResolvedValueOnce({ ok: true, removed: true })
+
+      const result = await useCloudAgentStore.getState().remove('a1')
+
+      expect(result.ok).toBe(true)
+      expect(useCloudAgentStore.getState().agents.map(a => a.id)).toEqual(['a2'])
+      expect(useCloudAgentStore.getState().selectedAgentId).toBeNull()
+      expect(useCloudAgentStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('clearCompleted', () => {
+    it('leaves every finished agent IN the store when the write is refused', async () => {
+      useCloudAgentStore.setState({
+        agents: [
+          makeAgent({ id: 'a1', status: 'completed' }),
+          makeAgent({ id: 'a2', status: 'failed' }),
+          makeAgent({ id: 'a3', status: 'running' }),
+        ],
+      })
+      api().clearCompleted.mockResolvedValueOnce({ ok: false, error: 'agents file unreadable' })
+
+      const result = await useCloudAgentStore.getState().clearCompleted()
+
+      expect(result.ok).toBe(false)
+      expect(useCloudAgentStore.getState().agents.map(a => a.id)).toEqual(['a1', 'a2', 'a3'])
+      expect(useCloudAgentStore.getState().error).toBe('agents file unreadable')
+    })
+
+    it('filters the finished agents and clears the error on success', async () => {
+      useCloudAgentStore.setState({
+        agents: [
+          makeAgent({ id: 'a1', status: 'completed' }),
+          makeAgent({ id: 'a3', status: 'running' }),
+        ],
+        selectedAgentId: 'a1',
+        error: 'stale failure from a previous attempt',
+      })
+      api().clearCompleted.mockResolvedValueOnce({ ok: true, removed: 1 })
+
+      const result = await useCloudAgentStore.getState().clearCompleted()
+
+      expect(result.ok).toBe(true)
+      expect(useCloudAgentStore.getState().agents.map(a => a.id)).toEqual(['a3'])
+      expect(useCloudAgentStore.getState().selectedAgentId).toBeNull()
+      expect(useCloudAgentStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('clearError', () => {
+    it('retires a failure message the user has read', async () => {
+      useCloudAgentStore.setState({ agents: [makeAgent({ id: 'a1' })] })
+      api().remove.mockResolvedValueOnce({ ok: false, error: 'boom' })
+      await useCloudAgentStore.getState().remove('a1')
+      expect(useCloudAgentStore.getState().error).toBe('boom')
+
+      useCloudAgentStore.getState().clearError()
+
+      expect(useCloudAgentStore.getState().error).toBeNull()
+    })
+  })
+})

--- a/tests/unit/renderer/conductor-mcp-store-vision-persist.test.ts
+++ b/tests/unit/renderer/conductor-mcp-store-vision-persist.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+/**
+ * #371 MAJOR-4 / MAJOR-5 / MINOR-5 — the vision settings round trip.
+ *
+ * `vision:getConfig` used to answer a bare `GlobalVisionConfig | null`, and null
+ * meant two different things: "nothing saved yet" and "the file could not be
+ * READ". The store took the second for the first, showed DEFAULT_CONFIG as if it
+ * were the user's saved settings, and the next save wrote those defaults over
+ * settings it had never read. `vision:saveConfig` then returned `{ ok: true }`
+ * unconditionally, so a failed write also looked like a success.
+ *
+ * Main now reports `{ config, generation, readFailed }` and takes the generation
+ * token back on save, refusing (`ok:false, stale:true`) a form built while the
+ * file was unreadable. This covers the renderer half of that contract.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const getConfigMock = vi.fn()
+const saveConfigMock = vi.fn()
+
+;(globalThis as any).window = (globalThis as any).window ?? {}
+;(globalThis as any).window.electronAPI = {
+  vision: {
+    getConfig: getConfigMock,
+    saveConfig: saveConfigMock,
+    status: vi.fn(),
+    onStatusChanged: vi.fn(),
+  },
+}
+
+const { useConductorMcpStore } = await import('../../../src/renderer/stores/conductorMcpStore')
+
+const DEFAULTS = { browser: 'chrome' as const, debugPort: 9222, headless: true }
+const SAVED = { browser: 'edge' as const, debugPort: 9333, headless: false, url: 'https://example.test' }
+
+describe('conductorMcpStore vision config persistence (#371)', () => {
+  beforeEach(() => {
+    getConfigMock.mockReset()
+    saveConfigMock.mockReset()
+    useConductorMcpStore.setState({
+      visionConfig: { ...DEFAULTS },
+      visionConfigGeneration: 0,
+      visionConfigReadFailed: false,
+      error: null,
+    })
+  })
+
+  describe('loadConfig', () => {
+    it('adopts the saved config and its generation token', async () => {
+      getConfigMock.mockResolvedValue({ config: SAVED, generation: 7, readFailed: false })
+
+      await useConductorMcpStore.getState().loadConfig()
+
+      const s = useConductorMcpStore.getState()
+      expect(s.visionConfig).toEqual(SAVED)
+      expect(s.visionConfigGeneration).toBe(7)
+      expect(s.visionConfigReadFailed).toBe(false)
+      expect(s.error).toBeNull()
+    })
+
+    it('does NOT present defaults as saved settings when readFailed is true', async () => {
+      getConfigMock.mockResolvedValue({ config: null, generation: 4, readFailed: true })
+
+      await useConductorMcpStore.getState().loadConfig()
+
+      const s = useConductorMcpStore.getState()
+      // The panel must say the file could not be read rather than silently
+      // rendering DEFAULT_CONFIG as if it were the user's settings.
+      expect(s.visionConfigReadFailed).toBe(true)
+      expect(s.error).toBeTruthy()
+      expect(s.error).toMatch(/could not be read/i)
+      expect(s.visionConfigGeneration).toBe(4)
+    })
+
+    it('a read failure does not overwrite the config already held', async () => {
+      useConductorMcpStore.setState({ visionConfig: { ...SAVED }, visionConfigGeneration: 7 })
+      getConfigMock.mockResolvedValue({ config: null, generation: 8, readFailed: true })
+
+      await useConductorMcpStore.getState().loadConfig()
+
+      expect(useConductorMcpStore.getState().visionConfig).toEqual(SAVED)
+    })
+
+    it('a genuine "nothing saved yet" (config null, readFailed false) is defaults with no error', async () => {
+      getConfigMock.mockResolvedValue({ config: null, generation: 1, readFailed: false })
+
+      await useConductorMcpStore.getState().loadConfig()
+
+      const s = useConductorMcpStore.getState()
+      expect(s.visionConfig).toEqual(DEFAULTS)
+      expect(s.visionConfigReadFailed).toBe(false)
+      expect(s.error).toBeNull()
+    })
+  })
+
+  describe('saveConfig', () => {
+    it('passes the generation token from the last load back to main', async () => {
+      getConfigMock.mockResolvedValue({ config: SAVED, generation: 7, readFailed: false })
+      await useConductorMcpStore.getState().loadConfig()
+      saveConfigMock.mockResolvedValue({ ok: true })
+
+      const next = { ...SAVED, debugPort: 9444 }
+      await useConductorMcpStore.getState().saveConfig(next)
+
+      expect(saveConfigMock).toHaveBeenCalledWith(next, 7)
+    })
+
+    it('does NOT commit visionConfig when main refuses the save as stale', async () => {
+      useConductorMcpStore.setState({ visionConfig: { ...SAVED }, visionConfigGeneration: 2 })
+      saveConfigMock.mockResolvedValue({
+        ok: false,
+        stale: true,
+        error: 'Vision settings were not saved: these settings were shown before the settings file could be read.',
+      })
+
+      const result = await useConductorMcpStore.getState().saveConfig({ ...DEFAULTS })
+
+      expect(result.ok).toBe(false)
+      // The store keeps the config it actually loaded — the defaults the form
+      // was built from never become the store's idea of "saved".
+      expect(useConductorMcpStore.getState().visionConfig).toEqual(SAVED)
+      expect(useConductorMcpStore.getState().error).toMatch(/were not saved/i)
+    })
+
+    it('does NOT commit visionConfig on a plain write failure', async () => {
+      useConductorMcpStore.setState({ visionConfig: { ...SAVED }, visionConfigGeneration: 2 })
+      saveConfigMock.mockResolvedValue({ ok: false, error: 'Vision settings could not be saved.' })
+
+      const result = await useConductorMcpStore.getState().saveConfig({ ...DEFAULTS })
+
+      expect(result.ok).toBe(false)
+      expect(useConductorMcpStore.getState().visionConfig).toEqual(SAVED)
+      expect(useConductorMcpStore.getState().error).toBe('Vision settings could not be saved.')
+    })
+
+    it('falls back to a plain-English error when main sends none', async () => {
+      saveConfigMock.mockResolvedValue({ ok: false })
+
+      const result = await useConductorMcpStore.getState().saveConfig({ ...DEFAULTS })
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeTruthy()
+      expect(useConductorMcpStore.getState().error).toBeTruthy()
+    })
+
+    it('commits the config and clears the error on success', async () => {
+      useConductorMcpStore.setState({ error: 'stale failure from a previous attempt', visionConfigReadFailed: true })
+      saveConfigMock.mockResolvedValue({ ok: true })
+
+      const result = await useConductorMcpStore.getState().saveConfig({ ...SAVED })
+
+      expect(result.ok).toBe(true)
+      const s = useConductorMcpStore.getState()
+      expect(s.visionConfig).toEqual(SAVED)
+      expect(s.visionConfigReadFailed).toBe(false)
+      expect(s.error).toBeNull()
+    })
+  })
+})

--- a/tests/unit/renderer/team-builder-save-failure.test.tsx
+++ b/tests/unit/renderer/team-builder-save-failure.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/**
+ * #371 BLOCKER-1 (renderer surface) — TeamBuilder used to `await saveTeam(team)`
+ * and then close unconditionally. When main refused or failed the disk write the
+ * dialog closed anyway, the only copy of the pipeline the user had just built
+ * went with it, and nothing said so. It must stay open and show why.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { useTeamStore } from '../../../src/renderer/stores/teamStore'
+import type { TeamTemplate } from '../../../src/renderer/types/electron'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// The agent library is irrelevant to the save path; stub it so the dialog can
+// render its one step row without pulling in the real store's config hydration.
+vi.mock('../../../src/renderer/stores/agentLibraryStore', () => ({
+  BUILTIN_TEMPLATES: [],
+  useAgentLibraryStore: (selector: (s: any) => unknown) =>
+    selector({ getAllTemplates: () => [{ id: 'builtin-code-reviewer', name: 'Code Reviewer' }] }),
+}))
+
+const { default: TeamBuilder } = await import('../../../src/renderer/components/TeamBuilder')
+
+const EDITING: TeamTemplate = {
+  id: 'team-t1',
+  name: 'Full Review Pipeline',
+  description: 'desc',
+  steps: [{ id: 'ts-1', templateId: 'builtin-code-reviewer', label: 'Code Review', mode: 'sequential' }],
+  projectPath: '/dev/project',
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+const api = () => (window as any).electronAPI.team
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const match = Array.from(container.querySelectorAll('button')).find(
+    b => (b.textContent ?? '').trim() === text,
+  )
+  if (!match) throw new Error(`no button labelled "${text}"`)
+  return match as HTMLButtonElement
+}
+
+describe('TeamBuilder save failure (#371 BLOCKER-1)', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let onClose: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    onClose = vi.fn()
+    useTeamStore.setState({
+      teams: [],
+      runs: [],
+      selectedTeamId: null,
+      selectedRunId: null,
+      showBuilder: true,
+      editingTeam: EDITING,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  async function clickSave() {
+    await act(async () => {
+      root.render(React.createElement(TeamBuilder, { onClose }))
+    })
+    await act(async () => {
+      buttonByText(container, 'Save Changes').click()
+    })
+  }
+
+  it('does NOT close the dialog when the write is refused', async () => {
+    api().save.mockResolvedValueOnce({ ok: false, error: 'Your team library could not be written to disk.' })
+
+    await clickSave()
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('shows the failure message from main inside the dialog', async () => {
+    api().save.mockResolvedValueOnce({ ok: false, error: 'Your team library could not be written to disk.' })
+
+    await clickSave()
+
+    expect(container.textContent).toContain('Your team library could not be written to disk.')
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+  })
+
+  it('leaves the pipeline out of the store, and the editor still usable', async () => {
+    api().save.mockResolvedValueOnce({ ok: false, error: 'nope' })
+
+    await clickSave()
+
+    expect(useTeamStore.getState().teams).toHaveLength(0)
+    // Not stuck on "Saving..." — the user can correct and try again.
+    expect(buttonByText(container, 'Save Changes').disabled).toBe(false)
+  })
+
+  it('closes and shows no error when the write succeeds', async () => {
+    api().save.mockResolvedValueOnce({ ok: true, team: EDITING })
+
+    await clickSave()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(useTeamStore.getState().teams.map(t => t.id)).toEqual(['team-t1'])
+  })
+
+  it('retires the previous failure message once a retry succeeds', async () => {
+    api().save.mockResolvedValueOnce({ ok: false, error: 'transient disk error' })
+    await clickSave()
+    expect(container.textContent).toContain('transient disk error')
+
+    api().save.mockResolvedValueOnce({ ok: true, team: EDITING })
+    await act(async () => {
+      buttonByText(container, 'Save Changes').click()
+    })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(container.textContent).not.toContain('transient disk error')
+  })
+})

--- a/tests/unit/renderer/team-store-persist-failure.test.ts
+++ b/tests/unit/renderer/team-store-persist-failure.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #371 BLOCKER-1 — a refused/failed disk write must not be reported as success.
+ *
+ * `team:save` and `team:delete` used to answer the saved team / a bare boolean,
+ * and the store mutated regardless. A write the main process REFUSED (the teams
+ * file could not be read, so it was left alone) or that simply failed therefore
+ * showed as a saved pipeline that was gone on the next restart — or as a deleted
+ * one that came back. Main now answers `{ ok:false, error }` and rolls its own
+ * in-memory library back; the store must do the same and keep local state.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useTeamStore } from '../../../src/renderer/stores/teamStore'
+import type { TeamTemplate } from '../../../src/renderer/types/electron'
+
+function makeTeam(overrides: Partial<TeamTemplate> = {}): TeamTemplate {
+  return {
+    id: 'team-t1',
+    name: 'Test Pipeline',
+    description: 'Test description',
+    steps: [{ id: 'ts-1', templateId: 'builtin-code-reviewer', label: 'Code Review', mode: 'sequential' }],
+    projectPath: '/dev/project',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+const api = () => (window as any).electronAPI.team
+
+describe('teamStore persistence failures (#371 BLOCKER-1)', () => {
+  beforeEach(() => {
+    useTeamStore.setState({
+      teams: [],
+      runs: [],
+      selectedTeamId: null,
+      selectedRunId: null,
+      showBuilder: false,
+      editingTeam: null,
+      error: null,
+    })
+  })
+
+  describe('saveTeam', () => {
+    it('leaves the team OUT of the store when the write is refused', async () => {
+      api().save.mockResolvedValueOnce({ ok: false, error: 'teams file unreadable' })
+      const result = await useTeamStore.getState().saveTeam(makeTeam({ id: 'team-new' }))
+
+      expect(result.ok).toBe(false)
+      // The pipeline is NOT on disk, so it must not be on screen either.
+      expect(useTeamStore.getState().teams).toHaveLength(0)
+    })
+
+    it('sets the store error to what main reported', async () => {
+      api().save.mockResolvedValueOnce({ ok: false, error: 'teams file unreadable' })
+      const result = await useTeamStore.getState().saveTeam(makeTeam())
+
+      expect(result.error).toBe('teams file unreadable')
+      expect(useTeamStore.getState().error).toBe('teams file unreadable')
+    })
+
+    it('falls back to a plain-English error when main sends none', async () => {
+      api().save.mockResolvedValueOnce({ ok: false })
+      const result = await useTeamStore.getState().saveTeam(makeTeam())
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeTruthy()
+      expect(useTeamStore.getState().error).toBeTruthy()
+    })
+
+    it('leaves an EXISTING team at its old value when the update is refused', async () => {
+      useTeamStore.setState({ teams: [makeTeam({ id: 'team-t1', name: 'Old name' })] })
+      api().save.mockResolvedValueOnce({ ok: false, error: 'disk full' })
+
+      await useTeamStore.getState().saveTeam(makeTeam({ id: 'team-t1', name: 'New name' }))
+
+      expect(useTeamStore.getState().teams).toHaveLength(1)
+      expect(useTeamStore.getState().teams[0].name).toBe('Old name')
+    })
+
+    it('keeps the builder OPEN on failure so the work is not discarded', async () => {
+      useTeamStore.setState({ showBuilder: true, editingTeam: makeTeam() })
+      api().save.mockResolvedValueOnce({ ok: false, error: 'nope' })
+
+      await useTeamStore.getState().saveTeam(makeTeam())
+
+      expect(useTeamStore.getState().showBuilder).toBe(true)
+      expect(useTeamStore.getState().editingTeam).not.toBeNull()
+    })
+
+    it('commits the team main returned and clears the error on success', async () => {
+      useTeamStore.setState({ error: 'stale failure from a previous attempt' })
+      api().save.mockResolvedValueOnce({ ok: true, team: makeTeam({ id: 'team-saved', name: 'Persisted' }) })
+
+      const result = await useTeamStore.getState().saveTeam(makeTeam({ id: 'team-saved' }))
+
+      expect(result.ok).toBe(true)
+      expect(useTeamStore.getState().teams.map(t => t.id)).toEqual(['team-saved'])
+      expect(useTeamStore.getState().teams[0].name).toBe('Persisted')
+      expect(useTeamStore.getState().error).toBeNull()
+      expect(useTeamStore.getState().showBuilder).toBe(false)
+    })
+  })
+
+  describe('deleteTeam', () => {
+    it('leaves the row IN the store when the delete is refused', async () => {
+      useTeamStore.setState({ teams: [makeTeam({ id: 't1' }), makeTeam({ id: 't2' })] })
+      api().delete.mockResolvedValueOnce({ ok: false, error: 'teams file unreadable' })
+
+      const result = await useTeamStore.getState().deleteTeam('t1')
+
+      expect(result.ok).toBe(false)
+      expect(useTeamStore.getState().teams.map(t => t.id)).toEqual(['t1', 't2'])
+      expect(useTeamStore.getState().error).toBe('teams file unreadable')
+    })
+
+    it('keeps the selection on a refused delete', async () => {
+      useTeamStore.setState({ teams: [makeTeam({ id: 't1' })], selectedTeamId: 't1' })
+      api().delete.mockResolvedValueOnce({ ok: false, error: 'nope' })
+
+      await useTeamStore.getState().deleteTeam('t1')
+
+      expect(useTeamStore.getState().selectedTeamId).toBe('t1')
+    })
+
+    it('removes the row and clears the error on success', async () => {
+      useTeamStore.setState({
+        teams: [makeTeam({ id: 't1' }), makeTeam({ id: 't2' })],
+        selectedTeamId: 't1',
+        error: 'stale failure from a previous attempt',
+      })
+      api().delete.mockResolvedValueOnce({ ok: true, deleted: true })
+
+      const result = await useTeamStore.getState().deleteTeam('t1')
+
+      expect(result.ok).toBe(true)
+      expect(useTeamStore.getState().teams.map(t => t.id)).toEqual(['t2'])
+      expect(useTeamStore.getState().selectedTeamId).toBeNull()
+      expect(useTeamStore.getState().error).toBeNull()
+    })
+  })
+
+  describe('clearError', () => {
+    it('retires a failure message the user has read', async () => {
+      api().save.mockResolvedValueOnce({ ok: false, error: 'boom' })
+      await useTeamStore.getState().saveTeam(makeTeam())
+      expect(useTeamStore.getState().error).toBe('boom')
+
+      useTeamStore.getState().clearError()
+
+      expect(useTeamStore.getState().error).toBeNull()
+    })
+  })
+})

--- a/tests/unit/renderer/teams-panel-delete-failure.test.tsx
+++ b/tests/unit/renderer/teams-panel-delete-failure.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+/**
+ * #371 BLOCKER-1 (renderer surface) — a refused `team:delete` now leaves the
+ * pipeline row on screen, which on its own is indistinguishable from a click
+ * that missed. TeamsPanel must say what happened.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { useTeamStore } from '../../../src/renderer/stores/teamStore'
+import type { TeamTemplate } from '../../../src/renderer/types/electron'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/stores/agentLibraryStore', () => ({
+  BUILTIN_TEMPLATES: [],
+  useAgentLibraryStore: (selector: (s: any) => unknown) =>
+    selector({ getAllTemplates: () => [] }),
+}))
+
+const { default: TeamsPanel } = await import('../../../src/renderer/components/TeamsPanel')
+
+const TEAM: TeamTemplate = {
+  id: 'team-t1',
+  name: 'Full Review Pipeline',
+  description: 'desc',
+  steps: [{ id: 'ts-1', templateId: 'builtin-code-reviewer', label: 'Code Review', mode: 'sequential' }],
+  projectPath: '/dev/project',
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+const api = () => (window as any).electronAPI.team
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const match = Array.from(container.querySelectorAll('button')).find(
+    b => (b.textContent ?? '').trim() === text,
+  )
+  if (!match) throw new Error(`no button labelled "${text}"`)
+  return match as HTMLButtonElement
+}
+
+describe('TeamsPanel delete failure (#371 BLOCKER-1)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    useTeamStore.setState({
+      teams: [TEAM],
+      runs: [],
+      selectedTeamId: 'team-t1',
+      selectedRunId: null,
+      showBuilder: false,
+      editingTeam: null,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  async function clickDelete() {
+    await act(async () => {
+      root.render(React.createElement(TeamsPanel))
+    })
+    await act(async () => {
+      buttonByText(container, 'Delete').click()
+    })
+  }
+
+  it('shows the failure message and keeps the row when the delete is refused', async () => {
+    api().delete.mockResolvedValueOnce({
+      ok: false,
+      error: 'Your team library could not be written to disk.',
+    })
+
+    await clickDelete()
+
+    expect(container.textContent).toContain('Your team library could not be written to disk.')
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+    expect(useTeamStore.getState().teams.map(t => t.id)).toEqual(['team-t1'])
+  })
+
+  it('shows nothing and drops the row when the delete succeeds', async () => {
+    api().delete.mockResolvedValueOnce({ ok: true, deleted: true })
+
+    await clickDelete()
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(useTeamStore.getState().teams).toHaveLength(0)
+  })
+})

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -88,7 +88,8 @@ const mockElectronAPI = {
       output: '',
     })),
     cancel: vi.fn(() => Promise.resolve(true)),
-    remove: vi.fn(() => Promise.resolve(true)),
+    // #371: remove/clearCompleted report the real disk outcome now.
+    remove: vi.fn(() => Promise.resolve({ ok: true, removed: true })),
     retry: vi.fn((id: string) => Promise.resolve({
       id: 'ca-retry123',
       name: 'Retried',
@@ -101,7 +102,7 @@ const mockElectronAPI = {
     })),
     list: vi.fn(() => Promise.resolve([])),
     getOutput: vi.fn(() => Promise.resolve('')),
-    clearCompleted: vi.fn(() => Promise.resolve(0)),
+    clearCompleted: vi.fn(() => Promise.resolve({ ok: true, removed: 0 })),
     onStatusChanged: vi.fn(() => () => {}),
     onOutputChunk: vi.fn(() => () => {}),
   },
@@ -116,8 +117,9 @@ const mockElectronAPI = {
   },
   team: {
     list: vi.fn(() => Promise.resolve([])),
-    save: vi.fn((team: any) => Promise.resolve({ ...team, id: team.id || 'team-mock123', updatedAt: Date.now() })),
-    delete: vi.fn(() => Promise.resolve(true)),
+    // #371: save/delete report the real disk outcome now.
+    save: vi.fn((team: any) => Promise.resolve({ ok: true, team: { ...team, id: team.id || 'team-mock123', updatedAt: Date.now() } })),
+    delete: vi.fn(() => Promise.resolve({ ok: true, deleted: true })),
     run: vi.fn((teamId: string) => Promise.resolve({
       id: 'tr-mock123',
       teamId,
@@ -144,6 +146,17 @@ const mockElectronAPI = {
     testConnection: vi.fn(() => Promise.resolve({ ok: true, message: 'connected' })),
   },
   dialog: { openFolder: vi.fn(() => Promise.resolve(null)) },
+  vision: {
+    start: vi.fn(() => Promise.resolve({ ok: true })),
+    stop: vi.fn(() => Promise.resolve({ ok: true })),
+    status: vi.fn(() => Promise.resolve({ running: false, connected: false, browser: '', mcpPort: 0 })),
+    launch: vi.fn(() => Promise.resolve({ ok: true })),
+    // #371: saveConfig takes the generation token getConfig handed out, and
+    // getConfig reports whether the read FAILED rather than answering a bare null.
+    saveConfig: vi.fn(() => Promise.resolve({ ok: true })),
+    getConfig: vi.fn(() => Promise.resolve({ config: null, generation: 1, readFailed: false })),
+    onStatusChanged: vi.fn(() => () => {}),
+  },
   memory: {
     scan: vi.fn(() => Promise.resolve({
       projects: [],

--- a/tests/unit/team-manager.test.ts
+++ b/tests/unit/team-manager.test.ts
@@ -3,8 +3,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 // Mock config-manager
 const mockReadConfig = vi.fn()
 const mockWriteConfig = vi.fn()
+/** #371: names the keys whose file EXISTS and cannot be read. The two files are
+ *  independent, so one failing must not latch the other. */
+const cfg = { readFails: new Set<string>() }
 vi.mock('../../src/main/config-manager', () => ({
   readConfig: (...args: any[]) => mockReadConfig(...args),
+  readConfigChecked: (key: string) => {
+    if (cfg.readFails.has(key)) return { value: null, outcome: 'failed' }
+    const v = mockReadConfig(key)
+    return v == null ? { value: null, outcome: 'absent' } : { value: v, outcome: 'ok' }
+  },
   writeConfig: (...args: any[]) => mockWriteConfig(...args),
 }))
 
@@ -29,6 +37,7 @@ import {
   runTeam,
   cancelRun,
   waitForBatch,
+  _resetTeamLatchesForTest,
 } from '../../src/main/team-manager'
 import type { TeamTemplate, TeamRun } from '../../src/shared/types'
 
@@ -70,6 +79,8 @@ describe('team-manager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    cfg.readFails.clear()
+    _resetTeamLatchesForTest()
     mockReadConfig.mockReturnValue(null)
     mockWindow = {
       isDestroyed: vi.fn(() => false),
@@ -381,6 +392,65 @@ describe('team-manager', () => {
       const run = oneStepRun('completed')
       await waitForBatch(run, ['ts-1'])
       expect(vi.getTimerCount()).toBe(0)
+    })
+  })
+
+  /**
+   * #371 — a failed read of agent-teams.json is not an empty team library.
+   *
+   * This is the highest-value one of the five: the library is user-authored
+   * work, and the very next `saveTeam()` used to write a ONE-element array over
+   * the whole thing.
+   */
+  describe('a read failure is not an absence', () => {
+    it('refuses to save the team library over a file it could not read', () => {
+      cfg.readFails.add('agentTeams')
+      initTeamManager(() => mockWindow)
+      expect(listTeams()).toHaveLength(0) // the empty library the failure produced
+
+      saveTeam(makeTeam({ id: 'team-new' }))
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+    })
+
+    it('refuses to delete through a library it could not read', () => {
+      cfg.readFails.add('agentTeams')
+      initTeamManager(() => mockWindow)
+      deleteTeam('team-test1')
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+    })
+
+    it('one file failing does not latch the other', () => {
+      cfg.readFails.add('agentTeams')
+      mockReadConfig.mockImplementation((key: string) =>
+        key === 'agentTeamRuns' ? [makeRun({ status: 'running' })] : null,
+      )
+      initTeamManager(() => mockWindow)
+
+      // The boot sweep marks the stuck run failed and persists it — runs read fine.
+      expect(mockWriteConfig).toHaveBeenCalledWith('agentTeamRuns', expect.any(Array))
+      // …while the unreadable team library is left alone.
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+    })
+
+    it('an ABSENT file still saves — a fresh install must be able to save its first team', () => {
+      initTeamManager(() => mockWindow)
+      saveTeam(makeTeam())
+      expect(mockWriteConfig).toHaveBeenCalledWith('agentTeams', expect.any(Array))
+    })
+
+    it('resumes saving once a load succeeds', () => {
+      cfg.readFails.add('agentTeams')
+      initTeamManager(() => mockWindow)
+      saveTeam(makeTeam({ id: 'team-lost' }))
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+
+      cfg.readFails.clear()
+      mockReadConfig.mockImplementation((key: string) => (key === 'agentTeams' ? [makeTeam()] : null))
+      initTeamManager(() => mockWindow)
+      expect(listTeams()).toHaveLength(1)
+
+      saveTeam(makeTeam({ id: 'team-new' }))
+      expect(mockWriteConfig).toHaveBeenCalledWith('agentTeams', expect.any(Array))
     })
   })
 })

--- a/tests/unit/team-manager.test.ts
+++ b/tests/unit/team-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock config-manager
 const mockReadConfig = vi.fn()
-const mockWriteConfig = vi.fn()
+const mockWriteConfig = vi.fn(() => true)
 /** #371: names the keys whose file EXISTS and cannot be read. The two files are
  *  independent, so one failing must not latch the other. */
 const cfg = { readFails: new Set<string>() }
@@ -172,7 +172,8 @@ describe('team-manager', () => {
     it('adds new team', () => {
       const team = makeTeam({ id: 'team-new' })
       const saved = saveTeam(team)
-      expect(saved.id).toBe('team-new')
+      expect(saved.ok).toBe(true)
+      expect(saved.team!.id).toBe('team-new')
       expect(listTeams()).toHaveLength(1)
       expect(mockWriteConfig).toHaveBeenCalledWith('agentTeams', expect.any(Array))
     })
@@ -180,20 +181,20 @@ describe('team-manager', () => {
     it('updates existing team', () => {
       saveTeam(makeTeam({ id: 'team-1', name: 'Original' }))
       const updated = saveTeam(makeTeam({ id: 'team-1', name: 'Updated' }))
-      expect(updated.name).toBe('Updated')
+      expect(updated.team!.name).toBe('Updated')
       expect(listTeams()).toHaveLength(1)
     })
 
     it('generates ID if missing', () => {
       const team = makeTeam({ id: '' })
       const saved = saveTeam(team)
-      expect(saved.id).toMatch(/^team-/)
+      expect(saved.team!.id).toMatch(/^team-/)
     })
 
     it('sets timestamps', () => {
       const before = Date.now()
       const saved = saveTeam(makeTeam({ id: 'team-ts', createdAt: 0, updatedAt: 0 }))
-      expect(saved.updatedAt).toBeGreaterThanOrEqual(before)
+      expect(saved.team!.updatedAt).toBeGreaterThanOrEqual(before)
     })
   })
 
@@ -201,13 +202,13 @@ describe('team-manager', () => {
     it('removes team from list', () => {
       saveTeam(makeTeam({ id: 'team-a' }))
       saveTeam(makeTeam({ id: 'team-b' }))
-      expect(deleteTeam('team-a')).toBe(true)
+      expect(deleteTeam('team-a')).toEqual({ ok: true, deleted: true })
       expect(listTeams()).toHaveLength(1)
       expect(listTeams()[0].id).toBe('team-b')
     })
 
     it('returns false for unknown id', () => {
-      expect(deleteTeam('nonexistent')).toBe(false)
+      expect(deleteTeam('nonexistent')).toEqual({ ok: true, deleted: false })
     })
 
     it('persists after deletion', () => {
@@ -403,20 +404,53 @@ describe('team-manager', () => {
    * the whole thing.
    */
   describe('a read failure is not an absence', () => {
-    it('refuses to save the team library over a file it could not read', () => {
+    it('refuses to save the team library over a file it could not read, and SAYS SO', () => {
       cfg.readFails.add('agentTeams')
       initTeamManager(() => mockWindow)
       expect(listTeams()).toHaveLength(0) // the empty library the failure produced
 
-      saveTeam(makeTeam({ id: 'team-new' }))
+      // Review BLOCKER-1: this used to return the team as though it had saved,
+      // so the editor closed and the work was gone on the next restart.
+      const res = saveTeam(makeTeam({ id: 'team-new' }))
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/could not be read/i)
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+      // …and the in-memory library is rolled back, so the screen keeps matching
+      // the disk rather than showing a team that does not exist.
+      expect(listTeams()).toHaveLength(0)
+    })
+
+    it('after a failed load there is nothing to delete, so a delete never reaches disk', () => {
+      // Stated as it actually is rather than as a latch assertion: a failed
+      // load leaves the library EMPTY, so `deleteTeam` finds nothing and
+      // returns before it would ever persist. The refusal path is unreachable
+      // from here — the write-failure test below is the one that exercises the
+      // reporting.
+      cfg.readFails.add('agentTeams')
+      mockReadConfig.mockImplementation(() => null)
+      initTeamManager(() => mockWindow)
+      expect(deleteTeam('team-test1')).toEqual({ ok: true, deleted: false })
       expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
     })
 
-    it('refuses to delete through a library it could not read', () => {
-      cfg.readFails.add('agentTeams')
+    it('a delete whose WRITE fails is reported, and the row stays', () => {
+      const a = makeTeam({ id: 'team-a' })
+      mockReadConfig.mockImplementation((key: string) => (key === 'agentTeams' ? [a] : null))
       initTeamManager(() => mockWindow)
-      deleteTeam('team-test1')
-      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+
+      mockWriteConfig.mockReturnValueOnce(false)
+      const res = deleteTeam('team-a')
+      expect(res.ok).toBe(false)
+      expect(res.error).toBeTruthy()
+      // Rolled back: the UI must not show the row gone when disk still has it.
+      expect(listTeams().map((t) => t.id)).toEqual(['team-a'])
+    })
+
+    it('a save whose WRITE fails is reported, and the team is not added', () => {
+      initTeamManager(() => mockWindow)
+      mockWriteConfig.mockReturnValueOnce(false)
+      expect(saveTeam(makeTeam({ id: 'team-x' })).ok).toBe(false)
+      expect(listTeams()).toHaveLength(0)
     })
 
     it('one file failing does not latch the other', () => {
@@ -438,19 +472,40 @@ describe('team-manager', () => {
       expect(mockWriteConfig).toHaveBeenCalledWith('agentTeams', expect.any(Array))
     })
 
-    it('resumes saving once a load succeeds', () => {
+    /**
+     * Review MAJOR-1. `initTeamManager` runs ONCE, at boot, so the first cut's
+     * "a later successful load clears the latch" had no production path: one
+     * transient lock at startup disabled team persistence for the whole
+     * process. The old test proved recovery by calling `initTeamManager` a
+     * second time — a seam the app never reaches.
+     *
+     * This drives the real one: init once, the lock lifts, and the NEXT SAVE
+     * recovers by itself.
+     */
+    it('recovers on the next save, with no second load — the production path', () => {
+      const existing = makeTeam({ id: 'team-existing', name: 'Built last week' })
+      mockReadConfig.mockImplementation((key: string) => (key === 'agentTeams' ? [existing] : null))
       cfg.readFails.add('agentTeams')
       initTeamManager(() => mockWindow)
-      saveTeam(makeTeam({ id: 'team-lost' }))
-      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
+      expect(listTeams()).toHaveLength(0)
 
+      // The AV scanner lets go. Nothing re-initialises; the user just saves.
       cfg.readFails.clear()
-      mockReadConfig.mockImplementation((key: string) => (key === 'agentTeams' ? [makeTeam()] : null))
-      initTeamManager(() => mockWindow)
-      expect(listTeams()).toHaveLength(1)
+      const res = saveTeam(makeTeam({ id: 'team-new', name: 'Built now' }))
 
-      saveTeam(makeTeam({ id: 'team-new' }))
-      expect(mockWriteConfig).toHaveBeenCalledWith('agentTeams', expect.any(Array))
+      expect(res.ok).toBe(true)
+      // The library that was on disk is BACK, and the new team is with it —
+      // the whole point of folding the recovered file in before writing.
+      const written = mockWriteConfig.mock.calls.filter((c: any[]) => c[0] === 'agentTeams').at(-1)![1] as any[]
+      expect(written.map((t) => t.id).sort()).toEqual(['team-existing', 'team-new'])
+      expect(listTeams().map((t) => t.id).sort()).toEqual(['team-existing', 'team-new'])
+    })
+
+    it('keeps refusing while the file is STILL unreadable', () => {
+      cfg.readFails.add('agentTeams')
+      initTeamManager(() => mockWindow)
+      for (let i = 0; i < 3; i++) expect(saveTeam(makeTeam({ id: `t-${i}` })).ok).toBe(false)
+      expect(mockWriteConfig).not.toHaveBeenCalledWith('agentTeams', expect.anything())
     })
   })
 })

--- a/tests/unit/usage-snapshots.test.ts
+++ b/tests/unit/usage-snapshots.test.ts
@@ -16,11 +16,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const store: Record<string, unknown> = {}
 let readThrows = false
 let writeThrows = false
+/** #371: the file is THERE and cannot be read — distinct from "not there". */
+let readFails = false
 
 vi.mock('../../src/main/config-manager', () => ({
   readConfig: (key: string) => {
     if (readThrows) throw new Error('unreadable')
     return store[key] ?? null
+  },
+  readConfigChecked: (key: string) => {
+    if (readThrows) throw new Error('unreadable')
+    if (readFails) return { value: null, outcome: 'failed' }
+    return key in store ? { value: store[key], outcome: 'ok' } : { value: null, outcome: 'absent' }
   },
   writeConfig: (key: string, data: unknown) => {
     if (writeThrows) throw new Error('read-only volume')
@@ -29,7 +36,7 @@ vi.mock('../../src/main/config-manager', () => ({
   },
 }))
 
-const { parseSnapshots, loadSnapshots, saveSnapshots } = await import('../../src/main/usage/usage-snapshots')
+const { parseSnapshots, loadSnapshots, saveSnapshots, _resetSnapshotsLatchForTest } = await import('../../src/main/usage/usage-snapshots')
 import type { UsageSnapshot } from '../../src/main/usage/usage-snapshots'
 
 const bucket = (over: Record<string, unknown> = {}) => ({
@@ -44,6 +51,49 @@ beforeEach(() => {
   for (const k of Object.keys(store)) delete store[k]
   readThrows = false
   writeThrows = false
+  readFails = false
+  _resetSnapshotsLatchForTest()
+})
+
+/**
+ * #371 — an unreadable file is NOT "no snapshots".
+ *
+ * The old comment on `loadSnapshots` said it was, and every caller rebuilds the
+ * whole map and saves it back, so one EBUSY read at the wrong moment dropped
+ * every OTHER profile's snapshot too.
+ */
+describe('a read failure is not an absence', () => {
+  it('refuses to save over a file it could not read', () => {
+    store.usageSnapshots = { p1: good(), p2: good({ fetchedAt: 2_000 }) }
+    readFails = true
+
+    // The caller sees an empty map and does the ordinary thing with it.
+    expect(loadSnapshots().size).toBe(0)
+    expect(saveSnapshots(new Map())).toBe(false)
+
+    // Both profiles are still on disk.
+    readFails = false
+    const back = loadSnapshots()
+    expect(back.size).toBe(2)
+    expect(back.get('p2')!.fetchedAt).toBe(2_000)
+  })
+
+  it('resumes saving once a load succeeds', () => {
+    store.usageSnapshots = { p1: good() }
+    readFails = true
+    loadSnapshots()
+    expect(saveSnapshots(new Map())).toBe(false)
+
+    readFails = false
+    expect(loadSnapshots().size).toBe(1)
+    expect(saveSnapshots(new Map([['p9', good({ fetchedAt: 9_000 }) as UsageSnapshot]]))).toBe(true)
+    expect(loadSnapshots().get('p9')!.fetchedAt).toBe(9_000)
+  })
+
+  it('an ABSENT file still saves — a fresh install must be able to write its first snapshot', () => {
+    expect(loadSnapshots().size).toBe(0)
+    expect(saveSnapshots(new Map([['p1', good() as UsageSnapshot]]))).toBe(true)
+  })
 })
 
 describe('parseSnapshots -- what it accepts', () => {


### PR DESCRIPTION
Closes the first checklist item on #371:

> - [ ] main-side null-vs-failed persisters (cloud agents, teams/runs, usage snapshots, vision config, window-state) — one shared pattern

## The shape

A failed READ is not an absence. A file can be there and unreadable for a moment — an AV scanner holding a just-written file (EBUSY), a permissions hiccup, a network share that blinked — and each of these loaders answered `null` for that exactly as for "no file". The caller then did the ordinary thing with the empty store it was handed and wrote it back over the file it had never read. Nothing failed loudly.

`session-state.ts` fixed this for saved sessions in #353; that pass explicitly asked for **one shared fix later, not five copies**.

## How each one reached the write

| Persister | The write that lost it |
| --- | --- |
| `cloud-agent-manager.ts` | dispatching an agent persisted a one-element array over the history |
| `team-manager.ts` (teams + runs) | the next `saveTeam()` wrote one team over the whole library |
| `usage/usage-snapshots.ts` | callers rebuild the whole map and save it back, so one bad read dropped every OTHER profile's snapshot |
| `ipc/vision-handlers.ts` | `getConfig` → null → form rendered defaults → user touched one control → `saveConfig` wrote defaults over the real config |
| `index.ts` window geometry | a bare `catch { /* ignore */ }` returned the hardcoded default, and the close handler wrote it back over the real geometry |

Vision was doubly quiet: it discarded `writeConfig`'s boolean and returned `{ ok: true }` unconditionally, so a failed save was reported as a successful one. Window state was the only one bypassing `config-manager`, so it never had the atomic write either.

## The pattern

`src/main/persist-latch.ts` — one latch, applied five times:

- `config-manager.readConfigChecked()` answers with an **outcome**: **absent** (an empty store is the truth), **unparseable** (moved aside to `<name>.corrupt-<ts>`, never silently destroyed; writes stay allowed because nothing is left to protect), **failed** (could not read).
- `createReadFailureLatch(name)` remembers the last outcome; while it was `failed`, saving is refused, and a later successful load clears it.

The signal rides on the latch, never on the return value, so callers keep their shape and only consult it before they WRITE. The asymmetry is what makes it safe everywhere: a refused write costs one unsaved change; an un-refused one costs the file.

Two files means two latches in `team-manager` — one file's read failure says nothing about the other's.

## Deliberately not changed

The renderer bulk load (`loadAllConfig` → `readConfigDetailed`) keeps its own #353 / GHSA-m8p2 contract: exists-but-unreadable **or** unparseable latches renderer writes, and nothing is quarantined. It now delegates to the same reader with `quarantineUnparseable: false`, so there is one implementation and no behaviour change.

Window geometry moved to `src/main/window-state.ts` (it is a persister like the others and needed a unit test) and onto the shared `windowState` key — which resolves to exactly the path it used to build by hand, so **upgrading installs keep their geometry with no migration**.

## Verification

- `npm run typecheck` clean.
- Full `npx vitest run`: **7111 passed, 15 skipped, 2 todo** (663 files, 2 skipped).
- Every latch mutation-tested: `refuses()` forced to return false, suites watched go red (10 tests across four files), guard restored byte-for-byte.
- That mutation caught a test that could not fail — the first cut of the cloud-agent case asserted "nothing was written" after a failed load, which is true whatever the latch does (an empty list gives the boot sweep nothing to change, so `persist()` is never reached). Dispatching is the only persist path reachable while latched, so that is what it drives now; the unreachable case is kept beside it, labelled as not a latch assertion.

Trust boundary touched: main-process config persistence (disk ↔ main). No IPC surface added; `vision:saveConfig` now returns an honest `{ ok: false, error }` where it previously always claimed success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)