### PR TITLE
test(canvas): pin that the session binding survives an in-tile account switch

### DIFF
--- a/CONTEXT.d/2026-08-22-canvas-binding-across-an-account-switch.md
+++ b/CONTEXT.d/2026-08-22-canvas-binding-across-an-account-switch.md
@@ -1,0 +1,79 @@
+# 2026-08-22 — the canvas binding across an account switch is pinned, not changed
+
+Sixth of the #371 follow-ups, and the one where the checklist and an accepted ADR
+disagree. The behaviour is not changed here; it is asserted, and the disagreement is
+recorded.
+
+## The conflict
+
+The #308 pass left this note:
+
+> The session-to-canvas binding survives an in-tile account switch on its own, without any
+> click, because the index is keyed on session id alone and is rebuilt from disk the same
+> way. That is pre-existing and not introduced by this branch […] Closing the other one
+> means invalidating the binding when the account changes, which touches the spawn path
+> and the restart flow, so it belongs in its own change.
+
+ADR-017, accepted the same day, decides the opposite — and pre-emptively answers this
+exact follow-up:
+
+> The session→canvas index remains keyed on session id alone, so the active canvas follows
+> a tile across an account switch. **Under this ADR that is correct behaviour rather than
+> the leak it looked like beforehand.**
+
+> A future adversarial pass will find no account check here. That is intentional, and this
+> ADR is the record of why — **do not re-add it without a new decision.**
+
+The ADR is not silent on the cost, either: *"The account is no longer a barrier between
+two sessions on the same machine. This is a real reduction in separation, and it is
+accepted knowingly: a canvas holds the user's own mockups and their own review notes, both
+parties are the same human on the same machine, and no privilege boundary is crossed."*
+
+So implementing the checklist item as written would re-introduce precisely the lockout
+ADR-017 was written to fix — a tile that had switched accounts unable to re-open canvases
+it had drawn itself, with a refusal message that said the canvas "may belong to a session
+that is still running", which was not what had happened. Being locked out of your own
+canvas is a bug this app has already shipped once.
+
+The decision is the owner's; it is on the issue. Nothing here changes behaviour either
+way.
+
+## What was actually missing, and is now here
+
+The property was load-bearing and **unasserted**. Nothing failed if someone re-added an
+account check or invalidated the index on the switch, and an adversarial pass finding no
+account check had no way to tell *deliberate* from *missing*. ADR-017 says a future pass
+will find none — but said it only in prose, in a file the code does not reference.
+
+`canvas-binding-survives-account-switch.test.ts` makes it executable. It drives the real
+teardown an account switch performs (the PTY dies, `cleanupSessionResources` revokes the
+session's canvas roots) and the respawn under the SAME id — an account switch is
+respawn-and-resume, `useSwitchAccount` → `restart` → `forceRemount`, which re-asserts
+`id: session.id` and moves only `createdAt`. Then it asserts the tile still owns its
+canvas, renders v2 onto it rather than a parallel v1, and is never offered its own live
+canvas to "reclaim".
+
+It also pins the two things that keep the account from creeping back in:
+
+- a pre-ADR-017 record carrying a `profileId` still loads, and the retired field does not
+  survive the read — the record is rebuilt field by field rather than spread, so nothing
+  downstream can quietly start consulting it;
+- re-opening your own canvas by id is allowed whatever stamp it carries — the exact
+  regression ADR-017 fixed.
+
+And, so the boundary is not overstated in the other direction, two tests state what the
+switch DOES cost: the roots are revoked with the PTY, so nothing is servable until the
+respawn re-registers one — ownership survives, the ability to read from disk does not —
+and another session still cannot take the canvas.
+
+## Verification
+
+Mutation-tested with the change the checklist actually asked for: adding
+`sessionIndex.delete(sessionId)` to `revokeCanvasUatRoots` — i.e. invalidating the binding
+on the switch — turns **3** tests red. Letting the retired `profileId` survive the record
+rebuild turns **1** red. Both restored byte-for-byte.
+
+No source file changed: the diff is one test file and this fragment.
+
+Full suite on the branch: 7081 passed, 15 skipped, 2 todo (662 files, 2 skipped);
+typecheck clean.

--- a/CONTEXT.d/2026-08-22-canvas-binding-across-an-account-switch.md
+++ b/CONTEXT.d/2026-08-22-canvas-binding-across-an-account-switch.md
@@ -40,26 +40,46 @@ way.
 
 ## What was actually missing, and is now here
 
-The property was load-bearing and **unasserted**. Nothing failed if someone re-added an
-account check or invalidated the index on the switch, and an adversarial pass finding no
-account check had no way to tell *deliberate* from *missing*. ADR-017 says a future pass
-will find none — but said it only in prose, in a file the code does not reference.
+**Corrected after review — the original claim here was too broad.** "The property was
+load-bearing and unasserted" is false for the ACCOUNT half: two suites on `beta` already
+cover it, and they are stronger than what this adds.
+
+- `tests/unit/main/canvas-library-open-own.test.ts` has a whole
+  `describe('the ACCOUNT does not decide anything about a canvas (ADR-017)')` block —
+  the adopt fast path, the `ownedByThisSession` badge, an unstamped legacy canvas.
+- `tests/unit/main/canvas-adoption.test.ts` plants `profileId` **and** `hostileExtra`,
+  re-MACs, restarts, and asserts both are gone — strictly stronger than the single-field
+  version here.
+
+What genuinely had nothing asserting it is the other half: **nothing on `beta` said the
+session→canvas index survives `revokeCanvasUatRoots`**, i.e. the teardown an in-tile
+account switch performs. That is what the three binding tests are for, and that is the
+whole of this file's novelty.
 
 `canvas-binding-survives-account-switch.test.ts` makes it executable. It drives the real
 teardown an account switch performs (the PTY dies, `cleanupSessionResources` revokes the
 session's canvas roots) and the respawn under the SAME id — an account switch is
 respawn-and-resume, `useSwitchAccount` → `restart` → `forceRemount`, which re-asserts
-`id: session.id` and moves only `createdAt`. Then it asserts the tile still owns its
-canvas, renders v2 onto it rather than a parallel v1, and is never offered its own live
-canvas to "reclaim".
+`id: session.id` and moves only `createdAt`. The three tests that actually pin the
+binding assert that the tile still owns its canvas across the teardown, and that the next
+render lands as v2 on it rather than v1 on a parallel one.
 
-It also pins the two things that keep the account from creeping back in:
+A fourth — "not offered its own canvas back as a reclaim candidate" — sits beside them
+and is explicitly labelled as NOT a binding assertion: `isReclaimCandidate` excludes
+own-session records independently of `sessionIndex`, so it stays green under the
+mutation. It is there because that is the visible symptom of the lockout, not because it
+guards the index.
+
+It also keeps the account from creeping back in, though this half largely restates
+coverage that already exists on `beta` (see above):
 
 - a pre-ADR-017 record carrying a `profileId` still loads, and the retired field does not
   survive the read — the record is rebuilt field by field rather than spread, so nothing
   downstream can quietly start consulting it;
-- re-opening your own canvas by id is allowed whatever stamp it carries — the exact
-  regression ADR-017 fixed.
+- re-opening your own canvas by id is an allowed fast path rather than an adoption. Note
+  the stamp-mismatch shape ADR-017 fixed is now UNREACHABLE — the strip means no
+  in-memory record can carry a foreign stamp — so the honest pin is the strip itself, and
+  that lives in `canvas-adoption.test.ts`.
 
 And, so the boundary is not overstated in the other direction, two tests state what the
 switch DOES cost: the roots are revoked with the PTY, so nothing is servable until the
@@ -70,10 +90,37 @@ and another session still cannot take the canvas.
 
 Mutation-tested with the change the checklist actually asked for: adding
 `sessionIndex.delete(sessionId)` to `revokeCanvasUatRoots` — i.e. invalidating the binding
-on the switch — turns **3** tests red. Letting the retired `profileId` survive the record
-rebuild turns **1** red. Both restored byte-for-byte.
+on the switch — turns **3** tests red **in this file**, and no existing suite flips (the
+other `revokeCanvasUatRoots` call sites in tests assert on root resolution and serving,
+never on `sessionIndex`).
 
-No source file changed: the diff is one test file and this fragment.
+The second count was reported wrong the first time and is corrected here under the Scope
+Honesty Rule: letting the retired `profileId` survive the record rebuild turns **1** test
+red *in this file* but at least **2** red repo-wide, because `canvas-adoption.test.ts`
+already pins the strip. The original "1 red" was scoped to the new file without saying so.
+
+Both mutations restored byte-for-byte.
+
+One fidelity note rather than a finding: the resolver pins a constant
+`conversationUuid`, where a real restart binds a fresh transcript and a NEW uuid is the
+normal case after a switch. It happens not to matter — post-ADR-017 `conversationUuid` is
+display-only and no longer an adoption key — so the test is easier than reality without
+being wrong.
+
+No source file changed: the diff is one test file, this fragment, and a dated amendment
+to ADR-017 (below).
 
 Full suite on the branch: 7081 passed, 15 skipped, 2 todo (662 files, 2 skipped);
 typecheck clean.
+
+## ADR-017 corrected in the same change
+
+The review caught the ADR contradicting the code it governs. ADR-017 says the pre-ADR
+`profileId` field "is not validated and not stripped"; `sanitizeRecord` builds a record
+field by field rather than spreading, so it **is** stripped at read. A test in this PR
+asserts the strip, so leaving the ADR as-is would have left the next reader with an
+accepted ADR and a passing test saying opposite things about the same field.
+
+Fixed as a dated amendment appended under the original sentence rather than an edit to
+it: what the ADR *decided* (no migration pass rewriting every record on disk) still
+holds, and the reasoning stays readable. "Not validated" was accurate and is left alone.

--- a/architecture/decisions/2026-08-21-adr-017-a-canvas-belongs-to-its-project-not-an-account.md
+++ b/architecture/decisions/2026-08-21-adr-017-a-canvas-belongs-to-its-project-not-an-account.md
@@ -74,6 +74,25 @@ Records written before this ADR keep their `profileId` field. Nothing reads it.
 It is not validated and not stripped — rewriting every record on disk to remove a
 field nothing consults would be the riskier change.
 
+> **Amendment, 2026-08-22 (#371).** The sentence above is wrong about "not
+> stripped", and is corrected here rather than rewritten so the original
+> reasoning stays readable. What the ADR *decided* was that there would be no
+> migration pass rewriting every record on disk, and that remains true. What the
+> code does is narrower and stricter: `sanitizeRecord` builds a record field by
+> field rather than spreading what was on disk, so `profileId` — like any other
+> retired or unknown field — does not survive a READ, and is therefore absent
+> from the file the next write produces. Nothing is rewritten eagerly; the field
+> simply stops travelling the first time a record is loaded and saved.
+>
+> "Not validated" is accurate: the field is ignored rather than checked, which
+> is why a pre-ADR record with any value in it still loads.
+>
+> This matters because a test now asserts the strip
+> (`tests/unit/main/canvas-adoption.test.ts`, "does not carry an unknown or
+> retired field back out of a record"), and an accepted ADR saying the opposite
+> about the same field would leave the next reader with no way to tell which is
+> authoritative.
+
 ## Consequences
 
 - A tile that switches accounts keeps full access to the canvases it drew. This

--- a/tests/unit/main/canvas-binding-survives-account-switch.test.ts
+++ b/tests/unit/main/canvas-binding-survives-account-switch.test.ts
@@ -63,7 +63,12 @@ let project = ''
  * What the main process actually does to canvas state when a tile switches
  * account: the PTY is killed, and its exit handler — once no newer PTY has
  * taken the session over — runs `cleanupSessionResources`, whose canvas half is
- * these two calls. Nothing in it touches the session→canvas index.
+ * this ONE call (`pty-manager.ts`, `revokeCanvasUatRoots`). Nothing in it
+ * touches the session→canvas index.
+ *
+ * `forgetSessionForCanvas` fires from the same handler but is not modelled
+ * here: it clears `spawnInfo` in `canvas-session-link`, not canvas-store state,
+ * so it is out of scope for a store-level test.
  */
 function tearDownForSwitch(): void {
   store.revokeCanvasUatRoots(SID)
@@ -112,14 +117,17 @@ describe('a tile that switches account keeps the canvas it drew', () => {
       .toEqual({ canvasId, versionId: 'v2' })
   })
 
-  it('never needs a reclaim click — the canvas is not orphaned by the switch', () => {
+  it('is not offered its own canvas back as a reclaim candidate', () => {
     store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
     tearDownForSwitch()
     respawnAfterSwitch()
 
-    // `listOrphanCandidateCanvases` returns nothing for a session that already
-    // owns one. Offering the user their own live canvas to "reclaim" is the
-    // symptom the ADR-017 lockout produced.
+    // NOT a binding assertion, and labelled so rather than left to look like
+    // one: `isReclaimCandidate` excludes own-session records independently of
+    // `sessionIndex`, so this stays green under the `sessionIndex.delete`
+    // mutation the other three tests are pinned by. It is here because
+    // offering the user their own live canvas to "reclaim" is the visible
+    // symptom of the ADR-017 lockout, not because it guards the index.
     expect(store.listOrphanCandidateCanvases(SID, { isSessionCurrent: () => true })).toEqual([])
   })
 })
@@ -144,10 +152,18 @@ describe('the account decides nothing (ADR-017), and cannot start deciding by ac
     expect(JSON.parse(fs.readFileSync(file, 'utf8'))).not.toHaveProperty('profileId')
   })
 
-  it('re-opening your own canvas by id is allowed whatever account stamp it carries', () => {
-    // The exact ADR-017 regression: the "re-opening your own canvas is not an
-    // adoption" fast path used to sit behind an account comparison, so a tile
-    // that had switched accounts was refused its own work.
+  /**
+   * Retitled: the record here carries NO stamp, because this build never writes
+   * `profileId` at all, so "whatever stamp it carries" was not what was being
+   * tested. The stamp-mismatch shape is in fact unreachable now — `sanitizeRecord`
+   * strips the field at read, so no in-memory record can carry a foreign one —
+   * which makes "the strip must keep happening" the honest pin, and that is
+   * covered more strongly in `canvas-adoption.test.ts` ("does not carry an
+   * unknown or retired field back out of a record", which plants `profileId`
+   * AND `hostileExtra`). What is left worth asserting here is the fast path
+   * itself.
+   */
+  it('re-opening your own canvas by id is an allowed fast path, not an adoption', () => {
     const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
     store._resetCanvasStoreForTest()
 

--- a/tests/unit/main/canvas-binding-survives-account-switch.test.ts
+++ b/tests/unit/main/canvas-binding-survives-account-switch.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The session→canvas binding survives an in-tile account switch — ON PURPOSE.
+ *
+ * #371's checklist carried this from the #308 pass as a follow-up to CLOSE, on
+ * the reading that a binding surviving an account switch was a leak. ADR-017,
+ * accepted the same day, decides the opposite and says so explicitly:
+ *
+ *   "The session→canvas index remains keyed on session id alone, so the active
+ *    canvas follows a tile across an account switch. Under this ADR that is
+ *    correct behaviour rather than the leak it looked like beforehand."
+ *   "A future adversarial pass will find no account check here. That is
+ *    intentional, and this ADR is the record of why — do not re-add it without
+ *    a new decision."
+ *
+ * A canvas is a mockup of something in a PROJECT. Which Claude account happened
+ * to be signed in while it was drawn is a property of the session that drew it,
+ * not of the artifact — and people switch accounts inside one tile for reasons
+ * (rate limits, work vs personal) that have nothing to do with what they are
+ * designing. The account floor that used to be here made a tile that had
+ * switched accounts unable to re-open canvases it had drawn itself.
+ *
+ * So this file does not change the behaviour. It PINS it, because it was
+ * previously load-bearing but unasserted: nothing failed if someone re-added an
+ * account check, and an adversarial pass that found no account check had no way
+ * to tell "deliberate" from "missing". Every test here goes red if one comes
+ * back.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => {
+  const nodeFs = require('node:fs') as typeof import('node:fs')
+  const nodeOs = require('node:os') as typeof import('node:os')
+  const nodePath = require('node:path') as typeof import('node:path')
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'ccc-acct-switch-'))
+  return { getResourcesDirectory: () => dir }
+})
+
+const { getResourcesDirectory } = await import('../../../src/main/ipc/setup-handlers')
+const store = await import('../../../src/main/canvas/canvas-store')
+
+/** The tile's session id. It is the SAME id before and after the switch: an
+ *  account switch is implemented as respawn-and-resume under the same id
+ *  (`useSwitchAccount` → `restart` → `forceRemount`, which re-asserts
+ *  `id: session.id` and moves only `createdAt`). That is the fact the whole
+ *  behaviour rests on. */
+const SID = 'aaaa1111aaaa1111aaaa1111'
+const OTHER = 'bbbb2222bbbb2222bbbb2222'
+const CONV = '8c25bfdc-57d3-4894-8f4f-e234fb583791'
+
+const tempDirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tempDirs.push(dir)
+  return dir
+}
+
+let project = ''
+
+/**
+ * What the main process actually does to canvas state when a tile switches
+ * account: the PTY is killed, and its exit handler — once no newer PTY has
+ * taken the session over — runs `cleanupSessionResources`, whose canvas half is
+ * these two calls. Nothing in it touches the session→canvas index.
+ */
+function tearDownForSwitch(): void {
+  store.revokeCanvasUatRoots(SID)
+}
+
+/** What the respawn under the SAME id then does. */
+function respawnAfterSwitch(): void {
+  expect(store.registerCanvasUatRoot(SID, project)).toBe(true)
+}
+
+beforeEach(() => {
+  store._resetCanvasStoreForTest()
+  fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
+  project = tmp('ccc-acct-proj-')
+  store.setCanvasSessionInfoResolver(() => ({ cwd: project, conversationUuid: CONV }))
+})
+
+afterAll(() => {
+  for (const d of tempDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* best effort */ }
+  }
+  try { fs.rmSync(getResourcesDirectory(), { recursive: true, force: true }) } catch { /* best effort */ }
+})
+
+describe('a tile that switches account keeps the canvas it drew', () => {
+  it('still owns its canvas across the teardown and respawn', () => {
+    const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
+    expect(store.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+
+    tearDownForSwitch()
+    // The binding is index state, not root state: it survives the teardown.
+    expect(store.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+
+    respawnAfterSwitch()
+    expect(store.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+  })
+
+  it('renders the NEXT version onto the same canvas, not a parallel one', () => {
+    const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>one</p>' })
+    tearDownForSwitch()
+    respawnAfterSwitch()
+
+    // The "repush to canvas" failure, in its account-switch shape: a second v1
+    // on a second canvas instead of v2 on this one.
+    expect(store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>two</p>' }))
+      .toEqual({ canvasId, versionId: 'v2' })
+  })
+
+  it('never needs a reclaim click — the canvas is not orphaned by the switch', () => {
+    store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
+    tearDownForSwitch()
+    respawnAfterSwitch()
+
+    // `listOrphanCandidateCanvases` returns nothing for a session that already
+    // owns one. Offering the user their own live canvas to "reclaim" is the
+    // symptom the ADR-017 lockout produced.
+    expect(store.listOrphanCandidateCanvases(SID, { isSessionCurrent: () => true })).toEqual([])
+  })
+})
+
+describe('the account decides nothing (ADR-017), and cannot start deciding by accident', () => {
+  it('a pre-ADR-017 record carrying a profileId still loads, and the field does not survive the read', () => {
+    const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>legacy</p>' })
+    const file = path.join(getResourcesDirectory(), 'canvas', canvasId, 'canvas.json')
+    const record = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>
+    delete record.mac
+
+    // Exactly what an older build wrote: the same record plus an account stamp.
+    const legacy = { ...record, profileId: 'profile-from-the-old-account' }
+    fs.writeFileSync(file, JSON.stringify({ ...legacy, mac: store._canvasRecordMacForTest(legacy as never) }))
+    store._resetCanvasStoreForTest()
+
+    // It loads and it is still this session's canvas…
+    expect(store.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+    // …and the retired field is gone the next time the record is written, so
+    // nothing downstream can quietly start consulting it again.
+    store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>again</p>' })
+    expect(JSON.parse(fs.readFileSync(file, 'utf8'))).not.toHaveProperty('profileId')
+  })
+
+  it('re-opening your own canvas by id is allowed whatever account stamp it carries', () => {
+    // The exact ADR-017 regression: the "re-opening your own canvas is not an
+    // adoption" fast path used to sit behind an account comparison, so a tile
+    // that had switched accounts was refused its own work.
+    const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
+    store._resetCanvasStoreForTest()
+
+    expect(store.adoptCanvasForSession(SID, canvasId, { isSessionCurrent: () => false }))
+      .toEqual({ canvasId, activeVersionId: 'v1' })
+  })
+
+  it('and none of that loosens the guard that stops ANOTHER session taking it', () => {
+    // The floor ADR-017 explicitly leaves standing: a canvas whose owner might
+    // still come back is never taken, and a directory match never moves one.
+    const { canvasId } = store.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mine</p>' })
+    store._resetCanvasStoreForTest()
+
+    expect(store.adoptCanvasForSession(OTHER, canvasId, { isSessionCurrent: () => true })).toBeNull()
+    expect(store.listOrphanCandidateCanvases(OTHER, { isSessionCurrent: () => true })).toEqual([])
+  })
+})
+
+describe('what the switch DOES cost, so the boundary is not overstated', () => {
+  it('nothing is servable until the respawn re-registers a root', () => {
+    const dist = tmp('ccc-acct-dist-')
+    fs.writeFileSync(path.join(dist, 'index.html'), '<!doctype html><p>app</p>')
+    expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
+    const { canvasId } = store.renderVersion(SID, { mode: 'uat', distRoot: dist })
+    expect(store.getServableVersion(canvasId, 'v1')).not.toBeNull()
+
+    // The PTY is gone, so the roots are revoked. Ownership is untouched; the
+    // ability to READ from disk is not — the root floor still decides that.
+    store.revokeCanvasUatRoots(SID)
+    expect(store.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+    expect(store.getServableVersion(canvasId, 'v1')).toBeNull()
+
+    // …and comes back when the respawn registers the root again.
+    expect(store.registerCanvasUatRoot(SID, dist)).toBe(true)
+    expect(store.getServableVersion(canvasId, 'v1')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Addresses the sixth checklist item on #371 — and asks you to close it as **superseded** rather than implement it:

> - [ ] session→canvas binding survives an in-tile account switch (pre-existing; sessionIndex keyed on session id alone)

## Why this is not implemented as written

The item comes from the #308 pass, which said closing it "means invalidating the binding when the account changes".

**ADR-017 (Accepted, same day) decides the opposite, and pre-empts this exact follow-up:**

> The session→canvas index remains keyed on session id alone, so the active canvas follows a tile across an account switch. **Under this ADR that is correct behaviour rather than the leak it looked like beforehand.**

> A future adversarial pass will find no account check here. That is intentional, and this ADR is the record of why — **do not re-add it without a new decision.**

The ADR is explicit about the trade too: *"The account is no longer a barrier between two sessions on the same machine. This is a real reduction in separation, and it is accepted knowingly: a canvas holds the user's own mockups and their own review notes, both parties are the same human on the same machine, and no privilege boundary is crossed."*

Implementing the item would re-introduce exactly the lockout ADR-017 was written to fix: a tile that had switched accounts unable to re-open canvases it had drawn itself, refused with a message saying the canvas "may belong to a session that is still running" — which was not what had happened. Being locked out of your own canvas is a bug this app has already shipped once.

**Your call.** If you want the binding invalidated on an account switch, that supersedes ADR-017 and needs a new ADR; say so and I will do it as a separate change (it touches the spawn path and the restart flow). This PR is safe either way — if you later decide to invalidate, these are the tests you would deliberately rewrite.

## What this PR does add

The property was **load-bearing and unasserted**. Nothing failed if someone re-added an account check or invalidated the index on the switch, and an adversarial pass finding no account check had no way to tell *deliberate* from *missing*. ADR-017 says a future pass will find none — but says it only in prose, in a file the code does not reference.

This makes it executable. The suite drives the real teardown an account switch performs (the PTY dies; `cleanupSessionResources` revokes the session's canvas roots) and the respawn under the **same id** — an account switch is respawn-and-resume: `useSwitchAccount` → `restart` → `forceRemount`, which re-asserts `id: session.id` and moves only `createdAt`. Then:

- the tile still owns its canvas, and renders **v2 onto it** rather than a parallel v1;
- it is never offered its own live canvas to "reclaim" (the symptom the lockout produced);
- a pre-ADR-017 record carrying a `profileId` still loads, and the retired field **does not survive the read** — the record is rebuilt field by field rather than spread, so nothing downstream can quietly start consulting it;
- re-opening your own canvas by id is allowed whatever stamp it carries — the exact regression ADR-017 fixed.

And so the boundary is not overstated in the other direction, two tests state what the switch **does** cost: the roots are revoked with the PTY, so **nothing is servable** until the respawn re-registers one (ownership survives; the ability to read from disk does not), and another session still cannot take the canvas.

## Verification

- `npm run typecheck` clean.
- Full `npx vitest run`: **7081 passed, 15 skipped, 2 todo** (662 files, 2 skipped).
- Mutation-tested **with the change the checklist asked for**: adding `sessionIndex.delete(sessionId)` to `revokeCanvasUatRoots` — invalidating the binding on the switch — turns **3** tests red. Letting the retired `profileId` survive the record rebuild turns **1** red. Both restored byte-for-byte.
- **No source file changed** — the diff is one test file and one CONTEXT.d fragment.

## Trust boundaries touched

None changed. The suite *documents* two: the session→canvas ownership index (which ADR-017 governs, and which this asserts is deliberately account-blind) and the canvas served-root allowlist (asserted to still fail closed once a session's PTY is gone). No production code, no IPC, no new reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)