### PR TITLE
fix(canvas): inspect and x-ray fuse into one named capsule (#469)

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -1,0 +1,28 @@
+# 2026-08-25 — rc.3 UI round: canvas-driven fixes
+
+The owner's rc.2 install pass ran as a live canvas-review session; the
+resulting rc.3 scope is milestone 5 (15 issues, owner: all of it ships in
+rc.3, cut on hold until their remaining issues are filed).
+
+Landed so far, each through the canvas loop where the owner reviewed:
+
+- **#462 polish** (PRs #472, #474): the Quick Start rows the owner approved on
+  canvas ("Perfect", three rounds, first use of Ctrl+V screenshot-in-note) —
+  identity colour on the thin border ONLY, transparent body (the mockup's
+  stage surface read too bright in light theme; real idle cards have no
+  background), running-count pill number-only.
+- **#473** (PR #477): ConfigRow's Saved-tab pill follows the same number-only
+  language.
+- **#469**: the x-ray segment fused into ONE capsule with Inspect
+  (canvas-picked option A; owner: "we should be calling it X-Ray — that's the
+  feature"), brand family, X-RAY label on the control, user-facing casing
+  unified. Review round dropped the capsule's overflow-hidden — `.focus-ring`
+  is an outward box-shadow, and clipping it had left keyboard focus invisible
+  (end children carry inner radii instead).
+
+Canvas findings the loop itself surfaced, filed for this same release:
+**#470** (review rounds stack per superseded ready version; requirements for
+the round state machine captured on the issue), **#476** (subject-level
+complete/sign-off state; pane returns to the front page), **#478** (submit
+review races the user's own back-to-terminal click — disable until the
+auto-return lands).

--- a/src/renderer/canvas/xray-mode.ts
+++ b/src/renderer/canvas/xray-mode.ts
@@ -37,7 +37,7 @@ export const CANVAS_XRAY_MODE_OPTIONS: readonly CanvasXrayModeOption[] = [
   {
     value: 'off',
     label: 'Off',
-    title: 'X-ray off — the page behaves like a normal browser tab. Hover resolves nothing and draws nothing, and a click selects nothing.',
+    title: 'X-Ray off — the page behaves like a normal browser tab. Hover resolves nothing and draws nothing, and a click selects nothing.',
   },
   {
     value: 'stealth',
@@ -47,7 +47,7 @@ export const CANVAS_XRAY_MODE_OPTIONS: readonly CanvasXrayModeOption[] = [
   {
     value: 'on',
     label: 'On',
-    title: 'X-ray on — hovering outlines the element on the page and labels it (the default).',
+    title: 'X-Ray on — hovering outlines the element on the page and labels it (the default).',
   },
 ] as const
 

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1166,7 +1166,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   // chip agree on one glance.
   const inspectHint =
     xrayMode === 'off'
-      ? 'the page is live and plain — x-ray is off, so hovering and clicking do nothing here'
+      ? 'the page is live and plain — X-Ray is off, so hovering and clicking do nothing here'
       : xrayMode === 'stealth'
         ? 'hovering names the element in the panel and draws nothing on the page · click selects · ↑ parent · Esc clears'
         : 'hover to inspect, click to select · ↑ parent · Esc clears'
@@ -1326,36 +1326,54 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             chip, since it only governs what Inspect does; Sketch and Region
             visibly pause both. */}
         <div className="shrink-0 flex items-center gap-1.5" role="group" aria-label="Canvas tools" data-testid="canvas-tool-chips">
-          {/* Inspect (browse) with the X-ray setting attached. */}
-          <div className="flex items-center gap-1">
+          {/* Inspect + X-Ray as ONE capsule (#469, canvas-picked option A):
+              a single bordered control, so the modes read as Inspect's own
+              setting — and the feature is NAMED on the control (owner note:
+              "we should be calling it X-Ray"). Locked to Stealth on a plan
+              (owner call, 2026-08-23) — the boxes-on-page x-ray adds nothing
+              over a document of steps, and Off would break note anchoring —
+              so the segments are shown, not hidden, but inert with a lock. */}
+          <div
+            className="flex items-stretch h-[26px] rounded-md overflow-hidden border transition-colors"
+            style={{ borderColor: inspectActive ? 'color-mix(in srgb, var(--brand) 52%, transparent)' : 'var(--border-subtle)' }}
+            data-testid="canvas-inspect-capsule"
+          >
             <button
               onClick={() => {
                 setMarqueeArmed(sessionId, false)
                 setInteractionMode(sessionId, 'browse')
               }}
               aria-pressed={inspectActive}
-              className={chipClass(inspectActive, false)}
-              style={chipStyle(inspectActive)}
+              className={`flex items-center gap-1.5 px-2.5 text-[12px] leading-none transition-colors focus-ring ${
+                inspectActive ? 'font-semibold text-[var(--brand)]' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+              }`}
+              style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 15%, transparent)' : 'color-mix(in srgb, var(--surface-panel) 60%, transparent)' }}
               title="Inspect — the content is live; hover identifies elements, click selects"
               data-testid="canvas-tool-inspect"
             >
               <ToolIcon kind="inspect" />
               Inspect
             </button>
