### PR TITLE
feat(canvas): pane redesign — mode-as-title, sectioned panel, two-level history, archive/delete

### DIFF
--- a/CONTEXT.d/2026-08-24-canvas-pane-redesign.md
+++ b/CONTEXT.d/2026-08-24-canvas-pane-redesign.md
@@ -1,0 +1,53 @@
+## 2026-08-24 -- Canvas pane redesign (item C), agreed v6, five phases
+
+The canvas review pane redesign the owner accepted on the "Canvas pane redesign"
+canvas (v6 mockup). Built as one branch off beta in five committed phases, each
+tested, plus an ADR-009 pass on the destructive phase.
+
+- **Phase 1 -- chrome.** The pane leads with the MODE as its title -- PLAN /
+  MOCKUP / TESTING in its own colour with a keel line -- instead of a small
+  badge. Browse/Draw/Region became app-family tool chips Inspect / Sketch /
+  Region; the X-ray Off/Stealth/On setting rides the Inspect chip (it only
+  governs Inspect), locked to Stealth on a plan. Pure presentation over the
+  existing pointer-owner + #367 x-ray state.
+- **Phase 2 -- framed content + provenance.** The reviewed page sits in a 2px
+  framed card with a "PAGE UNDER REVIEW" tag; the "canvas was filed" banner
+  became a one-line provenance sentence with "Reopen it".
+- **Phase 3 -- panel.** App surfaces (no mantle slab) + slim scrollbar; rounds
+  grouped under NEEDS YOU / WITH THE AGENT / CLOSED section headers; seen-aware
+  collapse (a round waiting on the user folds only once its addressed notes have
+  been SEEN, never before -- the canvas_verdict seen-barrier still gets its
+  dwell); a hide control that collapses the panel to a ~30px rail.
+- **Phase 4 -- two-level history.** The flat version select became a per-artifact
+  version stepper + a History picker that chooses the artifact (a plan, a
+  mockup, a legacy test build). A display projection over the version list
+  (shared `artifactRuns`, so main and the picker agree) -- no ids or review
+  anchors move. Legacy uat builds fall into a muted Archived group.
+- **Phase 5 -- archive + permanent delete-artifact.** Two history-row actions.
+  Archive is reversible (an `archived` flag on the versions, validated on load
+  like `draft`). Delete is permanent: it removes an artifact's versions, their
+  files, and their review notes. DURABLE via a new monotonic `nextVersion`
+  high-water counter on the (MAC-signed) canvas record -- healed on load, never
+  lowered on delete -- so a later render mints a fresh id and never resurrects a
+  deleted one. New IPC `canvas:archiveArtifact` / `canvas:deleteArtifact`.
+
+**ADR-009 (the destructive path).** An adversarial pass (two attacker lenses +
+a round-2 re-attack) found one MAJOR and one LOW, both fixed:
+- MAJOR -- `deleteArtifact` removed each version dir with `removeTreeNoFollow`
+  starting BELOW the realpath-checked canvas dir, so a junction planted at
+  `<canvasDir>/versions` redirected the per-version delete out of tree
+  (`deleteCanvas` was immune -- it walks node-by-node from the checked root).
+  Closed with a per-version realpath identity check plus a final-component lstat
+  of `versions/`. Regression test plants a real junction and proves the victim
+  survives; reverting either guard fails it.
+- LOW -- the sketch-file unlink now re-checks `PNG_PATH_RE`, mirroring
+  `unlinkPastedImage`. Record integrity (MAC / `archived` / `nextVersion`),
+  counter durability, note over-deletion, cross-canvas isolation, refused-delete,
+  and only-artifact refusal all held.
+
+**Deferred (owner-approved, tracked for a follow-up).** Two agreed affordances
+were not built and the owner chose to merge as-built and follow up: TESTING
+MODE's LIVE pill + "End test" (net-new live-test chrome; uat currently reads as
+an Archived artifact), and the consolidated one-primary-Approve + honest-words
+"⋯" verdict menu (the functionality already works through the existing per-note
+and per-round verdict controls -- this is UI consolidation, not a gap).

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -1924,7 +1924,11 @@ export function deleteAnnotationsForVersions(canvasId: string, versionIds: reado
   // undo the commit above.
   for (const a of doomed) {
     if (a.image) unlinkPastedImage(canvasId, a.image)
-    if (a.sketch && a.sketch.pngPath) {
+    // Re-validate the sketch path at unlink time, exactly as unlinkPastedImage
+    // re-checks its own — the record is validated on load today, but this guard
+    // keeps the unlink from becoming a delete-by-path primitive if any future
+    // path ever warms the cache with a less-validated sketch pngPath (ADR-009).
+    if (a.sketch && PNG_PATH_RE.test(a.sketch.pngPath)) {
       try {
         fs.unlinkSync(path.join(canvasDir(canvasId), a.sketch.pngPath))
       } catch {

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -1887,6 +1887,55 @@ export function closeOutCanvasReviews(canvasId: string): { closed: number; revie
 }
 
 /**
+ * Delete every note anchored to one of `versionIds`, because the artifact those
+ * versions belong to was permanently deleted (item C, phase 5). Reviews left
+ * with no notes are removed; the monotonic counters are untouched, so no id is
+ * ever reissued. Attachment files (sketch exports, pasted images) for the
+ * removed notes are unlinked best-effort — the record is the durable truth.
+ *
+ * Keyed by canvasId, like closeOutCanvasReviews and deleteCanvas: the caller
+ * (the delete-artifact IPC handler) holds both stores and drives this after the
+ * canvas store has removed the versions. Returns the number of notes removed,
+ * or null for an unreadable store.
+ */
+export function deleteAnnotationsForVersions(canvasId: string, versionIds: readonly string[]): number | null {
+  const base = recordByCanvasId(canvasId)
+  if (!base) return null
+  const targets = new Set<string>()
+  for (const id of versionIds) if (typeof id === 'string' && CANVAS_VERSION_ID_RE.test(id)) targets.add(id)
+  if (targets.size === 0) return 0
+
+  const doomed = base.annotations.filter((a) => targets.has(a.versionId))
+  if (doomed.length === 0) return 0
+  const doomedIds = new Set(doomed.map((a) => a.id))
+
+  const keptAnnotations = base.annotations.filter((a) => !doomedIds.has(a.id)).map(cloneAnnotation)
+  const reviews = base.reviews
+    .map((r) => ({ ...r, annotationIds: r.annotationIds.filter((id) => !doomedIds.has(id)) }))
+    // A review emptied of every note is removed — its number is not reused
+    // (nextReview never decreases), exactly like a deleted version's id.
+    .filter((r) => r.annotationIds.length > 0)
+
+  const next: ReviewFileRecord = { ...base, reviews, annotations: keptAnnotations }
+  commit(next)
+
+  // Best-effort file cleanup for the removed notes. The record already no longer
+  // references them, so a leftover file is harmless; a throw here must never
+  // undo the commit above.
+  for (const a of doomed) {
+    if (a.image) unlinkPastedImage(canvasId, a.image)
+    if (a.sketch && a.sketch.pngPath) {
+      try {
+        fs.unlinkSync(path.join(canvasDir(canvasId), a.sketch.pngPath))
+      } catch {
+        /* already gone, locked, or never exported — the record is the truth */
+      }
+    }
+  }
+  return doomed.length
+}
+
+/**
  * Forget everything held for one canvas, because that canvas has been deleted.
  *
  * `reviews.json` lives inside the canvas directory, so deleting the canvas

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -2013,8 +2013,9 @@ export function deleteArtifact(
   } catch {
     realRoot = root
   }
+  let realCanvasDir: string | null = null
   try {
-    const realCanvasDir = fs.realpathSync(canvasDir(canvasId))
+    realCanvasDir = fs.realpathSync(canvasDir(canvasId))
     const expected = path.join(realRoot, canvasId)
     const same =
       process.platform === 'win32'
@@ -2023,20 +2024,72 @@ export function deleteArtifact(
     if (!same) return { ok: false, reason: 'unsafe' }
   } catch (err) {
     // ENOENT — the canvas dir is already gone; the record mutation below is
-    // still the durable truth, so continue. Any other error means we cannot
-    // vouch for the path and must not remove under it.
+    // still the durable truth, so continue with no file removal. Any other
+    // error means we cannot vouch for the path and must not remove under it.
     if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') return { ok: false, reason: 'unsafe' }
+    realCanvasDir = null
   }
 
   const deletedVersionIds = run.map((v) => v.id)
   const deleted = new Set(deletedVersionIds)
-  for (const id of deletedVersionIds) {
+  // `versions/` itself is lstat'd as a FINAL component (which the OS does not
+  // follow), so a reparse point planted there is caught as a link and ALL file
+  // removal is skipped — the deterministic form of the intermediate-junction
+  // escape, closed the same way `deleteCanvas`'s walker catches it (ADR-009
+  // round 2). This is checked once, up front, before any per-version work.
+  if (realCanvasDir !== null) {
     try {
-      removeTreeNoFollow(versionDir(canvasId, id))
+      const vst = fs.lstatSync(path.join(canvasDir(canvasId), 'versions'))
+      if (vst.isSymbolicLink() || !vst.isDirectory()) {
+        console.warn('[canvas-store] refusing version-file removal: versions/ is not a plain directory')
+        realCanvasDir = null // skip all file removal; the metadata delete still lands
+      }
     } catch (err) {
-      // Best-effort: the record mutation is what makes the delete durable, so a
-      // file that will not unlink leaves an orphan, never a resurrected version.
-      console.warn('[canvas-store] artifact version files left behind:', err)
+      // No versions dir at all — nothing to remove. Skip file removal; the
+      // record mutation below is still the durable truth.
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') realCanvasDir = null
+    }
+  }
+  // Realpath EACH version directory to its expected slot before removing it —
+  // not just the canvas dir. `removeTreeNoFollow` refuses to follow the FINAL
+  // path component, but the OS resolves an intermediate reparse point (a
+  // junction planted at `<canvasDir>/versions`) transparently, so starting the
+  // walk below the checked boundary let a `versions` junction redirect the
+  // per-version delete out of the canvas dir entirely (ADR-009, this change).
+  // The identity check catches exactly that: a redirected version dir realpaths
+  // somewhere other than `<realCanvasDir>/versions/<id>` and is skipped. Its
+  // metadata still goes below, so the delete is durable; only the out-of-tree
+  // unlink is refused. Skipped whole when the canvas dir was already gone.
+  if (realCanvasDir !== null) {
+    for (const id of deletedVersionIds) {
+      const dir = versionDir(canvasId, id)
+      try {
+        const realDir = fs.realpathSync(dir)
+        const expectedDir = path.join(realCanvasDir, 'versions', id)
+        const same =
+          process.platform === 'win32'
+            ? realDir.toLowerCase() === expectedDir.toLowerCase()
+            : realDir === expectedDir
+        if (!same) {
+          console.warn(`[canvas-store] refusing to remove ${dir}: it resolves outside the canvas dir`)
+          continue
+        }
+      } catch (err) {
+        // ENOENT — nothing there to remove. Anything else — cannot vouch for
+        // the path; leave it rather than risk removing out of tree.
+        if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+          console.warn('[canvas-store] artifact version dir not removable:', err)
+        }
+        continue
+      }
+      try {
+        removeTreeNoFollow(dir)
+      } catch (err) {
+        // Best-effort: the record mutation is what makes the delete durable, so
+        // a file that will not unlink leaves an orphan, never a resurrected
+        // version.
+        console.warn('[canvas-store] artifact version files left behind:', err)
+      }
     }
   }
 

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -29,6 +29,7 @@ import {
   CanvasVersion,
   MAX_CANVAS_TITLE_CHARS,
   ReclaimableCanvas,
+  artifactRunContaining,
 } from '../../shared/canvas'
 import { atomicWriteSecure, mkdirSecure } from '../account-profiles'
 import { deriveInstallKey } from '../install-secret'
@@ -546,6 +547,16 @@ interface CanvasRecord extends CanvasState {
    */
   cwd?: string
   conversationUuid?: string
+  /**
+   * The next version number to mint — a MONOTONIC high-water mark (item C,
+   * phase 5). Without it, `nextVersionId` derives the next id from `max(existing
+   * ids) + 1`, so deleting the LATEST artifact would let a later render reuse a
+   * deleted id — resurrecting a version the user permanently removed. This
+   * counter never decreases on a delete, so a deleted id is never reissued.
+   * Absent on records written before this: healed to `max(id) + 1` on load,
+   * which is exactly the old behaviour for a canvas that has never deleted.
+   */
+  nextVersion?: number
 }
 
 /**
@@ -778,6 +789,10 @@ function isKeepableVersion(v: unknown): v is CanvasVersion {
   // (it means what absence means), so a future writer spelling ready-ness as
   // draft:false cannot silently destroy versions on load.
   if (ver.draft !== undefined && typeof ver.draft !== 'boolean') return false
+  // `archived` (item C, phase 5) is a BOOLEAN or absent, same posture as
+  // `draft`: a hand-edited truthy string must not survive into a field the
+  // history projection reads.
+  if (ver.archived !== undefined && typeof ver.archived !== 'boolean') return false
   // A hand-edited record must not smuggle a traversing/colon/device `entry`
   // past the live-render normalizer (the empty-path + SPA branches serve the
   // entry WITHOUT re-running the URL segment filter). distRoot containment is
@@ -857,6 +872,19 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
     }
   }
 
+  // The monotonic version high-water mark (item C, phase 5). Healed to at least
+  // `max(surviving id) + 1` so it can never mint an id that already exists, and
+  // never below a value the file already recorded — a delete persists a counter
+  // ABOVE the survivors precisely so the deleted ids are not reissued, and that
+  // must survive a reload. A non-integer or too-low value is repaired UP, never
+  // trusted down.
+  const maxId = versions.reduce((m, v) => {
+    const n = Number.parseInt(v.id.slice(1), 10)
+    return Number.isFinite(n) && n > m ? n : m
+  }, 0)
+  const rawNext = (r as { nextVersion?: unknown }).nextVersion
+  const nextVersion = Number.isInteger(rawNext) && (rawNext as number) > maxId ? (rawNext as number) : maxId + 1
+
   // Built field by field, not spread from what was on disk.
   //
   // The MAC is the envelope rather than part of the record, so it has to come
@@ -877,6 +905,7 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
     ...(r.title !== undefined ? { title: r.title } : {}),
     versions,
     activeVersionId,
+    nextVersion,
     ...(awaitingReview ? { awaitingReview } : {}),
   }
 }
@@ -1026,16 +1055,17 @@ export function getAgentCanvasStateForSession(sessionId: string): CanvasState | 
   return getCanvasStateForSession(sessionId)
 }
 
-/** The next linear version id: one past the highest number already present.
- *  Identical to `length + 1` for a contiguous list, and correct for one with a
- *  gap (a version dropped by sanitizeRecord). */
-function nextVersionId(versions: CanvasVersion[]): string {
+/** The next linear version NUMBER for a record with no counter yet: one past
+ *  the highest already present. The healing floor for a pre-counter record and
+ *  for a brand-new canvas; once a record has `nextVersion`, that is used
+ *  instead (it can sit ABOVE this after a delete). */
+function nextVersionNumber(versions: CanvasVersion[]): number {
   let max = 0
   for (const v of versions) {
     const n = Number.parseInt(v.id.slice(1), 10)
     if (Number.isFinite(n) && n > max) max = n
   }
-  return `v${max + 1}`
+  return max + 1
 }
 
 /**
@@ -1199,12 +1229,14 @@ export function renderVersion(
   // canvas state is created or mutated — a rejected render leaves nothing
   // behind (no empty canvas, no half-written version).
   const canvasId = existing?.canvasId ?? randomId()
-  // Highest existing number + 1, not `length + 1`. A record loaded from disk may
-  // legitimately have gaps now that sanitizeRecord drops individual versions
-  // ([v1, v3] has length 2), and `length + 1` would mint a SECOND 'v3' — two
-  // versions with one serve key. A superseding draft (or the promote of one)
-  // keeps the id it already holds.
-  const versionId = reuseLatest ? latest!.id : nextVersionId(existing?.versions ?? [])
+  // The next number from the MONOTONIC counter, not `max(existing) + 1`. A
+  // record loaded from disk always carries `nextVersion` (healed in
+  // sanitizeRecord to at least max+1), and a delete leaves it ABOVE the
+  // survivors — so a deleted id is never reissued. A brand-new canvas (no
+  // `existing`) starts at 1. A superseding draft (or the promote of one) keeps
+  // the id it already holds and mints nothing.
+  const mintNum = existing?.nextVersion ?? nextVersionNumber(existing?.versions ?? [])
+  const versionId = reuseLatest ? latest!.id : `v${mintNum}`
   const createdAt = nextRenderStamp()
   let version: CanvasVersion
 
@@ -1310,6 +1342,9 @@ export function renderVersion(
     ...(title && (comparable || !base.title) ? { title } : {}),
     versions: reuseLatest ? [...base.versions.slice(0, -1), version] : [...base.versions, version],
     activeVersionId: versionId,
+    // Advance the high-water mark only when a NEW id was minted — a superseding
+    // draft reuses its id and must not burn a number. Never goes backwards.
+    nextVersion: reuseLatest ? (base.nextVersion ?? mintNum) : mintNum + 1,
     ...(awaitingReview ? { awaitingReview } : {}),
   }
   persist(nextRecord)
@@ -1902,6 +1937,134 @@ export function deleteCanvas(canvasId: string): boolean {
     emitChanged({ ...record, activeVersionId: null })
   }
   return record !== undefined || outcome === 'removed'
+}
+
+/**
+ * Archive (or un-archive) the ARTIFACT a version belongs to (item C, phase 5).
+ *
+ * Reversible and non-destructive: it only sets the `archived` flag on every
+ * version of the artifact run, which moves it into the muted Archived history
+ * group. Nothing on disk is removed and no review note is touched. Keyed by
+ * canvasId (the pane passes its own), and it no-ops safely when the version or
+ * its run is not found.
+ */
+export function setArtifactArchived(canvasId: string, versionId: string, archived: boolean): CanvasState | null {
+  if (!CANVAS_ID_RE.test(canvasId) || !CANVAS_VERSION_ID_RE.test(versionId)) return null
+  const record = getRecord(canvasId)
+  if (!record) return null
+  const run = artifactRunContaining(record.versions, versionId)
+  if (!run) return toState(record)
+  const runIds = new Set(run.map((v) => v.id))
+  const nextRecord: CanvasRecord = {
+    ...record,
+    versions: record.versions.map((v) => {
+      if (!runIds.has(v.id)) return v
+      if (archived) return { ...v, archived: true as const }
+      const { archived: _drop, ...rest } = v
+      return rest
+    }),
+  }
+  persist(nextRecord)
+  canvases.set(canvasId, nextRecord)
+  emitChanged(nextRecord)
+  return toState(nextRecord)
+}
+
+/**
+ * Permanently delete the ARTIFACT a version belongs to (item C, phase 5): its
+ * versions, their rendered files on disk, and — via the caller, which holds the
+ * review store — their review notes. Irreversible, and DURABLE: the record's
+ * monotonic `nextVersion` counter is preserved untouched, so a later render
+ * mints a fresh id and never resurrects a deleted one.
+ *
+ * Returns the deleted version ids so the IPC handler can drop their reviews
+ * (the review store imports this one, so the cross-store step lives with the
+ * caller, exactly as `deleteCanvas` + `dropReviewsForCanvas` do). Refuses to
+ * delete the canvas's ONLY artifact — that is "delete the canvas", which the
+ * library owns and which has its own confirmation and path discipline.
+ *
+ * Path safety mirrors `deleteCanvas`: the canvas directory is realpath-confirmed
+ * to sit directly in the canvas root before anything is removed, and each
+ * version directory is removed through `removeTreeNoFollow`, which unlinks a
+ * planted junction AS a link rather than descending it.
+ */
+export function deleteArtifact(
+  canvasId: string,
+  versionId: string,
+): { ok: true; deletedVersionIds: string[] } | { ok: false; reason: 'not-found' | 'only-artifact' | 'unsafe' } {
+  if (!CANVAS_ID_RE.test(canvasId) || !CANVAS_VERSION_ID_RE.test(versionId)) return { ok: false, reason: 'not-found' }
+  const record = getRecord(canvasId)
+  if (!record) return { ok: false, reason: 'not-found' }
+  const run = artifactRunContaining(record.versions, versionId)
+  if (!run) return { ok: false, reason: 'not-found' }
+  // Deleting every version is deleting the canvas — a different operation, with
+  // its own confirmation, in the library. Refuse rather than silently emptying
+  // the pane to an id-less husk.
+  const readyCount = record.versions.filter((v) => !v.draft).length
+  const runReady = run.filter((v) => !v.draft).length
+  if (runReady >= readyCount) return { ok: false, reason: 'only-artifact' }
+
+  // Top-of-tree confinement (same as deleteCanvas): the canvas directory must
+  // realpath to <root>/<id> before any version directory under it is removed.
+  const root = canvasRoot()
+  let realRoot: string
+  try {
+    realRoot = fs.realpathSync(root)
+  } catch {
+    realRoot = root
+  }
+  try {
+    const realCanvasDir = fs.realpathSync(canvasDir(canvasId))
+    const expected = path.join(realRoot, canvasId)
+    const same =
+      process.platform === 'win32'
+        ? realCanvasDir.toLowerCase() === expected.toLowerCase()
+        : realCanvasDir === expected
+    if (!same) return { ok: false, reason: 'unsafe' }
+  } catch (err) {
+    // ENOENT — the canvas dir is already gone; the record mutation below is
+    // still the durable truth, so continue. Any other error means we cannot
+    // vouch for the path and must not remove under it.
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') return { ok: false, reason: 'unsafe' }
+  }
+
+  const deletedVersionIds = run.map((v) => v.id)
+  const deleted = new Set(deletedVersionIds)
+  for (const id of deletedVersionIds) {
+    try {
+      removeTreeNoFollow(versionDir(canvasId, id))
+    } catch (err) {
+      // Best-effort: the record mutation is what makes the delete durable, so a
+      // file that will not unlink leaves an orphan, never a resurrected version.
+      console.warn('[canvas-store] artifact version files left behind:', err)
+    }
+  }
+
+  const remaining = record.versions.filter((v) => !deleted.has(v.id))
+  // Repoint the active version if it was in the deleted run — to the newest
+  // survivor, the same fallback sanitizeRecord uses.
+  const activeVersionId =
+    record.activeVersionId && deleted.has(record.activeVersionId)
+      ? (remaining[remaining.length - 1]?.id ?? null)
+      : record.activeVersionId
+  // The review-needed stamp goes if it pointed at a deleted version.
+  const awaitingReview =
+    record.awaitingReview && deleted.has(record.awaitingReview.versionId) ? undefined : record.awaitingReview
+
+  const nextRecord: CanvasRecord = {
+    ...record,
+    versions: remaining,
+    activeVersionId,
+    // The counter is NEVER lowered — this is the durability guarantee.
+    nextVersion: record.nextVersion,
+    ...(awaitingReview ? { awaitingReview } : {}),
+  }
+  // A dropped awaitingReview must actually be removed, not left from the spread.
+  if (!awaitingReview) delete (nextRecord as { awaitingReview?: unknown }).awaitingReview
+  persist(nextRecord)
+  canvases.set(canvasId, nextRecord)
+  emitChanged(nextRecord)
+  return { ok: true, deletedVersionIds }
 }
 
 export function adoptCanvasForSession(

--- a/src/main/ipc/canvas-handlers.ts
+++ b/src/main/ipc/canvas-handlers.ts
@@ -13,12 +13,14 @@ import { z } from 'zod'
 import { IPC } from '../../shared/ipc-channels'
 import {
   clearAwaitingReview,
+  deleteArtifact,
   deleteCanvas,
   getCanvasStateForSession,
   listAllCanvases,
   onCanvasChanged,
   renderVersion,
   setActiveVersion,
+  setArtifactArchived,
 } from '../canvas/canvas-store'
 import {
   MAX_SKETCH_PNG_BYTES,
@@ -27,6 +29,7 @@ import {
   dropReviewsForCanvas,
   getReviewCountsForCanvas,
   getReviewStateForSession,
+  deleteAnnotationsForVersions,
   markAddressedNotesSeen,
   onReviewChanged,
   reopenAnnotation,
@@ -118,6 +121,26 @@ const listAllSchema = z
  *  canvas store even before the store re-checks and realpath-confirms it. */
 const deleteCanvasSchema = z
   .object({ canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/) })
+  .strict()
+
+/** Archive/unarchive one artifact (item C, phase 5): the canvas it is on, one
+ *  of its version ids, and the target state. Reversible; the store re-checks
+ *  everything and no-ops safely on a stranger id. */
+const artifactArchiveSchema = z
+  .object({
+    canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/),
+    versionId: z.string().regex(/^v[0-9]{1,9}$/),
+    archived: z.boolean(),
+  })
+  .strict()
+
+/** Permanently delete one artifact (item C, phase 5). Same id shapes; the store
+ *  applies the path discipline and refuses the canvas's only artifact. */
+const artifactDeleteSchema = z
+  .object({
+    canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/),
+    versionId: z.string().regex(/^v[0-9]{1,9}$/),
+  })
   .strict()
 
 /** Canvas ids are app-minted (see CANVAS_ID_RE); bounded here at the seam. */
@@ -378,6 +401,29 @@ export function registerCanvasHandlers(getWindow: () => BrowserWindow | null): v
   ipcMain.handle(IPC.CANVAS_RENDER, async (_e, args: unknown) => {
     const { sessionId, source } = renderSchema.parse(args)
     return renderVersion(sessionId, source)
+  })
+
+  // Archive/unarchive one artifact (item C, phase 5). Reversible: it only moves
+  // the artifact into (or out of) the muted Archived history group. Returns the
+  // updated state so the pane reflects it without waiting for the change push.
+  ipcMain.handle(IPC.CANVAS_ARCHIVE_ARTIFACT, async (_e, args: unknown) => {
+    const { canvasId, versionId, archived } = artifactArchiveSchema.parse(args)
+    const state = setArtifactArchived(canvasId, versionId, archived)
+    return { ok: state !== null, state }
+  })
+
+  // Permanently delete one artifact: its versions, their files, and their review
+  // notes. Two stores: the canvas store removes the versions (and returns their
+  // ids), then the review store drops the notes anchored to them — the same
+  // two-store shape CANVAS_DELETE uses for dropReviewsForCanvas. The review drop
+  // only runs on a successful version delete, so a refused delete never clears a
+  // note.
+  ipcMain.handle(IPC.CANVAS_DELETE_ARTIFACT, async (_e, args: unknown) => {
+    const { canvasId, versionId } = artifactDeleteSchema.parse(args)
+    const result = deleteArtifact(canvasId, versionId)
+    if (!result.ok) return { ok: false as const, reason: result.reason }
+    const notesDeleted = deleteAnnotationsForVersions(canvasId, result.deletedVersionIds)
+    return { ok: true as const, deletedVersions: result.deletedVersionIds.length, notesDeleted: notesDeleted ?? 0 }
   })
 
   ipcMain.handle(IPC.CANVAS_SET_ACTIVE_VERSION, async (_e, args: unknown) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -281,6 +281,12 @@ export interface ElectronAPI {
     listAll: (args?: { openTileSessionIds?: string[]; sessionId?: string }) => Promise<CanvasLibraryEntry[]>
     /** The user deletes a canvas and its files. The only destructive canvas call. */
     deleteCanvas: (args: { canvasId: string }) => Promise<{ ok: boolean }>
+    /** Archive/unarchive one artifact (item C): reversible, returns the state. */
+    archiveArtifact: (args: { canvasId: string; versionId: string; archived: boolean }) => Promise<{ ok: boolean; state: CanvasState | null }>
+    /** Permanently delete one artifact, its versions and their review notes. */
+    deleteArtifact: (args: { canvasId: string; versionId: string }) => Promise<
+      { ok: true; deletedVersions: number; notesDeleted: number } | { ok: false; reason: 'not-found' | 'only-artifact' | 'unsafe' }
+    >
     /** The user reclaims a named canvas — the only path that moves ownership. */
     reclaim: (args: {
       sessionId: string
@@ -895,6 +901,9 @@ const electronAPI: ElectronAPI = {
     listAll: (args?: { openTileSessionIds?: string[]; sessionId?: string }) =>
       ipcRenderer.invoke(IPC.CANVAS_LIST_ALL, args ?? {}),
     deleteCanvas: (args: { canvasId: string }) => ipcRenderer.invoke(IPC.CANVAS_DELETE, args),
+    archiveArtifact: (args: { canvasId: string; versionId: string; archived: boolean }) =>
+      ipcRenderer.invoke(IPC.CANVAS_ARCHIVE_ARTIFACT, args),
+    deleteArtifact: (args: { canvasId: string; versionId: string }) => ipcRenderer.invoke(IPC.CANVAS_DELETE_ARTIFACT, args),
     reviewGetState: (args: { sessionId: string }) => ipcRenderer.invoke(IPC.CANVAS_REVIEW_GET_STATE, args),
     annotationUpsert: (args: { sessionId: string; draft: CanvasAnnotationDraft }) =>
       ipcRenderer.invoke(IPC.CANVAS_ANNOTATION_UPSERT, args),

--- a/src/renderer/canvas/canvas-history.ts
+++ b/src/renderer/canvas/canvas-history.ts
@@ -1,0 +1,93 @@
+// Two-level canvas history (item C, phase 4) — a DISPLAY PROJECTION over the
+// flat version list. No data migration: version ids and review anchors are
+// untouched; this only decides how the chrome GROUPS them.
+//
+// Level 1 is the ARTIFACT — a plan, a mockup, a legacy test build — each a
+// contiguous run of versions of the same kind. Level 2 is the version run
+// WITHIN one artifact ("plan v3 of 3"). A plan can have ten versions and they
+// never mix into one flat number with the mockup's.
+//
+// Kinds: a version's `mode` ('plan' | 'design' | 'uat') is the artifact kind
+// ('design' reads as "mockup"). A 'uat' artifact is ARCHIVED — testing is live
+// now and no longer versioned, but builds saved by older betas stay readable so
+// their old review notes keep an anchor.
+
+import type { CanvasVersion } from '../../shared/canvas'
+import { CanvasMode } from '../../shared/canvas'
+
+export interface CanvasArtifact {
+  /** Stable within a render of the list: the id of the artifact's FIRST
+   *  version. Used as the picker key and to remember the open artifact. */
+  key: string
+  /** The artifact kind, from its versions' `mode`. */
+  kind: CanvasMode
+  /** The word the user reads — "Plan", "Mockup", or the build label. */
+  label: string
+  /** This artifact's own versions, in render order. */
+  versions: CanvasVersion[]
+  /** The latest version's timestamp — the "updated" the picker shows. */
+  updatedAt: string
+  /** A legacy test build: shown muted, read-only, under ARCHIVED. */
+  archived: boolean
+}
+
+/** "Plan" / "Mockup" / a uat build's label. Mirrors AgentCanvasPane.versionKind
+ *  but at the artifact grain (the first version carries the kind). */
+function artifactLabel(v: CanvasVersion): string {
+  if (v.source.mode === 'uat') return v.source.buildLabel?.trim() || 'Test build'
+  return v.mode === 'plan' ? 'Plan' : 'Mockup'
+}
+
+/**
+ * Group the ready (non-draft) versions into artifacts — a new artifact begins
+ * wherever the kind changes. Drafts are the agent's own loop (#366) and never
+ * appear in history.
+ */
+export function groupVersionsIntoArtifacts(versions: readonly CanvasVersion[]): CanvasArtifact[] {
+  const artifacts: CanvasArtifact[] = []
+  for (const v of versions) {
+    if (v.draft) continue
+    const kind = v.mode
+    const last = artifacts[artifacts.length - 1]
+    if (last && last.kind === kind) {
+      last.versions.push(v)
+      last.updatedAt = v.createdAt
+    } else {
+      artifacts.push({
+        key: v.id,
+        kind,
+        label: artifactLabel(v),
+        versions: [v],
+        updatedAt: v.createdAt,
+        archived: kind === 'uat',
+      })
+    }
+  }
+  return artifacts
+}
+
+/** The artifact a given version belongs to, and its 1-based position within
+ *  that artifact — the two facts the stepper needs ("plan v2 of 3"). Returns
+ *  null when the version is a draft or not present. */
+export function locateVersion(
+  artifacts: readonly CanvasArtifact[],
+  versionId: string,
+): { artifact: CanvasArtifact; index: number } | null {
+  for (const artifact of artifacts) {
+    const index = artifact.versions.findIndex((v) => v.id === versionId)
+    if (index >= 0) return { artifact, index }
+  }
+  return null
+}
+
+/** The live artifacts (plan/mockup) and the archived ones (legacy uat builds),
+ *  split for the two groups the picker renders. Order within each is preserved. */
+export function splitArchived(artifacts: readonly CanvasArtifact[]): {
+  live: CanvasArtifact[]
+  archived: CanvasArtifact[]
+} {
+  const live: CanvasArtifact[] = []
+  const archived: CanvasArtifact[] = []
+  for (const a of artifacts) (a.archived ? archived : live).push(a)
+  return { live, archived }
+}

--- a/src/renderer/canvas/canvas-history.ts
+++ b/src/renderer/canvas/canvas-history.ts
@@ -13,7 +13,7 @@
 // their old review notes keep an anchor.
 
 import type { CanvasVersion } from '../../shared/canvas'
-import { CanvasMode } from '../../shared/canvas'
+import { CanvasMode, artifactRuns } from '../../shared/canvas'
 
 export interface CanvasArtifact {
   /** Stable within a render of the list: the id of the artifact's FIRST
@@ -44,26 +44,17 @@ function artifactLabel(v: CanvasVersion): string {
  * appear in history.
  */
 export function groupVersionsIntoArtifacts(versions: readonly CanvasVersion[]): CanvasArtifact[] {
-  const artifacts: CanvasArtifact[] = []
-  for (const v of versions) {
-    if (v.draft) continue
-    const kind = v.mode
-    const last = artifacts[artifacts.length - 1]
-    if (last && last.kind === kind) {
-      last.versions.push(v)
-      last.updatedAt = v.createdAt
-    } else {
-      artifacts.push({
-        key: v.id,
-        kind,
-        label: artifactLabel(v),
-        versions: [v],
-        updatedAt: v.createdAt,
-        archived: kind === 'uat',
-      })
-    }
-  }
-  return artifacts
+  // Runs come from the SHARED grouping so this picker and main's archive/delete
+  // act on the exact same version sets. A run is archived when it is a legacy
+  // uat build OR the user tucked it away (the flag rides every version in it).
+  return artifactRuns(versions).map((run) => ({
+    key: run[0].id,
+    kind: run[0].mode,
+    label: artifactLabel(run[0]),
+    versions: run,
+    updatedAt: run[run.length - 1].createdAt,
+    archived: run[0].mode === 'uat' || run[0].archived === true,
+  }))
 }
 
 /** The artifact a given version belongs to, and its 1-based position within

--- a/src/renderer/canvas/canvas-history.ts
+++ b/src/renderer/canvas/canvas-history.ts
@@ -31,8 +31,8 @@ export interface CanvasArtifact {
   archived: boolean
 }
 
-/** "Plan" / "Mockup" / a uat build's label. Mirrors AgentCanvasPane.versionKind
- *  but at the artifact grain (the first version carries the kind). */
+/** "Plan" / "Mockup" / a uat build's label, at the artifact grain (the first
+ *  version carries the kind). */
 function artifactLabel(v: CanvasVersion): string {
   if (v.source.mode === 'uat') return v.source.buildLabel?.trim() || 'Test build'
   return v.mode === 'plan' ? 'Plan' : 'Mockup'

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1267,6 +1267,18 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           versions={versions}
           activeVersionId={version.id}
           onSelectVersion={(id) => void setActiveVersion(sessionId, id)}
+          onArchive={(artifact) => {
+            // Reversible: the store returns the new state and pushes a change,
+            // but refresh here makes the picker update without the round-trip.
+            void window.electronAPI.canvas
+              .archiveArtifact({ canvasId, versionId: artifact.key, archived: !artifact.archived })
+              .then(() => useCanvasStore.getState().refresh(sessionId))
+          }}
+          onDelete={(artifact) => {
+            void window.electronAPI.canvas
+              .deleteArtifact({ canvasId, versionId: artifact.key })
+              .then(() => useCanvasStore.getState().refresh(sessionId))
+          }}
         />
         {/* What is still owed on THIS canvas. From one, unlike the Canvas
             button's pill: in here you are already looking at the thing, so one

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -476,6 +476,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const [loadTimedOut, setLoadTimedOut] = useState(false)
   // Bumping this re-mounts the iframe: the retry affordance for a dead render.
   const [reloadNonce, setReloadNonce] = useState(0)
+  // The review panel can be hidden (item C): the page takes the full width and
+  // a thin rail keeps the outstanding count and the way back. Pane-local, like
+  // the zoom — it resets when the pane closes.
+  const [panelHidden, setPanelHidden] = useState(false)
 
   const contentUrl = useMemo(
     () => canvasContentUrl(canvasId, version.id, version.source.entry),
@@ -1732,24 +1736,50 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             the review, and keeping it out means the panel's own file is
             untouched by this change. The panel keeps its own width and left
             border; this column just stacks the two. */}
-        <div className="shrink-0 flex flex-col min-h-0">
-          <div className="flex-1 min-h-0 flex">
-            <CanvasNotesPanel
-              sessionId={sessionId}
-              version={version}
-              getGlassApi={() => glassApiRef.current}
-              onReturnToTerminal={() => togglePane(sessionId)}
-              isActive={isActive}
-            />
+        {panelHidden ? (
+          /* Collapsed rail (item C): the panel is away, the page has the width,
+             and this keeps the outstanding count and the way back. */
+          <button
+            onClick={() => setPanelHidden(false)}
+            data-testid="canvas-panel-rail"
+            aria-label="Show the review panel"
+            title="Show the review panel"
+            className="shrink-0 w-[30px] flex flex-col items-center gap-2 py-2.5 border-l border-[var(--border-subtle)] bg-[var(--surface-chrome)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors focus-ring"
+          >
+            <span aria-hidden>⟨</span>
+            {openReviewCount > 0 && (
+              <span
+                className="text-[10px] font-bold rounded-full px-[5px] leading-[1.4]"
+                style={{ background: 'var(--color-peach)', color: 'var(--surface-chrome)' }}
+              >
+                {openReviewCount}
+              </span>
+            )}
+            <span className="text-[10px] tracking-[0.12em]" style={{ writingMode: 'vertical-rl' }} aria-hidden>
+              REVIEW
+            </span>
+          </button>
+        ) : (
+          <div className="shrink-0 flex flex-col min-h-0 transition-[width] duration-[240ms] ease-out">
+            <div className="flex-1 min-h-0 flex">
+              <CanvasNotesPanel
+                sessionId={sessionId}
+                version={version}
+                getGlassApi={() => glassApiRef.current}
+                onReturnToTerminal={() => togglePane(sessionId)}
+                isActive={isActive}
+                onHide={() => setPanelHidden(true)}
+              />
+            </div>
+            {xrayReadsOutInPanel(xrayMode) && (
+              <CanvasXrayReadout
+                hit={pointerOwner === 'content' ? (hover?.hit ?? null) : null}
+                label={hoverLabel}
+                pointerOwner={pointerOwner}
+              />
+            )}
           </div>
-          {xrayReadsOutInPanel(xrayMode) && (
-            <CanvasXrayReadout
-              hit={pointerOwner === 'content' ? (hover?.hit ?? null) : null}
-              label={hoverLabel}
-              pointerOwner={pointerOwner}
-            />
-          )}
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1468,10 +1468,27 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
       </div>
 
       <div className="relative flex-1 flex min-h-0">
-        {/* Stage: content iframe below, glass above, transient overlay on top.
-            overflow-hidden so highlight boxes for offscreen page coords can
-            never bleed over the chrome around the stage. */}
-        <div className="flex-1 min-w-0 relative overflow-hidden">
+        {/* Stage: the reviewed page in a framed card (item C) so the boundary
+            between the agent's content and the app is unmistakable. The padded
+            outer holds the "PAGE UNDER REVIEW" tag over the frame's top border;
+            the inner frame is overflow-hidden, which is what keeps highlight
+            boxes for offscreen page coords from bleeding over the chrome. The
+            iframe, glass and overlay all fill this frame 1:1, so their pinning
+            is unchanged — the frame is a smaller box they share, not a new
+            coordinate space. */}
+        <div className="flex-1 min-w-0 relative p-2.5">
+          <span
+            className="absolute z-10 top-2.5 left-5 -translate-y-1/2 px-2 py-px rounded text-[9.5px] tracking-[0.08em] pointer-events-none"
+            style={{ background: 'var(--surface-stage)', border: '1px solid var(--border-subtle)', color: 'var(--text-muted)' }}
+            data-testid="canvas-content-tag"
+          >
+            PAGE UNDER REVIEW
+          </span>
+          <div
+            className="absolute inset-2.5 rounded-lg overflow-hidden"
+            style={{ border: '2px solid var(--border-subtle)', boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.28)' }}
+            data-testid="canvas-content-frame"
+          >
           <iframe
             // Keyed on the URL so a version switch mounts a NEW element. Reusing
             // one iframe leaves the OLD document in contentWindow until the new
@@ -1705,6 +1722,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                 </button>
               </div>
             )}
+          </div>
           </div>
         </div>
 

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -147,6 +147,48 @@ function canvasModeBadge(version: CanvasVersion): { label: string; title: string
     : { label: 'Mockup', title: 'A standalone mockup document', tone: 'var(--border-subtle)' }
 }
 
+/**
+ * The MODE, as the redesigned chrome's leading title (item C): the word the
+ * user thinks in — PLAN / MOCKUP / TESTING — in its own colour, with a keel
+ * line under the bar echoing it. This is the same fact `canvasModeBadge`
+ * carried as a small badge; the redesign promotes it to the title because it is
+ * the first thing that should read, and because a plan, a mockup and a live
+ * test are annotated differently.
+ */
+function canvasModeLockup(version: CanvasVersion): { word: string; color: string } {
+  if (version.source.mode === 'uat') return { word: 'TESTING MODE', color: 'var(--color-green)' }
+  return version.mode === 'plan'
+    ? { word: 'PLAN MODE', color: 'var(--color-mauve)' }
+    : { word: 'MOCKUP MODE', color: 'var(--color-blue)' }
+}
+
+/** The tool-chip glyphs (item C): eye = Inspect, pencil = Sketch, dashed
+ *  rectangle + arrow = Region. Stroke-only, sized for a 26px chip. */
+function ToolIcon({ kind }: { kind: 'inspect' | 'sketch' | 'region' }) {
+  const common = { width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const, 'aria-hidden': true }
+  if (kind === 'inspect') {
+    return (
+      <svg {...common}>
+        <path d="M3 12s3.5-6 9-6 9 6 9 6-3.5 6-9 6-9-6-9-6z" />
+        <circle cx="12" cy="12" r="2.5" />
+      </svg>
+    )
+  }
+  if (kind === 'sketch') {
+    return (
+      <svg {...common}>
+        <path d="M4 20l3.5-.8L19 7.7a2 2 0 0 0-2.8-2.8L4.8 16.4z" />
+      </svg>
+    )
+  }
+  return (
+    <svg {...common}>
+      <rect x="4" y="6" width="12" height="10" rx="1" strokeDasharray="3 2.4" />
+      <path d="M18 14l3 7-3.2-1.2L16 22z" />
+    </svg>
+  )
+}
+
 /** Full stamp for the label's tooltip — the human line is deliberately short. */
 function versionTooltip(version: CanvasVersion): string {
   const ms = Date.parse(version.createdAt)
@@ -1150,21 +1192,27 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   // review); the leftover chrome is hidden by the glass-scoped CSS.
   const glassUIOptions = useMemo(() => ({ welcomeScreen: false, tools: { image: false } }), [])
 
-  // What Browse actually does depends on the x-ray mode now, and the strip is
+  // What Inspect actually does depends on the x-ray mode now, and the hint is
   // the only thing that says so — a user who switched x-ray off and still read
   // "hover to inspect, click to select" would reasonably think it had failed.
-  const browseHint =
+  // The label carries the x-ray state (Inspect · Stealth) so the strip and the
+  // chip agree on one glance.
+  const inspectHint =
     xrayMode === 'off'
       ? 'the page is live and plain — x-ray is off, so hovering and clicking do nothing here'
       : xrayMode === 'stealth'
-        ? 'the page is live — hovering names the element in the panel and draws nothing · click to select · ↑ parent · Esc clear'
-        : 'the page is live — hover to inspect, click to select · ↑ parent · Esc clear'
+        ? 'hovering names the element in the panel and draws nothing on the page · click selects · ↑ parent · Esc clears'
+        : 'hover to inspect, click to select · ↑ parent · Esc clears'
 
   const modeStrip = marqueeArmed
     ? { color: 'text-peach', label: 'Region', hint: 'drag a rectangle over the area — Esc cancels' }
     : mode === 'draw'
-      ? { color: 'text-mauve', label: 'Draw', hint: 'sketch on the glass; select strokes, then attach them to a note' }
-      : { color: 'text-blue', label: 'Browse', hint: browseHint }
+      ? { color: 'text-mauve', label: 'Sketch', hint: 'the glass takes the pointer; draw over the content, then attach the strokes to a note' }
+      : {
+          color: 'text-blue',
+          label: xrayMode === 'on' ? 'Inspect' : `Inspect · ${xrayMode === 'off' ? 'Off' : 'Stealth'}`,
+          hint: inspectHint,
+        }
 
   /** Per USER, so it is written straight to settings rather than to any canvas
    *  state (#367). Fire-and-forget: the store applies the change synchronously
@@ -1174,43 +1222,64 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     void useSettingsStore.getState().updateSettings({ canvasXrayMode: next })
   }
 
-  const segmentClass = (active: boolean) =>
-    `px-2.5 py-[5px] rounded text-[11.5px] font-medium leading-none transition-colors focus-ring disabled:opacity-40 ${
-      active
-        ? 'bg-[var(--surface-overlay)] text-[var(--text-primary)]'
-        : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-    }`
-
   const versionClockLabel = versionClock(version.createdAt)
+  const modeLockup = canvasModeLockup(version)
+
+  // Which tool owns the pointer (item C): Inspect = browse, Sketch = draw,
+  // Region = the marquee. These are the same three states the pointer layers
+  // already switch on (pointerOwner); the chips are their presentation.
+  const inspectActive = mode === 'browse' && !marqueeArmed
+  const sketchActive = mode === 'draw' && !marqueeArmed
+  const regionActive = marqueeArmed
+  // Sketch and Region take the pointer off the content, so Inspect — and the
+  // X-ray setting that only governs Inspect — visibly pause.
+  const inspectPaused = !inspectActive
+  const planLocked = version.mode === 'plan'
+
+  /** A tool chip: app-family pill, accented when it owns the pointer, dimmed
+   *  when another tool has paused it. */
+  const chipClass = (active: boolean, paused: boolean) =>
+    `flex items-center gap-1.5 h-[26px] px-2.5 rounded-md text-[12px] leading-none transition-colors focus-ring border ${
+      active
+        ? 'font-semibold text-[var(--brand)]'
+        : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+    } ${paused ? 'opacity-40' : ''}`
+  const chipStyle = (active: boolean): React.CSSProperties =>
+    active
+      ? { background: 'color-mix(in srgb, var(--brand) 15%, transparent)', borderColor: 'color-mix(in srgb, var(--brand) 52%, transparent)' }
+      : { background: 'color-mix(in srgb, var(--surface-panel) 60%, transparent)', borderColor: 'var(--border-subtle)' }
 
   return (
     <div ref={paneRootRef} className="flex-1 flex flex-col min-h-0 bg-[var(--surface-stage)]">
-      {/* Pane chrome — 38px, one type size, and the mode switch given real
-          weight because it decides where the user's clicks land. */}
-      <div className="h-[38px] shrink-0 flex items-center gap-2.5 px-3 bg-[var(--surface-chrome)] border-b border-[var(--border-subtle)]">
-        <span className="w-[5px] h-[5px] shrink-0 rounded-full bg-[var(--brand)]" aria-hidden="true" />
-        {/* WHAT this canvas is of, leading, and the way to the others. "Agent
-            Canvas" was a label for a pane that could only ever show one thing;
-            a session authors many, so the pane has to say which one you are
-            looking at and let you reach the rest. */}
+      {/* Pane chrome — mode is the title (item C); the keel line under the bar
+          carries the mode colour, and the tool chips on the right decide where
+          the user's clicks land. */}
+      <div className="relative h-[42px] shrink-0 flex items-center gap-2.5 px-3 bg-[var(--surface-chrome)]">
+        <span
+          aria-hidden
+          className="absolute left-0 right-0 bottom-0 h-[2px]"
+          style={{ background: `linear-gradient(90deg, ${modeLockup.color}, transparent 72%)` }}
+          data-testid="canvas-mode-keel"
+        />
+        {/* Mode-as-title: the word the user thinks in, in its own colour. */}
+        <span
+          className="shrink-0 text-[13px] font-extrabold tracking-[0.09em] leading-none"
+          style={{ color: modeLockup.color }}
+          title={canvasModeBadge(version).title}
+          data-testid="canvas-mode-word"
+          data-canvas-mode={version.mode}
+        >
+          {modeLockup.word}
+        </span>
+        {/* WHAT this canvas is of, and the way to the others. A session authors
+            many canvases, so the pane has to say which one you are looking at
+            and let you reach the rest. */}
         <CanvasSubjectPicker
           sessionId={sessionId}
           canvasId={canvasId}
           title={canvasTitle}
           onOpenLibrary={onOpenLibrary}
         />
-        {/* The version identity, in words a person can act on. It lives here
-            because a version EXISTS — the empty state's own chrome carries no
-            version label and no picker, because there is nothing to version. */}
-        <span
-          className="shrink-0 text-[10px] rounded px-1.5 py-0.5 border text-[var(--text-secondary)]"
-          style={{ borderColor: `color-mix(in srgb, ${canvasModeBadge(version).tone} 55%, transparent)` }}
-          title={canvasModeBadge(version).title}
-          data-testid="canvas-mode-badge"
-          data-canvas-mode={version.mode}
-        >
-          {canvasModeBadge(version).label}
-        </span>
         {/* Content zoom (#368) — shown only when it is not 1:1, click resets.
             The chip is the visibility the forged-zoom analysis leans on: a zoom
             the user did not ask for is never silent. */}
@@ -1290,76 +1359,94 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           Library
         </button>
         <div className="flex-1" />
-        {/* THE control of this surface: who owns the pointer (spec §6). */}
-        <div
-          className="shrink-0 flex items-center gap-[2px] p-[2px] rounded-md bg-[var(--surface-panel)] border border-[var(--border-subtle)]"
-          role="group"
-          aria-label="Canvas interaction mode"
-        >
-          <button
-            onClick={() => {
-              setMarqueeArmed(sessionId, false)
-              setInteractionMode(sessionId, 'browse')
-            }}
-            aria-pressed={mode === 'browse' && !marqueeArmed}
-            className={segmentClass(mode === 'browse' && !marqueeArmed)}
-            title="Browse mode — the content is interactive; hover to inspect, click to select"
-          >
-            Browse
-          </button>
+        {/* Tools — Inspect / Sketch / Region (item C): app-family chips that
+            decide who owns the pointer. The X-ray setting rides the Inspect
+            chip, since it only governs what Inspect does; Sketch and Region
+            visibly pause both. */}
+        <div className="shrink-0 flex items-center gap-1.5" role="group" aria-label="Canvas tools" data-testid="canvas-tool-chips">
+          {/* Inspect (browse) with the X-ray setting attached. */}
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => {
+                setMarqueeArmed(sessionId, false)
+                setInteractionMode(sessionId, 'browse')
+              }}
+              aria-pressed={inspectActive}
+              className={chipClass(inspectActive, false)}
+              style={chipStyle(inspectActive)}
+              title="Inspect — the content is live; hover identifies elements, click selects"
+              data-testid="canvas-tool-inspect"
+            >
+              <ToolIcon kind="inspect" />
+              Inspect
+            </button>
+            {/* X-ray Off · Stealth · On (#367), attached to Inspect: it is the
+                one setting that only changes what Inspect does. Locked to
+                Stealth on a plan (owner call, 2026-08-23) — the boxes-on-page
+                x-ray adds nothing over a document of steps, and Off would break
+                note anchoring — so the segments are shown, not hidden, but
+                inert with a lock. */}
+            <div
+              className={`flex items-center rounded-md overflow-hidden border text-[11px] ${inspectPaused ? 'opacity-40' : ''}`}
+              style={{ borderColor: 'color-mix(in srgb, var(--color-teal) 40%, transparent)' }}
+              role="group"
+              aria-label="Canvas x-ray hover"
+              data-testid="canvas-xray-mode"
+              title={planLocked ? 'X-ray is locked to Stealth on a plan — a document of steps needs no boxes on the page, and Off would break note anchoring.' : undefined}
+            >
+              {CANVAS_XRAY_MODE_OPTIONS.map((option) => {
+                const selected = xrayMode === option.value
+                return (
+                  <button
+                    key={option.value}
+                    onClick={() => { if (!planLocked) setXrayMode(option.value) }}
+                    aria-pressed={selected}
+                    disabled={planLocked}
+                    className="px-2 py-[3px] leading-none transition-colors focus-ring disabled:cursor-default"
+                    style={selected
+                      ? { background: 'color-mix(in srgb, var(--color-teal) 16%, transparent)', color: 'var(--color-teal)', fontWeight: 600 }
+                      : { color: 'var(--text-secondary)' }}
+                    title={option.title}
+                    data-testid={`canvas-xray-${option.value}`}
+                  >
+                    {option.label}
+                  </button>
+                )
+              })}
+              {planLocked && (
+                <span className="px-1.5 py-[3px] leading-none text-[10px]" style={{ color: 'var(--text-muted)' }} aria-hidden>
+                  🔒
+                </span>
+              )}
+            </div>
+          </div>
           <button
             onClick={() => {
               setMarqueeArmed(sessionId, false)
               setInteractionMode(sessionId, 'draw')
             }}
-            aria-pressed={mode === 'draw' && !marqueeArmed}
-            className={segmentClass(mode === 'draw' && !marqueeArmed)}
-            title="Draw mode — the glass is interactive; sketch over the content"
+            aria-pressed={sketchActive}
+            className={chipClass(sketchActive, false)}
+            style={chipStyle(sketchActive)}
+            title="Sketch — the glass takes the pointer; draw over the content, then attach the strokes to a note"
+            data-testid="canvas-tool-sketch"
           >
-            Draw
+            <ToolIcon kind="sketch" />
+            Sketch
           </button>
           <button
             onClick={() => setMarqueeArmed(sessionId, !marqueeArmed)}
-            aria-pressed={marqueeArmed}
+            aria-pressed={regionActive}
             disabled={!viewport}
-            className={segmentClass(marqueeArmed)}
+            className={chipClass(regionActive, false)}
+            style={chipStyle(regionActive)}
             title="Region — drag a rectangle to select an area for a note (Esc cancels)"
+            data-testid="canvas-tool-region"
           >
+            <ToolIcon kind="region" />
             Region
           </button>
         </div>
-        {/* X-ray (#367) — whether pointing at the page marks it up, names it
-            quietly beside the stage, or does nothing at all. Beside the mode
-            switch because the two together are the whole answer to "what
-            happens when I move the mouse over this". A PLAN page pins x-ray to
-            stealth (owner call, 2026-08-23), so the switch would be three dead
-            buttons there — it is dropped rather than disabled. */}
-        {version.mode !== 'plan' && (
-          <>
-            <span className="shrink-0 text-[10px] uppercase tracking-wide text-[var(--text-secondary)]" aria-hidden="true">
-              X-ray
-            </span>
-            <div
-              className="shrink-0 flex items-center gap-[2px] p-[2px] rounded-md bg-[var(--surface-panel)] border border-[var(--border-subtle)]"
-              role="group"
-              aria-label="Canvas x-ray hover"
-              data-testid="canvas-xray-mode"
-            >
-              {CANVAS_XRAY_MODE_OPTIONS.map((option) => (
-                <button
-                  key={option.value}
-                  onClick={() => setXrayMode(option.value)}
-                  aria-pressed={xrayMode === option.value}
-                  className={segmentClass(xrayMode === option.value)}
-                  title={option.title}
-                  data-testid={`canvas-xray-${option.value}`}
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-          </>
-        )}
         <button
           onClick={() => togglePane(sessionId)}
           aria-label="Close Agent Canvas"

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -7,6 +7,7 @@ import { CanvasLibrary } from './CanvasLibrary'
 import CanvasSubjectPicker from './CanvasSubjectPicker'
 import CanvasFiledStrip from './CanvasFiledStrip'
 import CanvasNotesPanel from './CanvasNotesPanel'
+import CanvasHistoryControl from './CanvasHistoryControl'
 import CanvasXrayReadout from './CanvasXrayReadout'
 import { useCanvasStore } from '../stores/canvasStore'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -38,11 +39,6 @@ import {
 } from '../canvas/xray-mode'
 import { openReviewsOf, openSubmittedNotesOf, useCanvasReviewStore } from '../stores/canvasReviewStore'
 import { useCanvasTotalsStore } from '../stores/canvasTotalsStore'
-import { relativeTime } from '../utils/relativeTime'
-
-/** JetBrains Mono ships with the app (@font-face in styles.css) but Tailwind's
- *  `font-mono` resolves to the generic stack, so mono is named explicitly. */
-const MONO = "'JetBrains Mono', ui-monospace, monospace"
 
 /** How long a frame may sit silent before the pane stops claiming it is
  *  loading. A 404, a CSP-blocked bridge script and a crashed page otherwise
@@ -102,24 +98,6 @@ function isTypingTarget(el: Element | null): boolean {
   const tag = el.tagName.toLowerCase()
   if (tag === 'input' || tag === 'textarea' || tag === 'select') return true
   return (el as HTMLElement).isContentEditable === true
-}
-
-/** Wall-clock of a render, or null when the stored stamp will not parse. */
-function versionClock(iso: string): string | null {
-  const ms = Date.parse(iso)
-  if (!Number.isFinite(ms)) return null
-  return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
-
-/** What KIND of thing this version is, in the user's words. A UAT render is
- *  the app under test, so its build label (when the agent supplied one) is the
- *  most useful thing we can say about it. */
-function versionKind(version: CanvasVersion): string {
-  if (version.source.mode === 'uat') return version.source.buildLabel?.trim() || 'Live site'
-  // `version.mode`, not `source.mode`: a plan is STORED as a design document and
-  // its source says so, which is exactly what keeps plan mode off every serving
-  // path. What kind of thing it is lives on the version. See CanvasRenderSource.
-  return version.mode === 'plan' ? 'Plan' : 'Mockup'
 }
 
 /**
@@ -187,21 +165,6 @@ function ToolIcon({ kind }: { kind: 'inspect' | 'sketch' | 'region' }) {
       <path d="M18 14l3 7-3.2-1.2L16 22z" />
     </svg>
   )
-}
-
-/** Full stamp for the label's tooltip — the human line is deliberately short. */
-function versionTooltip(version: CanvasVersion): string {
-  const ms = Date.parse(version.createdAt)
-  const when = Number.isFinite(ms) ? new Date(ms).toLocaleString() : version.createdAt
-  return `${version.id} — ${versionKind(version)}, rendered ${when}`
-}
-
-/** One picker row: `v3 · 14:07 · 2m ago`. Raw ids told the user nothing about
- *  which render they were switching to. */
-function versionOptionLabel(version: CanvasVersion, now: number): string {
-  const ms = Date.parse(version.createdAt)
-  if (!Number.isFinite(ms)) return `${version.id} · ${versionKind(version)}`
-  return `${version.id} · ${versionClock(version.createdAt)} · ${relativeTime(ms, now)}`
 }
 
 interface Props {
@@ -1226,7 +1189,6 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
     void useSettingsStore.getState().updateSettings({ canvasXrayMode: next })
   }
 
-  const versionClockLabel = versionClock(version.createdAt)
   const modeLockup = canvasModeLockup(version)
 
   // Which tool owns the pointer (item C): Inspect = browse, Sketch = draw,
@@ -1297,31 +1259,15 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             {formatCanvasZoom(zoom)}
           </button>
         )}
-        <span
-          className="min-w-0 truncate text-[11.5px] text-[var(--text-primary)]"
-          title={versionTooltip(version)}
-        >
-          <span className="text-[var(--text-secondary)]" style={{ fontFamily: MONO }}>
-            {version.id}
-          </span>
-          {versionClockLabel ? ` · ${versionClockLabel}` : ''} · {versionKind(version)}
-        </span>
-        {versions.filter((v) => !v.draft).length > 1 && (
-          <select
-            value={version.id}
-            onChange={(e) => void setActiveVersion(sessionId, e.target.value)}
-            className="shrink-0 text-[11.5px] rounded px-1.5 py-0.5 bg-[var(--surface-panel)] text-[var(--text-secondary)] border border-[var(--border-subtle)] hover:text-[var(--text-primary)] transition-colors focus-ring"
-            aria-label="Switch version"
-            title="Switch version"
-          >
-            {/* Drafts are the agent's own loop (#366) — never offered here. */}
-            {versions.filter((v) => !v.draft).map((v) => (
-              <option key={v.id} value={v.id}>
-                {versionOptionLabel(v, Date.now())}
-              </option>
-            ))}
-          </select>
-        )}
+        {/* Two-level history (item C, phase 4): a per-artifact version stepper
+            + a History ▾ picker, replacing the flat version select. A single
+            version of a single artifact renders neither (the control returns
+            null), so the empty-state chrome stays quiet. */}
+        <CanvasHistoryControl
+          versions={versions}
+          activeVersionId={version.id}
+          onSelectVersion={(id) => void setActiveVersion(sessionId, id)}
+        />
         {/* What is still owed on THIS canvas. From one, unlike the Canvas
             button's pill: in here you are already looking at the thing, so one
             outstanding round is worth naming rather than hiding. */}

--- a/src/renderer/components/CanvasFiledStrip.tsx
+++ b/src/renderer/components/CanvasFiledStrip.tsx
@@ -46,38 +46,37 @@ export default function CanvasFiledStrip({ sessionId }: { sessionId: string }) {
 
   if (!notice) return null
 
+  // The provenance sentence (item C): one line, on the app's own surface, that
+  // says what was filed and offers the way back — not a coloured banner. The
+  // filed canvas KEEPS its notes; Reopen brings the whole thing back, so the
+  // line says "still there", not "gone".
   return (
     <div
       data-testid="canvas-filed-strip"
-      className="flex-none flex items-center gap-2 px-3 py-1.5 text-[11.5px]"
+      className="flex-none flex items-center gap-2 px-3.5 py-1.5 text-[12px]"
       style={{
-        background: 'color-mix(in srgb, var(--color-yellow) 10%, transparent)',
-        borderBottom: '1px solid color-mix(in srgb, var(--color-yellow) 30%, transparent)',
+        background: 'var(--surface-stage)',
+        borderBottom: '1px solid var(--border-subtle)',
         color: 'var(--text-secondary)',
       }}
     >
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--color-yellow)' }} aria-hidden className="shrink-0">
-        <path d="M4 4h5l2 3h9v13H4z" />
-      </svg>
+      <span className="shrink-0" style={{ color: 'var(--text-muted)' }} aria-hidden>▣</span>
       <span className="min-w-0 truncate">
-        <b style={{ color: 'var(--text-primary)', fontWeight: 620 }}>{notice.title || 'That canvas'}</b>
-        {' was filed'}
+        {'I filed '}
+        <b style={{ color: 'var(--text-primary)', fontWeight: 620 }}>{notice.title || 'that canvas'}</b>
+        {' to the Library when the agent started a different subject'}
         {describeLoss(notice.openNotes, notice.draftNotes)}
-        {' — the agent started a different subject.'}
+        {'.'}
       </span>
       <button
         onClick={() => void goBack()}
         disabled={busy}
         data-testid="canvas-filed-back"
-        className="ml-auto shrink-0 px-2 py-0.5 rounded-md text-[11px] font-semibold focus-ring disabled:opacity-50"
-        style={{
-          color: 'var(--color-yellow)',
-          background: 'color-mix(in srgb, var(--color-yellow) 13%, transparent)',
-          border: '1px solid color-mix(in srgb, var(--color-yellow) 42%, transparent)',
-        }}
+        className="ml-auto shrink-0 text-[11.5px] font-semibold focus-ring rounded px-1 disabled:opacity-50"
+        style={{ color: 'var(--brand)' }}
         title="Bring that canvas back into this session"
       >
-        Go back
+        Reopen it
       </button>
       <button
         onClick={() => dismissFiled(sessionId)}
@@ -92,13 +91,14 @@ export default function CanvasFiledStrip({ sessionId }: { sessionId: string }) {
   )
 }
 
-/** The unsubmitted notes lead when there are any: those are work the user has
- *  not handed over, and they are the reason this strip exists. */
+/** What went with the filing, in the "still there" framing — the notes are
+ *  preserved on the filed canvas and Reopen brings them back. Unsubmitted notes
+ *  lead when there are any: those are work the user has not handed over. */
 function describeLoss(openNotes: number, draftNotes: number): string {
   if (draftNotes > 0 && openNotes > 0) {
-    return ` — ${draftNotes} unsubmitted and ${openNotes} open note${openNotes === 1 ? '' : 's'} went with it`
+    return ` — its ${draftNotes} unsubmitted and ${openNotes} open note${openNotes === 1 ? '' : 's'} are still there`
   }
-  if (draftNotes > 0) return ` — ${draftNotes} unsubmitted note${draftNotes === 1 ? '' : 's'} went with it`
-  if (openNotes > 0) return ` — ${openNotes} open note${openNotes === 1 ? '' : 's'} went with it`
+  if (draftNotes > 0) return ` — its ${draftNotes} unsubmitted note${draftNotes === 1 ? '' : 's'} ${draftNotes === 1 ? 'is' : 'are'} still there`
+  if (openNotes > 0) return ` — its ${openNotes} open note${openNotes === 1 ? '' : 's'} ${openNotes === 1 ? 'is' : 'are'} still there`
   return ''
 }

--- a/src/renderer/components/CanvasHistoryControl.tsx
+++ b/src/renderer/components/CanvasHistoryControl.tsx
@@ -109,7 +109,9 @@ export default function CanvasHistoryControl({ versions, activeVersionId, onSele
             className="shrink-0 text-[9.5px] font-bold tracking-[0.06em] rounded px-1.5 py-px"
             style={{ background: `color-mix(in srgb, ${b.color} 18%, transparent)`, color: b.color }}
           >
-            {isArchivedGroup ? 'ARCHIVED' : b.label}
+            {/* A legacy uat build reads as ARCHIVED; a user-archived plan or
+                mockup keeps its KIND badge — it did not stop being a plan. */}
+            {a.kind === 'uat' ? 'ARCHIVED' : b.label}
           </span>
           <span className="min-w-0 truncate text-[12px]" style={{ color: 'var(--text-primary)' }}>
             {a.label}
@@ -141,7 +143,10 @@ export default function CanvasHistoryControl({ versions, activeVersionId, onSele
                 {a.archived ? 'unarchive' : 'archive'}
               </button>
             )}
-            {onDelete &&
+            {/* Delete is offered only when another artifact would remain — the
+                store refuses deleting a canvas's only artifact (that is the
+                library's delete-canvas), so showing it there is a dead end. */}
+            {onDelete && artifacts.length > 1 &&
               (confirming ? (
                 <button
                   type="button"
@@ -232,13 +237,13 @@ export default function CanvasHistoryControl({ versions, activeVersionId, onSele
           {archived.length > 0 && (
             <>
               <div className="px-2 pt-2 pb-1 text-[9.5px] font-semibold uppercase tracking-[0.09em]" style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border-subtle)', marginTop: 4 }}>
-                Archived — legacy test builds
+                Archived
               </div>
               {archived.map((a) => artifactRow(a, true))}
             </>
           )}
           <div className="px-2 pt-2 pb-1 text-[10.5px]" style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border-subtle)', marginTop: 4 }}>
-            Pick an artifact here; step its versions with ‹ ›. Tests are live and never versioned — builds saved by older betas stay under Archived.
+            Pick an artifact here; step its versions with ‹ ›. Archived holds what you tucked away (recoverable) and legacy test builds from older betas; tests are live now and never versioned.
           </div>
         </div>
       )}

--- a/src/renderer/components/CanvasHistoryControl.tsx
+++ b/src/renderer/components/CanvasHistoryControl.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { CanvasVersion } from '../../shared/canvas'
+import { CanvasArtifact, groupVersionsIntoArtifacts, locateVersion, splitArchived } from '../canvas/canvas-history'
+import { relativeTime } from '../utils/relativeTime'
+
+/**
+ * Two-level history (item C, phase 4): the version identity in the pane chrome
+ * becomes a per-artifact stepper — "Plan · v3", ‹ › within THIS plan's own
+ * versions — plus a History ▾ popover that picks the ARTIFACT (a plan, a
+ * mockup, a legacy test build). Picking an artifact opens its latest version;
+ * the stepper then walks that artifact's run. A plan's ten versions never mix
+ * into one number line with the mockup's.
+ *
+ * A pure display projection over the flat version list — no ids or anchors
+ * move. Row actions (archive, delete) are Phase 5 and arrive as optional props,
+ * so wiring them later does not reshape this component.
+ */
+interface Props {
+  versions: CanvasVersion[]
+  activeVersionId: string
+  onSelectVersion: (versionId: string) => void
+  /** Phase 5 — tuck an artifact into ARCHIVED (recoverable). */
+  onArchive?: (artifact: CanvasArtifact) => void
+  /** Phase 5 — delete an artifact, its versions and their notes (permanent). */
+  onDelete?: (artifact: CanvasArtifact) => void
+}
+
+function kindBadge(kind: CanvasVersion['mode']): { label: string; color: string } {
+  if (kind === 'plan') return { label: 'PLAN', color: 'var(--color-mauve)' }
+  if (kind === 'uat') return { label: 'TEST', color: 'var(--text-muted)' }
+  return { label: 'MOCKUP', color: 'var(--color-blue)' }
+}
+
+function updatedLabel(iso: string, now: number): string {
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? `updated ${relativeTime(ms, now)}` : 'updated recently'
+}
+
+export default function CanvasHistoryControl({ versions, activeVersionId, onSelectVersion, onArchive, onDelete }: Props) {
+  const [open, setOpen] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  const artifacts = useMemo(() => groupVersionsIntoArtifacts(versions), [versions])
+  const located = useMemo(() => locateVersion(artifacts, activeVersionId), [artifacts, activeVersionId])
+  const { live, archived } = useMemo(() => splitArchived(artifacts), [artifacts])
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+  useEffect(() => setConfirmDelete(null), [open])
+
+  const stepTo = useCallback(
+    (delta: number) => {
+      if (!located) return
+      const next = located.artifact.versions[located.index + delta]
+      if (next) onSelectVersion(next.id)
+    },
+    [located, onSelectVersion],
+  )
+
+  // A canvas with a single version and a single artifact needs neither control.
+  if (!located || (artifacts.length === 1 && located.artifact.versions.length === 1)) {
+    return null
+  }
+
+  const badge = kindBadge(located.artifact.kind)
+  const count = located.artifact.versions.length
+  const pos = located.index + 1
+  const now = Date.now()
+
+  const pickArtifact = (a: CanvasArtifact) => {
+    // Open the artifact's LATEST version — the freshest of that run.
+    onSelectVersion(a.versions[a.versions.length - 1].id)
+    setOpen(false)
+  }
+
+  const artifactRow = (a: CanvasArtifact, isArchivedGroup: boolean) => {
+    const b = kindBadge(a.kind)
+    const isCurrent = a.key === located.artifact.key
+    const confirming = confirmDelete === a.key
+    return (
+      <div
+        key={a.key}
+        className="flex items-center gap-2 px-2.5 py-1.5 rounded-md group"
+        style={{ background: isCurrent ? 'var(--surface-overlay)' : undefined, opacity: isArchivedGroup ? 0.72 : 1 }}
+        data-testid="canvas-history-row"
+        data-artifact-kind={a.kind}
+      >
+        <button
+          type="button"
+          onClick={() => pickArtifact(a)}
+          className="min-w-0 flex-1 flex items-center gap-2 text-left focus-ring rounded"
+          title={`Open ${a.label} — ${a.versions.length} version${a.versions.length === 1 ? '' : 's'}`}
+        >
+          <span
+            className="shrink-0 text-[9.5px] font-bold tracking-[0.06em] rounded px-1.5 py-px"
+            style={{ background: `color-mix(in srgb, ${b.color} 18%, transparent)`, color: b.color }}
+          >
+            {isArchivedGroup ? 'ARCHIVED' : b.label}
+          </span>
+          <span className="min-w-0 truncate text-[12px]" style={{ color: 'var(--text-primary)' }}>
+            {a.label}
+          </span>
+          <span className="shrink-0 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            · {a.versions.length} version{a.versions.length === 1 ? '' : 's'}
+          </span>
+          <span className="ml-auto shrink-0 text-[10.5px]" style={{ color: 'var(--text-muted)' }}>
+            {updatedLabel(a.updatedAt, now)}
+          </span>
+        </button>
+        {/* Row actions (Phase 5). Archive is recoverable; delete is permanent
+            and takes the notes with it, so it confirms first. */}
+        {(onArchive || onDelete) && (
+          <span className="shrink-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            {onArchive && !a.archived && (
+              <button
+                type="button"
+                onClick={() => onArchive(a)}
+                className="text-[10.5px] focus-ring rounded px-0.5"
+                style={{ color: 'var(--text-secondary)' }}
+                title="Tuck this artifact into Archived — out of the picker, recoverable any time."
+                data-testid="canvas-history-archive"
+              >
+                archive
+              </button>
+            )}
+            {onDelete &&
+              (confirming ? (
+                <button
+                  type="button"
+                  onClick={() => { onDelete(a); setConfirmDelete(null); setOpen(false) }}
+                  className="text-[10.5px] font-semibold focus-ring rounded px-1"
+                  style={{ color: 'var(--status-danger)', background: 'color-mix(in srgb, var(--status-danger) 15%, transparent)' }}
+                  title="Permanently delete this artifact, its versions and their review notes. This cannot be undone."
+                  data-testid="canvas-history-delete-confirm"
+                >
+                  delete {a.versions.length} + notes
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(a.key)}
+                  className="text-[10.5px] focus-ring rounded px-0.5"
+                  style={{ color: 'var(--text-muted)' }}
+                  title="Delete this artifact, its versions and their review notes — permanent, and it stays gone across restarts and re-renders."
+                  data-testid="canvas-history-delete"
+                >
+                  delete…
+                </button>
+              ))}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative shrink-0 flex items-center gap-1.5" ref={rootRef}>
+      {/* Per-artifact version stepper. */}
+      <div
+        className="flex items-center gap-0.5 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-panel)] text-[12px] px-1"
+        data-testid="canvas-version-stepper"
+      >
+        <button
+          type="button"
+          onClick={() => stepTo(-1)}
+          disabled={pos <= 1}
+          className="px-1.5 leading-none text-[var(--text-muted)] hover:text-[var(--text-primary)] disabled:opacity-30 focus-ring rounded"
+          aria-label="Previous version of this artifact"
+          title="Previous version of this artifact"
+        >
+          ‹
+        </button>
+        <span className="px-1 tabular-nums" style={{ color: 'var(--text-secondary)' }} title={`${activeVersionId} — ${pos} of ${count}`}>
+          <span style={{ color: badge.color, fontWeight: 600 }}>{badge.label.toLowerCase()}</span>{' '}
+          <span style={{ color: 'var(--text-primary)' }}>{activeVersionId}</span>{' '}
+          <span style={{ color: 'var(--text-muted)' }}>of {count}</span>
+        </span>
+        <button
+          type="button"
+          onClick={() => stepTo(1)}
+          disabled={pos >= count}
+          className="px-1.5 leading-none text-[var(--text-muted)] hover:text-[var(--text-primary)] disabled:opacity-30 focus-ring rounded"
+          aria-label="Next version of this artifact"
+          title="Next version of this artifact"
+        >
+          ›
+        </button>
+      </div>
+
+      {/* History ▾ — pick the artifact. */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        data-testid="canvas-history-button"
+        className="text-[12px] rounded-md border border-[var(--border-subtle)] px-2 py-0.5 text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-ring"
+        title="History — the artifacts on this canvas (a plan, a mockup); step versions with the ‹ › control"
+      >
+        History ▾
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="canvas-history-popover"
+          className="absolute left-0 top-full mt-1 z-30 w-[300px] rounded-lg p-1.5"
+          style={{ background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)', boxShadow: '0 16px 40px rgba(0,0,0,0.55)' }}
+        >
+          <div className="px-2 py-1 text-[9.5px] font-semibold uppercase tracking-[0.09em]" style={{ color: 'var(--text-muted)' }}>
+            Artifacts on this canvas
+          </div>
+          {live.map((a) => artifactRow(a, false))}
+          {archived.length > 0 && (
+            <>
+              <div className="px-2 pt-2 pb-1 text-[9.5px] font-semibold uppercase tracking-[0.09em]" style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border-subtle)', marginTop: 4 }}>
+                Archived — legacy test builds
+              </div>
+              {archived.map((a) => artifactRow(a, true))}
+            </>
+          )}
+          <div className="px-2 pt-2 pb-1 text-[10.5px]" style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border-subtle)', marginTop: 4 }}>
+            Pick an artifact here; step its versions with ‹ ›. Tests are live and never versioned — builds saved by older betas stay under Archived.
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/CanvasHistoryControl.tsx
+++ b/src/renderer/components/CanvasHistoryControl.tsx
@@ -125,16 +125,20 @@ export default function CanvasHistoryControl({ versions, activeVersionId, onSele
             and takes the notes with it, so it confirms first. */}
         {(onArchive || onDelete) && (
           <span className="shrink-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-            {onArchive && !a.archived && (
+            {/* Archive is reversible for a user-archived artifact; a legacy uat
+                build is inherently archived and has no toggle. */}
+            {onArchive && a.kind !== 'uat' && (
               <button
                 type="button"
                 onClick={() => onArchive(a)}
                 className="text-[10.5px] focus-ring rounded px-0.5"
                 style={{ color: 'var(--text-secondary)' }}
-                title="Tuck this artifact into Archived — out of the picker, recoverable any time."
+                title={a.archived
+                  ? 'Bring this artifact back out of Archived into the live picker.'
+                  : 'Tuck this artifact into Archived — out of the picker, recoverable any time.'}
                 data-testid="canvas-history-archive"
               >
-                archive
+                {a.archived ? 'unarchive' : 'archive'}
               </button>
             )}
             {onDelete &&

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -225,9 +225,10 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
   )
   /** The default fold state (item C, seen-aware). Closed rounds fold. A round
    *  waiting on the USER folds ONLY once every addressed note in it has been
-   *  seen — never before: the canvas_verdict seen-barrier releases from the
-   *  addressed note bodies actually rendering, so an unseen round MUST stay
-   *  expanded so its dwell timer can run. A round with the agent stays open. */
+   *  seen — never before: keeping an unseen round expanded is what puts the
+   *  addressed note bodies on screen so the user actually sees them before the
+   *  dwell timer marks them seen (the release the canvas_verdict barrier reads).
+   *  A round with the agent stays open. */
   const defaultCollapsedFor = useCallback((g: ReviewGroup): boolean => {
     if (g.waitingOn === 'closed') return true
     if (g.waitingOn === 'you') return g.notes.every((n) => n.state !== 'addressed' || n.userSawAddressed === true)

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -33,6 +33,10 @@ interface Props {
    * user closes the round themselves).
    */
   isActive: boolean
+  /** Hide the panel (item C): the page takes the full width and a thin rail
+   *  keeps the count and the way back. Owned by the pane, since the panel does
+   *  not control its own column; optional so other mounts need not wire it. */
+  onHide?: () => void
 }
 
 /**
@@ -127,6 +131,10 @@ const SCOPE_BADGE: Record<Annotation['scope'], string> = {
   general: 'text-overlay1',
 }
 
+/** Reading order of the panel's sections (item C): what needs the user, then
+ *  what is with the agent, then what is closed. */
+const SECTION_ORDER: Record<ReviewGroup['waitingOn'], number> = { you: 0, agent: 1, closed: 2 }
+
 /**
  * The label of a locked target, attributed.
  *
@@ -151,7 +159,7 @@ function FocusLabel({ focus, className }: { focus: FocusObject; className?: stri
  * from earlier reviews, the composer for the note being written, the draft
  * list, and Submit. GitHub-review vocabulary throughout.
  */
-export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onReturnToTerminal, isActive }: Props) {
+export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onReturnToTerminal, isActive, onHide }: Props) {
   const state = useCanvasReviewStore((s) => s.bySessionId[sessionId])
   const refresh = useCanvasReviewStore((s) => s.refresh)
   const markAddressedSeen = useCanvasReviewStore((s) => s.markAddressedSeen)
@@ -215,9 +223,19 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
     (reviewId: string) => `${state?.canvasId ?? ''}:${reviewId}`,
     [state?.canvasId],
   )
+  /** The default fold state (item C, seen-aware). Closed rounds fold. A round
+   *  waiting on the USER folds ONLY once every addressed note in it has been
+   *  seen — never before: the canvas_verdict seen-barrier releases from the
+   *  addressed note bodies actually rendering, so an unseen round MUST stay
+   *  expanded so its dwell timer can run. A round with the agent stays open. */
+  const defaultCollapsedFor = useCallback((g: ReviewGroup): boolean => {
+    if (g.waitingOn === 'closed') return true
+    if (g.waitingOn === 'you') return g.notes.every((n) => n.state !== 'addressed' || n.userSawAddressed === true)
+    return false
+  }, [])
   const isGroupCollapsed = useCallback(
-    (g: ReviewGroup) => groupOverride[overrideKey(g.review.id)] ?? g.waitingOn === 'closed',
-    [groupOverride, overrideKey],
+    (g: ReviewGroup) => groupOverride[overrideKey(g.review.id)] ?? defaultCollapsedFor(g),
+    [groupOverride, overrideKey, defaultCollapsedFor],
   )
   const toggleGroup = useCallback((reviewId: string, defaultCollapsed: boolean) => {
     const key = overrideKey(reviewId)
@@ -673,12 +691,56 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
     [sessionId, checklistStatus, setPanelHighlight],
   )
 
+  // Sections (item C): reviews grouped by who they wait on, in reading order —
+  // what NEEDS YOU first, then what is WITH THE AGENT, then what is CLOSED. The
+  // list is otherwise unchanged (newest-first within each section, same cards),
+  // so a header is injected wherever the section changes.
+  const sortedGroups = [...groups].sort((a, b) => SECTION_ORDER[a.waitingOn] - SECTION_ORDER[b.waitingOn])
+  const sectionCounts = {
+    you: groups.filter((g) => g.waitingOn === 'you').length,
+    agent: groups.filter((g) => g.waitingOn === 'agent').length,
+    closed: groups.filter((g) => g.waitingOn === 'closed').length,
+  }
+  const sectionHeader = (kind: ReviewGroup['waitingOn']) => {
+    const meta =
+      kind === 'you'
+        ? { label: 'NEEDS YOU', color: 'var(--color-peach)', count: sectionCounts.you }
+        : kind === 'agent'
+          ? { label: 'WITH THE AGENT', color: 'var(--color-blue)', count: sectionCounts.agent }
+          : { label: 'CLOSED', color: 'var(--text-muted)', count: sectionCounts.closed }
+    return (
+      <div
+        className="flex items-center gap-2 px-3 pt-2.5 pb-1 text-[10.5px] font-bold tracking-[0.09em]"
+        style={{ color: meta.color }}
+        data-testid={`review-section-${kind}`}
+      >
+        {meta.label}
+        <span
+          className="text-[10px] font-semibold rounded-full px-1.5 leading-[1.4]"
+          style={{ background: meta.color, color: 'var(--surface-chrome)' }}
+        >
+          {meta.count}
+        </span>
+      </div>
+    )
+  }
+
   return (
-    <div ref={panelRef} className="w-80 shrink-0 border-l border-surface0 bg-mantle flex flex-col min-h-0 text-[12px]">
-      <div className="px-3 py-2 border-b border-surface0 flex items-center gap-2 shrink-0">
+    <div ref={panelRef} className="w-80 shrink-0 border-l border-[var(--border-subtle)] bg-[var(--surface-panel)] flex flex-col min-h-0 text-[12px]">
+      <div className="px-3 py-2 border-b border-[var(--border-subtle)] flex items-center gap-2 shrink-0 bg-[var(--surface-chrome)]">
         <span className="font-medium text-subtext1">Review</span>
         {draftReview && <span className="text-overlay1">draft · {draftNotes.length} note{draftNotes.length === 1 ? '' : 's'}</span>}
         <div className="flex-1" />
+        {onHide && (
+          <button
+            onClick={onHide}
+            data-testid="canvas-panel-hide"
+            className="shrink-0 text-[11px] rounded px-1.5 py-0.5 border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-ring"
+            title="Hide the review panel — the page widens; a thin rail keeps the count and brings it back"
+          >
+            hide ⟩
+          </button>
+        )}
       </div>
 
       {/* ── Close out everything waiting on YOU ──
@@ -725,7 +787,7 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div className="flex-1 overflow-y-auto min-h-0 canvas-review-scroll">
         {/* ── First-use primer — until the first note exists or it's dismissed ── */}
         {!helpDismissed && draftNotes.length === 0 && (state?.reviews.length ?? 0) === 0 && (
           <div className="mx-3 mt-2 mb-1 rounded border border-mauve/40 bg-mauve/5 px-3 py-2.5">
@@ -753,13 +815,16 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
             open note under a single heading lost the round: nothing said a whole
             review was finished, there was no way to close one, and a note from
             this morning sat between two from ten minutes ago. */}
-        {groups.map((group) => {
+        {sortedGroups.map((group, i) => {
           const collapsed = isGroupCollapsed(group)
+          const showHeader = i === 0 || sortedGroups[i - 1].waitingOn !== group.waitingOn
           return (
-          <div key={group.review.id} className="border-b border-surface0" data-testid="review-group" data-review={group.review.id}>
+          <React.Fragment key={group.review.id}>
+          {showHeader && sectionHeader(group.waitingOn)}
+          <div className="border-b border-[var(--border-subtle)]" data-testid="review-group" data-review={group.review.id}>
             <button
               type="button"
-              onClick={() => toggleGroup(group.review.id, group.waitingOn === 'closed')}
+              onClick={() => toggleGroup(group.review.id, defaultCollapsedFor(group))}
               className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-surface0/40 focus-ring"
               aria-expanded={!collapsed}
             >
@@ -1020,6 +1085,7 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
               </div>
             )}
           </div>
+          </React.Fragment>
           )
         })}
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -282,6 +282,21 @@ body {
   background: var(--color-surface2);
 }
 
+/* Slim, self-coloured scrollbar for the canvas review panel (item C): a
+   transparent track so it sits on the panel's own surface rather than the
+   global mantle track, and a narrower thumb. */
+.canvas-review-scroll::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+.canvas-review-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.canvas-review-scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-surface2) 85%, transparent);
+  border-radius: 3px;
+}
+
 /* Title bar drag region */
 .titlebar-drag {
   -webkit-app-region: drag;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -389,6 +389,12 @@ export interface ElectronAPI {
     listReclaimable: (args: { sessionId: string; openTileSessionIds?: string[] }) => Promise<ReclaimableCanvas[]>
     listAll: (args?: { openTileSessionIds?: string[]; sessionId?: string }) => Promise<CanvasLibraryEntry[]>
     deleteCanvas: (args: { canvasId: string }) => Promise<{ ok: boolean }>
+    /** Archive/unarchive one artifact (item C): reversible, returns the state. */
+    archiveArtifact: (args: { canvasId: string; versionId: string; archived: boolean }) => Promise<{ ok: boolean; state: CanvasState | null }>
+    /** Permanently delete one artifact, its versions and their review notes. */
+    deleteArtifact: (args: { canvasId: string; versionId: string }) => Promise<
+      { ok: true; deletedVersions: number; notesDeleted: number } | { ok: false; reason: 'not-found' | 'only-artifact' | 'unsafe' }
+    >
     /** The user reclaims a named canvas — the only path that moves ownership. */
     reclaim: (args: {
       sessionId: string

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -45,6 +45,39 @@ export interface CanvasVersion {
    *  or counts — and the next draft render SUPERSEDES it in place rather than
    *  appending. Absent = ready (every version written before this field). */
   draft?: true
+  /** ARCHIVED (item C, phase 5): the user tucked this version's artifact into
+   *  the muted Archived history group — out of the way, recoverable. Set on
+   *  every version of the artifact together; a hand-edited value must be the
+   *  literal `true` (validated on load, like `draft`). Absent = live. */
+  archived?: true
+}
+
+/**
+ * The version runs that the two-level history (item C) groups into artifacts —
+ * shared so MAIN (archive/delete) and the RENDERER (the picker) agree on
+ * exactly which versions form one artifact. A run breaks when the KIND changes
+ * OR the archived state changes: two same-mode runs on either side of an
+ * archive are different artifacts, and a fresh render after an archived run
+ * starts a new LIVE artifact rather than joining the archived one. Drafts are
+ * the agent's own loop (#366) and never appear.
+ */
+export function artifactRuns(versions: readonly CanvasVersion[]): CanvasVersion[][] {
+  const runs: CanvasVersion[][] = []
+  for (const v of versions) {
+    if (v.draft) continue
+    const last = runs[runs.length - 1]
+    if (last && last[0].mode === v.mode && !!last[0].archived === !!v.archived) last.push(v)
+    else runs.push([v])
+  }
+  return runs
+}
+
+/** The version run (artifact) containing `versionId`, or null. */
+export function artifactRunContaining(versions: readonly CanvasVersion[], versionId: string): CanvasVersion[] | null {
+  for (const run of artifactRuns(versions)) {
+    if (run.some((v) => v.id === versionId)) return run
+  }
+  return null
 }
 
 /** The round the user owes a first review on: set when the agent deliberately

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -399,6 +399,8 @@ export const IPC = {
   CANVAS_RECLAIM: 'canvas:reclaim',                    // renderer -> main: the USER moves a named canvas to this session
   CANVAS_LIST_ALL: 'canvas:listAll',                   // renderer -> main: { openTileSessionIds?, sessionId? } -> CanvasLibraryEntry[] (the library, scoped to that session's project; read-only)
   CANVAS_DELETE: 'canvas:delete',                      // renderer -> main: the USER deletes a canvas and its files
+  CANVAS_ARCHIVE_ARTIFACT: 'canvas:archiveArtifact',   // renderer -> main: { canvasId, versionId, archived } -> tuck an artifact into (or out of) the Archived history group (reversible)
+  CANVAS_DELETE_ARTIFACT: 'canvas:deleteArtifact',     // renderer -> main: { canvasId, versionId } -> permanently delete an artifact, its versions and their review notes
 
   // Agent Canvas P3 — reviews & annotations (the review loop, spec §6)
   CANVAS_REVIEW_GET_STATE: 'canvas:reviewGetState',    // renderer -> main: { sessionId } -> CanvasReviewState | null

--- a/tests/unit/main/canvas-artifact-lifecycle.test.ts
+++ b/tests/unit/main/canvas-artifact-lifecycle.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
 import { vi } from 'vitest'
 
@@ -133,6 +134,38 @@ describe('delete-artifact durability', () => {
     const canvasId = store.getCanvasStateForSession(SID)!.canvasId
     expect(store.deleteArtifact(canvasId, 'v99').ok).toBe(false)
     expect(store.deleteArtifact('deadbeefdeadbeefdeadbeef', 'v1').ok).toBe(false)
+  })
+
+  it('refuses to delete THROUGH a junction planted at the versions/ dir (ADR-009)', () => {
+    // A reparse point at <canvasDir>/versions is resolved transparently by the
+    // OS, so a per-version removal that starts below the checked canvas dir
+    // would delete out of tree. The realpath identity check on each version dir
+    // must refuse it — the victim survives, and the metadata delete still lands.
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    const versionsDir = path.join(getResourcesDirectory(), 'canvas', canvasId, 'versions')
+    const victim = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-victim-'))
+    fs.mkdirSync(path.join(victim, 'v3'))
+    fs.writeFileSync(path.join(victim, 'v3', 'precious.txt'), 'keep me')
+    fs.rmSync(versionsDir, { recursive: true, force: true })
+    try {
+      fs.symlinkSync(victim, versionsDir, process.platform === 'win32' ? 'junction' : 'dir')
+    } catch {
+      // Some CI shells cannot create a link without privilege — skip rather than
+      // fail; the win32 leg (where junctions need none) is the one that matters.
+      fs.rmSync(victim, { recursive: true, force: true })
+      return
+    }
+    const res = store.deleteArtifact(canvasId, 'v3')
+    expect(res.ok).toBe(true) // metadata delete still succeeds
+    expect(fs.existsSync(path.join(victim, 'v3', 'precious.txt'))).toBe(true) // NOT deleted
+    // cleanup: detach the link (never the target), then the victim
+    try {
+      fs.rmdirSync(versionsDir)
+    } catch {
+      try { fs.unlinkSync(versionsDir) } catch { /* ignore */ }
+    }
+    fs.rmSync(victim, { recursive: true, force: true })
   })
 })
 

--- a/tests/unit/main/canvas-artifact-lifecycle.test.ts
+++ b/tests/unit/main/canvas-artifact-lifecycle.test.ts
@@ -1,0 +1,172 @@
+// Artifact archive + permanent delete (item C, phase 5) — the store half, which
+// is where the security-critical properties live: durability (a deleted version
+// id is never reissued), path-safe version-file removal, review-note deletion,
+// and the refusal to delete a canvas's only artifact.
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import { vi } from 'vitest'
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => {
+  const nodeFs = require('node:fs') as typeof import('node:fs')
+  const nodeOs = require('node:os') as typeof import('node:os')
+  const nodePath = require('node:path') as typeof import('node:path')
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'ccc-artifact-life-'))
+  return { getResourcesDirectory: () => dir }
+})
+
+const { getResourcesDirectory } = await import('../../../src/main/ipc/setup-handlers')
+const store = await import('../../../src/main/canvas/canvas-store')
+const reviews = await import('../../../src/main/canvas/canvas-review-store')
+
+const SID = 'a1b2c3d4e5f6a7b8c9d0e1f2'
+const TITLE = 'Feature X'
+
+/** Render one version on the session's single canvas (same title = same
+ *  subject, so versions accrue on ONE canvas). */
+function render(mode: 'plan' | 'design', n: number) {
+  return store.renderVersion(SID, { mode, html: `<!doctype html><p>${mode} ${n}</p>`, title: TITLE })
+}
+
+function stateVersions(): string[] {
+  return store.getCanvasStateForSession(SID)!.versions.map((v) => v.id)
+}
+
+/** A three-version canvas: plan v1, plan v2, mockup v3 — two artifacts. */
+function seedTwoArtifacts() {
+  render('plan', 1)
+  render('plan', 2)
+  render('design', 3)
+}
+
+beforeEach(() => {
+  store._resetCanvasStoreForTest()
+  reviews._resetCanvasReviewStoreForTest()
+  fs.rmSync(path.join(getResourcesDirectory(), 'canvas'), { recursive: true, force: true })
+})
+afterAll(() => {
+  try {
+    fs.rmSync(getResourcesDirectory(), { recursive: true, force: true })
+  } catch {
+    /* best-effort */
+  }
+})
+
+describe('archive is reversible', () => {
+  it('marks every version of the artifact archived, and clears it again', () => {
+    seedTwoArtifacts()
+    const s1 = store.setArtifactArchived(store.getCanvasStateForSession(SID)!.canvasId, 'v1', true)!
+    const byId = (id: string) => s1.versions.find((v) => v.id === id)!
+    expect(byId('v1').archived).toBe(true)
+    expect(byId('v2').archived).toBe(true) // same plan run
+    expect(byId('v3').archived).toBeUndefined() // the mockup is untouched
+
+    const s2 = store.setArtifactArchived(s1.canvasId, 'v2', false)!
+    expect(s2.versions.find((v) => v.id === 'v1')!.archived).toBeUndefined()
+    expect(s2.versions.find((v) => v.id === 'v2')!.archived).toBeUndefined()
+  })
+
+  it('survives a restart', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    store.setArtifactArchived(canvasId, 'v1', true)
+    store._resetCanvasStoreForTest()
+    const after = store.getCanvasStateForSession(SID)!
+    expect(after.versions.find((v) => v.id === 'v1')!.archived).toBe(true)
+  })
+})
+
+describe('delete-artifact durability', () => {
+  it('removes the run and never reissues a deleted id on the next render', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    // Delete the mockup artifact (v3, the LATEST) — the case where a max+1
+    // scheme would reuse the id.
+    const res = store.deleteArtifact(canvasId, 'v3')
+    expect(res).toEqual({ ok: true, deletedVersionIds: ['v3'] })
+    expect(stateVersions()).toEqual(['v1', 'v2'])
+
+    // A fresh render mints v4, NOT a second v3.
+    const next = render('design', 4)
+    expect(next.versionId).toBe('v4')
+    expect(stateVersions()).toEqual(['v1', 'v2', 'v4'])
+  })
+
+  it('keeps the counter across a restart, so a reload cannot reuse the id either', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    store.deleteArtifact(canvasId, 'v3')
+    store._resetCanvasStoreForTest()
+    const next = render('design', 4)
+    expect(next.versionId).toBe('v4')
+  })
+
+  it('repoints the active version when the active one was deleted', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    expect(store.getCanvasStateForSession(SID)!.activeVersionId).toBe('v3')
+    store.deleteArtifact(canvasId, 'v3')
+    expect(store.getCanvasStateForSession(SID)!.activeVersionId).toBe('v2')
+  })
+
+  it('removes the deleted versions’ files from disk, keeping the survivors', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    const vdir = (id: string) => path.join(getResourcesDirectory(), 'canvas', canvasId, 'versions', id)
+    expect(fs.existsSync(vdir('v3'))).toBe(true)
+    store.deleteArtifact(canvasId, 'v3')
+    expect(fs.existsSync(vdir('v3'))).toBe(false)
+    expect(fs.existsSync(vdir('v1'))).toBe(true)
+  })
+
+  it('refuses to delete the canvas’s ONLY artifact', () => {
+    render('plan', 1)
+    render('plan', 2) // one artifact, two versions
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    expect(store.deleteArtifact(canvasId, 'v1')).toEqual({ ok: false, reason: 'only-artifact' })
+    expect(stateVersions()).toEqual(['v1', 'v2'])
+  })
+
+  it('reports not-found for an unknown canvas or version', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    expect(store.deleteArtifact(canvasId, 'v99').ok).toBe(false)
+    expect(store.deleteArtifact('deadbeefdeadbeefdeadbeef', 'v1').ok).toBe(false)
+  })
+})
+
+describe('delete-artifact takes its review notes with it', () => {
+  it('drops notes anchored to the deleted versions and keeps the rest', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    // A note on v1 (plan) and a note on v3 (mockup, the active version).
+    store.setActiveVersion(SID, 'v1')
+    reviews.upsertAnnotation(SID, { scope: 'general', note: 'about the plan', versionId: 'v1' })
+    store.setActiveVersion(SID, 'v3')
+    reviews.upsertAnnotation(SID, { scope: 'general', note: 'about the mockup', versionId: 'v3' })
+    expect(reviews.getReviewStateForSession(SID)!.annotations).toHaveLength(2)
+
+    // Delete the mockup artifact, then drop its notes (the two-store step the
+    // IPC handler performs).
+    const res = store.deleteArtifact(canvasId, 'v3')
+    expect(res.ok).toBe(true)
+    const dropped = reviews.deleteAnnotationsForVersions(canvasId, (res as { deletedVersionIds: string[] }).deletedVersionIds)
+    expect(dropped).toBe(1)
+
+    const left = reviews.getReviewStateForSession(SID)!.annotations
+    expect(left).toHaveLength(1)
+    expect(left[0].versionId).toBe('v1')
+  })
+
+  it('deleteAnnotationsForVersions removes a review left with no notes', () => {
+    seedTwoArtifacts()
+    const canvasId = store.getCanvasStateForSession(SID)!.canvasId
+    store.setActiveVersion(SID, 'v3')
+    reviews.upsertAnnotation(SID, { scope: 'general', note: 'only note', versionId: 'v3' })
+    const beforeReviews = reviews.getReviewStateForSession(SID)!.reviews.length
+    expect(beforeReviews).toBeGreaterThan(0)
+    reviews.deleteAnnotationsForVersions(canvasId, ['v3'])
+    expect(reviews.getReviewStateForSession(SID)!.reviews).toHaveLength(0)
+  })
+})

--- a/tests/unit/renderer/canvas-history-control.test.tsx
+++ b/tests/unit/renderer/canvas-history-control.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// The two-level history control (item C, phase 4): a per-artifact version
+// stepper and a History ▾ picker. Row actions (archive/delete) arrive as props
+// in phase 5 and are covered there.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import CanvasHistoryControl from '../../../src/renderer/components/CanvasHistoryControl'
+import type { CanvasVersion } from '../../../src/shared/canvas'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const v = (id: string, mode: CanvasVersion['mode'], over: Partial<CanvasVersion> = {}): CanvasVersion => ({
+  id,
+  mode,
+  createdAt: '2026-08-24T10:00:00Z',
+  source: mode === 'uat' ? { mode: 'uat', distRoot: '/d', entry: 'index.html' } : { mode: 'design', entry: 'index.html' },
+  ...over,
+})
+
+let container: HTMLDivElement
+let root: Root
+
+async function render(props: Partial<React.ComponentProps<typeof CanvasHistoryControl>> & { versions: CanvasVersion[]; activeVersionId: string }): Promise<void> {
+  await act(async () => {
+    root.render(<CanvasHistoryControl onSelectVersion={() => {}} {...props} />)
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+describe('the version stepper', () => {
+  it('renders nothing for a single version of a single artifact', async () => {
+    await render({ versions: [v('v1', 'design')], activeVersionId: 'v1' })
+    expect(container.querySelector('[data-testid="canvas-version-stepper"]')).toBeNull()
+    expect(container.querySelector('[data-testid="canvas-history-button"]')).toBeNull()
+  })
+
+  it('steps within the current artifact only, and disables the ends', async () => {
+    const onSelectVersion = vi.fn()
+    // Plan run v1..v3, then a mockup v4 — the stepper walks the PLAN.
+    await render({ versions: [v('v1', 'plan'), v('v2', 'plan'), v('v3', 'plan'), v('v4', 'design')], activeVersionId: 'v2', onSelectVersion })
+    const stepper = container.querySelector('[data-testid="canvas-version-stepper"]')!
+    const [prev, next] = Array.from(stepper.querySelectorAll('button'))
+    expect(prev.disabled).toBe(false)
+    expect(next.disabled).toBe(false)
+    expect(stepper.textContent).toContain('of 3')
+
+    await act(async () => next.click())
+    expect(onSelectVersion).toHaveBeenCalledWith('v3')
+
+    // At v1 the previous is disabled (does not cross into another artifact).
+    await render({ versions: [v('v1', 'plan'), v('v2', 'plan'), v('v3', 'plan'), v('v4', 'design')], activeVersionId: 'v1', onSelectVersion })
+    const s2 = container.querySelector('[data-testid="canvas-version-stepper"]')!
+    expect((s2.querySelectorAll('button')[0] as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
+describe('the History picker', () => {
+  it('lists artifacts and opens one at its latest version', async () => {
+    const onSelectVersion = vi.fn()
+    await render({ versions: [v('v1', 'plan'), v('v2', 'plan'), v('v3', 'design')], activeVersionId: 'v1', onSelectVersion })
+    await act(async () => (container.querySelector('[data-testid="canvas-history-button"]') as HTMLButtonElement).click())
+    const rows = container.querySelectorAll('[data-testid="canvas-history-row"]')
+    expect(rows).toHaveLength(2)
+    // Pick the mockup artifact — opens its latest (only) version v3.
+    const mockupRow = Array.from(rows).find((r) => r.getAttribute('data-artifact-kind') === 'design')!
+    await act(async () => (mockupRow.querySelector('button') as HTMLButtonElement).click())
+    expect(onSelectVersion).toHaveBeenCalledWith('v3')
+  })
+
+  it('separates legacy uat builds into an Archived group', async () => {
+    await render({ versions: [v('v1', 'design'), v('v2', 'uat')], activeVersionId: 'v1' })
+    await act(async () => (container.querySelector('[data-testid="canvas-history-button"]') as HTMLButtonElement).click())
+    expect(container.querySelector('[data-testid="canvas-history-popover"]')?.textContent).toContain('Archived')
+    const uatRow = Array.from(container.querySelectorAll('[data-testid="canvas-history-row"]')).find(
+      (r) => r.getAttribute('data-artifact-kind') === 'uat',
+    )!
+    expect(uatRow.textContent).toContain('ARCHIVED')
+  })
+
+  it('shows archive + delete row actions only when wired (phase 5)', async () => {
+    const onArchive = vi.fn()
+    const onDelete = vi.fn()
+    await render({ versions: [v('v1', 'plan'), v('v2', 'design')], activeVersionId: 'v1', onArchive, onDelete })
+    await act(async () => (container.querySelector('[data-testid="canvas-history-button"]') as HTMLButtonElement).click())
+    expect(container.querySelector('[data-testid="canvas-history-archive"]')).not.toBeNull()
+    // Delete confirms first: the initial control is "delete…", the confirm is separate.
+    const del = container.querySelector('[data-testid="canvas-history-delete"]') as HTMLButtonElement
+    expect(del).not.toBeNull()
+    await act(async () => del.click())
+    expect(container.querySelector('[data-testid="canvas-history-delete-confirm"]')).not.toBeNull()
+    expect(onDelete).not.toHaveBeenCalled()
+    await act(async () => (container.querySelector('[data-testid="canvas-history-delete-confirm"]') as HTMLButtonElement).click())
+    expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/canvas-history-projection.test.ts
+++ b/tests/unit/renderer/canvas-history-projection.test.ts
@@ -1,0 +1,80 @@
+// Two-level canvas history projection (item C, phase 4): versions group into
+// artifacts by kind, drafts are excluded, uat runs are archived, and a version
+// locates to its artifact + position.
+
+import { describe, it, expect } from 'vitest'
+import type { CanvasVersion } from '../../../src/shared/canvas'
+import {
+  groupVersionsIntoArtifacts,
+  locateVersion,
+  splitArchived,
+} from '../../../src/renderer/canvas/canvas-history'
+
+const v = (id: string, mode: CanvasVersion['mode'], over: Partial<CanvasVersion> = {}): CanvasVersion => ({
+  id,
+  mode,
+  createdAt: `2026-08-24T10:0${id.replace('v', '')}:00Z`,
+  source: mode === 'uat' ? { mode: 'uat', distRoot: '/d', entry: 'index.html' } : { mode: 'design', entry: 'index.html' },
+  ...over,
+})
+
+describe('groupVersionsIntoArtifacts', () => {
+  it('starts a new artifact whenever the kind changes', () => {
+    const arts = groupVersionsIntoArtifacts([
+      v('v1', 'plan'),
+      v('v2', 'plan'),
+      v('v3', 'plan'),
+      v('v4', 'design'),
+    ])
+    expect(arts).toHaveLength(2)
+    expect(arts[0].kind).toBe('plan')
+    expect(arts[0].label).toBe('Plan')
+    expect(arts[0].versions.map((x) => x.id)).toEqual(['v1', 'v2', 'v3'])
+    expect(arts[0].updatedAt).toBe(v('v3', 'plan').createdAt)
+    expect(arts[1].kind).toBe('design')
+    expect(arts[1].label).toBe('Mockup')
+    expect(arts[1].versions.map((x) => x.id)).toEqual(['v4'])
+  })
+
+  it('keeps a plan and a later plan as SEPARATE artifacts when a mockup sits between', () => {
+    const arts = groupVersionsIntoArtifacts([v('v1', 'plan'), v('v2', 'design'), v('v3', 'plan')])
+    expect(arts.map((a) => a.kind)).toEqual(['plan', 'design', 'plan'])
+    // The two plan runs never merge into one number line.
+    expect(arts[0].versions).toHaveLength(1)
+    expect(arts[2].versions).toHaveLength(1)
+  })
+
+  it('excludes drafts — the agent’s own loop is never history', () => {
+    const arts = groupVersionsIntoArtifacts([v('v1', 'design'), v('v2', 'design', { draft: true })])
+    expect(arts).toHaveLength(1)
+    expect(arts[0].versions.map((x) => x.id)).toEqual(['v1'])
+  })
+
+  it('marks uat runs archived, with their build label', () => {
+    const arts = groupVersionsIntoArtifacts([
+      v('v1', 'uat', { source: { mode: 'uat', distRoot: '/d', entry: 'index.html', buildLabel: 'nightly-42' } }),
+    ])
+    expect(arts[0].archived).toBe(true)
+    expect(arts[0].label).toBe('nightly-42')
+  })
+})
+
+describe('locateVersion + splitArchived', () => {
+  const arts = groupVersionsIntoArtifacts([v('v1', 'plan'), v('v2', 'plan'), v('v3', 'design'), v('v4', 'uat')])
+
+  it('finds a version’s artifact and its 1-based position', () => {
+    const loc = locateVersion(arts, 'v2')
+    expect(loc?.artifact.kind).toBe('plan')
+    expect(loc?.index).toBe(1) // second of the plan run
+  })
+
+  it('returns null for an unknown version', () => {
+    expect(locateVersion(arts, 'v99')).toBeNull()
+  })
+
+  it('splits live artifacts from archived uat builds', () => {
+    const { live, archived } = splitArchived(arts)
+    expect(live.map((a) => a.kind)).toEqual(['plan', 'design'])
+    expect(archived.map((a) => a.kind)).toEqual(['uat'])
+  })
+})

--- a/tests/unit/renderer/canvas-panel-sections.test.tsx
+++ b/tests/unit/renderer/canvas-panel-sections.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+//
+// The redesigned review panel (item C, phase 3): reviews are grouped under
+// NEEDS YOU / WITH THE AGENT / CLOSED section headers, a round waiting on the
+// user folds by default ONLY once its addressed notes have been seen (the
+// seen-barrier must not be starved), and the panel offers a hide control.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import CanvasNotesPanel from '../../../src/renderer/components/CanvasNotesPanel'
+import type { Annotation, CanvasReviewState, CanvasVersion, Review } from '../../../src/shared/canvas'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+vi.mock('@excalidraw/excalidraw', () => ({ exportToBlob: vi.fn() }))
+
+const { useCanvasReviewStore } = await import('../../../src/renderer/stores/canvasReviewStore')
+
+const SID = 'session-1'
+const VERSION: CanvasVersion = { id: 'v1', mode: 'design', createdAt: '2026-08-24T10:00:00Z', source: { mode: 'design', entry: 'index.html' } } as CanvasVersion
+
+const review = (id: string, annotationIds: string[]): Review => ({
+  id,
+  canvas: { canvasId: 'canvas-1', versionId: 'v1' } as Review['canvas'],
+  versionId: 'v1',
+  annotationIds,
+  status: 'submitted',
+  createdAt: '2026-08-24T09:00:00Z',
+  submittedAt: '2026-08-24T09:05:00Z',
+})
+const note = (id: string, reviewId: string, over: Partial<Annotation>): Annotation => ({
+  id,
+  reviewId,
+  scope: 'general',
+  note: `note ${id}`,
+  versionId: 'v1',
+  state: 'open',
+  ...over,
+})
+
+/** One round in each section: R1 needs the user (addressed, unseen), R2 is with
+ *  the agent (open), R3 is closed (approved). */
+const STATE: CanvasReviewState = {
+  canvasId: 'canvas-1',
+  sessionId: SID,
+  reviews: [review('R1', ['a1']), review('R2', ['a2']), review('R3', ['a3'])],
+  annotations: [
+    note('a1', 'R1', { state: 'addressed' }),
+    note('a2', 'R2', { state: 'open' }),
+    note('a3', 'R3', { state: 'approved', closedBy: 'user', closedFrom: 'addressed' }),
+  ],
+}
+
+let container: HTMLDivElement
+let root: Root
+let current: CanvasReviewState = STATE
+
+;(globalThis as any).window.electronAPI = {
+  ...((globalThis as any).window?.electronAPI ?? {}),
+  pty: { ...((globalThis as any).window?.electronAPI?.pty ?? {}), write: vi.fn() },
+  canvas: { ...((globalThis as any).window?.electronAPI?.canvas ?? {}), reviewGetState: vi.fn(async () => current) },
+}
+
+async function render(props: { onHide?: () => void } = {}): Promise<void> {
+  await act(async () => {
+    root.render(
+      <CanvasNotesPanel sessionId={SID} version={VERSION} getGlassApi={() => null} onReturnToTerminal={() => {}} isActive onHide={props.onHide} />,
+    )
+  })
+}
+
+function seed(state: CanvasReviewState): void {
+  current = state
+  useCanvasReviewStore.setState((s) => ({ bySessionId: { ...s.bySessionId, [SID]: { ...s.bySessionId[SID], ...state } } }))
+}
+
+const header = (reviewId: string): HTMLButtonElement =>
+  container.querySelector(`[data-testid="review-group"][data-review="${reviewId}"] button`) as HTMLButtonElement
+
+beforeEach(() => {
+  useCanvasReviewStore.getState().reset()
+  current = STATE
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+describe('section headers', () => {
+  it('groups the rounds under NEEDS YOU / WITH THE AGENT / CLOSED', async () => {
+    seed(STATE)
+    await render()
+    const you = container.querySelector('[data-testid="review-section-you"]')
+    const agent = container.querySelector('[data-testid="review-section-agent"]')
+    const closed = container.querySelector('[data-testid="review-section-closed"]')
+    expect(you?.textContent).toContain('NEEDS YOU')
+    expect(agent?.textContent).toContain('WITH THE AGENT')
+    expect(closed?.textContent).toContain('CLOSED')
+    // Counts: one round each.
+    expect(you?.textContent).toContain('1')
+    expect(agent?.textContent).toContain('1')
+    expect(closed?.textContent).toContain('1')
+  })
+
+  it('orders the sections needs-you, then with-agent, then closed', async () => {
+    seed(STATE)
+    await render()
+    const order = Array.from(container.querySelectorAll('[data-testid^="review-section-"]')).map((el) =>
+      el.getAttribute('data-testid'),
+    )
+    expect(order).toEqual(['review-section-you', 'review-section-agent', 'review-section-closed'])
+  })
+})
+
+describe('seen-aware collapse', () => {
+  it('keeps an UNSEEN needs-you round expanded (the seen-barrier depends on it rendering)', async () => {
+    seed(STATE)
+    await render()
+    expect(header('R1').getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('folds a needs-you round once every addressed note in it has been seen', async () => {
+    seed({
+      ...STATE,
+      reviews: [review('R1', ['a1'])],
+      annotations: [note('a1', 'R1', { state: 'addressed', userSawAddressed: true })],
+    })
+    await render()
+    expect(header('R1').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('folds a closed round by default, and leaves an agent round open', async () => {
+    seed(STATE)
+    await render()
+    expect(header('R3').getAttribute('aria-expanded')).toBe('false') // closed
+    expect(header('R2').getAttribute('aria-expanded')).toBe('true') // with the agent
+  })
+})
+
+describe('hide control', () => {
+  it('shows a hide button only when the pane wired onHide, and it calls back', async () => {
+    seed(STATE)
+    await render({})
+    expect(container.querySelector('[data-testid="canvas-panel-hide"]')).toBeNull()
+
+    const onHide = vi.fn()
+    await render({ onHide })
+    const btn = container.querySelector('[data-testid="canvas-panel-hide"]') as HTMLButtonElement
+    expect(btn).not.toBeNull()
+    await act(async () => btn.click())
+    expect(onHide).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -600,6 +600,38 @@ describe('a request the frame never acknowledged', () => {
   })
 })
 
+describe('the redesigned chrome (item C)', () => {
+  it('leads with the mode as the title, with a keel line', async () => {
+    await renderPane('on')
+    // A 'design' version reads as MOCKUP MODE (plan/uat are the other two).
+    const word = container.querySelector('[data-testid="canvas-mode-word"]')
+    expect(word?.textContent).toBe('MOCKUP MODE')
+    expect(word?.getAttribute('data-canvas-mode')).toBe('design')
+    expect(container.querySelector('[data-testid="canvas-mode-keel"]')).not.toBeNull()
+  })
+
+  it('presents Inspect / Sketch / Region as tool chips, Inspect active in browse', async () => {
+    await renderPane('on')
+    expect(container.querySelector('[data-testid="canvas-tool-inspect"]')?.getAttribute('aria-pressed')).toBe('true')
+    expect(container.querySelector('[data-testid="canvas-tool-sketch"]')?.getAttribute('aria-pressed')).toBe('false')
+    expect(container.querySelector('[data-testid="canvas-tool-region"]')?.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('moves the active chip to Sketch when the pointer goes to the glass', async () => {
+    await renderPane('on')
+    await act(async () => useCanvasStore.getState().setInteractionMode(SID, 'draw'))
+    expect(container.querySelector('[data-testid="canvas-tool-inspect"]')?.getAttribute('aria-pressed')).toBe('false')
+    expect(container.querySelector('[data-testid="canvas-tool-sketch"]')?.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('carries the X-ray setting inside the Inspect group', async () => {
+    await renderPane('stealth')
+    const chips = container.querySelector('[data-testid="canvas-tool-chips"]')!
+    // The x-ray group is a descendant of the tool chips, not a separate control.
+    expect(chips.querySelector('[data-testid="canvas-xray-mode"]')).not.toBeNull()
+  })
+})
+
 describe('the header switch', () => {
   it('offers exactly three segments, with the current one pressed', async () => {
     await renderPane('stealth')

--- a/tests/unit/renderer/dialog-palette-retired.test.ts
+++ b/tests/unit/renderer/dialog-palette-retired.test.ts
@@ -108,6 +108,11 @@ const NOT_A_DIALOG: Record<string, string> = {
     'a pane, not a dialog: its inset-0 layers are the canvas/iframe/marquee ' +
     'layers, and its onClose props are passed DOWN to the dialogs it renders ' +
     '(CanvasLibrary, CanvasEmptyState), which are policed on their own',
+  'components/CanvasHistoryControl.tsx':
+    'pane chrome, not a dialog: the version stepper + History dropdown that ' +
+    'lives in AgentCanvasPane\'s toolbar (role="menu" is the dropdown). Its ' +
+    'palette classes are the mode/kind colours (mauve = plan, blue = mockup) ' +
+    'shared with that excluded chrome, which have no semantic token',
   'components/TerminalView.tsx':
     'queries [role="dialog"][aria-modal="true"] to detect whether a dialog is ' +
     'open; it does not render one',


### PR DESCRIPTION
## Canvas pane redesign (item C, agreed v6)

The owner-accepted canvas review-pane redesign, built as five committed phases plus an ADR-009 pass on the destructive path.

### What's in
- **Chrome** — mode-as-title (PLAN / MOCKUP / TESTING in its colour + keel line); Browse/Draw/Region become Inspect / Sketch / Region tool chips; X-ray Off·Stealth·On rides the Inspect chip (locked to Stealth on a plan). Pure presentation over the existing pointer-owner + #367 x-ray state.
- **Framed content + provenance** — the reviewed page in a 2px framed card with a "PAGE UNDER REVIEW" tag; the filed banner is now a one-line provenance sentence with "Reopen it".
- **Panel** — app surfaces + slim scrollbar; NEEDS YOU / WITH THE AGENT / CLOSED section headers; seen-aware collapse (folds a round waiting on you only once its addressed notes have been SEEN — the canvas_verdict barrier still gets its dwell); a hide control → ~30px rail.
- **Two-level history** — a per-artifact version stepper + a History picker choosing the artifact (plan / mockup / legacy build). Display projection over the version list (shared `artifactRuns`) — no ids or review anchors move. Legacy uat builds → muted Archived group.
- **Archive + permanent delete-artifact** — reversible archive (an `archived` flag); permanent delete of an artifact's versions, files, and review notes, DURABLE via a new monotonic `nextVersion` counter on the MAC-signed record (a deleted id is never reissued). New IPC `canvas:archiveArtifact` / `canvas:deleteArtifact`.

### Review
- **`/adversarial-review` (ADR-009) on the destructive path — PASS.** Two attacker lenses + a round-2 re-attack. One MAJOR found + fixed: `deleteArtifact` followed a junction planted at `<canvasDir>/versions` and deleted out of tree (`deleteCanvas` was immune); closed with a per-version realpath identity check + a final-component lstat of `versions/`, proven by a regression that plants a real junction (reverting either guard fails it). One LOW hardening (sketch-unlink re-validates its path). Record integrity, counter durability, note over-deletion, cross-canvas isolation, refused-delete, and only-artifact refusal all held.
- **Double Review — spec + code quality.** Code quality: merge-quality (counter durability, path safety, note deletion, seen-barrier all verified). Spec: 9/11 agreed points fully delivered; minors fixed (Archived labelling for user-archived artifacts, delete-affordance dead end, comment corrections).

### Deferred (owner-approved — merge as-built, follow-up tracked)
Two agreed affordances are not in this PR, by owner decision: TESTING MODE's LIVE pill + "End test" (net-new live-test chrome), and the consolidated one-Approve + "⋯" verdict menu (the functionality already works via the existing per-note/per-round controls). Tracked in the CONTEXT.d fragment.

Full `npx vitest run` green (8290 tests). Merge gated on green CI + the owner's admin-merge (the desktop-test gate is bypassed with `--admin` per the flow; owner verifies on the installed build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
