### PR TITLE
feat(onboarding): multi-page feature showcase for the upgrade flow's release notes

### DIFF
--- a/CONTEXT.d/2026-08-24-whatsnew-showcase.md
+++ b/CONTEXT.d/2026-08-24-whatsnew-showcase.md
@@ -1,0 +1,36 @@
+# 2026-08-24 — What's New multi-page feature showcase (upgrade flow)
+
+Owner-approved design (canvas "What's New feature showcase" v1, "yeah this
+looks good"): the upgrade flow's What's New is now a multi-page run — the
+one-line summary is page 0, and each flagship feature of the line gets a full
+page behind it with a drawn vignette.
+
+- **`onboarding/showcase-pages.ts` (new)** — the curated pages per line
+  (`SHOWCASES_21`: Agent Canvas, Session Watchdog, one-row bar) +
+  `showcasesFor(currentVersion)` with sectionsFor's fallback rule (2.0 → none;
+  a future line without a set → the newest set). Deliberately NOT in
+  `changelog.ts`, so `gen-changelog.js` and the Changelog-in-sync CI are
+  untouched by construction.
+- **`onboarding/ShowcaseVignette.tsx` (new)** — pure-CSS decorative
+  illustrations (mini canvas pane with mode title / Inspect chips / framed
+  page / note pin + A/B/C; terminal with rate-limit banner + watchdog chip;
+  one-row bar strip). aria-hidden, no emoji, tokens only (`.sv-*` in
+  onboarding.css).
+- **`WhatsNewV2Step`** — internal paging: footer dots (24px targets), "Skip
+  the showcase", Next → on inner pages, the harness CTA + hint only on the
+  last page; positional "Page N of M" hint earlier. Summary items grew
+  `seeIt` chips (canvas/watchdog/oneRow) that jump to their page — a chip
+  renders only when its page exists, so the two curated files cannot drift
+  into a dead button. SECTIONS_21 gained the Watchdog and one-row lines.
+  With no pages authored (2.0 builds) the step collapses to exactly the old
+  single-page behaviour — the harness contract (`onNext`, `ctaLabel`, `hint`)
+  is unchanged and OnboardingHarness was not touched.
+- The step registry is untouched: `whatsNewV2` always surfaces on an upgrade
+  (harness-level gate), so no `sinceVersion` bump and no frozen-table churn.
+- Tests: `whatsnew-showcase.test.tsx` — data invariants (unique ids, 3-4
+  points, seeIt resolution incl. the three flagships linked), paging (Next
+  never fires onNext inward; last page carries the CTA; Skip leaves; dots
+  jump both ways; per-kind vignette), and the 2.0 collapse via module
+  re-import.
+
+Changelog entry for the showcase lands with the rc.1 cut prep.

