### PR TITLE
fix(canvas): the served-root floor refuses the app's own resources directory

### DIFF
--- a/CONTEXT.d/2026-08-22-canvas-floor-refuses-the-resources-dir.md
+++ b/CONTEXT.d/2026-08-22-canvas-floor-refuses-the-resources-dir.md
@@ -68,3 +68,37 @@ refusing everything.
 
 Full suite on the branch: 7086 passed, 15 skipped, 2 todo (662 files, 2 skipped);
 typecheck clean.
+
+## Review follow-up (same day)
+
+**A refusal now says which floor it hit.** `canvasRootRefusalReason` /
+`describeCanvasRootRefusal` name the floor, the log line carries it, and
+`canvasRootRefusalFor` hands it to the Conductor MCP tool so an agent whose render was
+refused is told *why* instead of being told to write the file where it already wrote it.
+The generic message was unreachable-by-design for this case: the branch that names the
+folders which WOULD have worked only runs when there is a root, and the refusal is what
+emptied the list.
+
+**The worktree designation is no longer collateral.** It sat in the same `else if` chain
+as the project root, so any refused project directory also cost the session its worktree
+root — even though `<parent>/ccc-wt/<sid>` neither contains nor sits under the resources
+directory and would have been accepted. One refusal, not two.
+
+**Fixture hygiene.** Four relocated fixtures had FIXED names in shared temp
+(`ccc-adopt-confine-proj`, `ccc-prov-planted-dist`, …). This repo mandates parallel
+sessions, so two concurrent runs writing one path is an EPERM window on Windows — the
+repo's known "flaky suite = load, not a test" failure mode. All are `mkdtemp` now, every
+relocated directory is tracked and removed in `afterAll`, and the `PRIVATE KEY` fixture no
+longer persists in shared temp.
+
+One relocated assertion had gone **vacuous**: it kept a hardcoded `'confine-outside'`
+basename after the directory moved, so it normalised to a path that does not exist and
+passed on the missing-file branch — it would have passed with the containment logic
+deleted. It uses the real directory now.
+
+**Not symmetric, stated plainly.** The floor is re-applied per resolution for
+*designated* worktree roots (`liveDesignatedRoot`), and the suite proves it. It is **not**
+re-applied for live UAT roots: `resolvesUnderSessionRoot` compares against the registered
+set and never re-runs the floor, so a project root keeps serving until the session
+respawns. Defensible — live roots are registered once at spawn — but the earlier wording
+implied all three sites give a live re-check, and they do not.

--- a/CONTEXT.d/2026-08-22-canvas-floor-refuses-the-resources-dir.md
+++ b/CONTEXT.d/2026-08-22-canvas-floor-refuses-the-resources-dir.md
@@ -1,0 +1,70 @@
+# 2026-08-22 — the canvas served-root floor refuses the app's own resources directory
+
+Fifth of the #371 follow-ups, from the note the #308 adversarial pass left behind.
+
+## The gap
+
+The floor refused the home directory and every ancestor of it, a volume root, and the
+dot directories under home (`~/.ssh`, `~/.claude`, `~/.aws`, `~/.gnupg`) — the places a
+USER's credentials live. It did not refuse the place THIS APP keeps credentials.
+
+The resources directory holds `CONFIG/` — `ssh-credentials.json` (the DPAPI-encrypted SSH
+passwords, sudo passwords and secret arguments) and `conductor-secret.json` (the Conductor
+MCP HMAC key) — plus `account-profiles/` and `account-homes/` (Claude OAuth tokens), and
+the canvas store itself. Registered as a canvas served root, all of it becomes readable
+over the `ccc-ux://` surface.
+
+Same-user hardening, not a privilege boundary: the agent already runs as the user. What it
+removes is the canvas quietly turning "read a file" into "serve a credential store over
+HTTP" because a working directory happened to point there.
+
+## All three directions, and why
+
+`isResourcesDirOrAround` refuses the directory itself, anything UNDER it, and anything
+that CONTAINS it. The third is the one worth arguing for, and the precedent is already in
+the file: `isHomeOrAncestor` refuses ancestors of home for exactly this reason — serving a
+parent serves the child. It bites when someone points their resources directory inside a
+project they actually work in, which is the only configuration where the exposure is
+real *and* invisible.
+
+Applied at all three sites the floor is applied, because two of them would otherwise be a
+way round it:
+
+- `registerCanvasUatRoot` — the live root, at spawn;
+- `designateCanvasWorktreeRoot` — the lexical floor for a worktree that does not exist
+  yet;
+- `liveDesignatedRoot` — re-evaluated on EVERY resolution, so a directory that was fine
+  yesterday and is inside the resources directory today stops serving today.
+
+The store's own rule decides the direction when it is ambiguous: *"Over-denial is the
+intended direction: a refused root costs a canvas render, an accepted one costs a
+credential."*
+
+## Five existing suites changed, and why they had to
+
+Five canvas suites were laying their test content in places the new floor refuses, and it
+is worth being explicit that this is a test-layout problem rather than the rule being too
+strict:
+
+- `ccc-ux-protocol` and `canvas-distroot-confinement` registered
+  **`path.dirname(mkdtempSync(os.tmpdir()))`** — i.e. the whole system temp directory —
+  as the base. That also contains each suite's mocked resources directory, so the
+  contains-it rule refuses it. Each now gets its own dedicated parent, which is what
+  "the base the dist sits under" was always meant to be.
+- `canvas-content-egress`, `canvas-record-provenance` and `canvas-adoption` built their
+  dist / project directories **inside** the mocked resources directory. Moved out to
+  their own temp directories.
+
+None of the assertions changed; only where the fixtures live.
+
+## Verification
+
+Each of the three sites was mutated independently and watched go red — 6, 1 and 1 tests
+respectively — then restored byte-for-byte. The suite also covers a case-variant spelling
+(the Windows case that a string compare misses), a path reaching the directory through
+`..`, a sibling directory that must still be accepted, an ordinary project directory that
+must still be accepted, and an unresolvable resources directory abstaining rather than
+refusing everything.
+
+Full suite on the branch: 7086 passed, 15 skipped, 2 todo (662 files, 2 skipped);
+typecheck clean.

