### PR TITLE
feat(onboarding): the showcase tours everything since 2.0, and first-runners see it too (#463)

### DIFF
--- a/src/renderer/onboarding/OnboardingHarness.tsx
+++ b/src/renderer/onboarding/OnboardingHarness.tsx
@@ -109,7 +109,7 @@ const PAGES: BuiltStep[] = [
         onNext={nav.onNext}
         fresh
         ctaLabel={run.isLast ? 'Continue' : 'Set it up →'}
-        hint={run.isLast ? 'That’s the tour.' : 'The next pages set these up, one at a time.'}
+        hint={run.isLast ? "That's the tour." : 'The next pages set these up, one at a time.'}
       />
     ),
   },

--- a/src/renderer/onboarding/OnboardingHarness.tsx
+++ b/src/renderer/onboarding/OnboardingHarness.tsx
@@ -57,6 +57,14 @@ interface RunShape {
   isLast: boolean
 }
 
+/** #463: one predicate, used straight and negated, so the upgrade and
+ *  fresh What's-New steps can never both apply. lastSeenVersion is stamped
+ *  by settleOnboardingFinish (markWhatsNewSeen) at the end of EVERY run —
+ *  fresh included — which is what retires the fresh step after first launch.
+ *  whatsNewV2Fresh deliberately has NO steps.ts entry: it must never surface
+ *  via stepsNewSince; the stamp alone retires it. */
+const isUpgrader = () => !!useAppMetaStore.getState().meta.lastSeenVersion
+
 // The built onboarding pages in flow order. Grows as each page lands; the full
 // registry-driven flow (completedSteps stamping, per-step settle, finish, and
 // conditional steps) replaces this array once every page is signed off.
