### PR TITLE
feat(canvas): ctrl+wheel zoom in the canvas pane (#368)

### DIFF
--- a/src/main/canvas/bridge/index.ts
+++ b/src/main/canvas/bridge/index.ts
@@ -369,6 +369,62 @@ function install(): void {
     { capture: true, passive: true },
   )
 
+  // Ctrl+wheel is the browser's zoom gesture, and in the pane it belongs to the
+  // HOST (#368): while the pointer is over the content the wheel lands here, so
+  // without this relay the gesture would silently vanish. Relayed as INTENT —
+  // one 'in'/'out' per accumulated wheel notch, so a trackpad's stream of small
+  // deltas steps the same ladder a notched wheel does — never as raw deltas;
+  // the host owns the ladder and the clamp and may ignore the report (D8).
+  // preventDefault so the zoom gesture is not also a scroll; a plain
+  // (ctrl-less) wheel is untouched. Not gated on hoverReporting: zoom is pane
+  // chrome, not x-ray, and x-ray Off must not kill the zoom gesture.
+  let wheelAccum = 0
+  document.addEventListener(
+    'wheel',
+    (event: WheelEvent) => {
+      // altKey excluded: AltGr on Windows layouts reports ctrl+alt together.
+      if (!event.ctrlKey || event.altKey) return
+      event.preventDefault()
+      // DOM_DELTA_LINE (1) counts lines (~3 per notch); anything else is pixels.
+      const notch = event.deltaMode === 1 ? 3 : 100
+      wheelAccum += event.deltaY
+      while (wheelAccum >= notch) {
+        wheelAccum -= notch
+        send({ ns: NS, type: 'contentZoom', action: 'out' })
+      }
+      while (wheelAccum <= -notch) {
+        wheelAccum += notch
+        send({ ns: NS, type: 'contentZoom', action: 'in' })
+      }
+    },
+    { capture: true, passive: false },
+  )
+
+  // The zoom CHORDS, for when the frame owns keyboard focus (the user clicked
+  // the page): Ctrl+= / Ctrl+- / Ctrl+0, relayed as the same closed intents.
+  // Never from an editable target (consistent with the key relay above) and
+  // never the key value itself — there is no path from here to arbitrary keys.
+  document.addEventListener(
+    'keydown',
+    (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.altKey || event.metaKey) return
+      const action =
+        event.key === '=' || event.key === '+'
+          ? ('in' as const)
+          : event.key === '-' || event.key === '_'
+            ? ('out' as const)
+            : event.key === '0'
+              ? ('reset' as const)
+              : null
+      if (!action) return
+      const target = event.target
+      if (target instanceof Element && isEditableTarget(target)) return
+      event.preventDefault()
+      send({ ns: NS, type: 'contentZoom', action })
+    },
+    { capture: true, passive: false },
+  )
+
   function announceReady(): void {
     send({ ns: NS, type: 'ready' })
     send({ ns: NS, type: 'viewport', viewport: viewportInfo() })

--- a/src/main/canvas/bridge/index.ts
+++ b/src/main/canvas/bridge/index.ts
@@ -382,11 +382,13 @@ function install(): void {
   document.addEventListener(
     'wheel',
     (event: WheelEvent) => {
-      // altKey excluded: AltGr on Windows layouts reports ctrl+alt together.
+      // ctrlKey on every platform — a macOS trackpad pinch reports as
+      // ctrl+wheel too. altKey excluded: AltGr on Windows reports ctrl+alt.
       if (!event.ctrlKey || event.altKey) return
       event.preventDefault()
-      // DOM_DELTA_LINE (1) counts lines (~3 per notch); anything else is pixels.
-      const notch = event.deltaMode === 1 ? 3 : 100
+      // DOM_DELTA_LINE (1) counts lines (~3/notch), DOM_DELTA_PAGE (2) counts
+      // pages (~1/notch); anything else is pixels.
+      const notch = event.deltaMode === 1 ? 3 : event.deltaMode === 2 ? 1 : 100
       wheelAccum += event.deltaY
       while (wheelAccum >= notch) {
         wheelAccum -= notch
@@ -401,13 +403,16 @@ function install(): void {
   )
 
   // The zoom CHORDS, for when the frame owns keyboard focus (the user clicked
-  // the page): Ctrl+= / Ctrl+- / Ctrl+0, relayed as the same closed intents.
-  // Never from an editable target (consistent with the key relay above) and
-  // never the key value itself — there is no path from here to arbitrary keys.
+  // the page): Ctrl+= / Ctrl+- / Ctrl+0 — Cmd on macOS, the platform's own
+  // zoom chord — relayed as the same closed intents. Never from an editable
+  // target (consistent with the key relay above) and never the key value
+  // itself — there is no path from here to arbitrary keys.
+  const zoomChordIsMac = navigator.platform.startsWith('Mac')
   document.addEventListener(
     'keydown',
     (event: KeyboardEvent) => {
-      if (!event.ctrlKey || event.altKey || event.metaKey) return
+      const chord = zoomChordIsMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+      if (!chord || event.altKey) return
       const action =
         event.key === '=' || event.key === '+'
           ? ('in' as const)

--- a/src/renderer/canvas/canvas-inbound-channel.ts
+++ b/src/renderer/canvas/canvas-inbound-channel.ts
@@ -9,16 +9,17 @@
 // Three of the six inbound types are paint-only (`ready`, `viewport`,
 // `pointer`): the worst a forgery does is move a highlight box, and the geometry
 // guards bound it. `contentZoom` (#368) sits between the classes: it steps the
-// pane's clamped, chrome-visible zoom ladder — it cannot reach the review store
-// or the locked selection — and is honoured only with host-side evidence the
-// frame plausibly owns the gesture (pointer hover or keyboard focus; see
-// reportedZoomIsPlausible for why not user activation). What a hostile page CAN
-// do with it is fight the user for the camera (re-zooming after every Ctrl+0)
-// and provoke the host work a zoom change triggers (a reflow, a re-anchor
-// pass); its own budget exists for exactly that — past CONTENT_ZOOM_BUDGET the
-// channel is dropped whole, and the host's resolve path holds one RPC slot at
-// most however often the zoom moves. Two MUTATE HOST STATE and are handled
-// differently here:
+// pane's clamped, chrome-visible zoom ladder — it cannot write a note, a
+// review, or the locked selection's IDENTITY — and is honoured only with
+// host-side evidence the frame plausibly owns the gesture (pointer hover or
+// keyboard focus; see reportedZoomIsPlausible for why not user activation).
+// What a hostile page CAN do with it: fight the user for the camera
+// (re-zooming after a Ctrl+0 — briefly; sustained fighting trips
+// CONTENT_ZOOM_BUDGET and drops the channel whole) and provoke the re-anchor
+// pass a real zoom would provoke — which writes page-authored, page-labelled
+// BOXES into the resolution map and the live lock, exactly as any reflow does,
+// under the pane's single-flight and per-intent attempt budget. Two MUTATE
+// HOST STATE and are handled differently here:
 //
 //   `contentKey`  clears the user's locked focus / disarms an armed marquee. It
 //                 is honoured only when the host can see for itself that the
@@ -124,18 +125,27 @@ export const INBOUND_OVERSIZE_COST = 60
  */
 /**
  * How many contentZoom intents the frame may have HONOURED per rolling window
- * (#368). The flood budget bounds message COUNT and is far too generous to
- * bound this event's EFFECT: sixty accepted intents a second is 10 % of the
- * flood budget and enough to pin the zoom at an end of the ladder faster than
- * the user can reset it, indefinitely. A human's heaviest plausible input — a
- * full-ladder sweep is ten notches, a hard continuous spin a few dozen — sits
- * well under sixty in ten seconds; a page over it is fighting the user for the
- * pane's camera on purpose, and the answer is the one the flood budget already
- * gives: stop listening to that page. Charged only for intents that PASS the
- * plausibility gate — refused forgeries never count against a page the user is
- * not even hovering.
+ * (#368). The flood budget bounds message COUNT and is too generous to bound
+ * this event's EFFECT: sixty intents a second is 10 % of the flood budget and
+ * enough to re-pin the zoom after every Ctrl+0, indefinitely.
+ *
+ * The ceiling is set the way INBOUND_FLOOD_BUDGET's is — several times the
+ * heaviest REAL rate, not just above the average one. One intent is one wheel
+ * notch (the bridge accumulates deltas to notches before relaying), a hard
+ * continuous spin is a handful of notches a second, and a free-spin wheel's
+ * flick lands a dozen-plus at once — so a frustrated user riding the clamp can
+ * genuinely produce ~100 notches in ten seconds. Three hundred is ~3× that;
+ * nothing human clears it (independent review, N2). A page that does is
+ * holding the camera against the user — a sustained ≥30/s stream — and gets
+ * the flood budget's answer: the channel drops whole. What this deliberately
+ * does NOT bound is a brief fight (a page CAN re-zoom a few times before
+ * tripping it); the chrome chip, Ctrl+0 and the drop are the answer there,
+ * and the resolve path it can provoke holds one RPC slot inside its own
+ * attempt budget regardless. Charged only for intents that PASS the
+ * plausibility gate — refused forgeries never count against a page the user
+ * is not even hovering.
  */
-export const CONTENT_ZOOM_BUDGET = 60
+export const CONTENT_ZOOM_BUDGET = 300
 export const CONTENT_ZOOM_WINDOW_MS = 10_000
 
 export const MAX_INBOUND_STRING_CHARS = 4096

--- a/src/renderer/canvas/canvas-inbound-channel.ts
+++ b/src/renderer/canvas/canvas-inbound-channel.ts
@@ -9,11 +9,16 @@
 // Three of the six inbound types are paint-only (`ready`, `viewport`,
 // `pointer`): the worst a forgery does is move a highlight box, and the geometry
 // guards bound it. `contentZoom` (#368) sits between the classes: it steps the
-// pane's clamped zoom ladder — visible in the chrome, reversible with Ctrl+0,
-// and unable to reach the review store — and is honoured only with host-side
-// evidence the frame plausibly owns the gesture (pointer hover or keyboard
-// focus; see reportedZoomIsPlausible for why not user activation). Two MUTATE
-// HOST STATE and are handled differently here:
+// pane's clamped, chrome-visible zoom ladder — it cannot reach the review store
+// or the locked selection — and is honoured only with host-side evidence the
+// frame plausibly owns the gesture (pointer hover or keyboard focus; see
+// reportedZoomIsPlausible for why not user activation). What a hostile page CAN
+// do with it is fight the user for the camera (re-zooming after every Ctrl+0)
+// and provoke the host work a zoom change triggers (a reflow, a re-anchor
+// pass); its own budget exists for exactly that — past CONTENT_ZOOM_BUDGET the
+// channel is dropped whole, and the host's resolve path holds one RPC slot at
+// most however often the zoom moves. Two MUTATE HOST STATE and are handled
+// differently here:
 //
 //   `contentKey`  clears the user's locked focus / disarms an armed marquee. It
 //                 is honoured only when the host can see for itself that the
@@ -117,6 +122,22 @@ export const INBOUND_OVERSIZE_COST = 60
  * caps sit orders of magnitude above anything legitimate and still refuse a
  * megabyte.
  */
+/**
+ * How many contentZoom intents the frame may have HONOURED per rolling window
+ * (#368). The flood budget bounds message COUNT and is far too generous to
+ * bound this event's EFFECT: sixty accepted intents a second is 10 % of the
+ * flood budget and enough to pin the zoom at an end of the ladder faster than
+ * the user can reset it, indefinitely. A human's heaviest plausible input — a
+ * full-ladder sweep is ten notches, a hard continuous spin a few dozen — sits
+ * well under sixty in ten seconds; a page over it is fighting the user for the
+ * pane's camera on purpose, and the answer is the one the flood budget already
+ * gives: stop listening to that page. Charged only for intents that PASS the
+ * plausibility gate — refused forgeries never count against a page the user is
+ * not even hovering.
+ */
+export const CONTENT_ZOOM_BUDGET = 60
+export const CONTENT_ZOOM_WINDOW_MS = 10_000
+
 export const MAX_INBOUND_STRING_CHARS = 4096
 export const MAX_INBOUND_TOTAL_CHARS = 16_384
 /** Values (and keys) looked at before a message is refused for being a graph
@@ -323,12 +344,16 @@ export function reportedClickIsPlausible(facts: HostInputFacts): boolean {
  * own evidence for that is `:hover` on its iframe element; the zoom chords need
  * the frame to own keyboard focus, exactly as `contentKey` does. Either
  * suffices. Deliberately weaker than the key/click gates — no user-activation
- * requirement — because a wheel is not an activation-triggering input, so that
- * gate would drop every genuine first gesture; and unlike those two, a forged
- * zoom cannot touch the review store or the locked selection. It can only step
- * the pane's own zoom ladder: clamped, painted in the chrome, and reversible
- * with Ctrl+0 — nothing a page cannot already do to its own rendering with a
- * stylesheet.
+ * requirement (a wheel is not an activation-triggering input, so that gate
+ * would drop every genuine first gesture) and no editable-target refusal (the
+ * pointer resting on the frame while the user types a note is a REAL zoom
+ * posture — wheel over the page, draft open — and refusing it breaks the
+ * feature where it is most used).
+ *
+ * What that buys an attacker is stated where it is bounded: the header above
+ * and CONTENT_ZOOM_BUDGET. A forged intent moves a clamped, chrome-visible
+ * camera and provokes bounded host work; it cannot touch the review store, the
+ * locked selection's identity, or anything persisted.
  */
 export function reportedZoomIsPlausible(facts: Pick<HostInputFacts, 'activeElement' | 'frameElement'>): boolean {
   if (!facts.frameElement) return false
@@ -356,6 +381,9 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
 
   let windowStartedAt = Date.now()
   let windowCount = 0
+  // contentZoom's own rolling window (#368) — see CONTENT_ZOOM_BUDGET.
+  let zoomWindowStartedAt = Date.now()
+  let zoomWindowCount = 0
 
   let pendingViewport: CanvasViewportInfo | null = null
   let pendingPointer: { hit: CanvasHitInfo | null } | null = null
@@ -532,6 +560,20 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
       ) {
         return
       }
+      // This event's own budget (#368): past it the page is not zooming, it is
+      // fighting the user for the camera — a pinned zoom outlives every Ctrl+0
+      // — or farming the host work a zoom change triggers. Same answer as the
+      // flood budget, because it is the same offence at a rate that budget
+      // cannot see.
+      const now = Date.now()
+      if (now - zoomWindowStartedAt >= CONTENT_ZOOM_WINDOW_MS) {
+        zoomWindowStartedAt = now
+        zoomWindowCount = 0
+      }
+      if (++zoomWindowCount > CONTENT_ZOOM_BUDGET) {
+        dropFlooded()
+        return
+      }
       const current = pendingZoom ?? { steps: 0, reset: false }
       if (action === 'reset') {
         // Reset wins over whatever steps were queued beside it this frame.
@@ -543,6 +585,7 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
         pendingZoom = { steps, reset: false }
       }
       queueFlush()
+      return
     }
   }
 

--- a/src/renderer/canvas/canvas-inbound-channel.ts
+++ b/src/renderer/canvas/canvas-inbound-channel.ts
@@ -135,11 +135,12 @@ export const INBOUND_OVERSIZE_COST = 60
  * continuous spin is a handful of notches a second, and a free-spin wheel's
  * flick lands a dozen-plus at once — so a frustrated user riding the clamp can
  * genuinely produce ~100 notches in ten seconds. Three hundred is ~3× that;
- * nothing human clears it (independent review, N2). A page that does is
- * holding the camera against the user — a sustained ≥30/s stream — and gets
- * the flood budget's answer: the channel drops whole. What this deliberately
- * does NOT bound is a brief fight (a page CAN re-zoom a few times before
- * tripping it); the chrome chip, Ctrl+0 and the drop are the answer there,
+ * nothing human clears it (independent review, N2). What it bounds is THRASH
+ * — a page spending intents wholesale gets the flood budget's answer, the
+ * channel drops whole. What this deliberately does NOT bound is a patient
+ * fight (re-pinning after a user reset costs the page only a few intents, so
+ * the window funds a number of them); the chrome chip, Ctrl+0 and the drop
+ * are the answer there,
  * and the resolve path it can provoke holds one RPC slot inside its own
  * attempt budget regardless. Charged only for intents that PASS the
  * plausibility gate — refused forgeries never count against a page the user
@@ -362,8 +363,10 @@ export function reportedClickIsPlausible(facts: HostInputFacts): boolean {
  *
  * What that buys an attacker is stated where it is bounded: the header above
  * and CONTENT_ZOOM_BUDGET. A forged intent moves a clamped, chrome-visible
- * camera and provokes bounded host work; it cannot touch the review store, the
- * locked selection's identity, or anything persisted.
+ * camera and provokes bounded host work — the re-anchor pass, whose
+ * page-authored boxes land in the resolution map and the live lock's box,
+ * labelled as the page's word; it cannot write a note, a review, the lock's
+ * identity, or anything persisted.
  */
 export function reportedZoomIsPlausible(facts: Pick<HostInputFacts, 'activeElement' | 'frameElement'>): boolean {
   if (!facts.frameElement) return false

--- a/src/renderer/canvas/canvas-inbound-channel.ts
+++ b/src/renderer/canvas/canvas-inbound-channel.ts
@@ -6,9 +6,14 @@
 // Any claim that "everything arriving here is a report about the content, never
 // an instruction" is therefore only true of the events the host merely PAINTS.
 //
-// Three of the five inbound types are paint-only (`ready`, `viewport`,
+// Three of the six inbound types are paint-only (`ready`, `viewport`,
 // `pointer`): the worst a forgery does is move a highlight box, and the geometry
-// guards bound it. Two MUTATE HOST STATE and are handled differently here:
+// guards bound it. `contentZoom` (#368) sits between the classes: it steps the
+// pane's clamped zoom ladder — visible in the chrome, reversible with Ctrl+0,
+// and unable to reach the review store — and is honoured only with host-side
+// evidence the frame plausibly owns the gesture (pointer hover or keyboard
+// focus; see reportedZoomIsPlausible for why not user activation). Two MUTATE
+// HOST STATE and are handled differently here:
 //
 //   `contentKey`  clears the user's locked focus / disarms an armed marquee. It
 //                 is honoured only when the host can see for itself that the
@@ -45,6 +50,7 @@ import {
   type CanvasBridgeEvent,
   type CanvasHitInfo,
   type CanvasViewportInfo,
+  type CanvasZoomAction,
   canvasOrigin,
 } from '../../shared/canvas'
 import { finite, safeHit, safeViewport } from '../utils/canvas-geometry-guard'
@@ -216,6 +222,9 @@ export interface CanvasInboundHandlers {
   /** A click the host could verify was a real user click inside the frame. */
   onContentClick: (pageX: number, pageY: number) => void
   onContentKey: (key: 'Escape' | 'ArrowUp') => void
+  /** Zoom intent relayed from the frame (#368), coalesced per animation frame:
+   *  `steps` is the net ladder movement (+in / −out), `reset` wins over steps. */
+  onContentZoom: (intent: { steps: number; reset: boolean }) => void
   /** The page exceeded the flood budget: the channel is gone for this frame. */
   onFlood: () => void
 }
@@ -307,6 +316,30 @@ export function reportedClickIsPlausible(facts: HostInputFacts): boolean {
   return facts.userActivation === true
 }
 
+/**
+ * Could this reported zoom intent have been a real gesture in the frame (#368)?
+ *
+ * A wheel needs the POINTER over the frame, not keyboard focus, and the host's
+ * own evidence for that is `:hover` on its iframe element; the zoom chords need
+ * the frame to own keyboard focus, exactly as `contentKey` does. Either
+ * suffices. Deliberately weaker than the key/click gates — no user-activation
+ * requirement — because a wheel is not an activation-triggering input, so that
+ * gate would drop every genuine first gesture; and unlike those two, a forged
+ * zoom cannot touch the review store or the locked selection. It can only step
+ * the pane's own zoom ladder: clamped, painted in the chrome, and reversible
+ * with Ctrl+0 — nothing a page cannot already do to its own rendering with a
+ * stylesheet.
+ */
+export function reportedZoomIsPlausible(facts: Pick<HostInputFacts, 'activeElement' | 'frameElement'>): boolean {
+  if (!facts.frameElement) return false
+  if (facts.activeElement === facts.frameElement) return true
+  try {
+    return facts.frameElement.matches(':hover')
+  } catch {
+    return false
+  }
+}
+
 function nextFrame(run: () => void): void {
   if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => run())
   else setTimeout(run, 16)
@@ -327,6 +360,7 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
   let pendingViewport: CanvasViewportInfo | null = null
   let pendingPointer: { hit: CanvasHitInfo | null } | null = null
   let pendingClick: { pageX: number; pageY: number } | null = null
+  let pendingZoom: { steps: number; reset: boolean } | null = null
   let flushQueued = false
 
   const dispose = () => {
@@ -336,6 +370,7 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
     pendingViewport = null
     pendingPointer = null
     pendingClick = null
+    pendingZoom = null
   }
 
   // Latest wins. A page that reports twice inside one frame gets one delivery,
@@ -350,12 +385,15 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
       const viewport = pendingViewport
       const pointer = pendingPointer
       const click = pendingClick
+      const zoom = pendingZoom
       pendingViewport = null
       pendingPointer = null
       pendingClick = null
+      pendingZoom = null
       if (viewport) handlers.onViewport(viewport)
       if (pointer) handlers.onPointer(pointer.hit)
       if (click) handlers.onContentClick(click.pageX, click.pageY)
+      if (zoom && (zoom.reset || zoom.steps !== 0)) handlers.onContentZoom(zoom)
     })
   }
 
@@ -476,6 +514,35 @@ export function createCanvasInboundChannel(options: CanvasInboundChannelOptions)
         return
       }
       handlers.onContentKey(key)
+      return
+    }
+    if (msg.type === 'contentZoom') {
+      // A closed vocabulary, checked on arrival like every other field the
+      // page authors; anything else in `action` is not a report this protocol
+      // emits and is dropped unread.
+      const action = (msg as { action?: unknown }).action as CanvasZoomAction | unknown
+      if (action !== 'in' && action !== 'out' && action !== 'reset') return
+      // Gated on arrival (like the click gate): hover/focus is evidence about
+      // NOW, and a later tick is a different claim.
+      if (
+        !reportedZoomIsPlausible({
+          activeElement: document.activeElement,
+          frameElement: options.getFrameElement(),
+        })
+      ) {
+        return
+      }
+      const current = pendingZoom ?? { steps: 0, reset: false }
+      if (action === 'reset') {
+        // Reset wins over whatever steps were queued beside it this frame.
+        pendingZoom = { steps: 0, reset: true }
+      } else if (!current.reset) {
+        // Net movement, bounded well past the ladder's full sweep — the frame
+        // chooses how often it speaks, not how far the host walks.
+        const steps = Math.max(-16, Math.min(16, current.steps + (action === 'in' ? 1 : -1)))
+        pendingZoom = { steps, reset: false }
+      }
+      queueFlush()
     }
   }
 

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -992,7 +992,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         resolveSkippedRef.current = false
         const driftRetry =
           resolvedZoomRef.current !== zoomRef.current && resolveAttemptsRef.current < MAX_RESOLVE_ATTEMPTS
-        if (!cancelled && (skipped || driftRetry)) {
+        // The skip retry fires REGARDLESS of `cancelled`: a skip is recorded
+        // by a LATER effect run, and React has already cancelled this one by
+        // then — gating it on !cancelled made the path unreachable and
+        // silently dropped a zoom step that landed mid-pass (final review,
+        // M1). The bump is a component-level setState, not a stale write, and
+        // the re-armed effect re-keys its own intent and budget.
+        if (skipped || (!cancelled && driftRetry)) {
           setResolveRetryNonce((n) => n + 1)
         }
       }

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -21,7 +21,7 @@ import {
   type CanvasHoverReportingResult,
 } from '../../shared/canvas'
 import { contentPageRectToStage, stageToContentPagePoint, glassNeedsRepin, glassScrollForContent } from '../utils/canvas-coords'
-import { formatCanvasZoom, stepCanvasZoom } from '../utils/canvas-zoom'
+import { formatCanvasZoom, frameStyleForZoom, stepCanvasZoom } from '../utils/canvas-zoom'
 import { safeAnchorResolutions, safeInspectResult } from '../utils/canvas-geometry-guard'
 import { registerCanvasFrame } from '../canvas/canvas-snapshot-host'
 import { askCanvasFrame, framesInFlight, MAX_FRAME_REQUESTS_IN_FLIGHT } from '../canvas/canvas-frame-rpc'
@@ -352,6 +352,12 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   /** The zoom the last successful resolution pass ran under (#368): a pass
    *  belongs to a layout, and a zoom step changes the layout. */
   const resolvedZoomRef = useRef(1)
+  /** ONE resolveAnchors in flight from the resolution effect (A1); the skip
+   *  flag records that the guard turned something away, so the settle can
+   *  schedule the retry. */
+  const resolvePendingRef = useRef(false)
+  const resolveSkippedRef = useRef(false)
+  const [resolveRetryNonce, setResolveRetryNonce] = useState(0)
 
   const [bridgeReady, setBridgeReady] = useState(false)
   const bridgeReadyRef = useRef(false)
@@ -406,9 +412,16 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     })
   }, [])
 
