### PR TITLE
fix(release): the gate exempts in-beta issues — done-for-this-release is not outstanding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
   # ── Release gate (#375, #385) ──
   # Refuse the cut before a single installer is built: the GitHub milestone
   # titled after package.json's version must have no open issue without the
-  # `excluded` label (a missing milestone fails closed), and
+  # `excluded` or `in-beta` label (an open in-beta issue is done for this
+  # release; a missing milestone fails closed), and
   # resources/model-registry.json must cover every model in Anthropic's Claude
   # Code model configuration article (scripts/fixtures/ holds the expected set).
   # Every build job `needs` this one. Read-only: GITHUB_TOKEN with issues:read.

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -15,7 +15,9 @@
 // Checks
 //   1. MILESTONE  The GitHub milestone titled exactly <version> (e.g.
 //      "2.1.0-beta.17") must exist and have no open issue without the
-//      `excluded` label. Pull requests on the milestone are ignored (they are
+//      `excluded` or `in-beta` label (an open in-beta issue is done for this
+//      release — the lifecycle keeps it open until promotion auto-closes it).
+//      Pull requests on the milestone are ignored (they are
 //      not book-of-work items). A MISSING milestone fails closed: the gate
 //      cannot tell "nothing outstanding" from "nobody made the list".
 //   2. MODELS  Every id in the support article's "Supported models" table
@@ -59,10 +61,13 @@ export const EXCLUDED_LABEL = 'excluded'
 /**
  * The issue-lifecycle label (CONTRIBUTING.md): applied when an issue's fix
  * MERGES TO BETA, removed never — the issue stays open until promotion to
- * main auto-closes it. An open `in-beta` issue is therefore DONE for the
- * release being cut, not outstanding work, and the gate must not refuse on
- * it — otherwise the gate and the lifecycle make every cut impossible
- * together. Counted separately so the output still says what is riding along.
+ * main auto-closes it. The gate TRUSTS that label here: an open `in-beta`
+ * issue is treated as done for the release being cut, because refusing on it
+ * would make the gate and the lifecycle jointly forbid every cut. The label
+ * is applied by hand on the beta merge, so this is a trust in the lifecycle
+ * being followed, not a verification that a fix merged — the same trust
+ * `excluded` already extends. Counted separately so the output still says
+ * what is riding along.
  */
 export const IN_BETA_LABEL = 'in-beta'
 export const DEFAULT_REGISTRY_PATH = path.join(ROOT, 'resources', 'model-registry.json')
