### PR TITLE
feat(command-bar): breathing room (Balanced height) + hide empty band labels (#432)

### DIFF
--- a/CONTEXT.d/2026-08-23-432-command-bar-breathing-room.md
+++ b/CONTEXT.d/2026-08-23-432-command-bar-breathing-room.md
@@ -1,0 +1,30 @@
+## 2026-08-23 -- #432 command bar: breathing room + empty band labels hidden
+
+From live beta.17 review, agreed on the Agent Canvas (owner picked "Balanced"
+from A/B/C height variants; the canvas itself was under test at the same time).
+
+- **Breathing room.** The one-row bar was `px-2 py-0.5` (2px vertical) with a
+  top border, sandwiched between the status strip and the account footer, so it
+  did not read as a central control. Now `px-2.5 py-[9px]` with every bar button
+  a uniform `h-7` (28px) — the "Balanced" option, row ≈ 47px. One row kept;
+  overflow/fold unchanged. The height lives in one place per button type:
+  `CHIP_CLASS` (chips.tsx) covers command chips, collapsed-section chips, the
+  "N more" pill and the NotesTool trigger; the five core-tool components
+  (Screenshot/Logs/Webview/AgentCanvas + the inline Add and Partner buttons)
+  each carry the same `h-7`. All are bar-only, so no other surface is affected.
+- **Empty band labels hidden.** A band with no commands used to still show its
+  GLOBAL / SESSION label (a deliberate drop affordance — see the old
+  "empty band is the affordance" test). The owner found that noisy. Now the
+  label AND its leading divider are hidden while a band is empty and no drag is
+  in progress; both reappear the moment a drag starts (`dragId` set), because
+  the empty band is still the drop target that scopes a command global/session.
+  The band DIV itself always renders, so the row height no longer changes when
+  the first/last command in a band is added or removed (Add + core tools hold
+  the row open regardless).
+
+Settings → Custom Commands has no live bar preview, so nothing to re-space there
+(the owner asked to check "in case of impact").
+
+Tests: `commandbar-rows-and-scope.test.ts` updated — empty band label hidden
+while idle, present during a drag, present when non-empty; the drag case fires a
+`dragstart` on a chip to set `dragId`.

--- a/src/renderer/components/AgentCanvasButton.tsx
+++ b/src/renderer/components/AgentCanvasButton.tsx
@@ -76,7 +76,7 @@ export default function AgentCanvasButton({ sessionId }: Props) {
           if (!isOpen) trackUsage('canvas.opened')
           togglePane(sessionId)
         }}