--- a/src/main/canvas-mcp-tool.ts
+++ b/src/main/canvas-mcp-tool.ts
@@ -283,6 +283,7 @@ function captureFailureReason(err: unknown): string {
 function renderFailureReason(
   err: unknown,
   roots?: { project: string | null; worktree: string | null; worktreePending: boolean },
+  refusal?: string | null,
 ): string {
   const message = err instanceof Error ? err.message : ''
   if (/version cap/i.test(message)) {
@@ -298,6 +299,10 @@ function renderFailureReason(
     if (advice) {
       return `that directory is not inside the folders this session serves from: ${advice} Build into one of them (for example <that folder>/dist) and render that path.`
     }
+    // Same half-closed gap the design path had (#371): when a FLOOR emptied the
+    // root list, `rootAdvice` is null and "build inside the project" is advice
+    // the agent has already followed. Name the actual reason.
+    if (refusal) return `${refusal} Nothing can be served for this session until that is changed.`
     return 'that directory is not inside this session’s project folder, which is the only place the canvas serves from. Build inside the project you are working in and render that path.'
   }
   if (/distRoot does not exist|not a directory/i.test(message)) return 'that build directory does not exist.'
@@ -549,7 +554,14 @@ export async function runCanvasRender(
     // their own agent's work.
     rendered = deps.renderVersion(sessionId, source)
   } catch (err) {
-    return { text: `Could not render the canvas: ${renderFailureReason(err, safeRoots(deps, sessionId))}`, isError: true }
+    return {
+      text: `Could not render the canvas: ${renderFailureReason(
+        err,
+        safeRoots(deps, sessionId),
+        (() => { try { return deps.canvasRootRefusalFor?.(sessionId) ?? null } catch { return null } })(),
+      )}`,
+      isError: true,
+    }
   }
 
   // Both ids are ours: one minted by the store, one a `v<n>` counter. Nothing

--- a/src/main/canvas-mcp-tool.ts
+++ b/src/main/canvas-mcp-tool.ts
@@ -84,6 +84,10 @@ export interface CanvasToolDeps {
     worktree: string | null
     worktreePending: boolean
   }
+  /** Why this session has NO project root, when a floor refused it (#371).
+   *  Optional so existing wirings keep working; without it a refusal falls back
+   *  to the generic message, which is the pre-#371 behaviour. */
+  canvasRootRefusalFor?: (sessionId: string) => string | null
   /**
    * Read a design document the agent wrote to disk (`htmlPath`). Injected so
    * this module touches no filesystem; the caller confines the path to the
@@ -397,6 +401,7 @@ function rootAdvice(
 function designFileFailureReason(
   err: unknown,
   roots?: { project: string | null; worktree: string | null; worktreePending: boolean },
+  refusal?: string | null,
 ): string {
   const message = err instanceof Error ? err.message : ''
   if (/too large/i.test(message)) return 'that html file is too large to render.'
@@ -414,6 +419,14 @@ function designFileFailureReason(
     // happens to run in (that value comes out of a transcript the model can
     // write), and nothing at all when the configured directory is the home
     // directory.
+    // #371: when the root list is EMPTY because a floor refused it, say which
+    // floor. Telling the agent to "write it inside the project folder" is
+    // useless there — that is exactly where it already wrote it — and the
+    // branch above that names the folders which WOULD have worked is
+    // unreachable, because the refusal is what emptied the list.
+    if (refusal) {
+      return `${refusal} Nothing can be rendered by path for this session until that is changed.`
+    }
     return 'that file is outside this session’s project folder, which is the only place the canvas reads from. Write the html inside the project folder configured for this session, then render that path. (A session configured on your home folder has no project folder and cannot render by path.)'
   }
   return 'that html file could not be read. Check the path you wrote it to.'
@@ -466,7 +479,14 @@ export async function runCanvasRender(
         // one the render itself is keyed to — never rawArgs.cccSessionId.
         bytes = deps.readDesignFile(rawArgs.htmlPath, sessionId)
       } catch (err) {
-        return { text: `Could not render the canvas: ${designFileFailureReason(err, safeRoots(deps, sessionId))}`, isError: true }
+        return {
+          text: `Could not render the canvas: ${designFileFailureReason(
+            err,
+            safeRoots(deps, sessionId),
+            (() => { try { return deps.canvasRootRefusalFor?.(sessionId) ?? null } catch { return null } })(),
+          )}`,
+          isError: true,
+        }
       }
       // Re-measured here even though the reader guards too: this is the
       // untrusted ingress and the cap must hold in THIS file's logic.

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -236,29 +236,55 @@ export type CanvasRootRefusal =
   | 'dot-dir-under-home'
   | 'resources-dir'
 
-export function canvasRootRefusalReason(sessionId: string, baseDir: string): CanvasRootRefusal | null {
-  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return 'bad-session-id'
-  if (typeof baseDir !== 'string' || !path.isAbsolute(baseDir)) return 'not-absolute'
+/**
+ * The refusal, plus the RESOLVED path when there is none.
+ *
+ * Returning the resolution is what closes a TOCTOU (#371, ADR-009 pass):
+ * `registerCanvasUatRoot` used to realpath once to CHECK and again to ADD, so a
+ * directory swapped for a symlink between the two calls was checked as itself
+ * and added as its target. Check and use are now one resolution.
+ */
+export function canvasRootCheck(
+  sessionId: string,
+  baseDir: string,
+): { refusal: CanvasRootRefusal; real?: undefined } | { refusal: null; real: string } {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return { refusal: 'bad-session-id' }
+  if (typeof baseDir !== 'string' || !path.isAbsolute(baseDir)) return { refusal: 'not-absolute' }
   let real: string
   try {
     real = fs.realpathSync.native(path.resolve(baseDir))
   } catch {
-    return 'unresolvable'
+    return { refusal: 'unresolvable' }
   }
   try {
-    if (!fs.statSync(real).isDirectory()) return 'not-a-directory'
+    if (!fs.statSync(real).isDirectory()) return { refusal: 'not-a-directory' }
   } catch {
-    return 'not-a-directory'
+    return { refusal: 'not-a-directory' }
   }
-  if (isHomeOrAncestor(real)) return 'home-or-ancestor'
-  if (isVolumeRoot(real)) return 'volume-root'
-  if (isDotDirUnderHome(real)) return 'dot-dir-under-home'
-  if (isResourcesDirOrAround(real)) return 'resources-dir'
-  return null
+  if (isHomeOrAncestor(real)) return { refusal: 'home-or-ancestor' }
+  if (isVolumeRoot(real)) return { refusal: 'volume-root' }
+  if (isDotDirUnderHome(real)) return { refusal: 'dot-dir-under-home' }
+  if (isResourcesDirOrAround(real)) return { refusal: 'resources-dir' }
+  return { refusal: null, real }
 }
 
-/** One sentence a user or an agent can act on, for each refusal. */
-export function describeCanvasRootRefusal(reason: CanvasRootRefusal, dir: string): string {
+/** Just the reason, for callers that only have to explain themselves. */
+export function canvasRootRefusalReason(sessionId: string, baseDir: string): CanvasRootRefusal | null {
+  return canvasRootCheck(sessionId, baseDir).refusal
+}
+
+/**
+ * One sentence a user or an agent can act on, for each refusal.
+ *
+ * `dir` is SANITISED before it is interpolated (#371, ADR-009 pass). The path
+ * is CCC's own, but a folder NAME inside it is user-authored and this string is
+ * relayed to a model — so control, format and bidi characters go, and the
+ * length is capped. Same rule, and the same reason, as `safeRootLabel` in
+ * canvas-mcp-tool: nothing outside the envelope is anything but operator text.
+ */
+export function describeCanvasRootRefusal(reason: CanvasRootRefusal, rawDir: string): string {
+  const cleaned = String(rawDir ?? '').replace(FORMAT_CONTROLS_RE, '')
+  const dir = cleaned.length > 200 ? `${cleaned.slice(0, 200)}…` : cleaned
   switch (reason) {
     case 'resources-dir':
       return `the canvas cannot serve ${dir} because the app's own resources directory (which holds your saved credentials and accounts) is inside it, or is it. Point this session at a project folder that does not contain the resources directory, or move the resources directory somewhere else in Settings.`
@@ -297,9 +323,14 @@ export function canvasRootRefusalFor(sessionId: string): string | null {
 }
 
 export function registerCanvasUatRoot(sessionId: string, baseDir: string): boolean {
-  if (canvasRootRefusalReason(sessionId, baseDir) !== null) return false
+  // ONE resolution, used for both the check and the add. Resolving twice let a
+  // directory swapped for a symlink between the two calls be checked as itself
+  // and added as its target (#371, ADR-009 pass). `canvasRootCheck` never
+  // throws, so a mid-call ENOENT cannot escape into spawnPty either.
+  const checked = canvasRootCheck(sessionId, baseDir)
+  if (checked.refusal !== null) return false
   rootRefusalBySession.delete(sessionId) // it registered; there is nothing to explain
-  const real = fs.realpathSync.native(path.resolve(baseDir))
+  const real = checked.real
   let roots = uatRootsBySession.get(sessionId)
   if (!roots) {
     roots = new Set<string>()

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -135,6 +135,57 @@ function isDotDirUnderHome(p: string): boolean {
   return segments.some((s) => s.startsWith('.'))
 }
 
+/** True when `a` contains `b` (b lives somewhere under a). Case-insensitive on
+ *  win32, because `path.relative` is. */
+function contains(a: string, b: string): boolean {
+  const rel = path.relative(a, b)
+  if (rel === '' || path.isAbsolute(rel)) return false
+  const first = rel.split(/[\\/]/).filter((s) => s.length > 0)[0]
+  return first !== undefined && first !== '..'
+}
+
+/**
+ * True when `p` is the app's own RESOURCES directory, anything under it, or any
+ * ancestor of it (#371).
+ *
+ * The existing floor refuses the home directory, a volume root and the dot
+ * directories under home — the places a user's credentials live. It did not
+ * refuse the place THIS APP keeps credentials. The resources directory holds
+ * `CONFIG/` (`ssh-credentials.json`, the DPAPI-encrypted SSH and sudo passwords
+ * and secret arguments; `conductor-secret.json`, the MCP HMAC key),
+ * `account-profiles/` and `account-homes/` (Claude OAuth tokens), plus the
+ * canvas store itself. Served as a canvas root, all of it becomes readable over
+ * the canvas HTTP surface.
+ *
+ * All three directions are refused, matching what `isHomeOrAncestor` already
+ * does for home:
+ *   - the directory itself,
+ *   - anything UNDER it (`<resources>/CONFIG` named directly),
+ *   - anything that CONTAINS it — serving a parent serves the resources dir,
+ *     which is the case that bites when someone points their resources
+ *     directory inside a project they actually work in.
+ *
+ * Same-user hardening, not a privilege boundary: the agent already runs as the
+ * user. What it removes is the canvas turning "read a file" into "serve a
+ * credential store over HTTP" without anyone deciding to.
+ */
+function isResourcesDirOrAround(p: string): boolean {
+  let configured: string
+  try {
+    configured = getResourcesDirectory()
+  } catch {
+    return false // not resolvable this run — the other floors still apply
+  }
+  if (typeof configured !== 'string' || configured.length === 0) return false
+  let res: string
+  try {
+    res = fs.realpathSync.native(configured)
+  } catch {
+    res = path.resolve(configured) // not on disk yet; the lexical answer still holds
+  }
+  return sameFsPath(res, p) || contains(res, p) || contains(p, res)
+}
+
 /**
  * Register a directory under which one session's canvas paths may live.
  *
@@ -183,6 +234,7 @@ export function registerCanvasUatRoot(sessionId: string, baseDir: string): boole
   if (isHomeOrAncestor(real)) return false
   if (isVolumeRoot(real)) return false
   if (isDotDirUnderHome(real)) return false
+  if (isResourcesDirOrAround(real)) return false
   let roots = uatRootsBySession.get(sessionId)
   if (!roots) {
     roots = new Set<string>()
@@ -208,6 +260,7 @@ export function designateCanvasWorktreeRoot(sessionId: string, dir: string): boo
   if (isHomeOrAncestor(lexical)) return false
   if (isVolumeRoot(lexical)) return false
   if (isDotDirUnderHome(lexical)) return false
+  if (isResourcesDirOrAround(lexical)) return false
   // Refuse a path already designated for a DIFFERENT session. Distinct tiles
   // derive distinct segments, so this only fires on a segment collision — and
   // there the FIRST tile owns the directory it populated; serving it to a second
@@ -258,6 +311,7 @@ function liveDesignatedRoot(lexical: string): string | null {
   if (isHomeOrAncestor(real)) return null
   if (isVolumeRoot(real)) return null
   if (isDotDirUnderHome(real)) return null
+  if (isResourcesDirOrAround(real)) return null
   return real
 }
 

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -217,24 +217,89 @@ function isResourcesDirOrAround(p: string): boolean {
  * Over-denial is the intended direction: a refused root costs a canvas render,
  * an accepted one costs a credential.
  */
-export function registerCanvasUatRoot(sessionId: string, baseDir: string): boolean {
-  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return false
-  if (typeof baseDir !== 'string' || !path.isAbsolute(baseDir)) return false
+/**
+ * WHY a directory cannot be a canvas root, or null when it can.
+ *
+ * Split out so a refusal can SAY which floor it hit (#371). The floor is
+ * correct, but a refusal that reaches the user as nothing at all — and reaches
+ * the agent as "write the html inside the project folder", which is where it
+ * already wrote it — is an undiagnosable dead end. ADR-017's own words: being
+ * locked out of your own canvas is a bug this app has already shipped once.
+ */
+export type CanvasRootRefusal =
+  | 'bad-session-id'
+  | 'not-absolute'
+  | 'unresolvable'
+  | 'not-a-directory'
+  | 'home-or-ancestor'
+  | 'volume-root'
+  | 'dot-dir-under-home'
+  | 'resources-dir'
+
+export function canvasRootRefusalReason(sessionId: string, baseDir: string): CanvasRootRefusal | null {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return 'bad-session-id'
+  if (typeof baseDir !== 'string' || !path.isAbsolute(baseDir)) return 'not-absolute'
   let real: string
   try {
     real = fs.realpathSync.native(path.resolve(baseDir))
   } catch {
-    return false // an unresolvable base is simply not added
+    return 'unresolvable'
   }
   try {
-    if (!fs.statSync(real).isDirectory()) return false
+    if (!fs.statSync(real).isDirectory()) return 'not-a-directory'
   } catch {
-    return false
+    return 'not-a-directory'
   }
-  if (isHomeOrAncestor(real)) return false
-  if (isVolumeRoot(real)) return false
-  if (isDotDirUnderHome(real)) return false
-  if (isResourcesDirOrAround(real)) return false
+  if (isHomeOrAncestor(real)) return 'home-or-ancestor'
+  if (isVolumeRoot(real)) return 'volume-root'
+  if (isDotDirUnderHome(real)) return 'dot-dir-under-home'
+  if (isResourcesDirOrAround(real)) return 'resources-dir'
+  return null
+}
+
+/** One sentence a user or an agent can act on, for each refusal. */
+export function describeCanvasRootRefusal(reason: CanvasRootRefusal, dir: string): string {
+  switch (reason) {
+    case 'resources-dir':
+      return `the canvas cannot serve ${dir} because the app's own resources directory (which holds your saved credentials and accounts) is inside it, or is it. Point this session at a project folder that does not contain the resources directory, or move the resources directory somewhere else in Settings.`
+    case 'home-or-ancestor':
+      return `the canvas cannot serve ${dir} because it is your home directory or a folder above it. Set this session's working directory to the specific project folder.`
+    case 'volume-root':
+      return `the canvas cannot serve ${dir} because it is a whole drive. Set this session's working directory to the specific project folder.`
+    case 'dot-dir-under-home':
+      return `the canvas cannot serve ${dir} because it is inside a hidden folder in your home directory (where credentials live).`
+    case 'not-a-directory':
+      return `the canvas cannot serve ${dir} because it is not a directory.`
+    case 'unresolvable':
+      return `the canvas cannot serve ${dir} because that path could not be resolved on disk.`
+    case 'not-absolute':
+      return `the canvas cannot serve ${dir} because it is not an absolute path.`
+    case 'bad-session-id':
+      return 'the canvas cannot serve this session (its id is not usable).'
+  }
+}
+
+/**
+ * Why this session has no project root, in words, for the surfaces that have to
+ * tell somebody (#371). Without it the refusal reaches the agent as the generic
+ * "write the html inside the project folder" — which is where it already wrote
+ * it — and reaches the user as nothing at all.
+ */
+const rootRefusalBySession = new Map<string, string>()
+
+export function setCanvasRootRefusal(sessionId: string, explanation: string): void {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return
+  rootRefusalBySession.set(sessionId, explanation)
+}
+
+export function canvasRootRefusalFor(sessionId: string): string | null {
+  return rootRefusalBySession.get(sessionId) ?? null
+}
+
+export function registerCanvasUatRoot(sessionId: string, baseDir: string): boolean {
+  if (canvasRootRefusalReason(sessionId, baseDir) !== null) return false
+  rootRefusalBySession.delete(sessionId) // it registered; there is nothing to explain
+  const real = fs.realpathSync.native(path.resolve(baseDir))
   let roots = uatRootsBySession.get(sessionId)
   if (!roots) {
     roots = new Set<string>()
@@ -354,6 +419,7 @@ export function canvasRootsForSession(
 export function revokeCanvasUatRoots(sessionId: string): void {
   uatRootsBySession.delete(sessionId)
   designatedRootsBySession.delete(sessionId)
+  rootRefusalBySession.delete(sessionId)
 }
 
 /** True iff `candidate` physically resolves at/under a base registered for

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -42,7 +42,7 @@ import { resolveCdpPort, CDP_PORT_PROD } from '../shared/cdp-ports'
 import type { GlobalVisionConfig } from '../shared/types'
 import { registerCodexReviewTool } from './codex-review-mcp-tool'
 import { registerCanvasTools } from './canvas-mcp-tool'
-import { canvasRootsForSession, getCanvasStateForSession, renderVersion, resolveInsideCanvasRoot } from './canvas/canvas-store'
+import { canvasRootsForSession, canvasRootRefusalFor, getCanvasStateForSession, renderVersion, resolveInsideCanvasRoot } from './canvas/canvas-store'
 import {
   closeAnnotationsByAgent,
   getReviewCountsForCanvas,
@@ -872,6 +872,7 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
         getReviewCounts: (canvasId) => getReviewCountsForCanvas(canvasId),
         // So a refused render can NAME the folders it would have accepted.
         canvasRootsForSession: (sessionId) => canvasRootsForSession(sessionId),
+        canvasRootRefusalFor: (sessionId) => canvasRootRefusalFor(sessionId),
         /**
          * Read a design document the agent wrote to disk (`htmlPath`).
          *

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -43,7 +43,7 @@ import {
 } from './hooks/per-session-settings'
 import { registerCodexReviewSession, unregisterCodexReviewSession } from './conductor-mcp-server'
 import { ensureCanvasPlugin } from './canvas/canvas-plugin'
-import { registerCanvasUatRoot, revokeCanvasUatRoots, designateCanvasWorktreeRoot } from './canvas/canvas-store'
+import { registerCanvasUatRoot, revokeCanvasUatRoots, designateCanvasWorktreeRoot, canvasRootRefusalReason, describeCanvasRootRefusal, setCanvasRootRefusal } from './canvas/canvas-store'
 import { designatedWorktreeDir } from './canvas/canvas-worktree'
 import { forgetSessionForCanvas } from './canvas/canvas-session-link'
 import { disposeSession as disposeCodexReviewUsage } from './codex-review-usage'
@@ -3033,19 +3033,35 @@ export function spawnPty(
       // pre-allowed tool reading the bytes back). It is flagged, not changed.
       if (isHomeOrAncestor(resolvedCwd)) {
         logWarn(`[pty] canvas serving root NOT registered for ${sessionId}: the configured project directory resolves to (or above) the home directory (workingDirectory is '.', empty, a stale path, or points at home).`)
+        setCanvasRootRefusal(sessionId, describeCanvasRootRefusal('home-or-ancestor', resolvedCwd))
       } else if (!registerCanvasUatRoot(sessionId, resolvedCwd)) {
         // Floor-checked again inside the store (absolute, real, a directory, not
-        // home, not a volume root, not a dot-dir under home) — two independent
-        // refusals rather than one, because this is the only thing standing
-        // between a prompt-injected agent and a file read with the app's
-        // privileges.
-        logWarn(`[pty] canvas serving root NOT registered for ${sessionId}: the configured project directory was refused by the canvas store.`)
-      } else if (designatedWorktree) {
-        // The project is servable, so the worktree CCC designated beside it is
-        // too — PENDING: the store consults it only once it exists as a real,
-        // un-linked directory (canvas-store.designateCanvasWorktreeRoot). The
-        // path is CCC's, the contents are the agent's own; nothing an agent can
-        // write moves it (ADR-016).
+        // home, not a volume root, not a dot-dir under home, not the resources
+        // directory) — two independent refusals rather than one, because this is
+        // the only thing standing between a prompt-injected agent and a file
+        // read with the app's privileges.
+        //
+        // NAME the floor that refused (#371). "Refused by the canvas store" in a
+        // log file, with the agent told to write where it already wrote, is an
+        // undiagnosable dead end for the one configuration the resources-dir
+        // floor exists for.
+        const reason = canvasRootRefusalReason(sessionId, resolvedCwd)
+        const explanation = reason ? describeCanvasRootRefusal(reason, resolvedCwd) : 'the canvas store refused it.'
+        logWarn(`[pty] canvas serving root NOT registered for ${sessionId} (${reason ?? 'unknown'}): ${explanation}`)
+        setCanvasRootRefusal(sessionId, explanation)
+      }
+
+      // The worktree designation is INDEPENDENT of the project root (#371). It
+      // used to sit in the same else-if chain, so a project directory refused
+      // by any floor also cost the session its worktree root — even though
+      // `<parent>/ccc-wt/<sid>` neither contains nor sits under the resources
+      // directory and would have been accepted. One refusal, not two.
+      //
+      // PENDING: the store consults it only once it exists as a real, un-linked
+      // directory (canvas-store.designateCanvasWorktreeRoot). The path is CCC's,
+      // the contents are the agent's own; nothing an agent can write moves it
+      // (ADR-016).
+      if (designatedWorktree) {
         if (designateCanvasWorktreeRoot(sessionId, designatedWorktree)) {
           logInfo(`[pty] canvas: designated session worktree ${designatedWorktree} for ${sessionId} (served once it exists)`)
         } else {

--- a/tests/unit/main/canvas-adoption.test.ts
+++ b/tests/unit/main/canvas-adoption.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as os from 'os'
 import { vi } from 'vitest'
 
 vi.mock('../../../src/main/ipc/setup-handlers', () => {
@@ -343,8 +344,11 @@ describe('reclaim candidates + adoptCanvasForSession (user-chosen)', () => {
 
 describe('resolveInsideCanvasRoot (the htmlPath confinement)', () => {
   it('refuses everything when no root is registered, and confines to a registered one', () => {
-    const projectDir = path.join(getResourcesDirectory(), 'confine-proj')
-    const outsideDir = path.join(getResourcesDirectory(), 'confine-outside')
+    // Outside the resources directory: the floor now refuses a served root
+    // under it (#371). Both dirs move together so the "outside" one stays
+    // outside the registered root, which is what this test is about.
+    const projectDir = path.join(os.tmpdir(), 'ccc-adopt-confine-proj')
+    const outsideDir = path.join(os.tmpdir(), 'ccc-adopt-confine-outside')
     fs.mkdirSync(projectDir, { recursive: true })
     fs.mkdirSync(outsideDir, { recursive: true })
     const inside = path.join(projectDir, 'mockup.html')

--- a/tests/unit/main/canvas-adoption.test.ts
+++ b/tests/unit/main/canvas-adoption.test.ts
@@ -67,12 +67,25 @@ function restart() {
   reviews._resetCanvasReviewStoreForTest()
 }
 
+/** Temp dirs made outside the mocked resources directory, so `afterAll` can
+ *  still sweep them — the fixtures moved out of it in #371 and nothing was
+ *  removing them. */
+const extraTempDirs: string[] = []
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  extraTempDirs.push(dir)
+  return dir
+}
+
 beforeEach(() => {
   restart()
   fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
 })
 
 afterAll(() => {
+  for (const d of extraTempDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
   try {
     fs.rmSync(getResourcesDirectory(), { recursive: true, force: true })
   } catch {
@@ -347,8 +360,14 @@ describe('resolveInsideCanvasRoot (the htmlPath confinement)', () => {
     // Outside the resources directory: the floor now refuses a served root
     // under it (#371). Both dirs move together so the "outside" one stays
     // outside the registered root, which is what this test is about.
-    const projectDir = path.join(os.tmpdir(), 'ccc-adopt-confine-proj')
-    const outsideDir = path.join(os.tmpdir(), 'ccc-adopt-confine-outside')
+    // mkdtemp, not a fixed name: this repo mandates parallel sessions
+    // (AGENTS.md, ADR-012), and two `npx vitest run`s sharing
+    // `<tmp>/ccc-adopt-confine-proj` is an EPERM window on Windows. Both dirs
+    // live under one parent so `outsideDir` stays a real sibling OUTSIDE the
+    // registered root, which is what this test is about.
+    const confineBase = tmpDir('ccc-adopt-confine-')
+    const projectDir = path.join(confineBase, 'proj')
+    const outsideDir = path.join(confineBase, 'outside')
     fs.mkdirSync(projectDir, { recursive: true })
     fs.mkdirSync(outsideDir, { recursive: true })
     const inside = path.join(projectDir, 'mockup.html')
@@ -364,7 +383,11 @@ describe('resolveInsideCanvasRoot (the htmlPath confinement)', () => {
     // The read that the adversarial pass drove to a private key.
     expect(() => store.resolveInsideCanvasRoot(outside, SID_A)).toThrow(/registered canvas root/i)
     // Traversal out of a registered root, and a relative path.
-    expect(() => store.resolveInsideCanvasRoot(path.join(projectDir, '..', 'confine-outside', 'secret.txt'), SID_A)).toThrow(
+    // `outsideDir`, not a hardcoded basename: the fixtures moved and the literal
+    // stopped naming the real file, so this normalised to a path that does not
+    // exist and passed on the missing-file branch instead of the containment
+    // one — it would have passed with the containment logic deleted (#371).
+    expect(() => store.resolveInsideCanvasRoot(path.join(projectDir, '..', path.basename(outsideDir), 'secret.txt'), SID_A)).toThrow(
       /registered canvas root/i,
     )
     expect(() => store.resolveInsideCanvasRoot('mockup.html', SID_A)).toThrow(/registered canvas root/i)

--- a/tests/unit/main/canvas-content-egress.test.ts
+++ b/tests/unit/main/canvas-content-egress.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as os from 'os'
 import type { CanvasFrameNavigationDetails } from '../../../src/main/canvas/ccc-ux-protocol'
 
 vi.mock('../../../src/main/ipc/setup-handlers', () => {
@@ -81,7 +82,9 @@ describe('served CSP blocks WebRTC', () => {
   })
 
   it('carries webrtc \'block\' on a UAT document too', async () => {
-    const dist = fs.mkdtempSync(path.join(getResourcesDirectory(), 'dist-'))
+    // Outside the resources directory: served content may not live inside it,
+    // and the floor now refuses a root under it (#371).
+    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-egress-dist-'))
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><html><body>u</body></html>')
     expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
     const { canvasId } = store.renderVersion(SID, { mode: 'uat', distRoot: dist })
@@ -342,7 +345,8 @@ describe('resource hints cannot carry data out', () => {
     const { res } = await serveDesign('<!doctype html><html><body>x</body></html>')
     expect(res.headers.get('X-DNS-Prefetch-Control')).toBe('off')
 
-    const dist = fs.mkdtempSync(path.join(getResourcesDirectory(), 'dist-hints-'))
+    // Outside the resources directory — see the note on the UAT case above (#371).
+    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-egress-hints-'))
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><html><body>u</body></html>')
     expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
     const { canvasId } = store.renderVersion(SID, { mode: 'uat', distRoot: dist })

--- a/tests/unit/main/canvas-content-egress.test.ts
+++ b/tests/unit/main/canvas-content-egress.test.ts
@@ -58,7 +58,19 @@ beforeEach(() => {
   fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
 })
 
+/** Dist dirs moved OUT of the resources directory in #371, so the wholesale
+ *  sweep below no longer reached them. Tracked and removed here instead. */
+const extraTempDirs: string[] = []
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  extraTempDirs.push(dir)
+  return dir
+}
+
 afterAll(() => {
+  for (const d of extraTempDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
   try {
     fs.rmSync(getResourcesDirectory(), { recursive: true, force: true })
   } catch {
@@ -84,7 +96,7 @@ describe('served CSP blocks WebRTC', () => {
   it('carries webrtc \'block\' on a UAT document too', async () => {
     // Outside the resources directory: served content may not live inside it,
     // and the floor now refuses a root under it (#371).
-    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-egress-dist-'))
+    const dist = tmpDir('ccc-egress-dist-')
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><html><body>u</body></html>')
     expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
     const { canvasId } = store.renderVersion(SID, { mode: 'uat', distRoot: dist })
@@ -346,7 +358,7 @@ describe('resource hints cannot carry data out', () => {
     expect(res.headers.get('X-DNS-Prefetch-Control')).toBe('off')
 
     // Outside the resources directory — see the note on the UAT case above (#371).
-    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-egress-hints-'))
+    const dist = tmpDir('ccc-egress-hints-')
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><html><body>u</body></html>')
     expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
     const { canvasId } = store.renderVersion(SID, { mode: 'uat', distRoot: dist })

--- a/tests/unit/main/canvas-distroot-confinement.test.ts
+++ b/tests/unit/main/canvas-distroot-confinement.test.ts
@@ -47,7 +47,13 @@ afterAll(() => {
 
 // The attacker's crown-jewel repro: point distRoot at a dir full of secrets.
 function makeSecretDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-ux-secret-'))
+  // Its own parent, so a test can register the level ABOVE it without that
+  // being the whole system temp directory — which also contains this suite's
+  // mocked resources directory, and the floor now refuses any root that
+  // contains it (#371).
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-ux-secretbase-'))
+  const dir = path.join(base, 'secrets')
+  fs.mkdirSync(dir)
   fs.writeFileSync(path.join(dir, 'id_rsa'), 'PRIVATE-KEY-BYTES')
   fs.writeFileSync(path.join(dir, 'index.html'), '<html><body>x</body></html>')
   return dir

--- a/tests/unit/main/canvas-record-provenance.test.ts
+++ b/tests/unit/main/canvas-record-provenance.test.ts
@@ -79,12 +79,25 @@ beforeEach(() => {
   fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
   // Outside the resources directory: the floor now refuses a served root under
   // it, and served content has no business living beside CONFIG anyway (#371).
-  distDir = path.join(os.tmpdir(), 'ccc-prov-planted-dist')
-  fs.mkdirSync(distDir, { recursive: true })
+  // mkdtemp rather than a fixed name — this repo mandates parallel sessions, and
+  // two concurrent runs writing one `<tmp>/ccc-prov-planted-dist/index.html` is
+  // an EPERM window on Windows.
+  distDir = tmpDir('ccc-prov-planted-dist-')
   fs.writeFileSync(path.join(distDir, 'index.html'), '<!doctype html><html><body>planted</body></html>')
 })
 
+/** Temp dirs outside the mocked resources directory, swept below. */
+const extraTempDirs: string[] = []
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  extraTempDirs.push(dir)
+  return dir
+}
+
 afterAll(() => {
+  for (const d of extraTempDirs.splice(0)) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
   try {
     fs.rmSync(getResourcesDirectory(), { recursive: true, force: true })
   } catch {
@@ -174,7 +187,7 @@ describe('a record CCC wrote', () => {
   })
 
   it('stops verifying when a version\'s distRoot is edited', () => {
-    const dist = path.join(os.tmpdir(), 'ccc-prov-real-dist')
+    const dist = tmpDir('ccc-prov-real-dist-')
     fs.mkdirSync(dist, { recursive: true })
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><p>ok</p>')
     expect(store.registerCanvasUatRoot(VICTIM, dist)).toBe(true)

--- a/tests/unit/main/canvas-record-provenance.test.ts
+++ b/tests/unit/main/canvas-record-provenance.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as os from 'os'
 
 vi.mock('../../../src/main/ipc/setup-handlers', () => {
   const nodeFs = require('node:fs') as typeof import('node:fs')
@@ -76,7 +77,9 @@ let distDir: string
 beforeEach(() => {
   restart()
   fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
-  distDir = path.join(getResourcesDirectory(), 'planted-dist')
+  // Outside the resources directory: the floor now refuses a served root under
+  // it, and served content has no business living beside CONFIG anyway (#371).
+  distDir = path.join(os.tmpdir(), 'ccc-prov-planted-dist')
   fs.mkdirSync(distDir, { recursive: true })
   fs.writeFileSync(path.join(distDir, 'index.html'), '<!doctype html><html><body>planted</body></html>')
 })
@@ -171,7 +174,7 @@ describe('a record CCC wrote', () => {
   })
 
   it('stops verifying when a version\'s distRoot is edited', () => {
-    const dist = path.join(getResourcesDirectory(), 'real-dist')
+    const dist = path.join(os.tmpdir(), 'ccc-prov-real-dist')
     fs.mkdirSync(dist, { recursive: true })
     fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><p>ok</p>')
     expect(store.registerCanvasUatRoot(VICTIM, dist)).toBe(true)

--- a/tests/unit/main/canvas-resources-root-floor.test.ts
+++ b/tests/unit/main/canvas-resources-root-floor.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The canvas served-root floor refuses the app's own resources directory (#371).
+ *
+ * The floor already refused the home directory, a volume root and the dot
+ * directories under home — the places a USER's credentials live. It did not
+ * refuse the place THIS APP keeps credentials: the resources directory holds
+ * `CONFIG/` (`ssh-credentials.json`, the DPAPI-encrypted SSH and sudo passwords
+ * and secret arguments; `conductor-secret.json`, the MCP HMAC key),
+ * `account-profiles/` and `account-homes/` (Claude OAuth tokens).
+ *
+ * Same-user hardening rather than a privilege boundary — the agent already runs
+ * as the user. What it removes is the canvas turning "read a file" into "serve
+ * a credential store over HTTP" because a working directory happened to point
+ * there.
+ *
+ * Real filesystem throughout: every layer under test is a realpath/stat
+ * containment layer, which is exactly what a mocked fs cannot exercise. The
+ * resources directory is MUTABLE here so the floor can be watched being
+ * re-applied on a later resolution, not just at registration.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const h = vi.hoisted(() => ({ resourcesDir: '' }))
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => ({
+  getResourcesDirectory: () => h.resourcesDir,
+}))
+
+const store = await import('../../../src/main/canvas/canvas-store')
+
+const SID = 'aaaa1111aaaa1111aaaa1111'
+
+const tempDirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tempDirs.push(dir)
+  return dir
+}
+
+let resources = ''
+
+beforeEach(() => {
+  store._resetCanvasStoreForTest()
+  store.revokeCanvasUatRoots(SID)
+  resources = tmp('ccc-res-')
+  h.resourcesDir = resources
+})
+
+afterAll(() => {
+  for (const d of tempDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+})
+
+describe('a live root is refused anywhere near the resources directory', () => {
+  it('refuses the resources directory itself', () => {
+    expect(store.registerCanvasUatRoot(SID, resources)).toBe(false)
+    expect(store.canvasRootsForSession(SID).project).toBeNull()
+  })
+
+  it('refuses the credential directories UNDER it', () => {
+    for (const name of ['CONFIG', 'account-profiles', 'account-homes', 'canvas']) {
+      const dir = path.join(resources, name)
+      fs.mkdirSync(dir, { recursive: true })
+      expect(store.registerCanvasUatRoot(SID, dir), name).toBe(false)
+    }
+    // …and something nested deeper still.
+    const deep = path.join(resources, 'CONFIG', '_backups', '2026-08-22')
+    fs.mkdirSync(deep, { recursive: true })
+    expect(store.registerCanvasUatRoot(SID, deep)).toBe(false)
+  })
+
+  it('refuses a directory that CONTAINS it — serving a parent serves the resources dir', () => {
+    // The case that bites: resources pointed inside a directory you work in.
+    const project = tmp('ccc-proj-')
+    h.resourcesDir = path.join(project, 'resources')
+    fs.mkdirSync(h.resourcesDir, { recursive: true })
+    expect(store.registerCanvasUatRoot(SID, project)).toBe(false)
+  })
+
+  it('refuses a case-variant spelling on a case-insensitive filesystem', () => {
+    const variant = process.platform === 'win32' ? resources.toUpperCase() : resources
+    expect(store.registerCanvasUatRoot(SID, variant)).toBe(false)
+  })
+
+  it('refuses a path that reaches it through ..', () => {
+    const sibling = path.join(resources, 'CONFIG', '..')
+    fs.mkdirSync(path.join(resources, 'CONFIG'), { recursive: true })
+    expect(store.registerCanvasUatRoot(SID, sibling)).toBe(false)
+  })
+
+  it('still accepts an ordinary project directory — the refusal is scoped, not a blanket deny', () => {
+    const project = tmp('ccc-proj-')
+    expect(store.registerCanvasUatRoot(SID, project)).toBe(true)
+    expect(store.canvasRootsForSession(SID).project).toBe(project)
+  })
+
+  it('accepts a sibling of the resources directory', () => {
+    const sibling = path.join(path.dirname(resources), `${path.basename(resources)}-work`)
+    fs.mkdirSync(sibling, { recursive: true })
+    tempDirs.push(sibling)
+    expect(store.registerCanvasUatRoot(SID, sibling)).toBe(true)
+  })
+})
+
+describe('a designated worktree root gets the same floor', () => {
+  it('refuses one under the resources directory at designation time', () => {
+    expect(store.designateCanvasWorktreeRoot(SID, path.join(resources, 'CONFIG', 'wt'))).toBe(false)
+    expect(store.designateCanvasWorktreeRoot(SID, resources)).toBe(false)
+  })
+
+  it('accepts an ordinary worktree path that does not exist yet', () => {
+    const wt = path.join(tmp('ccc-wt-'), 'branch-a')
+    expect(store.designateCanvasWorktreeRoot(SID, wt)).toBe(true)
+    expect(store.canvasRootsForSession(SID).worktreePending).toBe(true)
+    fs.mkdirSync(wt, { recursive: true })
+    expect(store.canvasRootsForSession(SID).worktree).toBe(fs.realpathSync.native(wt))
+  })
+
+  /**
+   * The floor is re-applied on EVERY resolution, not just at designation — a
+   * directory that was fine yesterday and is inside the resources dir today
+   * stops serving today. Driven here by moving the resources directory onto an
+   * already-designated, already-serving root.
+   */
+  it('stops serving a designated root the moment the resources directory moves onto it', () => {
+    const wt = path.join(tmp('ccc-wt-'), 'branch-b')
+    fs.mkdirSync(wt, { recursive: true })
+    expect(store.designateCanvasWorktreeRoot(SID, wt)).toBe(true)
+    expect(store.canvasRootsForSession(SID).worktree).toBe(fs.realpathSync.native(wt))
+
+    h.resourcesDir = wt
+    expect(store.canvasRootsForSession(SID).worktree).toBeNull()
+
+    // …and comes back when it moves away again: this is a live check, not a latch.
+    h.resourcesDir = resources
+    expect(store.canvasRootsForSession(SID).worktree).toBe(fs.realpathSync.native(wt))
+  })
+})
+
+describe('an unresolvable resources directory does not take the floor down with it', () => {
+  it('falls back to the other refusals rather than accepting everything', () => {
+    h.resourcesDir = ''
+    const project = tmp('ccc-proj-')
+    // The resources check cannot answer, so it abstains — and the pre-existing
+    // floors still hold.
+    expect(store.registerCanvasUatRoot(SID, project)).toBe(true)
+    expect(store.registerCanvasUatRoot(SID, os.homedir())).toBe(false)
+  })
+
+  it('refuses a resources directory that is not on disk yet, lexically', () => {
+    const ghost = path.join(tmp('ccc-ghost-'), 'not-created')
+    h.resourcesDir = ghost
+    fs.mkdirSync(ghost, { recursive: true })
+    expect(store.registerCanvasUatRoot(SID, ghost)).toBe(false)
+  })
+})

--- a/tests/unit/main/canvas-resources-root-floor.test.ts
+++ b/tests/unit/main/canvas-resources-root-floor.test.ts
@@ -160,6 +160,47 @@ describe('a refusal says which floor it hit', () => {
     expect(words).toMatch(/Settings|move|Point this session/i)
   })
 
+  /**
+   * The refusal string is relayed to a MODEL, and a folder name inside the path
+   * is user-authored. Control/format/bidi characters and unbounded length are
+   * the same ingress class `safeRootLabel` already strips one layer up
+   * (#371, ADR-009 pass).
+   */
+  it('sanitises the path before putting it in model-facing text', () => {
+    const nasty = `${resources}\u0007\u001b[31m\u202Eevil\u0085\u200B`
+    const words = store.describeCanvasRootRefusal('resources-dir', nasty)
+    for (const ch of ['\u0007', '\u001b', '\u202E', '\u0085']) expect(words).not.toContain(ch)
+    expect(words).toContain('evil') // the NAME survives; only the controls go
+  })
+
+  it('caps an absurdly long path rather than relaying all of it', () => {
+    const words = store.describeCanvasRootRefusal('resources-dir', `C:\\${'a'.repeat(5000)}`)
+    expect(words.length).toBeLessThan(600)
+    expect(words).toContain('…')
+  })
+
+  /**
+   * TOCTOU: the check and the add used to realpath separately, so a directory
+   * swapped for a symlink between them was checked as itself and added as its
+   * target. `canvasRootCheck` resolves ONCE and hands that path back.
+   */
+  it('resolves once, and registers exactly what it checked', () => {
+    const project = tmp('ccc-proj-')
+    const checked = store.canvasRootCheck(SID, project)
+    expect(checked.refusal).toBeNull()
+    expect(checked.real).toBe(fs.realpathSync.native(project))
+
+    expect(store.registerCanvasUatRoot(SID, project)).toBe(true)
+    expect(store.canvasRootsForSession(SID).project).toBe(checked.real)
+  })
+
+  it('never throws, whatever it is handed — a spawn must not die on a bad path', () => {
+    for (const bad of ['', 'relative', 'C:\\does\\not\\exist\\at\\all', '\0', 'Z:\\unmapped']) {
+      expect(() => store.canvasRootCheck(SID, bad)).not.toThrow()
+      expect(() => store.registerCanvasUatRoot(SID, bad)).not.toThrow()
+    }
+  })
+
   it('distinguishes the floors rather than lumping them together', () => {
     const project = tmp('ccc-proj-')
     expect(store.canvasRootRefusalReason(SID, project)).toBeNull()

--- a/tests/unit/main/canvas-resources-root-floor.test.ts
+++ b/tests/unit/main/canvas-resources-root-floor.test.ts
@@ -141,6 +141,56 @@ describe('a designated worktree root gets the same floor', () => {
   })
 })
 
+/**
+ * #371 review MAJOR-1 — the refusal must not be a silent dead end.
+ *
+ * The one configuration the contains-it direction exists for (resources
+ * directory inside a project you work in) produced: a log line that did not say
+ * which floor refused, the loss of a worktree root that did not need refusing,
+ * and an agent told to "write the html inside the project folder" — which is
+ * exactly where it had just written it.
+ */
+describe('a refusal says which floor it hit', () => {
+  it('names the resources directory as the reason, and does not blame the path', () => {
+    expect(store.canvasRootRefusalReason(SID, resources)).toBe('resources-dir')
+    const words = store.describeCanvasRootRefusal('resources-dir', resources)
+    expect(words).toContain(resources)
+    expect(words).toMatch(/resources directory/i)
+    // It must tell the user what to DO, not just that it is refused.
+    expect(words).toMatch(/Settings|move|Point this session/i)
+  })
+
+  it('distinguishes the floors rather than lumping them together', () => {
+    const project = tmp('ccc-proj-')
+    expect(store.canvasRootRefusalReason(SID, project)).toBeNull()
+    expect(store.canvasRootRefusalReason(SID, os.homedir())).toBe('home-or-ancestor')
+    expect(store.canvasRootRefusalReason(SID, 'relative/path')).toBe('not-absolute')
+    // A drive root is ALSO an ancestor of home, and that floor is checked
+    // first — so it reports 'home-or-ancestor'. Refused either way; the point
+    // here is that the reasons are distinct, not that this one is 'volume-root'.
+    expect(store.canvasRootRefusalReason(SID, path.parse(process.cwd()).root)).not.toBeNull()
+  })
+
+  it('carries the explanation to whatever has to tell somebody, and clears once a root registers', () => {
+    store.setCanvasRootRefusal(SID, store.describeCanvasRootRefusal('resources-dir', resources))
+    expect(store.canvasRootRefusalFor(SID)).toMatch(/resources directory/i)
+
+    // A session that later registers a legitimate root has nothing to explain.
+    expect(store.registerCanvasUatRoot(SID, tmp('ccc-proj-'))).toBe(true)
+    expect(store.canvasRootRefusalFor(SID)).toBeNull()
+  })
+
+  it('a refused PROJECT root does not cost the session its worktree root', () => {
+    // They were in one else-if chain, so one refusal took both — even though
+    // `<parent>/ccc-wt/<sid>` neither contains nor sits under the resources dir.
+    expect(store.registerCanvasUatRoot(SID, resources)).toBe(false)
+    const wt = path.join(tmp('ccc-wt-'), 'branch-x')
+    expect(store.designateCanvasWorktreeRoot(SID, wt)).toBe(true)
+    fs.mkdirSync(wt, { recursive: true })
+    expect(store.canvasRootsForSession(SID).worktree).toBe(fs.realpathSync.native(wt))
+  })
+})
+
 describe('an unresolvable resources directory does not take the floor down with it', () => {
   it('falls back to the other refusals rather than accepting everything', () => {
     h.resourcesDir = ''

--- a/tests/unit/main/ccc-ux-protocol.test.ts
+++ b/tests/unit/main/ccc-ux-protocol.test.ts
@@ -173,14 +173,20 @@ describe('design serving', () => {
 // ---------------------------------------------------------------------------
 
 function makeDist(): string {
-  const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-ux-dist-'))
+  // The dist gets its OWN parent to be registered as the base. It used to be
+  // `path.dirname(mkdtemp(tmpdir))`, i.e. the whole system temp directory —
+  // which also contains this suite's mocked resources directory, and the floor
+  // now refuses any root that contains it (#371).
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-ux-base-'))
+  const dist = path.join(base, 'dist')
+  fs.mkdirSync(dist)
   fs.writeFileSync(path.join(dist, 'index.html'), '<html><head></head><body>app</body></html>')
   fs.mkdirSync(path.join(dist, 'assets'))
   fs.writeFileSync(path.join(dist, 'assets', 'app.js'), 'console.log(1)')
   fs.writeFileSync(path.join(dist, 'secret-sibling.txt'), 'inside-ok')
   // UAT roots are default-deny: the base the dist sits under must be registered
   // before renderVersion will accept it (serving still stays inside `dist`).
-  registerCanvasUatRoot(SID, path.dirname(dist))
+  registerCanvasUatRoot(SID, base)
   return dist
 }
 


### PR DESCRIPTION
Closes the fifth checklist item on #371:

> - [ ] canvas served-root floor could also refuse the resources directory (same-user hardening)

## The gap

The floor refused the home directory and every ancestor of it, a volume root, and the dot directories under home (`~/.ssh`, `~/.claude`, `~/.aws`, `~/.gnupg`) — the places a **user's** credentials live. It did not refuse the place **this app** keeps credentials.

The resources directory holds `CONFIG/` — `ssh-credentials.json` (DPAPI-encrypted SSH passwords, sudo passwords, secret arguments) and `conductor-secret.json` (the Conductor MCP HMAC key) — plus `account-profiles/` and `account-homes/` (Claude OAuth tokens), and the canvas store itself. Registered as a canvas served root, all of it is readable over the `ccc-ux://` surface.

Same-user hardening, not a privilege boundary: the agent already runs as the user. What it removes is the canvas quietly turning "read a file" into "serve a credential store over HTTP" because a working directory pointed there.

## All three directions

`isResourcesDirOrAround` refuses the directory itself, anything **under** it, and anything that **contains** it.

The third is the one worth arguing for, and the precedent is already in the file: `isHomeOrAncestor` refuses ancestors of home for exactly this reason — serving a parent serves the child. It bites when someone points their resources directory inside a project they work in, which is the one configuration where the exposure is both real and invisible.

Applied at **all three sites** the floor is applied, or two of them are a way round it:

| Site | Why it needs it |
| --- | --- |
| `registerCanvasUatRoot` | the live root, at spawn |
| `designateCanvasWorktreeRoot` | the lexical floor for a worktree that does not exist yet |
| `liveDesignatedRoot` | re-evaluated on **every** resolution, so a directory that was fine yesterday and is inside the resources dir today stops serving today |

The store's own rule settles the direction: *"Over-denial is the intended direction: a refused root costs a canvas render, an accepted one costs a credential."*

## Five existing suites changed — test layout, not the rule

Worth being explicit that these are fixture-placement problems, not the rule being too strict:

- **`ccc-ux-protocol`**, **`canvas-distroot-confinement`** registered `path.dirname(mkdtempSync(os.tmpdir()))` — the **whole system temp directory** — as the base. That also contains each suite's mocked resources directory, so the contains-it rule refuses it. Each now gets its own dedicated parent, which is what "the base the dist sits under" always meant.
- **`canvas-content-egress`**, **`canvas-record-provenance`**, **`canvas-adoption`** built dist/project directories **inside** the mocked resources directory. Moved to their own temp directories.

**No assertion changed** — only where the fixtures live.

## Verification

- `npm run typecheck` clean.
- Full `npx vitest run`: **7086 passed, 15 skipped, 2 todo** (662 files, 2 skipped).
- Each of the three sites mutated **independently** and watched go red — **6, 1 and 1** tests respectively — then restored byte-for-byte.
- The new suite covers: a case-variant spelling (the Windows case a string compare misses), a path reaching the directory through `..`, the credential subdirectories by name, a sibling directory that must still be accepted, an ordinary project directory that must still be accepted, a designated root that stops serving the moment the resources directory moves onto it (and resumes when it moves away — a live check, not a latch), and an unresolvable resources directory abstaining rather than refusing everything.

## Trust boundaries touched

- **Canvas served-root allowlist** (`canvas-store`) — the default-deny allowlist that decides which directories the `ccc-ux://` protocol may read from. This change only ever **removes** roots from it; there is no path by which it admits one.
- **The `ccc-ux://` read surface** indirectly: a refused root means `resolveInsideCanvasRoot` / `distRootAllowed` fail closed for it.
- No IPC surface, no new file reads, and no change to how the canvas store signs or verifies its own records.

Kept deliberately minimal (one new predicate + three one-line applications) given #403 is also in `src/main/canvas/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Correction (post-review): the "only ever removes roots" claim is retracted — the worktree-designation branch was lifted out of the else-if, so a session with a refused project root now gets a designated root it did not before. The predicate itself stays deny-only, and the newly-designated root is floor-checked at designation and re-checked on every resolution, so there is no exposure; documentation accuracy only._
