### PR TITLE
feat(sidebar): draggable width + quick start on the session-card language (#461, #462)

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -768,7 +768,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
       style={{ width: sidebarWidth, background: 'var(--surface-panel)', boxShadow: 'var(--shadow-panel), var(--highlight-inset)', ...sideType }}
     >
       {/* #461: drag the right edge to resize; width persists on release.
-          Straddles the border (right: -2px) so it does NOT sit over the
+          Sits astride the aside's edge (right: -4px) fully CLEAR of the
           session list's 6px scrollbar — grabbing the scrollbar must scroll. */}
       <div
         onPointerDown={startSidebarResize}
@@ -778,7 +778,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           void useSettingsStore.getState().updateSettings({ sidebarWidth: undefined })
         }}
         className="absolute top-0 bottom-0 w-1 z-20 cursor-col-resize hover:bg-surface1"
-        style={{ right: -2 }}
+        style={{ right: -4 }}
         title="Drag to resize — double-click to reset"
         data-testid="sidebar-resize-handle"
         aria-hidden="true"

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -191,36 +191,56 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   useEffect(() => {
     if (settingsLoaded && !sidebarWidthTouchedRef.current) setSidebarWidth(resolveSidebarWidth(storedSidebarWidth))
   }, [settingsLoaded, storedSidebarWidth])
-  // Detach mid-drag listeners if the sidebar unmounts or collapses mid-drag
+  // The width transition stays OFF until a frame after the stored width is
+  // adopted — otherwise every launch with a non-default width visibly slides
+  // 256px → stored. (Collapse keeps its animation from the next frame on.)
+  const [widthAnimated, setWidthAnimated] = useState(false)
+  useEffect(() => {
+    if (!settingsLoaded) return
+    const id = requestAnimationFrame(() => setWidthAnimated(true))
+    return () => cancelAnimationFrame(id)
+  }, [settingsLoaded])
+  // Detach mid-drag listeners if the sidebar unmounts mid-drag
   // (the GitHubPanel resize pattern).
   const resizeCleanupRef = useRef<(() => void) | null>(null)
   useEffect(() => () => resizeCleanupRef.current?.(), [])
   const startSidebarResize = (e: React.PointerEvent) => {
     e.preventDefault()
     resizeCleanupRef.current?.()
-    sidebarWidthTouchedRef.current = true
     setResizing(true)
     const startX = e.clientX
     const startW = sidebarWidth
+    // The typography setting can put CSS `zoom` on this aside; clientX is
+    // unzoomed viewport px while the width is zoomed units — divide, or the
+    // edge outruns the cursor.
+    const zoom = Number((sideType as Record<string, unknown>).zoom) || 1
     let latest = startW
     const onMove = (ev: PointerEvent) => {
       // Handle is on the sidebar's RIGHT edge: dragging right widens it.
-      latest = Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, startW + (ev.clientX - startX)))
+      sidebarWidthTouchedRef.current = true
+      latest = Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, Math.round(startW + (ev.clientX - startX) / zoom)))
       setSidebarWidth(latest)
     }
+    const prevCursor = document.body.style.cursor
     const cleanup = () => {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+      window.removeEventListener('blur', onUp)
+      document.body.style.cursor = prevCursor
       resizeCleanupRef.current = null
       setResizing(false)
     }
     const onUp = () => {
       cleanup()
-      // One settings write per drag, not one per frame.
-      void useSettingsStore.getState().updateSettings({ sidebarWidth: latest })
+      // One settings write per drag, on release — and none for a bare click.
+      if (latest !== startW) void useSettingsStore.getState().updateSettings({ sidebarWidth: latest })
     }
+    document.body.style.cursor = 'col-resize'
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+    window.addEventListener('blur', onUp)
     resizeCleanupRef.current = cleanup
   }
   // Roving tabIndex needs focus to FOLLOW arrow-key selection (APG tabs
