### PR TITLE
fix(dialogs): tokenise the #402 capture dialogs to the E5 palette

### DIFF
--- a/src/renderer/components/CapturedRunModal.tsx
+++ b/src/renderer/components/CapturedRunModal.tsx
@@ -120,11 +120,11 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
         aria-modal="true"
         aria-labelledby="captured-run-title"
         data-ux-id="captured-run-dialog"
-        className="bg-mantle border border-surface0 rounded-lg shadow-2xl w-full max-w-3xl mx-4 flex flex-col"
+        className="bg-[var(--surface-raised)] border border-[var(--border-subtle)] rounded-lg shadow-2xl w-full max-w-3xl mx-4 flex flex-col"
         style={{ maxHeight: '80vh' }}
       >
-        <div className="p-4 border-b border-surface0">
-          <h2 id="captured-run-title" className="text-sm font-semibold text-text">
+        <div className="p-4 border-b border-[var(--border-subtle)]">
+          <h2 id="captured-run-title" className="text-sm font-semibold text-[var(--text-primary)]">
             {label}
           </h2>
           <p className="text-[11px] font-mono break-all mt-1" style={{ color: 'var(--text-muted)' }}>
@@ -147,7 +147,7 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
             ref={scrollRef}
             data-ux-id="captured-run-output"
             className="flex-1 overflow-auto p-4 font-mono text-xs whitespace-pre-wrap break-words"
-            style={{ background: 'var(--color-crust, #11111b)', minHeight: '12rem' }}
+            style={{ background: 'var(--surface-sunken)', minHeight: '12rem' }}
           >
             {chunks.length === 0 && running && (
               <span style={{ color: 'var(--text-muted)' }}>Waiting for output…</span>
@@ -156,14 +156,14 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
               <span style={{ color: 'var(--text-muted)' }}>That program printed nothing.</span>
             )}
             {chunks.map((c, i) => (
-              <span key={i} className={c.stream === 'stderr' ? 'text-red' : 'text-text'}>
+              <span key={i} className={c.stream === 'stderr' ? 'text-[var(--status-danger)]' : 'text-[var(--text-primary)]'}>
                 {c.text}
               </span>
             ))}
           </div>
         )}
 
-        <div className="p-4 border-t border-surface0 flex items-center gap-3">
+        <div className="p-4 border-t border-[var(--border-subtle)] flex items-center gap-3">
           <span
             className="text-xs flex-1"
             data-ux-id="captured-run-status"
@@ -178,7 +178,7 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
               onClick={() => { if (runId) void window.electronAPI.exe.cancelRun(runId) }}
               data-ux-id="captured-run-cancel"
               title="Force-stop the program. Any unsaved work in it is lost."
-              className="py-1.5 px-4 text-xs rounded bg-surface1 hover:bg-surface2 text-text transition-colors focus-ring"
+              className="py-1.5 px-4 text-xs rounded bg-[var(--surface-overlay)] hover:bg-[var(--surface-raised)] text-[var(--text-primary)] transition-colors focus-ring"
             >
               Stop the program
             </button>
@@ -189,7 +189,7 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
             onClick={() => handleClose.current()}
             data-ux-id="captured-run-close"
             title={running ? 'Stop showing this log. The program keeps running.' : undefined}
-            className="py-1.5 px-4 text-xs rounded bg-surface1 hover:bg-surface2 text-text transition-colors focus-ring"
+            className="py-1.5 px-4 text-xs rounded bg-[var(--surface-overlay)] hover:bg-[var(--surface-raised)] text-[var(--text-primary)] transition-colors focus-ring"
           >
             Close
           </button>

--- a/src/renderer/components/CapturedRunModal.tsx
+++ b/src/renderer/components/CapturedRunModal.tsx
@@ -20,6 +20,7 @@
  */
 import { useEffect, useRef, useState } from 'react'
 import type { CapturedRunExit } from '../../shared/gui-exe'
