### PR TITLE
fix(ui): dual-state toolbar toggles keep one size (#464)

### DIFF
--- a/src/renderer/components/AgentCanvasButton.tsx
+++ b/src/renderer/components/AgentCanvasButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useExcalidrawStore } from '../stores/excalidrawStore'
 import { useCanvasStore } from '../stores/canvasStore'
+import { ReservedLabel } from './command-bar/chips'
 import { useCanvasReviewStore } from '../stores/canvasReviewStore'
 import { useCanvasTotalsStore } from '../stores/canvasTotalsStore'
 import { useCanvasQueue } from '../lib/canvasQueue'
@@ -117,7 +118,7 @@ export default function AgentCanvasButton({ sessionId }: Props) {
             <path d="M5 14h6" />
           </svg>
         )}
-        {label}
+        <ReservedLabel current={label} states={['Canvas', 'Terminal', { text: 'Review needed', bold: true }]} />
         {/* THE queue number (#364): ready-marked rounds + rounds awaiting your
             verdicts, across every canvas this session owns. Never decremented
             by merely opening anything — a round leaves when you submit on it,

--- a/src/renderer/components/AgentCanvasButton.tsx
+++ b/src/renderer/components/AgentCanvasButton.tsx
@@ -118,7 +118,13 @@ export default function AgentCanvasButton({ sessionId }: Props) {
             <path d="M5 14h6" />
           </svg>
         )}
-        <ReservedLabel current={label} states={['Canvas', 'Terminal', { text: 'Review needed', bold: true }]} />
+        {/* Reserve only the states a CLICK can reach: `waiting` flips on
+            queue changes, not clicks, so idle must not carry the bold
+            Review-needed width (~48px of dead space) permanently. */}
+        <ReservedLabel
+          current={label}
+          states={waiting ? ['Terminal', { text: 'Review needed', bold: true }] : ['Canvas', 'Terminal']}
+        />
         {/* THE queue number (#364): ready-marked rounds + rounds awaiting your
             verdicts, across every canvas this session owns. Never decremented
             by merely opening anything — a round leaves when you submit on it,

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -29,7 +29,7 @@ import CapturedRunModal from './CapturedRunModal'
 import { scheduleBleedRepaints } from './terminal/repaintRegistry'
 import { getCachedProbe, setCachedProbe } from '../lib/gui-exe-probe-cache'
 import type { ExeProbeResult } from '../../shared/gui-exe'
-import { CommandChip, TargetMark, SectionLabel, CHIP_CLASS, CHIP_STYLE } from './command-bar/chips'
+import { CommandChip, TargetMark, SectionLabel, ReservedLabel, CHIP_CLASS, CHIP_STYLE } from './command-bar/chips'
 import BandOverflow from './command-bar/BandOverflow'
 import ArgsPopover from './command-bar/ArgsPopover'
 import SectionNameInput from './command-bar/SectionNameInput'
@@ -781,7 +781,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
               ) : (
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="7 8 3 12 7 16" /><polyline points="17 8 21 12 17 16" /><line x1="14" y1="4" x2="10" y2="20" /></svg>
               )}
-              {isPartnerActive ? (caps.agentName || 'Terminal') : 'Partner'}
+              <ReservedLabel current={isPartnerActive ? (caps.agentName || 'Terminal') : 'Partner'} states={[caps.agentName || 'Terminal', 'Partner']} />
               {caps.panesOnDifferentMachines && (
                 <span className="rounded px-1 text-[7.5px] font-bold uppercase tracking-wide leading-[11px] border" style={{ background: 'var(--surface-overlay)', borderColor: 'var(--border-strong)', color: 'var(--text-secondary)' }} data-testid="command-machine-badge">this PC</span>
               )}

--- a/src/renderer/components/ScreenshotButton.tsx
+++ b/src/renderer/components/ScreenshotButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useMagicButtonStore } from '../stores/magicButtonStore'
 import WindowPickerModal from './WindowPickerModal'
+import { ReservedLabel } from './command-bar/chips'
 import { sendImageToSession } from '../utils/imageTransfer'
 
 interface Props {
@@ -86,7 +87,7 @@ export default function ScreenshotButton({ sessionId, sessionType }: Props) {
             <rect x="2" y="9" width="5" height="5" rx="0.5" />
             <rect x="9" y="9" width="5" height="5" rx="0.5" />
           </svg>
-          {capturing ? '...' : 'Snap'}
+          <ReservedLabel current={capturing ? '...' : 'Snap'} states={['...', 'Snap']} />
         </button>
 
         {showDropdown && dropdownPos && (

--- a/src/renderer/components/WebviewButton.tsx
+++ b/src/renderer/components/WebviewButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useWebviewStore } from '../stores/webviewStore'
 import { trackUsage } from '../stores/tipsStore'
+import { ReservedLabel } from './command-bar/chips'
 
 interface Props {
   sessionId: string
@@ -109,7 +110,7 @@ export default function WebviewButton({ sessionId }: Props) {
           <circle cx="5.5" cy="4.25" r="0.5" fill="currentColor" />
         </svg>
       )}
-      <span>{isOpen ? 'Terminal' : 'Browser'}</span>
+      <ReservedLabel current={isOpen ? 'Terminal' : 'Browser'} states={['Terminal', 'Browser']} />
       {/* The dot only appears while a watch has something to say. A plain
           grey dot on an idle button was a status indicator for no status. */}
       {watching && (

--- a/src/renderer/components/command-bar/chips.tsx
+++ b/src/renderer/components/command-bar/chips.tsx
@@ -9,6 +9,34 @@ import { chipTitle, clusterTitle, effectiveKind, type ClusterKind } from './layo
 export const CHIP_CLASS = 'flex items-center gap-1.5 px-2 h-7 text-xs rounded-md border whitespace-nowrap shrink-0 transition-colors duration-150 focus-ring'
 export const CHIP_STYLE: React.CSSProperties = { background: 'var(--surface-raised)', color: 'var(--text-secondary)', borderColor: 'var(--border-subtle)' }
 
+/** #464: a toggle label that reserves the width of its WIDEST state, so a
+ *  dual-state button never changes size on click (owner: jarring row
+ *  reflows). Every state renders invisibly stacked in one grid cell; the
+ *  current one shows. A state that renders bold reserves its BOLD width. */
+export function ReservedLabel({ current, states }: {
+  current: React.ReactNode
+  states: Array<string | { text: string; bold?: boolean }>
+}) {
+  return (
+    <span className="grid justify-items-start" data-testid="reserved-label">
+      {states.map((s) => {
+        const text = typeof s === 'string' ? s : s.text
+        const bold = typeof s !== 'string' && !!s.bold
+        return (
+          <span
+            key={`${text}${bold ? '#bold' : ''}`}
+            className={`col-start-1 row-start-1 invisible whitespace-nowrap ${bold ? 'font-semibold' : ''}`}
+            aria-hidden
+          >
+            {text}
+          </span>
+        )
+      })}
+      <span className="col-start-1 row-start-1 whitespace-nowrap" data-testid="reserved-label-current">{current}</span>
+    </span>
+  )
+}
+
 // Stroked marks, the same family as the Core tool glyphs.
 const Paths = {
   claude: 'M12 2v8.5M12 13.5V22M2 12h8.5M13.5 12H22M4.93 4.93l6.01 6.01M13.06 13.06l6.01 6.01M19.07 4.93l-6.01 6.01M10.94 13.06l-6.01 6.01',

--- a/src/renderer/components/command-bar/chips.tsx
+++ b/src/renderer/components/command-bar/chips.tsx
@@ -18,7 +18,7 @@ export function ReservedLabel({ current, states }: {
   states: Array<string | { text: string; bold?: boolean }>
 }) {
   return (
-    <span className="grid justify-items-start" data-testid="reserved-label">
+    <span className="grid justify-items-start">
       {states.map((s) => {
         const text = typeof s === 'string' ? s : s.text
         const bold = typeof s !== 'string' && !!s.bold

--- a/tests/unit/renderer/canvas-attention-pulse.test.tsx
+++ b/tests/unit/renderer/canvas-attention-pulse.test.tsx
@@ -126,7 +126,7 @@ describe('the Canvas button (pick B)', () => {
     useCanvasStore.getState().markUnseenRender(SID)
     const container = await render()
     expect(container.querySelector('[data-testid="canvas-attention-dot"]')).toBeNull()
-    expect(container.textContent).toContain('Canvas')
+    expect(container.querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Canvas')
   })
 
   /** The live mirror as the hydrated refresh would leave it. Seeded directly so
@@ -156,7 +156,7 @@ describe('the Canvas button (pick B)', () => {
     seedAwaiting()
     const container = await render()
     const button = container.querySelector('[data-testid="canvas-button"]') as HTMLButtonElement
-    expect(button.textContent).toContain('Review needed')
+    expect(button.querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Review needed')
     expect(button.dataset.waiting).toBe('true')
     expect(container.querySelector('[data-testid="canvas-queue-count"]')?.textContent).toBe('1')
   })

--- a/tests/unit/renderer/canvas-attention-pulse.test.tsx
+++ b/tests/unit/renderer/canvas-attention-pulse.test.tsx
@@ -164,8 +164,10 @@ describe('the Canvas button (pick B)', () => {
   it('with nothing owed the button is furniture again: no count, no warning label', async () => {
     const container = await render()
     const button = container.querySelector('[data-testid="canvas-button"]') as HTMLButtonElement
-    expect(button.textContent).toContain('Canvas')
-    expect(button.textContent).not.toContain('Review needed')
+    // The visible label carries the state; the width-reserving copies
+    // (#464) are aria-hidden and MAY mention other states.
+    expect(button.querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Canvas')
+    expect(button.querySelector('[data-testid="reserved-label-current"]')!.textContent).not.toContain('Review needed')
     expect(container.querySelector('[data-testid="canvas-queue-count"]')).toBeNull()
   })
 

--- a/tests/unit/renderer/canvas-open-reviews.test.tsx
+++ b/tests/unit/renderer/canvas-open-reviews.test.tsx
@@ -135,7 +135,7 @@ describe('AgentCanvasButton -- the queue pill (#364, pick B)', () => {
     seed([review('R1', 'submitted', ['a1'])], [note('a1', 'R1', 'addressed')])
     render()
     expect(pill()?.textContent).toBe('1')
-    expect(container.textContent).toContain('Review needed')
+    expect(container.querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Review needed')
   })
 
   it('a ready-marked render counts, and adds to the verdict rounds', () => {

--- a/tests/unit/renderer/canvas-open-reviews.test.tsx
+++ b/tests/unit/renderer/canvas-open-reviews.test.tsx
@@ -127,7 +127,7 @@ describe('AgentCanvasButton -- the queue pill (#364, pick B)', () => {
     seed([review('R1', 'submitted', ['a1'])], [note('a1', 'R1', 'open')])
     render()
     expect(pill()).toBeNull()
-    expect(container.textContent).not.toContain('Review needed')
+    expect(container.querySelector('[data-testid="reserved-label-current"]')!.textContent).not.toContain('Review needed')
   })
 
   it('a round waiting on YOU shows from ONE — every addressed note wants a verdict', () => {

--- a/tests/unit/renderer/webview-button-always-there.test.tsx
+++ b/tests/unit/renderer/webview-button-always-there.test.tsx
@@ -40,7 +40,7 @@ describe('always rendered, always clickable', () => {
   it('renders with no webview command at all, reads "Browser", is enabled, shows no status dot', () => {
     render()
     expect(btn()).not.toBeNull()
-    expect(btn().textContent).toContain('Browser')
+    expect(btn().querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Browser')
     expect(btn().disabled).toBe(false)
     expect(btn().getAttribute('data-watch-status')).toBe('idle')
     expect(btn().querySelector('span.rounded-full')).toBeNull()
@@ -53,10 +53,10 @@ describe('always rendered, always clickable', () => {
     render()
     act(() => { btn().click() })
     expect(useWebviewStore.getState().bySessionId['s1'].isOpen).toBe(true)
-    expect(btn().textContent).toContain('Terminal')
+    expect(btn().querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Terminal')
     act(() => { btn().click() })
     expect(useWebviewStore.getState().bySessionId['s1'].isOpen).toBe(false)
-    expect(btn().textContent).toContain('Browser')
+    expect(btn().querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Browser')
   })
   it('records webview.opened on OPEN only (closing is not discovering it)', () => {
     render()


### PR DESCRIPTION
Closes #464. The command-bar toggles (Canvas, Browser, Partner, Snap) no longer change size on click: a shared ReservedLabel stacks each CLICK-REACHABLE state invisibly in one grid cell (aria-hidden; bold states reserve bold widths), so every button sits at its widest reachable width. The Canvas button reserves conditionally — idle never carries the bold Review-needed width (that state is queue-driven, not click-driven).

Double Review: 1 fix round — HIGHs: idle dead-space trade rejected (~48px to smooth 8.5px; now conditional states, both click transitions measured exactly stable), and six label assertions had gone vacuous under the stacked copies (mutation-proven) — all six now pin the visible label via reserved-label-current, strictly stronger than before. Re-review **PASS** (both mutants re-run: 3 and 6 failures respectively — assertions bite).

Full suite 8323 passed / 730 files; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)