### PR TITLE
fix(canvas): delete on the front-page reclaim rows (#452)

### DIFF
--- a/src/renderer/components/CanvasEmptyState.tsx
+++ b/src/renderer/components/CanvasEmptyState.tsx
@@ -98,6 +98,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
   // before this the only way to be rid of an old canvas from here was to
   // open the library. Same two-step confirm + IPC as the library's delete.
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const refreshCanvas = useCanvasStore((s) => s.refresh)
 
@@ -150,6 +151,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
   )
 
   const removeCanvas = useCallback(async (canvasId: string) => {
+    setDeleting(canvasId)
     setDeleteError(null)
     try {
       const res = await window.electronAPI.canvas.deleteCanvas({ canvasId })
@@ -158,6 +160,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
     } catch {
       setDeleteError('That canvas could not be deleted.')
     } finally {
+      setDeleting(null)
       setConfirmingDelete(null)
     }
   }, [])
@@ -441,7 +444,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                     </div>
                     <button
                       onClick={() => void reclaim(c.canvasId)}
-                      disabled={reclaiming !== null}
+                      disabled={reclaiming !== null || deleting !== null}
                       className={GHOST_CLASS}
                       title="Reopen this canvas in this session, with its version history and notes"
                     >
@@ -450,16 +453,18 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                     {confirmingDelete === c.canvasId ? (
                       <button
                         onClick={() => void removeCanvas(c.canvasId)}
-                        disabled={reclaiming !== null}
+                        disabled={reclaiming !== null || deleting !== null}
                         className="shrink-0 rounded-md px-3 py-2 text-[12px] font-medium bg-[color-mix(in_srgb,var(--status-danger)_15%,transparent)] border border-[color-mix(in_srgb,var(--status-danger)_50%,transparent)] text-[var(--status-danger)] hover:bg-[color-mix(in_srgb,var(--status-danger)_25%,transparent)] disabled:opacity-40 transition-colors focus-ring"
                         data-testid="canvas-reclaim-confirm-delete"
                       >
-                        Delete {c.versionCount} version{c.versionCount === 1 ? '' : 's'}
+                        {deleting === c.canvasId
+                          ? 'Deleting…'
+                          : `Delete ${c.versionCount} version${c.versionCount === 1 ? '' : 's'}`}
                       </button>
                     ) : (
                       <button
                         onClick={() => { setConfirmingDelete(c.canvasId); setDeleteError(null) }}
-                        disabled={reclaiming !== null}
+                        disabled={reclaiming !== null || deleting !== null}
                         className={`${GHOST_CLASS} hover:!text-[var(--status-danger)]`}
                         title="Permanently delete this canvas — its versions and review notes go with it"
                         data-testid="canvas-reclaim-delete"

--- a/src/renderer/components/CanvasEmptyState.tsx
+++ b/src/renderer/components/CanvasEmptyState.tsx
@@ -470,7 +470,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                         onClick={() => void removeCanvas(c.canvasId)}
                         disabled={reclaiming !== null || deleting !== null}
                         className={DANGER_CLASS}
-                        aria-label={`Confirm: permanently delete canvas ${canvasLabel(c)}`}
+                        aria-label={`Delete ${c.versionCount} version${c.versionCount === 1 ? '' : 's'} of canvas ${canvasLabel(c)}`}
                         data-testid="canvas-reclaim-confirm-delete"
                       >
                         {deleting === c.canvasId

--- a/src/renderer/components/CanvasEmptyState.tsx
+++ b/src/renderer/components/CanvasEmptyState.tsx
@@ -94,6 +94,11 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
   const [libraryOpen, setLibraryOpen] = useState(false)
   const [reclaimable, setReclaimable] = useState<ReclaimableCanvas[]>([])
   const [reclaiming, setReclaiming] = useState<string | null>(null)
+  // Delete on the reclaim rows (#452): the front page has no top bar, so
+  // before this the only way to be rid of an old canvas from here was to
+  // open the library. Same two-step confirm + IPC as the library's delete.
+  const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const refreshCanvas = useCanvasStore((s) => s.refresh)
 
   // What this session could take back. A pure read — nothing moves until the
@@ -143,6 +148,19 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
     },
     [sessionId, refreshCanvas],
   )
+
+  const removeCanvas = useCallback(async (canvasId: string) => {
+    setDeleteError(null)
+    try {
+      const res = await window.electronAPI.canvas.deleteCanvas({ canvasId })
+      if (res?.ok) setReclaimable((list) => list.filter((c) => c.canvasId !== canvasId))
+      else setDeleteError('That canvas could not be deleted.')
+    } catch {
+      setDeleteError('That canvas could not be deleted.')
+    } finally {
+      setConfirmingDelete(null)
+    }
+  }, [])
 
   const typeIntoTerminal = useCallback(() => {
     // No newline: the terminal shows the request, the user sends it.
@@ -429,9 +447,34 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                     >
                       {reclaiming === c.canvasId ? 'Reopening…' : 'Reopen'}
                     </button>
+                    {confirmingDelete === c.canvasId ? (
+                      <button
+                        onClick={() => void removeCanvas(c.canvasId)}
+                        disabled={reclaiming !== null}
+                        className="shrink-0 rounded-md px-3 py-2 text-[12px] font-medium bg-[color-mix(in_srgb,var(--status-danger)_15%,transparent)] border border-[color-mix(in_srgb,var(--status-danger)_50%,transparent)] text-[var(--status-danger)] hover:bg-[color-mix(in_srgb,var(--status-danger)_25%,transparent)] disabled:opacity-40 transition-colors focus-ring"
+                        data-testid="canvas-reclaim-confirm-delete"
+                      >
+                        Delete {c.versionCount} version{c.versionCount === 1 ? '' : 's'}
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => { setConfirmingDelete(c.canvasId); setDeleteError(null) }}
+                        disabled={reclaiming !== null}
+                        className={`${GHOST_CLASS} hover:!text-[var(--status-danger)]`}
+                        title="Permanently delete this canvas — its versions and review notes go with it"
+                        data-testid="canvas-reclaim-delete"
+                      >
+                        Delete
+                      </button>
+                    )}
                   </li>
                 ))}
               </ul>
