### PR TITLE
fix(browser): wipe a session's webview profile when the session is closed

### DIFF
--- a/CONTEXT.d/2026-08-22-webview-profiles-die-with-the-session.md
+++ b/CONTEXT.d/2026-08-22-webview-profiles-die-with-the-session.md
@@ -1,0 +1,93 @@
+# 2026-08-22 — a closed session's browser profile does not outlive it
+
+Second of the #371 follow-ups from the ADR-009 pass before beta.16.
+
+## What was left on disk
+
+Every browser pane runs in its own Electron partition, `persist:webview-<sessionId>`,
+which Chromium turns into a profile directory under
+`sessionData/Partitions/webview-<id>` holding that pane's cookies, localStorage,
+IndexedDB, service workers and HTTP cache. That per-session isolation is the point
+(#348) — what was missing is the other end of the lifecycle.
+
+Nothing ever removed one. Session ids are minted per tile and never reused, so a closed
+tile's profile stayed on disk for the life of the install: logged-in cookies for whatever
+had been browsed in that pane, unreachable through the app (no tile owns that id any
+more), invisible in it, and growing by one directory per closed tab. `clearStorageData`
+appears in this repo only on the account-web partitions; the pane path never called it.
+
+The renderer half leaked too: `webviewStore.reset(sessionId)`, commented *"Wipe state for
+a session — e.g. on session removal"*, had **no callers at all**.
+
+## The distinction that shaped the fix
+
+Closing a session and deleting one are the same act here — there is no separate delete
+path, and the tile is gone from the saved-tile file either way. So the wipe belongs on
+close.
+
+But it must NOT be wired into `sessionStore.removeSession`, which looks like the obvious
+place: the Restart button, an in-tile account switch (`useSwitchAccount` → `restart`) and
+`askConductor`'s re-use all call `removeSession` followed by `addSession` with **the same
+id**. Wiping there would sign the user out of every site in the pane on every restart —
+a new bug wearing the fix's clothes.
+
+The wipe therefore hangs off the deliberate-close funnels: `requestCloseSession`,
+`endRemoteAndClose`, `leaveRunningAndClose`, the six sidebar bulk-close loops, and the
+launch-gate cancel. A unit test drives `removeSession` + `addSession` directly and
+asserts nothing is wiped, so pointing the call at the store action turns it red.
+
+## Shape
+
+- `forgetWebviewProfile(sessionId)` in `webview-manager.ts` — same path-safety gate as
+  `openWebview` (the id names an on-disk partition), destroys the live view FIRST so the
+  wipe cannot race a WebContents still writing to the jar, then `clearStorageData()` and
+  `clearCache()`. Clearing storage without the cache would leave page content behind.
+- Both calls are timeout-wrapped at 5 s and the whole thing is best-effort: the
+  account-web sign-out already learned that a `clearStorageData()` which never settles
+  leaves the caller stuck forever, and a tab close must never be blocked by a profile
+  that will not clear.
+- New channel `webview:forget`, distinct from `webview:close` (which only destroys the
+  view — a hidden tab, a restart and an account switch all use that and keep their
+  cookies).
+
+## Verification
+
+Mutation-tested both halves: the path-safety gate forced open (1 test red) and the
+renderer wipe made a no-op (3 tests red), each restored byte-for-byte. Coverage includes
+a wipe that rejects, one that never settles (fake timers, must give up rather than hang),
+a sibling session's partition left untouched, and a session whose pane was never opened
+this run — the profile from a previous run still has to go.
+
+Full suite on the branch: 7088 passed, 15 skipped, 2 todo (663 files); typecheck clean.
+
+## Scope: what ships, and what is deferred
+
+**Ships:** `forgetWebviewProfile` on the deliberate-close funnels. That is exactly #371
+item 2 — *"per-session `persist:webview-<id>` browser profiles cleared on session
+delete"* — and it is safe because it acts on ONE id the user just closed. No inference.
+
+**Deferred:** reclaiming profiles orphaned BEFORE this change. A startup sweep for those
+was built and then removed, after three separate data-loss findings in review:
+
+1. it deleted on a partial/empty live set (fixed by failing closed on the oracle);
+2. the resources directory could be repointed, so one root's session list judged another
+   root's partitions (a marker was added);
+3. the marker was re-recorded on mismatch, which only deferred the wipe one launch (the
+   marker was made write-once) — and then the MIRROR direction was still open: running
+   under the original root A after browsing under B deletes B's jars, because they are
+   absent from A's session list.
+
+The pattern is the point. A sweep decides "orphan" by ABSENCE from one root's session
+list, and absence is not evidence when the list and the partitions can come from
+different roots. Each fix closed the reported case and left an adjacent one, because the
+inference itself is unsound — not because the guards were sloppy.
+
+Making it safe needs **per-partition provenance**: each `webview-<id>` directory
+recording which config root minted it, so orphanhood is judged against the root that
+owns it rather than whichever one happens to be configured now. That is a real change to
+how partitions are created, and it belongs in its own issue rather than bolted onto this
+one. Filed as #415.
+
+Until then a pre-existing orphaned profile stays on disk. That is a known, bounded leak
+of the user's own data on their own machine — strictly better than a mechanism that has
+signed people out of every browser pane three different ways.

--- a/src/main/ipc/webview-handlers.ts
+++ b/src/main/ipc/webview-handlers.ts
@@ -6,6 +6,7 @@ import {
   checkUrl,
   openWebview,
   closeWebview,
+  forgetWebviewProfile,
   closeAllWebviews,
   setWebviewBounds,
   setWebviewVisible,
@@ -93,6 +94,15 @@ export function registerWebviewHandlers(getWindow: () => BrowserWindow | null): 
   ipcMain.handle(IPC.WEBVIEW_CLOSE, async (_event, sessionId: string) => {
     sessionIdSchema.parse(sessionId)
     return closeWebview(sessionId)
+  })
+
+  // The session is gone for good, so its browser profile goes with it (#371).
+  // Deliberately distinct from WEBVIEW_CLOSE, which only destroys the view: a
+  // hidden tab, a restart and an in-tile account switch all close the view and
+  // must KEEP the cookies — they come back under the same session id.
+  ipcMain.handle(IPC.WEBVIEW_FORGET, async (_event, sessionId: string) => {
+    sessionIdSchema.parse(sessionId)
+    return forgetWebviewProfile(sessionId)
   })
 
   ipcMain.handle(IPC.WEBVIEW_SET_BOUNDS, async (_event, sessionId: string, bounds: unknown) => {

--- a/src/main/webview-manager.ts
+++ b/src/main/webview-manager.ts
@@ -1,4 +1,6 @@
-import { BrowserWindow, WebContentsView, net, session } from 'electron'
+import { app, BrowserWindow, WebContentsView, net, session } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
 import type { Session as ElectronSession } from 'electron'
 import { logInfo, logError } from './debug-logger'
 import { IPC } from '../shared/ipc-channels'
@@ -303,6 +305,128 @@ export function closeWebview(sessionId: string): boolean {
   views.delete(sessionId)
   return true
 }
+
+/** A partition wipe must not be able to hang the close path (#371). The
+ *  account-web sign-out learned this the hard way — a `clearStorageData()` that
+ *  never settles left sign-out stuck forever. */
+const CLEAR_TIMEOUT_MS = 5_000
+
+/** Cancellable race, so a fast clear does not leave a 5 s timer holding a
+ *  reject closure. "Close all" across 50 tiles scheduled 100 of them. */
+function withClearTimeout<T>(p: Promise<T>, what: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined
+  const guard = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} timed out`)), CLEAR_TIMEOUT_MS)
+  })
+  return Promise.race([p, guard]).finally(() => { if (timer) clearTimeout(timer) }) as Promise<T>
+}
+
+/** The on-disk directory name Chromium gives `persist:webview-<id>`. Our ids
+ *  are `[A-Za-z0-9_-]` so nothing is percent-encoded. */
+const WEBVIEW_PARTITION_PREFIX = 'webview-'
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
+
+/**
+ * Empty a session's browser profile, and remove its directory.
+ *
+ * Each pane gets `persist:webview-<sessionId>`, which Chromium turns into a
+ * profile directory under `sessionData/Partitions/webview-<id>` holding that
+ * pane's cookies, localStorage and cache. Nothing ever removed one: a session
+ * id is minted per tile and never reused, so every closed tile left a fully
+ * populated profile on disk for the life of the install — logged-in cookies for
+ * whatever the user browsed, unreachable through the app and invisible in it.
+ *
+ * `clearStorageData()` EMPTIES the stores; Chromium leaves the directory in
+ * place with its scaffolding, so the directory is removed afterwards too (#371
+ * review MINOR-2 — the doc used to say "delete" while the code only emptied,
+ * and an auditor looking at `Partitions/` would have concluded the fix never
+ * ran). The clear still comes first: it is what releases the open handles, and
+ * it is the part that must succeed.
+ *
+ * Called when a session is CLOSED BY THE USER, which in this app is the same
+ * act as deleting it: the tile is gone from the saved-tile file and its id
+ * never comes back. It is deliberately NOT wired to the store's
+ * `removeSession`, which a restart and an in-tile account switch also call —
+ * those re-add the SAME id and must keep their cookies (a restart that signed
+ * you out of every site in the pane would be its own bug).
+ */
+export async function forgetWebviewProfile(sessionId: string): Promise<boolean> {
+  // Same gate as `openWebview`: this id names an on-disk partition.
+  if (!SESSION_ID_RE.test(sessionId)) {
+    logError(`[webview] refused profile wipe: session id is not path-safe`)
+    return false
+  }
+  const entry = views.get(sessionId)
+  // Do not MATERIALISE a partition just to clear it (#371 review MINOR-5).
+  // `session.fromPartition` creates a persist-backed session, so calling this
+  // for a tile that never opened a pane — the launch-gate cancel does exactly
+  // that — could leave behind the very empty profile directory the sweep is
+  // here to remove. Nothing open and nothing on disk means nothing to do.
+  if (!entry && !partitionDirExists(sessionId)) return true
+
+  // Destroy the view first: clearing a partition a live WebContents is still
+  // writing to races the wipe and can leave the cookie jar behind. `close()`
+  // only INITIATES that, so wait for the WebContents to actually go — the
+  // previous cut asserted call order, which cannot detect the race it names
+  // (#371 review MINOR-3).
+  const wc = entry?.view.webContents
+  closeWebview(sessionId)
+  if (wc && !wc.isDestroyed?.()) {
+    try {
+      await withClearTimeout(
+        new Promise<void>((resolve) => {
+          if (wc.isDestroyed?.()) return resolve()
+          wc.once('destroyed', () => resolve())
+        }),
+        'webContents destroy',
+      )
+    } catch {
+      // It did not confirm in time; clear anyway rather than leaving the jar.
+      logError(`[webview] view for ${sessionId} did not confirm destruction; clearing regardless`)
+    }
+  }
+  const partition = `persist:webview-${sessionId}`
+  try {
+    const ses = session.fromPartition(partition)
+    // Storage first (cookies, localStorage, IndexedDB, service workers), then
+    // the HTTP cache — a wipe that left the cache holds page content.
+    await withClearTimeout(Promise.resolve(ses.clearStorageData()), 'clearStorageData')
+    await withClearTimeout(Promise.resolve(ses.clearCache()), 'clearCache')
+    removePartitionDir(sessionId)
+    logInfo(`[webview] cleared browser profile for closed session ${sessionId}`)
+    return true
+  } catch (err) {
+    // Best effort: a session that will not clear must not block the tab close.
+    logError(`[webview] could not clear profile for ${sessionId}: ${(err as Error)?.message ?? err}`)
+    return false
+  }
+}
+
+/** Where Chromium keeps the `persist:` partition directories. */
+function partitionsRoot(): string {
+  return path.join(app.getPath('sessionData'), 'Partitions')
+}
+
+
+/** True when this session has a profile directory on disk. */
+function partitionDirExists(sessionId: string): boolean {
+  try {
+    return fs.existsSync(path.join(partitionsRoot(), `${WEBVIEW_PARTITION_PREFIX}${sessionId}`))
+  } catch {
+    return false
+  }
+}
+
+/** Remove one partition directory. Best-effort: Chromium may still hold a
+ *  handle, and an emptied-but-present directory is not a leak. */
+function removePartitionDir(sessionId: string): void {
+  try {
+    fs.rmSync(path.join(partitionsRoot(), `${WEBVIEW_PARTITION_PREFIX}${sessionId}`), { recursive: true, force: true })
+  } catch {
+    /* the clear is what matters; the directory is scaffolding */
+  }
+}
+
 
 export function setWebviewBounds(sessionId: string, bounds: WebviewBounds): void {
   const entry = views.get(sessionId)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -321,6 +321,8 @@ export interface ElectronAPI {
     open: (sessionId: string, url: string, bounds: { x: number; y: number; width: number; height: number }) => Promise<boolean>
     /** Detach + destroy the session's view. */
     close: (sessionId: string) => Promise<boolean>
+    /** Session closed for good: destroy the view AND wipe its browser profile. */
+    forget: (sessionId: string) => Promise<boolean>
     /** Re-position on resize/scroll. */
     setBounds: (sessionId: string, bounds: { x: number; y: number; width: number; height: number }) => Promise<void>
     /** Attach/detach without destroying — used to hide on session switch. */
@@ -931,6 +933,8 @@ const electronAPI: ElectronAPI = {
     check: (url: string) => ipcRenderer.invoke(IPC.WEBVIEW_CHECK, url),
     open: (sessionId: string, url: string, bounds: { x: number; y: number; width: number; height: number }) => ipcRenderer.invoke(IPC.WEBVIEW_OPEN, sessionId, url, bounds),
     close: (sessionId: string) => ipcRenderer.invoke(IPC.WEBVIEW_CLOSE, sessionId),
+    /** Session closed for good: destroy the view AND wipe its browser profile. */
+    forget: (sessionId: string) => ipcRenderer.invoke(IPC.WEBVIEW_FORGET, sessionId),
     setBounds: (sessionId: string, bounds: { x: number; y: number; width: number; height: number }) => ipcRenderer.invoke(IPC.WEBVIEW_SET_BOUNDS, sessionId, bounds),
     setVisible: (sessionId: string, visible: boolean) => ipcRenderer.invoke(IPC.WEBVIEW_SET_VISIBLE, sessionId, visible),
     reload: (sessionId: string) => ipcRenderer.invoke(IPC.WEBVIEW_RELOAD, sessionId),

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -11,7 +11,7 @@ import { useConductorMcpStore } from '../stores/conductorMcpStore'
 import { useAccountAuthStore } from '../stores/accountAuthStore'
 import SessionDialog from './SessionDialog'
 import { killSessionPty } from '../ptyTracker'
-import { requestCloseSession } from '../stores/sshCloseStore'
+import { requestCloseSession, forgetSessionBrowserProfile } from '../stores/sshCloseStore'
 import { ViewType } from '../types/views'
 import { trackUsage } from '../stores/tipsStore'
 import { generateId } from '../utils/id'
@@ -531,7 +531,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
     }
   }
   const handleBulkClose = () => {
-    selectedSessionIds.forEach(id => { killSessionPty(id); removeSession(id) })
+    selectedSessionIds.forEach(id => { killSessionPty(id); forgetSessionBrowserProfile(id); removeSession(id) })
     setSelectedSessionIds(new Set())
   }
 
@@ -1202,7 +1202,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
                   ...sectionGroups.flatMap((g) => g.sessions),
                   ...looseSessions
                 ]
-                allSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) })
+                allSessions.forEach((s) => { killSessionPty(s.id); forgetSessionBrowserProfile(s.id); removeSession(s.id) })
               }}
             />
             {!sessionSectionCollapsed[section.id] && (
@@ -1213,7 +1213,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
                       name={group.name}
                       collapsed={sessionGroupCollapsed[group.id]}
                       onToggleCollapse={() => setSessionGroupCollapsed((prev) => ({ ...prev, [group.id]: !prev[group.id] }))}
-                      onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
+                      onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); forgetSessionBrowserProfile(s.id); removeSession(s.id) }) }}
                     />
                     {!sessionGroupCollapsed[group.id] && (
                       <div className="space-y-0.5">
@@ -1230,7 +1230,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
                     <UngroupedSessionsHeader
                       collapsed={ungroupedSessionsCollapsed[section.id]}
                       onToggleCollapse={() => toggleUngroupedSessionsCollapsed(section.id)}
-                      onCloseAll={() => { looseSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
+                      onCloseAll={() => { looseSessions.forEach((s) => { killSessionPty(s.id); forgetSessionBrowserProfile(s.id); removeSession(s.id) }) }}
                     />
                     {!ungroupedSessionsCollapsed[section.id] && (
                       <div className="space-y-0.5">
@@ -1253,7 +1253,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
               name={group.name}
               collapsed={sessionGroupCollapsed[group.id]}
               onToggleCollapse={() => setSessionGroupCollapsed((prev) => ({ ...prev, [group.id]: !prev[group.id] }))}
-              onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
+              onCloseAll={() => { groupSessions.forEach((s) => { killSessionPty(s.id); forgetSessionBrowserProfile(s.id); removeSession(s.id) }) }}
             />
             {!sessionGroupCollapsed[group.id] && (
               <div className="space-y-0.5">
@@ -1274,7 +1274,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
             <UngroupedSessionsHeader
               collapsed={ungroupedSessionsCollapsed['']}
               onToggleCollapse={() => toggleUngroupedSessionsCollapsed('')}
-              onCloseAll={() => { unsectionedUngroupedSessions.forEach((s) => { killSessionPty(s.id); removeSession(s.id) }) }}
+              onCloseAll={() => { unsectionedUngroupedSessions.forEach((s) => { killSessionPty(s.id); forgetSessionBrowserProfile(s.id); removeSession(s.id) }) }}
             />
             {!ungroupedSessionsCollapsed[''] && (
               <div className="space-y-0.5">

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -20,6 +20,7 @@ import { useRestartSession } from '../hooks/useRestartSession'
 import { persistLastUsedAccount } from '../session-persistence'
 import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { useAccountGateStore, GATE_CANCELLED } from '../stores/accountGateStore'
+import { forgetSessionBrowserProfile } from '../stores/sshCloseStore'
 import { hasSpawned, markSpawned, clearSpawned, killSessionPty } from '../ptyTracker'
 import SshFlowOverlay from './SshFlowOverlay'
 import { shouldUseResumePicker } from '../utils/resumePicker'
@@ -782,7 +783,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               .then((chosen) => {
                 if (chosen === GATE_CANCELLED) {
                   // User aborted the launch: no PTY exists yet (the gate blocks
-                  // before doSpawn), so closing is just removing the tab.
+                  // before doSpawn), so closing is just removing the tab. The
+                  // tab is gone for good, so its browser profile goes with it —
+                  // a no-op for a session that never opened a pane (#371).
+                  forgetSessionBrowserProfile(sessionId)
                   useSessionStore.getState().removeSession(sessionId)
                   return
                 }

--- a/src/renderer/stores/sshCloseStore.ts
+++ b/src/renderer/stores/sshCloseStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { useSessionStore } from './sessionStore'
+import { useWebviewStore } from './webviewStore'
 import { killSessionPty } from '../ptyTracker'
 
 // SSH tmux enhancement (item 4): a one-slot store for the "you're closing a
@@ -32,6 +33,33 @@ export const useSshCloseStore = create<SshCloseState>((set) => ({
   clear: () => set({ pending: null }),
 }))
 
+/**
+ * Drop everything the browser pane kept for a session that is going away (#371).
+ *
+ * A pane runs in `persist:webview-<sessionId>`, which Chromium turns into a
+ * profile directory holding that pane's cookies, localStorage and cache.
+ * Session ids are minted per tile and never reused, so nothing ever came back
+ * for one: every closed tile left a populated profile on disk for the life of
+ * the install, with logged-in cookies for whatever had been browsed in it.
+ * (`webviewStore.reset` had no callers at all, so even the in-memory pane state
+ * leaked.)
+ *
+ * Call this ONLY where the user is closing a session for good. It is
+ * deliberately NOT inside `sessionStore.removeSession`, which the Restart button
+ * and an in-tile account switch also call — those re-add the SAME id a moment
+ * later, and signing the user out of every site in the pane on a restart would
+ * be its own bug.
+ */
+export function forgetSessionBrowserProfile(sessionId: string): void {
+  useWebviewStore.getState().reset(sessionId)
+  // Fire and forget: a profile that will not clear must never block a tab close.
+  try {
+    void Promise.resolve(window.electronAPI?.webview?.forget?.(sessionId)).catch(() => {})
+  } catch {
+    /* preload not available (tests, early boot) — the tab still closes */
+  }
+}
+
 /** Close a session, first checking whether it is a persistent SSH session that
  *  warrants the End-vs-Leave-running choice. Non-persistent / non-SSH sessions
  *  close immediately (kill the local PTY + drop the tab). */
@@ -51,6 +79,7 @@ export function requestCloseSession(sessionId: string): void {
     return
   }
   killSessionPty(sessionId)
+  forgetSessionBrowserProfile(sessionId)
   store.removeSession(sessionId)
 }
 
@@ -64,6 +93,7 @@ export async function endRemoteAndClose(sessionId: string): Promise<void> {
     // local tab (the remote at worst detaches, exactly the pre-enhancement path).
   }
   killSessionPty(sessionId)
+  forgetSessionBrowserProfile(sessionId)
   useSessionStore.getState().removeSession(sessionId)
   useSshCloseStore.getState().clear()
 }
@@ -72,6 +102,7 @@ export async function endRemoteAndClose(sessionId: string): Promise<void> {
  *  reattach. Identical to a plain close (which, for a live SSH PTY, detaches). */
 export function leaveRunningAndClose(sessionId: string): void {
   killSessionPty(sessionId)
+  forgetSessionBrowserProfile(sessionId)
   useSessionStore.getState().removeSession(sessionId)
   useSshCloseStore.getState().clear()
 }

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -437,6 +437,8 @@ export interface ElectronAPI {
     check: (url: string) => Promise<{ reachable: boolean; status?: number }>
     open: (sessionId: string, url: string, bounds: { x: number; y: number; width: number; height: number }) => Promise<boolean>
     close: (sessionId: string) => Promise<boolean>
+    /** Session closed for good: destroy the view AND wipe its browser profile. */
+    forget: (sessionId: string) => Promise<boolean>
     setBounds: (sessionId: string, bounds: { x: number; y: number; width: number; height: number }) => Promise<void>
     setVisible: (sessionId: string, visible: boolean) => Promise<void>
     reload: (sessionId: string) => Promise<void>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -301,6 +301,7 @@ export const IPC = {
   WEBVIEW_CHECK: 'webview:check',                 // HEAD probe (CORS-bypass)
   WEBVIEW_OPEN: 'webview:open',                   // create+attach view at bounds
   WEBVIEW_CLOSE: 'webview:close',                 // detach+destroy view
+  WEBVIEW_FORGET: 'webview:forget',               // destroy view AND wipe its persist:webview-<id> profile (session closed for good)
   WEBVIEW_SET_BOUNDS: 'webview:setBounds',        // re-position on resize/scroll
   WEBVIEW_SET_VISIBLE: 'webview:setVisible',      // attach/detach without destroying
   WEBVIEW_RELOAD: 'webview:reload',               // force-reload bypassing cache

--- a/tests/unit/main/webview-profile-cleanup.test.ts
+++ b/tests/unit/main/webview-profile-cleanup.test.ts
@@ -1,0 +1,251 @@
+/**
+ * A closed session's browser profile does not outlive it (#371).
+ *
+ * Each pane runs in `persist:webview-<sessionId>`, which Chromium turns into a
+ * profile directory under `sessionData/Partitions/webview-<id>` holding that
+ * pane's cookies, localStorage and cache. Nothing ever removed one — session
+ * ids are minted per tile and never reused — so every closed tile left a fully
+ * populated profile on disk for the life of the install: logged-in cookies for
+ * whatever had been browsed, unreachable through the app and invisible in it.
+ *
+ * The distinction that matters most here is the one the tests end on: this is
+ * for a session closed FOR GOOD, and must not fire for the close-and-reopen
+ * that a restart or an in-tile account switch performs under the same id.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+type Handler = (...args: unknown[]) => unknown
+
+const h = vi.hoisted(() => {
+  class FakeWebContents {
+    handlers = new Map<string, Handler[]>()
+    onceHandlers = new Map<string, Handler[]>()
+    loadURL = vi.fn(() => Promise.resolve())
+    destroyed = false
+    /** Set false to model a WebContents that never confirms destruction. */
+    autoDestroy = true
+    /** Ticks when 'destroyed' actually fires, so a test can prove the clear
+     *  waited for it rather than merely being called after `close()`. */
+    destroyedAt = 0
+    close = vi.fn(() => {
+      // `close()` only INITIATES teardown; the event is what says it is gone.
+      if (!this.autoDestroy) return
+      setTimeout(() => {
+        this.destroyed = true
+        this.destroyedAt = FakeWebContents.clock++
+        for (const fn of this.onceHandlers.get('destroyed') ?? []) fn()
+        this.onceHandlers.delete('destroyed')
+      }, 5)
+    })
+    static clock = 1
+    isDestroyed = () => this.destroyed
+    getURL = () => 'https://example.com/'
+    getTitle = () => 'Example'
+    navigationHistory = { canGoBack: () => false, canGoForward: () => false }
+    on(event: string, fn: Handler) {
+      const list = this.handlers.get(event) ?? []
+      list.push(fn)
+      this.handlers.set(event, list)
+      return this
+    }
+    once(event: string, fn: Handler) {
+      const list = this.onceHandlers.get(event) ?? []
+      list.push(fn)
+      this.onceHandlers.set(event, list)
+      return this
+    }
+    setWindowOpenHandler() { /* not under test here */ }
+  }
+  class FakeView {
+    webContents = new FakeWebContents()
+    setBounds = vi.fn()
+    constructor(public opts: { webPreferences: Record<string, unknown> }) { state.views.push(this) }
+  }
+  class FakeSession {
+    clearedAt = 0
+    clearStorageData = vi.fn(() => {
+      this.clearedAt = FakeWebContents.clock++
+      return Promise.resolve()
+    })
+    clearCache = vi.fn(() => Promise.resolve())
+    setPermissionRequestHandler() {}
+    setPermissionCheckHandler() {}
+    setDevicePermissionHandler() {}
+    on() { return this }
+  }
+  const state = {
+    views: [] as InstanceType<typeof FakeView>[],
+    sessions: new Map<string, InstanceType<typeof FakeSession>>(),
+    sessionDataDir: '',
+    resourcesDir: '',
+    FakeView,
+    FakeSession,
+  }
+  return state
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: (_n: string) => h.sessionDataDir },
+  BrowserWindow: class {},
+  WebContentsView: h.FakeView,
+  net: { request: vi.fn() },
+  session: {
+    fromPartition: (name: string) => {
+      let s = h.sessions.get(name)
+      if (!s) { s = new h.FakeSession(); h.sessions.set(name, s) }
+      return s
+    },
+  },
+  shell: { openExternal: vi.fn() },
+}))
+vi.mock('../../../src/main/debug-logger', () => ({ logInfo: vi.fn(), logWarn: vi.fn(), logError: vi.fn() }))
+vi.mock('../../../src/main/ipc/setup-handlers', () => ({
+  getResourcesDirectory: () => h.resourcesDir,
+  registerSetupHandlers: () => {},
+}))
+
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { openWebview, forgetWebviewProfile } from '../../../src/main/webview-manager'
+
+/** The directory Chromium would have made for this session's partition. */
+const partitionDir = (id: string) => path.join(h.sessionDataDir, 'Partitions', `webview-${id}`)
+/** Pretend Chromium already created one, with something in it. */
+function seedPartition(name: string): string {
+  const dir = path.join(h.sessionDataDir, 'Partitions', name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'Cookies'), 'cookie-bytes')
+  return dir
+}
+
+const parent = () => ({
+  isDestroyed: () => false,
+  contentView: { addChildView: vi.fn(), removeChildView: vi.fn(), children: [] as unknown[] },
+  webContents: { send: vi.fn() },
+}) as unknown as import('electron').BrowserWindow
+
+const bounds = { x: 0, y: 0, width: 800, height: 600 }
+const partition = (id: string) => `persist:webview-${id}`
+
+beforeEach(() => {
+  h.views.length = 0
+  h.sessions.clear()
+  h.sessionDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-sessiondata-'))
+  h.resourcesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-resources-'))
+  fs.mkdirSync(path.join(h.sessionDataDir, 'Partitions'), { recursive: true })
+})
+
+afterEach(() => {
+  try { fs.rmSync(h.sessionDataDir, { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+async function open(id: string) {
+  expect(await openWebview(parent(), id, 'https://example.com/', bounds)).toBe(true)
+  return { view: h.views.at(-1)!, ses: h.sessions.get(partition(id))! }
+}
+
+describe('forgetWebviewProfile', () => {
+  it('wipes storage AND cache for the session partition', async () => {
+    const { ses } = await open('sess1')
+    expect(await forgetWebviewProfile('sess1')).toBe(true)
+    expect(ses.clearStorageData).toHaveBeenCalledTimes(1)
+    // A wipe that left the HTTP cache still holds page content.
+    expect(ses.clearCache).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * #371 review MINOR-3, now actually exercised: the first version asserted
+   * `invocationCallOrder`, i.e. that `close()` was CALLED first — which is true
+   * however long teardown takes, so it could not detect the race it was named
+   * for. The fake now fires 'destroyed' asynchronously, so the assertion is
+   * that the clear waited for the EVENT.
+   */
+  it('waits for the view to be destroyed before clearing, not merely for close() to return', async () => {
+    seedPartition('webview-sess1')
+    const { view, ses } = await open('sess1')
+    await forgetWebviewProfile('sess1')
+    expect(view.webContents.close).toHaveBeenCalled()
+    expect(view.webContents.destroyed).toBe(true)
+    expect(view.webContents.destroyedAt).toBeGreaterThan(0)
+    expect(ses.clearedAt).toBeGreaterThan(view.webContents.destroyedAt)
+  })
+
+  it('clears anyway when the view never confirms destruction', async () => {
+    seedPartition('webview-sess1')
+    const { view, ses } = await open('sess1')
+    view.webContents.autoDestroy = false // never fires 'destroyed'
+    expect(await forgetWebviewProfile('sess1')).toBe(true)
+    // The timeout elapses and the jar is still cleared — leaving it is worse.
+    expect(ses.clearStorageData).toHaveBeenCalled()
+  }, 20_000)
+
+  it('clears only that session, never a sibling still in use', async () => {
+    const a = await open('sessA')
+    const b = await open('sessB')
+    await forgetWebviewProfile('sessA')
+    expect(a.ses.clearStorageData).toHaveBeenCalled()
+    expect(b.ses.clearStorageData).not.toHaveBeenCalled()
+    expect(b.view.webContents.close).not.toHaveBeenCalled()
+  })
+
+  it('works for a session whose pane was never opened this run', async () => {
+    // The tile is gone but its profile is still on disk from a previous run.
+    seedPartition('webview-sessNeverOpened')
+    expect(await forgetWebviewProfile('sessNeverOpened')).toBe(true)
+    expect(h.sessions.get(partition('sessNeverOpened'))!.clearStorageData).toHaveBeenCalled()
+  })
+
+  /**
+   * #371 review MINOR-5. `session.fromPartition` CREATES a persist-backed
+   * session, so calling this for a tile that never opened a pane — which the
+   * launch-gate cancel does — must not leave behind an empty profile
+   * directory that nothing would ever clear.
+   */
+  it('does not materialise a partition for a session that never had one', async () => {
+    expect(await forgetWebviewProfile('neverBrowsed')).toBe(true)
+    expect(h.sessions.size).toBe(0)
+    expect(fs.existsSync(partitionDir('neverBrowsed'))).toBe(false)
+  })
+
+  it('removes the directory, not just its contents', async () => {
+    const dir = seedPartition('webview-sess1')
+    expect(fs.existsSync(dir)).toBe(true)
+    await forgetWebviewProfile('sess1')
+    // MINOR-2: the doc said "delete" while the code only emptied, so an auditor
+    // looking at Partitions/ would conclude the fix never ran.
+    expect(fs.existsSync(dir)).toBe(false)
+  })
+})
+
+/**
+ * The rest of the on-delete behaviour: bad input, and the failure modes a tab
+ * close must survive.
+ */
+describe("forgetWebviewProfile — refusals and failure modes", () => {
+  it('refuses an id that is not path-safe, and touches no partition', async () => {
+    for (const bad of ['a/../../x', 'a\\b', '../etc', 'a b', '', 'x'.repeat(129)]) {
+      expect(await forgetWebviewProfile(bad)).toBe(false)
+    }
+    expect(h.sessions.size).toBe(0)
+  })
+
+  it('never throws when the wipe fails — a tab close must not be blocked by it', async () => {
+    const { ses } = await open('sess1')
+    ses.clearStorageData.mockRejectedValueOnce(new Error('locked'))
+    expect(await forgetWebviewProfile('sess1')).toBe(false)
+  })
+
+  it('gives up rather than hanging when a wipe never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      const { ses } = await open('sess1')
+      ses.clearStorageData.mockReturnValueOnce(new Promise(() => { /* never settles */ }))
+      const pending = forgetWebviewProfile('sess1')
+      await vi.advanceTimersByTimeAsync(6_000)
+      expect(await pending).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/tests/unit/renderer/close-forgets-browser-profile.test.ts
+++ b/tests/unit/renderer/close-forgets-browser-profile.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Which session teardowns wipe the browser profile, and which must not (#371).
+ *
+ * `persist:webview-<sessionId>` holds the pane's cookies. Closing a session for
+ * good should take them with it; a RESTART and an in-tile ACCOUNT SWITCH must
+ * not, because both tear the tile down and rebuild it under the SAME session id
+ * — wiping there would sign the user out of every site in the pane every time
+ * they restarted a session.
+ *
+ * That is exactly why the wipe is not wired into `sessionStore.removeSession`,
+ * which all of them call. This file is the guard on that decision: point it at
+ * the store action and the "restart keeps its cookies" tests go red.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const forget = vi.fn(() => Promise.resolve(true))
+
+vi.stubGlobal('window', {
+  electronAPI: {
+    webview: { forget },
+    pty: { write: vi.fn(), kill: vi.fn() },
+  },
+})
+
+vi.mock('../../../src/renderer/ptyTracker', () => ({
+  killSessionPty: vi.fn(),
+  clearSpawned: vi.fn(),
+}))
+
+const { useSessionStore } = await import('../../../src/renderer/stores/sessionStore')
+const { useWebviewStore } = await import('../../../src/renderer/stores/webviewStore')
+const { requestCloseSession, leaveRunningAndClose, forgetSessionBrowserProfile } = await import(
+  '../../../src/renderer/stores/sshCloseStore'
+)
+
+const session = (over: Record<string, unknown> = {}) => ({
+  id: 'sess-1',
+  label: 'One',
+  status: 'idle',
+  createdAt: 1,
+  ...over,
+}) as never
+
+beforeEach(() => {
+  forget.mockClear()
+  useSessionStore.setState({ sessions: [], activeSessionId: null })
+  useWebviewStore.setState({ bySessionId: {} })
+})
+
+describe('closing a session for good takes its browser profile with it', () => {
+  it('an ordinary tab close wipes the profile', () => {
+    useSessionStore.setState({ sessions: [session()], activeSessionId: 'sess-1' })
+    requestCloseSession('sess-1')
+    expect(forget).toHaveBeenCalledWith('sess-1')
+    expect(useSessionStore.getState().sessions).toHaveLength(0)
+  })
+
+  it('"leave running" on a persistent SSH session wipes it too', () => {
+    useSessionStore.setState({ sessions: [session()], activeSessionId: 'sess-1' })
+    leaveRunningAndClose('sess-1')
+    expect(forget).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('drops the renderer-side pane state as well', () => {
+    useSessionStore.setState({ sessions: [session()], activeSessionId: 'sess-1' })
+    useWebviewStore.setState({ bySessionId: { 'sess-1': { url: 'https://x.test/' } as never } })
+    requestCloseSession('sess-1')
+    expect(useWebviewStore.getState().bySessionId['sess-1']).toBeUndefined()
+  })
+
+  it('a persistent SSH session asks first and wipes nothing yet', () => {
+    useSessionStore.setState({
+      sessions: [session({ sessionType: 'ssh', sshTmuxPersistent: true })],
+      activeSessionId: 'sess-1',
+    })
+    requestCloseSession('sess-1')
+    expect(forget).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions).toHaveLength(1) // still open, dialog pending
+  })
+
+  it('a failing wipe never blocks the close', () => {
+    forget.mockRejectedValueOnce(new Error('locked'))
+    useSessionStore.setState({ sessions: [session()], activeSessionId: 'sess-1' })
+    expect(() => requestCloseSession('sess-1')).not.toThrow()
+    expect(useSessionStore.getState().sessions).toHaveLength(0)
+  })
+
+  it('survives a missing preload rather than taking the close down with it', () => {
+    vi.stubGlobal('window', {})
+    expect(() => forgetSessionBrowserProfile('sess-1')).not.toThrow()
+    vi.stubGlobal('window', { electronAPI: { webview: { forget } } })
+  })
+})
+
+describe('a teardown that re-uses the session id keeps its cookies', () => {
+  it('removeSession on its own wipes nothing — this is what restart and account-switch call', () => {
+    useSessionStore.setState({ sessions: [session()], activeSessionId: 'sess-1' })
+
+    // Exactly what useRestartSession.forceRemount does: same id, new createdAt.
+    const store = useSessionStore.getState()
+    store.removeSession('sess-1')
+    store.addSession(session({ createdAt: 2 }))
+
+    expect(forget).not.toHaveBeenCalled()
+    expect(useSessionStore.getState().sessions[0].id).toBe('sess-1')
+  })
+})


### PR DESCRIPTION
Closes the second checklist item on #371:

> - [ ] per-session `persist:webview-<id>` browser profiles cleared on session delete

## What was left on disk

Every browser pane runs in `persist:webview-<sessionId>`, which Chromium turns into a profile directory under `sessionData/Partitions/webview-<id>` holding that pane's cookies, localStorage, IndexedDB, service workers and HTTP cache. Per-session isolation is the point (#348) — what was missing is the other end of the lifecycle.

**Nothing ever removed one.** Session ids are minted per tile and never reused, so a closed tile's profile stayed on disk for the life of the install: logged-in cookies for whatever had been browsed in that pane, unreachable through the app, invisible in it, and growing by one directory per closed tab. `clearStorageData` appears in this repo only on the account-web partitions — the pane path never called it. The renderer half leaked too: `webviewStore.reset(sessionId)`, commented *"Wipe state for a session — e.g. on session removal"*, had **no callers at all**.

## The distinction that shaped the fix

Closing a session and deleting one are the same act here, so the wipe belongs on close. But it must **not** be wired into `sessionStore.removeSession`, which looks like the obvious place: the Restart button, an in-tile account switch (`useSwitchAccount` → `restart`) and `askConductor`'s re-use all call `removeSession` then `addSession` with **the same id**. Wiping there would sign the user out of every site in the pane on every restart — a new bug wearing the fix's clothes.

So it hangs off the deliberate-close funnels: `requestCloseSession`, `endRemoteAndClose`, `leaveRunningAndClose`, the six sidebar bulk-close loops, and the launch-gate cancel. A test drives `removeSession` + `addSession` directly and asserts nothing is wiped, so pointing the call at the store action turns it red.

## Shape

- `forgetWebviewProfile(sessionId)` — same path-safety gate as `openWebview` (the id names an on-disk partition); destroys the live view **first** so the wipe cannot race a WebContents still writing to the jar; then `clearStorageData()` **and** `clearCache()` (clearing storage alone leaves page content behind).
- Both calls timeout-wrapped at 5 s, whole thing best-effort — the account-web sign-out already learned that a `clearStorageData()` which never settles leaves the caller stuck forever, and a tab close must never be blocked by it.
- New channel `webview:forget`, distinct from `webview:close` (which only destroys the view — a hidden tab, a restart and an account switch use that and keep their cookies).

## Verification

- `npm run typecheck` clean.
- Full `npx vitest run`: **7088 passed, 15 skipped, 2 todo** (663 files, 2 skipped).
- Mutation-tested both halves: path-safety gate forced open (1 test red), renderer wipe made a no-op (3 tests red), each restored byte-for-byte.
- Covered: a wipe that rejects; one that never settles (fake timers — must give up, not hang); a sibling session's partition left untouched; a session whose pane was never opened this run (its profile from a previous run still has to go); a missing preload.

## Trust boundaries touched

- **New IPC channel** `webview:forget` (renderer → main), argument-validated with the same strict `sessionIdSchema` the other webview channels use, plus an independent regex gate in the manager for callers that do not go through IPC.
- **On-disk partition paths** — the id is re-validated before it can name a directory to delete.
- **Electron session storage** — a destructive operation (`clearStorageData`/`clearCache`) scoped to exactly one `persist:webview-<id>` partition; a test asserts a sibling's partition is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)