-            {/* X-ray Off · Stealth · On (#367), attached to Inspect: it is the
-                one setting that only changes what Inspect does. Locked to
-                Stealth on a plan (owner call, 2026-08-23) — the boxes-on-page
-                x-ray adds nothing over a document of steps, and Off would break
-                note anchoring — so the segments are shown, not hidden, but
-                inert with a lock. */}
+            <span
+              aria-hidden
+              className="w-px self-stretch"
+              style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 35%, transparent)' : 'var(--border-subtle)' }}
+            />
             <div
-              className={`flex items-center rounded-md overflow-hidden border text-[11px] ${inspectPaused ? 'opacity-40' : ''}`}
-              style={{ borderColor: 'color-mix(in srgb, var(--color-teal) 40%, transparent)' }}
+              className={`flex items-center text-[11px] ${inspectPaused ? 'opacity-40' : ''}`}
+              style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 6%, transparent)' : 'color-mix(in srgb, var(--surface-panel) 60%, transparent)' }}
               role="group"
-              aria-label="Canvas x-ray hover"
+              aria-label="X-Ray mode"
               data-testid="canvas-xray-mode"
-              title={planLocked ? 'X-ray is locked to Stealth on a plan — a document of steps needs no boxes on the page, and Off would break note anchoring.' : undefined}
+              title={planLocked ? 'X-Ray is locked to Stealth on a plan — a document of steps needs no boxes on the page, and Off would break note anchoring.' : undefined}
             >
+              <span
+                className="pl-2 pr-1 text-[9px] font-bold tracking-[0.08em] leading-none"
+                style={{ color: 'var(--text-muted)' }}
+                aria-hidden
+              >
+                X-RAY
+              </span>
               {CANVAS_XRAY_MODE_OPTIONS.map((option) => {
                 const selected = xrayMode === option.value
                 return (
@@ -1364,9 +1382,9 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                     onClick={() => { if (!planLocked) setXrayMode(option.value) }}
                     aria-pressed={selected}
                     disabled={planLocked}
-                    className="px-2 py-[3px] leading-none transition-colors focus-ring disabled:cursor-default"
+                    className="px-2 self-stretch leading-none transition-colors focus-ring disabled:cursor-default"
                     style={selected
-                      ? { background: 'color-mix(in srgb, var(--color-teal) 16%, transparent)', color: 'var(--color-teal)', fontWeight: 600 }
+                      ? { background: 'color-mix(in srgb, var(--brand) 18%, transparent)', color: 'var(--brand)', fontWeight: 600 }
                       : { color: 'var(--text-secondary)' }}
                     title={option.title}
                     data-testid={`canvas-xray-${option.value}`}
@@ -1376,7 +1394,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                 )
               })}
               {planLocked && (
-                <span className="px-1.5 py-[3px] leading-none text-[10px]" style={{ color: 'var(--text-muted)' }} aria-hidden>
+                <span className="px-1.5 leading-none text-[10px]" style={{ color: 'var(--text-muted)' }} aria-hidden>
                   🔒
                 </span>
               )}

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1334,7 +1334,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
               over a document of steps, and Off would break note anchoring —
               so the segments are shown, not hidden, but inert with a lock. */}
           <div
-            className="flex items-stretch h-[26px] rounded-md overflow-hidden border transition-colors"
+            // No overflow-hidden: .focus-ring is an outward box-shadow and
+            // clipping it left keyboard focus invisible (review HIGH). The end
+            // children carry their own inner radii instead.
+            className="flex items-stretch h-[26px] rounded-md border transition-colors"
             style={{ borderColor: inspectActive ? 'color-mix(in srgb, var(--brand) 52%, transparent)' : 'var(--border-subtle)' }}
             data-testid="canvas-inspect-capsule"
           >
@@ -1344,7 +1347,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                 setInteractionMode(sessionId, 'browse')
               }}
               aria-pressed={inspectActive}
