### PR TITLE
fix(sidebar): canvas-approved quick start polish — border-only identity, number-only pill (#462)

### DIFF
--- a/src/renderer/components/sidebar/QuickStartPanel.tsx
+++ b/src/renderer/components/sidebar/QuickStartPanel.tsx
@@ -65,11 +65,11 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
             key={config.id}
             className="mx-2 my-0.5 px-2 py-1 rounded-lg border flex items-center gap-1.5 transition-colors"
             style={{
-              // #462: the session-card recipe — a thin border in the config's
-              // own identity colour over a quiet tint of the same, instead of
-              // the old uniform brand wash (SessionRow.tsx is the reference).
+              // #462, canvas-approved 2026-08-25: identity on the BORDER ONLY
+              // (the session-card 55% mix); the interior stays the neutral
+              // stage surface like a non-active session card — no tint fill.
               borderColor: `color-mix(in srgb, ${chipColour} 55%, transparent)`,
-              background: chipColour + '12',
+              background: 'var(--surface-stage)',
             }}
             onContextMenu={(e) => onContextMenu(e, config.id)}
             data-testid="quick-start-item"
@@ -79,11 +79,10 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
             <span className="text-xs font-medium truncate flex-1 text-[var(--text-primary)]">{config.label}</span>
             {liveCount > 0 && (
               <span
-                className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
+                className="flex items-center text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
                 title={runningCountLabel(liveCount)}
                 data-testid="quick-start-running-count"
               >
-                <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
                 {liveCount}
               </span>
             )}

--- a/src/renderer/components/sidebar/QuickStartPanel.tsx
+++ b/src/renderer/components/sidebar/QuickStartPanel.tsx
@@ -79,7 +79,7 @@ export default function QuickStartPanel({ configs, running, onLaunch, onContextM
             <span className="text-xs font-medium truncate flex-1 text-[var(--text-primary)]">{config.label}</span>
             {liveCount > 0 && (
               <span
-                className="flex items-center text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
+                className="flex items-center text-[8.5px] font-semibold text-green bg-green/15 rounded-full px-1.5 py-0.5 shrink-0"
                 title={runningCountLabel(liveCount)}
                 data-testid="quick-start-running-count"
               >

--- a/tests/unit/renderer/quick-start-panel.test.tsx
+++ b/tests/unit/renderer/quick-start-panel.test.tsx
@@ -46,6 +46,8 @@ describe('QuickStartPanel', () => {
     const b = Array.from(items).find((el) => el.textContent!.includes('b'))!
     const pill = b.querySelector('[data-testid="quick-start-running-count"]')!
     expect(pill.textContent).toContain('2')
+    // Canvas note R1: number only — no dot glyph inside the pill.
+    expect(pill.querySelector('span')).toBeNull()
     // The idle pin carries no pill.
     const a = Array.from(items).find((el) => el.textContent!.includes('a'))!
     expect(a.querySelector('[data-testid="quick-start-running-count"]')).toBeNull()
@@ -131,8 +133,11 @@ describe('the #462 restyle — session-card language, no loud fill', () => {
     for (const row of rows) {
       const styleAttr = row.getAttribute('style') ?? ''
       expect(styleAttr).not.toContain('--brand')
-      // The row's tint background carries the SAME channels as its own chip.
+      // Canvas-approved 2026-08-25: identity on the BORDER only — its
+      // color-mix carries the same channels as the row's own chip — and the
+      // interior is the neutral stage surface, not a tint.
       expect(styleAttr).toContain(channelsOf(row))
+      expect(styleAttr).toContain('var(--surface-stage)')
     }
     // ...and the two rows genuinely differ.
     expect(channelsOf(rows[0])).not.toBe(channelsOf(rows[1]))

--- a/tests/unit/renderer/quick-start-panel.test.tsx
+++ b/tests/unit/renderer/quick-start-panel.test.tsx
@@ -45,7 +45,7 @@ describe('QuickStartPanel', () => {
     expect(items.length).toBe(2)
     const b = Array.from(items).find((el) => el.textContent!.includes('b'))!
     const pill = b.querySelector('[data-testid="quick-start-running-count"]')!
-    expect(pill.textContent).toContain('2')
+    expect(pill.textContent!.trim()).toBe('2')
     // Canvas note R1: number only — no dot glyph inside the pill.
     expect(pill.querySelector('span')).toBeNull()
     // The idle pin carries no pill.


### PR DESCRIPTION
The owner reviewed the shipped #462 restyle on the Agent Canvas (3 rounds; v3 verdict: "Perfect", with Ctrl+V screenshot-in-note used for the first time). Two approved changes, implemented pixel-exact against the approved v3 mockup (the reviewer diffed against the on-disk artifact):

1. **Running-count pill is number-only** — the dot glyph goes (canvas note R1).
2. **Identity on the border only** (canvas note R2): the row keeps the thin 55% identity border but the tint fill goes — the interior is the neutral `--surface-stage`, per the owner's reference screenshot of a session card.

Double Review: **PASS** — both assertions mutation-proven (revert to tint fill / re-add the dot each fail a test); NITs (vestigial `uppercase tracking-wide` on a bare digit, loose count assertion) taken as a trivial closing pass.

**One owner-call flagged by the review, not fixed here**: the approved mockup was dark-only, and its "like a non-active session card" reference is one rung off the real app — real idle cards are *transparent* on the panel, so Quick Start rows sit one surface brighter, a whisper in dark (1.07:1) but ~3× stronger in the light theme (1.21:1). Ships as approved; eyeball the light theme on your install pass and say if you want the body transparent instead.

Full suite green (one unrelated known canvas-plugin load-flake, passes in isolation); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)