-  /** Walk the zoom ladder (+in / −out); `reset` snaps to 1. */
+  /** Walk the zoom ladder (+in / −out); `reset` snaps to 1. The one choke
+   *  point for every zoom source — host wheel, host chords, the chip, and the
+   *  frame relay — so the guards here bind all of them. A zoom step reflows
+   *  the content, so it is refused while a marquee drag is in flight: the
+   *  drag's corners were sampled against the old layout and committing them
+   *  against the new one places the region wrong, with no fingerprint to
+   *  recover from (independent review, C3). */
   const applyZoom = useCallback(
     (intent: { steps: number; reset: boolean }) => {
+      if (marqueeDragRef.current) return
       setZoom((z) => (intent.reset ? 1 : stepCanvasZoom(z, intent.steps)))
     },
     [],
@@ -692,11 +705,14 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     if (!root) return
     let accum = 0
     const onWheel = (e: WheelEvent) => {
-      // altKey excluded: AltGr on Windows layouts reports ctrl+alt together.
+      // ctrlKey on every platform: a trackpad pinch reports as ctrl+wheel on
+      // macOS too. altKey excluded: AltGr on Windows layouts reports ctrl+alt.
       if (!e.ctrlKey || e.altKey) return
       e.preventDefault()
       e.stopPropagation()
-      const notch = e.deltaMode === 1 ? 3 : 100
+      // DOM_DELTA_LINE counts lines (~3/notch), DOM_DELTA_PAGE counts pages
+      // (~1/notch); anything else is pixels.
+      const notch = e.deltaMode === 1 ? 3 : e.deltaMode === 2 ? 1 : 100
       accum += e.deltaY
       let steps = 0
       while (accum >= notch) {
@@ -713,14 +729,20 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     return () => root.removeEventListener('wheel', onWheel, { capture: true })
   }, [applyZoom])
 
-  // The zoom chords, host side: Ctrl+= / Ctrl+- / Ctrl+0 while the pane is
-  // hovered or holds focus. The app registers no zoom accelerators of its own
-  // (no View menu), so there is nothing to fight — the scope check exists so a
-  // future shortcut elsewhere stays unaffected, and typing in the notes
-  // composer is unaffected because these are ctrl-chords, not text.
+  // The zoom chords, host side: Ctrl+= / Ctrl+- / Ctrl+0 (Cmd on macOS, the
+  // platform's own zoom chord). The app registers no zoom accelerators of its
+  // own (no View menu), so nothing is contested today; the scope rule is what
+  // keeps it that way. Focus INSIDE the pane always claims the chord (typing
+  // in the notes composer included — a browser zooms while you type). Hover
+  // claims it only while nothing OUTSIDE the pane holds focus: Chromium keeps
+  // `:hover` on the last pointer position, so a pointer parked over the pane
+  // must not eat a chord the user is typing into the terminal (independent
+  // review, C6).
   useEffect(() => {
+    const isMac = navigator.platform.startsWith('Mac')
     const onKey = (e: KeyboardEvent) => {
-      if (!e.ctrlKey || e.altKey || e.metaKey) return
+      const chord = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey
+      if (!chord || e.altKey) return
       const intent =
         e.key === '=' || e.key === '+'
           ? { steps: 1, reset: false }
@@ -732,8 +754,9 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       if (!intent) return
       const root = paneRootRef.current
       if (!root) return
-      let engaged = root.contains(document.activeElement)
-      if (!engaged) {
+      const active = document.activeElement
+      let engaged = root.contains(active)
+      if (!engaged && (!active || active === document.body)) {
         try {
           engaged = root.matches(':hover')
         } catch {
@@ -828,22 +851,40 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const openNotesKey = useMemo(() => openNotes.map((n) => n.id).join(','), [openNotes])
 
   useEffect(() => {
-    if (!bridgeReady || openNotes.length === 0) return
+    if (!bridgeReady) return
     const target = iframeRef.current?.contentWindow
     if (!target) return
     const store = useCanvasReviewStore.getState()
     const current = store.bySessionId[sessionId]?.resolution
     // A zoom step reflows the content (#368) — the CSS viewport narrows or
     // widens like a browser tab's — so page-space boxes measured under another
-    // zoom are stale: the whole pass runs again, same-version notes included,
-    // which is what lets a note placed at 150 % re-anchor at 100 %.
+    // zoom are stale: the pass runs again, same-version notes AND the live
+    // locked focus included, which is what lets a note placed at 150 %
+    // re-anchor at 100 %.
     const zoomChanged = resolvedZoomRef.current !== zoom
-    const done = !zoomChanged && current?.versionId === version.id ? current.byAnnotation : {}
+    const prior = current?.versionId === version.id ? current.byAnnotation : {}
+    const done = zoomChanged ? {} : prior
     const pending = openNotes.filter(
       (n) => (zoomChanged || n.versionId !== version.id) && n.focus && n.focus.targets.length > 0 && !(n.id in done),
     )
-    if (pending.length === 0) {
+    // The live element lock goes stale under the same reflow; its box is
+    // re-pointed through the same pass (S3). Read at arm time and guarded by
+    // reference on the way back, so a lock the user changed meanwhile is
+    // never touched.
+    const liveFocus = zoomChanged ? (store.bySessionId[sessionId]?.focus ?? null) : null
+    const liveFocusTargets = liveFocus && liveFocus.targets.length > 0 ? liveFocus.targets : null
+    if (pending.length === 0 && !liveFocusTargets) {
       resolvedZoomRef.current = zoom
+      return
+    }
+    // ONE resolve in flight from this effect, ever (A1). The RPC layer caps a
+    // frame at four requests; without this guard a page that provokes passes
+    // (zoom intents are page-relayable) and never answers them could hold all
+    // four slots and starve inspect, hover reporting and snapshots. With it,
+    // this path holds at most one — the retry nonce below picks up whatever
+    // was skipped once the outstanding call settles.
+    if (resolvePendingRef.current) {
+      resolveSkippedRef.current = true
       return
     }
 
@@ -857,7 +898,17 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         spans.push({ id: note.id, start: flat.length, count: targets.length })
         flat.push(...targets)
       }
-      if (flat.length === 0) return
+      // The live focus rides along after the notes; '~focus' cannot collide
+      // with a note id (ids are uuid-shaped).
+      if (liveFocusTargets && flat.length + liveFocusTargets.length <= MAX_RESOLVE_ANCHORS) {
+        spans.push({ id: '~focus', start: flat.length, count: liveFocusTargets.length })
+        flat.push(...liveFocusTargets)
+      }
+      if (flat.length === 0) {
+        resolvedZoomRef.current = zoom
+        return
+      }
+      resolvePendingRef.current = true
       try {
         const raw = await askCanvasFrame(target, canvasId, { type: 'resolveAnchors', anchors: flat }, 10_000)
         if (cancelled) return
@@ -865,15 +916,33 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         // the page writes this reply and it decides what the checklist tells
         // the reviewer about their own open notes.
         const results = safeAnchorResolutions(raw, flat)
-        const merged = { ...done }
+        // Merged over the PRIOR entries, never over a wiped map: a pass the
+        // anchor cap truncated must not demote the tail's notes from a located
+        // box to "locating…" — past the cap they keep their previous (old-zoom)
+        // boxes, which is exactly the pre-#368 behaviour for them (C1).
+        const merged = { ...prior }
         for (const span of spans) {
           const slice = results.slice(span.start, span.start + span.count)
-          merged[span.id] = slice.find((r) => r.found) ?? null
+          const hit = slice.find((r) => r.found) ?? null
+          if (span.id === '~focus') {
+            if (hit && liveFocus) useCanvasReviewStore.getState().updateFocusBox(sessionId, liveFocus, hit.box)
+          } else {
+            merged[span.id] = hit
+          }
         }
         resolvedZoomRef.current = zoom
         useCanvasReviewStore.getState().setResolution(sessionId, { versionId: version.id, byAnnotation: merged })
       } catch {
         /* frame gone or slow — the checklist keeps its ghosts */
+      } finally {
+        resolvePendingRef.current = false
+        // Whatever this run could not cover — a pass the in-flight guard
+        // skipped, or a zoom that moved again while it was out — gets one more
+        // look. Fires only on recorded drift or a recorded skip, so it cannot
+        // loop on a quiet pane.
+        const skipped = resolveSkippedRef.current
+        resolveSkippedRef.current = false
+        if (!cancelled && (skipped || resolvedZoomRef.current !== zoomRef.current)) setResolveRetryNonce((n) => n + 1)
       }
     }
     // Debounced only when the zoom moved it: rapid ladder steps supersede each
@@ -883,7 +952,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       cancelled = true
       window.clearTimeout(timer)
     }
-  }, [bridgeReady, version.id, openNotesKey, sessionId, canvasId, zoom]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [bridgeReady, version.id, openNotesKey, sessionId, canvasId, zoom, resolveRetryNonce]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleGlassScrolled = useCallback(() => {
     const vp = viewportRef.current
@@ -1254,12 +1323,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             // arrived. (The Excalidraw glass below stays theme="light" — that
             // one is deliberate, see the comment on glassInitialData.)
             className="absolute left-0 top-0 border-0 bg-[var(--surface-stage)]"
-            // Content zoom (#368): CSS zoom scales the element's box and paint
-            // together, so the layout size is compensated to keep the frame
-            // filling the stage exactly — the content lays out to a
-            // narrower/wider CSS viewport and paints scaled, which is what a
-            // browser tab's own Ctrl+wheel does.
-            style={{ zoom, width: `${100 / zoom}%`, height: `${100 / zoom}%` }}
+            // Content zoom (#368): percentage sizes self-compensate under
+            // standardized CSS zoom, so 100% keeps the frame filling the stage
+            // at every zoom while the content reflows to stage/zoom and paints
+            // scaled — see frameStyleForZoom for the measured rule.
+            style={frameStyleForZoom(zoom)}
           />
           {/* Glass — Excalidraw over the content, transparent board, pointer
               only in draw mode. A sibling overlay, never injected (D7). */}

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -21,6 +21,7 @@ import {
   type CanvasHoverReportingResult,
 } from '../../shared/canvas'
 import { contentPageRectToStage, stageToContentPagePoint, glassNeedsRepin, glassScrollForContent } from '../utils/canvas-coords'
+import { formatCanvasZoom, stepCanvasZoom } from '../utils/canvas-zoom'
 import { safeAnchorResolutions, safeInspectResult } from '../utils/canvas-geometry-guard'
 import { registerCanvasFrame } from '../canvas/canvas-snapshot-host'
 import { askCanvasFrame, framesInFlight, MAX_FRAME_REQUESTS_IN_FLIGHT } from '../canvas/canvas-frame-rpc'
@@ -278,6 +279,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const setMarqueeArmed = useCanvasReviewStore((s) => s.setMarqueeArmed)
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  /** The pane's root element — the scope of the HOST-side zoom gesture (#368):
+   *  a Ctrl+wheel over the chrome, the glass or the notes panel zooms the
+   *  content, and the zoom chords apply only while the pane is hovered or holds
+   *  focus, so a terminal's shortcuts in another pane are never contested. */
+  const paneRootRef = useRef<HTMLDivElement | null>(null)
   const glassApiRef = useRef<ExcalidrawImperativeAPI | null>(null)
   const repinPendingRef = useRef(false)
   const viewportRef = useRef<CanvasViewportInfo | null>(null)
@@ -343,6 +349,9 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   /** One outstanding inspect per frame — a page-driven click cannot open a
    *  second one while the first is unanswered. */
   const inspectPendingRef = useRef(false)
+  /** The zoom the last successful resolution pass ran under (#368): a pass
+   *  belongs to a layout, and a zoom step changes the layout. */
+  const resolvedZoomRef = useRef(1)
 
   const [bridgeReady, setBridgeReady] = useState(false)
   const bridgeReadyRef = useRef(false)
@@ -351,6 +360,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
    *  that has quietly stopped responding. */
   const [bridgeFlooded, setBridgeFlooded] = useState(false)
   const [viewport, setViewport] = useState<CanvasViewportInfo | null>(null)
+  /** Content zoom (#368) — a ladder value, 1 when unzoomed. Pane-local like a
+   *  browser tab's zoom: it survives version switches in this mount and resets
+   *  when the pane closes. The iframe carries it as CSS zoom with its layout
+   *  size compensated, so 1 content px paints as `zoom` stage px; every
+   *  content↔stage conversion and the glass binding fold the factor in. */
+  const [zoom, setZoom] = useState(1)
+  const zoomRef = useRef(1)
   const [hover, setHover] = useState<HoverState | null>(null)
   const [marqueeDrag, setMarqueeDrag] = useState<MarqueeDrag | null>(null)
   // Load health. `frameLoaded` is the browser's own load event (it fires for an
@@ -370,12 +386,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   modeRef.current = mode
   xrayModeRef.current = xrayMode
   versionIdRef.current = version.id
+  zoomRef.current = zoom
 
-  // Keep the glass pinned to the content: scene scroll ≡ −content scroll at
-  // zoom 1 (canvas-coords.glassScrollForContent). Applied on every viewport
-  // event, and re-applied if Excalidraw itself pans/zooms the scene (wheel or
-  // space-drag on the glass in draw mode) — the canvas glass has no free
-  // camera, the content is the camera.
+  // Keep the glass pinned to the content: scene scroll ≡ −content scroll, scene
+  // zoom ≡ the content zoom (canvas-coords.glassScrollForContent). Applied on
+  // every viewport event and every zoom step, and re-applied if Excalidraw
+  // itself pans/zooms the scene (wheel or space-drag on the glass in draw mode)
+  // — the canvas glass has no free camera, the content is the camera.
   const repinGlass = useCallback(() => {
     const api = glassApiRef.current
     const vp = viewportRef.current
@@ -385,9 +402,23 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       repinPendingRef.current = false
       const currentVp = viewportRef.current
       if (!currentVp || !glassApiRef.current) return
-      glassApiRef.current.updateScene({ appState: glassScrollForContent(currentVp) } as never)
+      glassApiRef.current.updateScene({ appState: glassScrollForContent(currentVp, zoomRef.current) } as never)
     })
   }, [])
+
+  /** Walk the zoom ladder (+in / −out); `reset` snaps to 1. */
+  const applyZoom = useCallback(
+    (intent: { steps: number; reset: boolean }) => {
+      setZoom((z) => (intent.reset ? 1 : stepCanvasZoom(z, intent.steps)))
+    },
+    [],
+  )
+
+  // The glass must follow the zoom in the same frame discipline it follows the
+  // scroll — its zoom is part of the same binding.
+  useEffect(() => {
+    repinGlass()
+  }, [zoom, repinGlass])
 
   /** A reported content click (browse mode) becomes a locked selection: ask
    *  the frame for the chain at that point, then lock its deepest entry. The
@@ -626,10 +657,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           if (modeRef.current === 'browse') void inspectAndLock(pageX, pageY)
         },
         onContentKey: handleReportedKey,
+        onContentZoom: applyZoom,
         onFlood: () => setBridgeFlooded(true),
       },
     })
-  }, [repinGlass, canvasId, inspectAndLock, handleReportedKey, syncHoverReporting])
+  }, [repinGlass, canvasId, inspectAndLock, handleReportedKey, applyZoom, syncHoverReporting])
 
   // The same two keys, host-side, for when the HOST document has keyboard
   // focus (after touching the panel or the chrome). Never while typing.
@@ -647,6 +679,74 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [sessionId, handleReportedKey])
+
+  // ── Content zoom, host side (#368) ─────────────────────────────────────────
+  // Ctrl+wheel anywhere over the pane's own chrome — the header, the glass in
+  // draw mode, the notes panel — zooms the content, exactly as the same gesture
+  // over the frame does via the bridge relay. Capture phase so the glass's own
+  // Excalidraw wheel handling (scene zoom, which the repin would fight) never
+  // sees the ctrl-chord; a plain wheel is untouched. Native listener because
+  // React's synthetic wheel is passive and could not preventDefault.
+  useEffect(() => {
+    const root = paneRootRef.current
+    if (!root) return
+    let accum = 0
+    const onWheel = (e: WheelEvent) => {
+      // altKey excluded: AltGr on Windows layouts reports ctrl+alt together.
+      if (!e.ctrlKey || e.altKey) return
+      e.preventDefault()
+      e.stopPropagation()
+      const notch = e.deltaMode === 1 ? 3 : 100
+      accum += e.deltaY
+      let steps = 0
+      while (accum >= notch) {
+        accum -= notch
+        steps -= 1
+      }
+      while (accum <= -notch) {
+        accum += notch
+        steps += 1
+      }
+      if (steps !== 0) applyZoom({ steps, reset: false })
+    }
+    root.addEventListener('wheel', onWheel, { capture: true, passive: false })
+    return () => root.removeEventListener('wheel', onWheel, { capture: true })
+  }, [applyZoom])
+
+  // The zoom chords, host side: Ctrl+= / Ctrl+- / Ctrl+0 while the pane is
+  // hovered or holds focus. The app registers no zoom accelerators of its own
+  // (no View menu), so there is nothing to fight — the scope check exists so a
+  // future shortcut elsewhere stays unaffected, and typing in the notes
+  // composer is unaffected because these are ctrl-chords, not text.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!e.ctrlKey || e.altKey || e.metaKey) return
+      const intent =
+        e.key === '=' || e.key === '+'
+          ? { steps: 1, reset: false }
+          : e.key === '-' || e.key === '_'
+            ? { steps: -1, reset: false }
+            : e.key === '0'
+              ? { steps: 0, reset: true }
+              : null
+      if (!intent) return
+      const root = paneRootRef.current
+      if (!root) return
+      let engaged = root.contains(document.activeElement)
+      if (!engaged) {
+        try {
+          engaged = root.matches(':hover')
+        } catch {
+          engaged = false
+        }
+      }
+      if (!engaged) return
+      e.preventDefault()
+      applyZoom(intent)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [applyZoom])
 
   // The user changed the mode: bring the frame in line with it. (A frame that
   // is not ready yet is told on its `ready` instead — see the channel above.)
@@ -733,14 +833,22 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     if (!target) return
     const store = useCanvasReviewStore.getState()
     const current = store.bySessionId[sessionId]?.resolution
-    const done = current?.versionId === version.id ? current.byAnnotation : {}
+    // A zoom step reflows the content (#368) — the CSS viewport narrows or
+    // widens like a browser tab's — so page-space boxes measured under another
+    // zoom are stale: the whole pass runs again, same-version notes included,
+    // which is what lets a note placed at 150 % re-anchor at 100 %.
+    const zoomChanged = resolvedZoomRef.current !== zoom
+    const done = !zoomChanged && current?.versionId === version.id ? current.byAnnotation : {}
     const pending = openNotes.filter(
-      (n) => n.versionId !== version.id && n.focus && n.focus.targets.length > 0 && !(n.id in done),
+      (n) => (zoomChanged || n.versionId !== version.id) && n.focus && n.focus.targets.length > 0 && !(n.id in done),
     )
-    if (pending.length === 0) return
+    if (pending.length === 0) {
+      resolvedZoomRef.current = zoom
+      return
+    }
 
     let cancelled = false
-    void (async () => {
+    const run = async () => {
       const flat: AnchorRef[] = []
       const spans: Array<{ id: string; start: number; count: number }> = []
       for (const note of pending) {
@@ -762,22 +870,27 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           const slice = results.slice(span.start, span.start + span.count)
           merged[span.id] = slice.find((r) => r.found) ?? null
         }
+        resolvedZoomRef.current = zoom
         useCanvasReviewStore.getState().setResolution(sessionId, { versionId: version.id, byAnnotation: merged })
       } catch {
         /* frame gone or slow — the checklist keeps its ghosts */
       }
-    })()
+    }
+    // Debounced only when the zoom moved it: rapid ladder steps supersede each
+    // other rather than racing one resolve per rung through the RPC cap.
+    const timer = window.setTimeout(() => void run(), zoomChanged ? 300 : 0)
     return () => {
       cancelled = true
+      window.clearTimeout(timer)
     }
-  }, [bridgeReady, version.id, openNotesKey, sessionId, canvasId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [bridgeReady, version.id, openNotesKey, sessionId, canvasId, zoom]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleGlassScrolled = useCallback(() => {
     const vp = viewportRef.current
     const api = glassApiRef.current
     if (!vp || !api) return
     const appState = api.getAppState()
-    if (glassNeedsRepin(appState, vp)) repinGlass()
+    if (glassNeedsRepin(appState, vp, zoomRef.current)) repinGlass()
   }, [repinGlass])
 
   // ── Marquee (spec §6 step 3: rectangle for region notes) ──────────────────
@@ -810,8 +923,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     const width = Math.abs(drag.x1 - drag.x0)
     const height = Math.abs(drag.y1 - drag.y0)
     if (width >= MARQUEE_MIN_PX && height >= MARQUEE_MIN_PX) {
-      const p0 = stageToContentPagePoint({ x: left, y: top }, vp)
-      const p1 = stageToContentPagePoint({ x: left + width, y: top + height }, vp)
+      // The zoom folds into the same slot the pinch scale occupies: 1 content
+      // px is `scale × zoom` stage px (#368).
+      const effVp = { ...vp, scale: vp.scale * zoomRef.current }
+      const p0 = stageToContentPagePoint({ x: left, y: top }, effVp)
+      const p1 = stageToContentPagePoint({ x: left + width, y: top + height }, effVp)
       useCanvasReviewStore
         .getState()
         .setRegionFocus(sessionId, { x: p0.x, y: p0.y, width: p1.x - p0.x, height: p1.y - p0.y }, versionIdRef.current)
@@ -820,10 +936,20 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     }
   }, [sessionId])
 