@@ -744,10 +764,12 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
 
   return (
     <aside
-      className={`flex flex-col border-r border-surface0 shrink-0 select-none titlebar-no-drag relative ${resizing ? '' : 'transition-[width] duration-200'}`}
+      className={`flex flex-col border-r border-surface0 shrink-0 select-none titlebar-no-drag relative ${resizing || !widthAnimated ? '' : 'transition-[width] duration-200'}`}
       style={{ width: sidebarWidth, background: 'var(--surface-panel)', boxShadow: 'var(--shadow-panel), var(--highlight-inset)', ...sideType }}
     >
-      {/* #461: drag the right edge to resize; width persists on release. */}
+      {/* #461: drag the right edge to resize; width persists on release.
+          Straddles the border (right: -2px) so it does NOT sit over the
+          session list's 6px scrollbar — grabbing the scrollbar must scroll. */}
       <div
         onPointerDown={startSidebarResize}
         onDoubleClick={() => {
@@ -755,7 +777,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           setSidebarWidth(resolveSidebarWidth(undefined))
           void useSettingsStore.getState().updateSettings({ sidebarWidth: undefined })
         }}
-        className="absolute right-0 top-0 bottom-0 w-1 z-20 cursor-col-resize hover:bg-surface1"
+        className="absolute top-0 bottom-0 w-1 z-20 cursor-col-resize hover:bg-surface1"
+        style={{ right: -2 }}
         title="Drag to resize — double-click to reset"
         data-testid="sidebar-resize-handle"
         aria-hidden="true"

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -33,7 +33,7 @@ import UngroupedSessionsHeader from './sidebar/UngroupedSessionsHeader'
 import { runningConfigCounts } from './sidebar/savedConfigsView'
 import AskConductorDock from './sidebar/AskConductorDock'
 import QuickStartPanel from './sidebar/QuickStartPanel'
-import { resolveDefaultPanelTab, launchableInGroup, launchableInSection, type PanelTab } from './sidebar/sessionsPanelState'
+import { resolveDefaultPanelTab, resolveSidebarWidth, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX, launchableInGroup, launchableInSection, type PanelTab } from './sidebar/sessionsPanelState'
 import FirstRunCard from './FirstRunCard'
 import ColourMigrationNotice from './ColourMigrationNotice'
 import ConfigHydrationNotice from './ConfigHydrationNotice'
@@ -179,6 +179,49 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const selectPanelTab = (tab: PanelTab) => {
     panelTabTouchedRef.current = true
     setPanelTab(tab)
+  }
+  // #461: draggable width. Live width is component state (per-frame updates);
+  // the settings write happens ONCE, on pointerup. The stored value is adopted
+  // when settings hydrate — but never over a width the user is/was dragging
+  // this session (same rule as the panel tab above).
+  const storedSidebarWidth = useSettingsStore((s) => s.settings.sidebarWidth)
+  const [sidebarWidth, setSidebarWidth] = useState(() => resolveSidebarWidth(storedSidebarWidth))
+  const sidebarWidthTouchedRef = useRef(false)
+  const [resizing, setResizing] = useState(false)
+  useEffect(() => {
+    if (settingsLoaded && !sidebarWidthTouchedRef.current) setSidebarWidth(resolveSidebarWidth(storedSidebarWidth))
+  }, [settingsLoaded, storedSidebarWidth])
+  // Detach mid-drag listeners if the sidebar unmounts or collapses mid-drag
+  // (the GitHubPanel resize pattern).
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+  useEffect(() => () => resizeCleanupRef.current?.(), [])
+  const startSidebarResize = (e: React.PointerEvent) => {
+    e.preventDefault()
+    resizeCleanupRef.current?.()
+    sidebarWidthTouchedRef.current = true
+    setResizing(true)
+    const startX = e.clientX
+    const startW = sidebarWidth
+    let latest = startW
+    const onMove = (ev: PointerEvent) => {
+      // Handle is on the sidebar's RIGHT edge: dragging right widens it.
+      latest = Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, startW + (ev.clientX - startX)))
+      setSidebarWidth(latest)
+    }
+    const cleanup = () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      resizeCleanupRef.current = null
+      setResizing(false)
+    }
+    const onUp = () => {
+      cleanup()
+      // One settings write per drag, not one per frame.
+      void useSettingsStore.getState().updateSettings({ sidebarWidth: latest })
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    resizeCleanupRef.current = cleanup
   }
   // Roving tabIndex needs focus to FOLLOW arrow-key selection (APG tabs
   // pattern) — selection alone would leave focus on a tabIndex={-1} button.
