### PR TITLE
feat(watchdog): thread the config knobs from settings — pattern lists stay compiled-in (#419 F13)

### DIFF
--- a/CONTEXT.d/2026-08-23-419-watchdog-config-threading.md
+++ b/CONTEXT.d/2026-08-23-419-watchdog-config-threading.md
@@ -1,0 +1,20 @@
+## 2026-08-23 -- #419 (partial): the watchdog config knobs become reachable; the pattern lists deliberately do not
+
+F13 from the #266 review: WatchdogManager threaded only `retryMessage` +
+`maxRetries` into a SessionWatchdog, so `overload.*`, `safeguard.*`,
+`marginSeconds`, and `fallbackWaitHours` were unreachable even by hand-editing
+settings.json. Now `threadedWatchdogConfig` passes them through, with
+`resolveWatchdogConfig` staying the single validator (every field fail-safes
+to the default).
+
+**The one thing NOT threaded, on purpose: the `patterns` lists.** settings.json
+is renderer-writable, and the overload/safeguard patterns decide WHEN the
+watchdog types into the user's PTY -- a hostile but regex-valid list could
+turn ordinary session output into a retry storm. The #266 review counted their
+unreachability as a security property; `threadedWatchdogConfig` strips
+`patterns` from both blocks before handing over, and a test pins that.
+
+Left open on #419 (noted on the issue): F11's live-apply half (enabling the
+feature mid-session still waits for the next spawn; `applySettings` handles
+the disable direction only), F12 (Settings page writes on every keystroke),
+N2 (screen-reader-mode gate blind spot), N3 (volumetric clamped-REP residual).