+  /** The viewport the STAGE actually paints under: the frame's own report with
+   *  the pane's zoom folded into the scale slot — 1 content px is
+   *  `scale × zoom` stage px (#368). Everything that converts content page
+   *  coords to stage pixels reads this one, so a box drawn on an element stays
+   *  on it at every zoom. */
+  const stageViewport = useMemo(
+    () => (viewport ? { ...viewport, scale: viewport.scale * zoom } : null),
+    [viewport, zoom],
+  )
+
   const hoverStageRect = useMemo(() => {
-    if (!hover || !viewport) return null
-    return contentPageRectToStage(hover.hit.box, viewport)
-  }, [hover, viewport])
+    if (!hover || !stageViewport) return null
+    return contentPageRectToStage(hover.hit.box, stageViewport)
+  }, [hover, stageViewport])
 
   /** Which layer the pointer is on — the same three-way the glass and marquee
    *  layers are wired from, named once so the stealth readout can tell the user
@@ -837,18 +963,18 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const stageHoverRect = mode === 'browse' && !marqueeArmed && xrayDrawsOnPage(xrayMode) ? hoverStageRect : null
 
   const focusStageRect = useMemo(() => {
-    if (!focus || !viewport) return null
-    return contentPageRectToStage(focus.bboxPage, viewport)
-  }, [focus, viewport])
+    if (!focus || !stageViewport) return null
+    return contentPageRectToStage(focus.bboxPage, stageViewport)
+  }, [focus, stageViewport])
 
   /** An element lock's label came out of an inspect reply — the page's own
    *  account of what the user clicked. A region's came from the marquee. */
   const focusIsPageReported = (focus?.targets.length ?? 0) > 0
 
   const highlightStageRect = useMemo(() => {
-    if (!panelHighlight || !viewport) return null
-    return contentPageRectToStage(panelHighlight.rect, viewport)
-  }, [panelHighlight, viewport])
+    if (!panelHighlight || !stageViewport) return null
+    return contentPageRectToStage(panelHighlight.rect, stageViewport)
+  }, [panelHighlight, stageViewport])
 
   const hoverLabel = useMemo(() => {
     if (!hover) return ''
@@ -904,7 +1030,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const versionClockLabel = versionClock(version.createdAt)
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-[var(--surface-stage)]">
+    <div ref={paneRootRef} className="flex-1 flex flex-col min-h-0 bg-[var(--surface-stage)]">
       {/* Pane chrome — 38px, one type size, and the mode switch given real
           weight because it decides where the user's clicks land. */}
       <div className="h-[38px] shrink-0 flex items-center gap-2.5 px-3 bg-[var(--surface-chrome)] border-b border-[var(--border-subtle)]">
@@ -931,6 +1057,19 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         >
           {canvasModeBadge(version).label}
         </span>
+        {/* Content zoom (#368) — shown only when it is not 1:1, click resets.
+            The chip is the visibility the forged-zoom analysis leans on: a zoom
+            the user did not ask for is never silent. */}
+        {zoom !== 1 && (
+          <button
+            onClick={() => applyZoom({ steps: 0, reset: true })}
+            data-testid="canvas-zoom-chip"
+            title="Canvas zoom — Ctrl+wheel or Ctrl+= / Ctrl+- · click or Ctrl+0 to reset"
+            className="shrink-0 text-[10px] rounded px-1.5 py-0.5 border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-panel)] transition-colors focus-ring"
+          >
+            {formatCanvasZoom(zoom)}
+          </button>
+        )}
         <span
           className="min-w-0 truncate text-[11.5px] text-[var(--text-primary)]"
           title={versionTooltip(version)}
@@ -1114,7 +1253,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             // flash in a dark pane read as a broken render every time a version
             // arrived. (The Excalidraw glass below stays theme="light" — that
             // one is deliberate, see the comment on glassInitialData.)
-            className="absolute inset-0 w-full h-full border-0 bg-[var(--surface-stage)]"
+            className="absolute left-0 top-0 border-0 bg-[var(--surface-stage)]"
+            // Content zoom (#368): CSS zoom scales the element's box and paint
+            // together, so the layout size is compensated to keep the frame
+            // filling the stage exactly — the content lays out to a
+            // narrower/wider CSS viewport and paints scaled, which is what a
+            // browser tab's own Ctrl+wheel does.
+            style={{ zoom, width: `${100 / zoom}%`, height: `${100 / zoom}%` }}
           />
           {/* Glass — Excalidraw over the content, transparent board, pointer
               only in draw mode. A sibling overlay, never injected (D7). */}

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -87,6 +87,23 @@ const MAX_HOVER_REPORTING_DEFERRALS = 12
 const MAX_HOVER_REPORTING_SENDS_PER_WINDOW = 12
 const HOVER_REPORTING_SEND_WINDOW_MS = 1000
 
+/** resolveAnchors RPCs one resolution intent may spend (#368, N1). The frame
+ *  can refuse or sit on a resolve forever, and the settle-time retry would
+ *  otherwise re-arm it indefinitely — a page-controlled call rate, the exact
+ *  class MAX_HOVER_REPORTING_ATTEMPTS exists for. A new intent (zoom, version,
+ *  or note set changed) is a fresh budget. */
+const MAX_RESOLVE_ATTEMPTS = 3
+
+/** Is the user TYPING here — an editable, or xterm's helper textarea? The
+ *  zoom-chord scope test (N3): typing focus refuses the hover claim; any
+ *  other focus does not. */
+function isTypingTarget(el: Element | null): boolean {
+  if (!el) return false
+  const tag = el.tagName.toLowerCase()
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true
+  return (el as HTMLElement).isContentEditable === true
+}
+
 /** Wall-clock of a render, or null when the stored stamp will not parse. */
 function versionClock(iso: string): string | null {
   const ms = Date.parse(iso)
@@ -358,6 +375,14 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const resolvePendingRef = useRef(false)
   const resolveSkippedRef = useRef(false)
   const [resolveRetryNonce, setResolveRetryNonce] = useState(0)
+  /** The retry's attempt budget, per intent (version + zoom + note set). The
+   *  frame can refuse or never answer a resolve, and the settle-time retry
+   *  re-arms it — so without a budget a page that never complies chooses the
+   *  host's call rate forever (the same reason hover reporting carries
+   *  MAX_HOVER_REPORTING_ATTEMPTS; independent review, N1). A new intent — the
+   *  user zooming again, a version switch, a note added — is a fresh budget. */
+  const resolveIntentRef = useRef('')
+  const resolveAttemptsRef = useRef(0)
 
   const [bridgeReady, setBridgeReady] = useState(false)
   const bridgeReadyRef = useRef(false)
@@ -756,7 +781,11 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       if (!root) return
       const active = document.activeElement
       let engaged = root.contains(active)
-      if (!engaged && (!active || active === document.body)) {
+      if (!engaged && !isTypingTarget(active)) {
+        // Hover claims the chord unless the user is TYPING somewhere else —
+        // an editable, or a terminal (xterm focuses a helper textarea, so the
+        // same test covers it). Focus merely resting on a button elsewhere
+        // does not un-claim a chord aimed at the hovered pane (N3).
         try {
           engaged = root.matches(':hover')
         } catch {
@@ -877,6 +906,13 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       resolvedZoomRef.current = zoom
       return
     }
+    // The attempt budget belongs to ONE intent; asking about anything new is a
+    // new budget (mirrors the hover-reporting intent key above).
+    const intent = `${version.id}:${zoom}:${openNotesKey}`
+    if (resolveIntentRef.current !== intent) {
+      resolveIntentRef.current = intent
+      resolveAttemptsRef.current = 0
+    }
     // ONE resolve in flight from this effect, ever (A1). The RPC layer caps a
     // frame at four requests; without this guard a page that provokes passes
     // (zoom intents are page-relayable) and never answers them could hold all
@@ -892,23 +928,27 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     const run = async () => {
       const flat: AnchorRef[] = []
       const spans: Array<{ id: string; start: number; count: number }> = []
+      // The live focus rides FIRST: it is the thing the user is actively
+      // holding, so the anchor cap must never be what drops it. '~focus'
+      // cannot collide with a note id (ids match CANVAS_ANNOTATION_ID_RE,
+      // /^a[0-9]{1,9}$/, enforced on load) and never enters `merged` — its
+      // result goes to updateFocusBox.
+      if (liveFocusTargets) {
+        spans.push({ id: '~focus', start: 0, count: liveFocusTargets.length })
+        flat.push(...liveFocusTargets)
+      }
       for (const note of pending) {
         const targets = note.focus!.targets
         if (flat.length + targets.length > MAX_RESOLVE_ANCHORS) break
         spans.push({ id: note.id, start: flat.length, count: targets.length })
         flat.push(...targets)
       }
-      // The live focus rides along after the notes; '~focus' cannot collide
-      // with a note id (ids are uuid-shaped).
-      if (liveFocusTargets && flat.length + liveFocusTargets.length <= MAX_RESOLVE_ANCHORS) {
-        spans.push({ id: '~focus', start: flat.length, count: liveFocusTargets.length })
-        flat.push(...liveFocusTargets)
-      }
       if (flat.length === 0) {
         resolvedZoomRef.current = zoom
         return
       }
       resolvePendingRef.current = true
+      resolveAttemptsRef.current += 1
       try {
         const raw = await askCanvasFrame(target, canvasId, { type: 'resolveAnchors', anchors: flat }, 10_000)
         if (cancelled) return
@@ -937,12 +977,24 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       } finally {
         resolvePendingRef.current = false
         // Whatever this run could not cover — a pass the in-flight guard
-        // skipped, or a zoom that moved again while it was out — gets one more
-        // look. Fires only on recorded drift or a recorded skip, so it cannot
-        // loop on a quiet pane.
+        // skipped, or a zoom that moved again while it was out — gets another
+        // look, INSIDE the intent's attempt budget. On success the drift
+        // clears and nothing fires; on failure the budget is what stops a
+        // frame that never answers from choosing the host's call rate (N1) —
+        // three attempts per intent, then the checklist keeps its ghosts
+        // until the user asks something new.
+        // A recorded skip always retries: the guard turned away a whole effect
+        // run over a HOST condition (this pass being out), possibly for a NEW
+        // intent whose budget is not this one's — the re-armed effect re-keys
+        // the intent and its own budget bounds any RPC it issues. Drift alone
+        // retries only inside this intent's budget.
         const skipped = resolveSkippedRef.current
         resolveSkippedRef.current = false
-        if (!cancelled && (skipped || resolvedZoomRef.current !== zoomRef.current)) setResolveRetryNonce((n) => n + 1)
+        const driftRetry =
+          resolvedZoomRef.current !== zoomRef.current && resolveAttemptsRef.current < MAX_RESOLVE_ATTEMPTS
+        if (!cancelled && (skipped || driftRetry)) {
+          setResolveRetryNonce((n) => n + 1)
+        }
       }
     }
     // Debounced only when the zoom moved it: rapid ladder steps supersede each

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -513,8 +513,18 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
    */
   const checklistStatus = useCallback(
     (note: Annotation): { text: string; kind: 'reported' | 'ghost' | 'current'; rect: Rect | null } => {
-      // A note written against the version on screen needs no re-anchoring.
+      // A note written against the version on screen needs no re-anchoring —
+      // unless the pane's zoom moved since (#368): a zoom step reflows the
+      // page, so the box recorded at note time belongs to another layout. The
+      // resolution pass re-measures same-version notes on a zoom change, and
+      // when it has, its box wins; like every re-anchor result it is the
+      // page's own answer, so it wears the page-reported kind, never the
+      // solid green that means the app measured it.
       if (note.versionId === version.id) {
+        const zoomEntry = resolution?.versionId === version.id ? resolution.byAnnotation[note.id] : undefined
+        if (zoomEntry && zoomEntry.found) {
+          return { text: 'on this version — page-located', kind: 'reported', rect: zoomEntry.box }
+        }
         return { text: 'on this version', kind: 'current', rect: note.focus?.bboxPage ?? null }
       }
       if (!note.focus) return { text: 'general', kind: 'current', rect: null }

--- a/src/renderer/stores/canvasReviewStore.ts
+++ b/src/renderer/stores/canvasReviewStore.ts
@@ -104,6 +104,9 @@ interface CanvasReviewStoreState {
   expandFocus: (sessionId: string) => void
   clearFocus: (sessionId: string) => void
   setRegionFocus: (sessionId: string, bboxPage: Rect, versionId: string) => void
+  /** Re-point the LIVE locked focus after a layout change (#368): applied only
+   *  while `forFocus` is still the focus, by reference — see the action. */
+  updateFocusBox: (sessionId: string, forFocus: FocusObject, bboxPage: Rect) => void
   setMarqueeArmed: (sessionId: string, armed: boolean) => void
   setEditingAnnotation: (sessionId: string, annotationId: string | null) => void
   setResolution: (sessionId: string, pass: ResolutionPass | null) => void
@@ -213,6 +216,19 @@ export const useCanvasReviewStore = create<CanvasReviewStoreState>((set, get) =>
         marqueeArmed: false,
       }),
     )
+  },
+
+  updateFocusBox: (sessionId, forFocus, bboxPage) => {
+    // Guarded by REFERENCE equality with the focus the box was resolved for:
+    // a lock the user changed, expanded or cleared while the resolve was in
+    // flight is a different claim and the stale answer is dropped, never
+    // applied to it. Only the box moves — the identity (targets, label,
+    // versionId) is the user's lock and stays theirs (#368, S3).
+    set((s) => {
+      const session = s.bySessionId[sessionId]
+      if (!session || session.focus !== forFocus) return s
+      return patch(s, sessionId, { focus: { ...forFocus, bboxPage } })
+    })
   },
 
   setMarqueeArmed: (sessionId, armed) => {

--- a/src/renderer/utils/canvas-coords.ts
+++ b/src/renderer/utils/canvas-coords.ts
@@ -11,9 +11,10 @@
 //      scene transform entry points; nothing here re-derives their math.
 //
 // The glass is LOCKED to the content: scene scroll is bound to the negated
-// content scroll at zoom 1 (glassScrollForContent), which makes scene coords
-// coincide with content page coords — a mark drawn on an element stays on it
-// through content scrolling. All functions are pure; unit tests cover them.
+// content scroll, and scene zoom to the pane's content zoom (#368; 1 when
+// unzoomed), which makes scene coords coincide with content page coords — a
+// mark drawn on an element stays on it through content scrolling and through
+// Ctrl+wheel zoom. All functions are pure; unit tests cover them.
 
 import { sceneCoordsToViewportCoords, viewportCoordsToSceneCoords } from '@excalidraw/excalidraw'
 import type { CanvasViewportInfo, Rect } from '../../shared/canvas'
@@ -118,25 +119,31 @@ export function sceneToContentPagePoint(
 
 /**
  * The appState scroll/zoom that pins the glass 1:1 over the content: scene
- * scroll = −content scroll at zoom 1. Under this binding (and the glass
- * canvas's own offset equal to the stage origin), scene coords coincide with
- * content page coords — verified by the round-trip unit tests.
+ * scroll = −content scroll, scene zoom = the pane's content zoom (#368; 1 when
+ * unzoomed). Excalidraw paints a scene point at (scene + scroll) × zoom, so
+ * under this binding scene coords coincide with CONTENT PAGE coords at every
+ * zoom — a mark drawn on an element stays on it through both content scrolling
+ * and Ctrl+wheel — verified by the round-trip unit tests.
  */
-export function glassScrollForContent(viewport: CanvasViewportInfo): {
+export function glassScrollForContent(
+  viewport: CanvasViewportInfo,
+  zoom = 1,
+): {
   scrollX: number
   scrollY: number
   zoom: { value: number }
 } {
-  return { scrollX: -viewport.scrollX, scrollY: -viewport.scrollY, zoom: { value: 1 } }
+  return { scrollX: -viewport.scrollX, scrollY: -viewport.scrollY, zoom: { value: zoom } }
 }
 
 /** Whether the glass has drifted from its content binding enough to re-pin. */
 export function glassNeedsRepin(
   appState: Pick<GlassAppState, 'scrollX' | 'scrollY' | 'zoom'>,
   viewport: CanvasViewportInfo,
+  zoom = 1,
   tolerance = 0.5,
 ): boolean {
-  const target = glassScrollForContent(viewport)
+  const target = glassScrollForContent(viewport, zoom)
   return (
     Math.abs(appState.scrollX - target.scrollX) > tolerance ||
     Math.abs(appState.scrollY - target.scrollY) > tolerance ||

--- a/src/renderer/utils/canvas-zoom.ts
+++ b/src/renderer/utils/canvas-zoom.ts
@@ -45,3 +45,21 @@ export function stepCanvasZoom(current: number, steps: number): number {
 export function formatCanvasZoom(zoom: number): string {
   return `${Math.round(zoom * 100)}%`
 }
+
+/**
+ * The iframe's inline style at a given content zoom.
+ *
+ * Standardized CSS `zoom` (Chromium 128+) resolves a PERCENTAGE length against
+ * the containing block divided by the element's effective zoom, so the zoom
+ * cancels: a percentage-sized box paints the same size at every zoom, and only
+ * absolute lengths are multiplied. Plain `width/height: 100%` therefore already
+ * gives the browser-tab behaviour this feature wants — the frame keeps filling
+ * the stage, the content's CSS viewport becomes stage/zoom, and the paint
+ * scales by zoom. Compensating the size (100/zoom %) double-applies the rule
+ * and shrinks or overflows the frame (measured on Electron 43 / Chromium 150 —
+ * independent review of PR #417, finding S1). Kept as a pure helper so a unit
+ * test pins the semantics jsdom cannot lay out.
+ */
+export function frameStyleForZoom(zoom: number): { zoom: number; width: '100%'; height: '100%' } {
+  return { zoom, width: '100%', height: '100%' }
+}

--- a/src/renderer/utils/canvas-zoom.ts
+++ b/src/renderer/utils/canvas-zoom.ts
@@ -1,0 +1,47 @@
+// Agent Canvas zoom (#368) — the ladder and the arithmetic, pure.
+//
+// Ctrl+wheel (and Ctrl+= / Ctrl+- / Ctrl+0) zoom the RENDERED PAGE, the way a
+// browser tab zooms: the iframe carries CSS `zoom` with its layout size
+// compensated (width = 100/zoom %), so the content lays out to a narrower or
+// wider CSS viewport and paints scaled — 1 content px = `zoom` stage px. The
+// pane folds the factor into every content↔stage conversion and into the glass
+// binding, which is what keeps notes anchored in page space at any zoom.
+//
+// The ladder is Chrome's own zoom ladder clipped to the issue's 50–200 % range,
+// so the steps feel like the browser's.
+
+export const CANVAS_ZOOM_LADDER = [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2] as const
+
+export const CANVAS_ZOOM_MIN = CANVAS_ZOOM_LADDER[0]
+export const CANVAS_ZOOM_MAX = CANVAS_ZOOM_LADDER[CANVAS_ZOOM_LADDER.length - 1]
+
+/** Index of the ladder entry nearest to `zoom` (ties resolve downward). */
+function nearestRungIndex(zoom: number): number {
+  if (!Number.isFinite(zoom)) return CANVAS_ZOOM_LADDER.indexOf(1)
+  let best = 0
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (let i = 0; i < CANVAS_ZOOM_LADDER.length; i++) {
+    const distance = Math.abs(CANVAS_ZOOM_LADDER[i] - zoom)
+    if (distance < bestDistance) {
+      best = i
+      bestDistance = distance
+    }
+  }
+  return best
+}
+
+/**
+ * Walk `steps` rungs from `current` (+in / −out), clamped to the ladder's ends.
+ * A `current` off the ladder snaps to its nearest rung first, so the walk is
+ * always rung-to-rung and repeated steps cannot drift.
+ */
+export function stepCanvasZoom(current: number, steps: number): number {
+  const walked = nearestRungIndex(current) + (Number.isFinite(steps) ? Math.trunc(steps) : 0)
+  const clamped = Math.max(0, Math.min(CANVAS_ZOOM_LADDER.length - 1, walked))
+  return CANVAS_ZOOM_LADDER[clamped]
+}
+
+/** "150%" — whole percent, for the chrome chip. */
+export function formatCanvasZoom(zoom: number): string {
+  return `${Math.round(zoom * 100)}%`
+}

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -514,12 +514,29 @@ export type CanvasBridgeResponse =
  */
 export const CANVAS_REPORTED_KEYS = ['Escape', 'ArrowUp'] as const
 
+/**
+ * Zoom intents the bridge REPORTS from inside the content frame ('contentZoom',
+ * #368).
+ *
+ * Ctrl+wheel and the Ctrl+= / Ctrl+- / Ctrl+0 chords are the browser's zoom
+ * gesture, and in the pane they belong to the HOST — but while the pointer or
+ * keyboard focus is on the content, those events land in the frame and the host
+ * never sees them. So the bridge relays the INTENT ('in' / 'out' / 'reset'),
+ * never raw deltas or key values: the host owns the ladder, the clamp and the
+ * application, and treats each report as a request it may ignore (D8). The
+ * worst a forgery achieves is stepping a clamped, visible, Ctrl+0-reversible
+ * visual zoom.
+ */
+export const CANVAS_ZOOM_ACTIONS = ['in', 'out', 'reset'] as const
+export type CanvasZoomAction = (typeof CANVAS_ZOOM_ACTIONS)[number]
+
 export type CanvasBridgeEvent =
   | { ns: typeof CANVAS_BRIDGE_NS; type: 'ready' }
   | { ns: typeof CANVAS_BRIDGE_NS; type: 'viewport'; viewport: CanvasViewportInfo }
   | { ns: typeof CANVAS_BRIDGE_NS; type: 'pointer'; pageX: number; pageY: number; hit: CanvasHitInfo | null }
   | { ns: typeof CANVAS_BRIDGE_NS; type: 'contentClick'; pageX: number; pageY: number; hit: CanvasHitInfo | null }
   | { ns: typeof CANVAS_BRIDGE_NS; type: 'contentKey'; key: string }
+  | { ns: typeof CANVAS_BRIDGE_NS; type: 'contentZoom'; action: CanvasZoomAction }
 
 // ── Semantic snapshot (P2, spec §4) ─────────────────────────────────────────
 // The richer tree the P2 bridge produces (dom-accessibility-api + aria-query +

--- a/tests/unit/renderer/canvas-coords.test.ts
+++ b/tests/unit/renderer/canvas-coords.test.ts
@@ -133,6 +133,44 @@ describe('glass binding', () => {
     expect(glassNeedsRepin({ scrollX: -140, scrollY: 0, zoom: { value: 1 } }, viewport)).toBe(true)
     expect(glassNeedsRepin({ scrollX: -100, scrollY: 0, zoom: { value: 1.2 } }, viewport)).toBe(true)
   })
+
+  it('pinned glass at content zoom (#368) ⇒ scene coords STILL coincide with page coords', () => {
+    // The pane zooms the content (#368): 1 content px paints as `zoom` stage
+    // px, and the glass binding carries the same factor as its scene zoom.
+    // Scene coords must keep coinciding with content page coords — that is
+    // what keeps a mark on its element through Ctrl+wheel.
+    const zoom = 1.5
+    const viewport = vp({ scrollX: 480, scrollY: 1500 })
+    const pinned = glassScrollForContent(viewport, zoom)
+    expect(pinned.zoom.value).toBe(zoom)
+    const state = appState({
+      scrollX: pinned.scrollX,
+      scrollY: pinned.scrollY,
+      zoom: pinned.zoom,
+      offsetLeft: STAGE.left,
+      offsetTop: STAGE.top,
+    })
+    const pagePoint = { x: 640, y: 1730 }
+    // Content → stage under zoom folds the factor into the scale slot, exactly
+    // as the pane's stageViewport does.
+    const stagePoint = contentPageToStagePoint(pagePoint, { ...viewport, scale: viewport.scale * zoom })
+    const scene = stageToScenePoint(stagePoint, STAGE, state)
+    expect(scene.x).toBeCloseTo(pagePoint.x, 6)
+    expect(scene.y).toBeCloseTo(pagePoint.y, 6)
+    const back = sceneToStagePoint(scene, STAGE, state)
+    expect(back.x).toBeCloseTo(stagePoint.x, 6)
+    expect(back.y).toBeCloseTo(stagePoint.y, 6)
+  })
+
+  it('repin detection watches the zoom axis of the binding too (#368)', () => {
+    const viewport = vp({ scrollX: 100, scrollY: 0 })
+    // Glass already at the content zoom: pinned.
+    expect(glassNeedsRepin({ scrollX: -100, scrollY: 0, zoom: { value: 1.5 } }, viewport, 1.5)).toBe(false)
+    // Excalidraw wandered off the content zoom (wheel on the glass): repin.
+    expect(glassNeedsRepin({ scrollX: -100, scrollY: 0, zoom: { value: 1 } }, viewport, 1.5)).toBe(true)
+    // The pane stepped its zoom while the glass still holds the old one: repin.
+    expect(glassNeedsRepin({ scrollX: -100, scrollY: 0, zoom: { value: 1.5 } }, viewport, 1.75)).toBe(true)
+  })
 })
 
 describe('stageRectIsVisible', () => {

--- a/tests/unit/renderer/canvas-inbound-channel.test.ts
+++ b/tests/unit/renderer/canvas-inbound-channel.test.ts
@@ -45,8 +45,15 @@ function makeHandlers(): CanvasInboundHandlers {
     onPointer: vi.fn(),
     onContentClick: vi.fn(),
     onContentKey: vi.fn(),
+    onContentZoom: vi.fn(),
     onFlood: vi.fn(),
   }
+}
+
+/** jsdom has no real hover state, so the host's `:hover` evidence is stubbed on
+ *  the element the channel actually consults. */
+function setFrameHovered(hovered: boolean): void {
+  iframe.matches = ((selector: string) => (selector === ':hover' ? hovered : false)) as typeof iframe.matches
 }
 
 function arm(): void {
@@ -250,6 +257,90 @@ describe('a forged contentClick cannot lock a focus', () => {
     fromFrame({ type: 'contentClick', pageX: Number.NaN, pageY: 'boom' })
     await flushFrame()
     expect(handlers.onContentClick).toHaveBeenCalledWith(0, 0)
+  })
+})
+
+describe('contentZoom (#368) is gated, closed-vocabulary and coalesced', () => {
+  it('is dropped when the pointer is not over the frame and the frame has no focus', async () => {
+    arm()
+    composer.focus()
+    setFrameHovered(false)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    await flushFrame()
+    expect(handlers.onContentZoom).not.toHaveBeenCalled()
+  })
+
+  it('is honoured on the host evidence of hover, focus not required, activation not required', async () => {
+    arm()
+    composer.focus()
+    setUserActivation(false)
+    setFrameHovered(true)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledWith({ steps: 1, reset: false })
+  })
+
+  it('is honoured on frame keyboard focus, hover not required (the zoom chords)', async () => {
+    arm()
+    iframe.focus()
+    setFrameHovered(false)
+    fromFrame({ type: 'contentZoom', action: 'out' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledWith({ steps: -1, reset: false })
+  })
+
+  it('refuses anything outside the closed action vocabulary', async () => {
+    arm()
+    iframe.focus()
+    for (const action of ['zoom', 5, null, undefined, { steps: 99 }, 'IN', 'reset ']) {
+      fromFrame({ type: 'contentZoom', action })
+    }
+    await flushFrame()
+    expect(handlers.onContentZoom).not.toHaveBeenCalled()
+  })
+
+  it('coalesces a burst to ONE delivery carrying the net movement', async () => {
+    arm()
+    setFrameHovered(true)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    fromFrame({ type: 'contentZoom', action: 'out' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledTimes(1)
+    expect(handlers.onContentZoom).toHaveBeenCalledWith({ steps: 2, reset: false })
+  })
+
+  it('reset wins over steps queued beside it, in either order', async () => {
+    arm()
+    setFrameHovered(true)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    fromFrame({ type: 'contentZoom', action: 'reset' })
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledTimes(1)
+    expect(handlers.onContentZoom).toHaveBeenCalledWith({ steps: 0, reset: true })
+  })
+
+  it('bounds the net movement a chatty frame can queue in one animation frame', async () => {
+    arm()
+    setFrameHovered(true)
+    for (let i = 0; i < 200; i++) fromFrame({ type: 'contentZoom', action: 'in' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledTimes(1)
+    const [intent] = (handlers.onContentZoom as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      { steps: number; reset: boolean },
+    ]
+    expect(Math.abs(intent.steps)).toBeLessThanOrEqual(16)
+  })
+
+  it('a zero-step frame delivers nothing at all', async () => {
+    arm()
+    setFrameHovered(true)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    fromFrame({ type: 'contentZoom', action: 'out' })
+    await flushFrame()
+    expect(handlers.onContentZoom).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/unit/renderer/canvas-inbound-channel.test.ts
+++ b/tests/unit/renderer/canvas-inbound-channel.test.ts
@@ -372,7 +372,9 @@ describe('contentZoom (#368) is gated, closed-vocabulary and coalesced', () => {
     arm()
     composer.focus()
     setFrameHovered(false)
-    for (let i = 0; i < CONTENT_ZOOM_BUDGET * 3; i++) fromFrame({ type: 'contentZoom', action: 'in' })
+    // Past the zoom budget but under the general flood budget — the refusals
+    // must be what saves the channel, not the message count.
+    for (let i = 0; i < CONTENT_ZOOM_BUDGET + 100; i++) fromFrame({ type: 'contentZoom', action: 'in' })
     expect(handlers.onFlood).not.toHaveBeenCalled()
     // The user hovers; a genuine gesture still gets through.
     setFrameHovered(true)

--- a/tests/unit/renderer/canvas-inbound-channel.test.ts
+++ b/tests/unit/renderer/canvas-inbound-channel.test.ts
@@ -19,7 +19,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   createCanvasInboundChannel,
   reportedKeyIsPlausible,
+  reportedZoomIsPlausible,
   withinInboundSizeBounds,
+  CONTENT_ZOOM_BUDGET,
   INBOUND_FLOOD_BUDGET,
   INBOUND_OVERSIZE_COST,
   MAX_INBOUND_STRING_CHARS,
@@ -325,7 +327,9 @@ describe('contentZoom (#368) is gated, closed-vocabulary and coalesced', () => {
   it('bounds the net movement a chatty frame can queue in one animation frame', async () => {
     arm()
     setFrameHovered(true)
-    for (let i = 0; i < 200; i++) fromFrame({ type: 'contentZoom', action: 'in' })
+    // Under the zoom budget (so the channel survives) but far over the walk
+    // bound — the clamp, not the budget, is what this test pins.
+    for (let i = 0; i < 40; i++) fromFrame({ type: 'contentZoom', action: 'in' })
     await flushFrame()
     expect(handlers.onContentZoom).toHaveBeenCalledTimes(1)
     const [intent] = (handlers.onContentZoom as ReturnType<typeof vi.fn>).mock.calls[0] as [
@@ -341,6 +345,40 @@ describe('contentZoom (#368) is gated, closed-vocabulary and coalesced', () => {
     fromFrame({ type: 'contentZoom', action: 'out' })
     await flushFrame()
     expect(handlers.onContentZoom).not.toHaveBeenCalled()
+  })
+
+  it('the gate fails closed on a missing frame element even when nothing holds focus', () => {
+    // `null === null` must not pass the focus branch — the null-frame check is
+    // load-bearing (independent review, A4).
+    expect(reportedZoomIsPlausible({ activeElement: null, frameElement: null })).toBe(false)
+  })
+
+  it('a page over the contentZoom budget loses the channel — pinning the camera is not a right', async () => {
+    // Sixty honoured intents per rolling window is beyond any human's wheel;
+    // a page past it is re-zooming against the user (a pinned zoom would
+    // outlive every Ctrl+0) or farming the host work a zoom change triggers.
+    arm()
+    setFrameHovered(true)
+    for (let i = 0; i < CONTENT_ZOOM_BUDGET; i++) fromFrame({ type: 'contentZoom', action: 'in' })
+    expect(handlers.onFlood).not.toHaveBeenCalled()
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    expect(handlers.onFlood).toHaveBeenCalledTimes(1)
+    // Dropped whole: nothing later is heard.
+    fromFrame({ type: 'ready' })
+    expect(handlers.onReady).not.toHaveBeenCalled()
+  })
+
+  it('refused forgeries do not spend the zoom budget — only honoured intents count', async () => {
+    arm()
+    composer.focus()
+    setFrameHovered(false)
+    for (let i = 0; i < CONTENT_ZOOM_BUDGET * 3; i++) fromFrame({ type: 'contentZoom', action: 'in' })
+    expect(handlers.onFlood).not.toHaveBeenCalled()
+    // The user hovers; a genuine gesture still gets through.
+    setFrameHovered(true)
+    fromFrame({ type: 'contentZoom', action: 'in' })
+    await flushFrame()
+    expect(handlers.onContentZoom).toHaveBeenCalledWith({ steps: 1, reset: false })
   })
 })
 

--- a/tests/unit/renderer/canvas-review-store.test.ts
+++ b/tests/unit/renderer/canvas-review-store.test.ts
@@ -51,6 +51,32 @@ describe('focus construction', () => {
   })
 })
 
+describe('updateFocusBox (#368) — re-pointing the live lock after a zoom reflow', () => {
+  it('moves ONLY the box, and only while the exact lock it was resolved for still stands', () => {
+    const store = useCanvasReviewStore.getState()
+    store.lockFocus(SID, [entry()], 'v3')
+    const locked = useCanvasReviewStore.getState().bySessionId[SID].focus!
+
+    store.updateFocusBox(SID, locked, { x: 5, y: 6, width: 70, height: 20 })
+    const moved = useCanvasReviewStore.getState().bySessionId[SID].focus!
+    expect(moved.bboxPage).toEqual({ x: 5, y: 6, width: 70, height: 20 })
+    expect(moved.label).toBe(locked.label)
+    expect(moved.targets).toBe(locked.targets)
+
+    // The user re-locked while the resolve was in flight: the stale answer is
+    // a claim about the OLD lock and must not land on the new one.
+    store.lockFocus(SID, [entry({ name: 'Cancel' })], 'v3')
+    const relocked = useCanvasReviewStore.getState().bySessionId[SID].focus!
+    store.updateFocusBox(SID, moved, { x: 999, y: 999, width: 1, height: 1 })
+    expect(useCanvasReviewStore.getState().bySessionId[SID].focus).toBe(relocked)
+
+    // A cleared lock is not resurrected by a late answer.
+    store.clearFocus(SID)
+    store.updateFocusBox(SID, relocked, { x: 1, y: 1, width: 1, height: 1 })
+    expect(useCanvasReviewStore.getState().bySessionId[SID].focus).toBeNull()
+  })
+})
+
 describe('the focus ladder', () => {
   it('locks the deepest entry, expands one parent per step, and stops at the top', () => {
     const chain = [entry({ name: 'Save' }), entry({ role: 'form', name: '' }), entry({ role: 'main', name: '' })]

--- a/tests/unit/renderer/canvas-zoom.test.ts
+++ b/tests/unit/renderer/canvas-zoom.test.ts
@@ -7,6 +7,7 @@ import {
   CANVAS_ZOOM_MAX,
   CANVAS_ZOOM_MIN,
   formatCanvasZoom,
+  frameStyleForZoom,
   stepCanvasZoom,
 } from '../../../src/renderer/utils/canvas-zoom'
 
@@ -69,5 +70,18 @@ describe('formatCanvasZoom', () => {
     expect(formatCanvasZoom(1)).toBe('100%')
     expect(formatCanvasZoom(0.67)).toBe('67%')
     expect(formatCanvasZoom(2)).toBe('200%')
+  })
+})
+
+describe('frameStyleForZoom', () => {
+  it('never compensates the percentage size — percentages self-compensate under standardized CSS zoom', () => {
+    // Measured on Electron 43 / Chromium 150 (PR #417 review, S1): a
+    // percentage length resolves against the containing block divided by the
+    // effective zoom, so `100%` fills the stage at EVERY zoom, and a
+    // 100/zoom% "compensation" double-applies the rule and breaks the layout.
+    // jsdom cannot lay this out, so this test pins the helper instead.
+    for (const zoom of CANVAS_ZOOM_LADDER) {
+      expect(frameStyleForZoom(zoom)).toEqual({ zoom, width: '100%', height: '100%' })
+    }
   })
 })

--- a/tests/unit/renderer/canvas-zoom.test.ts
+++ b/tests/unit/renderer/canvas-zoom.test.ts
@@ -1,0 +1,73 @@
+// Agent Canvas zoom ladder (#368) — the arithmetic the wheel and the chords
+// walk. Pure functions; the pane applies whatever these return.
+
+import { describe, it, expect } from 'vitest'
+import {
+  CANVAS_ZOOM_LADDER,
+  CANVAS_ZOOM_MAX,
+  CANVAS_ZOOM_MIN,
+  formatCanvasZoom,
+  stepCanvasZoom,
+} from '../../../src/renderer/utils/canvas-zoom'
+
+describe('the ladder itself', () => {
+  it('spans exactly the 50–200 % range the issue asks for', () => {
+    expect(CANVAS_ZOOM_MIN).toBe(0.5)
+    expect(CANVAS_ZOOM_MAX).toBe(2)
+  })
+
+  it('is strictly increasing and includes 1', () => {
+    for (let i = 1; i < CANVAS_ZOOM_LADDER.length; i++) {
+      expect(CANVAS_ZOOM_LADDER[i]).toBeGreaterThan(CANVAS_ZOOM_LADDER[i - 1])
+    }
+    expect(CANVAS_ZOOM_LADDER).toContain(1)
+  })
+})
+
+describe('stepCanvasZoom', () => {
+  it('walks one rung per step in both directions from 1', () => {
+    expect(stepCanvasZoom(1, 1)).toBe(1.1)
+    expect(stepCanvasZoom(1, -1)).toBe(0.9)
+    expect(stepCanvasZoom(1, 2)).toBe(1.25)
+  })
+
+  it('clamps at both ends of the ladder', () => {
+    expect(stepCanvasZoom(2, 1)).toBe(2)
+    expect(stepCanvasZoom(0.5, -1)).toBe(0.5)
+    expect(stepCanvasZoom(1, 100)).toBe(2)
+    expect(stepCanvasZoom(1, -100)).toBe(0.5)
+  })
+
+  it('walks the full ladder up and back down without drifting', () => {
+    let z = CANVAS_ZOOM_MIN
+    for (let i = 0; i < CANVAS_ZOOM_LADDER.length + 3; i++) z = stepCanvasZoom(z, 1)
+    expect(z).toBe(CANVAS_ZOOM_MAX)
+    for (let i = 0; i < CANVAS_ZOOM_LADDER.length + 3; i++) z = stepCanvasZoom(z, -1)
+    expect(z).toBe(CANVAS_ZOOM_MIN)
+  })
+
+  it('snaps an off-ladder value to its nearest rung before walking', () => {
+    expect(stepCanvasZoom(1.02, 1)).toBe(1.1)
+    expect(stepCanvasZoom(0.51, -1)).toBe(0.5)
+    expect(stepCanvasZoom(1.6, 0)).toBe(1.5)
+  })
+
+  it('treats a non-finite current or step as no movement from 1', () => {
+    expect(stepCanvasZoom(Number.NaN, 1)).toBe(1.1)
+    expect(stepCanvasZoom(1, Number.NaN)).toBe(1)
+    expect(stepCanvasZoom(Number.POSITIVE_INFINITY, 0)).toBe(1)
+  })
+
+  it('truncates fractional steps rather than inventing rungs', () => {
+    expect(stepCanvasZoom(1, 1.9)).toBe(1.1)
+    expect(stepCanvasZoom(1, -1.9)).toBe(0.9)
+  })
+})
+
+describe('formatCanvasZoom', () => {
+  it('prints whole percents', () => {
+    expect(formatCanvasZoom(1)).toBe('100%')
+    expect(formatCanvasZoom(0.67)).toBe('67%')
+    expect(formatCanvasZoom(2)).toBe('200%')
+  })
+})


### PR DESCRIPTION
Closes #368.

Ctrl+wheel zooms the rendered page **50–200 %** on Chrome's own zoom ladder; **Ctrl+= / Ctrl+-** step it, **Ctrl+0** resets, and a **% chip** in the pane chrome shows any non-1:1 zoom (click resets). Browser-tab semantics: the iframe carries CSS `zoom` with its layout size compensated, so the content reflows to the narrower/wider CSS viewport and paints scaled.

## How the gesture reaches the host

Over the content the wheel lands in the frame, so the **bridge relays a closed intent vocabulary** — `contentZoom: 'in' | 'out' | 'reset'`, never raw deltas or key values (one intent per accumulated wheel notch; the zoom chords relay the same intents, never from an editable target). The host:

- honours a report only with **its own evidence** the frame plausibly owns the gesture (`:hover` on its iframe element, or the frame holding keyboard focus) — `reportedZoomIsPlausible`, deliberately weaker than the key/click gates because a wheel is not a user-activation trigger and the blast radius is different in kind (see below);
- validates the closed vocabulary **on arrival**, coalesces to **one net delivery per animation frame**, and bounds the walk (±16 steps/frame vs an 11-rung ladder);
- keeps every existing channel bound: the flood budget charges each message, the size bounds apply unchanged.

**Forgery blast radius:** a hostile page can only step a **clamped, chrome-visible, Ctrl+0-reversible visual zoom** — it cannot reach the review store, the locked selection, or anything persisted; and a page can already scale its own rendering arbitrarily with a stylesheet.

## Note anchoring (the acceptance case)

- The **glass binding** carries the zoom as its scene zoom, so scene coords keep coinciding with content page coords — marks stay on their elements at every zoom (round-trip unit tests).
- Every content→stage conversion folds the factor into the pinch-scale slot (`stageViewport`).
- A zoom step **reflows** the content, so the **resolution pass re-runs, same-version notes included** (debounced 300 ms so rapid rungs supersede) — a note placed at 150 % re-anchors at 100 %.

## Not fighting other shortcuts

Host-side, Ctrl+wheel works over the pane chrome / glass / notes panel (capture phase, so Excalidraw's scene zoom never sees the chord); the zoom chords apply **only while the pane is hovered or holds focus**. The app registers no zoom accelerators of its own (no View menu) and the terminal has no wheel-zoom — nothing is contested. AltGr (`ctrl+alt`) is excluded on both sides.

## Tests

- `canvas-zoom.test.ts` — the ladder arithmetic (bounds, clamps, snapping, full-sweep no-drift).
- `canvas-inbound-channel.test.ts` — the gate (hover / focus / neither), closed vocabulary, per-frame net coalescing, reset-wins, bounded walk, zero-step silence.
- `canvas-coords.test.ts` — glass binding at zoom: scene ≡ page coords round-trip; repin watches the zoom axis.
- Full suite **7802 passed** + `npm run typecheck` clean.

ADR-009: touches the canvas bridge + inbound channel (page→host surface) — independent adversarial review to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)