### PR TITLE
feat(sidebar): running configs relaunch — count pill replaces the lock

### DIFF
--- a/CONTEXT.d/2026-08-24-relaunch-running-configs.md
+++ b/CONTEXT.d/2026-08-24-relaunch-running-configs.md
@@ -7,18 +7,23 @@ supersedes the locked-row half of the two-mode panel design from earlier the
 same day.
 
 - `runningConfigCounts(sessions)` (savedConfigsView) is the new source: live
-  sessions per config id, ask sessions excluded. `runningConfigIds` remains,
-  derived, for set-shaped callers.
+  sessions per config id, ask sessions excluded. (`runningConfigIds` was
+  deleted in the review round — nothing consumed set semantics.)
 - **ConfigRow**: the locked branch is DELETED. A running config is a normal
   row — Launch and Edit live — plus a green count pill (`● N`,
   `config-row-running-count`) whose click jumps to the LATEST live session.
-  Only Delete is refused while sessions run (`canDeleteConfig`,
-  `DELETE_WHILE_RUNNING_REASON`): removing the template under live sessions
-  would strand the Running rows. Drag-to-reorder no longer cares about
-  running.
-- **ConfigContextMenu**: Edit ENABLED while running (a template edit shapes
-  future launches — the point of relaunch), with the hint "Edits apply to
-  sessions launched from now on"; Delete stays refused with the shared
+  Only Delete is refused while sessions run (inline guards at both surfaces
+  sharing `DELETE_WHILE_RUNNING_REASON`): removing the template under live
+  sessions would strand the Running rows. Drag-to-reorder no longer cares
+  about running. Review round: the hover action strip parks LEFT of the pill
+  (right-12) so it cannot swallow the pill's clicks, and the pill carries an
+  aria-label.
+- **ConfigContextMenu**: Edit ENABLED while running, with the hint "Edits
+  apply to sessions launched from now on" — and SessionDialog shows an amber
+  note when the edited config has live sessions, naming the two restart
+  hazards (an SSH restart after a connection edit is REFUSED by
+  spawn-credential binding; a restarted shell whose command line changed runs
+  WITHOUT its secret argument); Delete stays refused with the shared
   reason. The pin hint reads "Quick Start can spawn another" (it used to
   promise deferral).
 - **QuickStartPanel**: every pinned config shows, running or not, with the

--- a/CONTEXT.d/2026-08-24-relaunch-running-configs.md
+++ b/CONTEXT.d/2026-08-24-relaunch-running-configs.md
@@ -1,0 +1,33 @@
+# 2026-08-24 — configs relaunch while running; count pill replaces the lock
+
+Owner revision (rc.1 install pass): "I got the design of sessions wrong — a
+running session SHOULD be allowed to be launched again; show how many are
+running but still allow another to be spawned. Quick Start too." This
+supersedes the locked-row half of the two-mode panel design from earlier the
+same day.
+
+- `runningConfigCounts(sessions)` (savedConfigsView) is the new source: live
+  sessions per config id, ask sessions excluded. `runningConfigIds` remains,
+  derived, for set-shaped callers.
+- **ConfigRow**: the locked branch is DELETED. A running config is a normal
+  row — Launch and Edit live — plus a green count pill (`● N`,
+  `config-row-running-count`) whose click jumps to the LATEST live session.
+  Only Delete is refused while sessions run (`canDeleteConfig`,
+  `DELETE_WHILE_RUNNING_REASON`): removing the template under live sessions
+  would strand the Running rows. Drag-to-reorder no longer cares about
+  running.
+- **ConfigContextMenu**: Edit ENABLED while running (a template edit shapes
+  future launches — the point of relaunch), with the hint "Edits apply to
+  sessions launched from now on"; Delete stays refused with the shared
+  reason. The pin hint reads "Quick Start can spawn another" (it used to
+  promise deferral).
+- **QuickStartPanel**: every pinned config shows, running or not, with the
+  count pill on live ones; Start always spawns another instance. The
+  "N running" header hint is gone (nothing is hidden any more).
+- **Launch-all (group/section)** still fills in only what is NOT running —
+  bring-up semantics kept deliberately: doubling a whole group silently is
+  never what "launch all" meant; a duplicate is the single row's deliberate
+  act.
+- Tests rewritten to pin the revision (relaunch fires, pill counts and jumps,
+  delete refused with reason, Quick Start keeps running pins, launch-all
+  bring-up), plus `runningConfigCounts` counting.

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -86,9 +86,14 @@ interface Props {
   onConfirm: (config: Omit<TerminalConfig, 'id'>, password?: string, sudoPassword?: string, argSecret?: string) => void
   onCancel: () => void
   initial?: Partial<TerminalConfig>
+  /** Live sessions of the config being edited (0 / absent = none). Edits only
+   *  shape FUTURE launches — and a live session that restarts after an
+   *  SSH/terminal change re-binds against the saved config, so the dialog
+   *  says so up front instead of letting a restart fail as a surprise. */
+  liveSessionCount?: number
 }
 
-export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
+export default function SessionDialog({ onConfirm, onCancel, initial, liveSessionCount = 0 }: Props) {
   const groups = useConfigStore((s) => s.groups)
   const addGroup = useConfigStore((s) => s.addGroup)
   const sections = useConfigStore((s) => s.sections)
@@ -576,6 +581,21 @@ export default function SessionDialog({ onConfirm, onCancel, initial }: Props) {
         />
 
         <div className="px-[18px] pb-4 overflow-y-auto flex-1 min-h-0">
+
+          {isEdit && liveSessionCount > 0 && (
+            <div
+              className="mt-4 px-3 py-2 rounded-lg text-[11.5px] leading-snug"
+              style={{
+                color: 'var(--status-warning)',
+                background: 'color-mix(in srgb, var(--status-warning) 9%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--status-warning) 40%, transparent)',
+              }}
+              data-testid="edit-while-running-note"
+            >
+              {liveSessionCount === 1 ? 'A session launched from this config is running.' : `${liveSessionCount} sessions launched from this config are running.`}{' '}
+              They keep the settings they launched with; your edits apply to sessions started from now on. Restarting a live SSH session after changing its connection details will be refused.
+            </div>
+          )}
 
           {/* ── 1 · WHAT THIS LAUNCHER RUNS ── */}
           <div className="flex items-center gap-2 pt-4 mb-2">

--- a/src/renderer/components/SessionDialog.tsx
+++ b/src/renderer/components/SessionDialog.tsx
@@ -593,7 +593,7 @@ export default function SessionDialog({ onConfirm, onCancel, initial, liveSessio
               data-testid="edit-while-running-note"
             >
               {liveSessionCount === 1 ? 'A session launched from this config is running.' : `${liveSessionCount} sessions launched from this config are running.`}{' '}
-              They keep the settings they launched with; your edits apply to sessions started from now on. Restarting a live SSH session after changing its connection details will be refused.
+              They keep the settings they launched with; your edits apply to sessions started from now on. Restarting a live SSH session after changing its connection details will be refused, and a restarted shell whose command line changed will run without its secret argument.
             </div>
           )}
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -189,8 +189,9 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
     ;(tab === 'saved' ? savedTabRef : runningTabRef).current?.focus()
   }
   const [configSearchQuery, setConfigSearchQuery] = useState('')
-  // Configs with a live session: locked in the Saved list and excluded from
-  // launch-all. `sessions` already excludes the Ask session.
+  // Live-session counts per config: the row/Quick Start pills and the
+  // delete guard read these; launch-all skips anything counted (bring-up).
+  // `sessions` already excludes the Ask session.
   const runningCounts = useMemo(() => runningConfigCounts(sessions), [sessions])
   const [dragConfigId, setDragConfigId] = useState<string | null>(null)
   const [dragOverConfigId, setDragOverConfigId] = useState<string | null>(null)
@@ -343,7 +344,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
 
   const launchGroup = async (groupId: string) => {
     // Running configs are skipped (launchableInGroup): launch-all is bring-up
-    // spawn the duplicate the locked row exists to prevent.
+    // — it fills in what is missing and never silently doubles what runs.
     for (const config of launchableInGroup(configs, groupId, runningCounts)) {
       await launchFromConfig(config)
     }
@@ -446,8 +447,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   }
 
   const launchSection = async (sectionId: string) => {
-    // Running configs skipped for the same reason as launchGroup: no duplicate
-    // sessions behind the locked row's back.
+    // Running configs skipped for the same reason as launchGroup: bring-up
+    // fills in what is missing, never silently doubles what runs.
     for (const config of launchableInSection(configs, groups, sectionId, runningCounts)) {
       await launchFromConfig(config)
     }
@@ -1274,6 +1275,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           onConfirm={handleEditConfig}
           onCancel={() => setEditingConfig(null)}
           initial={editingConfig}
+          liveSessionCount={runningCounts.get(editingConfig.id) ?? 0}
         />
       )}
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -30,7 +30,7 @@ import GroupHeader from './sidebar/GroupHeader'
 import SessionSectionHeader from './sidebar/SessionSectionHeader'
 import SessionGroupHeader from './sidebar/SessionGroupHeader'
 import UngroupedSessionsHeader from './sidebar/UngroupedSessionsHeader'
