### PR TITLE
fix(watchdog): send gate reads the dim attribute — placeholders are not drafts (#418)

### DIFF
--- a/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
+++ b/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
@@ -41,11 +41,17 @@ and future editors must not undo:
   prompt pointer whenever isLoading, and a masked re-match would blank the
   glyph, fail the regex, and flip a live type-ahead draft from refuse to SEND.
   Same for dim box gutters. Empty cells serialize as spaces so columns hold.
-- Accepted residual (documented, judged unreal-rare): a ONE-character draft
-  with the cursor sitting ON that character masks to blank and would send --
-  it needs the user to type one char, arrow back onto it, and a rate-limit
-  retry to fire in that instant; the damage is a concatenated line, not a
-  menu selection.
+- **Only a LONE inverse cell is the cursor.** Round 2 of the review: blanket
+  inverse masking blanked whole inverse RUNS -- the `[Image #1]` chip (which
+  claude.exe renders fully inverse when the cursor snaps to its edge) and an
+  inverse-highlighted picker row -- flipping a real draft into a sendable
+  pane. The mask blanks an inverse cell only when neither neighbour is
+  inverse; a multi-cell inverse run is content.
+- Accepted residuals (documented, judged unreal-rare): a ONE-character draft
+  with the cursor sitting ON that character masks to blank and would send
+  (two characters already refuse); and a single-option ALL-DIM caret picker
+  row no longer gates (claude.exe dims only disabled rows, where Enter is
+  inert -- and a picker with one option is not a real render).
 
 The trap for future edits: do NOT blanket-blank dim/inverse cells before the
 whole gate. Permission menus may dim their rows; blanking them before the menu

--- a/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
+++ b/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
@@ -1,0 +1,34 @@
+## 2026-08-23 -- #418 watchdog send gate: the styled read (dim placeholders)
+
+Follow-up from the #266 ADR-009 review (finding N1). `canSendNow` treated any
+`❯ <text>` row as a draft/picker and deferred. But Claude Code renders DIM
+placeholder text in an otherwise-empty input -- "Press up to edit queued
+messages" whenever the queue is non-empty, "Message @agent…" in an agent view,
+"Comment on N selected lines…" over an IDE selection, the model-generated
+prompt suggestion -- states that coexist with a live rate limit indefinitely.
+The gate fails closed, so it deferred forever: the auto-retry silently never
+fired, exactly when it should have.
+
+The fix keys the draft signal on the **dim attribute**, not on a placeholder
+denylist (wording changes with every claude.exe release; the attribute is the
+render's own statement that the text is a hint):
+
+- `readPanePair` (watchdog-manager) serializes the headless pane twice from
+  one buffer walk: `text` (translateToString, unchanged for every other
+  detector) and `nonDim` -- the same rows with every dim cell blanked to a
+  space, trailing blanks trimmed in lockstep so the two stay aligned
+  line-for-line.
+- `canSendNow(text, nonDimText?)`: a caret/boxed/bare-prompt row counts as a
+  DRAFT only if non-dim ink follows the prompt glyph in the aligned styled
+  row. Two deliberate asymmetries: menu rows are counted on the RAW text (a
+  selector's unfocused rows may render dim, and losing them would weaken the
+  menu guard -- the mis-send direction), and a missing or misaligned styled
+  read is ignored entirely, restoring the old fail-closed posture.
+- The adapter method is optional (`getTailNonDim?`), so every existing
+  test/stub and any future text-only tail source keeps the old behavior.
+
+The trap for future edits: do NOT blanket-blank dim cells before the whole
+gate. Permission menus may dim their unfocused rows; blanking them would
+collapse a menu into a sendable pane and turn an availability bug into a
+mis-send (auto-approving a permission prompt). Dim-awareness belongs to the
+draft signal only.

--- a/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
+++ b/CONTEXT.d/2026-08-23-418-watchdog-dim-placeholders.md
@@ -20,15 +20,35 @@ render's own statement that the text is a hint):
   line-for-line.
 - `canSendNow(text, nonDimText?)`: a caret/boxed/bare-prompt row counts as a
   DRAFT only if non-dim ink follows the prompt glyph in the aligned styled
-  row. Two deliberate asymmetries: menu rows are counted on the RAW text (a
-  selector's unfocused rows may render dim, and losing them would weaken the
-  menu guard -- the mis-send direction), and a missing or misaligned styled
-  read is ignored entirely, restoring the old fail-closed posture.
+  row. Two deliberate asymmetries: BOTH menu signals (numbered rows AND the
+  two-caret-row picker count) stay on the RAW text (a selector's rows may
+  render dim, and losing them would weaken the menu guard -- the mis-send
+  direction), and a missing or misaligned styled read is ignored entirely,
+  restoring the old fail-closed posture.
 - The adapter method is optional (`getTailNonDim?`), so every existing
   test/stub and any future text-only tail source keeps the old behavior.
 
-The trap for future edits: do NOT blanket-blank dim cells before the whole
-gate. Permission menus may dim their unfocused rows; blanking them would
-collapse a menu into a sendable pane and turn an availability bug into a
-mis-send (auto-approving a permission prompt). Dim-awareness belongs to the
-draft signal only.
+What the adversarial round (decompiling the real claude.exe renderer) forced,
+and future editors must not undo:
+
+- **The cursor is INVERSE, not dim.** A focused empty input renders the
+  placeholder as `inverse(first char) + dim(rest)` -- so a dim-only mask left
+  `❯ P` and the gate still deferred forever (the fix would have shipped
+  without fixing the bug). The mask blanks `isDim() || isInverse()` cells:
+  the inverse cell is the cursor, never draft ink.
+- **Ink is checked BY COLUMN after the glyph found in the RAW row**, never by
+  re-running the anchored shape regex on the masked line: claude.exe dims the
+  prompt pointer whenever isLoading, and a masked re-match would blank the
+  glyph, fail the regex, and flip a live type-ahead draft from refuse to SEND.
+  Same for dim box gutters. Empty cells serialize as spaces so columns hold.
+- Accepted residual (documented, judged unreal-rare): a ONE-character draft
+  with the cursor sitting ON that character masks to blank and would send --
+  it needs the user to type one char, arrow back onto it, and a rate-limit
+  retry to fire in that instant; the damage is a concatenated line, not a
+  menu selection.
+
+The trap for future edits: do NOT blanket-blank dim/inverse cells before the
+whole gate. Permission menus may dim their rows; blanking them before the menu
+counters would collapse a menu into a sendable pane and turn an availability
+bug into a mis-send (auto-approving a permission prompt). Attribute-awareness
+belongs to the draft signal only.

--- a/src/main/watchdog/patterns.ts
+++ b/src/main/watchdog/patterns.ts
@@ -632,31 +632,69 @@ export function canSendNow(text: string, nonDimText?: string): SendGateResult {
     nonDimLines !== null && nonDimLines.length === lines.length
       ? nonDimLines.slice(Math.max(0, nonDimLines.length - SEND_GATE_TAIL_LINES))
       : null
-  const hasInk = (rowIndex: number, re: RegExp): boolean => (nonDimTail ? re.test(nonDimTail[rowIndex] ?? '') : true)
+
+  // "Non-dim ink after the prompt glyph" — computed by COLUMN in the styled
+  // row, never by re-running the anchored shape regex on the masked line. The
+  // glyph itself renders DIM while Claude is loading (claude.exe dims the
+  // pointer on isLoading), so a masked re-match would blank the glyph, fail
+  // the regex, and flip a live type-ahead draft from refuse to SEND — the
+  // mis-send direction. The glyph is located in the RAW row; the masked row
+  // is then examined at and after that column only (and, for the boxed shape,
+  // before the closing gutter, which is chrome rather than draft ink).
+  const contentHasInk = (rowIndex: number, kind: 'caret' | 'boxed' | 'bare'): boolean => {
+    if (!nonDimTail) return true // no styled read: every raw match counts (fail closed)
+    const raw = tail[rowIndex]
+    const masked = nonDimTail[rowIndex] ?? ''
+    let start: number
+    let end = masked.length
+    if (kind === 'caret') {
+      const m = /^\s*❯/.exec(raw)
+      if (!m) return true
+      start = m[0].length
+    } else if (kind === 'bare') {
+      const m = /^\s*>/.exec(raw)
+      if (!m) return true
+      start = m[0].length
+    } else {
+      const m = /^\s*│\s*[>❯]/.exec(raw)
+      if (!m) return true
+      start = m[0].length
+      const gutter = raw.lastIndexOf('│')
+      if (gutter > start) end = gutter
+    }
+    return /\S/.test(masked.slice(start, end))
+  }
 
   let numberRows = 0
-  let caretTextRows = 0
+  let caretRowsRaw = 0
+  let caretRowsInk = 0
   for (let i = 0; i < tail.length; i++) {
     const l = tail[i]
     if (MENU_NUMBER_ROW.test(l)) numberRows++
-    if (CARET_TEXT_ROW.test(l) && hasInk(i, CARET_TEXT_ROW)) caretTextRows++
+    if (CARET_TEXT_ROW.test(l)) {
+      caretRowsRaw++
+      if (contentHasInk(i, 'caret')) caretRowsInk++
+    }
   }
 
   // A menu: two+ numbered rows (a selector always lists its alternatives; one
   // lone "1. …" can be a content list item), or two+ caret rows (an unnumbered
-  // picker with its options). Reported as 'menu'.
-  if (numberRows >= 2 || caretTextRows >= 2) return { ok: false, reason: 'menu' }
+  // picker with its options). BOTH menu signals count on the RAW text — a
+  // selector's rows may render dim (disabled options do), and an all-dim
+  // picker collapsing to a sendable pane would press Enter on its focused
+  // row. Only the DRAFT signal below is ink-filtered. Reported as 'menu'.
+  if (numberRows >= 2 || caretRowsRaw >= 2) return { ok: false, reason: 'menu' }
 
   // A single caret-with-text row is ambiguous between the filled input and a
   // one-line picker — both gate. Anywhere in the window, because the real
   // render puts a bottom rule and a footer BELOW it, so it is never the last
   // line (the bug F1 exposed). Reported as 'draft' (the commoner case).
-  if (caretTextRows >= 1) return { ok: false, reason: 'draft' }
+  if (caretRowsInk >= 1) return { ok: false, reason: 'draft' }
 
   // The boxed form, anywhere in the window.
   for (let i = 0; i < tail.length; i++) {
     const l = tail[i]
-    if (BOXED_DRAFT_ROW.test(l) && hasInk(i, BOXED_DRAFT_ROW) && !isWorkingLine(l)) {
+    if (BOXED_DRAFT_ROW.test(l) && contentHasInk(i, 'boxed') && !isWorkingLine(l)) {
       return { ok: false, reason: 'draft' }
     }
   }
@@ -672,7 +710,7 @@ export function canSendNow(text: string, nonDimText?: string): SendGateResult {
   }
   if (lastNonBlankIndex >= 0) {
     const l = tail[lastNonBlankIndex]
-    if (BARE_ASCII_DRAFT_ROW.test(l) && hasInk(lastNonBlankIndex, BARE_ASCII_DRAFT_ROW) && !isWorkingLine(l)) {
+    if (BARE_ASCII_DRAFT_ROW.test(l) && contentHasInk(lastNonBlankIndex, 'bare') && !isWorkingLine(l)) {
       return { ok: false, reason: 'draft' }
     }
   }

--- a/src/main/watchdog/patterns.ts
+++ b/src/main/watchdog/patterns.ts
@@ -603,7 +603,7 @@ export interface SendGateResult {
  * consuming an attempt. An empty prompt under a live banner is the one
  * sendable state and returns ok.
  */
-export function canSendNow(text: string): SendGateResult {
+export function canSendNow(text: string, nonDimText?: string): SendGateResult {
   // The purpose-built /rate-limit-options detector first (chrome-aware): the
   // menu a rate-limit retry is most likely to collide with.
   if (isRateLimitOptionsPrompt(text, SEND_GATE_TAIL_LINES)) return { ok: false, reason: 'menu' }
@@ -613,11 +613,33 @@ export function canSendNow(text: string): SendGateResult {
   // how the earlier revision ended up blind at exactly the wrong moment.
   const tail = lines.slice(Math.max(0, lines.length - SEND_GATE_TAIL_LINES))
 
+  // The styled companion of the same pane (#418): every DIM cell blanked to a
+  // space, lines aligned 1:1 with `text`. Claude Code renders the placeholder
+  // in an EMPTY input dim — "Press up to edit queued messages" whenever the
+  // queue is non-empty, "Message @agent…" in an agent view, "Comment on N
+  // selected lines…" over an IDE selection — states that coexist with a live
+  // rate limit indefinitely, so reading text alone made the gate defer forever
+  // and the retry silently never fired. A DRAFT row must show NON-DIM ink
+  // after its prompt glyph; a row whose after-caret text is all placeholder is
+  // the sendable empty prompt wearing a hint. Two deliberate asymmetries:
+  //   - menu rows are counted on the RAW text (a selector's unfocused rows may
+  //     render dim, and losing them would weaken the menu guard);
+  //   - no styled read, or line counts that do not match, means the styled
+  //     read is IGNORED and every caret row gates as before — the fail-closed
+  //     posture this gate has always had.
+  const nonDimLines = nonDimText !== undefined ? stripAnsi(nonDimText).split('\n') : null
+  const nonDimTail =
+    nonDimLines !== null && nonDimLines.length === lines.length
+      ? nonDimLines.slice(Math.max(0, nonDimLines.length - SEND_GATE_TAIL_LINES))
+      : null
+  const hasInk = (rowIndex: number, re: RegExp): boolean => (nonDimTail ? re.test(nonDimTail[rowIndex] ?? '') : true)
+
   let numberRows = 0
   let caretTextRows = 0
-  for (const l of tail) {
+  for (let i = 0; i < tail.length; i++) {
+    const l = tail[i]
     if (MENU_NUMBER_ROW.test(l)) numberRows++
-    if (CARET_TEXT_ROW.test(l)) caretTextRows++
+    if (CARET_TEXT_ROW.test(l) && hasInk(i, CARET_TEXT_ROW)) caretTextRows++
   }
 
   // A menu: two+ numbered rows (a selector always lists its alternatives; one
@@ -632,15 +654,27 @@ export function canSendNow(text: string): SendGateResult {
   if (caretTextRows >= 1) return { ok: false, reason: 'draft' }
 
   // The boxed form, anywhere in the window.
-  for (const l of tail) {
-    if (BOXED_DRAFT_ROW.test(l) && !isWorkingLine(l)) return { ok: false, reason: 'draft' }
+  for (let i = 0; i < tail.length; i++) {
+    const l = tail[i]
+    if (BOXED_DRAFT_ROW.test(l) && hasInk(i, BOXED_DRAFT_ROW) && !isWorkingLine(l)) {
+      return { ok: false, reason: 'draft' }
+    }
   }
 
   // The bare ASCII prompt: only as the last non-blank line, so a markdown
   // blockquote in content is never mistaken for a draft.
-  const lastNonBlank = [...tail].reverse().find((l) => l.trim() !== '')
-  if (lastNonBlank && BARE_ASCII_DRAFT_ROW.test(lastNonBlank) && !isWorkingLine(lastNonBlank)) {
-    return { ok: false, reason: 'draft' }
+  let lastNonBlankIndex = -1
+  for (let i = tail.length - 1; i >= 0; i--) {
+    if (tail[i].trim() !== '') {
+      lastNonBlankIndex = i
+      break
+    }
+  }
+  if (lastNonBlankIndex >= 0) {
+    const l = tail[lastNonBlankIndex]
+    if (BARE_ASCII_DRAFT_ROW.test(l) && hasInk(lastNonBlankIndex, BARE_ASCII_DRAFT_ROW) && !isWorkingLine(l)) {
+      return { ok: false, reason: 'draft' }
+    }
   }
   return { ok: true }
 }

--- a/src/main/watchdog/session-watchdog.ts
+++ b/src/main/watchdog/session-watchdog.ts
@@ -57,6 +57,12 @@ export interface WatchdogPublicState {
 
 export interface WatchdogAdapter {
   getTail(): string
+  /** The DIM-BLANKED companion of getTail() (#418): same lines, every dim cell
+   *  a space. The send gate uses it to tell an empty prompt wearing a dim
+   *  placeholder ("Press up to edit queued messages") from a real draft.
+   *  Optional — without it the gate reads text alone and fails closed (defers
+   *  on any caret text, placeholder or not). */
+  getTailNonDim?(): string
   isSessionAlive(): boolean
   send(text: string): void
   now(): number
@@ -417,7 +423,7 @@ export class SessionWatchdog {
    *  shows a menu or the user's draft), with the wait pushed out by `deferMs`
    *  and no attempt consumed. */
   private sendGate(tail: string, now: number, deferMs: number): boolean {
-    const gate = canSendNow(tail)
+    const gate = canSendNow(tail, this.adapter.getTailNonDim?.())
     if (gate.ok) return true
     this.waitUntil = now + deferMs
     this.adapter.log(

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -228,18 +228,48 @@ interface Entry {
 }
 
 /** Serialize the pane's last `maxLines` rendered lines (screen + genuinely
- *  scrolled-off scrollback), trailing blank rows trimmed. */
-function readPane(term: Terminal, maxLines: number): string {
+ *  scrolled-off scrollback), trailing blank rows trimmed — plus a DIM-BLANKED
+ *  companion of the same lines for the send gate (#418).
+ *
+ *  `translateToString` discards attributes, and the gate needs exactly one:
+ *  Claude Code renders the placeholder text in an EMPTY input dim ("Press up
+ *  to edit queued messages", "Message @agent…"), so text-only reading cannot
+ *  tell that `❯ <placeholder>` is the sendable empty prompt, not a draft —
+ *  which made the gate defer forever whenever a queue/agent-view placeholder
+ *  coexisted with a live rate limit. `nonDim` is the same rows with every dim
+ *  cell blanked to a space, trimmed in LOCKSTEP with `text` so the two stay
+ *  aligned line-for-line (canSendNow ignores the styled read if they are not). */
+function readPanePair(term: Terminal, maxLines: number): { text: string; nonDim: string } {
   const buf = term.buffer.active
   const total = buf.length
   const start = Math.max(0, total - maxLines)
   const out: string[] = []
+  const outNonDim: string[] = []
+  const work = buf.getNullCell()
   for (let i = start; i < total; i++) {
     const line = buf.getLine(i)
-    out.push(line ? line.translateToString(true) : '')
+    if (!line) {
+      out.push('')
+      outNonDim.push('')
+      continue
+    }
+    out.push(line.translateToString(true))
+    let masked = ''
+    for (let x = 0; x < line.length; x++) {
+      const cell = line.getCell(x, work)
+      if (!cell) continue
+      if (cell.getWidth() === 0) continue // the hidden tail cell of a wide glyph
+      const chars = cell.getChars()
+      if (cell.isDim()) masked += ' '.repeat(Math.max(1, chars.length))
+      else masked += chars.length > 0 ? chars : ' '
+    }
+    outNonDim.push(masked.replace(/\s+$/, ''))
   }
-  while (out.length > 0 && out[out.length - 1].trim() === '') out.pop()
-  return out.join('\n')
+  while (out.length > 0 && out[out.length - 1].trim() === '') {
+    out.pop()
+    outNonDim.pop()
+  }
+  return { text: out.join('\n'), nonDim: outNonDim.join('\n') }
 }
 
 function readWatchdogSettings(): WatchdogSettings {
@@ -410,7 +440,11 @@ export class WatchdogManager {
     const adapter: WatchdogAdapter = {
       getTail: () => {
         const e = this.entries.get(sessionId)
-        return e ? readPane(e.term, TAIL_MAX_LINES) : ''
+        return e ? readPanePair(e.term, TAIL_MAX_LINES).text : ''
+      },
+      getTailNonDim: () => {
+        const e = this.entries.get(sessionId)
+        return e ? readPanePair(e.term, TAIL_MAX_LINES).nonDim : ''
       },
       isSessionAlive: () => this.host.isSessionAlive(sessionId),
       send: (text: string) => this.host.send(sessionId, text),

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -239,7 +239,7 @@ interface Entry {
  *  coexisted with a live rate limit. `nonDim` is the same rows with every dim
  *  cell blanked to a space, trimmed in LOCKSTEP with `text` so the two stay
  *  aligned line-for-line (canSendNow ignores the styled read if they are not). */
-function readPanePair(term: Terminal, maxLines: number): { text: string; nonDim: string } {
+function readPanePair(term: Terminal, maxLines: number, withNonDim: boolean): { text: string; nonDim: string } {
   const buf = term.buffer.active
   const total = buf.length
   const start = Math.max(0, total - maxLines)
@@ -254,13 +254,24 @@ function readPanePair(term: Terminal, maxLines: number): { text: string; nonDim:
       continue
     }
     out.push(line.translateToString(true))
+    if (!withNonDim) {
+      outNonDim.push('')
+      continue
+    }
     let masked = ''
     for (let x = 0; x < line.length; x++) {
       const cell = line.getCell(x, work)
       if (!cell) continue
       if (cell.getWidth() === 0) continue // the hidden tail cell of a wide glyph
       const chars = cell.getChars()
-      if (cell.isDim()) masked += ' '.repeat(Math.max(1, chars.length))
+      // INVERSE is masked alongside dim (#418 review BLOCKER): the focused
+      // empty input renders its cursor as an inverse block OVER the
+      // placeholder's first character (claude.exe: i(e[0]) + dim(e.slice(1))),
+      // so a dim-only mask left `❯ P` and the gate still deferred forever.
+      // The inverse cell is the cursor, not draft ink. An empty cell keeps a
+      // SPACE, never '', so masked columns stay aligned with the raw row —
+      // the gate's ink check is by column.
+      if (cell.isDim() || cell.isInverse()) masked += ' '.repeat(Math.max(1, chars.length))
       else masked += chars.length > 0 ? chars : ' '
     }
     outNonDim.push(masked.replace(/\s+$/, ''))
@@ -440,11 +451,14 @@ export class WatchdogManager {
     const adapter: WatchdogAdapter = {
       getTail: () => {
         const e = this.entries.get(sessionId)
-        return e ? readPanePair(e.term, TAIL_MAX_LINES).text : ''
+        // No masked build here: getTail runs on every debounced feed, and the
+        // cell walk costs ~2.5x translateToString. The styled read happens
+        // only at send-gate time below.
+        return e ? readPanePair(e.term, TAIL_MAX_LINES, false).text : ''
       },
       getTailNonDim: () => {
         const e = this.entries.get(sessionId)
-        return e ? readPanePair(e.term, TAIL_MAX_LINES).nonDim : ''
+        return e ? readPanePair(e.term, TAIL_MAX_LINES, true).nonDim : ''
       },
       isSessionAlive: () => this.host.isSessionAlive(sessionId),
       send: (text: string) => this.host.send(sessionId, text),

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -258,21 +258,31 @@ function readPanePair(term: Terminal, maxLines: number, withNonDim: boolean): { 
       outNonDim.push('')
       continue
     }
-    let masked = ''
+    // Two passes: collect the visible cells, then blank dim cells and
+    // SINGLE-CELL inverse runs. The focused empty input renders its cursor as
+    // an inverse block OVER the placeholder's first character (claude.exe:
+    // i(e[0]) + dim(e.slice(1))), so a dim-only mask left `❯ P` and the gate
+    // still deferred forever (#418 review BLOCKER) — but ONLY a lone inverse
+    // cell is the cursor. A multi-cell inverse run is content: a selected
+    // range, or an atomic [Image #1] chip (claude.exe renders the whole chip
+    // inverse when the cursor snaps to its edge), and blanking those flipped
+    // a real draft into a sendable pane (round-2 MAJOR). An empty cell keeps
+    // a SPACE, never '', so masked columns stay aligned with the raw row —
+    // the gate's ink check is by column.
+    const cells: Array<{ chars: string; dim: boolean; inverse: boolean }> = []
     for (let x = 0; x < line.length; x++) {
       const cell = line.getCell(x, work)
       if (!cell) continue
       if (cell.getWidth() === 0) continue // the hidden tail cell of a wide glyph
-      const chars = cell.getChars()
-      // INVERSE is masked alongside dim (#418 review BLOCKER): the focused
-      // empty input renders its cursor as an inverse block OVER the
-      // placeholder's first character (claude.exe: i(e[0]) + dim(e.slice(1))),
-      // so a dim-only mask left `❯ P` and the gate still deferred forever.
-      // The inverse cell is the cursor, not draft ink. An empty cell keeps a
-      // SPACE, never '', so masked columns stay aligned with the raw row —
-      // the gate's ink check is by column.
-      if (cell.isDim() || cell.isInverse()) masked += ' '.repeat(Math.max(1, chars.length))
-      else masked += chars.length > 0 ? chars : ' '
+      cells.push({ chars: cell.getChars(), dim: !!cell.isDim(), inverse: !!cell.isInverse() })
+    }
+    let masked = ''
+    for (let c = 0; c < cells.length; c++) {
+      const cur = cells[c]
+      const loneInverse =
+        cur.inverse && !(c > 0 && cells[c - 1].inverse) && !(c + 1 < cells.length && cells[c + 1].inverse)
+      if (cur.dim || loneInverse) masked += ' '.repeat(Math.max(1, cur.chars.length))
+      else masked += cur.chars.length > 0 ? cur.chars : ' '
     }
     outNonDim.push(masked.replace(/\s+$/, ''))
   }

--- a/tests/unit/main/watchdog/patterns.test.ts
+++ b/tests/unit/main/watchdog/patterns.test.ts
@@ -657,6 +657,8 @@ describe('canSendNow (#266 BLOCKER-2 / MAJOR-3) — the send gate, against REAL 
       // ink check would start past 'x' and send over a real draft.
       const raw = [BANNER, RULE, '❯ x', RULE, FOOTER].join('\n')
       expect(canSendNow(raw, raw)).toEqual({ ok: false, reason: 'draft' })
+      // Same pin for the bare ASCII locator (/^\s*>/).
+      expect(canSendNow('banner\n> x', 'banner\n> x')).toEqual({ ok: false, reason: 'draft' })
     })
 
     it('an ALL-DIM unnumbered picker still reads as a menu — raw caret rows count', () => {

--- a/tests/unit/main/watchdog/patterns.test.ts
+++ b/tests/unit/main/watchdog/patterns.test.ts
@@ -567,4 +567,69 @@ describe('canSendNow (#266 BLOCKER-2 / MAJOR-3) — the send gate, against REAL 
     expect(canSendNow('banner\n> half-typed thought')).toEqual({ ok: false, reason: 'draft' })
     expect(canSendNow(`> quoted earlier\n${BANNER}`)).toEqual({ ok: true })
   })
+
+  // --- #418: the styled read. Claude Code renders placeholder text in an
+  // EMPTY input dim; the second argument is the same pane with every dim cell
+  // blanked. A caret row is a draft only if NON-DIM ink follows the caret.
+  describe('#418 dim placeholders', () => {
+    it('every real placeholder shape is the sendable empty prompt — and still defers without the styled read', () => {
+      const placeholders = [
+        'Press up to edit queued messages',
+        'Message @reviewer…',
+        'Comment on 4 selected lines…',
+        'Try "fix lint errors"', // the model-generated prompt suggestion
+      ]
+      for (const ph of placeholders) {
+        const raw = [BANNER, RULE, `❯ ${ph}`, RULE, FOOTER].join('\n')
+        const nonDim = [BANNER, RULE, '❯ ', RULE, FOOTER].join('\n')
+        expect(canSendNow(raw, nonDim), ph).toEqual({ ok: true })
+        // Text-only reading keeps the old fail-closed posture.
+        expect(canSendNow(raw).ok, `${ph} (no styled read)`).toBe(false)
+      }
+    })
+
+    it('a real draft carries non-dim ink and still gates', () => {
+      const raw = [BANNER, RULE, '❯ fix the failing auth test first', RULE, FOOTER].join('\n')
+      expect(canSendNow(raw, raw)).toEqual({ ok: false, reason: 'draft' })
+    })
+
+    it('part-typed text with a trailing dim hint gates — any non-dim ink is a draft', () => {
+      const raw = [BANNER, RULE, '❯ fix the (tab to accept)', RULE, FOOTER].join('\n')
+      const nonDim = [BANNER, RULE, '❯ fix the', RULE, FOOTER].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: false, reason: 'draft' })
+    })
+
+    it('a styled read that does not align line-for-line is IGNORED (fail closed)', () => {
+      const raw = [BANNER, RULE, '❯ Press up to edit queued messages', RULE, FOOTER].join('\n')
+      const misaligned = [BANNER, RULE, '❯ '].join('\n')
+      expect(canSendNow(raw, misaligned)).toEqual({ ok: false, reason: 'draft' })
+    })
+
+    it('menu detection stays on the RAW text — dim unfocused rows still count', () => {
+      const raw = [
+        'Do you want to run this command?',
+        '❯ 1. Yes',
+        "  2. Yes, and don't ask again",
+        '  3. No (esc)',
+      ].join('\n')
+      // A selector may render its unfocused rows dim; blanking them must not
+      // let the menu collapse to a sendable pane.
+      const nonDim = ['Do you want to run this command?', '❯ 1. Yes', '', ''].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: false, reason: 'menu' })
+    })
+
+    it('an unnumbered picker (focused row is not dim) still gates with the styled read', () => {
+      const raw = ['Review the proposed auto-mode setup?', '❯ Looks good — save it', RULE].join('\n')
+      expect(canSendNow(raw, raw).ok).toBe(false)
+    })
+
+    it('a dim placeholder in the BOXED render is sendable too; a boxed draft is not', () => {
+      const box = (inner: string) => [BANNER, '╭──────────────────────────────╮', `│ > ${inner} │`, '╰──────────────────────────────╯', FOOTER]
+      const raw = box('Press up to edit queued messages').join('\n')
+      const nonDim = [BANNER, '╭──────────────────────────────╮', '│ >  │', '╰──────────────────────────────╯', FOOTER].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: true })
+      const draft = box('fix the failing test').join('\n')
+      expect(canSendNow(draft, draft)).toEqual({ ok: false, reason: 'draft' })
+    })
+  })
 })

--- a/tests/unit/main/watchdog/patterns.test.ts
+++ b/tests/unit/main/watchdog/patterns.test.ts
@@ -623,10 +623,47 @@ describe('canSendNow (#266 BLOCKER-2 / MAJOR-3) — the send gate, against REAL 
       expect(canSendNow(raw, raw).ok).toBe(false)
     })
 
+    it('a DIM PROMPT GLYPH over a live type-ahead draft still gates (the glyph dims while loading)', () => {
+      // claude.exe dims the pointer whenever isLoading — the ink check must be
+      // by column after the glyph found in the RAW row, never a masked
+      // re-match of the whole shape (which the blanked glyph would fail,
+      // flipping refuse to SEND).
+      const raw = [BANNER, RULE, '❯ fix the failing auth test', RULE, FOOTER].join('\n')
+      const nonDim = [BANNER, RULE, '  fix the failing auth test', RULE, FOOTER].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: false, reason: 'draft' })
+    })
+
+    it('DIM box borders around a non-dim draft still gate', () => {
+      const raw = [BANNER, '╭────────────────────────╮', '│ > fix the failing test │', '╰────────────────────────╯', FOOTER].join('\n')
+      const nonDim = [BANNER, '', '    fix the failing test', '', FOOTER].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: false, reason: 'draft' })
+    })
+
+    it('a DIM bare ASCII glyph over a draft as the last line still gates', () => {
+      expect(canSendNow('banner\n> half-typed thought', 'banner\n  half-typed thought')).toEqual({
+        ok: false,
+        reason: 'draft',
+      })
+    })
+
+    it('an ALL-DIM unnumbered picker still reads as a menu — raw caret rows count', () => {
+      const raw = [
+        'Review the proposed auto-mode setup?',
+        '❯ Looks good — save it',
+        '❯ Let me adjust the arguments first',
+        RULE,
+      ].join('\n')
+      const nonDim = ['Review the proposed auto-mode setup?', '', '', RULE].join('\n')
+      expect(canSendNow(raw, nonDim)).toEqual({ ok: false, reason: 'menu' })
+    })
+
     it('a dim placeholder in the BOXED render is sendable too; a boxed draft is not', () => {
+      const ph = 'Press up to edit queued messages'
       const box = (inner: string) => [BANNER, '╭──────────────────────────────╮', `│ > ${inner} │`, '╰──────────────────────────────╯', FOOTER]
-      const raw = box('Press up to edit queued messages').join('\n')
-      const nonDim = [BANNER, '╭──────────────────────────────╮', '│ >  │', '╰──────────────────────────────╯', FOOTER].join('\n')
+      const raw = box(ph).join('\n')
+      // Column-faithful mask: the dim placeholder blanks to spaces IN PLACE,
+      // so the closing gutter stays at the same column as the raw row.
+      const nonDim = box(' '.repeat(ph.length)).join('\n')
       expect(canSendNow(raw, nonDim)).toEqual({ ok: true })
       const draft = box('fix the failing test').join('\n')
       expect(canSendNow(draft, draft)).toEqual({ ok: false, reason: 'draft' })

--- a/tests/unit/main/watchdog/patterns.test.ts
+++ b/tests/unit/main/watchdog/patterns.test.ts
@@ -646,6 +646,19 @@ describe('canSendNow (#266 BLOCKER-2 / MAJOR-3) — the send gate, against REAL 
       })
     })
 
+    it('a dim placeholder behind the BARE prompt is sendable', () => {
+      const ph = 'Press up to edit queued messages'
+      expect(canSendNow(`banner\n> ${ph}`, `banner\n> ${' '.repeat(ph.length)}`)).toEqual({ ok: true })
+    })
+
+    it('pins the glyph locator column: a one-character draft right after the caret still gates', () => {
+      // The locator is /^\s*❯/ — start = the column AFTER the glyph. If it
+      // drifted to include the first non-space (the full shape regex), the
+      // ink check would start past 'x' and send over a real draft.
+      const raw = [BANNER, RULE, '❯ x', RULE, FOOTER].join('\n')
+      expect(canSendNow(raw, raw)).toEqual({ ok: false, reason: 'draft' })
+    })
+
     it('an ALL-DIM unnumbered picker still reads as a menu — raw caret rows count', () => {
       const raw = [
         'Review the proposed auto-mode setup?',

--- a/tests/unit/main/watchdog/watchdog-manager.test.ts
+++ b/tests/unit/main/watchdog/watchdog-manager.test.ts
@@ -389,22 +389,26 @@ describe('WatchdogManager — feedData debounce', () => {
   // #418: the styled read. The placeholder in an empty input arrives as SGR
   // dim (\x1b[2m); getTailNonDim() blanks those cells so the send gate can
   // tell the empty prompt wearing a hint from a real draft.
-  it('getTailNonDim blanks DIM cells and stays line-aligned with getTail', () => {
+  it('getTailNonDim blanks the REAL placeholder render — inverse cursor block + dim tail', () => {
     const { host } = makeHost()
     const mgr = new WatchdogManager(host)
     mgr.startWatchdog('s1', { provider: 'claude' })
     const wd = instances[0]
 
+    // The exact shape claude.exe emits for a focused empty input wearing a
+    // placeholder: the FIRST character is the cursor (SGR 7 inverse), the rest
+    // is dim (#418 review BLOCKER — a dim-only mask left '❯ P' and the gate
+    // still deferred forever).
     mgr.feedData(
       's1',
-      'Claude usage limit reached. Your limit resets at 4:30pm.\r\n❯ \x1b[2mPress up to edit queued messages\x1b[22m\r\n  footer',
+      'Claude usage limit reached. Your limit resets at 4:30pm.\r\n❯ \x1b[7mP\x1b[27m\x1b[2mress up to edit queued messages\x1b[22m\r\n  footer',
     )
     vi.advanceTimersByTime(50)
 
     const text = wd.adapter.getTail() as string
     const nonDim = wd.adapter.getTailNonDim() as string
     expect(text).toContain('Press up to edit queued messages')
-    expect(nonDim).not.toContain('Press up')
+    expect(nonDim).not.toContain('P')
     expect(nonDim.split('\n').length).toBe(text.split('\n').length)
     // The caret row carries no ink after the caret in the styled read…
     const caretRow = nonDim.split('\n').find((l) => l.includes('❯'))!
@@ -412,6 +416,43 @@ describe('WatchdogManager — feedData debounce', () => {
     // …while non-dim rows come through intact.
     expect(nonDim).toContain('usage limit reached')
     expect(nonDim).toContain('footer')
+  })
+
+  it('getTailNonDim blanks the empty-input inverse-space cursor and dim WIDE glyphs', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    // Row 1: empty input, cursor = inverse space. Row 2: a dim wide-glyph
+    // hint (each glyph spans two cells; the hidden tail cell must be skipped,
+    // and each dim glyph must still blank to at least one space).
+    mgr.feedData('s1', '❯ \x1b[7m \x1b[27m\r\n❯ \x1b[2m你好\x1b[22m\r\n  footer')
+    vi.advanceTimersByTime(50)
+
+    const nonDim = (wd.adapter.getTailNonDim() as string).split('\n')
+    const text = (wd.adapter.getTail() as string).split('\n')
+    expect(nonDim.length).toBe(text.length)
+    expect(nonDim[0].trim()).toBe('❯')
+    expect(nonDim[1].trim()).toBe('❯')
+    expect(text[1]).toContain('你好')
+  })
+
+  it('getTailNonDim preserves COLUMNS across empty cells — ink lands where the raw row shows it', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    // A dim glyph at column 0, a cursor jump, then non-dim text at column 7.
+    // The gate's ink check is BY COLUMN, so the untouched cells in between
+    // must serialize as spaces, never collapse.
+    mgr.feedData('s1', '\x1b[2m❯\x1b[22m\x1b[8Gdraft\r\n  footer')
+    vi.advanceTimersByTime(50)
+
+    const nonDim = (wd.adapter.getTailNonDim() as string).split('\n')
+    expect(nonDim[0].indexOf('draft')).toBe(7)
+    expect(nonDim[0].slice(0, 7).trim()).toBe('')
   })
 
   it('getTailNonDim keeps NON-dim input text — a real draft is never blanked', () => {

--- a/tests/unit/main/watchdog/watchdog-manager.test.ts
+++ b/tests/unit/main/watchdog/watchdog-manager.test.ts
@@ -438,6 +438,42 @@ describe('WatchdogManager — feedData debounce', () => {
     expect(text[1]).toContain('你好')
   })
 
+  it('getTailNonDim keeps multi-cell INVERSE runs — an [Image #1] chip or a highlighted row is content, not a cursor', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    // claude.exe renders the whole [Image #N] chip inverse when the cursor
+    // snaps to its edge, and a selector may render its focused row inverse.
+    // Blanking those flipped a real draft into a sendable pane (round-2
+    // MAJOR): only a LONE inverse cell is the cursor.
+    mgr.feedData('s1', '❯ \x1b[7m[Image #1]\x1b[27m\r\n\x1b[7m❯ Looks good — save it\x1b[27m\r\n  footer')
+    vi.advanceTimersByTime(50)
+
+    const nonDim = (wd.adapter.getTailNonDim() as string).split('\n')
+    expect(nonDim[0]).toContain('[Image #1]')
+    expect(nonDim[1]).toContain('Looks good')
+  })
+
+  it('getTailNonDim keeps columns across WIDE glyphs — the hidden tail cell is skipped, dim wide glyphs blank in place', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    // ❯, space, dim 你 (wide), non-dim 好x. If the width-0 tail cell were
+    // serialized too, every later column would shift right of the raw row.
+    mgr.feedData('s1', '❯ \x1b[2m你\x1b[22m好x\r\n  footer')
+    vi.advanceTimersByTime(50)
+
+    const text = (wd.adapter.getTail() as string).split('\n')
+    const nonDim = (wd.adapter.getTailNonDim() as string).split('\n')
+    expect(nonDim[0].indexOf('好')).toBe(text[0].indexOf('好'))
+    expect(nonDim[0]).not.toContain('你')
+    expect(nonDim[0]).toContain('好x')
+  })
+
   it('getTailNonDim preserves COLUMNS across empty cells — ink lands where the raw row shows it', () => {
     const { host } = makeHost()
     const mgr = new WatchdogManager(host)

--- a/tests/unit/main/watchdog/watchdog-manager.test.ts
+++ b/tests/unit/main/watchdog/watchdog-manager.test.ts
@@ -386,6 +386,45 @@ describe('WatchdogManager — feedData debounce', () => {
     expect(tail).not.toContain('esc to interrupt')
   })
 
+  // #418: the styled read. The placeholder in an empty input arrives as SGR
+  // dim (\x1b[2m); getTailNonDim() blanks those cells so the send gate can
+  // tell the empty prompt wearing a hint from a real draft.
+  it('getTailNonDim blanks DIM cells and stays line-aligned with getTail', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    mgr.feedData(
+      's1',
+      'Claude usage limit reached. Your limit resets at 4:30pm.\r\n❯ \x1b[2mPress up to edit queued messages\x1b[22m\r\n  footer',
+    )
+    vi.advanceTimersByTime(50)
+
+    const text = wd.adapter.getTail() as string
+    const nonDim = wd.adapter.getTailNonDim() as string
+    expect(text).toContain('Press up to edit queued messages')
+    expect(nonDim).not.toContain('Press up')
+    expect(nonDim.split('\n').length).toBe(text.split('\n').length)
+    // The caret row carries no ink after the caret in the styled read…
+    const caretRow = nonDim.split('\n').find((l) => l.includes('❯'))!
+    expect(caretRow.trim()).toBe('❯')
+    // …while non-dim rows come through intact.
+    expect(nonDim).toContain('usage limit reached')
+    expect(nonDim).toContain('footer')
+  })
+
+  it('getTailNonDim keeps NON-dim input text — a real draft is never blanked', () => {
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const wd = instances[0]
+
+    mgr.feedData('s1', 'banner\r\n❯ fix the failing test\r\n  footer')
+    vi.advanceTimersByTime(50)
+    expect(wd.adapter.getTailNonDim() as string).toContain('❯ fix the failing test')
+  })
+
   it('lone-\\r spinner redraws overwrite one row instead of growing without bound', () => {
     const { host } = makeHost()
     const mgr = new WatchdogManager(host)


### PR DESCRIPTION
Closes #418 (follow-up from the #266 ADR-009 review, finding N1).

## The bug
`canSendNow` treats any `❯ <text>` row as a draft/picker and defers (fail closed). But Claude Code renders **dim placeholder text** in an otherwise-empty input — `Press up to edit queued messages` (non-empty queue), `Message @agent…`, `Comment on N selected lines…`, the model-generated prompt suggestion — all states that coexist with a live rate limit indefinitely. The watchdog deferred forever: the auto-retry **silently never fired** exactly when it should have.

## The fix — the issue's styled-read option, not a denylist
- `readPanePair` (watchdog-manager) serializes the headless pane twice from one buffer walk: `text` (translateToString — unchanged for every other detector) and `nonDim` — the same rows with every **dim cell blanked to a space**, trailing blanks trimmed in lockstep so the two stay aligned line-for-line.
- `canSendNow(text, nonDimText?)`: a caret/boxed/bare-prompt row counts as a **draft** only if non-dim ink follows the prompt glyph in the aligned styled row.
- Two deliberate asymmetries, both in the mis-send-safe direction:
  - **menu rows are counted on the RAW text** — a selector's unfocused rows may render dim, and blanking them would collapse a permission menu into a sendable pane (an auto-approve, the #266 BLOCKER-2 scenario);
  - **a missing or misaligned styled read is ignored** — the gate reverts to text-only and defers on any caret text, the old fail-closed posture. The adapter method is optional, so text-only tail sources keep working.

## Tests
- `patterns.test.ts`: all four real placeholder shapes sendable with the styled read AND still deferred without it; real draft / part-typed-with-dim-hint still gate; misaligned styled read ignored; dim unfocused menu rows still count; boxed-render placeholder.
- `watchdog-manager.test.ts`: real `@xterm/headless` terminal fed SGR `\x1b[2m` — dim cells blanked, line counts aligned, non-dim draft text never blanked.

Full suite 8168/0 local; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)