+import { scrim } from './ui/Dialog'
 
 export interface CapturedRunModalProps {
   /** Null when the run was refused; the panel then explains the fallback. */
@@ -112,7 +113,7 @@ export default function CapturedRunModal({ runId, label, command, exePath, start
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'color-mix(in srgb, var(--color-base) 80%, transparent)' }}
+      style={{ background: scrim(0.8) }}
       data-ux-id="captured-run-backdrop"
     >
       <div

--- a/src/renderer/components/GuiExeDialog.tsx
+++ b/src/renderer/components/GuiExeDialog.tsx
@@ -58,9 +58,9 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
         aria-modal="true"
         aria-labelledby="gui-exe-title"
         data-ux-id="gui-exe-dialog"
-        className="bg-surface0 border border-surface1 rounded-lg shadow-2xl p-6 max-w-md w-full mx-4"
+        className="bg-[var(--surface-raised)] border border-[var(--border-subtle)] rounded-lg shadow-2xl p-6 max-w-md w-full mx-4"
       >
-        <h2 id="gui-exe-title" className="text-lg font-semibold text-text mb-2">
+        <h2 id="gui-exe-title" className="text-lg font-semibold text-[var(--text-primary)] mb-2">
           {label} is a Windows GUI program
         </h2>
         <p className="text-sm mb-2" style={{ color: 'var(--text-secondary)' }}>
@@ -80,7 +80,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
           {operators.length > 0 ? (
             <>
               {' '}This line uses{' '}
-              <span className="font-mono text-yellow">{operators.join(' ')}</span>
+              <span className="font-mono text-[var(--status-warning)]">{operators.join(' ')}</span>
               , which {operators.length === 1 ? 'will be passed through as a literal argument' : 'will be passed through as literal arguments'} rather than
               interpreted — so it will not do the same thing as running it in the terminal.
             </>
@@ -97,7 +97,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
             checked={remember}
             onChange={(e) => setRemember(e.target.checked)}
             data-ux-id="gui-exe-remember"
-            className="accent-blue"
+            className="accent-[var(--brand)]"
           />
           Remember this choice for this button
         </label>
@@ -108,7 +108,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
             type="button"
             onClick={() => choose('capture')}
             data-ux-id="gui-exe-capture"
-            className="w-full py-2 px-4 text-sm font-medium rounded bg-blue hover:bg-blue/80 text-crust transition-colors focus-ring"
+            className="w-full py-2 px-4 text-sm font-medium rounded bg-[var(--brand)] hover:brightness-110 text-[var(--text-on-brand)] transition-colors focus-ring"
           >
             Capture the output
           </button>
@@ -116,7 +116,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
             type="button"
             onClick={() => choose('terminal')}
             data-ux-id="gui-exe-terminal"
-            className="w-full py-2 px-4 text-sm font-medium rounded bg-surface1 hover:bg-surface2 text-text transition-colors focus-ring"
+            className="w-full py-2 px-4 text-sm font-medium rounded bg-[var(--surface-overlay)] hover:bg-[var(--surface-raised)] text-[var(--text-primary)] transition-colors focus-ring"
           >
             Run in the terminal anyway
           </button>
@@ -124,7 +124,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
             type="button"
             onClick={onCancel}
             data-ux-id="gui-exe-cancel"
-            className="w-full py-1.5 px-4 text-xs text-overlay1 hover:text-text transition-colors focus-ring"
+            className="w-full py-1.5 px-4 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors focus-ring"
           >
             Cancel
           </button>

--- a/src/renderer/components/GuiExeDialog.tsx
+++ b/src/renderer/components/GuiExeDialog.tsx
@@ -14,6 +14,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { shellOperatorsIn } from '../../shared/gui-exe'
+import { scrim } from './ui/Dialog'
 
 export interface GuiExeDialogProps {
   /** The button's label, for the title. */
@@ -50,7 +51,7 @@ export default function GuiExeDialog({ label, command, exePath, onChoose, onCanc
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
-      style={{ background: 'color-mix(in srgb, var(--color-base) 80%, transparent)' }}
+      style={{ background: scrim(0.8) }}
       data-ux-id="gui-exe-backdrop"
     >
       <div


### PR DESCRIPTION
Hotfix: **beta is red.** `GuiExeDialog.tsx` and `CapturedRunModal.tsx` shipped in #402 (branched off beta *before* the #360 palette-scan test landed via #401). Once both #401 and #402 were on beta, `dialog-palette-retired.test.ts:173` began failing on beta itself (2 offenders), which blocks **every** open PR branched off beta.

Swaps the two dialogs' Catppuccin palette classes to E5 semantic tokens. Styling only, no behaviour change. Unblocks #403–#409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)