--- a/src/renderer/onboarding/ShowcaseVignette.tsx
+++ b/src/renderer/onboarding/ShowcaseVignette.tsx
@@ -1,0 +1,100 @@
+import type { ShowcaseArtKind } from './showcase-pages'
+
+/**
+ * The drawn illustrations for the What's New showcase pages — pure CSS
+ * mini-app vignettes (styles in onboarding.css under `.sv-*`), no screenshots
+ * and no emoji, per the project's JSX conventions. Decorative: every vignette
+ * is aria-hidden, because the copy beside it says everything it draws.
+ *
+ * These are pictures OF the features, not the features: a change to the real
+ * canvas pane or command bar does not oblige a change here, only a glance at
+ * whether the picture still tells the truth.
+ */
+
+function CanvasVignette() {
+  return (
+    <div className="sv-mini" aria-hidden data-ux-id="showcase-art-canvas">
+      <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
+      <div className="sv-toolrow">
+        <span className="sv-toolchip">Snap</span>
+        <span className="sv-toolchip sv-amber">Review needed · 2</span>
+        <span className="sv-toolchip">Logs</span>
+        <span className="sv-toolchip">Browser</span>
+      </div>
+      <div className="sv-body">
+        <div className="sv-main">
+          <div className="sv-mode-line"><span className="sv-mode">MOCKUP</span><span className="sv-keel" /></div>
+          <div className="sv-chips"><span className="sv-chip sv-on">Inspect</span><span className="sv-chip">Sketch</span><span className="sv-chip">Region</span></div>
+          <div className="sv-framed">
+            <span className="sv-frame-tag">PAGE UNDER REVIEW</span>
+            <div className="sv-form">
+              <div className="sv-mock-h" />
+              <div className="sv-mock-field" />
+              <div className="sv-mock-field" />
+              <div className="sv-mock-btn" />
+            </div>
+            <span className="sv-pin">1</span>
+            <div className="sv-note">
+              <div className="sv-note-who">Your note · #1</div>
+              <div className="sv-note-txt">The button feels cramped against the fields.</div>
+              <div className="sv-abc"><span className="sv-pick">A · more gap</span><span>B · full width</span><span>C · move right</span></div>
+            </div>
+          </div>
+        </div>
+        <div className="sv-panel">
+          <div className="sv-pn-h">NEEDS YOU (2)</div>
+          <div className="sv-pn-row" />
+          <div className="sv-pn-row" />
+          <div className="sv-pn-h sv-pn-dim">WITH THE AGENT</div>
+          <div className="sv-pn-row sv-pn-faint" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function WatchdogVignette() {
+  return (
+    <div className="sv-term" aria-hidden data-ux-id="showcase-art-watchdog">
+      <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
+      <div className="sv-term-body">
+        <div className="sv-tline sv-dim">&gt; refactoring src/pipeline/ingest.ts …</div>
+        <div className="sv-tline sv-dim">&gt; 14 files changed, tests green</div>
+        <div className="sv-banner">You&apos;ve hit your usage limit. Resets at 3:00 PM.</div>
+        <div className="sv-wd-chip"><span className="sv-wd-dot" /> Watchdog: waiting 42 min, retry 1 of 3</div>
+        <div className="sv-typed">&gt; continue where you left off<span className="sv-caret" /></div>
+      </div>
+    </div>
+  )
+}
+
+function OneRowVignette() {
+  return (
+    <div className="sv-mini" aria-hidden data-ux-id="showcase-art-oneRow">
+      <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
+      <div className="sv-term-lines">
+        <div>&gt; claude …</div>
+        <div className="sv-dim">&gt; working…</div>
+      </div>
+      <div className="sv-toolrow sv-toolrow-bar">
+        <span className="sv-toolchip">+ Add</span>
+        <span className="sv-toolchip">Snap</span>
+        <span className="sv-toolchip">Canvas</span>
+        <span className="sv-toolchip">Logs</span>
+        <span className="sv-toolchip">Browser</span>
+        <span className="sv-sep" />
+        <span className="sv-toolchip sv-blue">build</span>
+        <span className="sv-toolchip sv-green">test</span>
+        <span className="sv-sep" />
+        <span className="sv-toolchip sv-peach">deploy</span>
+        <span className="sv-toolchip">3 more</span>
+      </div>
+    </div>
+  )
+}
+
+export function ShowcaseVignette({ kind }: { kind: ShowcaseArtKind }) {
+  if (kind === 'canvas') return <CanvasVignette />
+  if (kind === 'watchdog') return <WatchdogVignette />
+  return <OneRowVignette />
+}

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -232,10 +232,10 @@ export function WhatsNewV2Step({
           {isLast ? hint : `Page ${pageIx + 1} of ${total}.`}
         </span>
         {total > 1 && (
-          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" aria-label="What's New pages">
-            <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" aria-current={pageIx === 0 ? 'true' : undefined} data-ux-id="whatsnew-dot-summary"><i /></button>
+          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" role="group" aria-label="What's New pages">
+            <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" aria-current={pageIx === 0 ? 'page' : undefined} data-ux-id="whatsnew-dot-summary"><i /></button>
             {showcases.map((p, ix) => (
-              <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} aria-current={pageIx === ix + 1 ? 'true' : undefined} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>
+              <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} aria-current={pageIx === ix + 1 ? 'page' : undefined} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>
             ))}
           </div>
         )}

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -120,12 +120,15 @@ export function sectionsFor(lastSeenVersion: string | undefined, currentVersion:
   return from === '2.0' || from === '2.1' ? SECTIONS_21 : [...SECTIONS_20, ...SECTIONS_21]
 }
 
-function ShowcasePageView({ page, index, total }: { page: ShowcasePage; index: number; total: number }) {
+function ShowcasePageView({ page, index, ofShowcases }: { page: ShowcasePage; index: number; ofShowcases: number }) {
   return (
     <div className="p2">
       <div className="p2-inner sc-page" style={{ width: 'min(1000px, 95vw)' }} data-ux-id={`showcase-page-${page.id}`}>
         <div className="sc-copy">
-          <div className="sc-eyebrow" data-ux-id="showcase-eyebrow">Feature showcase · {index} of {total}</div>
+          {/* Counts SHOWCASES (1 of 3), not run pages — the footer's "Page 2 of
+              4" includes the summary. Named apart so the two denominators are
+              never confused for each other. */}
+          <div className="sc-eyebrow" data-ux-id="showcase-eyebrow">Feature showcase · {index} of {ofShowcases}</div>
           <h2 className="sc-h" data-ux-id="showcase-heading">{page.heading}</h2>
           <p className="sc-tagline" data-ux-id="showcase-tagline">{page.tagline}</p>
           <div className="sc-points" data-ux-id="showcase-points">
@@ -217,17 +220,22 @@ export function WhatsNewV2Step({
           </div>
         </div>
       ) : (
-        <ShowcasePageView page={showcases[pageIx - 1]} index={pageIx} total={showcases.length} />
+        <ShowcasePageView page={showcases[pageIx - 1]} index={pageIx} ofShowcases={showcases.length} />
       )}
       <div className="foot">
         <span className="hint" data-ux-id="whatsnew-hint">
-          {isLast ? hint : `Page ${pageIx + 1} of ${total} — the tour continues afterwards.`}
+          {/* Only the last page may promise what comes next — that is the
+              harness-supplied `hint`, which knows whether anything follows.
+              Earlier pages say only where you are: a hard-coded "the tour
+              continues" is a lie on the common notes-only upgrade, the exact
+              bug the hint plumbing exists to prevent (see OnboardingHarness). */}
+          {isLast ? hint : `Page ${pageIx + 1} of ${total}.`}
         </span>
         {total > 1 && (
-          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" role="tablist" aria-label="What's New pages">
-            <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" data-ux-id="whatsnew-dot-summary"><i /></button>
+          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" aria-label="What's New pages">
+            <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" aria-current={pageIx === 0 ? 'true' : undefined} data-ux-id="whatsnew-dot-summary"><i /></button>
             {showcases.map((p, ix) => (
-              <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>
+              <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} aria-current={pageIx === ix + 1 ? 'true' : undefined} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>
             ))}
           </div>
         )}

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
 import { releaseLine } from '../utils/versionLabel'
 import { useAppMetaStore } from '../stores/appMetaStore'
+import { showcasesFor, ShowcasePage } from './showcase-pages'
+import { ShowcaseVignette } from './ShowcaseVignette'
 
 declare const __APP_VERSION__: string
 
@@ -14,6 +17,9 @@ export interface WhatsNewItem {
   /** ONE line. If it needs two sentences, it belongs in the Feature Guide. */
   desc: string
   beta?: boolean
+  /** Id of a showcase page (showcase-pages.ts). Grows a "See it →" chip that
+   *  jumps to that page; an id with no matching page renders no chip. */
+  seeIt?: string
 }
 
 export interface WhatsNewSection {
@@ -68,12 +74,14 @@ const SECTIONS_21: WhatsNewSection[] = [
     items: [
       { title: 'Detachable SSH.', desc: 'Runs under tmux, so a dropped VPN no longer kills the work.' },
       { title: 'Partner terminal.', desc: 'A plain shell beside Claude, now labelled so you know which is which.' },
+      { title: 'One row.', desc: 'The tools and your command buttons sit in a single row under the terminal.', seeIt: 'oneRow' },
     ],
   },
   {
     heading: 'Working with Claude',
     items: [
-      { title: 'Agent Canvas.', desc: "Claude draws a mockup in the app. Mark up what's wrong; it picks the notes up." },
+      { title: 'Agent Canvas.', desc: "Claude draws a mockup in the app. Mark up what's wrong; it picks the notes up.", seeIt: 'canvas' },
+      { title: 'Session Watchdog.', desc: 'Waits out a rate limit and types the retry itself. Off by default.', seeIt: 'watchdog' },
       { title: 'Ask Conductor.', desc: 'A session that has read the docs. Docked at the bottom of the sidebar.' },
     ],
   },
@@ -112,6 +120,34 @@ export function sectionsFor(lastSeenVersion: string | undefined, currentVersion:
   return from === '2.0' || from === '2.1' ? SECTIONS_21 : [...SECTIONS_20, ...SECTIONS_21]
 }
 
+function ShowcasePageView({ page, index, total }: { page: ShowcasePage; index: number; total: number }) {
+  return (
+    <div className="p2">
+      <div className="p2-inner sc-page" style={{ width: 'min(1000px, 95vw)' }} data-ux-id={`showcase-page-${page.id}`}>
+        <div className="sc-copy">
+          <div className="sc-eyebrow" data-ux-id="showcase-eyebrow">Feature showcase · {index} of {total}</div>
+          <h2 className="sc-h" data-ux-id="showcase-heading">{page.heading}</h2>
+          <p className="sc-tagline" data-ux-id="showcase-tagline">{page.tagline}</p>
+          <div className="sc-points" data-ux-id="showcase-points">
+            {page.points.map((pt) => (
+              <div className="sc-pt" key={pt.lead}>
+                <span className="wn-dot sc-dot" />
+                <div><b>{pt.lead}</b> {pt.rest}</div>
+              </div>
+            ))}
+          </div>
+          <p className="sc-where" data-ux-id="showcase-where">
+            {page.where.pre}<b>{page.where.em}</b>{page.where.post}
+          </p>
+        </div>
+        <div className="sc-art" data-ux-id="showcase-art">
+          <ShowcaseVignette kind={page.art} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function WhatsNewV2Step({
   onNext,
   ctaLabel = 'Set it up →',
@@ -125,42 +161,88 @@ export function WhatsNewV2Step({
 }) {
   const sections = sectionsFor(useAppMetaStore.getState().meta.lastSeenVersion, LINE_SOURCE)
   const count = sections.reduce((n, s) => n + s.items.length, 0)
+  // The showcase (owner design 2026-08-24): the summary is page 0; each
+  // flagship feature of the line gets a full page behind it. With no pages
+  // authored for a line this collapses to exactly the old single-page step —
+  // no dots, no skip, the harness CTA — so nothing regresses.
+  const showcases = showcasesFor(LINE_SOURCE)
+  const [pageIx, setPageIx] = useState(0)
+  const total = 1 + showcases.length
+  const isLast = pageIx === total - 1
+  const jumpTo = (id: string) => {
+    const ix = showcases.findIndex((p) => p.id === id)
+    if (ix >= 0) setPageIx(1 + ix)
+  }
   return (
     <>
-      <div className="p2">
-        <div className="p2-inner" style={{ width: 'min(920px, 95vw)' }}>
-          <h2 className="h2" data-ux-id="whatsnew-heading">What&apos;s new in {LINE}</h2>
-          <p className="p2-sub" data-ux-id="whatsnew-sub">
-            {count} things worth knowing, in one line each.
-          </p>
+      {pageIx === 0 ? (
+        <div className="p2">
+          <div className="p2-inner" style={{ width: 'min(920px, 95vw)' }}>
+            <h2 className="h2" data-ux-id="whatsnew-heading">What&apos;s new in {LINE}</h2>
+            <p className="p2-sub" data-ux-id="whatsnew-sub">
+              {count} things worth knowing, in one line each{showcases.length > 0 ? ` — and ${showcases.length} of them have a page of their own, just behind this one` : ''}.
+            </p>
 
-          <div className="wn-sections" data-ux-id="whatsnew-sections">
-            {sections.map((s) => (
-              <section key={s.heading} data-ux-id={`section-${s.heading.toLowerCase().replace(/[^a-z]+/g, '-')}`}>
-                <h3 className="wn-sec-h">{s.heading}</h3>
-                {s.items.map((it) => (
-                  <div className="wn-item" key={it.title}>
-                    <span className="wn-dot" />
-                    <div>
-                      <span className="wn-t">{it.title}</span>{' '}
-                      <span className="wn-d">{it.desc}</span>
-                      {it.beta && <span className="gh-tag">Beta</span>}
+            <div className="wn-sections" data-ux-id="whatsnew-sections">
+              {sections.map((s) => (
+                <section key={s.heading} data-ux-id={`section-${s.heading.toLowerCase().replace(/[^a-z]+/g, '-')}`}>
+                  <h3 className="wn-sec-h">{s.heading}</h3>
+                  {s.items.map((it) => (
+                    <div className="wn-item" key={it.title}>
+                      <span className="wn-dot" />
+                      <div>
+                        <span className="wn-t">{it.title}</span>{' '}
+                        <span className="wn-d">{it.desc}</span>
+                        {it.beta && <span className="gh-tag">Beta</span>}
+                        {it.seeIt && showcases.some((p) => p.id === it.seeIt) && (
+                          <button
+                            type="button"
+                            className="wn-see"
+                            onClick={() => jumpTo(it.seeIt!)}
+                            data-ux-id={`see-${it.seeIt}`}
+                          >
+                            See it &rarr;
+                          </button>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </section>
+                  ))}
+                </section>
+              ))}
+            </div>
+
+            <p className="gh-freebie" data-ux-id="whatsnew-pointer">
+              The detail for any of these lives in <b>Feature Guide &rarr; What&apos;s New</b>, any time.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <ShowcasePageView page={showcases[pageIx - 1]} index={pageIx} total={showcases.length} />
+      )}
+      <div className="foot">
+        <span className="hint" data-ux-id="whatsnew-hint">
+          {isLast ? hint : `Page ${pageIx + 1} of ${total} — the tour continues afterwards.`}
+        </span>
+        {total > 1 && (
+          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" role="tablist" aria-label="What's New pages">
+            <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" data-ux-id="whatsnew-dot-summary"><i /></button>
+            {showcases.map((p, ix) => (
+              <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>
             ))}
           </div>
-
-          <p className="gh-freebie" data-ux-id="whatsnew-pointer">
-            The detail for any of these lives in <b>Feature Guide &rarr; What&apos;s New</b>, any time.
-          </p>
-        </div>
-      </div>
-      <div className="foot">
-        <span className="hint">{hint}</span>
-        <button className="cta" onClick={onNext} type="button" data-ux-id="whatsnew-cta">
-          {ctaLabel}
+        )}
+        {!isLast && (
+          <button type="button" className="skip wn-skip" onClick={onNext} data-ux-id="whatsnew-skip">
+            Skip the showcase
+          </button>
+        )}
+        <button
+          className="cta"
+          onClick={() => (isLast ? onNext() : setPageIx(pageIx + 1))}
+          type="button"
+          data-ux-id="whatsnew-cta"
+        >
+          {isLast ? ctaLabel : 'Next →'}
         </button>
       </div>
     </>

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -388,7 +388,7 @@
 .ob-root .sc-pt b { color: var(--text-primary); font-weight: 650; }
 .ob-root .sc-dot { background: var(--status-warning); }
 .ob-root .sc-where { margin: 22px 0 0; font-size: 12px; color: var(--text-secondary); border-left: 2px solid var(--border-strong); padding-left: 10px; }
-.ob-root .sc-where b { color: var(--text-secondary); }
+
 .ob-root .sc-art { flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center; }
 @media (max-width: 900px) { .ob-root .sc-page { flex-direction: column; gap: 22px; } .ob-root .sc-copy { flex: none; } }
 

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -353,3 +353,92 @@
 .ob-root .off-ic { width: 28px; height: 28px; border-radius: 8px; background: var(--surface-overlay); color: var(--text-muted); display: grid; place-items: center; font-size: 15px; flex: none; }
 .ob-root .sl-offnote b { font-size: 14px; color: var(--text-primary); }
 .ob-root .sl-offnote span { display: block; font-size: 12.5px; color: var(--text-muted); margin-top: 3px; line-height: 1.5; }
+
+/* ─── What's New feature showcase (owner design 2026-08-24) ───────────────────
+   The summary page is page 0; each flagship feature gets a page of its own.
+   Copy column left, drawn vignette right; the shared .foot gains dots + skip.
+   Tokens only: the --ob azure family + the app's semantic/status tokens. */
+
+/* summary page: the "See it" jump chip on a flagship line */
+.ob-root .wn-see { display: inline-flex; align-items: center; margin-left: 8px; font-size: 11px; font-weight: 650;
+  color: var(--ob); background: var(--ob-soft); border: 1px solid var(--ob-line); border-radius: 999px;
+  padding: 3px 11px; min-height: 24px; cursor: pointer; white-space: nowrap; vertical-align: 1px; }
+.ob-root .wn-see:hover { filter: brightness(1.15); }
+
+/* footer dots: 24px hit targets around a 7px dot; active stretches to a pill */
+.ob-root .wn-foot-dots { display: flex; align-items: center; margin-left: auto; }
+.ob-root .wn-fdot { width: 24px; height: 24px; border: 0; background: none; padding: 0; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; }
+.ob-root .wn-fdot i { width: 7px; height: 7px; border-radius: 999px; background: var(--border-strong); transition: all .15s; }
+.ob-root .wn-fdot.on i { width: 18px; background: var(--ob); }
+.ob-root .wn-fdot:hover:not(.on) i { background: var(--text-muted); }
+.ob-root .wn-skip { margin-left: 14px; text-decoration: none; }
+.ob-root .wn-skip:hover { color: var(--text-secondary); }
+/* the dots own the flexible gap, so the CTA loses its own auto margin here */
+.ob-root .wn-foot-dots ~ .cta { margin-left: 14px; }
+
+/* showcase page layout */
+.ob-root .sc-page { display: flex; gap: 40px; align-items: center; }
+.ob-root .sc-copy { flex: 0 0 340px; }
+.ob-root .sc-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: .14em; color: var(--ob); font-weight: 700; margin-bottom: 10px; }
+.ob-root .sc-h { font-size: 30px; font-weight: 650; letter-spacing: -.4px; line-height: 1.15; color: var(--text-primary); margin: 0; }
+.ob-root .sc-tagline { color: var(--text-secondary); font-size: 15px; margin: 10px 0 0; line-height: 1.45; }
+.ob-root .sc-points { margin-top: 20px; display: flex; flex-direction: column; gap: 11px; }
+.ob-root .sc-pt { display: flex; gap: 10px; align-items: baseline; font-size: 13px; color: var(--text-secondary); line-height: 1.45; }
+.ob-root .sc-pt b { color: var(--text-primary); font-weight: 650; }
+.ob-root .sc-dot { background: var(--status-warning); }
+.ob-root .sc-where { margin: 22px 0 0; font-size: 12px; color: var(--text-muted); border-left: 2px solid var(--border-strong); padding-left: 10px; }
+.ob-root .sc-where b { color: var(--text-secondary); }
+.ob-root .sc-art { flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center; }
+@media (max-width: 900px) { .ob-root .sc-page { flex-direction: column; gap: 22px; } .ob-root .sc-copy { flex: none; } }
+
+/* vignettes: mini app window / terminal, purely decorative */
+.ob-root .sv-mini { width: 100%; max-width: 560px; background: var(--surface-raised); border: 1px solid var(--border-strong); border-radius: 12px; overflow: hidden; box-shadow: 0 18px 50px rgba(0,0,0,.35); }
+.ob-root .sv-tb { display: flex; align-items: center; gap: 6px; padding: 8px 12px; background: var(--surface-sunken); border-bottom: 1px solid var(--border-subtle); }
+.ob-root .sv-tl { width: 9px; height: 9px; border-radius: 999px; background: var(--border-strong); }
+.ob-root .sv-toolrow { display: flex; align-items: center; gap: 8px; padding: 7px 12px; border-bottom: 1px solid var(--border-subtle); flex-wrap: wrap; }
+.ob-root .sv-toolrow-bar { border-bottom: 0; border-top: 1px solid var(--border-subtle); padding: 9px 12px; }
+.ob-root .sv-toolchip { font-size: 10.5px; color: var(--text-muted); border: 1px solid var(--border-strong); border-radius: 6px; padding: 2.5px 8px; white-space: nowrap; }
+.ob-root .sv-amber { color: var(--surface-sunken); background: var(--status-warning); border-color: var(--status-warning); font-weight: 700; }
+.ob-root .sv-blue { color: var(--ob); border-color: var(--ob-line); }
+.ob-root .sv-green { color: var(--status-success); border-color: color-mix(in srgb, var(--status-success) 40%, transparent); }
+.ob-root .sv-peach { color: var(--status-warning); border-color: color-mix(in srgb, var(--status-warning) 40%, transparent); }
+.ob-root .sv-sep { width: 1px; height: 14px; background: var(--border-strong); }
+.ob-root .sv-body { display: flex; min-height: 300px; }
+.ob-root .sv-main { flex: 1; padding: 14px; min-width: 0; }
+.ob-root .sv-mode-line { display: flex; align-items: center; gap: 10px; }
+.ob-root .sv-mode { font-size: 15px; font-weight: 800; letter-spacing: .06em; color: var(--ob); }
+.ob-root .sv-keel { flex: 1; height: 2px; background: linear-gradient(90deg, var(--ob), transparent); border-radius: 2px; opacity: .6; }
+.ob-root .sv-chips { display: flex; gap: 6px; margin-top: 9px; }
+.ob-root .sv-chip { font-size: 10px; border: 1px solid var(--border-strong); color: var(--text-muted); border-radius: 6px; padding: 2px 8px; }
+.ob-root .sv-chip.sv-on { color: var(--ob); border-color: var(--ob-line); background: var(--ob-soft); }
+.ob-root .sv-framed { margin-top: 12px; border: 2px solid var(--border-strong); border-radius: 10px; position: relative; background: var(--surface-stage); padding: 18px 16px 16px; }
+.ob-root .sv-frame-tag { position: absolute; top: -8px; left: 12px; font-size: 8.5px; letter-spacing: .1em; background: var(--surface-raised); color: var(--text-muted); padding: 1px 7px; border-radius: 4px; border: 1px solid var(--border-strong); }
+.ob-root .sv-form { width: 200px; margin: 6px auto; display: flex; flex-direction: column; gap: 8px; }
+.ob-root .sv-mock-h { height: 12px; width: 90px; background: var(--border-strong); border-radius: 4px; margin-bottom: 4px; }
+.ob-root .sv-mock-field { height: 22px; background: var(--surface-overlay); border: 1px solid var(--border-strong); border-radius: 6px; }
+.ob-root .sv-mock-btn { height: 24px; background: var(--ob); border-radius: 6px; width: 84px; opacity: .9; }
+.ob-root .sv-pin { position: absolute; right: 118px; bottom: 44px; width: 18px; height: 18px; border-radius: 999px; background: var(--status-warning); color: var(--surface-sunken); font-size: 11px; font-weight: 800; display: flex; align-items: center; justify-content: center; box-shadow: 0 0 0 3px color-mix(in srgb, var(--status-warning) 30%, transparent); }
+.ob-root .sv-note { position: absolute; right: -10px; bottom: -34px; width: 210px; background: var(--surface-raised); border: 1px solid var(--border-strong); border-radius: 9px; padding: 9px 11px; box-shadow: 0 12px 30px rgba(0,0,0,.4); }
+.ob-root .sv-note-who { font-size: 9.5px; color: var(--text-muted); margin-bottom: 3px; }
+.ob-root .sv-note-txt { font-size: 11.5px; color: var(--text-primary); line-height: 1.4; }
+.ob-root .sv-abc { display: flex; gap: 5px; margin-top: 7px; flex-wrap: wrap; }
+.ob-root .sv-abc span { font-size: 9.5px; font-weight: 700; border: 1px solid var(--border-strong); border-radius: 5px; padding: 1.5px 7px; color: var(--text-secondary); }
+.ob-root .sv-abc .sv-pick { color: var(--surface-sunken); background: var(--status-success); border-color: var(--status-success); }
+.ob-root .sv-panel { width: 118px; border-left: 1px solid var(--border-subtle); padding: 10px 9px; background: var(--surface-raised); }
+.ob-root .sv-pn-h { font-size: 8.5px; letter-spacing: .1em; color: var(--status-warning); font-weight: 700; margin-bottom: 6px; }
+.ob-root .sv-pn-h.sv-pn-dim { color: var(--text-muted); margin-top: 8px; }
+.ob-root .sv-pn-row { height: 26px; border: 1px solid var(--border-subtle); border-radius: 6px; margin-bottom: 6px; background: var(--surface-stage); }
+.ob-root .sv-pn-row.sv-pn-faint { opacity: .5; }
+.ob-root .sv-term { width: 100%; max-width: 540px; background: var(--surface-sunken); border: 1px solid var(--border-strong); border-radius: 12px; overflow: hidden; box-shadow: 0 18px 50px rgba(0,0,0,.35); }
+.ob-root .sv-term-body { padding: 16px 18px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; }
+.ob-root .sv-term-lines { padding: 22px 14px 8px; font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 11px; color: var(--text-muted); }
+.ob-root .sv-tline { color: var(--text-muted); margin-bottom: 6px; white-space: nowrap; overflow: hidden; }
+.ob-root .sv-dim { opacity: .5; }
+.ob-root .sv-banner { margin: 10px 0; border: 1px solid color-mix(in srgb, var(--status-warning) 50%, transparent); background: color-mix(in srgb, var(--status-warning) 8%, transparent); color: var(--status-warning); border-radius: 8px; padding: 8px 12px; font-size: 12px; }
+.ob-root .sv-wd-chip { display: inline-flex; align-items: center; gap: 8px; margin-top: 8px; border: 1px solid var(--border-strong); border-radius: 999px; padding: 5px 12px; font-size: 11.5px; color: var(--text-secondary); font-family: inherit; }
+.ob-root .sv-wd-dot { width: 7px; height: 7px; border-radius: 999px; background: var(--status-success); animation: sv-pulse 2s infinite; }
+.ob-root .sv-typed { color: var(--status-success); margin-top: 10px; }
+.ob-root .sv-caret { display: inline-block; width: 7px; height: 13px; background: var(--status-success); vertical-align: -2px; animation: sv-pulse 1s infinite; }
+@keyframes sv-pulse { 50% { opacity: .35; } }
+@media (prefers-reduced-motion: reduce) { .ob-root .sv-wd-dot, .ob-root .sv-caret { animation: none; } }

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -387,7 +387,7 @@
 .ob-root .sc-pt { display: flex; gap: 10px; align-items: baseline; font-size: 13px; color: var(--text-secondary); line-height: 1.45; }
 .ob-root .sc-pt b { color: var(--text-primary); font-weight: 650; }
 .ob-root .sc-dot { background: var(--status-warning); }
-.ob-root .sc-where { margin: 22px 0 0; font-size: 12px; color: var(--text-muted); border-left: 2px solid var(--border-strong); padding-left: 10px; }
+.ob-root .sc-where { margin: 22px 0 0; font-size: 12px; color: var(--text-secondary); border-left: 2px solid var(--border-strong); padding-left: 10px; }
 .ob-root .sc-where b { color: var(--text-secondary); }
 .ob-root .sc-art { flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center; }
 @media (max-width: 900px) { .ob-root .sc-page { flex-direction: column; gap: 22px; } .ob-root .sc-copy { flex: none; } }

--- a/src/renderer/onboarding/showcase-pages.ts
+++ b/src/renderer/onboarding/showcase-pages.ts
@@ -60,7 +60,7 @@ export const SHOWCASES_21: ShowcasePage[] = [
       { lead: 'Careful hands.', rest: 'It never types over your draft or an open prompt.' },
       { lead: 'It watches the screen you see', rest: '— the rendered pane, not a stale log.' },
     ],
-    where: { pre: 'Where: ', em: 'Settings → Sessions → Session Watchdog', post: '.' },
+    where: { pre: 'Where: ', em: 'Settings → General → Session Watchdog', post: '.' },
     art: 'watchdog',
   },
   {

--- a/src/renderer/onboarding/showcase-pages.ts
+++ b/src/renderer/onboarding/showcase-pages.ts
@@ -1,0 +1,91 @@
+import { releaseLine } from '../utils/versionLabel'
+
+/**
+ * The What's New feature showcase (owner-approved design, 2026-08-24): after
+ * the one-line summary page, each flagship feature of the release line gets a
+ * full page of its own — heading, tagline, a few one-liner points, a "where to
+ * find it" locator, and a drawn vignette (ShowcaseVignette).
+ *
+ * Curated HERE, not in changelog.ts, for the same reason WhatsNewV2Step's
+ * SECTIONS are: changelog.ts is a fragile pure-data literal that
+ * scripts/gen-changelog.js extracts by bracket-matching, and the showcase is
+ * editorial content for the upgrade flow, not part of the release record. By
+ * construction nothing in this file can break `npm run changelog` or the
+ * "Changelog in sync" CI.
+ *
+ * The summary page links here: a WhatsNewItem carrying `seeIt: '<page id>'`
+ * grows a "See it →" chip that jumps to that page. An id with no matching page
+ * renders no chip, so the two files cannot drift into a dead button.
+ */
+
+export type ShowcaseArtKind = 'canvas' | 'watchdog' | 'oneRow'
+
+export interface ShowcasePoint {
+  /** Bold lead-in, ending in a full stop unless the rest continues the sentence. */
+  lead: string
+  rest: string
+}
+
+export interface ShowcasePage {
+  id: string
+  heading: string
+  tagline: string
+  /** Three or four; more is a wall and belongs in the Feature Guide. */
+  points: ShowcasePoint[]
+  /** The muted locator under the points: pre + emphasised + post. */
+  where: { pre: string; em: string; post: string }
+  art: ShowcaseArtKind
+}
+
+export const SHOWCASES_21: ShowcasePage[] = [
+  {
+    id: 'canvas',
+    heading: 'The Agent Canvas grew a real review flow',
+    tagline: "Claude renders the work in the app. You point at what's wrong; it fixes everything in one pass.",
+    points: [
+      { lead: 'Review needed, counted.', rest: 'The button turns amber with one number for every round owed.' },
+      { lead: 'Drafts stay private.', rest: 'You only ever see versions the agent marks ready.' },
+      { lead: 'A note can offer choices.', rest: 'A/B/C chips — your click picks the winner, or name it in chat.' },
+      { lead: 'Nothing is overwritten.', rest: 'History picks the artifact; a stepper walks its versions.' },
+    ],
+    where: { pre: 'Where: the ', em: 'Canvas', post: ' button in the session toolbar, beside Snap.' },
+    art: 'canvas',
+  },
+  {
+    id: 'watchdog',
+    heading: "The Watchdog waits so you don't have to",
+    tagline: 'A rate limit used to end your evening. Now the session reads the banner, waits out the reset, and types the retry itself.',
+    points: [
+      { lead: 'Off by default.', rest: 'One switch in Settings turns it on.' },
+      { lead: 'Careful hands.', rest: 'It never types over your draft or an open prompt.' },
+      { lead: 'It watches the screen you see', rest: '— the rendered pane, not a stale log.' },
+    ],
+    where: { pre: 'Where: ', em: 'Settings → Sessions → Session Watchdog', post: '.' },
+    art: 'watchdog',
+  },
+  {
+    id: 'oneRow',
+    heading: 'Three rows became one',
+    tagline: "Tools first, then your Global buttons, then this config's Session buttons. The bar knows what kind of session it's in.",
+    points: [
+      { lead: 'Nothing you had is changed without asking', rest: '— clashes carry a small amber mark until you look.' },
+      { lead: 'Overflow folds', rest: 'into a per-band "N more" pill instead of wrapping.' },
+      { lead: 'Two terminal lines come back', rest: 'to every session.' },
+    ],
+    where: { pre: 'Where: ', em: "under every session's terminal", post: '.' },
+    art: 'oneRow',
+  },
+]
+
+/**
+ * Which showcase pages a build shows. Same fallback rule as sectionsFor: a
+ * line with no set of its own (2.2 before anyone authors one) gets the NEWEST
+ * set, never nothing-with-a-heading; the 2.0 line predates the showcase and
+ * gets none. Unlike sectionsFor this does not depend on where the user came
+ * FROM — the showcase presents the current line's flagships, and stacking a
+ * second line's pages behind them is exactly the wall the one-line summary
+ * exists to avoid.
+ */
+export function showcasesFor(currentVersion: string): ShowcasePage[] {
+  return releaseLine(currentVersion) === '2.0' ? [] : SHOWCASES_21
+}

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+/**
+ * The What's New feature showcase (owner design, 2026-08-24): the summary is
+ * page 0 and each flagship feature of the line gets a full page behind it,
+ * paged by footer dots / Next, escapable by Skip, with the harness CTA only on
+ * the last page.
+ *
+ * What this file holds shut:
+ *  - the harness contract is untouched: onNext fires exactly when the run is
+ *    left (last-page CTA, or Skip), never on internal paging;
+ *  - the "See it" chips only render for items whose showcase page exists, so
+ *    the two curated files cannot drift into a dead button;
+ *  - a line with no showcase (2.0) collapses to exactly the old single-page
+ *    step — no dots, no skip, the incoming CTA label.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+;(globalThis as any).__APP_VERSION__ = '2.1.0-rc.1'
+
+const metaState: any = { meta: { lastSeenVersion: '2.1.0-beta.17' } }
+vi.mock('../../../src/renderer/stores/appMetaStore', () => {
+  const useAppMetaStore: any = (sel: any) => sel(metaState)
+  useAppMetaStore.getState = () => metaState
+  return { useAppMetaStore }
+})
+
+const { WhatsNewV2Step, sectionsFor } = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
+const { SHOWCASES_21, showcasesFor } = await import('../../../src/renderer/onboarding/showcase-pages')
+
+let container: HTMLDivElement
+let root: Root
+let nexts: number
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  nexts = 0
+  metaState.meta = { lastSeenVersion: '2.1.0-beta.17' }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const q = (id: string) => container.querySelector(`[data-ux-id="${id}"]`)
+const click = (el: Element | null) => act(() => { (el as HTMLElement).click() })
+
+function render(props: Partial<React.ComponentProps<typeof WhatsNewV2Step>> = {}) {
+  act(() => {
+    root.render(<WhatsNewV2Step onNext={() => { nexts++ }} ctaLabel="Continue" hint="Nothing to set up." {...props} />)
+  })
+}
+
+// ── the curated data ───────────────────────────────────────────────
+describe('showcase-pages — the curated set', () => {
+  it('the 2.1 line has pages; the 2.0 line has none; a future line falls back to the newest set', () => {
+    expect(showcasesFor('2.1.0-rc.1').length).toBeGreaterThan(0)
+    expect(showcasesFor('2.0.5')).toEqual([])
+    expect(showcasesFor('2.2.0')).toEqual(SHOWCASES_21)
+  })
+
+  it('page ids are unique and every page keeps to 3-4 points', () => {
+    const ids = SHOWCASES_21.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const p of SHOWCASES_21) {
+      expect(p.points.length, p.id).toBeGreaterThanOrEqual(3)
+      expect(p.points.length, p.id).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it('every seeIt on the summary resolves to a real showcase page — no dead chips', () => {
+    // undefined lastSeen yields the widest summary (both section sets).
+    const items = sectionsFor(undefined, '2.1.0').flatMap((s) => s.items)
+    const pageIds = new Set(SHOWCASES_21.map((p) => p.id))
+    for (const it of items) {
+      if (it.seeIt) expect(pageIds.has(it.seeIt), `seeIt "${it.seeIt}" on "${it.title}"`).toBe(true)
+    }
+    // And the flagships are actually linked, not merely linkable.
+    const linked = items.filter((i) => i.seeIt).map((i) => i.seeIt)
+    expect(linked).toContain('canvas')
+    expect(linked).toContain('watchdog')
+    expect(linked).toContain('oneRow')
+  })
+})
+
+// ── the paged step ─────────────────────────────────────────────────
+describe('WhatsNewV2Step — multi-page showcase', () => {
+  it('opens on the summary, with dots and a positional hint', () => {
+    render()
+    expect(q('whatsnew-heading')).not.toBeNull()
+    expect(q('showcase-heading')).toBeNull()
+    expect(q('whatsnew-dots')).not.toBeNull()
+    expect(q('whatsnew-hint')!.textContent).toContain('Page 1 of 4')
+  })
+
+  it('Next pages inward without leaving the run; the last page carries the harness CTA', () => {
+    render()
+    const cta = () => q('whatsnew-cta')!
+    expect(cta().textContent).toContain('Next')
+    click(cta()) // -> canvas
+    expect(nexts).toBe(0)
+    expect(q('showcase-page-canvas')).not.toBeNull()
+    expect(q('showcase-eyebrow')!.textContent).toContain('1 of 3')
+    click(cta()) // -> watchdog
+    click(cta()) // -> oneRow (last)
+    expect(q('showcase-page-oneRow')).not.toBeNull()
+    expect(cta().textContent).toBe('Continue')
+    expect(q('whatsnew-hint')!.textContent).toBe('Nothing to set up.')
+    expect(q('whatsnew-skip'), 'skip duplicates the CTA on the last page').toBeNull()
+    expect(nexts).toBe(0)
+    click(cta())
+    expect(nexts).toBe(1)
+  })
+
+  it('a "See it" chip jumps straight to its page', () => {
+    render()
+    click(q('see-watchdog'))
+    expect(q('showcase-page-watchdog')).not.toBeNull()
+    expect(q('showcase-eyebrow')!.textContent).toContain('2 of 3')
+    expect(nexts).toBe(0)
+  })
+
+  it('the dots jump anywhere, including back to the summary', () => {
+    render()
+    click(q('whatsnew-dot-oneRow'))
+    expect(q('showcase-page-oneRow')).not.toBeNull()
+    click(q('whatsnew-dot-summary'))
+    expect(q('whatsnew-heading')).not.toBeNull()
+    expect(nexts).toBe(0)
+  })
+
+  it('Skip leaves the run from an inner page', () => {
+    render()
+    click(q('whatsnew-cta')) // -> canvas
+    click(q('whatsnew-skip'))
+    expect(nexts).toBe(1)
+  })
+
+  it('each showcase page draws its vignette', () => {
+    render()
+    click(q('whatsnew-dot-canvas'))
+    expect(q('showcase-art-canvas')).not.toBeNull()
+    click(q('whatsnew-dot-watchdog'))
+    expect(q('showcase-art-watchdog')).not.toBeNull()
+    click(q('whatsnew-dot-oneRow'))
+    expect(q('showcase-art-oneRow')).not.toBeNull()
+  })
+
+  it('a line with no showcase collapses to the old single-page step', async () => {
+    vi.resetModules()
+    ;(globalThis as any).__APP_VERSION__ = '2.0.5'
+    const fresh = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
+    act(() => {
+      root.render(<fresh.WhatsNewV2Step onNext={() => { nexts++ }} ctaLabel="Continue" hint="Nothing to set up." />)
+    })
+    expect(container.querySelector('[data-ux-id="whatsnew-dots"]')).toBeNull()
+    expect(container.querySelector('[data-ux-id="whatsnew-skip"]')).toBeNull()
+    const cta = container.querySelector('[data-ux-id="whatsnew-cta"]')!
+    expect(cta.textContent).toBe('Continue')
+    click(cta)
+    expect(nexts).toBe(1)
+    ;(globalThis as any).__APP_VERSION__ = '2.1.0-rc.1'
+    vi.resetModules()
+  })
+})

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -75,9 +75,11 @@ describe('showcase-pages — the curated set', () => {
   })
 
   it('every seeIt on the summary resolves to a real showcase page — no dead chips', () => {
-    // undefined lastSeen yields the widest summary (both section sets).
+    // undefined lastSeen yields the widest summary (both section sets), and
+    // the page set is the one the COMPONENT consumes (showcasesFor), not the
+    // raw constant — so this pins the pair that actually renders together.
     const items = sectionsFor(undefined, '2.1.0').flatMap((s) => s.items)
-    const pageIds = new Set(SHOWCASES_21.map((p) => p.id))
+    const pageIds = new Set(showcasesFor('2.1.0').map((p) => p.id))
     for (const it of items) {
       if (it.seeIt) expect(pageIds.has(it.seeIt), `seeIt "${it.seeIt}" on "${it.title}"`).toBe(true)
     }
@@ -150,6 +152,27 @@ describe('WhatsNewV2Step — multi-page showcase', () => {
     expect(q('showcase-art-watchdog')).not.toBeNull()
     click(q('whatsnew-dot-oneRow'))
     expect(q('showcase-art-oneRow')).not.toBeNull()
+  })
+
+  it('a chip renders ONLY when its showcase page exists — the anti-drift guard', async () => {
+    // Serve a page set holding only the canvas page: the summary still carries
+    // seeIt ids for watchdog and oneRow, so an unguarded chip would render for
+    // pages that cannot be jumped to. Deleting the `showcases.some` guard in
+    // WhatsNewV2Step fails this test.
+    vi.resetModules()
+    vi.doMock('../../../src/renderer/onboarding/showcase-pages', async (importOriginal) => {
+      const real: any = await importOriginal()
+      return { ...real, showcasesFor: () => real.SHOWCASES_21.filter((p: any) => p.id === 'canvas') }
+    })
+    const fresh = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
+    act(() => {
+      root.render(<fresh.WhatsNewV2Step onNext={() => { nexts++ }} ctaLabel="Continue" hint="h" />)
+    })
+    expect(container.querySelector('[data-ux-id="see-canvas"]')).not.toBeNull()
+    expect(container.querySelector('[data-ux-id="see-watchdog"]')).toBeNull()
+    expect(container.querySelector('[data-ux-id="see-oneRow"]')).toBeNull()
+    vi.doUnmock('../../../src/renderer/onboarding/showcase-pages')
+    vi.resetModules()
   })
 
   it('a line with no showcase collapses to the old single-page step', async () => {

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -164,15 +164,21 @@ describe('WhatsNewV2Step — multi-page showcase', () => {
       const real: any = await importOriginal()
       return { ...real, showcasesFor: () => real.SHOWCASES_21.filter((p: any) => p.id === 'canvas') }
     })
-    const fresh = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
-    act(() => {
-      root.render(<fresh.WhatsNewV2Step onNext={() => { nexts++ }} ctaLabel="Continue" hint="h" />)
-    })
-    expect(container.querySelector('[data-ux-id="see-canvas"]')).not.toBeNull()
-    expect(container.querySelector('[data-ux-id="see-watchdog"]')).toBeNull()
-    expect(container.querySelector('[data-ux-id="see-oneRow"]')).toBeNull()
-    vi.doUnmock('../../../src/renderer/onboarding/showcase-pages')
-    vi.resetModules()
+    try {
+      const fresh = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
+      act(() => {
+        root.render(<fresh.WhatsNewV2Step onNext={() => { nexts++ }} ctaLabel="Continue" hint="h" />)
+      })
+      expect(container.querySelector('[data-ux-id="see-canvas"]')).not.toBeNull()
+      expect(container.querySelector('[data-ux-id="see-watchdog"]')).toBeNull()
+      expect(container.querySelector('[data-ux-id="see-oneRow"]')).toBeNull()
+    } finally {
+      // resetModules does NOT clear the mock registry — without the unmock a
+      // failed assertion above would leak the reduced page set into the next
+      // test's fresh import and fail it with a misleading message.
+      vi.doUnmock('../../../src/renderer/onboarding/showcase-pages')
+      vi.resetModules()
+    }
   })
 
   it('a line with no showcase collapses to the old single-page step', async () => {


### PR DESCRIPTION
## What

The upgrade flow's What's New becomes a **multi-page feature showcase** (owner-approved canvas design, 2026-08-24 — "What's New feature showcase" v1): the existing one-line summary is page 0, and each flagship feature of the release line gets a full page — big heading, tagline, 3–4 one-liners, a "Where: …" locator, and a drawn pure-CSS vignette. For the 2.1 line: **Agent Canvas**, **Session Watchdog**, **one-row bar**.

## How

- **`onboarding/showcase-pages.ts` (new)** — the curated pages + `showcasesFor(currentVersion)` (sectionsFor's fallback rule: 2.0 → none; a future line with no set → the newest set). Deliberately **not** in `changelog.ts`: `gen-changelog.js` and the "Changelog in sync" CI are untouched by construction.
- **`onboarding/ShowcaseVignette.tsx` (new)** — aria-hidden decorative illustrations (mini canvas pane with mode title / Inspect chips / framed page / note pin + A/B/C chips; terminal with rate-limit banner + watchdog chip + typed retry; one-row bar strip). Tokens only, no emoji, reduced-motion respected.
- **`WhatsNewV2Step`** — internal paging: footer dots (24px hit targets, active pill), "Skip the showcase", "Next →" on inner pages, the harness-provided CTA + hint only on the last page, positional "Page N of M" hint earlier. Summary flagship items grew **"See it →" chips** that jump to their page — a chip renders only when its page exists, so the two curated files cannot drift into a dead button. `SECTIONS_21` gains Watchdog and one-row lines (containment tests in upgrade-flow.test.ts unaffected).
- **Harness + registry untouched**: `whatsNewV2` already always surfaces on an upgrade, so no `sinceVersion` bump, no frozen-table churn, and the `onNext`/`ctaLabel`/`hint` contract is identical. On a line with no pages the step collapses to exactly the old single-page behaviour.

## Verification

- New `whatsnew-showcase.test.tsx`: data invariants (unique ids, 3–4 points, every `seeIt` resolves + all three flagships linked), paging contract (inner Next never fires `onNext`; last page carries the CTA and drops Skip; Skip leaves; dots jump both ways incl. back to summary; per-kind vignette renders), and the 2.0 collapse via module re-import.
- Full `npx vitest run`: 8330 passed / 16 skipped. `npm run typecheck` clean.
- Owner verifies visually on install (upgrade-cohort page; fresh installs never see it).

## Scope notes

- The Settings "What's New" modal (on-demand reader) is unchanged — the showcase belongs to the upgrade delivery surface per the 2026-08-21 call that made the harness the single delivery.
- Changelog entry for the showcase lands with the rc.1 cut prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