+              {deleteError && (
+                <p className="mt-2 m-0 text-[11.5px] text-[var(--status-danger)]" data-testid="canvas-reclaim-delete-error">
+                  {deleteError}
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/src/renderer/components/CanvasEmptyState.tsx
+++ b/src/renderer/components/CanvasEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import ExcalidrawPane from './ExcalidrawPane'
 import { useCanvasStore } from '../stores/canvasStore'
 import { useSessionStore } from '../stores/sessionStore'
@@ -73,6 +73,15 @@ const GHOST_CLASS =
   'hover:text-[var(--text-primary)] hover:border-[var(--border-strong)] ' +
   'disabled:opacity-40 transition-colors focus-ring'
 
+/** The armed delete confirm — same geometry as GHOST_CLASS, danger colours
+ *  (the library's own confirm recipe). */
+const DANGER_CLASS =
+  'shrink-0 rounded-md px-3 py-2 text-[12px] font-medium ' +
+  'bg-[color-mix(in_srgb,var(--status-danger)_15%,transparent)] ' +
+  'border border-[color-mix(in_srgb,var(--status-danger)_50%,transparent)] ' +
+  'text-[var(--status-danger)] hover:bg-[color-mix(in_srgb,var(--status-danger)_25%,transparent)] ' +
+  'disabled:opacity-40 transition-colors focus-ring'
+
 /**
  * The Agent Canvas landing (owner feedback 2026-08-13): with nothing rendered
  * yet, the pane used to fall straight back to the old Draw sketchpad —
@@ -110,25 +119,31 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
   // exists only between a graceful Save & Close and the next restore), so it
   // was offering canvases whose own tile was open and visible. The renderer is
   // the only party that knows, and the hint can only shorten the list.
-  useEffect(() => {
-    let cancelled = false
+  //
+  // Callable, not just an effect: the library overlay can delete a canvas this
+  // list still shows, and a stale row's Delete would then dead-end on a
+  // truthful-but-inverted "could not be deleted". The epoch keeps overlapping
+  // loads last-write-wins.
+  const reclaimEpoch = useRef(0)
+  const loadReclaimable = useCallback(async () => {
+    const epoch = ++reclaimEpoch.current
     const openTileSessionIds = useSessionStore.getState().sessions.map((s) => s.id)
-    void window.electronAPI.canvas
-      .listReclaimable({ sessionId, openTileSessionIds })
-      .then((list) => {
-        if (!cancelled) setReclaimable(Array.isArray(list) ? list : [])
-      })
-      .catch(() => {
-        /* nothing to offer is the safe default */
-      })
-    return () => {
-      cancelled = true
+    try {
+      const list = await window.electronAPI.canvas.listReclaimable({ sessionId, openTileSessionIds })
+      if (reclaimEpoch.current === epoch) setReclaimable(Array.isArray(list) ? list : [])
+    } catch {
+      /* nothing to offer is the safe default */
     }
   }, [sessionId])
