### PR TITLE
fix(sidebar): saved-tab count pill drops its dot — number only (#473)

### DIFF
--- a/src/renderer/components/sidebar/ConfigRow.tsx
+++ b/src/renderer/components/sidebar/ConfigRow.tsx
@@ -77,12 +77,11 @@ export default function ConfigRow({ config, onLaunch, onEdit, onDelete, onPin, o
       {runningCount > 0 && (
         <button
           onClick={(e) => { e.stopPropagation(); onOpenSession?.() }}
-          className="flex items-center gap-1 text-[8.5px] font-semibold uppercase tracking-wide text-green bg-green/15 hover:bg-green/25 rounded-full px-1.5 py-0.5 shrink-0 focus-ring transition-colors"
+          className="flex items-center text-[8.5px] font-semibold text-green bg-green/15 hover:bg-green/25 rounded-full px-1.5 py-0.5 shrink-0 focus-ring transition-colors"
           title={runningCountLabel(runningCount)}
           aria-label={runningCountLabel(runningCount)}
           data-testid="config-row-running-count"
         >
-          <span className="w-1.5 h-1.5 rounded-full bg-green" aria-hidden />
           {runningCount}
         </button>
       )}

--- a/tests/unit/renderer/config-row-running.test.tsx
+++ b/tests/unit/renderer/config-row-running.test.tsx
@@ -70,7 +70,9 @@ describe('ConfigRow — relaunch with a running-count indicator', () => {
     renderRow({ runningCount: 3, onOpenSession: opened })
     const pill = container.querySelector('[data-testid="config-row-running-count"]') as HTMLElement
     expect(pill).toBeTruthy()
-    expect(pill.textContent).toContain('3')
+    // #473: number only — no dot glyph (the canvas-approved pill language).
+    expect(pill.textContent!.trim()).toBe('3')
+    expect(pill.querySelector('span')).toBeNull()
     act(() => { pill.click() })
     expect(opened).toHaveBeenCalledTimes(1)
     // The retired locked row is gone for good.


### PR DESCRIPTION
Closes #473. ConfigRow's running-count pill now matches the canvas-approved Quick Start pill (#462 note R1: number only, no dot). Same vestigial-class cleanup; test pins the contract. Trivial-edit tier (documented in the commit); full suite 8322 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)