-import { runningConfigIds } from './sidebar/savedConfigsView'
+import { runningConfigCounts } from './sidebar/savedConfigsView'
 import AskConductorDock from './sidebar/AskConductorDock'
 import QuickStartPanel from './sidebar/QuickStartPanel'
 import { resolveDefaultPanelTab, launchableInGroup, launchableInSection, type PanelTab } from './sidebar/sessionsPanelState'
@@ -191,7 +191,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const [configSearchQuery, setConfigSearchQuery] = useState('')
   // Configs with a live session: locked in the Saved list and excluded from
   // launch-all. `sessions` already excludes the Ask session.
-  const runningIds = useMemo(() => runningConfigIds(sessions), [sessions])
+  const runningCounts = useMemo(() => runningConfigCounts(sessions), [sessions])
   const [dragConfigId, setDragConfigId] = useState<string | null>(null)
   const [dragOverConfigId, setDragOverConfigId] = useState<string | null>(null)
   // The LOOSE configs: in no group and no section (a stale id pointing at a
@@ -342,9 +342,9 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   }
 
   const launchGroup = async (groupId: string) => {
-    // Running configs are skipped (launchableInGroup): launch-all must never
+    // Running configs are skipped (launchableInGroup): launch-all is bring-up
     // spawn the duplicate the locked row exists to prevent.
-    for (const config of launchableInGroup(configs, groupId, runningIds)) {
+    for (const config of launchableInGroup(configs, groupId, runningCounts)) {
       await launchFromConfig(config)
     }
   }
@@ -448,7 +448,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const launchSection = async (sectionId: string) => {
     // Running configs skipped for the same reason as launchGroup: no duplicate
     // sessions behind the locked row's back.
-    for (const config of launchableInSection(configs, groups, sectionId, runningIds)) {
+    for (const config of launchableInSection(configs, groups, sectionId, runningCounts)) {
       await launchFromConfig(config)
     }
   }
@@ -644,7 +644,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
     // neither drag sources nor drop targets, so a stray drag over them shows
     // no drop affordance and does nothing.
     const loose = looseConfigIds.has(config.id)
-    const running = runningIds.has(config.id)
+    const runningCount = runningCounts.get(config.id) ?? 0
     return (
       <ConfigRow
         key={config.id}
@@ -654,18 +654,18 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
         onDelete={() => handleDeleteConfig(config.id)}
         onPin={() => togglePinned(config.id)}
         onContextMenu={(e) => handleConfigContextMenu(e, config.id)}
-        running={running}
-        onOpenSession={running ? () => {
-          // The locked row's affordance: jump to the live session — on the
-          // Running tab, in the sessions view.
-          const live = sessions.find((s) => s.configId === config.id)
+        runningCount={runningCount}
+        onOpenSession={runningCount > 0 ? () => {
+          // The count pill's affordance: jump to the LATEST live session of
+          // this config — on the Running tab, in the sessions view.
+          const live = [...sessions].reverse().find((s) => s.configId === config.id)
           if (live) {
             setActiveSession(live.id)
             selectPanelTab('running')
             onViewChange('sessions')
           }
         } : undefined}
-        draggable={loose && !running}
+        draggable={loose}
         onDragStart={loose ? (e) => handleConfigDragStart(e, config.id) : undefined}
         onDragOver={loose ? (e) => handleConfigDragOver(e, config.id) : undefined}
         onDrop={loose ? (e) => handleConfigDrop(e, config.id) : undefined}
@@ -939,7 +939,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           currentGroupId={configs.find((c) => c.id === contextMenuConfig.configId)?.groupId}
           currentSectionId={configs.find((c) => c.id === contextMenuConfig.configId)?.sectionId}
           isPinned={configs.find((c) => c.id === contextMenuConfig.configId)?.pinned}
-          running={runningIds.has(contextMenuConfig.configId)}
+          running={(runningCounts.get(contextMenuConfig.configId) ?? 0) > 0}
           onMoveToGroup={(gid) => handleMoveToGroup(contextMenuConfig.configId, gid)}
           onCreateGroup={(name) => handleCreateGroupAndMove(contextMenuConfig.configId, name)}
           onMoveToSection={(sid) => handleMoveConfigToSection(contextMenuConfig.configId, sid)}
@@ -987,7 +987,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
       <div id="running-tabpanel" role="tabpanel" aria-labelledby="panel-tab-running" className="flex flex-col flex-1 min-h-0" data-testid="running-tab">
       <QuickStartPanel
         configs={configs}
-        running={runningIds}
+        running={runningCounts}
         onLaunch={launchFromConfig}
         onContextMenu={handleConfigContextMenu}
       />

--- a/src/renderer/components/sidebar/ConfigContextMenu.tsx
+++ b/src/renderer/components/sidebar/ConfigContextMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react'
 import { ConfigGroup, ConfigSection } from '../../stores/configStore'
 import { useClickOutside } from '../../hooks/useClickOutside'
-import { pinMenuLabel, PIN_WHILE_RUNNING_HINT } from './sessionsPanelState'
+import { pinMenuLabel, PIN_WHILE_RUNNING_HINT, DELETE_WHILE_RUNNING_REASON } from './sessionsPanelState'
 
 interface ConfigContextMenuProps {
   x: number
@@ -11,8 +11,9 @@ interface ConfigContextMenuProps {
   currentGroupId?: string
   currentSectionId?: string
   isPinned?: boolean
-  /** The config's session is live: Edit/Delete lock (a running template must
-   *  not be edited by accident) and the pin item explains its deferral. */
+  /** The config has live sessions. Delete locks (removing the template under
+   *  live sessions); Edit stays available — a template edit shapes future
+   *  launches, which is the point of relaunch (owner revision 2026-08-24). */
   running?: boolean
   onMoveToGroup: (groupId: string | undefined) => void
   onCreateGroup: (name: string) => void
@@ -55,12 +56,10 @@ export default function ConfigContextMenu({ x, y, groups, sections, currentGroup
       style={{ left: x, top: y, background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)' }}
     >
       <button
-        onClick={running ? undefined : onEdit}
-        disabled={running}
-        aria-disabled={running}
-        className={`w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2 ${running ? 'cursor-not-allowed opacity-45' : 'hover:bg-[var(--surface-overlay)]'}`}
+        onClick={onEdit}
+        className="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2 hover:bg-[var(--surface-overlay)]"
         style={{ color: 'var(--text-primary)' }}
-        title={running ? 'Running — a live config cannot be edited' : undefined}
+        title={running ? 'Edits apply to sessions launched from now on' : undefined}
         data-testid="ctx-edit"
       >
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M8.5 1.5l2 2-7 7H1.5v-2z"/></svg>
@@ -99,7 +98,7 @@ export default function ConfigContextMenu({ x, y, groups, sections, currentGroup
         aria-disabled={running}
         className={`w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2 ${running ? 'cursor-not-allowed opacity-45' : 'hover:bg-[var(--surface-overlay)]'}`}
         style={{ color: 'var(--status-danger)' }}
-        title={running ? 'Running — close the session before deleting this config' : undefined}
+        title={running ? DELETE_WHILE_RUNNING_REASON : undefined}
         data-testid="ctx-delete"
       >
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg>

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -44,7 +44,7 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
 
   // No locked state (owner revision 2026-08-24): a config is a template and
   // may relaunch while running. Live sessions surface as the count pill below;
-  // only DELETE stays guarded (see canDeleteConfig).
+  // only DELETE stays guarded while any session runs.
   const deleteBlocked = runningCount > 0
 
   return (
@@ -79,6 +79,7 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
           onClick={(e) => { e.stopPropagation(); onOpenSession?.() }}
           className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 hover:bg-green/25 rounded-full px-1.5 py-0.5 shrink-0 focus-ring transition-colors"
           title={runningCountLabel(runningCount)}
+          aria-label={runningCountLabel(runningCount)}
           data-testid="config-row-running-count"
         >
           <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
@@ -92,7 +93,11 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
           positioning gives the label the full row at rest and still avoids the
           reflow that display:none would cause on hover. The backdrop keeps the
           buttons legible over the tail of a long label. */}
-      <div className="absolute right-2 flex gap-0.5 items-center rounded pl-2 bg-gradient-to-l from-surface0 via-surface0 to-transparent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity">
+      {/* When the count pill occupies the right edge, the hover strip parks to
+          ITS LEFT — anchored over the pill it would otherwise paint across,
+          leaving the pill visible and clickable (review HIGH: the overlay used
+          to swallow every mouse click aimed at the pill). */}
+      <div className={`absolute ${runningCount > 0 ? 'right-10' : 'right-2'} flex gap-0.5 items-center rounded pl-2 bg-gradient-to-l from-surface0 via-surface0 to-transparent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity`}>
         <button
           onClick={launchBlocked ? undefined : onLaunch}
           disabled={launchBlocked}

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -94,10 +94,14 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
           reflow that display:none would cause on hover. The backdrop keeps the
           buttons legible over the tail of a long label. */}
       {/* When the count pill occupies the right edge, the hover strip parks to
-          ITS LEFT — anchored over the pill it would otherwise paint across,
+          ITS LEFT — anchored clear of the pill it would otherwise paint across,
           leaving the pill visible and clickable (review HIGH: the overlay used
-          to swallow every mouse click aimed at the pill). */}
-      <div className={`absolute ${runningCount > 0 ? 'right-10' : 'right-2'} flex gap-0.5 items-center rounded pl-2 bg-gradient-to-l from-surface0 via-surface0 to-transparent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity`}>
+          to swallow every mouse click aimed at the pill). Budget: right-12 is
+          3rem; minus the row's px-2 inset that leaves ~2.5rem of pill room —
+          measured clear for 1-2 digit counts across every UI font and the 0.8
+          scale (text-[8.5px] is a fixed px size, so small scales are the tight
+          case). No jsdom test can pin layout; re-measure if this moves. */}
+      <div className={`absolute ${runningCount > 0 ? 'right-12' : 'right-2'} flex gap-0.5 items-center rounded pl-2 bg-gradient-to-l from-surface0 via-surface0 to-transparent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto transition-opacity`}>
         <button
           onClick={launchBlocked ? undefined : onLaunch}
           disabled={launchBlocked}

--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -5,6 +5,7 @@ import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/id
 import { useResolvedTheme } from '../../hooks/useThemeController'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { CODEX_OFF_LAUNCH_REASON } from '../../hooks/useLaunchConfig'
+import { DELETE_WHILE_RUNNING_REASON, runningCountLabel } from './sessionsPanelState'
 
 interface ConfigRowProps {
   config: TerminalConfig
@@ -13,9 +14,10 @@ interface ConfigRowProps {
   onDelete: () => void
   onPin?: () => void
   onContextMenu: (e: React.MouseEvent) => void
-  /** The config has a live session (design pass 2026-08-24): the row locks —
-   *  greyed, no launch/edit/delete — and a click jumps to that session. */
-  running?: boolean
+  /** How many live sessions this config has (owner revision 2026-08-24: a
+   *  config is a template — it may relaunch while running, so the row shows a
+   *  COUNT pill instead of locking; clicking the pill opens the session). */
+  runningCount?: number
   onOpenSession?: () => void
   draggable?: boolean
   onDragStart?: (e: React.DragEvent) => void
@@ -25,7 +27,7 @@ interface ConfigRowProps {
   isDragOver?: boolean
 }
 
-export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, onContextMenu, running, onOpenSession, draggable, onDragStart, onDragOver, onDrop, onDragEnd, isDragOver }: ConfigRowProps) {
+export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, onContextMenu, runningCount = 0, onOpenSession, draggable, onDragStart, onDragOver, onDrop, onDragEnd, isDragOver }: ConfigRowProps) {
   // Icon order is the design's identity split: the session TYPE leads the row
   // (the prominent mark — Claude / Codex / Shell), and the config's own colour
   // is a small chip beside the name. The big coloured square read as an
@@ -40,40 +42,10 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
 
   const typeKind = config.shellOnly ? 'shell' : (config.provider ?? 'claude') === 'codex' ? 'codex' : 'claude'
 
-  // ── Locked row: the config's session is live. Greyed + dashed, a lock and a
-  // Running pill instead of the hover actions — editing a template a running
-  // session already consumed invites divergence, so the affordance is "go to
-  // the session", not the editor. Context menu stays (pin/unpin still applies).
-  if (running) {
-    return (
-      <div
-        className="relative flex items-center gap-1.5 rounded py-1 px-2 border border-dashed cursor-pointer transition-colors hover:bg-surface0/40 focus-ring"
-        style={{ borderColor: 'color-mix(in srgb, var(--color-green) 40%, var(--color-surface1))' }}
-        role="button"
-        tabIndex={0}
-        onClick={onOpenSession}
-        onKeyDown={(e) => {
-          // The locked row's ONLY affordance — keyboard users get it too.
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenSession?.() }
-        }}
-        onContextMenu={onContextMenu}
-        title="Running — click to open its session"
-        data-testid="config-row-running"
-      >
-        <span className="opacity-60 grayscale-[0.4]"><SessionTypeBadge kind={typeKind} /></span>
-        <span className="w-2 h-2 rounded-[3px] shrink-0 opacity-60" style={{ backgroundColor: chipColour }} aria-hidden />
-        <span className="text-xs truncate flex-1 text-overlay1">{config.label}</span>
-        {config.sessionType === 'ssh' && <SshBadge />}
-        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-overlay0 shrink-0" aria-hidden>
-          <rect x="4" y="11" width="16" height="10" rx="2" /><path d="M8 11V7a4 4 0 0 1 8 0v4" />
-        </svg>
-        <span className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0">
-          <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
-          Running
-        </span>
-      </div>
-    )
-  }
+  // No locked state (owner revision 2026-08-24): a config is a template and
+  // may relaunch while running. Live sessions surface as the count pill below;
+  // only DELETE stays guarded (see canDeleteConfig).
+  const deleteBlocked = runningCount > 0
 
   return (
     <div
@@ -102,6 +74,17 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
       )}
       {/* Transport badge stays at the tail — the type now leads the row. */}
       {config.sessionType === 'ssh' && <SshBadge />}
+      {runningCount > 0 && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onOpenSession?.() }}
+          className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 hover:bg-green/25 rounded-full px-1.5 py-0.5 shrink-0 focus-ring transition-colors"
+          title={runningCountLabel(runningCount)}
+          data-testid="config-row-running-count"
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
+          {runningCount}
+        </button>
+      )}
       {/* Overlaid on hover rather than held in the row's flex line. As
           layout children these buttons reserved their width permanently, even
           at opacity-0 -- so every label truncated against a strip of blank
@@ -142,9 +125,15 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><path d="M8.5 1.5l2 2-7 7H1.5v-2z"/></svg>
         </button>
         <button
-          onClick={onDelete}
-          className="p-1 rounded hover:bg-surface1 text-overlay1 hover:text-red focus-ring"
-          title="Delete"
+          onClick={deleteBlocked ? undefined : onDelete}
+          disabled={deleteBlocked}
+          aria-disabled={deleteBlocked}
+          className={
+            deleteBlocked
+              ? 'p-1 rounded text-overlay0/50 cursor-not-allowed'
+              : 'p-1 rounded hover:bg-surface1 text-overlay1 hover:text-red focus-ring'
+          }
+          title={deleteBlocked ? DELETE_WHILE_RUNNING_REASON : 'Delete'}
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg>
         </button>

--- a/src/renderer/components/sidebar/QuickStartPanel.tsx
+++ b/src/renderer/components/sidebar/QuickStartPanel.tsx
@@ -5,11 +5,11 @@ import { resolveIdentityColor, bucketLegacyColorToKey } from '../../../shared/id
 import { useResolvedTheme } from '../../hooks/useThemeController'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { CODEX_OFF_LAUNCH_REASON } from '../../hooks/useLaunchConfig'
-import { quickStartConfigs, quickStartRunningCount, resolveQuickStartCollapsed } from './sessionsPanelState'
+import { quickStartConfigs, resolveQuickStartCollapsed, runningCountLabel } from './sessionsPanelState'
 
 interface QuickStartPanelProps {
   configs: TerminalConfig[]
-  running: ReadonlySet<string>
+  running: ReadonlyMap<string, number>
   onLaunch: (config: TerminalConfig) => void
   onContextMenu: (e: React.MouseEvent, configId: string) => void
 }
@@ -17,10 +17,9 @@ interface QuickStartPanelProps {
 /**
  * Quick Start — the launch-only strip at the top of the Running tab (design
  * pass 2026-08-24; replaces the always-below PinnedConfigsPanel). Fed by
- * `pinned` configs; one whose session is LIVE is omitted entirely (it is in
- * the sessions list just below — that omission is what killed the old
- * duplicate-pinned-at-top bug) and returns when the session closes. The
- * header collapses, persisted in settings.
+ * `pinned` configs. A running pin STAYS (owner revision 2026-08-24: a config
+ * is a template — Start spawns another instance) and carries a count pill.
+ * The header collapses, persisted in settings.
  */
 export default function QuickStartPanel({ configs, running, onLaunch, onContextMenu }: QuickStartPanelProps) {
   const theme = useResolvedTheme()
@@ -28,11 +27,10 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
   const updateSettings = useSettingsStore((s) => s.updateSettings)
   const codexOff = useSettingsStore((s) => s.settings.codexEnabled === false)
 
-  const items = quickStartConfigs(configs, running)
-  const hiddenRunning = quickStartRunningCount(configs, running)
+  const items = quickStartConfigs(configs)
   // Nothing pinned at all: no strip, no empty state — Quick Start is opt-in
   // via the context menus and absent until used.
-  if (items.length === 0 && hiddenRunning === 0) return null
+  if (items.length === 0) return null
 
   return (
     <div className="shrink-0 border-b border-surface1 pb-1.5 mb-1" data-testid="quick-start">
@@ -56,19 +54,12 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
         </svg>
         <span className="text-[10.5px] font-bold uppercase tracking-wider text-yellow">Quick Start</span>
         <span className="text-[10px] text-overlay0">{items.length}</span>
-        {hiddenRunning > 0 && (
-          <span
-            className="ml-auto text-[9px] text-overlay0"
-            title={`${hiddenRunning} pinned config${hiddenRunning === 1 ? ' is' : 's are'} running — back here when the session closes`}
-          >
-            {hiddenRunning} running
-          </span>
-        )}
       </button>
       {!collapsed && items.map((config) => {
         const chipColour = resolveIdentityColor(config.identityColorKey ?? bucketLegacyColorToKey(config.color), theme)
         const typeKind = config.shellOnly ? 'shell' : (config.provider ?? 'claude') === 'codex' ? 'codex' : 'claude'
         const blocked = codexOff && config.provider === 'codex'
+        const liveCount = running.get(config.id) ?? 0
         return (
           <div
             key={config.id}
@@ -83,6 +74,16 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
             <SessionTypeBadge kind={typeKind} />
             <span className="w-2 h-2 rounded-[3px] shrink-0" style={{ backgroundColor: chipColour }} aria-hidden />
             <span className="text-xs font-medium truncate flex-1 text-text">{config.label}</span>
+            {liveCount > 0 && (
+              <span
+                className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
+                title={runningCountLabel(liveCount)}
+                data-testid="quick-start-running-count"
+              >
+                <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
+                {liveCount}
+              </span>
+            )}
             {config.sessionType === 'ssh' && <SshBadge />}
             <button
               onClick={blocked ? undefined : () => onLaunch(config)}

--- a/src/renderer/components/sidebar/savedConfigsView.ts
+++ b/src/renderer/components/sidebar/savedConfigsView.ts
@@ -3,21 +3,27 @@
 // History: this module held the pure half of the #362 cards/find views. The
 // two-mode Sessions panel (design pass 2026-08-24) superseded those views and
 // their helpers went with them; what remains is the one fact several surfaces
-// still share — which saved configs have a live session. The Saved tab locks
-// those rows, Quick Start omits them, and launch paths skip them.
+// still share — which saved configs have live sessions, and HOW MANY (owner
+// revision 2026-08-24: a config may relaunch while running, so the surfaces
+// show a count instead of locking).
 
 import type { Session } from '../../stores/sessionStore'
 
 /**
- * Ids of the saved configs that currently have a live session. The Ask
- * Conductor session is deliberately config-less (see sessionStore.Session.kind)
- * and is skipped here too, so it can never hide a config.
+ * Live-session COUNT per saved config id. The Ask Conductor session is
+ * deliberately config-less (see sessionStore.Session.kind) and is skipped, so
+ * it can never mark a config running.
  */
-export function runningConfigIds(sessions: ReadonlyArray<Pick<Session, 'configId' | 'kind'>>): Set<string> {
-  const ids = new Set<string>()
+export function runningConfigCounts(sessions: ReadonlyArray<Pick<Session, 'configId' | 'kind'>>): Map<string, number> {
+  const counts = new Map<string, number>()
   for (const s of sessions) {
     if (s.kind === 'ask') continue
-    if (s.configId) ids.add(s.configId)
+    if (s.configId) counts.set(s.configId, (counts.get(s.configId) ?? 0) + 1)
   }
-  return ids
+  return counts
+}
+
+/** Ids only — kept for callers that need set semantics. */
+export function runningConfigIds(sessions: ReadonlyArray<Pick<Session, 'configId' | 'kind'>>): Set<string> {
+  return new Set(runningConfigCounts(sessions).keys())
 }

--- a/src/renderer/components/sidebar/savedConfigsView.ts
+++ b/src/renderer/components/sidebar/savedConfigsView.ts
@@ -23,7 +23,3 @@ export function runningConfigCounts(sessions: ReadonlyArray<Pick<Session, 'confi
   return counts
 }
 
-/** Ids only — kept for callers that need set semantics. */
-export function runningConfigIds(sessions: ReadonlyArray<Pick<Session, 'configId' | 'kind'>>): Set<string> {
-  return new Set(runningConfigCounts(sessions).keys())
-}

--- a/src/renderer/components/sidebar/sessionsPanelState.ts
+++ b/src/renderer/components/sidebar/sessionsPanelState.ts
@@ -45,16 +45,15 @@ export function quickStartConfigs(configs: ReadonlyArray<TerminalConfig>): Termi
 }
 
 /**
- * Whether a config may be DELETED right now. Editing while running is fine —
- * a template edit only shapes FUTURE launches, which is now the whole point
- * of relaunch — but deleting the template out from under live sessions is
- * still refused: the Running rows and any relaunch would point at nothing.
+ * The reason shown wherever delete is refused for a running config. The
+ * guard itself lives at the two surfaces (ConfigRow's disabled button, the
+ * context menu's `running` prop) — deleting the template out from under live
+ * sessions would strand the Running rows and any relaunch. Editing while
+ * running IS allowed: a template edit shapes future launches — with the
+ * caveat that a LIVE session restarting after an SSH/terminal edit re-binds
+ * against the saved config (SessionDialog warns; see the 2026-08-24 relaunch
+ * fragment).
  */
-export function canDeleteConfig(configId: string, running: ReadonlyMap<string, number>): boolean {
-  return !running.get(configId)
-}
-
-/** The reason shown wherever delete is refused for a running config. */
 export const DELETE_WHILE_RUNNING_REASON = 'Running — close its sessions before deleting the config'
 
 /**

--- a/src/renderer/components/sidebar/sessionsPanelState.ts
+++ b/src/renderer/components/sidebar/sessionsPanelState.ts
@@ -4,14 +4,20 @@
 // The owner's agreed design: the whole left panel switches between two tabs —
 // Saved (the launcher) and Running (live sessions). Quick Start is a
 // collapsible, LAUNCH-ONLY strip at the top of Running fed by `pinned`
-// configs; a pinned config whose session is live simply is not shown there
-// until it closes (that is what killed the old duplicate-pinned-at-top bug).
-// In Saved, a config with a live session stays visible but LOCKED — greyed,
-// not editable, click jumps to the session — so a running config can never be
-// edited by accident.
+// configs.
+//
+// REVISED (owner, 2026-08-24 rc.1 install pass): a config is a TEMPLATE — a
+// running one may be launched AGAIN, spawning another session. The old locked
+// row ("a running config cannot relaunch") was wrong by the owner's own call.
+// A config with live sessions shows a COUNT indicator instead, and Quick
+// Start keeps showing pinned configs while they run (spawn as many as you
+// like). What remains guarded: DELETE while sessions run (removing the
+// template under live sessions), and group/section launch-all still fills in
+// only what is not already running (bring-up semantics — it never doubles a
+// whole group silently; doubling is the single row's deliberate act).
 //
 // Everything decidable without a DOM lives here so it unit-tests flat.
-// Running detection reuses runningConfigIds from savedConfigsView.ts.
+// Running detection reuses runningConfigCounts from savedConfigsView.ts.
 
 import type { TerminalConfig, ConfigGroup } from '../../stores/configStore'
 
@@ -29,77 +35,72 @@ export function resolveQuickStartCollapsed(value: unknown): boolean {
 }
 
 /**
- * The Quick Start strip: pinned configs WITHOUT a live session, in config
- * order. Launch-only by design — a pinned config that is running is omitted
- * entirely (it lives in the sessions list just below) and returns when its
- * session closes. Existing `pinned` flags carry over as Quick Start pins
- * (plan Q2): the field is reused, so there is no data migration.
+ * The Quick Start strip: every pinned config, in config order, running or
+ * not — a config is a template, and Quick Start may spawn another instance
+ * at any time (owner revision 2026-08-24). Existing `pinned` flags carry
+ * over as Quick Start pins (plan Q2): the field is reused, no migration.
  */
-export function quickStartConfigs(
-  configs: ReadonlyArray<TerminalConfig>,
-  running: ReadonlySet<string>,
-): TerminalConfig[] {
-  return configs.filter((c) => !!c.pinned && !running.has(c.id))
-}
-
-/** How many pinned configs are hidden from Quick Start because they run now. */
-export function quickStartRunningCount(
-  configs: ReadonlyArray<TerminalConfig>,
-  running: ReadonlySet<string>,
-): number {
-  return configs.filter((c) => !!c.pinned && running.has(c.id)).length
+export function quickStartConfigs(configs: ReadonlyArray<TerminalConfig>): TerminalConfig[] {
+  return configs.filter((c) => !!c.pinned)
 }
 
 /**
- * Whether a config may be EDITED (or deleted) right now. A config with a live
- * session is locked — the dialog writes template fields the session already
- * consumed at spawn, so an edit mid-run is at best confusing and at worst a
- * divergence between what runs and what is saved. The row's affordance for a
- * locked config is "jump to session", not the editor.
+ * Whether a config may be DELETED right now. Editing while running is fine —
+ * a template edit only shapes FUTURE launches, which is now the whole point
+ * of relaunch — but deleting the template out from under live sessions is
+ * still refused: the Running rows and any relaunch would point at nothing.
  */
-export function canEditConfig(configId: string, running: ReadonlySet<string>): boolean {
-  return !running.has(configId)
+export function canDeleteConfig(configId: string, running: ReadonlyMap<string, number>): boolean {
+  return !running.get(configId)
 }
+
+/** The reason shown wherever delete is refused for a running config. */
+export const DELETE_WHILE_RUNNING_REASON = 'Running — close its sessions before deleting the config'
 
 /**
  * The pin/unpin label for the context menus (config row AND running session
  * row — both pin the underlying config). `running` only changes the HINT the
- * menu shows, never the action: pinning a running config is allowed and takes
- * effect in Quick Start when the session closes.
+ * menu shows, never the action.
  */
 export function pinMenuLabel(pinned: boolean | undefined): string {
   return pinned ? 'Unpin from Quick Start' : 'Pin to Quick Start'
 }
 
 /** The hint under the pin item when the config's session is live. */
-export const PIN_WHILE_RUNNING_HINT = 'Running now — will quick-start when this session closes'
+export const PIN_WHILE_RUNNING_HINT = 'Running now — Quick Start can spawn another'
+
+/** The running-count pill's accessible/tooltip text. */
+export function runningCountLabel(count: number): string {
+  return count === 1 ? '1 session running — click to open it' : `${count} sessions running — click to open the latest`
+}
 
 /**
  * Launch-all targets for a GROUP: its configs minus anything already running.
- * Launch-all must never spawn the duplicate the locked row exists to prevent
- * (the retired cards/find views filtered the same way via launchAllTargets).
+ * Deliberate even now that relaunch is allowed: launch-all is BRING-UP — it
+ * fills in what is missing. Doubling a whole group is never what "launch all"
+ * meant; spawning a duplicate is the single row's deliberate act.
  */
 export function launchableInGroup(
   configs: ReadonlyArray<TerminalConfig>,
   groupId: string,
-  running: ReadonlySet<string>,
+  running: ReadonlyMap<string, number>,
 ): TerminalConfig[] {
-  return configs.filter((c) => c.groupId === groupId && !running.has(c.id))
+  return configs.filter((c) => c.groupId === groupId && !running.get(c.id))
 }
 
 /**
  * Launch-all targets for a SECTION: configs in its groups plus its loose
- * configs, minus anything already running.
+ * configs, minus anything already running (same bring-up rule as the group).
  */
 export function launchableInSection(
   configs: ReadonlyArray<TerminalConfig>,
   groups: ReadonlyArray<ConfigGroup>,
   sectionId: string,
-  running: ReadonlySet<string>,
+  running: ReadonlyMap<string, number>,
 ): TerminalConfig[] {
   const sectionGroupIds = new Set(groups.filter((g) => g.sectionId === sectionId).map((g) => g.id))
   return configs.filter((c) => {
-    if (running.has(c.id)) return false
+    if (running.get(c.id)) return false
     if (c.groupId && sectionGroupIds.has(c.groupId)) return true
     if (!c.groupId && c.sectionId === sectionId) return true
     return false

--- a/tests/unit/renderer/config-row-running.test.tsx
+++ b/tests/unit/renderer/config-row-running.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-// The locked launcher row (design pass 2026-08-24): a config with a live
-// session shows the type icon leading, greyed label, lock + Running pill, NO
-// launch/edit/delete affordances, and a click jumps to its session.
+// The launcher row under the owner's 2026-08-24 revision: a config is a
+// TEMPLATE. A running config keeps ALL its affordances except Delete — it can
+// be launched again — and shows a live-session COUNT pill whose click jumps
+// to the session. (This file replaced the locked-row suite the revision
+// retired: no more grey lock, no more launch refusal.)
 import React from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
@@ -21,6 +23,7 @@ vi.mock('../../../src/renderer/hooks/useLaunchConfig', () => ({
 }))
 
 const { default: ConfigRow } = await import('../../../src/renderer/components/sidebar/ConfigRow')
+const { DELETE_WHILE_RUNNING_REASON } = await import('../../../src/renderer/components/sidebar/sessionsPanelState')
 
 const config: any = {
   id: 'c1',
@@ -32,7 +35,7 @@ const config: any = {
   pinned: true,
 }
 
-describe('ConfigRow — running lock', () => {
+describe('ConfigRow — relaunch with a running-count indicator', () => {
   let container: HTMLDivElement; let root: Root
   beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
   afterEach(() => { act(() => root.unmount()); container.remove() })
@@ -47,23 +50,36 @@ describe('ConfigRow — running lock', () => {
       ...props,
     } as any)))
 
-  it('a running config locks: Running pill, no launch/edit/delete buttons, click opens the session', () => {
-    const opened = vi.fn()
-    renderRow({ running: true, onOpenSession: opened })
-    const row = container.querySelector('[data-testid="config-row-running"]') as HTMLElement
-    expect(row).toBeTruthy()
-    expect(row.textContent).toMatch(/running/i)
-    // The type icon still leads the row.
-    expect(row.querySelector('[data-testid="type-badge-claude"]')).toBeTruthy()
-    // No action buttons at all on a locked row.
-    expect(row.querySelectorAll('button').length).toBe(0)
-    act(() => { row.click() })
-    expect(opened).toHaveBeenCalledTimes(1)
+  it('a running config can be LAUNCHED AGAIN — Launch and Edit live, only Delete refused', () => {
+    const launched = vi.fn()
+    renderRow({ runningCount: 2, onLaunch: launched, onPin: () => {} })
+    const titles = Array.from(container.querySelectorAll('button')).map((b) => b.getAttribute('title'))
+    expect(titles).toContain('Launch')
+    expect(titles).toContain('Edit')
+    expect(titles).toContain(DELETE_WHILE_RUNNING_REASON) // Delete refused with the reason
+    expect(titles).not.toContain('Delete')
+    const launch = Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('title') === 'Launch')!
+    act(() => { (launch as HTMLElement).click() })
+    expect(launched).toHaveBeenCalledTimes(1)
+    const del = Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('title') === DELETE_WHILE_RUNNING_REASON)!
+    expect((del as HTMLButtonElement).disabled).toBe(true)
   })
 
-  it('a launchable config keeps the actions and the Quick Start pin verb', () => {
-    renderRow({ running: false, onPin: () => {} })
+  it('the count pill shows N and its click opens the session — not a row-wide hijack', () => {
+    const opened = vi.fn()
+    renderRow({ runningCount: 3, onOpenSession: opened })
+    const pill = container.querySelector('[data-testid="config-row-running-count"]') as HTMLElement
+    expect(pill).toBeTruthy()
+    expect(pill.textContent).toContain('3')
+    act(() => { pill.click() })
+    expect(opened).toHaveBeenCalledTimes(1)
+    // The retired locked row is gone for good.
     expect(container.querySelector('[data-testid="config-row-running"]')).toBeNull()
+  })
+
+  it('an idle config shows no pill and keeps every action, Delete included', () => {
+    renderRow({ runningCount: 0, onPin: () => {} })
+    expect(container.querySelector('[data-testid="config-row-running-count"]')).toBeNull()
     const titles = Array.from(container.querySelectorAll('button')).map((b) => b.getAttribute('title'))
     expect(titles).toContain('Launch')
     expect(titles).toContain('Edit')

--- a/tests/unit/renderer/quick-start-panel.test.tsx
+++ b/tests/unit/renderer/quick-start-panel.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-// Quick Start (Running tab, design pass 2026-08-24): launch-only — a pinned
-// config with a live session is omitted and counted in the header; Start
+// Quick Start (Running tab, design pass 2026-08-24; owner revision the same
+// day): every pinned config shows, running or not — a config is a template
+// and Start spawns another instance. Running pins carry a count pill. Start
 // launches; the header collapse persists via settings; absent entirely when
 // nothing is pinned.
 import React from 'react'
@@ -35,15 +36,29 @@ describe('QuickStartPanel', () => {
 
   const render = (props: Record<string, unknown>) =>
     act(() => root.render(React.createElement(QuickStartPanel, {
-      onLaunch: () => {}, onContextMenu: () => {}, running: new Set(), ...props,
+      onLaunch: () => {}, onContextMenu: () => {}, running: new Map(), ...props,
     } as any)))
 
-  it('lists only launchable pins and counts the running ones in the header', () => {
-    render({ configs: [cfg('a'), cfg('b'), cfg('c', { pinned: false })], running: new Set(['b']) })
+  it('lists EVERY pin — a running one stays, with its count pill (owner revision)', () => {
+    render({ configs: [cfg('a'), cfg('b'), cfg('c', { pinned: false })], running: new Map([['b', 2]]) })
     const items = container.querySelectorAll('[data-testid="quick-start-item"]')
-    expect(items.length).toBe(1)
-    expect(items[0].textContent).toContain('a')
-    expect(container.querySelector('[data-testid="quick-start-header"]')!.textContent).toMatch(/1 running/)
+    expect(items.length).toBe(2)
+    const b = Array.from(items).find((el) => el.textContent!.includes('b'))!
+    const pill = b.querySelector('[data-testid="quick-start-running-count"]')!
+    expect(pill.textContent).toContain('2')
+    // The idle pin carries no pill.
+    const a = Array.from(items).find((el) => el.textContent!.includes('a'))!
+    expect(a.querySelector('[data-testid="quick-start-running-count"]')).toBeNull()
+  })
+
+  it('a running pin can still START another instance', () => {
+    const onLaunch = vi.fn()
+    render({ configs: [cfg('b')], running: new Map([['b', 1]]), onLaunch })
+    const start = Array.from(container.querySelectorAll('[data-testid="quick-start-item"] button'))
+      .find((el) => el.textContent!.includes('Start')) as HTMLButtonElement
+    expect(start.disabled).toBe(false)
+    act(() => { start.click() })
+    expect(onLaunch).toHaveBeenCalledTimes(1)
   })
 
   it('Start launches the config', () => {
@@ -70,10 +85,10 @@ describe('QuickStartPanel', () => {
     expect(container.querySelector('[data-testid="quick-start"]')).toBeNull()
   })
 
-  it('still shows the strip when every pin is running (the counter explains why it is empty)', () => {
-    render({ configs: [cfg('a')], running: new Set(['a']) })
+  it('every pin running: the strip shows them all, each with a pill — never empty rows', () => {
+    render({ configs: [cfg('a')], running: new Map([['a', 1]]) })
     expect(container.querySelector('[data-testid="quick-start"]')).toBeTruthy()
-    expect(container.querySelectorAll('[data-testid="quick-start-item"]').length).toBe(0)
-    expect(container.querySelector('[data-testid="quick-start-header"]')!.textContent).toMatch(/1 running/)
+    expect(container.querySelectorAll('[data-testid="quick-start-item"]').length).toBe(1)
+    expect(container.querySelector('[data-testid="quick-start-running-count"]')!.textContent).toContain('1')
   })
 })

--- a/tests/unit/renderer/saved-configs-view-helpers.test.ts
+++ b/tests/unit/renderer/saved-configs-view-helpers.test.ts
@@ -1,29 +1,27 @@
-/**
- * Running-config detection (the surviving pure helper of the old #362 module;
- * the cards/find views and their helpers retired with the two-mode Sessions
- * panel). A config with a live session is "running"; the config-less Ask
- * session can never mark one.
- */
 import { describe, it, expect } from 'vitest'
-import { runningConfigIds } from '../../../src/renderer/components/sidebar/savedConfigsView'
+// Live-session counting for the sessions panel (owner revision 2026-08-24:
+// counts, not a set — the surfaces show HOW MANY and relaunch is allowed).
+import { runningConfigCounts } from '../../../src/renderer/components/sidebar/savedConfigsView'
 
-describe('runningConfigIds', () => {
-  it('collects the configIds of live sessions', () => {
-    const ids = runningConfigIds([
+describe('runningConfigCounts', () => {
+  it('counts sessions per config id', () => {
+    const c = runningConfigCounts([
+      { configId: 'a', kind: undefined },
       { configId: 'a', kind: undefined },
       { configId: 'b', kind: undefined },
-      { configId: 'a', kind: undefined }, // second session of the same config
-      { configId: undefined, kind: undefined }, // adopted/config-less
+      { configId: undefined, kind: undefined },
     ] as never)
-    expect([...ids].sort()).toEqual(['a', 'b'])
+    expect(c.get('a')).toBe(2)
+    expect(c.get('b')).toBe(1)
+    expect(c.size).toBe(2)
   })
 
-  it('skips the Ask session even when it somehow carries a configId', () => {
-    const ids = runningConfigIds([{ configId: 'a', kind: 'ask' }] as never)
-    expect(ids.size).toBe(0)
+  it('the Ask Conductor session never marks a config running', () => {
+    const c = runningConfigCounts([{ configId: 'a', kind: 'ask' }] as never)
+    expect(c.size).toBe(0)
   })
 
   it('is empty for no sessions', () => {
-    expect(runningConfigIds([]).size).toBe(0)
+    expect(runningConfigCounts([]).size).toBe(0)
   })
 })

--- a/tests/unit/renderer/session-dialog-logging-toggle.test.tsx
+++ b/tests/unit/renderer/session-dialog-logging-toggle.test.tsx
@@ -230,3 +230,45 @@ describe('SessionDialog indexing toggle', () => {
     expect(cb).toBeNull()
   })
 })
+
+describe('SessionDialog edit-while-running note (relaunch revision 2026-08-24)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+  })
+
+  const initial: any = { id: 'c1', label: 'App Dev', workingDirectory: '/x', color: '', sessionType: 'local', provider: 'claude' }
+
+  it('shows when the edited config has live sessions, naming BOTH restart hazards', () => {
+    act(() => {
+      root.render(React.createElement(SessionDialog, { onConfirm: () => {}, onCancel: () => {}, initial, liveSessionCount: 2 } as any))
+    })
+    const note = container.querySelector('[data-testid="edit-while-running-note"]')!
+    expect(note).toBeTruthy()
+    expect(note.textContent).toContain('2 sessions')
+    expect(note.textContent).toMatch(/from now on/)
+    expect(note.textContent).toMatch(/SSH session .* will be refused/)
+    // The silent half of the hazard must be named too (review follow-up B).
+    expect(note.textContent).toMatch(/without its secret argument/)
+  })
+
+  it('absent with no live sessions, and absent on the create dialog regardless', () => {
+    act(() => {
+      root.render(React.createElement(SessionDialog, { onConfirm: () => {}, onCancel: () => {}, initial, liveSessionCount: 0 } as any))
+    })
+    expect(container.querySelector('[data-testid="edit-while-running-note"]')).toBeNull()
+    act(() => {
+      root.render(React.createElement(SessionDialog, { onConfirm: () => {}, onCancel: () => {}, liveSessionCount: 3 } as any))
+    })
+    expect(container.querySelector('[data-testid="edit-while-running-note"]')).toBeNull()
+  })
+})

--- a/tests/unit/renderer/sessions-panel-state.test.ts
+++ b/tests/unit/renderer/sessions-panel-state.test.ts
@@ -11,7 +11,6 @@ import {
   resolveDefaultPanelTab,
   resolveQuickStartCollapsed,
   quickStartConfigs,
-  canDeleteConfig,
   DELETE_WHILE_RUNNING_REASON,
   pinMenuLabel,
   PIN_WHILE_RUNNING_HINT,
@@ -82,24 +81,8 @@ describe('quickStartConfigs — every pinned config, running or not', () => {
   })
 })
 
-describe('canDeleteConfig — the one surviving guard', () => {
-  it('refuses while sessions run and frees when they close', () => {
-    const running = runningConfigCounts([
-      { configId: 'a', kind: undefined },
-      { configId: 'a', kind: undefined },
-      { configId: undefined, kind: undefined },
-    ] as never)
-    expect(canDeleteConfig('a', running)).toBe(false)
-    expect(canDeleteConfig('b', running)).toBe(true)
-    expect(canDeleteConfig('a', new Map())).toBe(true)
-  })
-
-  it('an ask session blocks nothing (config-less by design)', () => {
-    const running = runningConfigCounts([{ configId: 'a', kind: 'ask' }] as never)
-    expect(canDeleteConfig('a', running)).toBe(true)
-  })
-
-  it('the refusal reason says what to do', () => {
+describe('the delete-refusal reason (the guard itself lives at the two surfaces)', () => {
+  it('says what to do', () => {
     expect(DELETE_WHILE_RUNNING_REASON).toMatch(/close/i)
     expect(DELETE_WHILE_RUNNING_REASON).toMatch(/delet/i)
   })

--- a/tests/unit/renderer/sessions-panel-state.test.ts
+++ b/tests/unit/renderer/sessions-panel-state.test.ts
@@ -1,24 +1,25 @@
 /**
- * Sessions panel (two-mode left panel, canvas design pass 2026-08-24): the
- * pure state helpers. The default tab resolves to Running unless 'saved' is
- * stored; Quick Start is launch-only (a pinned config with a live session is
- * omitted and returns when it closes — the old duplicate-pinned-at-top bug
- * cannot recur); a running config is locked against editing; the pin menu
- * verb flips with the pinned flag and pinning-while-running stays allowed.
+ * Sessions panel (two-mode left panel, canvas design pass 2026-08-24; REVISED
+ * by the owner 2026-08-24 rc.1 pass): the pure state helpers. A config is a
+ * TEMPLATE — it may relaunch while running, Quick Start keeps running pins,
+ * and the surfaces show a live-session COUNT. What stays guarded: DELETE
+ * while sessions run, and group/section launch-all fills in only what is not
+ * already running (bring-up, never a silent doubling).
  */
 import { describe, it, expect } from 'vitest'
 import {
   resolveDefaultPanelTab,
   resolveQuickStartCollapsed,
   quickStartConfigs,
-  quickStartRunningCount,
-  canEditConfig,
+  canDeleteConfig,
+  DELETE_WHILE_RUNNING_REASON,
   pinMenuLabel,
   PIN_WHILE_RUNNING_HINT,
+  runningCountLabel,
   launchableInGroup,
   launchableInSection,
 } from '../../../src/renderer/components/sidebar/sessionsPanelState'
-import { runningConfigIds } from '../../../src/renderer/components/sidebar/savedConfigsView'
+import { runningConfigCounts } from '../../../src/renderer/components/sidebar/savedConfigsView'
 import type { TerminalConfig } from '../../../src/renderer/stores/configStore'
 
 const cfg = (id: string, over: Partial<TerminalConfig> = {}): TerminalConfig => ({
@@ -30,6 +31,8 @@ const cfg = (id: string, over: Partial<TerminalConfig> = {}): TerminalConfig => 
   provider: 'claude',
   ...over,
 })
+
+const counts = (entries: Array<[string, number]>) => new Map(entries)
 
 describe('resolveDefaultPanelTab', () => {
   it("defaults to 'running' when absent (plan Q1)", () => {
@@ -55,7 +58,7 @@ describe('resolveQuickStartCollapsed', () => {
   })
 })
 
-describe('quickStartConfigs', () => {
+describe('quickStartConfigs — every pinned config, running or not', () => {
   const configs = [
     cfg('a', { pinned: true }),
     cfg('b', { pinned: true }),
@@ -63,48 +66,60 @@ describe('quickStartConfigs', () => {
     cfg('d', { pinned: true }),
   ]
 
-  it('is the pinned configs when nothing runs (pinned carries over, plan Q2)', () => {
-    expect(quickStartConfigs(configs, new Set()).map((c) => c.id)).toEqual(['a', 'b', 'd'])
+  it('is the pinned configs, in config order (pinned carries over, plan Q2)', () => {
+    expect(quickStartConfigs(configs).map((c) => c.id)).toEqual(['a', 'b', 'd'])
   })
 
-  it('omits a pinned config whose session is live — launch-only', () => {
-    const running = new Set(['b'])
-    expect(quickStartConfigs(configs, running).map((c) => c.id)).toEqual(['a', 'd'])
-    expect(quickStartRunningCount(configs, running)).toBe(1)
+  it('a running pin STAYS — Quick Start can spawn another (owner revision)', () => {
+    // The old design omitted running pins; the mutant that re-adds the filter
+    // has no `running` argument to lean on any more, but pin the outcome:
+    // membership is decided by `pinned` alone.
+    expect(quickStartConfigs(configs).map((c) => c.id)).toContain('b')
   })
 
-  it('returns the config when its session closes', () => {
-    const while_running = quickStartConfigs(configs, new Set(['a', 'b', 'd']))
-    expect(while_running).toEqual([])
-    expect(quickStartRunningCount(configs, new Set(['a', 'b', 'd']))).toBe(3)
-    const after_close = quickStartConfigs(configs, new Set(['b']))
-    expect(after_close.map((c) => c.id)).toEqual(['a', 'd'])
-  })
-
-  it('never shows an unpinned running config anywhere in Quick Start', () => {
-    expect(quickStartConfigs(configs, new Set(['c'])).map((c) => c.id)).toEqual(['a', 'b', 'd'])
-    expect(quickStartRunningCount(configs, new Set(['c']))).toBe(0)
+  it('never shows an unpinned config', () => {
+    expect(quickStartConfigs(configs).map((c) => c.id)).not.toContain('c')
   })
 })
 
-describe('canEditConfig — the running lock', () => {
-  it('locks a config with a live session and frees it after', () => {
-    const running = runningConfigIds([
+describe('canDeleteConfig — the one surviving guard', () => {
+  it('refuses while sessions run and frees when they close', () => {
+    const running = runningConfigCounts([
+      { configId: 'a', kind: undefined },
       { configId: 'a', kind: undefined },
       { configId: undefined, kind: undefined },
     ] as never)
-    expect(canEditConfig('a', running)).toBe(false)
-    expect(canEditConfig('b', running)).toBe(true)
-    expect(canEditConfig('a', new Set())).toBe(true)
+    expect(canDeleteConfig('a', running)).toBe(false)
+    expect(canDeleteConfig('b', running)).toBe(true)
+    expect(canDeleteConfig('a', new Map())).toBe(true)
   })
 
-  it('an ask session locks nothing (config-less by design)', () => {
-    const running = runningConfigIds([{ configId: 'a', kind: 'ask' }] as never)
-    expect(canEditConfig('a', running)).toBe(true)
+  it('an ask session blocks nothing (config-less by design)', () => {
+    const running = runningConfigCounts([{ configId: 'a', kind: 'ask' }] as never)
+    expect(canDeleteConfig('a', running)).toBe(true)
+  })
+
+  it('the refusal reason says what to do', () => {
+    expect(DELETE_WHILE_RUNNING_REASON).toMatch(/close/i)
+    expect(DELETE_WHILE_RUNNING_REASON).toMatch(/delet/i)
   })
 })
 
-describe('launch-all skips running configs (no duplicate behind the locked row)', () => {
+describe('runningConfigCounts — the indicator source', () => {
+  it('counts per config, ask sessions excluded', () => {
+    const c = runningConfigCounts([
+      { configId: 'a', kind: undefined },
+      { configId: 'a', kind: undefined },
+      { configId: 'b', kind: undefined },
+      { configId: 'a', kind: 'ask' },
+    ] as never)
+    expect(c.get('a')).toBe(2)
+    expect(c.get('b')).toBe(1)
+    expect(c.get('missing')).toBeUndefined()
+  })
+})
+
+describe('launch-all fills in what is missing (bring-up, not doubling)', () => {
   const configs = [
     cfg('g1', { groupId: 'G' }),
     cfg('g2', { groupId: 'G' }),
@@ -114,28 +129,32 @@ describe('launch-all skips running configs (no duplicate behind the locked row)'
   const groups = [{ id: 'G', name: 'Group', sectionId: 'S' }]
 
   it('group launch-all filters the running config out', () => {
-    expect(launchableInGroup(configs, 'G', new Set(['g1'])).map((c) => c.id)).toEqual(['g2'])
-    expect(launchableInGroup(configs, 'G', new Set()).map((c) => c.id)).toEqual(['g1', 'g2'])
+    expect(launchableInGroup(configs, 'G', counts([['g1', 1]])).map((c) => c.id)).toEqual(['g2'])
+    expect(launchableInGroup(configs, 'G', new Map()).map((c) => c.id)).toEqual(['g1', 'g2'])
   })
 
   it('group launch-all is empty when every member runs (silent no-op, like an empty group)', () => {
-    expect(launchableInGroup(configs, 'G', new Set(['g1', 'g2']))).toEqual([])
+    expect(launchableInGroup(configs, 'G', counts([['g1', 1], ['g2', 2]]))).toEqual([])
   })
 
   it("section launch-all covers the section's groups + loose configs, minus running", () => {
-    expect(launchableInSection(configs, groups, 'S', new Set(['g2'])).map((c) => c.id)).toEqual(['g1', 'loose'])
-    expect(launchableInSection(configs, groups, 'S', new Set()).map((c) => c.id)).toEqual(['g1', 'g2', 'loose'])
+    expect(launchableInSection(configs, groups, 'S', counts([['g2', 1]])).map((c) => c.id)).toEqual(['g1', 'loose'])
+    expect(launchableInSection(configs, groups, 'S', new Map()).map((c) => c.id)).toEqual(['g1', 'g2', 'loose'])
   })
 })
 
-describe('pin menu', () => {
+describe('pin menu + count labels', () => {
   it('verb flips with the pinned flag', () => {
     expect(pinMenuLabel(undefined)).toBe('Pin to Quick Start')
     expect(pinMenuLabel(false)).toBe('Pin to Quick Start')
     expect(pinMenuLabel(true)).toBe('Unpin from Quick Start')
   })
-  it('the while-running hint names the deferred behaviour', () => {
-    expect(PIN_WHILE_RUNNING_HINT).toMatch(/quick-start/i)
-    expect(PIN_WHILE_RUNNING_HINT).toMatch(/closes/i)
+  it('the while-running hint says Quick Start can spawn another — not that it waits', () => {
+    expect(PIN_WHILE_RUNNING_HINT).toMatch(/another/i)
+    expect(PIN_WHILE_RUNNING_HINT).not.toMatch(/closes/i)
+  })
+  it('the count pill label reads naturally for one and many', () => {
+    expect(runningCountLabel(1)).toMatch(/^1 session running/)
+    expect(runningCountLabel(3)).toMatch(/^3 sessions running/)
   })
 })

--- a/tests/unit/renderer/sidebar-context-menus.test.tsx
+++ b/tests/unit/renderer/sidebar-context-menus.test.tsx
@@ -27,13 +27,15 @@ describe('sidebar context menus — Quick Start + running lock', () => {
       ...over,
     } as any)))
 
-  it('config menu: running disables Edit and Delete with reasons', () => {
+  it('config menu: running keeps Edit live (edits shape future launches) and refuses only Delete', () => {
+    // Owner revision 2026-08-24: a config is a template — it may relaunch and
+    // be edited while running; deleting it under live sessions stays refused.
     renderConfigMenu({ running: true })
     const edit = container.querySelector('[data-testid="ctx-edit"]') as HTMLButtonElement
     const del = container.querySelector('[data-testid="ctx-delete"]') as HTMLButtonElement
-    expect(edit.disabled).toBe(true)
+    expect(edit.disabled).toBe(false)
+    expect(edit.title).toMatch(/launched from now on/i)
     expect(del.disabled).toBe(true)
-    expect(edit.title).toMatch(/running/i)
     expect(del.title).toMatch(/running/i)
   })
 

--- a/tests/unit/renderer/sidebar-context-menus.test.tsx
+++ b/tests/unit/renderer/sidebar-context-menus.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 // The Quick Start / running-lock contract on BOTH context menus (design pass
 // 2026-08-24): the pin verb flips with the pinned flag; Edit/Delete disable
-// with reasons while the config runs; the deferral hint shows only when
+// with reasons while the config runs; the while-running hint shows only when
 // running && !pinned; the session menu's pin item vanishes for config-less
 // sessions (Ask, adopted shells).
 import React from 'react'


### PR DESCRIPTION
Owner design revision (rc.1 install pass): *"a running session should not be allowed to be launched again — that's not true. Show how many are running but still allow another to be spawned; Quick Start too."*

## What changed

- **A config is a template.** The locked row is gone: a running config keeps Launch and Edit; rows and Quick Start pins carry a green **count pill** (`● N`) whose click jumps to the latest live session.
- **Quick Start** shows every pinned config, running or not — Start always spawns another instance. The "N running" hidden-count header hint is gone (nothing is hidden any more).
- **Edit while running is allowed** — a template edit shapes future launches, which is the point of relaunch; the context menu says so ("Edits apply to sessions launched from now on").
- **Delete stays refused while sessions run** (row button + context menu, shared reason): removing the template under live sessions would strand the Running rows. Judgement call — flag if you want delete-while-running too.
- **Group/section launch-all keeps bring-up semantics** (fills in only what is not running) — doubling a whole group silently is never what "launch all" meant; duplicates are the single row's deliberate act. Also a judgement call, flagged for your install pass.
- New `runningConfigCounts` per-config live-session counts (ask sessions excluded).

## Verification

Suites rewritten to pin the revision (relaunch fires; pill counts and jumps; delete refused with reason; Quick Start keeps running pins with pills and Start works on them; launch-all bring-up; counts counting). Full `npx vitest run`: 8342 passed. Typecheck clean. Owner verifies feel on install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)