+
+  useEffect(() => {
+    void loadReclaimable()
+  }, [loadReclaimable])
 
   const reclaim = useCallback(
     async (canvasId: string) => {
       setReclaiming(canvasId)
+      setDeleteError(null)
       try {
         // Re-read the tiles at CLICK time, not at list time: main applies the
         // same rule on both calls and the truth may have changed in between.
@@ -454,7 +469,8 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                       <button
                         onClick={() => void removeCanvas(c.canvasId)}
                         disabled={reclaiming !== null || deleting !== null}
-                        className="shrink-0 rounded-md px-3 py-2 text-[12px] font-medium bg-[color-mix(in_srgb,var(--status-danger)_15%,transparent)] border border-[color-mix(in_srgb,var(--status-danger)_50%,transparent)] text-[var(--status-danger)] hover:bg-[color-mix(in_srgb,var(--status-danger)_25%,transparent)] disabled:opacity-40 transition-colors focus-ring"
+                        className={DANGER_CLASS}
+                        aria-label={`Confirm: permanently delete canvas ${canvasLabel(c)}`}
                         data-testid="canvas-reclaim-confirm-delete"
                       >
                         {deleting === c.canvasId
@@ -467,6 +483,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                         disabled={reclaiming !== null || deleting !== null}
                         className={`${GHOST_CLASS} hover:!text-[var(--status-danger)]`}
                         title="Permanently delete this canvas — its versions and review notes go with it"
+                        aria-label={`Delete canvas ${canvasLabel(c)}`}
                         data-testid="canvas-reclaim-delete"
                       >
                         Delete
@@ -476,7 +493,7 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
                 ))}
               </ul>
               {deleteError && (
-                <p className="mt-2 m-0 text-[11.5px] text-[var(--status-danger)]" data-testid="canvas-reclaim-delete-error">
+                <p className="mt-2 m-0 text-[11.5px] text-[var(--status-danger)]" role="alert" data-testid="canvas-reclaim-delete-error">
                   {deleteError}
                 </p>
               )}
@@ -485,7 +502,15 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
         </div>
       </div>
       {libraryOpen && (
-        <CanvasLibrary sessionId={sessionId} onClose={() => setLibraryOpen(false)} />
+        <CanvasLibrary
+          sessionId={sessionId}
+          onClose={() => {
+            setLibraryOpen(false)
+            // The library can delete (or adopt) a canvas the reclaim list still
+            // shows — re-read so no row offers an action on a ghost.
+            void loadReclaimable()
+          }}
+        />
       )}
     </div>
   )