-        className={`relative flex items-center gap-1.5 px-2 py-0.5 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
+        className={`relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
           isOpen
             ? 'bg-mauve/20 border-mauve/70 text-mauve hover:bg-mauve/30'
             : waiting

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -61,7 +61,7 @@ function CodexModelDropdown({ value, onChange }: { value: string; onChange: (nex
       <select
         value={value}
         onChange={(e) => { setDirty(true); onChange(e.target.value) }}
-        className="bg-base border border-surface1 rounded px-1.5 h-[22px] py-0 text-xs text-text"
+        className="bg-base border border-surface1 rounded px-1.5 h-7 text-xs text-text"
       >
         {CODEX_MODELS.map((m) => (<option key={m} value={m}>{m}</option>))}
       </select>
@@ -77,7 +77,7 @@ function PermissionsPresetDropdown({ value, onChange }: { value: CodexPreset; on
       <select
         value={value}
         onChange={(e) => { setDirty(true); onChange(e.target.value as CodexPreset) }}
-        className="bg-base border border-surface1 rounded px-1.5 h-[22px] py-0 text-xs text-text"
+        className="bg-base border border-surface1 rounded px-1.5 h-7 text-xs text-text"
       >
         {CODEX_PRESETS.map((p) => (<option key={p} value={p}>{p}</option>))}
       </select>

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -557,9 +557,16 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
     const moreCount = foldedChips.length + plan.inapplicable.length
     let chipIndex = 0
     const sectionName = (id?: string) => plan.sections.find((s) => s.id === id)?.name
+    // An empty band shows nothing but its GLOBAL/SESSION label, which just adds
+    // noise to the row (owner). Hide the label — and its leading divider — when
+    // the band carries no commands at all, EXCEPT while a drag is in progress:
+    // an empty band is still the drop target that makes a command global or
+    // session-scoped, so the label must reappear then to give somewhere to drop.
+    const bandEmpty = plan.chips.length === 0 && plan.inapplicable.length === 0
+    const showBandLabel = !bandEmpty || !!dragId
     return (
       <React.Fragment key={band}>
-        <div className="w-px h-4 mx-0.5 shrink-0" style={{ background: 'var(--border-subtle)' }} />
+        {showBandLabel && <div className="w-px h-4 mx-0.5 shrink-0" style={{ background: 'var(--border-subtle)' }} />}
         <div
           role="toolbar"
           aria-label={`${plan.label} commands`}
@@ -570,14 +577,16 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           onDragOver={(e) => onSlotDragOver(e, band)}
           onDrop={(e) => onSlotDrop(e, band)}
         >
-          <span
-            className="shrink-0 text-[9.5px] font-semibold uppercase tracking-[.09em] px-1 select-none"
-            style={{ color: 'var(--text-muted)' }}
-            title={band === 'global' ? 'Global — these buttons show in every config' : `Session — this config only${configName ? ` (${configName})` : ''}`}
-            data-testid={`command-band-label-${band}`}
-          >
-            {plan.label}
-          </span>
+          {showBandLabel && (
+            <span
+              className="shrink-0 text-[9.5px] font-semibold uppercase tracking-[.09em] px-1 select-none"
+              style={{ color: 'var(--text-muted)' }}
+              title={band === 'global' ? 'Global — these buttons show in every config' : `Session — this config only${configName ? ` (${configName})` : ''}`}
+              data-testid={`command-band-label-${band}`}
+            >
+              {plan.label}
+            </span>
+          )}
           {plan.clusters.map((cluster) => (
             <React.Fragment key={cluster.kind}>
               {cluster.chips.some((c) => !foldedIds.has(c.id) && !(c.sectionId && collapsedSectionIds.includes(c.sectionId))) && <TargetMark kind={cluster.kind} caps={caps} />}
@@ -645,7 +654,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           ))}
           {dragId && (
             <span
-              className="inline-block w-7 h-[22px] rounded-md border border-dashed shrink-0"
+              className="inline-block w-7 h-7 rounded-md border border-dashed shrink-0"
               style={{ borderColor: dragOverSlot === band ? 'var(--brand)' : 'var(--border-strong)', background: dragOverSlot === band ? 'color-mix(in srgb, var(--brand) 12%, transparent)' : 'transparent' }}
               onDragOver={(e) => onSlotDragOver(e, band)}
               onDrop={(e) => onSlotDrop(e, band)}
@@ -694,7 +703,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
       <PasteHint sessionId={sessionId} />
       <div
         ref={rowRef}
-        className={`flex items-center gap-1 px-2 py-0.5 border-t ${overflowMode === 'wrap2' ? 'flex-wrap' : 'overflow-hidden'}`}
+        className={`flex items-center gap-1.5 px-2.5 py-[9px] border-t ${overflowMode === 'wrap2' ? 'flex-wrap gap-y-1.5' : 'overflow-hidden'}`}
         style={{ background: 'var(--surface-chrome)', borderColor: 'var(--border-subtle)' }}
         data-testid="command-row"
         data-overflow={overflowMode}
@@ -704,7 +713,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           <button
             type="button"
             onClick={() => setShowDialog({ scope: configId ? 'config' : 'global' })}
-            className="flex items-center gap-1 px-2 py-0.5 text-xs font-semibold focus-ring"
+            className="flex items-center gap-1 px-2.5 h-7 text-xs font-semibold focus-ring"
             style={{ color: '#5cb0ff' }}
             title="Add a command button"
             aria-label="Add command"
@@ -736,7 +745,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           {partnerEnabled && onTogglePartner && !hiddenHere.has('partner') && coreWrap('partner', (
             <button
               onClick={onTogglePartner}
-              className={`relative flex items-center gap-1.5 px-2 py-0.5 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring ${
+              className={`relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring ${
                 isPartnerActive
                   ? 'bg-green/20 border-green/70 text-green hover:bg-green/30'
                   : 'bg-surface0/60 border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text'

--- a/src/renderer/components/LogsButton.tsx
+++ b/src/renderer/components/LogsButton.tsx
@@ -42,7 +42,7 @@ export default function LogsButton({ sessionId, structuralReason = null, remoteH
   return (
     <button
       onClick={() => togglePane(sessionId)}
-      className={`flex items-center gap-1.5 px-2 py-0.5 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
+      className={`flex items-center gap-1.5 px-2 h-7 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
         isOpen
           ? 'bg-surface1 border-surface1 text-text'
           : 'bg-surface0/60 border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text'

--- a/src/renderer/components/ScreenshotButton.tsx
+++ b/src/renderer/components/ScreenshotButton.tsx
@@ -76,7 +76,7 @@ export default function ScreenshotButton({ sessionId, sessionType }: Props) {
           ref={buttonRef}
           onClick={toggleDropdown}
           disabled={capturing}
-          className="flex items-center gap-1.5 px-2 py-0.5 text-xs rounded bg-surface0/60 border border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text transition-colors whitespace-nowrap shrink-0 disabled:opacity-50"
+          className="flex items-center gap-1.5 px-2 h-7 text-xs rounded bg-surface0/60 border border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text transition-colors whitespace-nowrap shrink-0 disabled:opacity-50"
           title="Take a screenshot and send it to the agent"
           data-testid="snap-button"
         >

--- a/src/renderer/components/WebviewButton.tsx
+++ b/src/renderer/components/WebviewButton.tsx
@@ -83,7 +83,7 @@ export default function WebviewButton({ sessionId }: Props) {
         if (!isOpen) trackUsage('webview.opened')
         togglePane(sessionId)
       }}
-      className={`flex items-center gap-1.5 px-2 py-0.5 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring ${classes}`}
+      className={`flex items-center gap-1.5 px-2 h-7 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring ${classes}`}
       title={titleParts.join('').trim()}
       data-testid="browser-toggle"
       data-watch-status={status}

--- a/src/renderer/components/command-bar/chips.tsx
+++ b/src/renderer/components/command-bar/chips.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_COMMAND_COLOR } from '../../lib/command-swatches'
 import { chipTitle, clusterTitle, effectiveKind, type ClusterKind } from './layout'
 
 /** The neutral chip every Core tool and user button shares (D1, D4). */
-export const CHIP_CLASS = 'flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-md border whitespace-nowrap shrink-0 transition-colors duration-150 focus-ring'
+export const CHIP_CLASS = 'flex items-center gap-1.5 px-2 h-7 text-xs rounded-md border whitespace-nowrap shrink-0 transition-colors duration-150 focus-ring'
 export const CHIP_STYLE: React.CSSProperties = { background: 'var(--surface-raised)', color: 'var(--text-secondary)', borderColor: 'var(--border-subtle)' }
 
 // Stroked marks, the same family as the Core tool glyphs.

--- a/tests/unit/renderer/commandbar-rows-and-scope.test.ts
+++ b/tests/unit/renderer/commandbar-rows-and-scope.test.ts
@@ -116,27 +116,50 @@ describe('both scope bands are present whenever the session has a config', () =>
     expect(spans).not.toContain('Commands')
   })
 
-  it('keeps the Session band when NOTHING is scoped to it -- the empty band is the affordance', () => {
-    // The case that used to make the bar's height change under the pointer:
-    // no config buttons meant no row, so creating the first one materialised a
-    // row nobody knew was possible, and deleting the last took it away again.
+  it('keeps the Session band as a drop target when NOTHING is scoped to it, but HIDES its label while idle (#430-followup)', () => {
+    // The band DIV stays (the row height no longer changes under the pointer —
+    // Add + core tools always hold the row open — and it is still the drop
+    // target that scopes a command Session-only). But an empty band's GLOBAL/
+    // SESSION label is just noise on the row, so it is hidden while idle (owner)
+    // and reappears during a drag (covered below).
     COMMANDS = ALL.filter((c) => c.scope !== 'config')
     render({ partnerEnabled: true, partnerSessionId: 's-1-partner' })
     const band = byTestId('command-band-config')
-    expect(band).not.toBeNull()
-    expect(byTestId('command-band-label-config', band!)?.textContent).toBe('Session')
-    // …and it really is empty: no chip in it, and no target mark opening a cluster.
+    expect(band).not.toBeNull()                                  // drop target still present
+    expect(byTestId('command-band-label-config')).toBeNull()     // label hidden while idle
     expect(allByTestId('command-chip', band!)).toHaveLength(0)
     expect(band!.querySelector('[data-testid^="command-cluster-"]')).toBeNull()
   })
 
-  it('keeps the Global band when nothing is global either', () => {
+  it('hides the Global band label too when nothing is global', () => {
     COMMANDS = ALL.filter((c) => c.scope !== 'global')
     render({ partnerEnabled: true, partnerSessionId: 's-1-partner' })
     const band = byTestId('command-band-global')
     expect(band).not.toBeNull()
-    expect(byTestId('command-band-label-global', band!)?.textContent).toBe('Global')
+    expect(byTestId('command-band-label-global')).toBeNull()
     expect(allByTestId('command-chip', band!)).toHaveLength(0)
+  })
+
+  it('shows a non-empty band label as normal', () => {
+    render({ partnerEnabled: true, partnerSessionId: 's-1-partner' })
+    expect(byTestId('command-band-label-global')?.textContent).toBe('Global')
+    expect(byTestId('command-band-label-config')?.textContent).toBe('Session')
+  })
+
+  it('brings the empty band label back during a drag, so there is somewhere to drop (affordance preserved)', () => {
+    COMMANDS = ALL.filter((c) => c.scope !== 'config')          // empty Session band
+    render({ partnerEnabled: true, partnerSessionId: 's-1-partner' })
+    expect(byTestId('command-band-label-config')).toBeNull()     // idle: hidden
+    // Start dragging a global chip: onDragStart sets dragId, which reveals every
+    // empty band's label as a drop target.
+    const chip = allByTestId('command-chip')[0]
+    expect(chip).toBeTruthy()
+    act(() => {
+      const ev = new Event('dragstart', { bubbles: true }) as any
+      ev.dataTransfer = { setData: vi.fn(), setDragImage: vi.fn(), effectAllowed: '' }
+      chip!.dispatchEvent(ev)
+    })
+    expect(byTestId('command-band-label-config')?.textContent).toBe('Session')
   })
 
   it('draws no Session band at all when the session has no saved config', () => {


### PR DESCRIPTION
Closes #432. Agreed on the Agent Canvas from live beta.17 review — owner picked the **Balanced** height from A/B/C variants, plus hide the GLOBAL/SESSION label on an empty band.

- **Breathing room:** the row goes from `px-2 py-0.5` (2px) to `px-2.5 py-[9px]`, and every bar button is a uniform **h-7 (28px)** — row ≈ 47px. One row kept; overflow/fold unchanged. The height lives in one place per button type: `CHIP_CLASS` (command chips, collapsed-section chips, "N more" pill, NotesTool trigger) + the five bar-only tool components (Screenshot/Logs/Webview/AgentCanvas) + the inline Add/Partner buttons + the drag-slot placeholder. All bar-only — no other surface changes.
- **Empty band labels:** a band with no commands hides its GLOBAL/SESSION label and its leading divider **while idle**, and both reappear **during a drag** — the empty band is still the drop target that scopes a command global/session. The band div always renders, so the row height no longer changes when the first/last command in a band is added or removed.
- **Settings → Custom Commands:** no live bar preview there, so nothing to re-space (checked per the owner's "in case of impact").

Tests: `commandbar-rows-and-scope.test.ts` updated to the new behavior — label hidden while idle, present during a drag (fires a `dragstart` to set `dragId`), present when non-empty. Full suite 8198/0 local; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)