### PR TITLE
fix(sessions): session-state durability + fail-open restore (#397)

### DIFF
--- a/CONTEXT.d/2026-08-22-n397-e2e-restore.md
+++ b/CONTEXT.d/2026-08-22-n397-e2e-restore.md
@@ -1,0 +1,40 @@
+## 2026-08-22 -- #397 desktop-gate e2e: session-state durability + fail-open restore
+
+**What changed.** Added `tests/e2e/session-restore.spec.ts` -- the desktop-gate
+evidence for #397 (session-state durability + fail-open restore). It proves, in the
+REAL packaged app, that an open session survives a HARD crash and that a corrupt
+persisted file never wedges boot. Test-only; no product code touched.
+
+- Two launches share ONE data dir. `helpers/electron-app` mkdtemps a fresh dir per
+  launch and rm's it on close, so it is used only for launch #1 (seed + boot); it
+  hands back its `dataDir`, and every relaunch re-launches Electron directly against
+  that same `CCC_E2E_DATA_DIR` with a per-launch `--user-data-dir` (a killed
+  instance's single-instance lock lives in the userdata dir). The dataDir is rm'd
+  once, in `afterAll`.
+- The session under test is a Terminal x Local config: no real `claude` needed
+  (absent in CI), yet it is a first-class persisted session (shellOnly, provider
+  'claude') that the autosave writes to `session-state.json` like any other.
+- Crash simulation = `taskkill /pid <electron> /T /F` on the process tree (not a
+  graceful `app.close()`), after polling `session-state.json` + its `.bak` to disk
+  so the debounced autosave (~1s) has actually flushed.
+- Asserts: (1) after crash+relaunch the "Resume previous sessions?" card lists the
+  session by name and Resume brings the `.session-card` row back; (2) fail-open --
+  a corrupt primary with an intact `.bak` boots clean AND recovers the last-good set
+  from the `.bak`, moving the unparseable primary aside to `*.corrupt-*`; (3)
+  fail-open -- a corrupt primary with NO usable `.bak` boots clean with no resume
+  prompt (no wedge, no phantom).
+
+**Boundaries (kept unit-only, stated in the spec header).** The per-field spawn
+repair (invalid resume uuid / codex preset -> dropped/floored) is
+`sanitize-restored-spawn-options.spec.ts` -- pure argv logic, no DOM. The
+read-failure latch (EBUSY/EACCES != absence) is `session-state-read-failure.spec.ts`
+-- holding a file unreadable mid-launch is not scriptable cross-platform.
+
+**How verified.** `npm run build` first (stale `out/` flakes every e2e), then
+`npx playwright test tests/e2e/session-restore.spec.ts`: 3 passed (plus the
+crash-and-restore setup in `beforeAll`), ~47s, screenshots attached
+(`01-resume-prompt-after-crash`, `02-session-restored`, `03-recovered-from-bak`,
+`04-clean-start-no-bak`).
+
+**Left.** Human still applies the `desktop-tested` label; the spec is evidence, not
+the attestation. HELD AT COMMIT -- not pushed, PR #413 not updated.

--- a/CONTEXT.d/2026-08-22-n397-e2e-restore.md
+++ b/CONTEXT.d/2026-08-22-n397-e2e-restore.md
@@ -26,8 +26,8 @@ persisted file never wedges boot. Test-only; no product code touched.
 
 **Boundaries (kept unit-only, stated in the spec header).** The per-field spawn
 repair (invalid resume uuid / codex preset -> dropped/floored) is
-`sanitize-restored-spawn-options.spec.ts` -- pure argv logic, no DOM. The
-read-failure latch (EBUSY/EACCES != absence) is `session-state-read-failure.spec.ts`
+`sanitize-restored-spawn-options.test.ts` -- pure argv logic, no DOM. The
+read-failure latch (EBUSY/EACCES != absence) is `session-state-read-failure.test.ts`
 -- holding a file unreadable mid-launch is not scriptable cross-platform.
 
 **How verified.** `npm run build` first (stale `out/` flakes every e2e), then
@@ -37,4 +37,4 @@ crash-and-restore setup in `beforeAll`), ~47s, screenshots attached
 `04-clean-start-no-bak`).
 
 **Left.** Human still applies the `desktop-tested` label; the spec is evidence, not
-the attestation. HELD AT COMMIT -- not pushed, PR #413 not updated.
+the attestation. Pushed on PR #413 (rebased onto beta 2026-08-23; independent-review fix round applied).

