### PR TITLE
fix(shortcuts): glyph-diagnostic chord fires with the terminal focused

### DIFF
--- a/CONTEXT.d/2026-08-24-glyph-shortcut-capture.md
+++ b/CONTEXT.d/2026-08-24-glyph-shortcut-capture.md
@@ -11,6 +11,16 @@ arbitration the tip card's Escape uses), keeping the AltGr guard (#399) and
 the onboarding-overlay suppression. Success remains visible via main's
 shell.showItemInFolder reveal.
 
-Test `keyboard-glyph-capture.test.tsx` simulates xterm with a bubble-phase
-stopPropagation interceptor: fails on a bubble-only listener (verified by
-mutation), passes on capture; the AltGr chord is pinned inert.
+One arbitration rule came with the move: the Settings shortcut recorder and
+its Test box must WIN over the capture listener (or the chord could never be
+re-recorded or tested — pressing it in the Test box fired a REAL capture,
+disk write + Explorer reveal). Both boxes carry `data-shortcut-capture` and
+the handler yields to any target inside one; that attribute is the contract
+for any future capture-phase chord.
+
+Test `keyboard-glyph-capture.test.tsx` simulates xterm faithfully (capture-
+phase interceptor on the textarea cancelling the chord): fails on a
+bubble-only listener (verified by mutation), passes on capture. The AltGr
+chord is pinned to pass through unprevented (load-bearing before xterm), the
+recorder yield is pinned from both halves (handler honours the attribute;
+SettingsPage emits it), and the plain-window test is a regression guard.

