### PR TITLE
build(release): 2.1.0-beta.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-beta.16",
+  "version": "2.1.0-beta.17",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump for the 2.1.0-beta.17 cut. Changelog entry + CHANGELOG.md already landed in #425. Release gate: PASS (27 shipping in-beta, 0 blocking, models covered).

By-number scope (feedback rule — the full in/out list):
- **IN (27, all in-beta):** #358 #359 #360 #361 #362 #363 #364 #365 #366 #367 #368 #369 #370 #371 #372 #373 #375 #377 #378 #379 #380 #381 #382 #383 #384 #385 #398 — plus off-milestone work shipped on beta: #266/#235 (watchdog), #397/#413 (session durability), #411 (pricing re-price), #417/#368 (zoom), #418 (send-gate placeholders), #419-F13 (config knobs), #426-adjacent gate fix (#427), and the GHSA-49cm security fix (publish after cut, patched = 2.1.0-beta.17).
- **OUT (deliberate, owner's items):** #309 (make desktop gate required — repo settings), #226/#128 (dev tooling), #172 (signing-key decision), #412 (Ask Conductor reach decision), #415 (no release label), #419's remaining halves (F11 live-apply, F12, N2, N3 — noted on the issue), #426 (command-secret line-scan follow-up), #428 (gate hardening follow-up), #374 (closed, owner decision recorded).

After merge: dispatch release.yml from beta (channel=beta, skip_vt=false) and watch to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)