--- a/CONTEXT.d/2026-08-23-397-session-durability.md
+++ b/CONTEXT.d/2026-08-23-397-session-durability.md
@@ -1,0 +1,32 @@
+# 2026-08-23 — #397 session-state durability + fail-open restore (PR #413)
+
+**What changed.** Sessions restart no matter how the app closes. A durability
+core (`src/main/session-durability.ts`) makes `session:save` the single choke
+point: every renderer writer is enriched in main with each Claude session's
+exact resume target from the live transcript binder, cached, and persisted —
+so every file on disk is resumable, not only the graceful close. The cache is
+flushed on every exit path (`before-quit`, SIGTERM, powerMonitor shutdown) and
+dropped on an intentional clear so a flush can never resurrect a discarded
+set. Loading is crash-safe: a `.bak` previous-good mirror recovers external
+corruption of the primary (shape-corrupt JSON included — never coerced into an
+invented empty set), corrupt files are moved aside rather than destroyed, and
+migration is guarded per entry. Restoring is fail-open: corrupt persisted
+spawn fields (`resume`, codex preset, `permissionMode`, `extraArgs`) are
+dropped or floored by `sanitize-restored-spawn-options.ts` before the strict
+spawn parse, whose enum/charset/refine now live in that module so the
+sanitizer and the parse cannot drift. `permissionMode`/`extraArgs` round-trip
+through persistence, and the restore saves the live set instead of clearing —
+no gap where a crash lost everything.
+
+**Deliberate non-goal.** No flush inside main's `uncaughtException` handler
+(#397 Group 2 names it): synchronous atomic-write retries inside a dying
+handler risk more than the bounded loss — the on-disk file is already the
+last enriched save, so only the exit-time re-enrichment is lost.
+
+**Review.** ADR-009 adversarial PASS recorded on #397 (3 rounds, SSBN build);
+after the 66-commit rebase onto beta, an independent review round found and
+fixed an exit-flush/GitHub-writer clobber (R3), sanitizer coverage for the two
+newly persisted fields (S2), and the shape-corruption coercion (R4); the
+verification round PASSed with the schema extraction proven value-identical
+(byte comparison + 972-case fuzz). Security delta since the ADR-009 PASS:
+none — no new argv construction, no widened guard.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -733,18 +733,19 @@ if (!gotTheLock) {
 
   app.whenReady().then(() => {
     // #397 Group 2: exit paths that skip app 'before-quit'. An OS shutdown/logoff
-    // (powerMonitor; macOS/Linux) and a process signal (SIGTERM/SIGINT, e.g. a
-    // console Ctrl+C on a dev run or a task-manager terminate) can end the app
-    // without the window-close flow running. Persist sessions first, then quit
-    // gracefully so before-quit's own teardown still runs.
+    // (powerMonitor; macOS/Linux) and SIGTERM (task-manager terminate / OS teardown)
+    // can end the app without the window-close flow running. Persist sessions first.
     powerMonitor.on('shutdown', () => sessionDurability.flushOnExit('powerMonitor shutdown'))
     powerMonitor.on('suspend', () => sessionDurability.flushOnExit('powerMonitor suspend'))
-    for (const sig of ['SIGTERM', 'SIGINT'] as const) {
-      process.on(sig, () => {
-        sessionDurability.flushOnExit(sig)
-        app.quit()
-      })
-    }
+    // Only SIGTERM. SIGINT is intentionally LEFT to Node's default so a console
+    // Ctrl+C on a dev run still terminates in one press — a SIGINT handler here
+    // re-entered the vetoable graceful-close dialog and left the app alive
+    // (adversarial-review round-2). Flush, then exit HARD: app.quit() would be
+    // vetoed by that same dialog, so a signal must not route through it.
+    process.on('SIGTERM', () => {
+      sessionDurability.flushOnExit('SIGTERM')
+      app.exit(0)
+    })
 
     // Set up application menu with Edit roles so Ctrl+C/V/X/A work in frameless window
     // On macOS, include the app name menu (About, Hide, Quit) and Window menu (macOS convention)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -89,7 +89,7 @@ import { startServiceStatusPoller, stopServiceStatusPoller, getLastServiceStatus
 import { initUpdateWatcher, stopUpdateWatcher, getProjectRootPath, isPackagedApp } from './update-watcher'
 import { startUpdateServer, stopUpdateServer } from './update-server'
 import { saveSessionState, loadSessionState, clearSessionState, hasSavedSessionState, SessionState } from './session-state'
-import { enrichSessionStateWithResumeTargets } from './session-resume-enrich'
+import { createSessionDurability } from './session-durability'
 import { resolveResumeTargetFromTranscript } from './logging/transcript-discovery'
 import { getConfigDir, ensureConfigDir, snapshotConfig } from './config-manager'
 import { stopGlobalVision, killSpawnedBrowser, cleanupLegacyVisionMarkers } from './vision-manager'
@@ -108,44 +108,22 @@ import { installGlobalErrorHandlers, logInfo, logError, closeDebugLogger, setVer
 // Install global error handlers that log to file
 installGlobalErrorHandlers()
 
-// #397: the most recent session state pushed from the renderer, already enriched
-// with exact-conversation resume targets. Cached so a durable flush on a
-// non-graceful exit (before-quit / signal / power event) can write it even when
-// the renderer never reached its graceful Save-&-Close path.
-let lastKnownSessionState: SessionState | null = null
-
-// Enrich a renderer-supplied SessionState from the live transcript binder, then
-// persist it. This is the SINGLE session-state write choke point: every renderer
-// writer (autosave, account flush, GitHub flush, Save-&-Close) routes through the
-// `session:save` IPC into here, so EVERY persisted file carries a resumable target
-// — not just the graceful-close one. That closes #397 Group 1 (a non-graceful exit
-// left a non-enriched file → next launch fell back to the resume picker) and the
-// autosave-clobber race (there is no longer a non-enriched writer). Also caches the
-// enriched state for the exit-time durable flush (#397 Group 2).
-function saveEnrichedSessionState(state: SessionState): boolean {
-  const binder = getTranscriptBinder()
-  const enriched = enrichSessionStateWithResumeTargets(state, {
-    getLatestTranscriptPath: (id) => binder?.getLatestTranscriptPath(id) ?? null,
+// #397: the cross-exit session-state durability core. `session:save` routes every
+// renderer writer (autosave, account flush, GitHub flush, Save-&-Close) through
+// saveEnriched — enriching each Claude session's exact resume target from the live
+// transcript binder — so EVERY persisted file is resumable, not only the graceful
+// close (Group 1), and the old autosave-clobber race dissolves. flushOnExit persists
+// the cached state on any non-graceful exit (Group 2); noteCleared drops the cache
+// on an intentional clear so the flush never resurrects a discarded set (F1). The
+// binder is read lazily per call — it may init after this module loads.
+const sessionDurability = createSessionDurability({
+  enrichDeps: {
+    getLatestTranscriptPath: (id) => getTranscriptBinder()?.getLatestTranscriptPath(id) ?? null,
     resolveResumeTargetFromTranscript,
-  })
-  lastKnownSessionState = enriched
-  return saveSessionState(enriched)
-}
-
-// #397 Group 2: write the last-known session state on ANY exit path — not only the
-// renderer's graceful Save-&-Close. Re-enriches from the still-live binder so the
-// freshest resume target is written. saveSessionState is atomic and idempotent, so
-// being called from several exit hooks in one teardown is harmless. A no-op until
-// the renderer has pushed at least one state this run.
-function flushSessionStateOnExit(reason: string): void {
-  if (!lastKnownSessionState) return
-  try {
-    saveEnrichedSessionState(lastKnownSessionState)
-    logInfo(`[session-state] durable flush on ${reason}`)
-  } catch (err) {
-    logError(`[session-state] durable flush on ${reason} failed: ${(err as Error)?.message ?? err}`)
-  }
-}
+  },
+  save: saveSessionState,
+  log: logInfo,
+})
 
 // Multi-instance (dev alongside prod): a dev build must NOT share prod's data
 // dir (CONFIG/sessions/transcripts/profiles). Point it at a dedicated dev root
@@ -501,7 +479,7 @@ function createWindow(): void {
   // #397 Group 2: a renderer crash / OOM kills the window before it can run its
   // graceful save. Persist the last-known session state so the sessions survive.
   mainWindow.webContents.on('render-process-gone', (_e, details) => {
-    flushSessionStateOnExit(`render-process-gone (${details?.reason ?? 'unknown'})`)
+    sessionDurability.flushOnExit(`render-process-gone (${details?.reason ?? 'unknown'})`)
   })
 
   // Renderer calls this after saving sessions and graceful exit
@@ -531,7 +509,7 @@ function createWindow(): void {
   ipcMain.on('window:forceClose', () => {
     // #397 Group 2: destroy() bypasses the 'close' event and the graceful save;
     // persist the last-known session state before the window is torn down.
-    flushSessionStateOnExit('window:forceClose')
+    sessionDurability.flushOnExit('window:forceClose')
     if (mainWindow) {
       mainWindow.destroy()  // Force close without triggering close event
     }
@@ -624,7 +602,7 @@ function createWindow(): void {
 
   // Session state persistence IPC handlers
   ipcMain.handle('session:save', async (_event, state: SessionState) => {
-    return saveEnrichedSessionState(state)
+    return sessionDurability.saveEnriched(state)
   })
 
   ipcMain.handle('session:load', async () => {
@@ -632,7 +610,12 @@ function createWindow(): void {
   })
 
   ipcMain.handle('session:clear', async () => {
-    return clearSessionState()
+    const ok = clearSessionState()
+    // #397 F1: a successful clear is the user intentionally discarding the saved set
+    // (Don't-open / Close-without-saving). Drop the cache so the exit-time flush
+    // cannot resurrect it on the next launch.
+    if (ok) sessionDurability.noteCleared()
+    return ok
   })
 
   ipcMain.handle('session:hasSaved', async () => {
@@ -754,11 +737,11 @@ if (!gotTheLock) {
     // console Ctrl+C on a dev run or a task-manager terminate) can end the app
     // without the window-close flow running. Persist sessions first, then quit
     // gracefully so before-quit's own teardown still runs.
-    powerMonitor.on('shutdown', () => flushSessionStateOnExit('powerMonitor shutdown'))
-    powerMonitor.on('suspend', () => flushSessionStateOnExit('powerMonitor suspend'))
+    powerMonitor.on('shutdown', () => sessionDurability.flushOnExit('powerMonitor shutdown'))
+    powerMonitor.on('suspend', () => sessionDurability.flushOnExit('powerMonitor suspend'))
     for (const sig of ['SIGTERM', 'SIGINT'] as const) {
       process.on(sig, () => {
-        flushSessionStateOnExit(sig)
+        sessionDurability.flushOnExit(sig)
         app.quit()
       })
     }
@@ -1211,7 +1194,7 @@ if (!gotTheLock) {
     logInfo('App quitting...')
     // #397 Group 2: persist sessions BEFORE the logging teardown below tears the
     // transcript binder down — flushing after that would lose the resume targets.
-    flushSessionStateOnExit('before-quit')
+    sessionDurability.flushOnExit('before-quit')
     // S5: mark the supervisor shutting-down BEFORE killAllPty() so a hooks-child
     // exit during teardown does NOT trigger a restart (race-free shutdown).
     try { _hooksSupervisor?.shutdown() } catch { /* never started / hooks disabled */ }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, Menu, session, shell, powerMonitor } from 'electron'
 import { join } from 'path'
 import { homedir } from 'os'
 import { writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
@@ -89,7 +89,9 @@ import { startServiceStatusPoller, stopServiceStatusPoller, getLastServiceStatus
 import { initUpdateWatcher, stopUpdateWatcher, getProjectRootPath, isPackagedApp } from './update-watcher'
 import { startUpdateServer, stopUpdateServer } from './update-server'
 import { saveSessionState, loadSessionState, clearSessionState, hasSavedSessionState, SessionState } from './session-state'
-import { getConfigDir, snapshotConfig } from './config-manager'
+import { enrichSessionStateWithResumeTargets } from './session-resume-enrich'
+import { resolveResumeTargetFromTranscript } from './logging/transcript-discovery'
+import { getConfigDir, ensureConfigDir, snapshotConfig } from './config-manager'
 import { stopGlobalVision, killSpawnedBrowser, cleanupLegacyVisionMarkers } from './vision-manager'
 import { startConductorMcpServer, stopConductorMcpServer, startBrowserAtBoot } from './conductor-mcp-server'
 import { readConfig } from './config-manager'
@@ -105,6 +107,45 @@ import { installGlobalErrorHandlers, logInfo, logError, closeDebugLogger, setVer
 
 // Install global error handlers that log to file
 installGlobalErrorHandlers()
+
+// #397: the most recent session state pushed from the renderer, already enriched
+// with exact-conversation resume targets. Cached so a durable flush on a
+// non-graceful exit (before-quit / signal / power event) can write it even when
+// the renderer never reached its graceful Save-&-Close path.
+let lastKnownSessionState: SessionState | null = null
+
+// Enrich a renderer-supplied SessionState from the live transcript binder, then
+// persist it. This is the SINGLE session-state write choke point: every renderer
+// writer (autosave, account flush, GitHub flush, Save-&-Close) routes through the
+// `session:save` IPC into here, so EVERY persisted file carries a resumable target
+// — not just the graceful-close one. That closes #397 Group 1 (a non-graceful exit
+// left a non-enriched file → next launch fell back to the resume picker) and the
+// autosave-clobber race (there is no longer a non-enriched writer). Also caches the
+// enriched state for the exit-time durable flush (#397 Group 2).
+function saveEnrichedSessionState(state: SessionState): boolean {
+  const binder = getTranscriptBinder()
+  const enriched = enrichSessionStateWithResumeTargets(state, {
+    getLatestTranscriptPath: (id) => binder?.getLatestTranscriptPath(id) ?? null,
+    resolveResumeTargetFromTranscript,
+  })
+  lastKnownSessionState = enriched
+  return saveSessionState(enriched)
+}
+
+// #397 Group 2: write the last-known session state on ANY exit path — not only the
+// renderer's graceful Save-&-Close. Re-enriches from the still-live binder so the
+// freshest resume target is written. saveSessionState is atomic and idempotent, so
+// being called from several exit hooks in one teardown is harmless. A no-op until
+// the renderer has pushed at least one state this run.
+function flushSessionStateOnExit(reason: string): void {
+  if (!lastKnownSessionState) return
+  try {
+    saveEnrichedSessionState(lastKnownSessionState)
+    logInfo(`[session-state] durable flush on ${reason}`)
+  } catch (err) {
+    logError(`[session-state] durable flush on ${reason} failed: ${(err as Error)?.message ?? err}`)
+  }
+}
 
 // Multi-instance (dev alongside prod): a dev build must NOT share prod's data
 // dir (CONFIG/sessions/transcripts/profiles). Point it at a dedicated dev root
@@ -457,6 +498,12 @@ function createWindow(): void {
     }
   })
 
+  // #397 Group 2: a renderer crash / OOM kills the window before it can run its
+  // graceful save. Persist the last-known session state so the sessions survive.
+  mainWindow.webContents.on('render-process-gone', (_e, details) => {
+    flushSessionStateOnExit(`render-process-gone (${details?.reason ?? 'unknown'})`)
+  })
+
   // Renderer calls this after saving sessions and graceful exit
   ipcMain.on('window:allowClose', () => {
     allowClose = true
@@ -482,6 +529,9 @@ function createWindow(): void {
   // then calls 'window:forceClose' to actually close
   ipcMain.on('window:close', () => mainWindow?.close())
   ipcMain.on('window:forceClose', () => {
+    // #397 Group 2: destroy() bypasses the 'close' event and the graceful save;
+    // persist the last-known session state before the window is torn down.
+    flushSessionStateOnExit('window:forceClose')
     if (mainWindow) {
       mainWindow.destroy()  // Force close without triggering close event
     }
@@ -574,7 +624,7 @@ function createWindow(): void {
 
   // Session state persistence IPC handlers
   ipcMain.handle('session:save', async (_event, state: SessionState) => {
-    return saveSessionState(state)
+    return saveEnrichedSessionState(state)
   })
 
   ipcMain.handle('session:load', async () => {
@@ -699,6 +749,20 @@ if (!gotTheLock) {
   }
 
   app.whenReady().then(() => {
+    // #397 Group 2: exit paths that skip app 'before-quit'. An OS shutdown/logoff
+    // (powerMonitor; macOS/Linux) and a process signal (SIGTERM/SIGINT, e.g. a
+    // console Ctrl+C on a dev run or a task-manager terminate) can end the app
+    // without the window-close flow running. Persist sessions first, then quit
+    // gracefully so before-quit's own teardown still runs.
+    powerMonitor.on('shutdown', () => flushSessionStateOnExit('powerMonitor shutdown'))
+    powerMonitor.on('suspend', () => flushSessionStateOnExit('powerMonitor suspend'))
+    for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+      process.on(sig, () => {
+        flushSessionStateOnExit(sig)
+        app.quit()
+      })
+    }
+
     // Set up application menu with Edit roles so Ctrl+C/V/X/A work in frameless window
     // On macOS, include the app name menu (About, Hide, Quit) and Window menu (macOS convention)
     const menuTemplate: Electron.MenuItemConstructorOptions[] = []
@@ -1145,6 +1209,9 @@ if (!gotTheLock) {
 
   app.on('before-quit', () => {
     logInfo('App quitting...')
+    // #397 Group 2: persist sessions BEFORE the logging teardown below tears the
+    // transcript binder down — flushing after that would lose the resume targets.
+    flushSessionStateOnExit('before-quit')
     // S5: mark the supervisor shutting-down BEFORE killAllPty() so a hooks-child
     // exit during teardown does NOT trigger a restart (race-free shutdown).
     try { _hooksSupervisor?.shutdown() } catch { /* never started / hooks disabled */ }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,7 +91,7 @@ import { startUpdateServer, stopUpdateServer } from './update-server'
 import { saveSessionState, loadSessionState, clearSessionState, hasSavedSessionState, SessionState } from './session-state'
 import { createSessionDurability } from './session-durability'
 import { resolveResumeTargetFromTranscript } from './logging/transcript-discovery'
-import { getConfigDir, ensureConfigDir, snapshotConfig } from './config-manager'
+import { getConfigDir, snapshotConfig } from './config-manager'
 import { stopGlobalVision, killSpawnedBrowser, cleanupLegacyVisionMarkers } from './vision-manager'
 import { startConductorMcpServer, stopConductorMcpServer, startBrowserAtBoot } from './conductor-mcp-server'
 import { readConfig } from './config-manager'
@@ -1004,7 +1004,12 @@ if (!gotTheLock) {
       loadSessions: async () => loadSessionState()?.sessions ?? [],
       saveSessions: async (sessions) => {
         const existing = loadSessionState()
-        saveSessionState({
+        // Through the durability core, never saveSessionState directly: a
+        // direct write leaves the exit-flush cache stale, so the flush on
+        // quit would overwrite this very patch with the pre-patch state —
+        // reverting the GitHub binding (or a cleanup that removed one) on
+        // the next launch (independent review of #413, R3).
+        sessionDurability.saveEnriched({
           sessions,
           activeSessionId: existing?.activeSessionId ?? null,
           savedAt: Date.now(),

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -12,7 +12,13 @@ import { IPC } from '../../shared/ipc-channels'
 import { getPtyIntegrityMonitor } from '../services/pty-integrity-monitor'
 import type { PtyIntegrityReport } from '../../shared/service-health'
 import { noteSessionSpawnForCanvas } from '../canvas/canvas-session-link'
-import { sanitizeRestoredSpawnOptions } from '../sanitize-restored-spawn-options'
+import {
+  sanitizeRestoredSpawnOptions,
+  PERMISSION_MODES,
+  EXTRA_ARGS_MAX,
+  EXTRA_ARGS_CHARSET_RE,
+  extraArgsRefineOk,
+} from '../sanitize-restored-spawn-options'
 
 /** SSH options as received from the renderer (no passwords — only configId) */
 interface RendererSSHOptions {
@@ -139,7 +145,10 @@ export const spawnOptionsSchema = z.object({
   // Shell-interpolated UNQUOTED at spawn. Constrained to the CLI's own --permission-mode
   // choices (+ 'default'/'' meaning "emit no flag") so an arbitrary string can never
   // reach the shell. 'default'/'' are accepted but not emitted.
-  permissionMode: z.enum(['default', 'acceptEdits', 'auto', 'plan', 'dontAsk', 'bypassPermissions', 'manual']).optional().or(z.literal('')),
+  // The value list lives in sanitize-restored-spawn-options.ts so the fail-open
+  // sanitizer drops exactly what this parse would reject — never more, never
+  // less (#413 review, S2).
+  permissionMode: z.enum(PERMISSION_MODES).optional().or(z.literal('')),
   // Advanced escape hatch, shell-interpolated UNQUOTED at spawn. Charset guard blocks
   // every shell metacharacter (; | & $ ` ( ) < > ' " * ? ~ ! % ^ newline), leaving only
   // characters that make up ordinary flags/paths. The refine rejects CCC-managed flags
@@ -177,14 +186,15 @@ export const spawnOptionsSchema = z.object({
   // already excluded), dropping `[` and `]` removes pathname expansion from
   // this hatch entirely. A literal bracket in a path is the cost; nothing in
   // an ordinary flag or path needs one.
-  extraArgs: z.string().max(512).regex(/^[A-Za-z0-9 _\-=.\/\\:@,+]*$/).refine(
+  // Cap, charset and refine are shared with the fail-open sanitizer (see the
+  // permissionMode note above) — the collapse/trailing-backslash analysis
+  // stays here, the values live in sanitize-restored-spawn-options.ts.
+  extraArgs: z.string().max(EXTRA_ARGS_MAX).regex(EXTRA_ARGS_CHARSET_RE).refine(
     // Collapse backslashes before matching -- see the note above. Also reject a
     // trailing backslash outright: it turns the SSH launch line into a shell
     // line continuation, which hangs the session on a `>` prompt waiting for
     // input that never comes.
-    (v) => !v.endsWith('\\')
-      && !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/
-        .test(v.replace(/\\/g, '')),
+    (v) => extraArgsRefineOk(v),
     { message: 'extraArgs must not include a CCC-managed flag (--model/--effort/--permission-mode/--settings/--mcp-config/--agents/--resume), nor end in a backslash' },
   ).optional(),
   disableAutoMemory: z.boolean().optional(),

--- a/src/main/ipc/pty-handlers.ts
+++ b/src/main/ipc/pty-handlers.ts
@@ -12,6 +12,7 @@ import { IPC } from '../../shared/ipc-channels'
 import { getPtyIntegrityMonitor } from '../services/pty-integrity-monitor'
 import type { PtyIntegrityReport } from '../../shared/service-health'
 import { noteSessionSpawnForCanvas } from '../canvas/canvas-session-link'
+import { sanitizeRestoredSpawnOptions } from '../sanitize-restored-spawn-options'
 
 /** SSH options as received from the renderer (no passwords — only configId) */
 interface RendererSSHOptions {
@@ -269,6 +270,10 @@ export function registerPtyHandlers(getWindow: () => BrowserWindow | null): void
       permissionsPreset: 'read-only' | 'standard' | 'auto' | 'unrestricted'
     }
   }) => {
+    // #397 Group 5: repair persisted fields fail-open BEFORE the strict parse, so a
+    // corrupt session-state.json cannot abort the whole spawn (the session never
+    // launched). Dropped/floored values never reach the shell; the rest still parses.
+    options = sanitizeRestoredSpawnOptions(options, logInfo)
     try {
       sessionIdSchema.parse(sessionId)
       spawnOptionsSchema.parse(options)

--- a/src/main/logging/transcript-discovery.ts
+++ b/src/main/logging/transcript-discovery.ts
@@ -201,16 +201,33 @@ export const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F
 // #397 N2: the cwd this resolver needs is written into the transcript's FIRST
 // entries, so read only a bounded HEAD, not the whole file. Enrichment now runs on
 // the MAIN process on every debounced autosave; a full sync read of a multi-MB
-// transcript there stalls all IPC. A head read keeps it O(constant). Fail-safe: any
-// error (or a missing file) yields '' → the resolver returns null → prior behaviour.
-const RESUME_HEAD_BYTES = 131072
+// transcript there stalls all IPC. A head read keeps it O(bounded).
+//
+// #397 round-2 (adversarial-review F1): the cap is 1 MB, not 128 KB, and the
+// trailing PARTIAL line is dropped when the file is larger than the cap. The
+// opening message of a Claude session is frequently the biggest (a pasted log /
+// diff), and it carries the cwd on that same line; a 128 KB slice cut that line
+// mid-way, JSON.parse failed, and the resume target was silently lost. 1 MB covers
+// a realistic first line, and dropping the truncated tail line means the resolver
+// only ever parses COMPLETE lines. Residual (fail-safe): a first line larger than
+// 1 MB still yields no cwd → null → the resume picker, exactly as before this file.
+const RESUME_HEAD_BYTES = 1_048_576
 function readTranscriptHead(p: string): string {
   let fd: number | null = null
   try {
     fd = fs.openSync(p, 'r')
-    const buf = Buffer.alloc(RESUME_HEAD_BYTES)
-    const n = fs.readSync(fd, buf, 0, RESUME_HEAD_BYTES, 0)
-    return buf.toString('utf-8', 0, n)
+    const size = fs.fstatSync(fd).size
+    const readLen = Math.min(RESUME_HEAD_BYTES, size)
+    const buf = Buffer.alloc(readLen)
+    const n = fs.readSync(fd, buf, 0, readLen, 0)
+    let text = buf.toString('utf-8', 0, n)
+    // If the file is larger than what we read, the last line is (almost certainly)
+    // truncated — drop it so a mid-line cut is never handed to JSON.parse.
+    if (readLen < size) {
+      const lastNl = text.lastIndexOf('\n')
+      text = lastNl === -1 ? '' : text.slice(0, lastNl + 1)
+    }
+    return text
   } catch {
     return ''
   } finally {

--- a/src/main/logging/transcript-discovery.ts
+++ b/src/main/logging/transcript-discovery.ts
@@ -198,9 +198,29 @@ export function canonicalizeTranscriptPath(p: string): string | null {
  *  uuid before it is interpolated into a spawn shell command (defense-in-depth). */
 export const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
 
+// #397 N2: the cwd this resolver needs is written into the transcript's FIRST
+// entries, so read only a bounded HEAD, not the whole file. Enrichment now runs on
+// the MAIN process on every debounced autosave; a full sync read of a multi-MB
+// transcript there stalls all IPC. A head read keeps it O(constant). Fail-safe: any
+// error (or a missing file) yields '' → the resolver returns null → prior behaviour.
+const RESUME_HEAD_BYTES = 131072
+function readTranscriptHead(p: string): string {
+  let fd: number | null = null
+  try {
+    fd = fs.openSync(p, 'r')
+    const buf = Buffer.alloc(RESUME_HEAD_BYTES)
+    const n = fs.readSync(fd, buf, 0, RESUME_HEAD_BYTES, 0)
+    return buf.toString('utf-8', 0, n)
+  } catch {
+    return ''
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd) } catch { /* ignore */ } }
+  }
+}
+
 export function resolveResumeTargetFromTranscript(
   transcriptPath: string,
-  readFile: (p: string, enc: 'utf-8') => string = (p, enc) => fs.readFileSync(p, enc),
+  readFile: (p: string, enc: 'utf-8') => string = (p, _enc) => readTranscriptHead(p),
 ): { uuid: string; cwd: string } | null {
   if (!transcriptPath) return null
 

--- a/src/main/sanitize-restored-spawn-options.ts
+++ b/src/main/sanitize-restored-spawn-options.ts
@@ -26,6 +26,27 @@ import { UUID_RE } from './logging/transcript-discovery'
 
 export const CODEX_PRESETS = ['read-only', 'standard', 'auto', 'unrestricted'] as const
 
+// ── The spawn schema's own rules for the two persisted claude fields ─────────
+// Exported and consumed by spawnOptionsSchema (pty-handlers) so the sanitizer
+// and the strict parse can NEVER drift: what this module drops is exactly what
+// the schema would reject (#413 review, S2). Values and comments live with the
+// schema's fields — see pty-handlers for why each rule exists.
+
+export const PERMISSION_MODES = ['default', 'acceptEdits', 'auto', 'plan', 'dontAsk', 'bypassPermissions', 'manual'] as const
+
+export const EXTRA_ARGS_MAX = 512
+export const EXTRA_ARGS_CHARSET_RE = /^[A-Za-z0-9 _\-=.\/\\:@,+]*$/
+
+/** The managed-flag refine, on a backslash-collapsed copy, plus the trailing-
+ *  backslash ban — byte-identical to the schema's refine (see pty-handlers for
+ *  the shell-expansion analysis behind it). */
+export function extraArgsRefineOk(v: string): boolean {
+  return (
+    !v.endsWith('\\') &&
+    !/(^|\s)--(model|effort|permission-mode|settings|mcp-config|agents|resume)\b/.test(v.replace(/\\/g, ''))
+  )
+}
+
 export function sanitizeRestoredSpawnOptions<T>(
   options: T,
   log: (msg: string) => void = () => {},
@@ -51,6 +72,31 @@ export function sanitizeRestoredSpawnOptions<T>(
     } else if (!(CODEX_PRESETS as readonly string[]).includes(out.codexOptions.permissionsPreset)) {
       log('[pty] #397: restored codex session had an invalid permissionsPreset; defaulting to read-only')
       out.codexOptions = { ...out.codexOptions, permissionsPreset: 'read-only' }
+    }
+  }
+
+  // Phase 5 started PERSISTING these two, so a corrupt-but-parseable file can
+  // now carry values the strict parse rejects — which would wedge the whole
+  // spawn this helper exists to rescue (#413 review, S2). Dropped, never
+  // coerced: an absent value means "emit no flag", the least-privilege shape,
+  // and dropping preserves this helper's only-removes-or-floors property.
+  if (out.permissionMode !== undefined) {
+    const ok =
+      out.permissionMode === '' || (PERMISSION_MODES as readonly string[]).includes(out.permissionMode)
+    if (!ok) {
+      log('[pty] #397: dropping an invalid persisted permissionMode; the session launches with the default')
+      out.permissionMode = undefined
+    }
+  }
+  if (out.extraArgs !== undefined) {
+    const ok =
+      typeof out.extraArgs === 'string' &&
+      out.extraArgs.length <= EXTRA_ARGS_MAX &&
+      EXTRA_ARGS_CHARSET_RE.test(out.extraArgs) &&
+      extraArgsRefineOk(out.extraArgs)
+    if (!ok) {
+      log('[pty] #397: dropping invalid persisted extraArgs; the session launches without them')
+      out.extraArgs = undefined
     }
   }
 

--- a/src/main/sanitize-restored-spawn-options.ts
+++ b/src/main/sanitize-restored-spawn-options.ts
@@ -1,0 +1,58 @@
+/**
+ * sanitize-restored-spawn-options.ts — fail-open repair of a RESTORED session's
+ * persisted spawn fields (#397 Group 5).
+ *
+ * A relaunched session's spawn options come straight out of session-state.json.
+ * When that file is corrupt (or was written by an older schema), two fields can be
+ * invalid, and the strict spawnOptionsSchema parse in pty-handlers would reject the
+ * WHOLE spawn on any of them — so the session never launches, defeating the goal
+ * that a session on disk is always restartable.
+ *
+ * Repair them fail-OPEN, before the strict parse:
+ *   - `resume` ({uuid,cwd}): an invalid uuid or cwd is DROPPED, and the spawn falls
+ *     back to the resume picker. Dropping — never ACCEPTING — an invalid uuid keeps
+ *     the charset guard that stops shell injection at the unquoted interpolation
+ *     site; this helper only ever removes or floors, it never widens what the
+ *     strict schema would accept.
+ *   - codex `permissionsPreset`: a missing/invalid preset is floored to the
+ *     least-privilege 'read-only' so the codex session still launches.
+ *
+ * Every other field is left untouched and still strict-parses downstream. Pure and
+ * dependency-injected for logging so it unit-tests without the Electron ABI (and
+ * without pulling node-pty through pty-manager). Returns a shallow copy; never
+ * mutates the input.
+ */
+import { UUID_RE } from './logging/transcript-discovery'
+
+export const CODEX_PRESETS = ['read-only', 'standard', 'auto', 'unrestricted'] as const
+
+export function sanitizeRestoredSpawnOptions<T>(
+  options: T,
+  log: (msg: string) => void = () => {},
+): T {
+  const o = options as any
+  if (!o || typeof o !== 'object') return options
+  const out: any = { ...o }
+
+  if (out.resume) {
+    const r = out.resume
+    const okUuid = r && typeof r.uuid === 'string' && UUID_RE.test(r.uuid)
+    const okCwd = r && typeof r.cwd === 'string' && r.cwd.length >= 1 && r.cwd.length <= 4096
+    if (!okUuid || !okCwd) {
+      log('[pty] #397: dropping an invalid persisted resume target; falling back to the resume picker')
+      out.resume = undefined
+    }
+  }
+
+  if (out.provider === 'codex') {
+    if (!out.codexOptions || typeof out.codexOptions !== 'object') {
+      log('[pty] #397: restored codex session had no codexOptions; defaulting to read-only')
+      out.codexOptions = { permissionsPreset: 'read-only' }
+    } else if (!(CODEX_PRESETS as readonly string[]).includes(out.codexOptions.permissionsPreset)) {
+      log('[pty] #397: restored codex session had an invalid permissionsPreset; defaulting to read-only')
+      out.codexOptions = { ...out.codexOptions, permissionsPreset: 'read-only' }
+    }
+  }
+
+  return out as T
+}

--- a/src/main/session-durability.ts
+++ b/src/main/session-durability.ts
@@ -1,0 +1,65 @@
+/**
+ * session-durability.ts — the cross-exit durability core for session-state (#397).
+ *
+ * Holds the last-known ENRICHED session state and the save / flush / clear logic
+ * that index.ts wires to the `session:save` IPC and the process-exit hooks. Kept
+ * out of index.ts so it is unit-testable without the Electron main entry (the
+ * adversarial-review lens that found the cache was untestable, and F1 — the exit
+ * flush resurrecting an intentionally-cleared set — lived here unseen).
+ *
+ * Dependency-injected: `save` is session-state.saveSessionState (which honours the
+ * read-failure latch and refuses when appropriate), `enrichDeps` reaches the live
+ * transcript binder. Pure logic otherwise; one instance per app.
+ */
+import type { SessionState } from './session-state'
+import { enrichSessionStateWithResumeTargets, type ResumeEnrichDeps } from './session-resume-enrich'
+
+export interface DurabilityDeps {
+  /** Binder-backed enrichment (lazily reads getTranscriptBinder each call). */
+  enrichDeps: ResumeEnrichDeps
+  /** session-state.saveSessionState — returns false when the latch refuses. */
+  save: (state: SessionState) => boolean
+  log?: (msg: string) => void
+}
+
+export interface SessionDurability {
+  /** Enrich (from the binder) + cache + persist. The single `session:save` path. */
+  saveEnriched: (state: SessionState) => boolean
+  /** Re-enrich the cached state and persist it on an exit path. No-op until a
+   *  state has been saved this run; honest about a latch refusal. Never throws. */
+  flushOnExit: (reason: string) => void
+  /** Drop the cache after a successful clear so the exit flush cannot resurrect a
+   *  set the user intentionally discarded (F1). */
+  noteCleared: () => void
+  /** Test-only: read the cached state. */
+  peek: () => SessionState | null
+}
+
+export function createSessionDurability(deps: DurabilityDeps): SessionDurability {
+  let last: SessionState | null = null
+  const log = deps.log ?? (() => {})
+
+  function saveEnriched(state: SessionState): boolean {
+    const enriched = enrichSessionStateWithResumeTargets(state, deps.enrichDeps)
+    last = enriched
+    return deps.save(enriched)
+  }
+
+  function flushOnExit(reason: string): void {
+    if (!last) return
+    try {
+      const ok = saveEnriched(last)
+      log(ok
+        ? `[session-state] durable flush on ${reason}`
+        : `[session-state] durable flush on ${reason} REFUSED (read-failure latch); on-disk file kept`)
+    } catch (err) {
+      log(`[session-state] durable flush on ${reason} failed: ${(err as Error)?.message ?? err}`)
+    }
+  }
+
+  function noteCleared(): void {
+    last = null
+  }
+
+  return { saveEnriched, flushOnExit, noteCleared, peek: () => last }
+}

--- a/src/main/session-durability.ts
+++ b/src/main/session-durability.ts
@@ -37,30 +37,25 @@ export interface SessionDurability {
 
 export function createSessionDurability(deps: DurabilityDeps): SessionDurability {
   let last: SessionState | null = null
-  // #397 round-2: dedup redundant exit-flush I/O. Several exit hooks can fire in one
-  // teardown (e.g. SIGTERM → before-quit, or forceClose → render-process-gone); each
-  // flush re-enriches (a head read per Claude session) + atomic write + .bak copy.
-  // A real save resets this so a suspend-then-resume-then-quit still flushes fresh.
-  let flushedSinceSave = false
   const log = deps.log ?? (() => {})
 
-  // Enrich from the binder, cache, persist. Never touches the dedup flag.
-  function persist(state: SessionState): boolean {
+  function saveEnriched(state: SessionState): boolean {
     const enriched = enrichSessionStateWithResumeTargets(state, deps.enrichDeps)
     last = enriched
     return deps.save(enriched)
   }
 
-  function saveEnriched(state: SessionState): boolean {
-    flushedSinceSave = false
-    return persist(state)
-  }
-
+  // Re-enriches from the (still-live) binder and persists on EVERY exit path. It is
+  // NOT deduped across hooks: an exit-flush dedup latch (removed in round-3) had to
+  // be reset per-exit, but powerMonitor 'suspend' is not an exit and poisoned it, so
+  // a later real exit skipped re-enrichment and dropped a now-available resume
+  // target to the picker. The cost of not deduping is a few bounded head reads if
+  // two exit hooks fire in one teardown (SIGTERM→before-quit) — negligible, and
+  // saveSessionState's atomic write is idempotent — so correctness wins over it.
   function flushOnExit(reason: string): void {
-    if (!last || flushedSinceSave) return
-    flushedSinceSave = true
+    if (!last) return
     try {
-      const ok = persist(last)
+      const ok = saveEnriched(last)
       log(ok
         ? `[session-state] durable flush on ${reason}`
         : `[session-state] durable flush on ${reason} REFUSED (read-failure latch); on-disk file kept`)

--- a/src/main/session-durability.ts
+++ b/src/main/session-durability.ts
@@ -37,18 +37,30 @@ export interface SessionDurability {
 
 export function createSessionDurability(deps: DurabilityDeps): SessionDurability {
   let last: SessionState | null = null
+  // #397 round-2: dedup redundant exit-flush I/O. Several exit hooks can fire in one
+  // teardown (e.g. SIGTERM → before-quit, or forceClose → render-process-gone); each
+  // flush re-enriches (a head read per Claude session) + atomic write + .bak copy.
+  // A real save resets this so a suspend-then-resume-then-quit still flushes fresh.
+  let flushedSinceSave = false
   const log = deps.log ?? (() => {})
 
-  function saveEnriched(state: SessionState): boolean {
+  // Enrich from the binder, cache, persist. Never touches the dedup flag.
+  function persist(state: SessionState): boolean {
     const enriched = enrichSessionStateWithResumeTargets(state, deps.enrichDeps)
     last = enriched
     return deps.save(enriched)
   }
 
+  function saveEnriched(state: SessionState): boolean {
+    flushedSinceSave = false
+    return persist(state)
+  }
+
   function flushOnExit(reason: string): void {
-    if (!last) return
+    if (!last || flushedSinceSave) return
+    flushedSinceSave = true
     try {
-      const ok = saveEnriched(last)
+      const ok = persist(last)
       log(ok
         ? `[session-state] durable flush on ${reason}`
         : `[session-state] durable flush on ${reason} REFUSED (read-failure latch); on-disk file kept`)

--- a/src/main/session-resume-enrich.ts
+++ b/src/main/session-resume-enrich.ts
@@ -1,0 +1,67 @@
+/**
+ * session-resume-enrich.ts — main-side exact-conversation resume enrichment (#397).
+ *
+ * The renderer persists `session-state.json` from several call sites (the graceful
+ * Save-&-Close, the debounced autosave, the account flush, the GitHub per-session
+ * flush). Before #397 only ONE of them — Save-&-Close — enriched each session with
+ * its exact-conversation resume target ({resumeUuid, resumeCwd}); every other
+ * writer wrote a NON-enriched record, and the debounced autosave could even fire
+ * after the enriched save and clobber it. So any non-graceful exit left a file
+ * that, on the next launch, fell back to the terminal resume PICKER instead of
+ * resuming the exact conversation.
+ *
+ * The transcript binder that knows each session's latest conversation lives in the
+ * MAIN process. So enrichment belongs here, at the single `session:save` IPC choke
+ * point, not spread across the renderer's writers: run it once in main and EVERY
+ * writer persists a resumable record for free, and the clobber race dissolves
+ * (there is no longer a non-enriched writer to clobber with).
+ *
+ * Pure + dependency-injected so it is unit-testable without the Electron ABI or a
+ * live binder (the repo's spawn-claude-command / resume-picker convention).
+ */
+import type { SessionState } from './session-state'
+
+export interface ResumeEnrichDeps {
+  /** The binder's latest canonical transcript path for a session, or null. */
+  getLatestTranscriptPath: (sessionId: string) => string | null
+  /** Derive {uuid, cwd} from a transcript path, or null on any failure. */
+  resolveResumeTargetFromTranscript: (transcriptPath: string) => { uuid: string; cwd: string } | null
+}
+
+/**
+ * Enrich a SessionState IN PLACE with each Claude session's exact-conversation
+ * resume target, read from the live transcript binder.
+ *
+ * FAIL-SAFE throughout:
+ *   - A session whose target cannot be resolved KEEPS whatever the record already
+ *     carried (from restore, or the renderer's own enrichment). The fallback is
+ *     therefore never worse than today's behaviour.
+ *   - A null binder (logging disabled) is a whole no-op.
+ *   - Shell-only and non-Claude (Codex/SSH) sessions are skipped — the binder only
+ *     tracks local Claude transcripts.
+ *   - Never throws: a per-session failure leaves that one record unchanged.
+ *
+ * Returns the same object (mutated) for call-site convenience.
+ */
+export function enrichSessionStateWithResumeTargets(
+  state: SessionState,
+  deps: ResumeEnrichDeps,
+): SessionState {
+  if (!state || !Array.isArray(state.sessions)) return state
+  for (const s of state.sessions) {
+    try {
+      if (!s || s.shellOnly) continue
+      if ((s.provider ?? 'claude') !== 'claude') continue
+      const latest = deps.getLatestTranscriptPath(s.id)
+      if (!latest) continue
+      const target = deps.resolveResumeTargetFromTranscript(latest)
+      if (target && target.uuid && target.cwd) {
+        s.resumeUuid = target.uuid
+        s.resumeCwd = target.cwd
+      }
+    } catch {
+      // best-effort: leave this record exactly as it was
+    }
+  }
+  return state
+}

--- a/src/main/session-state.ts
+++ b/src/main/session-state.ts
@@ -87,7 +87,14 @@ export function saveSessionState(state: SessionState): boolean {
     // AFTER the atomic write -- not the prior file before it -- guarantees the .bak
     // is always a valid, recently-persisted state, never a half-written one. Best
     // effort: a copy failure must not fail the save the user actually asked for.
-    try { copyFileSync(file, getSessionStateBakFile()) } catch { /* .bak is a bonus, not a requirement */ }
+    // #397 round-2: log a copy failure. A silently-lagged .bak (the copy loses the
+    // same EBUSY/AV race the primary write can hit) would let a later recovery
+    // reinstate an OLDER set with no trace; the log gives that a trail.
+    try {
+      copyFileSync(file, getSessionStateBakFile())
+    } catch (bakErr) {
+      logError(`[session-state] .bak mirror copy failed (previous-good may be stale): ${(bakErr as Error)?.message ?? bakErr}`)
+    }
     logInfo(`[session-state] Saved ${state.sessions.length} sessions`)
     return true
   } catch (err) {

--- a/src/main/session-state.ts
+++ b/src/main/session-state.ts
@@ -5,7 +5,7 @@
  */
 
 import { join } from 'path'
-import { readFileSync, existsSync, unlinkSync, renameSync } from 'fs'
+import { readFileSync, existsSync, unlinkSync, renameSync, copyFileSync } from 'fs'
 import { getConfigDir, ensureConfigDir, migrateConfigToProviderShape } from './config-manager'
 import { logInfo, logError } from './debug-logger'
 import { atomicWriteFileSync } from './atomic-write'
@@ -20,6 +20,15 @@ const LEGACY_CLAUDE_FIELDS = ['model', 'effortLevel', 'legacyVersion', 'disableA
 // Lazy getter -- can't call getConfigDir() at module load time
 function getSessionStateFile(): string {
   return join(getConfigDir(), 'session-state.json')
+}
+
+// #397 Group 3: a previous-good mirror of session-state.json. Written after every
+// successful save; read back only when the primary file exists but does NOT parse.
+// Atomic writes already rule out a partial write, so this guards the OTHER way the
+// file goes bad -- external corruption (an AV scanner, a disk fault, a bad edit) --
+// so a corrupt primary recovers the last-good set instead of losing every session.
+function getSessionStateBakFile(): string {
+  return `${getSessionStateFile()}.bak`
 }
 
 /**
@@ -72,13 +81,40 @@ export function saveSessionState(state: SessionState): boolean {
   }
   try {
     ensureConfigDir()
-    atomicWriteSessionState(getSessionStateFile(), state)
+    const file = getSessionStateFile()
+    atomicWriteSessionState(file, state)
+    // #397 Group 3: mirror the just-written (known-good) file to the .bak. Copying
+    // AFTER the atomic write -- not the prior file before it -- guarantees the .bak
+    // is always a valid, recently-persisted state, never a half-written one. Best
+    // effort: a copy failure must not fail the save the user actually asked for.
+    try { copyFileSync(file, getSessionStateBakFile()) } catch { /* .bak is a bonus, not a requirement */ }
     logInfo(`[session-state] Saved ${state.sessions.length} sessions`)
     return true
   } catch (err) {
     console.error('[session-state] Failed to save:', err)
     return false
   }
+}
+
+/**
+ * Parse session-state JSON text into a SessionState, tolerating the two content
+ * defects that used to lose the WHOLE saved set (#397 Group 3):
+ *   - a missing/non-array `sessions` (it reached the renderer and threw on
+ *     `.length`, silently dropping the Resume prompt) -- coerced to [];
+ *   - the top-level value not being an object at all.
+ * Returns null ONLY when the JSON itself does not parse (the caller then tries the
+ * .bak). A single malformed session ENTRY is handled later, per-entry, not here.
+ */
+function parseSessionStateText(text: string): SessionState | null {
+  let state: SessionState
+  try {
+    state = JSON.parse(text) as SessionState
+  } catch {
+    return null
+  }
+  if (!state || typeof state !== 'object') return null
+  if (!Array.isArray(state.sessions)) state.sessions = []
+  return state
 }
 
 /**
@@ -95,38 +131,62 @@ export function loadSessionState(): SessionState | null {
       return null
     }
     const data = readFileSync(file, 'utf-8')
-    let state: SessionState
-    try {
-      state = JSON.parse(data) as SessionState
-    } catch (parseErr) {
-      // Unreadable CONTENT, not an unreadable FILE: keep it for forensics, start clean.
+    let state = parseSessionStateText(data)
+    if (!state) {
+      // The primary file exists but its CONTENT does not parse. Before starting
+      // clean, try the .bak previous-good mirror (#397 Group 3) so external
+      // corruption of the primary recovers the last-good set instead of losing it.
+      const bak = getSessionStateBakFile()
+      let recovered: SessionState | null = null
+      try {
+        if (existsSync(bak)) recovered = parseSessionStateText(readFileSync(bak, 'utf-8'))
+      } catch { /* .bak unreadable too -- fall through to clean start */ }
+
       const aside = `${file}.corrupt-${Date.now()}`
       try { renameSync(file, aside) } catch { /* best effort; the next save overwrites it */ }
-      logError(`[session-state] session-state.json did not parse (${(parseErr as Error)?.message ?? parseErr}); moved aside to ${aside} and starting with no saved sessions`)
       lastLoadFailed = false
-      return null
-    }
-    lastLoadFailed = false
 
-    if (!Array.isArray(state.sessions)) {
-      logInfo('[session-state] No sessions array in state; skipping migration')
-      return state
+      if (recovered) {
+        // Reinstate the recovered set as the primary so the next save has a baseline.
+        try { atomicWriteSessionState(file, recovered) } catch { /* best effort */ }
+        logError(`[session-state] session-state.json did not parse; RECOVERED ${recovered.sessions.length} sessions from ${bak} (corrupt file moved aside to ${aside})`)
+        state = recovered
+      } else {
+        logError(`[session-state] session-state.json did not parse and no usable .bak exists; moved aside to ${aside} and starting with no saved sessions`)
+        return null
+      }
+    } else {
+      lastLoadFailed = false
     }
 
     // v1.5: back-fill provider field + claudeOptions on each SavedSession.
     // Strips legacy top-level Claude fields; persists back only if something changed.
+    // #397 Group 3: guarded PER ENTRY. A null/primitive entry, or a migration that
+    // throws on one row, must not throw the whole load away (that used to null the
+    // set AND wrongly trip the read-failure latch, refusing all later saves).
     let dirty = false
-    const migratedSessions = state.sessions.map((s: any) => {
-      const out = migrateConfigToProviderShape(s)
-      if (!s.provider || LEGACY_CLAUDE_FIELDS.some(f => f in s)) {
-        dirty = true
+    const migratedSessions: SavedSession[] = []
+    for (const s of state.sessions as any[]) {
+      if (!s || typeof s !== 'object') {
+        dirty = true // dropping an un-restorable entry changes the set; persist the cleaned one
+        logError('[session-state] dropped a malformed (null/non-object) session entry during load')
+        continue
       }
-      return out
-    })
+      try {
+        const out = migrateConfigToProviderShape(s)
+        if (!s.provider || LEGACY_CLAUDE_FIELDS.some(f => f in s)) dirty = true
+        migratedSessions.push(out)
+      } catch (perEntryErr) {
+        // Keep the raw entry rather than losing it or nuking the whole set.
+        logError(`[session-state] migration failed for one session; keeping it unmigrated: ${(perEntryErr as Error)?.message ?? perEntryErr}`)
+        migratedSessions.push(s as SavedSession)
+      }
+    }
+    state.sessions = migratedSessions
     if (dirty) {
-      state.sessions = migratedSessions
       try {
         atomicWriteSessionState(getSessionStateFile(), state)
+        try { copyFileSync(getSessionStateFile(), getSessionStateBakFile()) } catch { /* .bak is a bonus */ }
         logInfo('[session-state] Migrated sessions to provider shape')
       } catch (writeErr) {
         logError(`[session-state] migration write failed; in-memory state preserved: ${(writeErr as Error)?.message ?? writeErr}`)

--- a/src/main/session-state.ts
+++ b/src/main/session-state.ts
@@ -107,10 +107,14 @@ export function saveSessionState(state: SessionState): boolean {
  * Parse session-state JSON text into a SessionState, tolerating the two content
  * defects that used to lose the WHOLE saved set (#397 Group 3):
  *   - a missing/non-array `sessions` (it reached the renderer and threw on
- *     `.length`, silently dropping the Resume prompt) -- coerced to [];
+ *     `.length`, silently dropping the Resume prompt);
  *   - the top-level value not being an object at all.
- * Returns null ONLY when the JSON itself does not parse (the caller then tries the
- * .bak). A single malformed session ENTRY is handled later, per-entry, not here.
+ * Both are treated as UNPARSEABLE (null), not coerced: the caller then tries
+ * the .bak, which either recovers the last-good set or moves the corrupt file
+ * aside — so downstream consumers (the canvas session-link's fail-closed
+ * "cannot tell whose canvases are current" contract included) never see a
+ * shape-corrupt file dressed up as an empty one (#413 review, R4). A single
+ * malformed session ENTRY is handled later, per-entry, not here.
  */
 function parseSessionStateText(text: string): SessionState | null {
   let state: SessionState
@@ -120,7 +124,7 @@ function parseSessionStateText(text: string): SessionState | null {
     return null
   }
   if (!state || typeof state !== 'object') return null
-  if (!Array.isArray(state.sessions)) state.sessions = []
+  if (!Array.isArray(state.sessions)) return null
   return state
 }
 

--- a/src/main/session-state.ts
+++ b/src/main/session-state.ts
@@ -219,6 +219,13 @@ export function clearSessionState(): boolean {
       unlinkSync(file)
       logInfo('[session-state] Cleared saved state')
     }
+    // #397 N1: remove the previous-good mirror too. Leaving it behind would keep a
+    // copy of the discarded set (cwds, machine names, GitHub config) on disk, and a
+    // later corrupt-primary load could recover the PRE-clear set the user discarded.
+    try {
+      const bak = getSessionStateBakFile()
+      if (existsSync(bak)) unlinkSync(bak)
+    } catch { /* best effort; recovery also re-parses + re-sanitizes before any use */ }
     return true
   } catch (err) {
     console.error('[session-state] Failed to clear:', err)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -83,7 +83,7 @@ import AutoDetectBanner from './components/github/AutoDetectBanner'
 import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import type { SessionState, SavedSession } from './types/electron'
 import { buildSessionState, buildSessionStateWithResumeTargets, markRestoredSessionsPredetermined } from './session-persistence'
-import { useSessionAutosave } from './hooks/useSessionAutosave'
+import { useSessionAutosave, cancelSessionAutosave } from './hooks/useSessionAutosave'
 
 // Re-export ViewType from its canonical location for backwards compatibility
 export type { ViewType } from './types/views'
@@ -766,6 +766,9 @@ export default function App() {
     if (isUpdate) setIsUpdating(true)
     try {
       await flushPendingConfigSaves()
+      // #397 round-2: kill any pending debounced autosave first, so it cannot fire
+      // after the clear and rewrite the set the user just chose to discard.
+      cancelSessionAutosave()
       await window.electronAPI.session.clear()
       console.log('[App] Session state cleared')
       if (isUpdate) {
@@ -804,9 +807,15 @@ export default function App() {
       if (state.sessions.length === 0) {
         // No dialog on the zero-session path, so drain pending debounced
         // config saves here before letting the window die.
-        void flushPendingConfigSaves().finally(() => {
-          window.electronAPI.window.allowClose()
-        })
+        // #397 round-2: the user has closed every card. Cancel any pending autosave
+        // and clear the saved set so the exit-time flush cannot re-assert sessions
+        // the user closed (the file/cache could still hold the last non-empty set
+        // in the sub-second window before the empty autosave would have fired).
+        cancelSessionAutosave()
+        void flushPendingConfigSaves()
+          .then(() => window.electronAPI.session.clear())
+          .catch(() => { /* best-effort: the empty store still yields no card next launch */ })
+          .finally(() => window.electronAPI.window.allowClose())
         return
       }
       setCloseDialog('close')
@@ -1253,6 +1262,9 @@ export default function App() {
               useCommandBarStore.getState().reconcile(useSessionStore.getState().sessions.map((s) => s.id))
               // Discard the saved cards so the next boot doesn't re-prompt; the
               // conversations themselves stay resumable from inside Claude.
+              // #397 round-2: cancel a pending autosave first so it can't rewrite
+              // the discarded set into the file after the clear.
+              cancelSessionAutosave()
               void window.electronAPI.session.clear()
             }}
             onRefresh={async () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -619,11 +619,11 @@ export default function App() {
     try {
       console.log(`[App] Restoring ${savedState.sessions.length} sessions...`)
 
-      // Idempotent session colour migration (no guard). session.clear() below wipes
-      // the on-disk copy right after restore, and migrated keys only reach disk on a
-      // graceful close (buildSessionState). So this recomputes each launch until then
-      // -- harmless: it is a no-op once keyed, raw `color` is always preserved, and the
-      // notice guard below prevents re-notifying.
+      // Idempotent session colour migration (no guard). The restore SAVES the live
+      // set right after this (#397 -- the clear that used to sit there left a gap
+      // where a crash lost everything), so migrated keys reach disk immediately.
+      // Still safe to recompute each launch: it is a no-op once keyed, raw `color` is
+      // always preserved, and the notice guard below prevents re-notifying.
       const { records: migratedSaved, summary: sessionSummary } = migrateColorRecords(savedState.sessions || [])
       console.log('[colourMigration] sessions', sessionSummary)
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -657,6 +657,10 @@ export default function App() {
           disableAutoMemory: claude?.disableAutoMemory ?? saved.disableAutoMemory,
           enableCodexReview: claude?.enableCodexReview,
           loggingEnabled: claude?.loggingEnabled,
+          // #397 Group 4: these were dropped on save+restore, so a restored session
+          // came back with the wrong permission mode / without its extra CLI args.
+          permissionMode: claude?.permissionMode,
+          extraArgs: claude?.extraArgs,
           machineName: saved.machineName,
           githubIntegration: saved.githubIntegration,
           status: 'idle' as const,
@@ -696,7 +700,17 @@ export default function App() {
       // Per-session "hide this tool" entries key on session ids, which persist
       // across restarts; drop the ones whose session did not come back (ADR-018 M3).
       useCommandBarStore.getState().reconcile(useSessionStore.getState().sessions.map((s) => s.id))
-      await window.electronAPI.session.clear()
+      // #397 Group 4: previously session.clear() unlinked the file here and relied on
+      // the ~1s debounced autosave to rewrite it -- a crash in that window lost every
+      // session. Instead persist the restored (live) set immediately so the on-disk
+      // copy is always current, with no empty gap. main enriches on save, and the
+      // restored resumeUuid/resumeCwd are still on the records (TerminalView clears
+      // them only at spawn), so the exact-resume targets are preserved.
+      try {
+        await window.electronAPI.session.save(buildSessionState())
+      } catch {
+        /* best-effort: the debounced autosave rewrites on the next session-set change */
+      }
 
       if (sessionSummary.changed > 0) {
         const s = useSettingsStore.getState()

--- a/src/renderer/hooks/useSessionAutosave.ts
+++ b/src/renderer/hooks/useSessionAutosave.ts
@@ -35,8 +35,24 @@ function sessionsKey(sessions: { id: string }[]): string {
   return sessions.map((s) => s.id).join('\n')
 }
 
+// Module-level so the discard paths can cancel a pending autosave (#397 round-2).
+let autosaveTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Cancel a pending debounced autosave. Call this on the discard paths
+ * (Close-without-saving / Don't-open) BEFORE `session.clear()`: a timer armed by a
+ * recent session add/remove would otherwise fire in the ~1s gap AFTER the clear and
+ * rewrite the on-disk file (and the main-side cache) with the very set the user
+ * just discarded — which the exit flush then re-asserts on the next launch.
+ */
+export function cancelSessionAutosave(): void {
+  if (autosaveTimer) {
+    clearTimeout(autosaveTimer)
+    autosaveTimer = null
+  }
+}
+
 export function useSessionAutosave(): void {
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastKey = useRef<string>(sessionsKey(useSessionStore.getState().sessions))
   useEffect(() => {
     const unsub = useSessionStore.subscribe((state, prev) => {
@@ -46,14 +62,15 @@ export function useSessionAutosave(): void {
       const key = sessionsKey(state.sessions)
       if (key === lastKey.current) return
       lastKey.current = key
-      if (timer.current) clearTimeout(timer.current)
-      timer.current = setTimeout(() => {
+      if (autosaveTimer) clearTimeout(autosaveTimer)
+      autosaveTimer = setTimeout(() => {
+        autosaveTimer = null
         void window.electronAPI?.session?.save(buildSessionState())
       }, DEBOUNCE_MS)
     })
     return () => {
       unsub()
-      if (timer.current) clearTimeout(timer.current)
+      cancelSessionAutosave()
     }
   }, [])
 }

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -62,6 +62,10 @@ export function buildSessionState(): SessionState {
       effortLevel: s.effortLevel,
       disableAutoMemory: s.disableAutoMemory,
       enableCodexReview: s.enableCodexReview ? true : undefined,
+      // #397 Group 4: round-trip these so a restored session keeps its permission
+      // mode and extra CLI args (previously dropped on save, so relaunch lost them).
+      permissionMode: s.permissionMode,
+      extraArgs: s.extraArgs,
     } : undefined,
     codexOptions: s.codexOptions,
   }))

--- a/tests/e2e/session-restore.spec.ts
+++ b/tests/e2e/session-restore.spec.ts
@@ -25,11 +25,11 @@
  *
  * Boundaries (NOT covered here, and why):
  *   - The per-field fail-open repair of a restored SPAWN (invalid resume uuid /
- *     codex preset) is unit-tested (sanitize-restored-spawn-options.spec.ts): it is
+ *     codex preset) is unit-tested (sanitize-restored-spawn-options.test.ts): it is
  *     pure argv-construction logic with no DOM surface, and exercising it E2E would
  *     need a real resumable Claude conversation on disk.
  *   - The read-failure latch (EBUSY/EACCES makes a load a non-absence) is unit-
- *     tested (session-state-read-failure.spec.ts): reliably holding a file
+ *     tested (session-state-read-failure.test.ts): reliably holding a file
  *     unreadable mid-launch is not scriptable cross-platform.
  */
 import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test'

--- a/tests/e2e/session-restore.spec.ts
+++ b/tests/e2e/session-restore.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * E2E: session-state DURABILITY + fail-open restore (#397), driven in the REAL
+ * packaged app across TWO launches sharing one data dir.
+ *
+ * This is the desktop-gate evidence for #397. The feature's whole promise is that
+ * an open session survives "no matter how the app closes" — including a hard crash,
+ * not a graceful quit — and that a CORRUPT persisted session-state file never
+ * wedges boot (it fails OPEN: recover from the .bak, else start clean). A single
+ * launch cannot prove either; this spec launches, creates a session, HARD-KILLS the
+ * process tree to simulate a crash, then RELAUNCHES against the same data dir and
+ * asserts what came back.
+ *
+ * Why a Terminal x Local session: it needs no real `claude` binary (absent in CI),
+ * yet it is a first-class persisted session (shellOnly, provider 'claude') that the
+ * autosave writes to session-state.json exactly like any other — so the durability
+ * path under test is the real one, with no external dependency to flake.
+ *
+ * The isolated-app helper (helpers/electron-app) mkdtemps a FRESH data dir per
+ * launch and rm's it on close, which is wrong for a two-launch test. So launch #1
+ * uses the helper only to SEED + boot (it hands back its dataDir), and every
+ * relaunch here re-launches Electron directly against that SAME dataDir with its own
+ * --user-data-dir (a killed instance's single-instance lock lives in the userdata
+ * dir, so a fresh one per relaunch sidesteps it). The dataDir is rm'd once, in
+ * afterAll — never by closeIsolatedApp.
+ *
+ * Boundaries (NOT covered here, and why):
+ *   - The per-field fail-open repair of a restored SPAWN (invalid resume uuid /
+ *     codex preset) is unit-tested (sanitize-restored-spawn-options.spec.ts): it is
+ *     pure argv-construction logic with no DOM surface, and exercising it E2E would
+ *     need a real resumable Claude conversation on disk.
+ *   - The read-failure latch (EBUSY/EACCES makes a load a non-absence) is unit-
+ *     tested (session-state-read-failure.spec.ts): reliably holding a file
+ *     unreadable mid-launch is not scriptable cross-platform.
+ */
+import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test'
+import { execSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { launchIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+const APP_PATH = path.resolve(__dirname, '../../out/main/index.js')
+const SESSION_NAME = 'E2E Restore'
+
+let seeded: IsolatedApp
+let dataDir: string
+let workDir: string
+let stateFile: string
+let bakFile: string
+let configDir: string
+
+// Live app under test at any given moment (so teardown can always kill it).
+let live: { app: ElectronApplication; page: Page } | null = null
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  test.setTimeout(120000)
+  // Launch #1 via the helper: seeds past the boot gates and hands back its dataDir.
+  seeded = await launchIsolatedApp()
+  live = { app: seeded.app, page: seeded.page }
+  dataDir = seeded.dataDir
+  configDir = path.join(dataDir, 'resources', 'CONFIG')
+  stateFile = path.join(configDir, 'session-state.json')
+  bakFile = `${stateFile}.bak`
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-e2e-restore-work-'))
+
+  await createTerminalSession(seeded.page)
+
+  // The autosave debounces ~1s after a session is added, then writes
+  // session-state.json (+ a .bak mirror). Wait for BOTH to hit disk — that on-disk
+  // file is the entire thing a crash must not lose.
+  await expect
+    .poll(() => (fs.existsSync(stateFile) && fs.existsSync(bakFile) ? readState(stateFile)?.sessions?.length ?? 0 : 0), {
+      timeout: 20000,
+      intervals: [250],
+    })
+    .toBeGreaterThan(0)
+
+  // Prove the persisted record carries the identity we will assert on restore.
+  const saved = readState(stateFile)!
+  const row = saved.sessions.find((s) => s.label === SESSION_NAME)
+  expect(row, 'the created session was not persisted to session-state.json').toBeTruthy()
+  expect(row!.workingDirectory).toBe(workDir)
+
+  // HARD crash: tree-kill launch #1. NOT a graceful app.close() — the point of #397
+  // is durability across a non-graceful death. The debounced autosave already
+  // flushed above, so nothing is lost by killing now.
+  hardKill(live.app)
+  live = null
+})
+
+test.afterAll(async () => {
+  test.setTimeout(60000)
+  if (live) {
+    hardKill(live.app)
+    live = null
+  }
+  // Remove ONLY the unique dirs we created.
+  for (const d of [dataDir, workDir]) {
+    try {
+      if (d) fs.rmSync(d, { recursive: true, force: true })
+    } catch {
+      /* a spawned shell may still hold a handle on Windows */
+    }
+  }
+})
+
+test('restores a session after a HARD crash (relaunch, same data dir)', async () => {
+  test.setTimeout(90000)
+  const { page } = await launchAppAt('relaunch-1')
+
+  // The restore surfaces as the "Resume previous sessions?" card, listing the saved
+  // session by name — proof the crashed session's record was read back on boot.
+  const prompt = page.getByRole('dialog', { name: /Resume previous sessions/i })
+  await expect(prompt).toBeVisible({ timeout: 20000 })
+  await expect(prompt.getByText(SESSION_NAME, { exact: false })).toBeVisible()
+  await shot(page, '01-resume-prompt-after-crash')
+
+  // Accept the restore: the session card comes back with the same name.
+  await prompt.getByRole('button', { name: 'Resume' }).click()
+  await expect(page.locator('.session-card').filter({ hasText: SESSION_NAME }).first()).toBeVisible({ timeout: 30000 })
+  await shot(page, '02-session-restored')
+
+  hardKill(live!.app)
+  live = null
+})
+
+test('fail-open: a CORRUPT session-state.json recovers from the .bak, never wedges', async () => {
+  test.setTimeout(90000)
+
+  // Corrupt ONLY the primary; leave the .bak (the last known-good mirror) intact.
+  fs.writeFileSync(stateFile, '{ "sessions": [ this is deliberately not valid JSON', 'utf-8')
+  expect(fs.existsSync(bakFile), 'precondition: the .bak mirror should exist from launch #1').toBe(true)
+
+  const { page } = await launchAppAt('relaunch-corrupt-bak')
+
+  // 1) It BOOTED — the main shell rendered (new-config present), so a corrupt file
+  //    did not wedge startup.
+  await expect(page.locator('[data-tour="new-config"]').first()).toBeVisible({ timeout: 20000 })
+
+  // 2) It RECOVERED the last-good set from the .bak: the Resume card lists the
+  //    session that was only in the (now-corrupt) primary.
+  const prompt = page.getByRole('dialog', { name: /Resume previous sessions/i })
+  await expect(prompt).toBeVisible({ timeout: 20000 })
+  await expect(prompt.getByText(SESSION_NAME, { exact: false })).toBeVisible()
+  await shot(page, '03-recovered-from-bak')
+
+  // 3) The unparseable primary was moved aside (never silently destroyed).
+  const asideExists = fs
+    .readdirSync(configDir)
+    .some((f) => f.startsWith('session-state.json.corrupt-'))
+  expect(asideExists, 'the corrupt primary should have been moved aside to *.corrupt-*').toBe(true)
+
+  hardKill(live!.app)
+  live = null
+})
+
+test('fail-open: a CORRUPT primary with NO usable .bak boots clean (no wedge, no phantom)', async () => {
+  test.setTimeout(90000)
+
+  // Corrupt the primary AND remove the .bak, so there is nothing to recover.
+  fs.writeFileSync(stateFile, 'not json at all }{', 'utf-8')
+  try {
+    if (fs.existsSync(bakFile)) fs.unlinkSync(bakFile)
+  } catch {
+    /* ignore */
+  }
+
+  const { page } = await launchAppAt('relaunch-corrupt-nobak')
+
+  // Booted to the main shell...
+  await expect(page.locator('[data-tour="new-config"]').first()).toBeVisible({ timeout: 20000 })
+  // ...and offered NO resume (nothing recoverable => clean start, not a wedge and
+  // not a phantom prompt). Give the async session.load time to have fired first.
+  await page.waitForTimeout(3000)
+  await expect(page.getByRole('dialog', { name: /Resume previous sessions/i })).toHaveCount(0)
+  await shot(page, '04-clean-start-no-bak')
+
+  hardKill(live!.app)
+  live = null
+})
+
+// ─────────────────────────────────────────────────────────────── helpers
+
+/** Create + launch a Terminal x Local session named SESSION_NAME in workDir. */
+async function createTerminalSession(page: Page): Promise<void> {
+  await page.locator('[data-tour="new-config"]').first().click()
+  await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
+
+  await page
+    .locator('[role="radiogroup"][aria-label="Provider"] label:has(input[value="terminal"])')
+    .click()
+  await page
+    .locator('[role="radiogroup"][aria-label="Where it runs"] label:has(input[value="local"])')
+    .click()
+
+  // Working directory is optional for a terminal config; fill it so we can assert
+  // it round-trips through persist -> crash -> restore.
+  await page.locator('input[placeholder*="home folder"]').first().fill(workDir)
+  await page.locator('input[placeholder="e.g. App Dev"]').fill(SESSION_NAME)
+
+  await page.locator('button:has-text("Create config")').click()
+  // Creating from the sidebar launches the config immediately (App.onConfirm ->
+  // launchConfig), so a real running session row appears.
+  await expect(page.locator('.session-card').filter({ hasText: SESSION_NAME }).first()).toBeVisible({
+    timeout: 30000,
+  })
+}
+
+/**
+ * Launch the packaged app directly against the SHARED dataDir (mirrors
+ * helpers/electron-app's launch env), with a per-launch --user-data-dir so a prior
+ * killed instance's single-instance lock does not collide. Waits until the main
+ * shell has hydrated.
+ */
+async function launchAppAt(tag: string): Promise<{ app: ElectronApplication; page: Page }> {
+  const app = await electron.launch({
+    args: [APP_PATH, `--user-data-dir=${path.join(dataDir, `electron-userdata-${tag}`)}`],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      E2E_HEADLESS: '1',
+      CCC_E2E_DATA_DIR: dataDir,
+      CCC_FORCE_SPLASH: '0',
+    },
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('[data-tour="new-config"]', { timeout: 20000 })
+  live = { app, page }
+  return { app, page }
+}
+
+/** Tree-kill the whole Electron process group — simulates a crash, and leaves no
+ *  orphan PTY child holding an inherited pipe open (which hangs worker teardown). */
+function hardKill(app: ElectronApplication): void {
+  try {
+    const pid = app.process().pid
+    if (!pid) return
+    if (process.platform === 'win32') {
+      execSync(`taskkill /pid ${pid} /T /F`, { windowsHide: true, timeout: 10000, stdio: 'ignore' })
+    } else {
+      try {
+        process.kill(-pid, 'SIGKILL')
+      } catch {
+        process.kill(pid, 'SIGKILL')
+      }
+    }
+  } catch {
+    /* already gone */
+  }
+}
+
+/** Read + parse a session-state file, tolerating an absent/garbage file. */
+function readState(file: string): { sessions: Array<{ label: string; workingDirectory: string }> } | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+/** Capture desktop-gate evidence: write the PNG to the test output dir (persists
+ *  under any reporter) AND attach it by path (shows inline in the report). */
+async function shot(page: Page, name: string): Promise<void> {
+  const file = test.info().outputPath(`${name}.png`)
+  await page.screenshot({ path: file })
+  await test.info().attach(name, { path: file, contentType: 'image/png' })
+}

--- a/tests/unit/main/resume-target-head-read.test.ts
+++ b/tests/unit/main/resume-target-head-read.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { resolveResumeTargetFromTranscript } from '../../../src/main/logging/transcript-discovery'
+
+// #397 N2: the DEFAULT reader now reads only a bounded head, because enrichment
+// runs on the main process on every debounced autosave and a full multi-MB sync
+// read would stall all IPC. The cwd sits in the first entries, so a head read must
+// still resolve it — even when a large tail follows.
+
+const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+let dir = ''
+
+beforeAll(() => { dir = mkdtempSync(join(tmpdir(), 'rt-head-')) })
+afterAll(() => { try { rmSync(dir, { recursive: true, force: true }) } catch { /* best effort */ } })
+
+describe('resolveResumeTargetFromTranscript — bounded head read (#397 N2)', () => {
+  it('resolves cwd from the head with the DEFAULT reader, past a 5 MB tail', () => {
+    const f = join(dir, `${uuid}.jsonl`)
+    const head = JSON.stringify({ type: 'user', cwd: 'C:/proj/app' }) + '\n'
+    writeFileSync(f, head + 'x'.repeat(5 * 1024 * 1024)) // huge non-JSON tail after the cwd line
+    expect(resolveResumeTargetFromTranscript(f)).toEqual({ uuid, cwd: 'C:/proj/app' })
+  })
+
+  it('returns null (fail-safe) when the head carries no cwd line', () => {
+    const f = join(dir, `${uuid}.jsonl`)
+    writeFileSync(f, JSON.stringify({ type: 'summary' }) + '\n')
+    expect(resolveResumeTargetFromTranscript(f)).toBeNull()
+  })
+})

--- a/tests/unit/main/sanitize-restored-spawn-options.test.ts
+++ b/tests/unit/main/sanitize-restored-spawn-options.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { sanitizeRestoredSpawnOptions } from '../../../src/main/sanitize-restored-spawn-options'
+
+// #397 Group 5: a corrupt persisted resume/codex field must not abort the spawn.
+// The sanitizer repairs fail-open (drop resume / floor codex preset) BEFORE the
+// strict schema parse, and never widens what that schema accepts.
+
+const goodUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+describe('sanitizeRestoredSpawnOptions', () => {
+  it('passes a valid resume target through unchanged', () => {
+    const out = sanitizeRestoredSpawnOptions({ resume: { uuid: goodUuid, cwd: 'C:/p' } })
+    expect(out.resume).toEqual({ uuid: goodUuid, cwd: 'C:/p' })
+  })
+
+  it('drops a resume with a non-UUID uuid (falls back to the picker) and logs', () => {
+    const log = vi.fn()
+    const out = sanitizeRestoredSpawnOptions({ resume: { uuid: 'not-a-uuid', cwd: 'C:/p' } }, log)
+    expect(out.resume).toBeUndefined()
+    expect(log).toHaveBeenCalledOnce()
+  })
+
+  it('drops a resume with an empty cwd', () => {
+    const out = sanitizeRestoredSpawnOptions({ resume: { uuid: goodUuid, cwd: '' } })
+    expect(out.resume).toBeUndefined()
+  })
+
+  it('drops a resume with an over-long cwd (> 4096)', () => {
+    const out = sanitizeRestoredSpawnOptions({ resume: { uuid: goodUuid, cwd: 'x'.repeat(4097) } })
+    expect(out.resume).toBeUndefined()
+  })
+
+  it('defaults a codex session with NO codexOptions to read-only', () => {
+    const out: any = sanitizeRestoredSpawnOptions({ provider: 'codex' })
+    expect(out.codexOptions).toEqual({ permissionsPreset: 'read-only' })
+  })
+
+  it('floors an invalid codex permissionsPreset to read-only, keeping other codex fields', () => {
+    const out: any = sanitizeRestoredSpawnOptions({
+      provider: 'codex',
+      codexOptions: { model: 'gpt', reasoningEffort: 'high', permissionsPreset: 'root' as any },
+    })
+    expect(out.codexOptions).toEqual({ model: 'gpt', reasoningEffort: 'high', permissionsPreset: 'read-only' })
+  })
+
+  it('leaves a valid codex preset untouched', () => {
+    const out: any = sanitizeRestoredSpawnOptions({
+      provider: 'codex',
+      codexOptions: { permissionsPreset: 'auto' },
+    })
+    expect(out.codexOptions.permissionsPreset).toBe('auto')
+  })
+
+  it('does NOT inject codexOptions for a non-codex provider', () => {
+    const out: any = sanitizeRestoredSpawnOptions({ provider: 'claude' })
+    expect(out.codexOptions).toBeUndefined()
+  })
+
+  it('returns undefined input as-is without throwing', () => {
+    expect(() => sanitizeRestoredSpawnOptions(undefined)).not.toThrow()
+    expect(sanitizeRestoredSpawnOptions(undefined)).toBeUndefined()
+  })
+
+  it('never mutates the input object', () => {
+    const input = { resume: { uuid: 'bad', cwd: 'C:/p' }, provider: 'codex' as const }
+    const out = sanitizeRestoredSpawnOptions(input)
+    expect(input.resume).toEqual({ uuid: 'bad', cwd: 'C:/p' }) // original untouched
+    expect(out).not.toBe(input)
+  })
+})

--- a/tests/unit/main/sanitize-restored-spawn-options.test.ts
+++ b/tests/unit/main/sanitize-restored-spawn-options.test.ts
@@ -67,4 +67,43 @@ describe('sanitizeRestoredSpawnOptions', () => {
     expect(input.resume).toEqual({ uuid: 'bad', cwd: 'C:/p' }) // original untouched
     expect(out).not.toBe(input)
   })
+
+  // #413 review S2: Phase 5 persists permissionMode/extraArgs, so a
+  // corrupt-but-parseable file can carry values the strict parse rejects —
+  // they must be dropped here (never coerced), or the spawn this helper
+  // exists to rescue is wedged by the exact corruption it guards against.
+
+  it('drops an invalid persisted permissionMode and logs; the session launches with the default', () => {
+    const log = vi.fn()
+    const out = sanitizeRestoredSpawnOptions({ permissionMode: 'acceptEdit' }, log) // pre-rename spelling
+    expect(out.permissionMode).toBeUndefined()
+    expect(log).toHaveBeenCalledOnce()
+  })
+
+  it('keeps every valid permissionMode, the empty string included', () => {
+    for (const mode of ['default', 'acceptEdits', 'auto', 'plan', 'dontAsk', 'bypassPermissions', 'manual', '']) {
+      expect(sanitizeRestoredSpawnOptions({ permissionMode: mode }).permissionMode).toBe(mode)
+    }
+  })
+
+  it('drops extraArgs that the strict parse would reject, for each of its rules', () => {
+    const bad = [
+      '--flag; rm -rf /', // charset (metacharacters)
+      'x'.repeat(513), // over the cap
+      '--setting\\s', // managed flag via backslash collapse
+      '--model opus', // managed flag, literal
+      'C:\\path\\', // trailing backslash (SSH line continuation)
+      42 as unknown as string, // not a string at all
+    ]
+    for (const value of bad) {
+      const out = sanitizeRestoredSpawnOptions({ extraArgs: value })
+      expect(out.extraArgs, String(value).slice(0, 40)).toBeUndefined()
+    }
+  })
+
+  it('keeps extraArgs the strict parse would accept', () => {
+    for (const value of ['', '--verbose', '--add-dir C:\\work\\repo', '--flag=a,b']) {
+      expect(sanitizeRestoredSpawnOptions({ extraArgs: value }).extraArgs).toBe(value)
+    }
+  })
 })

--- a/tests/unit/main/session-durability.test.ts
+++ b/tests/unit/main/session-durability.test.ts
@@ -63,6 +63,25 @@ describe('createSessionDurability', () => {
     expect(log.mock.calls[0][0]).toMatch(/REFUSED/)
   })
 
+  it('F: dedups redundant exit flushes within one teardown (single write)', () => {
+    const { d, save } = make()
+    d.saveEnriched(state())
+    save.mockClear()
+    d.flushOnExit('before-quit')
+    d.flushOnExit('render-process-gone') // same teardown, no intervening save
+    expect(save).toHaveBeenCalledOnce()
+  })
+
+  it('F: a real save between flushes re-arms the flush', () => {
+    const { d, save } = make()
+    d.saveEnriched(state())
+    d.flushOnExit('powerMonitor suspend') // flush #1
+    d.saveEnriched(state()) // app kept running, a new authoritative save
+    save.mockClear()
+    d.flushOnExit('before-quit') // must flush again
+    expect(save).toHaveBeenCalledOnce()
+  })
+
   it('flushOnExit swallows a save throw and reports it', () => {
     const log = vi.fn()
     let throwNow = false

--- a/tests/unit/main/session-durability.test.ts
+++ b/tests/unit/main/session-durability.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createSessionDurability } from '../../../src/main/session-durability'
+import type { SessionState } from '../../../src/main/session-state'
+
+// #397: the cross-exit durability core. These pin F1 (a cleared set is never
+// resurrected by the exit flush), N3 (an honest log on a latch-refused flush), and
+// the fail-safe rules the adversarial-review lead required.
+
+const target = { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', cwd: 'C:/p' }
+
+function make(saveImpl?: (s: SessionState) => boolean, log?: (m: string) => void) {
+  const save = vi.fn(saveImpl ?? (() => true))
+  const enrichDeps = {
+    getLatestTranscriptPath: () => '/x/f.jsonl',
+    resolveResumeTargetFromTranscript: () => target,
+  }
+  const d = createSessionDurability({ enrichDeps, save, log })
+  return { d, save }
+}
+
+const state = (): SessionState =>
+  ({ sessions: [{ id: 's1', provider: 'claude' } as any], activeSessionId: 's1', savedAt: 1 } as SessionState)
+
+describe('createSessionDurability', () => {
+  it('saveEnriched enriches from the binder, caches, and returns the save result', () => {
+    const { d, save } = make()
+    expect(d.saveEnriched(state())).toBe(true)
+    expect(save).toHaveBeenCalledOnce()
+    expect(d.peek()?.sessions[0]).toMatchObject({ resumeUuid: target.uuid, resumeCwd: target.cwd })
+  })
+
+  it('flushOnExit persists the cached state', () => {
+    const { d, save } = make()
+    d.saveEnriched(state())
+    save.mockClear()
+    d.flushOnExit('before-quit')
+    expect(save).toHaveBeenCalledOnce()
+  })
+
+  it('flushOnExit is a no-op before anything was saved this run', () => {
+    const { d, save } = make()
+    d.flushOnExit('before-quit')
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('F1: flushOnExit does NOT resurrect a set after noteCleared()', () => {
+    const { d, save } = make()
+    d.saveEnriched(state())
+    d.noteCleared()
+    save.mockClear()
+    d.flushOnExit('before-quit')
+    expect(save).not.toHaveBeenCalled()
+    expect(d.peek()).toBeNull()
+  })
+
+  it('N3: flushOnExit logs REFUSED (not success) when the save is refused by the latch', () => {
+    const log = vi.fn()
+    const { d } = make(() => false, log)
+    d.saveEnriched(state())
+    log.mockClear()
+    d.flushOnExit('SIGTERM')
+    expect(log).toHaveBeenCalledOnce()
+    expect(log.mock.calls[0][0]).toMatch(/REFUSED/)
+  })
+
+  it('flushOnExit swallows a save throw and reports it', () => {
+    const log = vi.fn()
+    let throwNow = false
+    const { d } = make(() => { if (throwNow) throw new Error('disk gone'); return true }, log)
+    d.saveEnriched(state()) // seeds cache, save returns true
+    throwNow = true
+    log.mockClear()
+    expect(() => d.flushOnExit('before-quit')).not.toThrow()
+    expect(log.mock.calls[0][0]).toMatch(/failed/)
+  })
+})

--- a/tests/unit/main/session-durability.test.ts
+++ b/tests/unit/main/session-durability.test.ts
@@ -63,23 +63,13 @@ describe('createSessionDurability', () => {
     expect(log.mock.calls[0][0]).toMatch(/REFUSED/)
   })
 
-  it('F: dedups redundant exit flushes within one teardown (single write)', () => {
+  it('flushOnExit re-persists on every exit path (no dedup — a suspend then a later exit both flush)', () => {
     const { d, save } = make()
     d.saveEnriched(state())
     save.mockClear()
-    d.flushOnExit('before-quit')
-    d.flushOnExit('render-process-gone') // same teardown, no intervening save
-    expect(save).toHaveBeenCalledOnce()
-  })
-
-  it('F: a real save between flushes re-arms the flush', () => {
-    const { d, save } = make()
-    d.saveEnriched(state())
-    d.flushOnExit('powerMonitor suspend') // flush #1
-    d.saveEnriched(state()) // app kept running, a new authoritative save
-    save.mockClear()
-    d.flushOnExit('before-quit') // must flush again
-    expect(save).toHaveBeenCalledOnce()
+    d.flushOnExit('powerMonitor suspend') // app keeps running after this
+    d.flushOnExit('before-quit')          // a later real exit must still flush fresh
+    expect(save).toHaveBeenCalledTimes(2)
   })
 
   it('flushOnExit swallows a save throw and reports it', () => {

--- a/tests/unit/main/session-resume-enrich.test.ts
+++ b/tests/unit/main/session-resume-enrich.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { enrichSessionStateWithResumeTargets } from '../../../src/main/session-resume-enrich'
+import type { SessionState } from '../../../src/main/session-state'
+
+// #397 Group 1: main-side enrichment is the single write choke point that stamps
+// each Claude session's exact-conversation resume target, so EVERY renderer writer
+// (autosave, account flush, GitHub flush, Save-&-Close) persists a resumable
+// record — not only the graceful-close path. These tests pin the fail-safe rules.
+
+function state(sessions: any[]): SessionState {
+  return { sessions, activeSessionId: sessions[0]?.id, savedAt: 1 } as unknown as SessionState
+}
+
+const okTarget = { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', cwd: 'C:/proj' }
+
+describe('enrichSessionStateWithResumeTargets', () => {
+  it('stamps uuid+cwd on a Claude session from the binder', () => {
+    const s = state([{ id: 's1', provider: 'claude' }])
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: () => '/x/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl',
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(s.sessions[0]).toMatchObject({ resumeUuid: okTarget.uuid, resumeCwd: okTarget.cwd })
+  })
+
+  it('treats an absent provider as claude (default) and enriches it', () => {
+    const s = state([{ id: 's1' }])
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: () => '/x/f.jsonl',
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(s.sessions[0].resumeUuid).toBe(okTarget.uuid)
+  })
+
+  it('skips shell-only sessions', () => {
+    const s = state([{ id: 's1', provider: 'claude', shellOnly: true }])
+    const getLatest = vi.fn(() => '/x/f.jsonl')
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: getLatest,
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(getLatest).not.toHaveBeenCalled()
+    expect(s.sessions[0].resumeUuid).toBeUndefined()
+  })
+
+  it('skips non-Claude (codex) sessions', () => {
+    const s = state([{ id: 's1', provider: 'codex' }])
+    const getLatest = vi.fn(() => '/x/f.jsonl')
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: getLatest,
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(getLatest).not.toHaveBeenCalled()
+    expect(s.sessions[0].resumeUuid).toBeUndefined()
+  })
+
+  it('KEEPS the existing target when the binder has no path (logging off)', () => {
+    const s = state([{ id: 's1', provider: 'claude', resumeUuid: 'old-uuid', resumeCwd: 'C:/old' }])
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: () => null,
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(s.sessions[0]).toMatchObject({ resumeUuid: 'old-uuid', resumeCwd: 'C:/old' })
+  })
+
+  it('KEEPS the existing target when the transcript does not resolve a target', () => {
+    const s = state([{ id: 's1', provider: 'claude', resumeUuid: 'old-uuid', resumeCwd: 'C:/old' }])
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: () => '/x/f.jsonl',
+      resolveResumeTargetFromTranscript: () => null,
+    })
+    expect(s.sessions[0]).toMatchObject({ resumeUuid: 'old-uuid', resumeCwd: 'C:/old' })
+  })
+
+  it('never throws on a per-session dep failure; leaves that record unchanged and continues', () => {
+    const s = state([
+      { id: 'bad', provider: 'claude', resumeUuid: 'keep' },
+      { id: 'good', provider: 'claude' },
+    ])
+    enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: (id) => {
+        if (id === 'bad') throw new Error('binder blew up')
+        return '/x/f.jsonl'
+      },
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })
+    expect(s.sessions[0].resumeUuid).toBe('keep')          // untouched despite the throw
+    expect(s.sessions[1].resumeUuid).toBe(okTarget.uuid)   // later session still enriched
+  })
+
+  it('is a whole no-op on a non-array sessions field', () => {
+    const s = { sessions: undefined, savedAt: 1 } as unknown as SessionState
+    expect(() => enrichSessionStateWithResumeTargets(s, {
+      getLatestTranscriptPath: () => '/x/f.jsonl',
+      resolveResumeTargetFromTranscript: () => okTarget,
+    })).not.toThrow()
+  })
+})

--- a/tests/unit/renderer/session-persistence-resume.test.ts
+++ b/tests/unit/renderer/session-persistence-resume.test.ts
@@ -151,4 +151,15 @@ describe('session-persistence — resumeUuid/resumeCwd (T8b)', () => {
     const state = await buildSessionStateWithResumeTargets()
     expect(state.sessions[0].resumeUuid).toBe('r')
   })
+
+  it('#397: round-trips permissionMode/extraArgs through claudeOptions', () => {
+    useSessionStore.setState({
+      sessions: [makeSession({ permissionMode: 'plan', extraArgs: '--verbose' })],
+      activeSessionId: 'sess-resume-1',
+      isRestoring: false,
+    })
+    const co = buildSessionState().sessions[0].claudeOptions
+    expect(co?.permissionMode).toBe('plan')
+    expect(co?.extraArgs).toBe('--verbose')
+  })
 })

--- a/tests/unit/session-state-read-failure.test.ts
+++ b/tests/unit/session-state-read-failure.test.ts
@@ -154,6 +154,27 @@ describe('an absent file and an unparseable file are NOT read failures', () => {
     expect(JSON.parse(readFileSync(file(), 'utf-8')).sessions).toHaveLength(2)
   })
 
+  it('SHAPE-corrupt JSON (sessions not an array) is unparseable, not coerced: the .bak recovers it (#413 R4)', () => {
+    // Parses as JSON but the shape is wrong. Coercing it to an empty set used
+    // to dress a corrupt file up as "genuinely no sessions", which flipped the
+    // canvas session-link's fail-closed "cannot tell" contract to fail-open.
+    // It now routes through the same recovery as garbage content.
+    expect(saveSessionState(saved)).toBe(true)
+    writeFileSync(file(), JSON.stringify({ sessions: { not: 'an array' }, activeSessionId: null, savedAt: 1 }))
+    const loaded = loadSessionState()
+    expect(loaded?.sessions.length).toBe(2) // recovered from .bak, not coerced to []
+    expect(sessionStateReadFailed()).toBe(false)
+  })
+
+  it('SHAPE-corrupt JSON with no .bak: moved aside, clean start — never an invented empty set (#413 R4)', () => {
+    rmSync(file() + '.bak', { force: true })
+    writeFileSync(file(), JSON.stringify({ sessions: 42 }))
+    expect(loadSessionState()).toBeNull()
+    expect(sessionStateReadFailed()).toBe(false)
+    const aside = readdirSync(join(tmp, 'CONFIG')).filter((f) => f.startsWith('session-state.json.corrupt-'))
+    expect(aside.length).toBeGreaterThanOrEqual(1)
+  })
+
   it('#397 N1: clear removes the .bak previous-good mirror as well as the primary', () => {
     expect(saveSessionState(saved)).toBe(true)
     expect(existsSync(file() + '.bak')).toBe(true)

--- a/tests/unit/session-state-read-failure.test.ts
+++ b/tests/unit/session-state-read-failure.test.ts
@@ -153,4 +153,12 @@ describe('an absent file and an unparseable file are NOT read failures', () => {
     expect(aside.length).toBeGreaterThanOrEqual(1)
     expect(JSON.parse(readFileSync(file(), 'utf-8')).sessions).toHaveLength(2)
   })
+
+  it('#397 N1: clear removes the .bak previous-good mirror as well as the primary', () => {
+    expect(saveSessionState(saved)).toBe(true)
+    expect(existsSync(file() + '.bak')).toBe(true)
+    expect(clearSessionState()).toBe(true)
+    expect(existsSync(file())).toBe(false)
+    expect(existsSync(file() + '.bak')).toBe(false)
+  })
 })

--- a/tests/unit/session-state-read-failure.test.ts
+++ b/tests/unit/session-state-read-failure.test.ts
@@ -66,6 +66,9 @@ beforeAll(() => {
 beforeEach(() => {
   h.failReads = false
   h.errno = 'EBUSY'
+  // #397: isolate the .bak previous-good mirror between cases (a real save writes
+  // it; this direct writeFileSync does not, so a stale one could otherwise leak in).
+  rmSync(file() + '.bak', { force: true })
   // Reset the latch by performing a successful load over a known file.
   writeFileSync(file(), JSON.stringify(saved))
   expect(loadSessionState()?.sessions.length).toBe(2)
@@ -124,7 +127,8 @@ describe('an absent file and an unparseable file are NOT read failures', () => {
     expect(saveSessionState(empty)).toBe(true)
   })
 
-  it('garbage content: moved aside (never destroyed), null, not latched, save allowed', () => {
+  it('garbage content, no .bak: moved aside (never destroyed), null, not latched, save allowed', () => {
+    rmSync(file() + '.bak', { force: true }) // no previous-good mirror to recover from
     writeFileSync(file(), '{ this is not json')
     expect(loadSessionState()).toBeNull()
     expect(sessionStateReadFailed()).toBe(false)
@@ -133,5 +137,20 @@ describe('an absent file and an unparseable file are NOT read failures', () => {
     expect(readFileSync(join(tmp, 'CONFIG', aside[aside.length - 1]), 'utf-8')).toBe('{ this is not json')
     expect(saveSessionState(empty)).toBe(true)
     expect(JSON.parse(readFileSync(file(), 'utf-8')).sessions).toHaveLength(0)
+  })
+
+  it('garbage content WITH a good .bak: recovers the last-good set and reinstates it (#397 Group 3)', () => {
+    // A real save writes the primary AND mirrors it to the .bak.
+    expect(saveSessionState(saved)).toBe(true)
+    expect(existsSync(file() + '.bak')).toBe(true)
+    // External corruption of the primary only (AV / disk fault / bad edit); .bak intact.
+    writeFileSync(file(), 'not json at all')
+    const loaded = loadSessionState()
+    expect(loaded?.sessions.length).toBe(2)      // recovered, not lost
+    expect(sessionStateReadFailed()).toBe(false) // a parse miss is not a read failure
+    // The corrupt primary was moved aside AND the recovered set reinstated as primary.
+    const aside = readdirSync(join(tmp, 'CONFIG')).filter((f) => f.startsWith('session-state.json.corrupt-'))
+    expect(aside.length).toBeGreaterThanOrEqual(1)
+    expect(JSON.parse(readFileSync(file(), 'utf-8')).sessions).toHaveLength(2)
   })
 })


### PR DESCRIPTION
Implements #397 — sessions restart no matter how the app closes (session-state durability + fail-open restore).

Carries an ADR-009 adversarial-review **PASS** (recorded on #397). 247/247 tests pass across the persistence/resume/spawn cluster.

## What's here (base `444c052d` → HEAD `4d165ac0`, +768/-35, 16 files)

- **Phase 1+2** — enrich resume targets in main + flush on every exit
- **Phase 3** — crash-safe load: `.bak` recovery + per-entry migration guard
- **Phase 4** — fail-open spawn for corrupt persisted resume/codex fields
- **Phase 5** — restore fidelity: round-trip `permissionMode`/`extraArgs`, no clear gap
- 3 adversarial-review rounds of fixes
- New main-process modules: `session-durability.ts`, `session-resume-enrich.ts`, `sanitize-restored-spawn-options.ts`
- 6 new/extended vitest files

## Gate status

- **ADR-009:** PASS (recorded on the issue).
- **Desktop test:** NOT yet done — the code was exercised only as vitest unit tests, never in a packaged Electron runtime. Needs a human desktop test + the `desktop-tested` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