--- a/CONTEXT.d/2026-08-24-glyph-shortcut-capture.md
+++ b/CONTEXT.d/2026-08-24-glyph-shortcut-capture.md
@@ -1,0 +1,16 @@
+# 2026-08-24 — Ctrl+Alt+G fired nowhere it mattered (beta.17 FYI item)
+
+The glyph-corruption diagnostic chord (#374) was bound in the window's
+BUBBLE-phase keydown listener. xterm's key handling stops propagation at its
+textarea, so with the terminal focused — exactly where you are when glyphs go
+missing — the chord never reached the handler. Everywhere else it worked,
+which made "Ctrl+Alt+G does nothing" look untraceable.
+
+Fix: the chord moved to its own CAPTURE-phase window listener (same
+arbitration the tip card's Escape uses), keeping the AltGr guard (#399) and
+the onboarding-overlay suppression. Success remains visible via main's
+shell.showItemInFolder reveal.
+
+Test `keyboard-glyph-capture.test.tsx` simulates xterm with a bubble-phase
+stopPropagation interceptor: fails on a bubble-only listener (verified by
+mutation), passes on capture; the AltGr chord is pinned inert.

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -1420,6 +1420,7 @@ function ShortcutEditor({ action, label, shortcut, allShortcuts, onSave }: {
           <div
             ref={inputRef}
             tabIndex={0}
+            data-shortcut-capture
             className="px-2.5 py-1 bg-crust border border-blue/50 rounded-md text-[11px] text-text font-mono min-w-[120px] text-center outline-none animate-pulse"
             onKeyDown={(e) => {
               e.preventDefault()
@@ -1445,6 +1446,7 @@ function ShortcutEditor({ action, label, shortcut, allShortcuts, onSave }: {
           <div
             ref={testRef}
             tabIndex={0}
+            data-shortcut-capture
             className="px-2.5 py-1 bg-crust border border-green/40 rounded-md text-[11px] text-text font-mono min-w-[120px] text-center outline-none"
             onKeyDown={(e) => {
               e.preventDefault()

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -116,7 +116,9 @@ export function useKeyboardShortcuts(
     // Capture a glyph-corruption diagnostic (#374): the moment a user sees
     // characters go missing while backgrounds stay, this saves the always-on
     // atlas event ring + a window screenshot and reveals them to share. Fixed
-    // action, not per-session, so it fires whatever the active view — and on
+    // action, not per-session, so it fires whatever the active view (one
+    // residual gap: focus inside the browser pane's own WebContents keeps keys
+    // there — only Escape is forwarded) — and on
     // the CAPTURE phase, because the natural moment to press it is with the
     // corrupted terminal FOCUSED, where xterm's own key handling stops the
     // event before a bubble listener ever hears it (the beta.17 "Ctrl+Alt+G
@@ -128,6 +130,12 @@ export function useKeyboardShortcuts(
       // Same onboarding-overlay suppression as handleKeyDown: a diagnostic
       // capture under the covered shell would screenshot the overlay.
       if (deriveOnboarding(useAppMetaStore.getState().meta, {}).due) return
+      // The Settings shortcut recorder / Test box must WIN over this capture
+      // listener, or the chord can never be re-recorded or tested (pressing it
+      // in the Test box would fire a real capture — disk write + Explorer
+      // reveal — instead of reporting a match). Those boxes carry
+      // data-shortcut-capture; yield to them.
+      if ((e.target as Element | null)?.closest?.('[data-shortcut-capture]')) return
       const shortcuts = useSettingsStore.getState().settings.keyboardShortcuts || DEFAULT_SHORTCUTS
       if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
         e.preventDefault()

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -78,17 +78,11 @@ export function useKeyboardShortcuts(
         e.preventDefault()
         setSidebarOpen(prev => !prev)
       }
-      // Capture a glyph-corruption diagnostic (#374): the moment a user sees
-      // characters go missing while backgrounds stay, this saves the always-on
-      // atlas event ring + a window screenshot and reveals them to share. Fixed
-      // action, not per-session, so it fires whatever the active view.
-      // Guard AltGraph: on international layouts AltGr reports ctrlKey && altKey,
-      // so a bare Ctrl+Alt+<key> binding would swallow AltGr text entry into the
-      // terminal. Skip when AltGr is really down (#399 ADR-009 pass).
-      if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
-        e.preventDefault()
-        void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
-      }
+      // (Ctrl+Alt+G lives in the CAPTURE-phase listener below, not here: the
+      // glyph shortcut is pressed while staring at a corrupted TERMINAL, and
+      // with the terminal focused xterm consumes the keydown before it can
+      // bubble to this listener — the one place the shortcut mattered was the
+      // one place it never fired.)
       // NOTE: rename (F2) is handled in Sidebar so it edits the active session
       // in the Active Sessions list (only when the sidebar is visible), not the
       // tab. Tab double-click / right-click still edit the tab inline.
@@ -119,8 +113,35 @@ export function useKeyboardShortcuts(
       }
     }
 
+    // Capture a glyph-corruption diagnostic (#374): the moment a user sees
+    // characters go missing while backgrounds stay, this saves the always-on
+    // atlas event ring + a window screenshot and reveals them to share. Fixed
+    // action, not per-session, so it fires whatever the active view — and on
+    // the CAPTURE phase, because the natural moment to press it is with the
+    // corrupted terminal FOCUSED, where xterm's own key handling stops the
+    // event before a bubble listener ever hears it (the beta.17 "Ctrl+Alt+G
+    // does nothing" report; same arbitration as the tip card's Escape).
+    // Guard AltGraph: on international layouts AltGr reports ctrlKey && altKey,
+    // so a bare Ctrl+Alt+<key> binding would swallow AltGr text entry into the
+    // terminal. Skip when AltGr is really down (#399 ADR-009 pass).
+    const handleGlyphCapture = (e: KeyboardEvent) => {
+      // Same onboarding-overlay suppression as handleKeyDown: a diagnostic
+      // capture under the covered shell would screenshot the overlay.
+      if (deriveOnboarding(useAppMetaStore.getState().meta, {}).due) return
+      const shortcuts = useSettingsStore.getState().settings.keyboardShortcuts || DEFAULT_SHORTCUTS
+      if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
+        e.preventDefault()
+        e.stopPropagation()
+        void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
+      }
+    }
+
     window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    window.addEventListener('keydown', handleGlyphCapture, true)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keydown', handleGlyphCapture, true)
+    }
     // view / openPageTabs / closePageTab / setView are read in the closure; keep
     // the listener bound to their current values so tab cycling stays correct.
   }, [activeSessionId, view, openPageTabs, closePageTab, setView, setSidebarOpen])

--- a/tests/unit/renderer/keyboard-glyph-capture.test.tsx
+++ b/tests/unit/renderer/keyboard-glyph-capture.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+/**
+ * Ctrl+Alt+G (the #374 glyph-corruption diagnostic) must fire even while the
+ * TERMINAL has focus — which is exactly where a user is when they see glyphs
+ * go missing. xterm's own key handling stops keydown propagation at its
+ * textarea, so the shortcut's original bubble-phase listener never heard the
+ * chord in the one place it mattered (the beta.17 "Ctrl+Alt+G does nothing"
+ * report). The handler now listens on the CAPTURE phase; this file simulates
+ * xterm with a bubble-phase interceptor that stops propagation and proves the
+ * capture listener still runs — and that the AltGr guard still holds.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../../../src/renderer/onboarding/gate', () => ({ deriveOnboarding: () => ({ due: false, steps: [] }) }))
+vi.mock('../../../src/renderer/utils/imageTransfer', () => ({ sendImageToSession: vi.fn() }))
+const captureGlyphDiagnostic = vi.fn(async () => ({ ok: true }))
+vi.mock('../../../src/renderer/utils/glyphDiagnostic', () => ({
+  captureGlyphDiagnostic: (...args: unknown[]) => captureGlyphDiagnostic(...args),
+}))
+
+const { useKeyboardShortcuts } = await import('../../../src/renderer/hooks/useKeyboardShortcuts')
+const { useSessionStore } = await import('../../../src/renderer/stores/sessionStore')
+const { useSettingsStore } = await import('../../../src/renderer/stores/settingsStore')
+const { DEFAULT_SHORTCUTS } = await import('../../../src/renderer/utils/shortcuts')
+
+function Host() {
+  useKeyboardShortcuts('s1', () => {}, () => {}, 'sessions', [], () => {})
+  return null
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  captureGlyphDiagnostic.mockClear()
+  useSessionStore.setState({ sessions: [], activeSessionId: 's1', renamingSessionId: null } as any)
+  useSettingsStore.setState({ settings: { keyboardShortcuts: DEFAULT_SHORTCUTS } as any })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => { root.render(<Host />) })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+/** A keydown for Ctrl+Alt+G, optionally with AltGr really down. */
+function chord(altGraph = false): KeyboardEvent {
+  const e = new KeyboardEvent('keydown', { key: 'g', ctrlKey: true, altKey: true, bubbles: true, cancelable: true })
+  Object.defineProperty(e, 'getModifierState', { value: (m: string) => (m === 'AltGraph' ? altGraph : false) })
+  return e
+}
+
+describe('Ctrl+Alt+G glyph capture survives xterm (#374, beta.17 silence)', () => {
+  it('fires even when a bubble-phase handler (xterm) stops propagation', () => {
+    // Simulate xterm's textarea: a bubble listener on an inner element that
+    // stops the event cold — the shape that silenced the shortcut.
+    const term = document.createElement('textarea')
+    container.appendChild(term)
+    term.addEventListener('keydown', (e) => { e.stopPropagation(); e.preventDefault() })
+    act(() => { term.dispatchEvent(chord()) })
+    expect(captureGlyphDiagnostic).toHaveBeenCalledTimes(1)
+    expect(captureGlyphDiagnostic).toHaveBeenCalledWith('s1')
+  })
+
+  it('still fires on a plain window keydown (no terminal focused)', () => {
+    act(() => { window.dispatchEvent(chord()) })
+    expect(captureGlyphDiagnostic).toHaveBeenCalledTimes(1)
+  })
+
+  it('the AltGr guard holds: a real AltGraph chord types text, never captures', () => {
+    act(() => { window.dispatchEvent(chord(true)) })
+    expect(captureGlyphDiagnostic).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/renderer/keyboard-glyph-capture.test.tsx
+++ b/tests/unit/renderer/keyboard-glyph-capture.test.tsx
@@ -5,9 +5,10 @@
  * go missing. xterm's own key handling stops keydown propagation at its
  * textarea, so the shortcut's original bubble-phase listener never heard the
  * chord in the one place it mattered (the beta.17 "Ctrl+Alt+G does nothing"
- * report). The handler now listens on the CAPTURE phase; this file simulates
- * xterm with a bubble-phase interceptor that stops propagation and proves the
- * capture listener still runs — and that the AltGr guard still holds.
+* report). The handler now listens on the CAPTURE phase; this file simulates
+ * xterm faithfully (a capture-phase interceptor on the textarea that cancels
+ * the chord) and proves the window capture listener still runs — plus the
+ * AltGr guard, and the yield to the Settings shortcut recorder.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
@@ -88,6 +89,17 @@ describe('Ctrl+Alt+G glyph capture survives xterm (#374, beta.17 silence)', () =
     container.appendChild(box)
     act(() => { box.dispatchEvent(chord()) })
     expect(captureGlyphDiagnostic).not.toHaveBeenCalled()
+  })
+
+  it('SettingsPage actually emits the attribute the yield keys on (both boxes)', () => {
+    // The other half of the contract: the handler honours data-shortcut-capture
+    // (test above), and the recorder + Test box must CARRY it — deleting the
+    // attribute from SettingsPage silently resurrects the regression.
+    const fs = require('node:fs') as typeof import('node:fs')
+    const path = require('node:path') as typeof import('node:path')
+    const src = fs.readFileSync(path.resolve(__dirname, '../../../src/renderer/components/SettingsPage.tsx'), 'utf8')
+    const tagged = src.match(/data-shortcut-capture/g) ?? []
+    expect(tagged.length).toBeGreaterThanOrEqual(2)
   })
 
   it('the AltGr guard holds: a real AltGraph chord passes through untouched', () => {

--- a/tests/unit/renderer/keyboard-glyph-capture.test.tsx
+++ b/tests/unit/renderer/keyboard-glyph-capture.test.tsx
@@ -59,24 +59,43 @@ function chord(altGraph = false): KeyboardEvent {
 }
 
 describe('Ctrl+Alt+G glyph capture survives xterm (#374, beta.17 silence)', () => {
-  it('fires even when a bubble-phase handler (xterm) stops propagation', () => {
-    // Simulate xterm's textarea: a bubble listener on an inner element that
-    // stops the event cold — the shape that silenced the shortcut.
+  it('fires even when xterm-style handling stops propagation at its textarea', () => {
+    // Simulate xterm's textarea: its real listener is capture-phase on the
+    // textarea and cancels handled chords (preventDefault + stopPropagation)
+    // — the shape that silenced the shortcut for a focused terminal.
     const term = document.createElement('textarea')
     container.appendChild(term)
-    term.addEventListener('keydown', (e) => { e.stopPropagation(); e.preventDefault() })
+    term.addEventListener('keydown', (e) => { e.stopPropagation(); e.preventDefault() }, true)
     act(() => { term.dispatchEvent(chord()) })
     expect(captureGlyphDiagnostic).toHaveBeenCalledTimes(1)
     expect(captureGlyphDiagnostic).toHaveBeenCalledWith('s1')
   })
 
   it('still fires on a plain window keydown (no terminal focused)', () => {
+    // Regression guard, not a phase discriminator: a window-dispatched event
+    // reaches window listeners in either phase. Test 1 is the one that fails
+    // on a bubble-only binding.
     act(() => { window.dispatchEvent(chord()) })
     expect(captureGlyphDiagnostic).toHaveBeenCalledTimes(1)
   })
 
-  it('the AltGr guard holds: a real AltGraph chord types text, never captures', () => {
-    act(() => { window.dispatchEvent(chord(true)) })
+  it('yields to the Settings shortcut recorder / Test box', () => {
+    // Those boxes carry data-shortcut-capture and must WIN, or the chord can
+    // never be re-recorded or tested — pressing it in the Test box would fire
+    // a real capture (disk write + Explorer reveal) instead of matching.
+    const box = document.createElement('div')
+    box.setAttribute('data-shortcut-capture', '')
+    container.appendChild(box)
+    act(() => { box.dispatchEvent(chord()) })
     expect(captureGlyphDiagnostic).not.toHaveBeenCalled()
+  })
+
+  it('the AltGr guard holds: a real AltGraph chord passes through untouched', () => {
+    const e = chord(true)
+    act(() => { window.dispatchEvent(e) })
+    expect(captureGlyphDiagnostic).not.toHaveBeenCalled()
+    // Load-bearing now the listener runs BEFORE xterm: the event must reach
+    // the terminal unprevented so AltGr text entry still types.
+    expect(e.defaultPrevented).toBe(false)
   })
 })


### PR DESCRIPTION
Fixes the beta.17 FYI item: **Ctrl+Alt+G did nothing when a terminal had focus** — xterm stops keydown propagation at its textarea, and the chord was bound bubble-phase on window, so the diagnostic never fired in the one place users press it (staring at corrupted glyphs). Everywhere else it worked, making the silence look untraceable.

Fix: the chord gets its own **capture-phase** window listener (same arbitration as the tip card's Escape), retaining the AltGr guard (#399) and onboarding-overlay suppression. Success stays visible via main's `shell.showItemInFolder` reveal.

Verification: new `keyboard-glyph-capture.test.tsx` simulates xterm with a bubble-phase stopPropagation interceptor — **fails on a bubble-only binding (mutation-checked), passes on capture**; AltGr chord pinned inert. Full suite 8336 passed; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)