--- a/src/main/watchdog/config.ts
+++ b/src/main/watchdog/config.ts
@@ -73,12 +73,17 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
-function positiveNumber(v: unknown, fallback: number): number {
-  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : fallback
-}
-
-function nonNegativeNumber(v: unknown, fallback: number): number {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : fallback
+/**
+ * A tuning knob with a hard floor and ceiling (#419 review). These fields
+ * became settings.json-reachable with F13; a degenerate value cannot open a
+ * new injection path (the tick cadence bounds the send rate and the message
+ * is sanitized), but sub-second backoffs and effectively-infinite caps turn
+ * the retry loops into a self-DoS. Out-of-range values fall back rather than
+ * clamp — a config that far off is a mistake, and the default is the honest
+ * resolution of a mistake.
+ */
+function boundedNumber(v: unknown, fallback: number, min: number, max: number): number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max ? v : fallback
 }
 
 function boolean(v: unknown, fallback: boolean): boolean {
@@ -119,7 +124,7 @@ function sanitizedRetryMessage(v: unknown, fallback: string): string {
 
 function positiveNumberArray(v: unknown, fallback: number[]): number[] {
   if (!Array.isArray(v) || v.length === 0) return fallback
-  const cleaned = v.filter((n): n is number => typeof n === 'number' && Number.isFinite(n) && n > 0)
+  const cleaned = v.filter((n): n is number => typeof n === 'number' && Number.isFinite(n) && n >= 1 && n <= 3600)
   return cleaned.length === v.length ? cleaned : fallback
 }
 
@@ -138,9 +143,9 @@ function resolveOverload(partial: unknown, defaultRetryMessage: string): Overloa
   return {
     enabled: boolean(p.enabled, DEFAULT_OVERLOAD.enabled),
     backoffSeconds: positiveNumberArray(p.backoffSeconds, DEFAULT_OVERLOAD.backoffSeconds),
-    steadyStateSeconds: positiveNumber(p.steadyStateSeconds, DEFAULT_OVERLOAD.steadyStateSeconds),
-    jitterPct: nonNegativeNumber(p.jitterPct, DEFAULT_OVERLOAD.jitterPct),
-    maxTotalWaitMinutes: positiveNumber(p.maxTotalWaitMinutes, DEFAULT_OVERLOAD.maxTotalWaitMinutes),
+    steadyStateSeconds: boundedNumber(p.steadyStateSeconds, DEFAULT_OVERLOAD.steadyStateSeconds, 1, 86_400),
+    jitterPct: boundedNumber(p.jitterPct, DEFAULT_OVERLOAD.jitterPct, 0, 100),
+    maxTotalWaitMinutes: boundedNumber(p.maxTotalWaitMinutes, DEFAULT_OVERLOAD.maxTotalWaitMinutes, 1, 1_440),
     retryMessage: sanitizedRetryMessage(p.retryMessage, defaultRetryMessage),
     patterns: stringArray(p.patterns, DEFAULT_OVERLOAD.patterns),
   }
@@ -150,8 +155,8 @@ function resolveSafeguard(partial: unknown, defaultRetryMessage: string): Safegu
   const p = isPlainObject(partial) ? partial : {}
   return {
     enabled: boolean(p.enabled, DEFAULT_SAFEGUARD.enabled),
-    maxRetries: positiveNumber(p.maxRetries, DEFAULT_SAFEGUARD.maxRetries),
-    retryDelaySeconds: positiveNumber(p.retryDelaySeconds, DEFAULT_SAFEGUARD.retryDelaySeconds),
+    maxRetries: boundedNumber(p.maxRetries, DEFAULT_SAFEGUARD.maxRetries, 1, 100),
+    retryDelaySeconds: boundedNumber(p.retryDelaySeconds, DEFAULT_SAFEGUARD.retryDelaySeconds, 1, 3600),
     retryMessage: sanitizedRetryMessage(p.retryMessage, defaultRetryMessage),
     patterns: stringArray(p.patterns, DEFAULT_SAFEGUARD.patterns),
   }
@@ -161,9 +166,9 @@ export function resolveWatchdogConfig(partial?: unknown): WatchdogConfig {
   const p = isPlainObject(partial) ? partial : {}
   const retryMessage = sanitizedRetryMessage(p.retryMessage, DEFAULT_WATCHDOG_CONFIG.retryMessage)
   return {
-    maxRetries: positiveNumber(p.maxRetries, DEFAULT_WATCHDOG_CONFIG.maxRetries),
-    marginSeconds: nonNegativeNumber(p.marginSeconds, DEFAULT_WATCHDOG_CONFIG.marginSeconds),
-    fallbackWaitHours: positiveNumber(p.fallbackWaitHours, DEFAULT_WATCHDOG_CONFIG.fallbackWaitHours),
+    maxRetries: boundedNumber(p.maxRetries, DEFAULT_WATCHDOG_CONFIG.maxRetries, 1, 100),
+    marginSeconds: boundedNumber(p.marginSeconds, DEFAULT_WATCHDOG_CONFIG.marginSeconds, 0, 3600),
+    fallbackWaitHours: boundedNumber(p.fallbackWaitHours, DEFAULT_WATCHDOG_CONFIG.fallbackWaitHours, 1, 24),
     retryMessage,
     overload: resolveOverload(p.overload, retryMessage),
     safeguard: resolveSafeguard(p.safeguard, retryMessage),

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -189,6 +189,41 @@ export interface WatchdogSettings {
   /** Silence window (ms). A session with no PTY output for this long is marked
    *  "silent". 0 disables. Absent = DEFAULT_SILENCE_WINDOW_MS. */
   silenceWindowMs?: number
+  /** #419 F13 — the rest of the WatchdogConfig knobs, reachable from
+   *  settings.json. Typed loosely on purpose: `resolveWatchdogConfig` is the
+   *  one validator/sanitizer, and it fail-safes every field. The per-block
+   *  `patterns` lists are stripped before threading (see
+   *  threadedWatchdogConfig) and stay compiled-in. */
+  marginSeconds?: number
+  fallbackWaitHours?: number
+  overload?: unknown
+  safeguard?: unknown
+}
+
+/**
+ * The settings keys threaded into a SessionWatchdog's config (#419 F13).
+ * `resolveWatchdogConfig` remains the validator — this only decides WHAT is
+ * reachable from settings.json. The overload/safeguard `patterns` lists are
+ * deliberately NOT threaded: settings.json is renderer-writable, and the
+ * patterns decide WHEN the watchdog types into the user's PTY — a hostile but
+ * regex-valid pattern list could turn ordinary output into a retry storm.
+ * They stay compiled-in (the #266 review counted that unreachability as a
+ * security property; keep it).
+ */
+function threadedWatchdogConfig(settings: WatchdogSettings): Record<string, unknown> {
+  const dropPatterns = (block: unknown): unknown => {
+    if (typeof block !== 'object' || block === null || Array.isArray(block)) return block
+    const { patterns: _patterns, ...rest } = block as Record<string, unknown>
+    return rest
+  }
+  return {
+    retryMessage: settings.retryMessage,
+    maxRetries: settings.maxRetries,
+    marginSeconds: settings.marginSeconds,
+    fallbackWaitHours: settings.fallbackWaitHours,
+    ...(settings.overload !== undefined ? { overload: dropPatterns(settings.overload) } : {}),
+    ...(settings.safeguard !== undefined ? { safeguard: dropPatterns(settings.safeguard) } : {}),
+  }
 }
 
 export interface WatchdogHostOptions {
@@ -482,10 +517,7 @@ export class WatchdogManager {
       onStateChange: (state: WatchdogPublicState) => this.pushState(state),
     }
 
-    const wd = new SessionWatchdog(sessionId, adapter, {
-      retryMessage: settings.retryMessage,
-      maxRetries: settings.maxRetries,
-    })
+    const wd = new SessionWatchdog(sessionId, adapter, threadedWatchdogConfig(settings))
     const term = new Terminal({
       cols: info?.cols ?? DEFAULT_COLS,
       rows: info?.rows ?? DEFAULT_ROWS,

--- a/tests/unit/main/watchdog/config.test.ts
+++ b/tests/unit/main/watchdog/config.test.ts
@@ -155,3 +155,44 @@ describe('resolveWatchdogConfig — retryMessage sanitization (single-submit / c
     expect(c.retryMessage).toBe('continue')
   })
 })
+
+// #419 review: the F13-reachable numeric knobs carry hard floors and ceilings.
+// A degenerate value falls back to the default rather than clamping — a config
+// that far off is a mistake, and the default is the honest resolution.
+describe('bounded numeric knobs (#419)', () => {
+  it('rejects sub-second and absurd values back to defaults', () => {
+    const c = resolveWatchdogConfig({
+      maxRetries: 1e9,
+      marginSeconds: 1e9,
+      fallbackWaitHours: 0.0001,
+      overload: {
+        backoffSeconds: [0.001, 20],
+        steadyStateSeconds: 1e-9,
+        jitterPct: 100000,
+        maxTotalWaitMinutes: 1e9,
+      },
+      safeguard: { maxRetries: 1e9, retryDelaySeconds: 0.001 },
+    })
+    expect(c.maxRetries).toBe(DEFAULT_WATCHDOG_CONFIG.maxRetries)
+    expect(c.marginSeconds).toBe(DEFAULT_WATCHDOG_CONFIG.marginSeconds)
+    expect(c.fallbackWaitHours).toBe(DEFAULT_WATCHDOG_CONFIG.fallbackWaitHours)
+    expect(c.overload.backoffSeconds).toEqual(DEFAULT_OVERLOAD.backoffSeconds)
+    expect(c.overload.steadyStateSeconds).toBe(DEFAULT_OVERLOAD.steadyStateSeconds)
+    expect(c.overload.jitterPct).toBe(DEFAULT_OVERLOAD.jitterPct)
+    expect(c.overload.maxTotalWaitMinutes).toBe(DEFAULT_OVERLOAD.maxTotalWaitMinutes)
+    expect(c.safeguard.maxRetries).toBe(DEFAULT_SAFEGUARD.maxRetries)
+    expect(c.safeguard.retryDelaySeconds).toBe(DEFAULT_SAFEGUARD.retryDelaySeconds)
+  })
+
+  it('accepts sane in-range tuning', () => {
+    const c = resolveWatchdogConfig({
+      maxRetries: 10,
+      overload: { backoffSeconds: [15, 45], maxTotalWaitMinutes: 240 },
+      safeguard: { retryDelaySeconds: 30 },
+    })
+    expect(c.maxRetries).toBe(10)
+    expect(c.overload.backoffSeconds).toEqual([15, 45])
+    expect(c.overload.maxTotalWaitMinutes).toBe(240)
+    expect(c.safeguard.retryDelaySeconds).toBe(30)
+  })
+})

--- a/tests/unit/main/watchdog/watchdog-manager.test.ts
+++ b/tests/unit/main/watchdog/watchdog-manager.test.ts
@@ -574,6 +574,45 @@ describe('WatchdogManager — StopFailure hook forwarding', () => {
   })
 })
 
+describe('WatchdogManager — config threading (#419 F13)', () => {
+  it('threads every knob from settings into the SessionWatchdog config', () => {
+    watchdogSettings = {
+      enabled: true,
+      retryMessage: 'keep going',
+      maxRetries: 7,
+      marginSeconds: 90,
+      fallbackWaitHours: 2,
+      overload: { backoffSeconds: [10, 20], jitterPct: 5, patterns: ['EVIL('] },
+      safeguard: { retryDelaySeconds: 3, patterns: ['ALSO EVIL'] },
+    }
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const cfg = instances[0].config as Record<string, any>
+    expect(cfg.retryMessage).toBe('keep going')
+    expect(cfg.maxRetries).toBe(7)
+    expect(cfg.marginSeconds).toBe(90)
+    expect(cfg.fallbackWaitHours).toBe(2)
+    expect(cfg.overload).toMatchObject({ backoffSeconds: [10, 20], jitterPct: 5 })
+    expect(cfg.safeguard).toMatchObject({ retryDelaySeconds: 3 })
+    // The pattern lists are NEVER threaded — they decide when the watchdog
+    // types into the user's PTY and stay compiled-in (#266 review, security
+    // property). resolveWatchdogConfig then fills the defaults.
+    expect(cfg.overload).not.toHaveProperty('patterns')
+    expect(cfg.safeguard).not.toHaveProperty('patterns')
+  })
+
+  it('threads nothing surprising when the extra knobs are absent', () => {
+    watchdogSettings = { enabled: true, retryMessage: 'continue', maxRetries: 3 }
+    const { host } = makeHost()
+    const mgr = new WatchdogManager(host)
+    mgr.startWatchdog('s1', { provider: 'claude' })
+    const cfg = instances[0].config as Record<string, any>
+    expect(cfg.overload).toBeUndefined()
+    expect(cfg.safeguard).toBeUndefined()
+  })
+})
+
 describe('WatchdogManager — adapter wiring', () => {
   it('adapter.send/isSessionAlive delegate to the host, scoped to the session id', () => {
     const { host, send, isSessionAlive } = makeHost()


### PR DESCRIPTION
Partial for #419 — the config-threading half (F13). The rest (F11 live-apply, F12 debounce, N2 screen-reader, N3 volumetric) stays open on the issue with a note.

- `threadedWatchdogConfig` passes `marginSeconds`, `fallbackWaitHours`, `overload.*`, `safeguard.*` from settings.json into the SessionWatchdog; `resolveWatchdogConfig` remains the single validator and fail-safes every field.
- **The `patterns` lists are deliberately NOT threaded**: settings.json is renderer-writable, and the patterns decide WHEN the watchdog types into the user's PTY — the #266 review counted their unreachability as a security property. They are stripped before hand-over and a test pins it.

Full suite 8180/0 local, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)