@@ -701,9 +744,22 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
 
   return (
     <aside
-      className="w-64 flex flex-col border-r border-surface0 shrink-0 select-none titlebar-no-drag relative transition-[width] duration-200"
-      style={{ background: 'var(--surface-panel)', boxShadow: 'var(--shadow-panel), var(--highlight-inset)', ...sideType }}
+      className={`flex flex-col border-r border-surface0 shrink-0 select-none titlebar-no-drag relative ${resizing ? '' : 'transition-[width] duration-200'}`}
+      style={{ width: sidebarWidth, background: 'var(--surface-panel)', boxShadow: 'var(--shadow-panel), var(--highlight-inset)', ...sideType }}
     >
+      {/* #461: drag the right edge to resize; width persists on release. */}
+      <div
+        onPointerDown={startSidebarResize}
+        onDoubleClick={() => {
+          sidebarWidthTouchedRef.current = true
+          setSidebarWidth(resolveSidebarWidth(undefined))
+          void useSettingsStore.getState().updateSettings({ sidebarWidth: undefined })
+        }}
+        className="absolute right-0 top-0 bottom-0 w-1 z-20 cursor-col-resize hover:bg-surface1"
+        title="Drag to resize — double-click to reset"
+        data-testid="sidebar-resize-handle"
+        aria-hidden="true"
+      />
       {/* Navigation */}
       <SidebarNav
         currentView={currentView}

--- a/src/renderer/components/sidebar/QuickStartPanel.tsx
+++ b/src/renderer/components/sidebar/QuickStartPanel.tsx
@@ -63,17 +63,20 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
         return (
           <div
             key={config.id}
-            className="mx-2 my-0.5 px-2 py-1.5 rounded-lg border flex items-center gap-1.5 transition-colors"
+            className="mx-2 my-0.5 px-2 py-1 rounded-lg border flex items-center gap-1.5 transition-colors"
             style={{
-              borderColor: 'color-mix(in srgb, var(--brand) 40%, var(--color-surface1))',
-              background: 'color-mix(in srgb, var(--brand) 9%, var(--color-surface0))',
+              // #462: the session-card recipe — a thin border in the config's
+              // own identity colour over a quiet tint of the same, instead of
+              // the old uniform brand wash (SessionRow.tsx is the reference).
+              borderColor: `color-mix(in srgb, ${chipColour} 55%, transparent)`,
+              background: chipColour + '12',
             }}
             onContextMenu={(e) => onContextMenu(e, config.id)}
             data-testid="quick-start-item"
           >
             <SessionTypeBadge kind={typeKind} />
             <span className="w-2 h-2 rounded-[3px] shrink-0" style={{ backgroundColor: chipColour }} aria-hidden />
-            <span className="text-xs font-medium truncate flex-1 text-text">{config.label}</span>
+            <span className="text-xs font-medium truncate flex-1 text-[var(--text-primary)]">{config.label}</span>
             {liveCount > 0 && (
               <span
                 className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
@@ -90,9 +93,11 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
               disabled={blocked}
               aria-disabled={blocked}
               className={
+                // #462: no solid brand fill — the subtle tinted language the
+                // command bar's + Add uses, sized down so the row stays short.
                 blocked
-                  ? 'h-6 px-2 rounded-md text-[10px] font-bold flex items-center gap-1 shrink-0 bg-surface1 text-overlay0/60 cursor-not-allowed'
-                  : 'h-6 px-2 rounded-md text-[10px] font-bold flex items-center gap-1 shrink-0 bg-blue text-crust hover:bg-blue/90 transition-colors focus-ring'
+                  ? 'h-5 px-2 rounded-md text-[10px] font-bold flex items-center gap-1 shrink-0 border border-[var(--border-subtle)] bg-[var(--surface-raised)] text-[var(--text-muted)] cursor-not-allowed'
+                  : 'h-5 px-2 rounded-md text-[10px] font-bold flex items-center gap-1 shrink-0 border border-[color-mix(in_srgb,var(--brand)_50%,transparent)] bg-[color-mix(in_srgb,var(--brand)_15%,transparent)] text-[var(--brand)] hover:bg-[color-mix(in_srgb,var(--brand)_25%,transparent)] transition-colors focus-ring'
               }
               title={blocked ? CODEX_OFF_LAUNCH_REASON : `Start ${config.label}`}
             >

--- a/src/renderer/components/sidebar/sessionsPanelState.ts
+++ b/src/renderer/components/sidebar/sessionsPanelState.ts
@@ -34,6 +34,20 @@ export function resolveQuickStartCollapsed(value: unknown): boolean {
   return value === true
 }
 
+/** Sidebar width bounds (#461). The floor protects ConfigRow's measured
+ *  right-12 hover-strip budget and keeps the Saved⇄Running tabs from hitting
+ *  min-content overflow (~170px); the ceiling keeps the terminal usable. */
+export const SIDEBAR_WIDTH_DEFAULT = 256
+export const SIDEBAR_WIDTH_MIN = 200
+export const SIDEBAR_WIDTH_MAX = 420
+
+/** Absent, non-numeric, or out-of-range (hand-edited settings) => clamped or
+ *  the default — a bad stored value must never wedge the panel off-screen. */
+export function resolveSidebarWidth(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return SIDEBAR_WIDTH_DEFAULT
+  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, Math.round(value)))
+}
+
 /**
  * The Quick Start strip: every pinned config, in config order, running or
  * not — a config is a template, and Quick Start may spawn another instance

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -252,6 +252,10 @@ export interface AppSettings {
   /** Sessions panel: the Quick Start section on the Running tab is collapsed.
    *  Absent = expanded. Persisted so the choice survives restarts. */
   quickStartCollapsed?: boolean
+  /** #461: the expanded sidebar's width in px, set by the drag handle on its
+   *  right edge. Absent = the built-in default. Read via resolveSidebarWidth,
+   *  which clamps — never trust the raw number. */
+  sidebarWidth?: number
   /** #367: the Agent Canvas x-ray hover mode. 'on' is the outline + label chip
    *  drawn over the content (what shipped); 'stealth' still resolves the
    *  hovered element but draws nothing, reading it out in the canvas side panel

--- a/tests/unit/renderer/quick-start-panel.test.tsx
+++ b/tests/unit/renderer/quick-start-panel.test.tsx
@@ -114,17 +114,28 @@ describe('the #462 restyle — session-card language, no loud fill', () => {
     expect(cls).toContain('h-5')
   })
 
-  it('the row border carries the config identity colour, not a uniform brand wash', () => {
-    render({ configs: [cfg('a', { identityColorKey: 'red' })] })
-    const row = container.querySelector('[data-testid="quick-start-item"]') as HTMLElement
-    const styleAttr = row.getAttribute('style') ?? ''
-    const chip = row.querySelector('span[aria-hidden]') as HTMLElement
-    const chipHex = chip.style.backgroundColor
-    // The tint background is the identity hex + alpha; the border mixes the
-    // same colour. Neither mentions the brand token any more.
-    expect(styleAttr).not.toContain('--brand')
-    expect(styleAttr).toContain('color-mix')
-    expect(chipHex.length).toBeGreaterThan(0)
+  it('each row carries ITS OWN identity colour — not a uniform wash of any kind', () => {
+    // Two valid palette keys (see identity-colors.ts) — an invalid key would
+    // silently fall back to mauve and make this a false pass.
+    render({ configs: [cfg('a', { identityColorKey: 'pink' }), cfg('b', { identityColorKey: 'indigo' })] })
+    const rows = Array.from(container.querySelectorAll('[data-testid="quick-start-item"]')) as HTMLElement[]
+    expect(rows).toHaveLength(2)
+    const channelsOf = (el: HTMLElement) => {
+      // jsdom normalizes the chip hex to rgb(r, g, b) — the row's hex8 tint
+      // normalizes to rgba(r, g, b, a) — so the channel triplet links them.
+      const chip = el.querySelector('span[aria-hidden]') as HTMLElement
+      const m = chip.style.backgroundColor.match(/rgb\((.+)\)/)
+      expect(m, 'chip colour must resolve').toBeTruthy()
+      return m![1]
+    }
+    for (const row of rows) {
+      const styleAttr = row.getAttribute('style') ?? ''
+      expect(styleAttr).not.toContain('--brand')
+      // The row's tint background carries the SAME channels as its own chip.
+      expect(styleAttr).toContain(channelsOf(row))
+    }
+    // ...and the two rows genuinely differ.
+    expect(channelsOf(rows[0])).not.toBe(channelsOf(rows[1]))
   })
 
   it('a blocked Codex pin still reads as disabled in the new language', () => {

--- a/tests/unit/renderer/quick-start-panel.test.tsx
+++ b/tests/unit/renderer/quick-start-panel.test.tsx
@@ -92,3 +92,46 @@ describe('QuickStartPanel', () => {
     expect(container.querySelector('[data-testid="quick-start-running-count"]')!.textContent).toContain('1')
   })
 })
+
+describe('the #462 restyle — session-card language, no loud fill', () => {
+  const start = () =>
+    Array.from(container.querySelectorAll('[data-testid="quick-start-item"] button'))
+      .find((el) => el.textContent!.includes('Start')) as HTMLButtonElement
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container); SETTINGS.settings.quickStartCollapsed = false; SETTINGS.settings.codexEnabled = true })
+  afterEach(() => { act(() => root.unmount()); container.remove() })
+  const render = (props: Record<string, unknown>) =>
+    act(() => root.render(React.createElement(QuickStartPanel, {
+      onLaunch: () => {}, onContextMenu: () => {}, running: new Map(), ...props,
+    } as any)))
+
+  it('Start is the subtle tinted-brand treatment, not a solid fill', () => {
+    render({ configs: [cfg('a')] })
+    const cls = start().className
+    expect(cls).not.toContain('bg-blue')
+    expect(cls).not.toContain('text-crust')
+    expect(cls).toContain('var(--brand)')
+    expect(cls).toContain('h-5')
+  })
+
+  it('the row border carries the config identity colour, not a uniform brand wash', () => {
+    render({ configs: [cfg('a', { identityColorKey: 'red' })] })
+    const row = container.querySelector('[data-testid="quick-start-item"]') as HTMLElement
+    const styleAttr = row.getAttribute('style') ?? ''
+    const chip = row.querySelector('span[aria-hidden]') as HTMLElement
+    const chipHex = chip.style.backgroundColor
+    // The tint background is the identity hex + alpha; the border mixes the
+    // same colour. Neither mentions the brand token any more.
+    expect(styleAttr).not.toContain('--brand')
+    expect(styleAttr).toContain('color-mix')
+    expect(chipHex.length).toBeGreaterThan(0)
+  })
+
+  it('a blocked Codex pin still reads as disabled in the new language', () => {
+    SETTINGS.settings.codexEnabled = false
+    render({ configs: [cfg('a', { provider: 'codex' })] })
+    expect(start().disabled).toBe(true)
+    expect(start().className).toContain('cursor-not-allowed')
+    expect(start().className).not.toContain('bg-blue')
+  })
+})

--- a/tests/unit/renderer/sessions-panel-state.test.ts
+++ b/tests/unit/renderer/sessions-panel-state.test.ts
@@ -10,6 +10,10 @@ import { describe, it, expect } from 'vitest'
 import {
   resolveDefaultPanelTab,
   resolveQuickStartCollapsed,
+  resolveSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX,
   quickStartConfigs,
   DELETE_WHILE_RUNNING_REASON,
   pinMenuLabel,
@@ -139,5 +143,24 @@ describe('pin menu + count labels', () => {
   it('the count pill label reads naturally for one and many', () => {
     expect(runningCountLabel(1)).toMatch(/^1 session running/)
     expect(runningCountLabel(3)).toMatch(/^3 sessions running/)
+  })
+})
+
+describe('resolveSidebarWidth (#461)', () => {
+  it('absent or garbage falls back to the default', () => {
+    expect(resolveSidebarWidth(undefined)).toBe(SIDEBAR_WIDTH_DEFAULT)
+    expect(resolveSidebarWidth(null)).toBe(SIDEBAR_WIDTH_DEFAULT)
+    expect(resolveSidebarWidth('wide')).toBe(SIDEBAR_WIDTH_DEFAULT)
+    expect(resolveSidebarWidth(NaN)).toBe(SIDEBAR_WIDTH_DEFAULT)
+    expect(resolveSidebarWidth(Infinity)).toBe(SIDEBAR_WIDTH_DEFAULT)
+  })
+  it('clamps a hand-edited value into the working range', () => {
+    expect(resolveSidebarWidth(0)).toBe(SIDEBAR_WIDTH_MIN)
+    expect(resolveSidebarWidth(-50)).toBe(SIDEBAR_WIDTH_MIN)
+    expect(resolveSidebarWidth(99999)).toBe(SIDEBAR_WIDTH_MAX)
+  })
+  it('keeps an in-range value (rounded)', () => {
+    expect(resolveSidebarWidth(300)).toBe(300)
+    expect(resolveSidebarWidth(300.6)).toBe(301)
   })
 })

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -130,21 +130,36 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
 
 describe('Sidebar width (#461)', () => {
   let container: HTMLDivElement; let root: Root
+  const updateSettingsSpy = vi.fn()
   beforeEach(() => {
     container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container)
     SETTINGS_STATE.isLoaded = true
+    SETTINGS_STATE.updateSettings = updateSettingsSpy
+    updateSettingsSpy.mockClear()
     delete SETTINGS_STATE.settings.sidebarWidth
   })
-  afterEach(() => { act(() => root.unmount()); container.remove(); delete SETTINGS_STATE.settings.sidebarWidth })
+  afterEach(() => {
+    act(() => root.unmount()); container.remove()
+    delete SETTINGS_STATE.settings.sidebarWidth
+    SETTINGS_STATE.isLoaded = false
+    SETTINGS_STATE.updateSettings = () => {}
+  })
 
   const render = () =>
     act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {} } as any)))
   const aside = () => container.querySelector('aside') as HTMLElement
+  const handle = () => container.querySelector('[data-testid="sidebar-resize-handle"]') as HTMLElement
+
+  const drag = (from: number, to: number) => {
+    act(() => { handle().dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: from })) })
+    act(() => { window.dispatchEvent(new MouseEvent('pointermove', { clientX: to })) })
+    act(() => { window.dispatchEvent(new MouseEvent('pointerup', {})) })
+  }
 
   it('defaults to the built-in width and carries the resize handle', () => {
     render()
     expect(aside().style.width).toBe('256px')
-    expect(container.querySelector('[data-testid="sidebar-resize-handle"]')).toBeTruthy()
+    expect(handle()).toBeTruthy()
   })
 
   it('adopts a stored width once settings are loaded', () => {
@@ -162,5 +177,44 @@ describe('Sidebar width (#461)', () => {
     SETTINGS_STATE.settings.sidebarWidth = 3
     render()
     expect(aside().style.width).toBe('200px')
+  })
+
+  it('a drag resizes live, writes settings ONCE on release, and clamps', () => {
+    render()
+    drag(256, 316)
+    expect(aside().style.width).toBe('316px')
+    expect(updateSettingsSpy).toHaveBeenCalledTimes(1)
+    expect(updateSettingsSpy).toHaveBeenCalledWith({ sidebarWidth: 316 })
+    // A second drag past the max clamps and still writes once.
+    updateSettingsSpy.mockClear()
+    drag(316, 2000)
+    expect(aside().style.width).toBe('420px')
+    expect(updateSettingsSpy).toHaveBeenCalledTimes(1)
+    expect(updateSettingsSpy).toHaveBeenCalledWith({ sidebarWidth: 420 })
+  })
+
+  it('a bare click on the handle writes nothing', () => {
+    render()
+    drag(256, 256)
+    expect(updateSettingsSpy).not.toHaveBeenCalled()
+    expect(aside().style.width).toBe('256px')
+  })
+
+  it('a later settings hydrate does not stomp a width the user dragged', () => {
+    render()
+    drag(256, 300)
+    expect(aside().style.width).toBe('300px')
+    SETTINGS_STATE.settings.sidebarWidth = 250
+    render()
+    expect(aside().style.width).toBe('300px')
+  })
+
+  it('double-click on the handle resets to the default and persists the reset', () => {
+    SETTINGS_STATE.settings.sidebarWidth = 380
+    render()
+    expect(aside().style.width).toBe('380px')
+    act(() => { handle().dispatchEvent(new MouseEvent('dblclick', { bubbles: true })) })
+    expect(aside().style.width).toBe('256px')
+    expect(updateSettingsSpy).toHaveBeenCalledWith({ sidebarWidth: undefined })
   })
 })

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -127,3 +127,40 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     expect(anchor).toBe(tabs().saved)
   })
 })
+
+describe('Sidebar width (#461)', () => {
+  let container: HTMLDivElement; let root: Root
+  beforeEach(() => {
+    container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container)
+    SETTINGS_STATE.isLoaded = true
+    delete SETTINGS_STATE.settings.sidebarWidth
+  })
+  afterEach(() => { act(() => root.unmount()); container.remove(); delete SETTINGS_STATE.settings.sidebarWidth })
+
+  const render = () =>
+    act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {} } as any)))
+  const aside = () => container.querySelector('aside') as HTMLElement
+
+  it('defaults to the built-in width and carries the resize handle', () => {
+    render()
+    expect(aside().style.width).toBe('256px')
+    expect(container.querySelector('[data-testid="sidebar-resize-handle"]')).toBeTruthy()
+  })
+
+  it('adopts a stored width once settings are loaded', () => {
+    SETTINGS_STATE.settings.sidebarWidth = 320
+    render()
+    expect(aside().style.width).toBe('320px')
+  })
+
+  it('clamps a hand-edited stored width — a bad value cannot wedge the panel', () => {
+    SETTINGS_STATE.settings.sidebarWidth = 99999
+    render()
+    expect(aside().style.width).toBe('420px')
+    act(() => root.unmount())
+    root = createRoot(container)
+    SETTINGS_STATE.settings.sidebarWidth = 3
+    render()
+    expect(aside().style.width).toBe('200px')
+  })
+})

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -152,6 +152,9 @@ describe('Sidebar width (#461)', () => {
 
   const drag = (from: number, to: number) => {
     act(() => { handle().dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: from })) })
+    // TWO moves, so a write leaked into onMove shows up as two calls — the
+    // one-write-per-drag assertion must be able to tell release from frame.
+    act(() => { window.dispatchEvent(new MouseEvent('pointermove', { clientX: Math.round((from + to) / 2) })) })
     act(() => { window.dispatchEvent(new MouseEvent('pointermove', { clientX: to })) })
     act(() => { window.dispatchEvent(new MouseEvent('pointerup', {})) })
   }
@@ -215,6 +218,10 @@ describe('Sidebar width (#461)', () => {
     expect(aside().style.width).toBe('380px')
     act(() => { handle().dispatchEvent(new MouseEvent('dblclick', { bubbles: true })) })
     expect(aside().style.width).toBe('256px')
-    expect(updateSettingsSpy).toHaveBeenCalledWith({ sidebarWidth: undefined })
+    // Loose-equality trap: toHaveBeenCalledWith({sidebarWidth: undefined})
+    // also matches {}. Assert the key is genuinely present-and-undefined.
+    const resetArg = updateSettingsSpy.mock.calls.at(-1)![0] as Record<string, unknown>
+    expect(Object.hasOwn(resetArg, 'sidebarWidth')).toBe(true)
+    expect(resetArg.sidebarWidth).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #461, closes #462.

**#461 — sidebar resize.** The expanded sidebar's right edge is a drag handle (the GitHubPanel pointer pattern, cleanup-ref survives unmount mid-drag): live width while dragging, ONE settings write on release (none for a bare click), double-click resets to the default and persists it, stored value clamped through `resolveSidebarWidth` (200–420: floor keeps the Saved⇄Running tabs above their ~187px min-content), the width transition is suppressed while dragging AND at launch (no 256→stored slide), drag math divides by the region-typography zoom, the handle sits astride the edge fully clear of the session list's 6px scrollbar, body cursor + pointercancel/blur teardown.

**#462 — Quick Start restyle** (owner spec, screenshots + 3 follow-ups): rows wear the active-session-card recipe — thin 1px border in the config's own identity colour over a quiet tint of the same (SessionRow reference), replacing the uniform brand wash; rows shortened (~38→~30px); Start drops the solid `bg-blue` pill for the subtle tinted-brand language; blocked state on tokens. **Owner eyeball note:** the reference "+ Add" is itself a solid fill in code — what shipped is the session-card/tinted language your follow-ups spec'd ("what an unlocked session looks like… that's what we should go for"); shout if you wanted something closer to + Add literally.

Reviews (bound: one round): Double Review found 4 HIGHs (handle over the scrollbar, zoom-blind drag math, un-driven drag machinery, a false-pass identity test on an invalid palette key) — all fixed, re-review **PASS**; residual NITs (right:-4, two test-tightness tweaks) taken as a trivial closing pass. Light-theme tinted-Start contrast noted on #458 (shared recipe). Not security-sensitive (renderer styling/layout + settings key; no IPC/preload).

Tests: +11 (drag drives real pointer events: one-write-per-drag distinguishes release from frame, clamp-by-drag, no-stomp hydrate, dblclick reset with present-and-undefined payload; resolveSidebarWidth clamps; per-row identity linkage via channel triplets, two keys, rows must differ). Full suite 8284 passed / 729 files; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)