--- a/tests/unit/renderer/canvas-empty-state.test.tsx
+++ b/tests/unit/renderer/canvas-empty-state.test.tsx
@@ -28,6 +28,7 @@ const ptyWriteMock = vi.fn()
 const listReclaimableMock = vi.fn(async () => [] as unknown[])
 const reclaimMock = vi.fn(async () => ({ ok: true, state: null }))
 const deleteCanvasMock = vi.fn(async () => ({ ok: true }))
+const listAllMock = vi.fn(async () => [] as unknown[])
 ;(globalThis as any).window.electronAPI = {
   ...((globalThis as any).window?.electronAPI ?? {}),
   pty: { ...((globalThis as any).window?.electronAPI?.pty ?? {}), write: ptyWriteMock },
@@ -36,6 +37,7 @@ const deleteCanvasMock = vi.fn(async () => ({ ok: true }))
     listReclaimable: listReclaimableMock,
     reclaim: reclaimMock,
     deleteCanvas: deleteCanvasMock,
+    listAll: listAllMock,
   },
 }
 
@@ -260,6 +262,7 @@ describe('deleting a canvas from the front page (#452)', () => {
     deleteCanvasMock.mockReset()
     deleteCanvasMock.mockResolvedValue({ ok: true })
     reclaimMock.mockClear()
+    listReclaimableMock.mockClear()
   })
 
   it('arms on the first click, deletes only on the confirm — and drops the row', async () => {
@@ -335,11 +338,19 @@ describe('deleting a canvas from the front page (#452)', () => {
     const sibling = { ...candidate, canvasId: 'def456abc123def456abc123', conversationShortId: '59596c8b' }
     await renderWith([candidate, sibling])
 
+    // 'ul > li' — the loop track's steps are an <ol>; the reclaim rows are the
+    // only <ul> on the default view.
+    const rows = () => Array.from(container.querySelectorAll('ul > li'))
     const arms = container.querySelectorAll('[data-testid="canvas-reclaim-delete"]')
     expect(arms).toHaveLength(2)
     click(arms[0])
+    expect(rows()[0].querySelector('[data-testid="canvas-reclaim-confirm-delete"]')).toBeTruthy()
+
+    // The first row is armed, so the one remaining arm button is row 2's.
     click(container.querySelector('[data-testid="canvas-reclaim-delete"]'))
     expect(container.querySelectorAll('[data-testid="canvas-reclaim-confirm-delete"]')).toHaveLength(1)
+    expect(rows()[0].querySelector('[data-testid="canvas-reclaim-confirm-delete"]')).toBeNull()
+    expect(rows()[1].querySelector('[data-testid="canvas-reclaim-confirm-delete"]')).toBeTruthy()
   })
 
   it('is disabled while a reclaim is in flight', async () => {
@@ -348,6 +359,27 @@ describe('deleting a canvas from the front page (#452)', () => {
 
     click(buttonByText('Reopen'))
     expect(testid('canvas-reclaim-delete')?.disabled).toBe(true)
+  })
+
+  it('re-reads the list when the library overlay closes — a library delete cannot strand a row', async () => {
+    // The library sits OVER the front page; deleting there used to leave the
+    // reclaim row behind, whose Delete then dead-ended on "could not be
+    // deleted" — for a canvas that was already gone.
+    await renderWith([candidate])
+    expect(listReclaimableMock).toHaveBeenCalledTimes(1)
+
+    click(buttonByText('Browse the canvas library'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // The refetch after Done returns without the canvas the library deleted.
+    listReclaimableMock.mockResolvedValueOnce([])
+    click(buttonByText('Done'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(listReclaimableMock).toHaveBeenCalledTimes(2)
+    expect(container.textContent).not.toContain('Pick up where you left off')
   })
 })
 

--- a/tests/unit/renderer/canvas-empty-state.test.tsx
+++ b/tests/unit/renderer/canvas-empty-state.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../../src/renderer/components/ExcalidrawPane', () => ({
 const ptyWriteMock = vi.fn()
 const listReclaimableMock = vi.fn(async () => [] as unknown[])
 const reclaimMock = vi.fn(async () => ({ ok: true, state: null }))
+const deleteCanvasMock = vi.fn(async () => ({ ok: true }))
 ;(globalThis as any).window.electronAPI = {
   ...((globalThis as any).window?.electronAPI ?? {}),
   pty: { ...((globalThis as any).window?.electronAPI?.pty ?? {}), write: ptyWriteMock },
@@ -34,6 +35,7 @@ const reclaimMock = vi.fn(async () => ({ ok: true, state: null }))
     ...((globalThis as any).window?.electronAPI?.canvas ?? {}),
     listReclaimable: listReclaimableMock,
     reclaim: reclaimMock,
+    deleteCanvas: deleteCanvasMock,
   },
 }
 
@@ -226,6 +228,126 @@ describe('reclaiming an earlier canvas (the user is the authorization)', () => {
       await Promise.resolve()
     })
     expect(container.textContent).not.toContain('Pick up where you left off')
+  })
+})
+
+describe('deleting a canvas from the front page (#452)', () => {
+  // The front page has no top bar, so before this the reclaim rows offered
+  // Reopen and nothing else — an old canvas could only be removed by opening
+  // the library. Same guarantees as the library's delete: permanent, two-step
+  // confirmed, and the second click names what will go.
+  const candidate = {
+    canvasId: 'abc123def456abc123def456',
+    versionCount: 3,
+    lastRenderedAt: '2026-08-13T19:15:53.893Z',
+    cwd: 'C:\\proj',
+    sameProject: true,
+    conversationShortId: '8c25bfdc',
+  }
+
+  const testid = (id: string): HTMLButtonElement | null =>
+    container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`)
+
+  async function renderWith(candidates: unknown[]): Promise<void> {
+    listReclaimableMock.mockResolvedValueOnce(candidates)
+    render()
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+
+  beforeEach(() => {
+    deleteCanvasMock.mockReset()
+    deleteCanvasMock.mockResolvedValue({ ok: true })
+    reclaimMock.mockClear()
+  })
+
+  it('arms on the first click, deletes only on the confirm — and drops the row', async () => {
+    await renderWith([candidate])
+
+    click(testid('canvas-reclaim-delete'))
+    // Armed, not done: the confirm names what will go, nothing has been deleted.
+    expect(deleteCanvasMock).not.toHaveBeenCalled()
+    expect(testid('canvas-reclaim-confirm-delete')?.textContent).toBe('Delete 3 versions')
+
+    click(testid('canvas-reclaim-confirm-delete'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(deleteCanvasMock).toHaveBeenCalledTimes(1)
+    expect(deleteCanvasMock).toHaveBeenCalledWith({ canvasId: candidate.canvasId })
+    // The row is gone, and with it the whole section (it was the only one).
+    expect(container.textContent).not.toContain('Pick up where you left off')
+  })
+
+  it('keeps the row and shows the error when the delete is refused', async () => {
+    deleteCanvasMock.mockResolvedValueOnce({ ok: false })
+    await renderWith([candidate])
+
+    click(testid('canvas-reclaim-delete'))
+    click(testid('canvas-reclaim-confirm-delete'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(testid('canvas-reclaim-delete-error')?.textContent).toContain('could not be deleted')
+    expect(container.textContent).toContain('Pick up where you left off')
+    // Disarmed — a retry is a fresh, deliberate two-step.
+    expect(testid('canvas-reclaim-confirm-delete')).toBeNull()
+    expect(testid('canvas-reclaim-delete')).toBeTruthy()
+  })
+
+  it('treats a thrown IPC the same as a refusal', async () => {
+    deleteCanvasMock.mockRejectedValueOnce(new Error('ipc gone'))
+    await renderWith([candidate])
+
+    click(testid('canvas-reclaim-delete'))
+    click(testid('canvas-reclaim-confirm-delete'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(testid('canvas-reclaim-delete-error')?.textContent).toContain('could not be deleted')
+    expect(container.textContent).toContain('Pick up where you left off')
+  })
+
+  it('disables the row while the delete is in flight — no double-fire, no reclaim mid-delete', async () => {
+    let settle: (v: { ok: boolean }) => void = () => {}
+    deleteCanvasMock.mockImplementationOnce(
+      () => new Promise<{ ok: boolean }>((resolve) => { settle = resolve }),
+    )
+    await renderWith([candidate])
+
+    click(testid('canvas-reclaim-delete'))
+    click(testid('canvas-reclaim-confirm-delete'))
+    const confirm = testid('canvas-reclaim-confirm-delete')
+    expect(confirm?.disabled).toBe(true)
+    expect(confirm?.textContent).toBe('Deleting…')
+    expect((buttonByText('Reopen') as HTMLButtonElement).disabled).toBe(true)
+
+    await act(async () => {
+      settle({ ok: true })
+      await Promise.resolve()
+    })
+    expect(deleteCanvasMock).toHaveBeenCalledTimes(1)
+    expect(container.textContent).not.toContain('Pick up where you left off')
+  })
+
+  it('arming another row disarms the first — one confirm at a time', async () => {
+    const sibling = { ...candidate, canvasId: 'def456abc123def456abc123', conversationShortId: '59596c8b' }
+    await renderWith([candidate, sibling])
+
+    const arms = container.querySelectorAll('[data-testid="canvas-reclaim-delete"]')
+    expect(arms).toHaveLength(2)
+    click(arms[0])
+    click(container.querySelector('[data-testid="canvas-reclaim-delete"]'))
+    expect(container.querySelectorAll('[data-testid="canvas-reclaim-confirm-delete"]')).toHaveLength(1)
+  })
+
+  it('is disabled while a reclaim is in flight', async () => {
+    reclaimMock.mockImplementationOnce(() => new Promise(() => {}))
+    await renderWith([candidate])
+
+    click(buttonByText('Reopen'))
+    expect(testid('canvas-reclaim-delete')?.disabled).toBe(true)
   })
 })
 


### PR DESCRIPTION
Closes #452 (front-page half; the library rows already carry delete).

The canvas front page's **Pick up where you left off** rows offered Reopen only — with no top bar on the front page, nothing offered delete. Each row now carries a Delete beside Reopen: two-step confirm in place (the confirm names the version count), same `canvas.deleteCanvas` IPC and guarantees as the library's delete (permanent, cannot resurrect), inline `role=alert` error, per-row accessible names.

Beyond the minimum:
- In-flight `deleting` state disables the whole row — no double-fire, no reclaim mid-delete (the library has this via `busy`; the first cut here lacked it).
- The reclaim list re-reads when the library overlay closes (review HIGH): deleting a listed canvas in the library used to strand its row, whose Delete then dead-ended on an inverted "could not be deleted". Loader is epoch-guarded, last-write-wins.
- A stale delete error clears when a reclaim starts.

Tests: 7 new cases in `canvas-empty-state.test.tsx` — arm/confirm two-step, list removal on ok, refusal + thrown-IPC error paths, in-flight disable, one-armed-confirm-at-a-time (asserts which row), reclaim-in-flight disable, and the library-close refetch (mounts the real CanvasLibrary).

Double Review: independent Opus review (spec + quality), 1 fix round (HIGH + 5 NITs), re-review **PASS**. Post-PASS one-liner: reviewer-specified aria-label fix (WCAG 2.5.3). Follow-up filed: #456 (double-click can defeat the two-step confirm — parity across all three delete surfaces, dedicated pass).

Not security-sensitive (renderer component + tests only; no IPC/preload/PTY/credential surface) — no ADR-009 pass required.

Verify: `npm run typecheck` green; full `npx vitest run` 8349 passed / 736 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)