@@ -66,8 +74,10 @@ const PAGES: BuiltStep[] = [
     phase: 0,
     // Upgraders only: lastSeenVersion is stamped by every What's-New/finish
     // dismissal since 1.2.x, so it exists exactly when there is a "before" to
-    // compare against. Fresh installs have nothing "new" and start at welcome.
-    when: () => !!useAppMetaStore.getState().meta.lastSeenVersion,
+    // compare against. Fresh installs have nothing "new" and start at welcome
+    // (they meet the showcase at whatsNewV2Fresh below — the two gates are
+    // isUpgrader() and its negation, so exactly one can ever apply).
+    when: isUpgrader,
     render: (nav, _ctx, _done, run) => (
       <WhatsNewV2Step
         onNext={nav.onNext}
@@ -93,7 +103,7 @@ const PAGES: BuiltStep[] = [
     // here instead of never. The component swaps its heading off the
     // "what's new" diff framing; sectionsFor already yields the full
     // 2.0 + 2.1 story when there is no lastSeenVersion.
-    when: () => !useAppMetaStore.getState().meta.lastSeenVersion,
+    when: () => !isUpgrader(),
     render: (nav, _ctx, _done, run) => (
       <WhatsNewV2Step
         onNext={nav.onNext}

--- a/src/renderer/onboarding/OnboardingHarness.tsx
+++ b/src/renderer/onboarding/OnboardingHarness.tsx
@@ -85,6 +85,24 @@ const PAGES: BuiltStep[] = [
     ),
   },
   { id: 'welcome', phase: 0, render: (nav) => <WelcomeStep onNext={nav.onNext} /> },
+  {
+    id: 'whatsNewV2Fresh',
+    phase: 0,
+    // First-runners (#463): the same showcase, right after Welcome — the
+    // flagships ARE the app's introduction, so a fresh install meets them
+    // here instead of never. The component swaps its heading off the
+    // "what's new" diff framing; sectionsFor already yields the full
+    // 2.0 + 2.1 story when there is no lastSeenVersion.
+    when: () => !useAppMetaStore.getState().meta.lastSeenVersion,
+    render: (nav, _ctx, _done, run) => (
+      <WhatsNewV2Step
+        onNext={nav.onNext}
+        fresh
+        ctaLabel={run.isLast ? 'Continue' : 'Set it up →'}
+        hint={run.isLast ? 'That’s the tour.' : 'The next pages set these up, one at a time.'}
+      />
+    ),
+  },
   // The one-row command bar (#382): new in 2.1.0-beta.17, so an upgrader's
   // notes run shows it right after the release notes; the full flow shows it
   // after Welcome. Back is offered only when there is a page before it.

--- a/src/renderer/onboarding/ShowcaseVignette.tsx
+++ b/src/renderer/onboarding/ShowcaseVignette.tsx
@@ -105,7 +105,7 @@ function PanelVignette() {
           <span className="sv-qs-count">1</span>
           <span className="sv-chip sv-on sv-qs-start">▸ Start</span>
         </div>
-        <div className="sv-pn-h">Active sessions</div>
+        <div className="sv-pn-h sv-pn-neutral">Active sessions</div>
         <div className="sv-pn-row" />
         <div className="sv-pn-row" />
         <div className="sv-pn-row sv-pn-faint" />
@@ -119,7 +119,7 @@ function AccountsVignette() {
     <div className="sv-mini" aria-hidden data-ux-id="showcase-art-accounts">
       <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
       <div className="sv-panel-body">
-        <div className="sv-pn-h">Accounts</div>
+        <div className="sv-pn-h sv-pn-neutral">Accounts</div>
         <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--ob)' }} />work<span className="sv-meter"><i style={{ width: '62%' }} /></span>62%</div>
         <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--status-warning)' }} />personal<span className="sv-meter"><i style={{ width: '28%' }} /></span>28%</div>
         <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--status-success)' }} />team<span className="sv-meter"><i style={{ width: '9%' }} /></span>9%</div>

--- a/src/renderer/onboarding/ShowcaseVignette.tsx
+++ b/src/renderer/onboarding/ShowcaseVignette.tsx
@@ -93,8 +93,46 @@ function OneRowVignette() {
   )
 }
 
+function PanelVignette() {
+  return (
+    <div className="sv-mini" aria-hidden data-ux-id="showcase-art-panel">
+      <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
+      <div className="sv-panel-body">
+        <div className="sv-chips"><span className="sv-chip">Saved 23</span><span className="sv-chip sv-on">Running 3</span></div>
+        <div className="sv-qs">
+          <span className="sv-qs-dot" />
+          Orchid
+          <span className="sv-qs-count">1</span>
+          <span className="sv-chip sv-on sv-qs-start">▸ Start</span>
+        </div>
+        <div className="sv-pn-h">Active sessions</div>
+        <div className="sv-pn-row" />
+        <div className="sv-pn-row" />
+        <div className="sv-pn-row sv-pn-faint" />
+      </div>
+    </div>
+  )
+}
+
+function AccountsVignette() {
+  return (
+    <div className="sv-mini" aria-hidden data-ux-id="showcase-art-accounts">
+      <div className="sv-tb"><span className="sv-tl" /><span className="sv-tl" /><span className="sv-tl" /></div>
+      <div className="sv-panel-body">
+        <div className="sv-pn-h">Accounts</div>
+        <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--ob)' }} />work<span className="sv-meter"><i style={{ width: '62%' }} /></span>62%</div>
+        <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--status-warning)' }} />personal<span className="sv-meter"><i style={{ width: '28%' }} /></span>28%</div>
+        <div className="sv-acct"><span className="sv-acct-dot" style={{ background: 'var(--status-success)' }} />team<span className="sv-meter"><i style={{ width: '9%' }} /></span>9%</div>
+        <div className="sv-wd-chip"><span className="sv-wd-dot" /> Switched account — the session kept going</div>
+      </div>
+    </div>
+  )
+}
+
 export function ShowcaseVignette({ kind }: { kind: ShowcaseArtKind }) {
   if (kind === 'canvas') return <CanvasVignette />
   if (kind === 'watchdog') return <WatchdogVignette />
+  if (kind === 'panel') return <PanelVignette />
+  if (kind === 'accounts') return <AccountsVignette />
   return <OneRowVignette />
 }

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -75,7 +75,7 @@ const SECTIONS_21: WhatsNewSection[] = [
   {
     heading: 'Sessions',
     items: [
-      { title: 'Detachable SSH.', desc: 'Runs under tmux, so a dropped VPN no longer kills the work.' },
+      { title: 'Detachable SSH.', desc: 'Runs under tmux, so the work survives a dropped VPN.' },
       { title: 'Partner terminal.', desc: 'A plain shell beside Claude, labelled so you always know which is which.' },
       { title: 'One row.', desc: 'The tools and your command buttons sit in a single row under the terminal.', seeIt: 'oneRow' },
       { title: 'Two-mode panel.', desc: 'Saved configs and Running sessions each get a tab, with Quick Start pins — and the panel resizes.', seeIt: 'panel' },

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -75,6 +75,7 @@ const SECTIONS_21: WhatsNewSection[] = [
       { title: 'Detachable SSH.', desc: 'Runs under tmux, so a dropped VPN no longer kills the work.' },
       { title: 'Partner terminal.', desc: 'A plain shell beside Claude, now labelled so you know which is which.' },
       { title: 'One row.', desc: 'The tools and your command buttons sit in a single row under the terminal.', seeIt: 'oneRow' },
+      { title: 'Two-mode panel.', desc: 'Saved configs and Running sessions each get a tab, with Quick Start pins — and the panel resizes.', seeIt: 'panel' },
     ],
   },
   {
@@ -88,7 +89,7 @@ const SECTIONS_21: WhatsNewSection[] = [
   {
     heading: 'Accounts & usage',
     items: [
-      { title: 'Switch mid-session.', desc: 'Sign in to claude.ai in-app, change account without losing the session.' },
+      { title: 'Switch mid-session.', desc: 'Sign in to claude.ai in-app, change account without losing the session.', seeIt: 'accounts' },
       { title: 'Insights.', desc: 'Usage reports across every account at once, not one at a time.' },
     ],
   },
@@ -155,12 +156,17 @@ export function WhatsNewV2Step({
   onNext,
   ctaLabel = 'Set it up →',
   hint = 'The next pages set these up, one at a time.',
+  fresh = false,
 }: {
   onNext: () => void
   /** Footer CTA. The harness passes "Continue" when this page ends the run —
    *  on an ordinary upgrade there is usually nothing left to set up. */
   ctaLabel?: string
   hint?: string
+  /** #463: first-run cohort — nothing is "new" to them, so the heading
+   *  introduces the app instead of diffing it. sectionsFor already returns
+   *  the full 2.0+2.1 story when there is no lastSeenVersion. */
+  fresh?: boolean
 }) {
   const sections = sectionsFor(useAppMetaStore.getState().meta.lastSeenVersion, LINE_SOURCE)
   const count = sections.reduce((n, s) => n + s.items.length, 0)
@@ -181,7 +187,7 @@ export function WhatsNewV2Step({
       {pageIx === 0 ? (
         <div className="p2">
           <div className="p2-inner" style={{ width: 'min(920px, 95vw)' }}>
-            <h2 className="h2" data-ux-id="whatsnew-heading">What&apos;s new in {LINE}</h2>
+            <h2 className="h2" data-ux-id="whatsnew-heading">{fresh ? 'What you’re getting' : <>What&apos;s new in {LINE}</>}</h2>
             <p className="p2-sub" data-ux-id="whatsnew-sub">
               {count} things worth knowing, in one line each{showcases.length > 0 ? ` — and ${showcases.length} of them have a page of their own, just behind this one` : ''}.
             </p>

--- a/src/renderer/onboarding/WhatsNewV2Step.tsx
+++ b/src/renderer/onboarding/WhatsNewV2Step.tsx
@@ -17,6 +17,9 @@ export interface WhatsNewItem {
   /** ONE line. If it needs two sentences, it belongs in the Feature Guide. */
   desc: string
   beta?: boolean
+  /** #463: a line that only makes sense against a BEFORE (“the app was
+   *  renamed”) — hidden from the fresh-install cohort, who have no before. */
+  upgradeOnly?: boolean
   /** Id of a showcase page (showcase-pages.ts). Grows a "See it →" chip that
    *  jumps to that page; an id with no matching page renders no chip. */
   seeIt?: string
@@ -63,7 +66,7 @@ const SECTIONS_20: WhatsNewSection[] = [
   {
     heading: 'Under the hood',
     items: [
-      { title: 'A newer engine.', desc: 'Electron 43, React 19 and xterm.js 6 — faster, on a current security baseline.' },
+      { title: 'A modern engine.', desc: 'Electron 43, React 19 and xterm.js 6 — fast, on a current security baseline.' },
     ],
   },
 ]
@@ -73,7 +76,7 @@ const SECTIONS_21: WhatsNewSection[] = [
     heading: 'Sessions',
     items: [
       { title: 'Detachable SSH.', desc: 'Runs under tmux, so a dropped VPN no longer kills the work.' },
-      { title: 'Partner terminal.', desc: 'A plain shell beside Claude, now labelled so you know which is which.' },
+      { title: 'Partner terminal.', desc: 'A plain shell beside Claude, labelled so you always know which is which.' },
       { title: 'One row.', desc: 'The tools and your command buttons sit in a single row under the terminal.', seeIt: 'oneRow' },
       { title: 'Two-mode panel.', desc: 'Saved configs and Running sessions each get a tab, with Quick Start pins — and the panel resizes.', seeIt: 'panel' },
     ],
@@ -96,7 +99,7 @@ const SECTIONS_21: WhatsNewSection[] = [
   {
     heading: 'The app itself',
     items: [
-      { title: 'New name.', desc: 'Claude Command Center is now AI Code Conductor. Same data, same settings.' },
+      { title: 'New name.', desc: 'Claude Command Center is now AI Code Conductor. Same data, same settings.', upgradeOnly: true },
       { title: 'Signed and notarised.', desc: 'Windows signed, macOS notarised, every update SHA-256 checked.' },
     ],
   },
@@ -169,6 +172,8 @@ export function WhatsNewV2Step({
   fresh?: boolean
 }) {
   const sections = sectionsFor(useAppMetaStore.getState().meta.lastSeenVersion, LINE_SOURCE)
+    .map((s) => (fresh ? { ...s, items: s.items.filter((it) => !it.upgradeOnly) } : s))
+    .filter((s) => s.items.length > 0)
   const count = sections.reduce((n, s) => n + s.items.length, 0)
   // The showcase (owner design 2026-08-24): the summary is page 0; each
   // flagship feature of the line gets a full page behind it. With no pages
@@ -187,7 +192,7 @@ export function WhatsNewV2Step({
       {pageIx === 0 ? (
         <div className="p2">
           <div className="p2-inner" style={{ width: 'min(920px, 95vw)' }}>
-            <h2 className="h2" data-ux-id="whatsnew-heading">{fresh ? 'What you’re getting' : <>What&apos;s new in {LINE}</>}</h2>
+            <h2 className="h2" data-ux-id="whatsnew-heading">{fresh ? <>What you&apos;re getting</> : <>What&apos;s new in {LINE}</>}</h2>
             <p className="p2-sub" data-ux-id="whatsnew-sub">
               {count} things worth knowing, in one line each{showcases.length > 0 ? ` — and ${showcases.length} of them have a page of their own, just behind this one` : ''}.
             </p>
@@ -238,7 +243,7 @@ export function WhatsNewV2Step({
           {isLast ? hint : `Page ${pageIx + 1} of ${total}.`}
         </span>
         {total > 1 && (
-          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" role="group" aria-label="What's New pages">
+          <div className="wn-foot-dots" data-ux-id="whatsnew-dots" role="group" aria-label="Showcase pages">
             <button type="button" className={`wn-fdot${pageIx === 0 ? ' on' : ''}`} onClick={() => setPageIx(0)} aria-label="Summary" aria-current={pageIx === 0 ? 'page' : undefined} data-ux-id="whatsnew-dot-summary"><i /></button>
             {showcases.map((p, ix) => (
               <button type="button" key={p.id} className={`wn-fdot${pageIx === ix + 1 ? ' on' : ''}`} onClick={() => setPageIx(ix + 1)} aria-label={p.heading} aria-current={pageIx === ix + 1 ? 'page' : undefined} data-ux-id={`whatsnew-dot-${p.id}`}><i /></button>

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -442,3 +442,15 @@
 .ob-root .sv-caret { display: inline-block; width: 7px; height: 13px; background: var(--status-success); vertical-align: -2px; animation: sv-pulse 1s infinite; }
 @keyframes sv-pulse { 50% { opacity: .35; } }
 @media (prefers-reduced-motion: reduce) { .ob-root .sv-wd-dot, .ob-root .sv-caret { animation: none; } }
+
+/* Panel + accounts vignettes (#463). Same drawn-mini language as the rest of
+   the sv- set: token colours only, pictures OF the features. */
+.ob-root .sv-panel-body { padding: 10px 14px 14px; }
+.ob-root .sv-qs { display: flex; align-items: center; gap: 8px; margin: 10px 0 12px; border: 1px solid var(--ob-line); background: var(--ob-soft); border-radius: 8px; padding: 6px 10px; font-size: 11px; color: var(--text-secondary); }
+.ob-root .sv-qs-dot { width: 8px; height: 8px; border-radius: 3px; background: var(--ob); }
+.ob-root .sv-qs-count { font-size: 9.5px; border: 1px solid var(--border-strong); border-radius: 999px; padding: 1px 6px; color: var(--text-muted); }
+.ob-root .sv-qs-start { margin-left: auto; }
+.ob-root .sv-acct { display: flex; align-items: center; gap: 8px; margin: 8px 0; font-size: 11px; color: var(--text-secondary); }
+.ob-root .sv-acct-dot { width: 7px; height: 7px; border-radius: 999px; flex: none; }
+.ob-root .sv-meter { flex: 1; height: 5px; border-radius: 999px; background: var(--surface-overlay); overflow: hidden; }
+.ob-root .sv-meter > i { display: block; height: 100%; border-radius: 999px; background: var(--ob); }

--- a/src/renderer/onboarding/onboarding.css
+++ b/src/renderer/onboarding/onboarding.css
@@ -445,6 +445,7 @@
 
 /* Panel + accounts vignettes (#463). Same drawn-mini language as the rest of
    the sv- set: token colours only, pictures OF the features. */
+.ob-root .sv-pn-h.sv-pn-neutral { color: var(--text-muted); }
 .ob-root .sv-panel-body { padding: 10px 14px 14px; }
 .ob-root .sv-qs { display: flex; align-items: center; gap: 8px; margin: 10px 0 12px; border: 1px solid var(--ob-line); background: var(--ob-soft); border-radius: 8px; padding: 6px 10px; font-size: 11px; color: var(--text-secondary); }
 .ob-root .sv-qs-dot { width: 8px; height: 8px; border-radius: 3px; background: var(--ob); }

--- a/src/renderer/onboarding/showcase-pages.ts
+++ b/src/renderer/onboarding/showcase-pages.ts
@@ -1,10 +1,17 @@
 import { releaseLine } from '../utils/versionLabel'
 
 /**
- * The What's New feature showcase (owner-approved design, 2026-08-24): after
- * the one-line summary page, each flagship feature of the release line gets a
- * full page of its own — heading, tagline, a few one-liner points, a "where to
- * find it" locator, and a drawn vignette (ShowcaseVignette).
+ * The What's New feature showcase (owner-approved design, 2026-08-24; scope
+ * revised 2026-08-25, #463): after the one-line summary page, each flagship
+ * gets a full page of its own — heading, tagline, a few one-liner points, a
+ * "where to find it" locator, and a drawn vignette (ShowcaseVignette).
+ *
+ * The set tours EVERYTHING the 2.1 line added over 2.0 — the Agent Canvas is
+ * completely new since 2.0, and the pages say so — because the showcase has
+ * two audiences (#463): a 2.0 user deciding what the update gave them, and a
+ * first-run user meeting these features for the first time. Copy must read
+ * for both: name what the feature IS before what it replaced, and keep
+ * upgrade-only framing ("three rows became one") out of headings.
  *
  * Curated HERE, not in changelog.ts, for the same reason WhatsNewV2Step's
  * SECTIONS are: changelog.ts is a fragile pure-data literal that
@@ -18,7 +25,7 @@ import { releaseLine } from '../utils/versionLabel'
  * renders no chip, so the two files cannot drift into a dead button.
  */
 
-export type ShowcaseArtKind = 'canvas' | 'watchdog' | 'oneRow'
+export type ShowcaseArtKind = 'canvas' | 'watchdog' | 'oneRow' | 'panel' | 'accounts'
 
 export interface ShowcasePoint {
   /** Bold lead-in, ending in a full stop unless the rest continues the sentence. */
@@ -40,16 +47,52 @@ export interface ShowcasePage {
 export const SHOWCASES_21: ShowcasePage[] = [
   {
     id: 'canvas',
-    heading: 'The Agent Canvas grew a real review flow',
-    tagline: "Claude renders the work in the app. You point at what's wrong; it fixes everything in one pass.",
+    heading: 'The Agent Canvas — new to this line',
+    tagline: "Claude renders its work as a real page inside the app. You point at what's wrong; it reads every note and fixes it all in one pass.",
     points: [
+      { lead: 'Mockups, plans, your build.', rest: 'Ask for something visual and it appears on the canvas, versioned.' },
       { lead: 'Review needed, counted.', rest: 'The button turns amber with one number for every round owed.' },
-      { lead: 'Drafts stay private.', rest: 'You only ever see versions the agent marks ready.' },
       { lead: 'A note can offer choices.', rest: 'A/B/C chips — your click picks the winner, or name it in chat.' },
       { lead: 'Nothing is overwritten.', rest: 'History picks the artifact; a stepper walks its versions.' },
     ],
     where: { pre: 'Where: the ', em: 'Canvas', post: ' button in the session toolbar, beside Snap.' },
     art: 'canvas',
+  },
+  {
+    id: 'oneRow',
+    heading: 'One row runs the session',
+    tagline: "Tools first, then your Global buttons, then this config's Session buttons — under every terminal, in a single row.",
+    points: [
+      { lead: 'It knows its session.', rest: 'A Codex session says Codex; on SSH, buttons say which computer runs them.' },
+      { lead: 'Overflow folds', rest: 'into a per-band "N more" pill instead of wrapping under the terminal.' },
+      { lead: 'Your buttons are reviewed, never changed.', rest: 'A clash carries a small amber mark until you look at it.' },
+    ],
+    where: { pre: 'Where: ', em: "under every session's terminal", post: '.' },
+    art: 'oneRow',
+  },
+  {
+    id: 'panel',
+    heading: 'The left panel has two modes',
+    tagline: 'Saved configs are the launcher; Running sessions are the work. Quick Start keeps your pinned configs one click away.',
+    points: [
+      { lead: 'Saved ⇄ Running.', rest: 'Two tabs, so launching and tending sessions stop sharing one crowded list.' },
+      { lead: 'A config is a template.', rest: 'A running one shows a count pill and can Start another instance any time.' },
+      { lead: 'Sized by you.', rest: 'Drag the panel edge; the width sticks. Double-click resets it.' },
+    ],
+    where: { pre: 'Where: the ', em: 'left panel', post: ' — the two tabs sit at its top.' },
+    art: 'panel',
+  },
+  {
+    id: 'accounts',
+    heading: 'Every account, one app',
+    tagline: 'Sign in to more than one Claude account and switch mid-session — usage, costs and insights follow each account separately.',
+    points: [
+      { lead: 'Switch without losing work.', rest: 'Change the account under a session; the conversation stays put.' },
+      { lead: 'Usage at a glance.', rest: "The footer meters each account's window while you work." },
+      { lead: 'Insights across accounts.', rest: 'Reports read every account at once, not one at a time.' },
+    ],
+    where: { pre: 'Where: the ', em: 'account strip', post: ' in the footer, and Insights in the sidebar.' },
+    art: 'accounts',
   },
   {
     id: 'watchdog',
@@ -63,18 +106,6 @@ export const SHOWCASES_21: ShowcasePage[] = [
     where: { pre: 'Where: ', em: 'Settings → General → Session Watchdog', post: '.' },
     art: 'watchdog',
   },
-  {
-    id: 'oneRow',
-    heading: 'Three rows became one',
-    tagline: "Tools first, then your Global buttons, then this config's Session buttons. The bar knows what kind of session it's in.",
-    points: [
-      { lead: 'Nothing you had is changed without asking', rest: '— clashes carry a small amber mark until you look.' },
-      { lead: 'Overflow folds', rest: 'into a per-band "N more" pill instead of wrapping.' },
-      { lead: 'Two terminal lines come back', rest: 'to every session.' },
-    ],
-    where: { pre: 'Where: ', em: "under every session's terminal", post: '.' },
-    art: 'oneRow',
-  },
 ]
 
 /**
@@ -84,7 +115,8 @@ export const SHOWCASES_21: ShowcasePage[] = [
  * gets none. Unlike sectionsFor this does not depend on where the user came
  * FROM — the showcase presents the current line's flagships, and stacking a
  * second line's pages behind them is exactly the wall the one-line summary
- * exists to avoid.
+ * exists to avoid. (First-run users see the same pages via the fresh-install
+ * step, #463 — the flagships ARE the app's introduction.)
  */
 export function showcasesFor(currentVersion: string): ShowcasePage[] {
   return releaseLine(currentVersion) === '2.0' ? [] : SHOWCASES_21

--- a/src/renderer/onboarding/showcase-pages.ts
+++ b/src/renderer/onboarding/showcase-pages.ts
@@ -76,10 +76,10 @@ export const SHOWCASES_21: ShowcasePage[] = [
     tagline: 'Saved configs are the launcher; Running sessions are the work. Quick Start keeps your pinned configs one click away.',
     points: [
       { lead: 'Saved ⇄ Running.', rest: 'Two tabs, so launching and tending sessions stop sharing one crowded list.' },
-      { lead: 'A config is a template.', rest: 'A running one shows a count pill and can Start another instance any time.' },
+      { lead: 'A config is a template.', rest: 'A running one shows a count pill, and its Quick Start pin can Start another instance.' },
       { lead: 'Sized by you.', rest: 'Drag the panel edge; the width sticks. Double-click resets it.' },
     ],
-    where: { pre: 'Where: the ', em: 'left panel', post: ' — the two tabs sit at its top.' },
+    where: { pre: 'Where: the ', em: 'left panel', post: ' — the tabs sit at the top of its sessions list.' },
     art: 'panel',
   },
   {
@@ -87,17 +87,17 @@ export const SHOWCASES_21: ShowcasePage[] = [
     heading: 'Every account, one app',
     tagline: 'Sign in to more than one Claude account and switch mid-session — usage, costs and insights follow each account separately.',
     points: [
-      { lead: 'Switch without losing work.', rest: 'Change the account under a session; the conversation stays put.' },
+      { lead: 'Switch mid-session.', rest: 'The session restarts under the new account and resumes the same conversation.' },
       { lead: 'Usage at a glance.', rest: "The footer meters each account's window while you work." },
-      { lead: 'Insights across accounts.', rest: 'Reports read every account at once, not one at a time.' },
+      { lead: 'Insights across accounts.', rest: 'With two or more signed in, reports read them all at once.' },
     ],
-    where: { pre: 'Where: the ', em: 'account strip', post: ' in the footer, and Insights in the sidebar.' },
+    where: { pre: 'Where: add a second account and the ', em: 'account strip', post: ' appears in the footer; Insights sits in the sidebar.' },
     art: 'accounts',
   },
   {
     id: 'watchdog',
     heading: "The Watchdog waits so you don't have to",
-    tagline: 'A rate limit used to end your evening. Now the session reads the banner, waits out the reset, and types the retry itself.',
+    tagline: "A rate limit doesn't have to end your evening: the session reads the banner, waits out the reset, and types the retry itself.",
     points: [
       { lead: 'Off by default.', rest: 'One switch in Settings turns it on.' },
       { lead: 'Careful hands.', rest: 'It never types over your draft or an open prompt.' },

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -248,6 +248,17 @@ describe('#463 — since-2.0 coverage and the first-run cohort', () => {
     expect(text).not.toContain('New name.')
   })
 
+  it('no upgrade-only line carries a See-it link — the fresh page count must not desync', () => {
+    // The sub-line says "N of them have a page of their own"; an upgradeOnly
+    // item with a seeIt would make that true for upgraders and false for the
+    // fresh cohort, silently.
+    for (const s2 of sectionsFor(undefined, '2.1.0')) {
+      for (const it2 of s2.items) {
+        expect(!(it2.upgradeOnly && it2.seeIt), `${it2.title} is upgradeOnly with a seeIt`).toBe(true)
+      }
+    }
+  })
+
   it('the upgrader still sees the upgrade-only lines', () => {
     render()
     expect(container.textContent).toContain('New name.')

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../../src/renderer/stores/appMetaStore', () => {
 
 const { WhatsNewV2Step, sectionsFor } = await import('../../../src/renderer/onboarding/WhatsNewV2Step')
 const { SHOWCASES_21, showcasesFor } = await import('../../../src/renderer/onboarding/showcase-pages')
+const { ShowcaseVignette } = await import('../../../src/renderer/onboarding/ShowcaseVignette')
 
 let container: HTMLDivElement
 let root: Root
@@ -98,20 +99,20 @@ describe('WhatsNewV2Step — multi-page showcase', () => {
     expect(q('whatsnew-heading')).not.toBeNull()
     expect(q('showcase-heading')).toBeNull()
     expect(q('whatsnew-dots')).not.toBeNull()
-    expect(q('whatsnew-hint')!.textContent).toContain('Page 1 of 4')
+    // Derived, not hardcoded: 1 summary + one page per flagship.
+    expect(q('whatsnew-hint')!.textContent).toContain(`Page 1 of ${1 + SHOWCASES_21.length}`)
   })
 
   it('Next pages inward without leaving the run; the last page carries the harness CTA', () => {
     render()
     const cta = () => q('whatsnew-cta')!
     expect(cta().textContent).toContain('Next')
-    click(cta()) // -> canvas
+    click(cta()) // -> the first flagship
     expect(nexts).toBe(0)
-    expect(q('showcase-page-canvas')).not.toBeNull()
-    expect(q('showcase-eyebrow')!.textContent).toContain('1 of 3')
-    click(cta()) // -> watchdog
-    click(cta()) // -> oneRow (last)
-    expect(q('showcase-page-oneRow')).not.toBeNull()
+    expect(q(`showcase-page-${SHOWCASES_21[0].id}`)).not.toBeNull()
+    expect(q('showcase-eyebrow')!.textContent).toContain(`1 of ${SHOWCASES_21.length}`)
+    for (let i = 1; i < SHOWCASES_21.length; i++) click(cta()) // -> walk to the last
+    expect(q(`showcase-page-${SHOWCASES_21[SHOWCASES_21.length - 1].id}`)).not.toBeNull()
     expect(cta().textContent).toBe('Continue')
     expect(q('whatsnew-hint')!.textContent).toBe('Nothing to set up.')
     expect(q('whatsnew-skip'), 'skip duplicates the CTA on the last page').toBeNull()
@@ -124,7 +125,8 @@ describe('WhatsNewV2Step — multi-page showcase', () => {
     render()
     click(q('see-watchdog'))
     expect(q('showcase-page-watchdog')).not.toBeNull()
-    expect(q('showcase-eyebrow')!.textContent).toContain('2 of 3')
+    const ix = SHOWCASES_21.findIndex((pg: { id: string }) => pg.id === 'watchdog')
+    expect(q('showcase-eyebrow')!.textContent).toContain(`${ix + 1} of ${SHOWCASES_21.length}`)
     expect(nexts).toBe(0)
   })
 
@@ -196,5 +198,52 @@ describe('WhatsNewV2Step — multi-page showcase', () => {
     expect(nexts).toBe(1)
     ;(globalThis as any).__APP_VERSION__ = '2.1.0-rc.1'
     vi.resetModules()
+  })
+})
+
+// ── #463: the showcase tours everything since 2.0, for both audiences ──
+describe('#463 — since-2.0 coverage and the first-run cohort', () => {
+  it('the flagship set covers the full 2.1-over-2.0 story, canvas first', () => {
+    const ids = SHOWCASES_21.map((p) => p.id)
+    for (const flagship of ['canvas', 'oneRow', 'panel', 'accounts', 'watchdog']) {
+      expect(ids, `missing flagship page "${flagship}"`).toContain(flagship)
+    }
+    expect(ids[0]).toBe('canvas')
+  })
+
+  it('no heading or tagline uses upgrade-only diff framing a first-runner cannot parse', () => {
+    // "Three rows became one" reads as gibberish to someone who never saw
+    // three rows. Headings must name what the feature IS.
+    for (const p of SHOWCASES_21) {
+      expect(p.heading.toLowerCase(), p.id).not.toContain('became')
+      expect(p.heading.toLowerCase(), p.id).not.toContain('grew')
+    }
+  })
+
+  it('every showcase page\'s art kind renders a drawn vignette', () => {
+    for (const p of SHOWCASES_21) {
+      act(() => { root.render(<ShowcaseVignette kind={p.art} />) })
+      expect(
+        container.querySelector(`[data-ux-id="showcase-art-${p.art}"]`),
+        `no vignette rendered for art kind "${p.art}"`,
+      ).toBeTruthy()
+    }
+  })
+
+  it('the fresh cohort gets an introduction heading and the FULL story, not a diff', () => {
+    metaState.meta = {}
+    render({ fresh: true })
+    expect(q('whatsnew-heading')!.textContent).toContain('What you’re getting')
+    expect(q('whatsnew-heading')!.textContent).not.toContain("What's new")
+    const text = container.textContent!
+    // One item from the 2.0 set and one from the 2.1 set — both present,
+    // because a first-runner missed everything.
+    expect(text).toContain('Guided setup.')
+    expect(text).toContain('Agent Canvas.')
+  })
+
+  it('an upgrader keeps the diff heading — fresh framing never leaks', () => {
+    render()
+    expect(q('whatsnew-heading')!.textContent).toContain("What's new in 2.1")
   })
 })

--- a/tests/unit/renderer/whatsnew-showcase.test.tsx
+++ b/tests/unit/renderer/whatsnew-showcase.test.tsx
@@ -213,10 +213,14 @@ describe('#463 — since-2.0 coverage and the first-run cohort', () => {
 
   it('no heading or tagline uses upgrade-only diff framing a first-runner cannot parse', () => {
     // "Three rows became one" reads as gibberish to someone who never saw
-    // three rows. Headings must name what the feature IS.
+    // three rows. A tripwire, not a proof: it catches the phrasings that have
+    // actually slipped in ("became", "grew", "used to", "no longer", "now X"
+    // comparatives) — review still owns the judgment call.
     for (const p of SHOWCASES_21) {
-      expect(p.heading.toLowerCase(), p.id).not.toContain('became')
-      expect(p.heading.toLowerCase(), p.id).not.toContain('grew')
+      const copy = `${p.heading} ${p.tagline}`.toLowerCase()
+      for (const phrase of ['became', 'grew', 'used to', 'no longer', 'renamed']) {
+        expect(copy, `${p.id}: "${phrase}"`).not.toContain(phrase)
+      }
     }
   })
 
@@ -233,13 +237,20 @@ describe('#463 — since-2.0 coverage and the first-run cohort', () => {
   it('the fresh cohort gets an introduction heading and the FULL story, not a diff', () => {
     metaState.meta = {}
     render({ fresh: true })
-    expect(q('whatsnew-heading')!.textContent).toContain('What you’re getting')
+    expect(q('whatsnew-heading')!.textContent).toContain("What you're getting")
     expect(q('whatsnew-heading')!.textContent).not.toContain("What's new")
     const text = container.textContent!
     // One item from the 2.0 set and one from the 2.1 set — both present,
     // because a first-runner missed everything.
     expect(text).toContain('Guided setup.')
     expect(text).toContain('Agent Canvas.')
+    // ...but a line that only makes sense against a BEFORE stays out.
+    expect(text).not.toContain('New name.')
+  })
+
+  it('the upgrader still sees the upgrade-only lines', () => {
+    render()
+    expect(container.textContent).toContain('New name.')
   })
 
   it('an upgrader keeps the diff heading — fresh framing never leaks', () => {


### PR DESCRIPTION
Closes #463 (owner: the showcase must read as the full 2.0→2.1 story — the Agent Canvas is completely new — and first-time runners should be introduced there anyway).

**Flagship set: 3 → 5 pages** (canvas, one-row bar, two-mode panel + Quick Start, multi-account, watchdog), two new drawn vignettes in the existing sv- language (neutral section headers, not the canvas panel's warning-amber). Headings/taglines drop upgrade-only diff framing ('Three rows became one') and name what each feature IS; a widened tripwire scans heading+tagline for became/grew/'used to'/'no longer'/renamed — verified it trips on the old copy. Summary gains panel + accounts See-it links.

**Fresh installs meet the same showcase** right after Welcome (`whatsNewV2Fresh`, gated on no `lastSeenVersion`): heading becomes "What you're getting", sections are the full 2.0+2.1 story, and lines that only make sense against a before (`New name… Same data, same settings`) are marked `upgradeOnly` and filtered for that cohort (a test pins both cohorts' behaviour, and that no upgradeOnly item carries a seeIt). The upgrade/fresh gates are ONE predicate used straight and negated — mutually exclusive by construction — with the retiring stamp chain documented (`settleOnboardingFinish` → `markWhatsNewSeen`). `upgrade-flow.ts` keeps a first install out of whatsNewOnly runs (reviewer-traced).

**Copy verified against the app** by the reviewer (locators, resize, pills, A/B/C, watchdog switch), including the fix round's corrections: the accounts page no longer points a single-account first-runner at an account strip that only exists with two (`MultiAccountStatusline` hides below 2), and the switch-account claim now states the real respawn-and-resume behaviour.

Reviews (bound: one round): Double Review found 5 HIGHs (two false-for-first-runner claims, fresh diff-framing, a tripwire that didn't cover what its name promised, no harness coverage) — fixed; re-review **PASS**; residual NITs taken as a trivial closing pass. Not security-sensitive (renderer onboarding content + one gating predicate).

Full suite 8290 passed / 729 files; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)