-              className={`flex items-center gap-1.5 px-2.5 text-[12px] leading-none transition-colors focus-ring ${
+              className={`flex items-center gap-1.5 px-2.5 rounded-l-[5px] text-[12px] leading-none transition-colors focus-ring ${
                 inspectActive ? 'font-semibold text-[var(--brand)]' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
               }`}
               style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 15%, transparent)' : 'color-mix(in srgb, var(--surface-panel) 60%, transparent)' }}
@@ -1360,7 +1363,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
               style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 35%, transparent)' : 'var(--border-subtle)' }}
             />
             <div
-              className={`flex items-center text-[11px] ${inspectPaused ? 'opacity-40' : ''}`}
+              className={`flex items-center rounded-r-[5px] text-[11px] ${inspectPaused ? 'opacity-40' : ''}`}
               style={{ background: inspectActive ? 'color-mix(in srgb, var(--brand) 6%, transparent)' : 'color-mix(in srgb, var(--surface-panel) 60%, transparent)' }}
               role="group"
               aria-label="X-Ray mode"
@@ -1369,7 +1372,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             >
               <span
                 className="pl-2 pr-1 text-[9px] font-bold tracking-[0.08em] leading-none"
-                style={{ color: 'var(--text-muted)' }}
+                style={{ color: 'var(--text-secondary)' }}
                 aria-hidden
               >
                 X-RAY
@@ -1382,7 +1385,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                     onClick={() => { if (!planLocked) setXrayMode(option.value) }}
                     aria-pressed={selected}
                     disabled={planLocked}
-                    className="px-2 self-stretch leading-none transition-colors focus-ring disabled:cursor-default"
+                    className="px-2 self-stretch rounded-none last:rounded-r-[5px] leading-none transition-colors focus-ring disabled:cursor-default"
                     style={selected
                       ? { background: 'color-mix(in srgb, var(--brand) 18%, transparent)', color: 'var(--brand)', fontWeight: 600 }
                       : { color: 'var(--text-secondary)' }}

--- a/src/renderer/components/CanvasXrayReadout.tsx
+++ b/src/renderer/components/CanvasXrayReadout.tsx
@@ -63,7 +63,7 @@ export default function CanvasXrayReadout({ hit, label, pointerOwner }: Props) {
       data-testid="canvas-xray-readout"
     >
       <div className="flex items-center gap-2">
-        <span className="font-medium text-subtext1">X-ray</span>
+        <span className="font-medium text-subtext1">X-Ray</span>
         <span className="text-[11px] text-overlay1">stealth — nothing is drawn on the page</span>
       </div>
       {hit ? (

--- a/src/renderer/tips-library.ts
+++ b/src/renderer/tips-library.ts
@@ -848,10 +848,10 @@ export const TIPS_LIBRARY: Tip[] = [
     requires: ['canvas.opened'],
     variants: {
       primary: {
-        shortText: 'X-ray and zoom: inspect a render without disturbing it',
-        title: 'Canvas X-ray and Zoom',
-        body: 'The pane header carries three tool chips -- **Inspect**, **Sketch** and **Region** -- and X-ray belongs to Inspect (it only governs inspecting, so the Off/Stealth/On setting rides that chip):\n\n**X-ray** decides what hovering does while you Inspect. **On** outlines and labels the element under the pointer (the default). **Stealth** still identifies it -- the identity and box are read out in the panel -- but draws nothing on the page, so a hover-sensitive design stays undisturbed. **Off** makes the page behave like a normal browser tab. Plan pages lock to Stealth: the flow itself is the picture, and boxes on top of it were noise.\n\n**Zoom** is **Ctrl+wheel** anywhere over the pane -- chrome, render or notes panel. The level shows in the header while you are zoomed and holds for as long as the pane is open, so a dense mockup can be read at 150% without asking the agent to render it bigger.',
-        focusHint: 'Canvas pane header -- the Inspect chip (X-ray rides it) and the zoom readout',
+        shortText: 'X-Ray and zoom: inspect a render without disturbing it',
+        title: 'Canvas X-Ray and Zoom',
+        body: 'The pane header carries three tool chips -- **Inspect**, **Sketch** and **Region** -- and X-Ray belongs to Inspect (it only governs inspecting, so the Off/Stealth/On setting rides that chip):\n\n**X-Ray** decides what hovering does while you Inspect. **On** outlines and labels the element under the pointer (the default). **Stealth** still identifies it -- the identity and box are read out in the panel -- but draws nothing on the page, so a hover-sensitive design stays undisturbed. **Off** makes the page behave like a normal browser tab. Plan pages lock to Stealth: the flow itself is the picture, and boxes on top of it were noise.\n\n**Zoom** is **Ctrl+wheel** anywhere over the pane -- chrome, render or notes panel. The level shows in the header while you are zoomed and holds for as long as the pane is open, so a dense mockup can be read at 150% without asking the agent to render it bigger.',
+        focusHint: 'Canvas pane header -- the Inspect chip (X-Ray rides it) and the zoom readout',
       },
     },
   },

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -421,17 +421,6 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     expect(overlay().textContent).not.toContain('button "Save"')
   })
 
-  it('#469: Inspect and X-Ray are one fused capsule, and the feature is named on it', async () => {
-    await renderPane('on')
-    const capsule = container.querySelector('[data-testid="canvas-inspect-capsule"]')!
-    expect(capsule, 'the fused capsule').toBeTruthy()
-    // Both halves live INSIDE the one bordered control...
-    expect(capsule.querySelector('[data-testid="canvas-tool-inspect"]')).toBeTruthy()
-    expect(capsule.querySelector('[data-testid="canvas-xray-mode"]')).toBeTruthy()
-    // ...and the segment carries the feature's name.
-    expect(capsule.textContent).toContain('X-RAY')
-  })
-
   it('says in the mode strip that hovering and clicking do nothing', async () => {
     await renderPane('off')
     expect(container.textContent).toContain('X-Ray is off')
@@ -612,6 +601,17 @@ describe('a request the frame never acknowledged', () => {
 })
 
 describe('the redesigned chrome (item C)', () => {
+  it('#469: Inspect and X-Ray are one fused capsule, and the feature is named on it', async () => {
+    await renderPane('on')
+    const capsule = container.querySelector('[data-testid="canvas-inspect-capsule"]')!
+    expect(capsule, 'the fused capsule').toBeTruthy()
+    // Both halves live INSIDE the one bordered control...
+    expect(capsule.querySelector('[data-testid="canvas-tool-inspect"]')).toBeTruthy()
+    expect(capsule.querySelector('[data-testid="canvas-xray-mode"]')).toBeTruthy()
+    // ...and the segment carries the feature's name.
+    expect(capsule.textContent).toContain('X-RAY')
+  })
+
   it('leads with the mode as the title, with a keel line', async () => {
     await renderPane('on')
     // A 'design' version reads as MOCKUP MODE (plan/uat are the other two).

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -421,9 +421,20 @@ describe('x-ray OFF — the page behaves like a normal browser tab', () => {
     expect(overlay().textContent).not.toContain('button "Save"')
   })
 
+  it('#469: Inspect and X-Ray are one fused capsule, and the feature is named on it', async () => {
+    await renderPane('on')
+    const capsule = container.querySelector('[data-testid="canvas-inspect-capsule"]')!
+    expect(capsule, 'the fused capsule').toBeTruthy()
+    // Both halves live INSIDE the one bordered control...
+    expect(capsule.querySelector('[data-testid="canvas-tool-inspect"]')).toBeTruthy()
+    expect(capsule.querySelector('[data-testid="canvas-xray-mode"]')).toBeTruthy()
+    // ...and the segment carries the feature's name.
+    expect(capsule.textContent).toContain('X-RAY')
+  })
+
   it('says in the mode strip that hovering and clicking do nothing', async () => {
     await renderPane('off')
-    expect(container.textContent).toContain('x-ray is off')
+    expect(container.textContent).toContain('X-Ray is off')
   })
 })
 


### PR DESCRIPTION
Closes #469. Canvas-picked **option A** with the owner's naming note ("we should be calling it X-Ray — that's the feature"): the Off/Stealth/On segment no longer floats as a detached teal pill — it fuses with the Inspect chip into ONE bordered brand-family capsule with a small X-RAY label naming the feature. Behaviour byte-identical (handlers, aria-pressed, plan-lock 🔒 shown-inert, paused dim, all five testids). User-facing X-Ray casing unified (option titles, mode strip, readout heading, tips).

Double Review: 1 fix round — HIGHs: the readout heading missed the casing sweep; the capsule's overflow-hidden clipped the outward focus-ring box-shadow leaving keyboard focus invisible (WCAG 2.4.7) — now shell radius + inner radii on end children, selected-background/radius interaction verified in the emitted CSS, mutation-tested. Re-review **PASS**. X-RAY label at --text-secondary (≈8.4:1).

Full suite 8323 passed / 730 files; typecheck clean. CONTEXT.d fragment for the rc.3 UI round rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)