### PR TITLE
fix(sentinel): surface the real analysis failure reason (rate limit) and name the account (#430)

### DIFF
--- a/CONTEXT.d/2026-08-23-430-sentinel-ratelimit-message.md
+++ b/CONTEXT.d/2026-08-23-430-sentinel-ratelimit-message.md
@@ -1,0 +1,41 @@
+## 2026-08-23 -- #430 Sentinel: a rate-limited analysis account showed the vague "could not complete"
+
+First bug found installing beta.17. The Sentinel panel said "AI analysis could
+not complete this run. The deterministic checks still ran. Use Re-run to try
+again." Re-run did nothing.
+
+**Root cause (from the live install log + a direct repro).** `claude --version`
+succeeded, but `claude -p --model sonnet --output-format json` exited **1**
+fast (~2s, not a timeout). The `-p` envelope on stdout carried the real reason:
+`is_error: true`, `api_error_status: 429`, `result: "You've hit your weekly
+limit · resets 4am (Europe/London)"`. `analysisFailureMessage` only ever
+special-cased the word "timed out" in **stderr** — it never looked at the
+stdout envelope — so every non-timeout failure, a 429 included, collapsed to
+the generic line. Re-run is futile against a weekly limit, and nothing said so.
+
+Two install-side facts made it bite: the configured `sentinelAccountProfileId`
+no longer existed on disk, so `resolveHeadlessProfileHome` fell back to the
+first signed-in profile — which happened to be the weekly-limited one — and
+nothing named which account was in use.
+
+**Fix (this PR).**
+- `envelopeError(stdout)` reads the RAW top-level `-p` envelope (NOT
+  `unwrapPayload`, which peels `.result` — on an error that field is the human
+  string, not nested JSON; routing through it was the first-cut bug, now a
+  regression test). It returns `{ rateLimited, reason }` from
+  `api_error_status` / `is_error` / `terminal_reason`, with `result` cleaned
+  (control chars stripped) and capped at 160 chars.
+- `analysisFailureMessage(stderr, envErr?, accountLabel?)` now says the real
+  reason and NAMES the account: a rate limit reads "The Sentinel analysis
+  account (email) has hit its usage limit — <reason>. Pick a different account
+  in Settings → Sentinel, or Re-run once it resets."
+- `runAnalysis` captures the envelope from a non-zero attempt and **stops after
+  one attempt on a rate limit** (a weekly wall will not clear on an immediate
+  retry); a transient non-429 API error still gets the second attempt.
+- `analysisHome()` now also returns the account label (email), and flags the
+  fallback case ("auto-picked — your chosen analysis account is no longer
+  available") so a limit on an account the user never chose is explained.
+
+The account email appears only in a local panel message; it is the user's own
+account, never sent anywhere. The deterministic backstop is unchanged and still
+runs regardless.

--- a/src/main/sentinel/index.ts
+++ b/src/main/sentinel/index.ts
@@ -66,7 +66,11 @@ async function analysisHome(): Promise<{ home: string | null; accountLabel: stri
     // limit on an account they never picked and has no idea why.
     let accountLabel: string | null = null
     if (profileId) {
-      const email = listProfiles().find((p) => p.id === profileId)?.accountEmail ?? null
+      // `|| null`, not `?? null`: a not-yet-signed-in profile has accountEmail
+      // '' (account-profiles), and an empty string must fall back to the
+      // profileId — otherwise the fallback label reads "; auto-picked …" with
+      // no identifier, defeating the "which account to change" goal.
+      const email = listProfiles().find((p) => p.id === profileId)?.accountEmail || null
       const fellBack = !!chosen && chosen !== profileId
       accountLabel = fellBack
         ? `${email ?? profileId}; auto-picked — your chosen analysis account is no longer available`

--- a/src/main/sentinel/index.ts
+++ b/src/main/sentinel/index.ts
@@ -53,14 +53,28 @@ async function headlessRunner(): Promise<typeof import('../claude-headless')> {
  * hangs at auth / carries stale rate-limit state (live repro: both analysis
  * attempts timed out at 180s on 2026-06-12).
  */
-async function analysisHome(): Promise<string | null> {
+async function analysisHome(): Promise<{ home: string | null; accountLabel: string | null }> {
   try {
     const { readConfig } = await import('../config-manager')
-    const { resolveHeadlessProfileHome } = await import('../account-profiles')
+    const { resolveHeadlessProfileHome, listProfiles } = await import('../account-profiles')
     const settings = readConfig<{ sentinelAccountProfileId?: string | null }>('settings')
-    return resolveHeadlessProfileHome(settings?.sentinelAccountProfileId).home
+    const chosen = settings?.sentinelAccountProfileId ?? null
+    const { home, profileId } = resolveHeadlessProfileHome(chosen)
+    // Name the account the analysis actually ran under, so a failure message can
+    // say WHICH account to change (#430). When the chosen account no longer
+    // resolves and we fell back to another, say so — otherwise the user sees a
+    // limit on an account they never picked and has no idea why.
+    let accountLabel: string | null = null
+    if (profileId) {
+      const email = listProfiles().find((p) => p.id === profileId)?.accountEmail ?? null
+      const fellBack = !!chosen && chosen !== profileId
+      accountLabel = fellBack
+        ? `${email ?? profileId}; auto-picked — your chosen analysis account is no longer available`
+        : email ?? profileId
+    }
+    return { home, accountLabel }
   } catch {
-    return null // fail-open: bare global is still better than no analysis
+    return { home: null, accountLabel: null } // fail-open: bare global is still better than no analysis
   }
 }
 
@@ -96,7 +110,7 @@ export async function sentinelStartupCheck(): Promise<void> {
   await runModelCoverageCheck()
   try {
     const { spawnClaudeHeadless } = await headlessRunner()
-    const res = await spawnClaudeHeadless(['--version'], 15000, undefined, await analysisHome())
+    const res = await spawnClaudeHeadless(['--version'], 15000, undefined, (await analysisHome()).home)
     const version = res.code === 0 ? parseClaudeVersion(res.stdout) : null
     if (!version) { logInfo('[sentinel] claude --version unavailable; skipping (fail-open)'); return }
     for (const f of minVersionFindings(version, manifest)) state.upsertFinding(f)
@@ -126,11 +140,11 @@ async function analyzeVersionChange(last: string, version: string): Promise<void
     return
   }
   const { spawnClaudeHeadless } = await headlessRunner()
-  const home = await analysisHome()
+  const { home, accountLabel } = await analysisHome()
   const result = await runAnalysis({
     runner: (args, t, stdin) => spawnClaudeHeadless(args, t, stdin, home, ac.signal),
     changelog: sliceChangelog(md, last, version),
-    from: last, to: version,
+    from: last, to: version, accountLabel,
   })
   if (currentAnalysis === ac) currentAnalysis = null
   if (ac.signal.aborted) return                        // superseded / cancelled: drop the result
@@ -154,7 +168,7 @@ export async function sentinelRerun(): Promise<void> {
   if (!state) return
   try {
     const { spawnClaudeHeadless } = await headlessRunner()
-    const res = await spawnClaudeHeadless(['--version'], 15000, undefined, await analysisHome())
+    const res = await spawnClaudeHeadless(['--version'], 15000, undefined, (await analysisHome()).home)
     const version = res.code === 0 ? parseClaudeVersion(res.stdout) : null
     if (!version) { state.setAnalyzing(false, 'claude --version unavailable'); return }
     const last = state.snapshot().lastSeenCcVersion ?? version

--- a/src/main/sentinel/sentinel-analysis.ts
+++ b/src/main/sentinel/sentinel-analysis.ts
@@ -76,33 +76,101 @@ export function parseAnalysisOutput(stdout: string, from: string, to: string): S
 
 export type HeadlessRunner = (args: string[], timeoutMs: number, stdin?: string) => Promise<{ code: number; stdout: string; stderr: string }>
 
+/** The subset of the `claude -p --output-format json` envelope we react to on a
+ *  FAILED (non-zero) run. claude -p exits 1 on an API error but still prints the
+ *  envelope to stdout, carrying a human `result` (e.g. a rate-limit line) and an
+ *  `api_error_status`. */
+interface HeadlessEnvelope {
+  is_error?: unknown
+  api_error_status?: unknown
+  terminal_reason?: unknown
+  result?: unknown
+}
+
+/** Longest envelope `result` we echo. The CLI's error strings are short; the cap
+ *  bounds what a surprising payload can put in front of the user. */
+const ENVELOPE_REASON_MAX = 160
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g
+
+/**
+ * Read a user-facing failure reason out of a non-zero run's JSON envelope, or
+ * null when it is not an error envelope we can read (so the caller falls back to
+ * the generic message). The old code only ever looked at stderr, so a 429
+ * ("You've hit your weekly limit · resets 4am") was shown as the vague "could
+ * not complete" with no hint that it was a usage limit or that Re-run was futile
+ * until reset (#430).
+ */
+export function envelopeError(stdout: string): { rateLimited: boolean; reason: string } | null {
+  // Parse the RAW top-level envelope — NOT unwrapPayload, which peels `.result`,
+  // and on an error envelope `.result` is the human string ("You've hit your
+  // weekly limit …"), not nested JSON. The error envelope's is_error /
+  // api_error_status / result all live at the top level.
+  let env: HeadlessEnvelope
+  try {
+    env = JSON.parse(stdout.trim()) as HeadlessEnvelope
+  } catch {
+    return null
+  }
+  if (!env || typeof env !== 'object') return null
+  const status = typeof env.api_error_status === 'number' ? env.api_error_status : null
+  const isError = env.is_error === true || env.terminal_reason === 'api_error' || (status !== null && status >= 400)
+  if (!isError) return null
+  // `result` on an api_error is the CLI's own error string (not model output).
+  // Strip control chars + trim + cap, so nothing pathological reaches the panel.
+  const raw = typeof env.result === 'string' ? env.result.replace(CONTROL_CHARS, ' ').trim() : ''
+  const reason = raw ? raw.slice(0, ENVELOPE_REASON_MAX) : status !== null ? `the account returned HTTP ${status}` : 'the account could not be reached'
+  const rateLimited = status === 429 || /\blimit\b/i.test(reason)
+  return { rateLimited, reason }
+}
+
 // Graceful-degrade copy for a failed AI pass. The deterministic backstop runs
 // separately (and is shown regardless), so a failed AI analysis is a soft,
 // retryable condition, not an error. Keep it calm and human: never surface raw
-// stderr / "Timed out after 180s" to the user (that detail is in the logs). A
-// timeout most often means the signed-in account is busy or rate limited, so the
-// message hints at that and points to Re-run.
-export function analysisFailureMessage(stderr: string): string {
+// stderr / "Timed out after 180s" to the user (that detail is in the logs). When
+// the envelope gives a real reason (a rate limit, an API error), say it — and
+// name the analysis account, so the user knows WHICH account to change and that
+// the fix is in Settings, not Re-run.
+export function analysisFailureMessage(
+  stderr: string,
+  envErr?: { rateLimited: boolean; reason: string } | null,
+  accountLabel?: string | null,
+): string {
+  const who = accountLabel ? ` (${accountLabel})` : ''
+  if (envErr) {
+    if (envErr.rateLimited) {
+      return `The Sentinel analysis account${who} has hit its usage limit — ${envErr.reason}. Pick a different account in Settings → Sentinel, or Re-run once it resets. The deterministic checks still ran.`
+    }
+    return `AI analysis could not complete: ${envErr.reason}. The deterministic checks still ran. Use Re-run to try again.`
+  }
   const timedOut = /timed out after/i.test(stderr)
   const base = timedOut
-    ? 'AI analysis could not finish in time this run. This usually means the signed-in account is busy or rate limited, or the update was large.'
+    ? `AI analysis could not finish in time this run. This usually means the analysis account${who} is busy or rate limited, or the update was large.`
     : 'AI analysis could not complete this run.'
   return `${base} The deterministic checks still ran. Use Re-run to try again.`
 }
 
 export async function runAnalysis(opts: {
-  runner: HeadlessRunner; changelog: string; from: string; to: string
+  runner: HeadlessRunner; changelog: string; from: string; to: string; accountLabel?: string | null
 }): Promise<{ ok: true; findings: SentinelFinding[] } | { ok: false; error: string }> {
   const prompt = buildAnalysisPrompt(opts.changelog)
   const args = ['-p', '--model', 'sonnet', '--output-format', 'json']
   let lastStderr = ''
+  let lastEnvErr: { rateLimited: boolean; reason: string } | null = null
   for (let attempt = 0; attempt < 2; attempt++) {
     const res = await opts.runner(args, 180000, prompt)          // 3-minute cap
     lastStderr = res.stderr
     if (res.code === 0) {
       const findings = parseAnalysisOutput(res.stdout, opts.from, opts.to)
       if (findings) return { ok: true, findings }
+      lastEnvErr = null                              // ran, but output unparseable: not an API error
+    } else {
+      lastEnvErr = envelopeError(res.stdout)
+      // A usage limit will not clear on an immediate retry — stop and report it
+      // rather than burning the second attempt on the same wall.
+      if (lastEnvErr?.rateLimited) break
     }
   }
-  return { ok: false, error: analysisFailureMessage(lastStderr) }
+  return { ok: false, error: analysisFailureMessage(lastStderr, lastEnvErr, opts.accountLabel) }
 }

--- a/tests/unit/sentinel-analysis.test.ts
+++ b/tests/unit/sentinel-analysis.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { buildAnalysisPrompt, parseAnalysisOutput, runAnalysis, analysisFailureMessage } from '../../src/main/sentinel/sentinel-analysis'
+import { buildAnalysisPrompt, parseAnalysisOutput, runAnalysis, analysisFailureMessage, envelopeError } from '../../src/main/sentinel/sentinel-analysis'
+
+/** The real shape claude -p prints on a 429 (captured from CC 2.1.239, #430). */
+const rateLimitEnvelope = JSON.stringify({
+  is_error: true,
+  api_error_status: 429,
+  terminal_reason: 'api_error',
+  subtype: 'success',
+  result: "You've hit your weekly limit · resets 4am (Europe/London)",
+})
 
 const goodJson = JSON.stringify({ breakingChanges: [{
   title: 'Hooks schema changed',
@@ -79,6 +88,29 @@ describe('runAnalysis', () => {
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.error).toMatch(/deterministic checks still ran/i)
   })
+  it('a 429 envelope -> a rate-limit message that names the account and stops after ONE attempt (#430)', async () => {
+    let calls = 0
+    const runner = async () => { calls++; return { code: 1, stdout: rateLimitEnvelope, stderr: '' } }
+    const r = await runAnalysis({ runner, changelog: 'x', from: '1', to: '2', accountLabel: 'nick@example.com' })
+    expect(calls).toBe(1)                                   // a weekly limit will not clear on retry
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.error).toMatch(/usage limit/i)
+      expect(r.error).toMatch(/resets 4am/)
+      expect(r.error).toContain('nick@example.com')
+      expect(r.error).toMatch(/Settings . Sentinel/)
+      expect(r.error).toMatch(/deterministic checks still ran/i)
+    }
+  })
+  it('a non-rate-limit API error envelope -> the real reason, still retried', async () => {
+    let calls = 0
+    const env = JSON.stringify({ is_error: true, api_error_status: 500, result: 'Internal server error' })
+    const runner = async () => { calls++; return { code: 1, stdout: env, stderr: '' } }
+    const r = await runAnalysis({ runner, changelog: 'x', from: '1', to: '2' })
+    expect(calls).toBe(2)                                   // a transient 500 is worth the retry
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/Internal server error/)
+  })
   it('timeout degrades to a calm message that never leaks raw stderr', async () => {
     const runner = async () => ({ code: 1, stdout: '', stderr: '\nTimed out after 180s' })
     const r = await runAnalysis({ runner, changelog: 'x', from: '1', to: '2' })
@@ -103,5 +135,44 @@ describe('analysisFailureMessage', () => {
     expect(m).toMatch(/could not complete/i)
     expect(m).toMatch(/deterministic checks still ran/i)
     expect(m).not.toContain('not logged in')
+  })
+  it('a rate-limit envelope -> names the limit, the account, and points at Settings not Re-run', () => {
+    const m = analysisFailureMessage('', { rateLimited: true, reason: "You've hit your weekly limit · resets 4am" }, 'nick@example.com')
+    expect(m).toMatch(/usage limit/i)
+    expect(m).toContain('nick@example.com')
+    expect(m).toMatch(/resets 4am/)
+    expect(m).toMatch(/Settings . Sentinel/)
+  })
+})
+
+describe('envelopeError', () => {
+  it('reads a 429 as rate-limited with the CLI reason', () => {
+    const e = envelopeError(rateLimitEnvelope)!
+    expect(e.rateLimited).toBe(true)
+    expect(e.reason).toContain("weekly limit")
+  })
+  it('reads the RAW top-level envelope, not the peeled .result (the error string is not JSON)', () => {
+    // Regression for the first cut: routing through unwrapPayload peeled `.result`
+    // to "You've hit your weekly limit …", which then failed JSON.parse → null,
+    // so the rate limit was never detected. Parsing raw is what fixes it.
+    const e = envelopeError(rateLimitEnvelope)
+    expect(e?.rateLimited).toBe(true)
+  })
+  it('a 500 is an error but not rate-limited', () => {
+    const e = envelopeError(JSON.stringify({ is_error: true, api_error_status: 500, result: 'boom' }))!
+    expect(e.rateLimited).toBe(false)
+    expect(e.reason).toBe('boom')
+  })
+  it('a clean success envelope is not an error', () => {
+    expect(envelopeError(JSON.stringify({ is_error: false, result: '{"breakingChanges":[]}' }))).toBeNull()
+  })
+  it('non-JSON / non-envelope -> null (falls back to the generic message)', () => {
+    expect(envelopeError('garbage')).toBeNull()
+    expect(envelopeError('')).toBeNull()
+  })
+  it('strips control chars and caps a pathological result', () => {
+    const e = envelopeError(JSON.stringify({ is_error: true, api_error_status: 400, result: 'a\n\tb' + 'x'.repeat(500) }))!
+    expect(e.reason).not.toMatch(/[\n\t]/)
+    expect(e.reason.length).toBeLessThanOrEqual(160)
   })
 })


### PR DESCRIPTION
Closes #430. First bug found installing beta.17.

**Diagnosed from the live install log + a direct repro:** `claude --version` succeeded but `claude -p --model sonnet --output-format json` exited 1 fast with a **429** — `is_error:true`, `api_error_status:429`, `result:"You've hit your weekly limit · resets 4am (Europe/London)"`. `analysisFailureMessage` only read **stderr** for "timed out", so the 429 collapsed to the generic "could not complete" and Re-run (futile on a weekly limit) was the only hint.

**Fix:**
- `envelopeError(stdout)` reads the **raw** top-level `-p` envelope (not `unwrapPayload`, which peels `.result` — on an error that's the human string, not JSON; that mis-route was the first-cut bug, now a regression test). Returns `{rateLimited, reason}` from `api_error_status`/`is_error`/`terminal_reason`, `result` control-stripped + capped at 160.
- `analysisFailureMessage` now names the account and the real reason: *"The Sentinel analysis account (email) has hit its usage limit — <reason>. Pick a different account in Settings → Sentinel, or Re-run once it resets."*
- `runAnalysis` stops after **one** attempt on a rate limit (a weekly wall won't clear on retry); a transient non-429 still gets the retry.
- `analysisHome()` returns the account label and flags the fallback ("auto-picked — your chosen analysis account is no longer available") — the install's configured `sentinelAccountProfileId` no longer existed, so it silently fell back to a limited account.

Account email appears only in a local panel message (the user's own account, never transmitted). Deterministic backstop unchanged.

Tests: `sentinel-analysis.test.ts` +10 (envelopeError raw-parse regression, 429 → one-attempt + named message, 500 → retried, control-strip/cap, generic fallback). Full unit suite 8184/0 local (one file flaked red under 25-node load — canvas-bridge-bounds, passes alone, known #213-family); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)