@@ -86,7 +91,8 @@ function labelNames(labels) {
  * @param {Array<{number:number,title:string,labels?:any[],pull_request?:object,state?:string}>} input.issues
  *        open issues ON that milestone (already filtered by the API; re-filtered here defensively)
  * @param {string} [input.excludedLabel]
- * @returns {{ ok: boolean, reason: string|null, milestone: object|null, blocking: Array<{number:number,title:string,labels:string[]}>, excluded: Array<{number:number,title:string}> }}
+ * @param {string} [input.inBetaLabel]
+ * @returns {{ ok: boolean, reason: string|null, milestone: object|null, blocking: Array<{number:number,title:string,labels:string[]}>, excluded: Array<{number:number,title:string}>, shipped: Array<{number:number,title:string}> }}
  */
 export function evaluateMilestone({ version, milestones, issues, excludedLabel = EXCLUDED_LABEL, inBetaLabel = IN_BETA_LABEL }) {
   const title = String(version || '').trim()

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -56,6 +56,15 @@ export const EXIT_REFUSED = 1
 export const EXIT_CANNOT_EVALUATE = 2
 
 export const EXCLUDED_LABEL = 'excluded'
+/**
+ * The issue-lifecycle label (CONTRIBUTING.md): applied when an issue's fix
+ * MERGES TO BETA, removed never — the issue stays open until promotion to
+ * main auto-closes it. An open `in-beta` issue is therefore DONE for the
+ * release being cut, not outstanding work, and the gate must not refuse on
+ * it — otherwise the gate and the lifecycle make every cut impossible
+ * together. Counted separately so the output still says what is riding along.
+ */
+export const IN_BETA_LABEL = 'in-beta'
 export const DEFAULT_REGISTRY_PATH = path.join(ROOT, 'resources', 'model-registry.json')
 // Lives under resources/ (not scripts/fixtures/) so the packaged app can read
 // the SAME snapshot: the Sentinel model check imports it at runtime (#385).
@@ -79,31 +88,37 @@ function labelNames(labels) {
  * @param {string} [input.excludedLabel]
  * @returns {{ ok: boolean, reason: string|null, milestone: object|null, blocking: Array<{number:number,title:string,labels:string[]}>, excluded: Array<{number:number,title:string}> }}
  */
-export function evaluateMilestone({ version, milestones, issues, excludedLabel = EXCLUDED_LABEL }) {
+export function evaluateMilestone({ version, milestones, issues, excludedLabel = EXCLUDED_LABEL, inBetaLabel = IN_BETA_LABEL }) {
   const title = String(version || '').trim()
   const milestone = (milestones || []).find((m) => m && String(m.title).trim() === title) || null
   if (!milestone) {
     return {
       ok: false,
       reason: `no GitHub milestone titled "${title}" — create it (and put the release's issues on it) before cutting; the gate fails closed on a missing milestone`,
-      milestone: null, blocking: [], excluded: [],
+      milestone: null, blocking: [], excluded: [], shipped: [],
     }
   }
   const blocking = []
   const excluded = []
+  const shipped = []
   for (const it of issues || []) {
     if (!it || it.pull_request) continue          // PRs are not book-of-work items
     if (it.state && it.state !== 'open') continue
     const labels = labelNames(it.labels)
     if (labels.includes(excludedLabel)) excluded.push({ number: it.number, title: it.title })
+    // The lifecycle keeps a DONE issue open until promotion, marked `in-beta`
+    // when its fix merged to beta. That is the release being cut, so it is
+    // shipping work, not outstanding work.
+    else if (labels.includes(inBetaLabel)) shipped.push({ number: it.number, title: it.title })
     else blocking.push({ number: it.number, title: it.title, labels })
   }
   blocking.sort((a, b) => a.number - b.number)
   excluded.sort((a, b) => a.number - b.number)
+  shipped.sort((a, b) => a.number - b.number)
   return {
     ok: blocking.length === 0,
-    reason: blocking.length === 0 ? null : `${blocking.length} open issue(s) on milestone "${title}" without the "${excludedLabel}" label`,
-    milestone, blocking, excluded,
+    reason: blocking.length === 0 ? null : `${blocking.length} open issue(s) on milestone "${title}" without the "${excludedLabel}" or "${inBetaLabel}" label`,
+    milestone, blocking, excluded, shipped,
   }
 }
 
@@ -171,13 +186,15 @@ export function formatReport({ version, repo, milestoneResult, modelsResult, exp
   if (milestoneResult) {
     const mr = milestoneResult
     if (mr.ok) {
-      out.push(`  OK    milestone "${version}" (#${mr.milestone.number}) has no open issues left` +
+      out.push(`  OK    milestone "${version}" (#${mr.milestone.number}) has no outstanding issues` +
+        ((mr.shipped || []).length ? ` (${mr.shipped.length} shipping in this release: ${mr.shipped.map((i) => `#${i.number}`).join(' ')})` : '') +
         (mr.excluded.length ? ` (${mr.excluded.length} excluded by the owner: ${mr.excluded.map((i) => `#${i.number}`).join(' ')})` : ''))
     } else {
       out.push(`  FAIL  milestone: ${mr.reason}`)
       for (const i of mr.blocking) out.push(`          #${i.number}  ${i.title}${i.labels.length ? `  [${i.labels.join(', ')}]` : ''}`)
+      if ((mr.shipped || []).length) out.push(`          (in-beta, shipping in this release: ${mr.shipped.map((i) => `#${i.number}`).join(' ')})`)
       if (mr.excluded.length) out.push(`          (excluded, not counted: ${mr.excluded.map((i) => `#${i.number}`).join(' ')})`)
-      if (mr.milestone) out.push(`          Close them, move them to a later milestone, or have the owner label them "${EXCLUDED_LABEL}".`)
+      if (mr.milestone) out.push(`          Merge their fixes (label "${IN_BETA_LABEL}"), close them, move them to a later milestone, or have the owner label them "${EXCLUDED_LABEL}".`)
     }
   }
   // ── models

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -489,7 +489,7 @@ try {
   ok(`Release gate passed for v${version}`)
 } catch {
   fail(`RELEASE GATE REFUSED v${version} — see the FAIL lines above.\n      ` +
-    'Close or move the open milestone issues (or have the owner label them "excluded"),\n      ' +
+    'Merge their fixes (label "in-beta"), close or move the open milestone issues (or have the owner label them "excluded"),\n      ' +
     'and align resources/model-registry.json with the Claude Code model configuration article.')
 }
 
@@ -634,7 +634,7 @@ try {
       runInherit(`node scripts/release-gate.mjs --version ${version}`)
     } catch {
       fail(`RELEASE GATE REFUSED v${version} before the stale-release delete — the existing ${tag} release is left intact.\n      ` +
-        'Resolve the open milestone issues (or label them "excluded") and re-run.')
+        'Resolve the open milestone issues (merge + label "in-beta", close, or label "excluded") and re-run.')
     }
     warn(`A release for ${tag} already exists — deleting so the workflow can recreate cleanly`)
     run(`gh release delete ${tag} --yes`)

--- a/tests/unit/scripts/release-gate.test.ts
+++ b/tests/unit/scripts/release-gate.test.ts
@@ -8,6 +8,7 @@ import { resolve } from 'path'
 import {
   evaluateMilestone,
   evaluateModels,
+  formatReport,
   registryIdCovers,
   repoFromUrl,
   repoFromPackageJson,
@@ -105,6 +106,33 @@ describe('release-gate evaluateMilestone', () => {
     expect(r.ok).toBe(true)
     expect(r.shipped.map((i) => i.number)).toEqual([373, 377])
     expect(r.blocking).toEqual([])
+  })
+
+  it('the FAIL report lists blockers, the in-beta riders, and the in-beta remediation route', () => {
+    const issues: Issue[] = [
+      { number: 373, title: 'shipped', labels: ['in-beta'] },
+      { number: 412, title: 'still outstanding', labels: ['enhancement'] },
+    ]
+    const mr = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    const text = formatReport({ version: '2.1.0-beta.17', repo: 'o/r', milestoneResult: mr, modelsResult: null, expectedMeta: null }).join('\n')
+    expect(text).toContain('#412  still outstanding')
+    expect(text).toContain('(in-beta, shipping in this release: #373)')
+    expect(text).toContain('Merge their fixes (label "in-beta")')
+  })
+
+  it('the OK report names what is shipping', () => {
+    const mr = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues: [{ number: 373, title: 's', labels: ['in-beta'] }] })
+    const text = formatReport({ version: '2.1.0-beta.17', repo: 'o/r', milestoneResult: mr, modelsResult: null, expectedMeta: null }).join('\n')
+    expect(text).toContain('has no outstanding issues')
+    expect(text).toContain('(1 shipping in this release: #373)')
+  })
+
+  it('an issue carrying BOTH labels lands in excluded — the stronger owner claim wins', () => {
+    const issues: Issue[] = [{ number: 1, title: 'x', labels: ['excluded', 'in-beta'] }]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(true)
+    expect(r.excluded.map((i) => i.number)).toEqual([1])
+    expect(r.shipped).toEqual([])
   })
 
   it('an in-beta issue does not shield a genuinely open one beside it', () => {

--- a/tests/unit/scripts/release-gate.test.ts
+++ b/tests/unit/scripts/release-gate.test.ts
@@ -96,6 +96,29 @@ describe('release-gate evaluateMilestone', () => {
     expect(r.ok).toBe(true)
   })
 
+  it('an open in-beta issue is DONE for this release, not outstanding — the lifecycle keeps it open until promotion', () => {
+    const issues: Issue[] = [
+      { number: 373, title: 'Canvas: per-note A/B/C approve', labels: [{ name: 'in-beta' }, { name: 'canvas' }] },
+      { number: 377, title: 'Tips re-review', labels: [{ name: 'in-beta' }] },
+    ]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(true)
+    expect(r.shipped.map((i) => i.number)).toEqual([373, 377])
+    expect(r.blocking).toEqual([])
+  })
+
+  it('an in-beta issue does not shield a genuinely open one beside it', () => {
+    const issues: Issue[] = [
+      { number: 373, title: 'shipped', labels: [{ name: 'in-beta' }] },
+      { number: 412, title: 'still outstanding', labels: [{ name: 'enhancement' }] },
+    ]
+    const r = evaluateMilestone({ version: '2.1.0-beta.17', milestones, issues })
+    expect(r.ok).toBe(false)
+    expect(r.blocking.map((i) => i.number)).toEqual([412])
+    expect(r.shipped.map((i) => i.number)).toEqual([373])
+    expect(r.reason).toContain('"in-beta"')
+  })
+
   it('ignores pull requests and non-open items on the milestone', () => {
     const issues: Issue[] = [
       { number: 390, title: 'feat: something', pull_request: { url: 'x' } },


### PR DESCRIPTION
First real cut with the #375 gate exposed a rules collision: the gate refuses on ANY open milestone issue, but CONTRIBUTING's lifecycle keeps a DONE issue open (`in-beta` on merge-to-beta) until promotion auto-closes it. Under both rules together no beta can ever be cut.

Reconciliation: an open `in-beta` issue is DONE for the release being cut — its fix is in the very build being released — so the gate counts it separately as "shipping in this release" and does not block. A bare open issue (no `in-beta`, no `excluded`) still blocks exactly as before; `excluded` semantics unchanged; missing milestone still fails closed.

Live dry-run against the real milestone: PASS — 27 shipping, 0 blocking, models covered. Tests extended (in-beta passes + does not shield a bare open issue beside it); 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)