### PR TITLE
feat(ui): one central New button in the Saved panel, Config/Section as its menu

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -20,6 +20,24 @@ Landed so far, each through the canvas loop where the owner reviewed:
   is an outward box-shadow, and clipping it had left keyboard focus invisible
   (end children carry inner radii instead).
 
+- **#464** (PR #482): dual-state toolbar toggles keep one size — width
+  reserved for the widest state (ReservedLabel), click-reachable states only;
+  the review round un-voided six label assertions, mutation-proven.
+- **#456** (PR #484): the two-step delete confirms were double-click-defeatable
+  on all four in-place confirm surfaces (three delete + library close-out) —
+  shared `useArmedConfirm` hook: 600ms activation guard that re-arms on any
+  blocked attempt (also kills held-Enter key-repeat, which the new
+  focus-moves-to-confirm behaviour would otherwise have armed), focus no
+  longer drops to body on the swap. Review found the key-repeat ride-out;
+  follow-up #485 filed for CanvasNotesPanel's two same-shaped confirms.
+- **#483** (PR #486): the Saved tab's two creation buttons became one central
+  "+ New" button with a Config/Section menu (owner request, same morning).
+  `role="menu"` pulled Sidebar into the #360 palette guard's dialog scan —
+  joined PARTIAL_MAX at its pre-existing chrome count (52; the menu itself is
+  token-clean). Review rounds: menu no longer latches open across the Saved
+  body unmounting (tab switch / rail collapse), and the guided-tour +
+  Feature-Guide copy that still said "+ New config" now names the menu path.
+
 Canvas findings the loop itself surfaced, filed for this same release:
 **#470** (review rounds stack per superseded ready version; requirements for
 the round state machine captured on the issue), **#476** (subject-level

--- a/src/renderer/components/GuidedTour.tsx
+++ b/src/renderer/components/GuidedTour.tsx
@@ -24,13 +24,13 @@ const STEPS: TourStep[] = [
     body: 'Cloud Agents, Insights, Tokenomics, Memory, Logs and the built-in tools (Conductor MCP) all live on this rail. Each opens a full page.',
   },
   {
-    // Anchored on the always-mounted Saved TAB, not the "+ New config" button
+    // Anchored on the always-mounted Saved TAB, not the "+ New" button
     // inside it: the panel defaults to the Running tab, so a selector into the
     // Saved body would be unresolvable at tour time and available() would
     // silently skip the step that explains the app's core concept.
     selector: '[data-tour="new-config"]',
     title: 'Saved configs live here',
-    body: 'The left panel has two modes — Saved is your launcher, Running is your live sessions. A saved config is a reusable launcher: project folder, model, account. Open the Saved tab and press "+ New config" to create one, then start a session from it whenever you want (Claude or Codex, local or over SSH).',
+    body: 'The left panel has two modes — Saved is your launcher, Running is your live sessions. A saved config is a reusable launcher: project folder, model, account. Open the Saved tab, press "+ New" and pick Config to create one, then start a session from it whenever you want (Claude or Codex, local or over SSH).',
   },
   {
     // Anchored on data-tour, not aria-label: the nav button's label is dynamic

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -18,6 +18,7 @@ import { generateId } from '../utils/id'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
 import { canSwitchAccountForSession } from '../utils/sessionLaunch'
 import { useLaunchConfig } from '../hooks/useLaunchConfig'
+import { useClickOutside } from '../hooks/useClickOutside'
 import { useRegionTypography } from '../hooks/useTypography'
 import SidebarNav from './sidebar/SidebarNav'
 import ConfigRow from './sidebar/ConfigRow'
@@ -162,6 +163,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const [sessionSectionCollapsed, setSessionSectionCollapsed] = useState<Record<string, boolean>>({})
   const [groupContextMenu, setGroupContextMenu] = useState<{ groupId: string; x: number; y: number } | null>(null)
   const [showNewSectionInput, setShowNewSectionInput] = useState(false)
+  // One central + New button (#483); the menu offers Config / Section.
+  const [showNewMenu, setShowNewMenu] = useState(false)
   const [newSectionName, setNewSectionName] = useState('')
   // Two-mode left panel (design pass 2026-08-24): 'saved' is the launcher,
   // 'running' the live sessions. Replaces the #217 hover fly-out + pin
@@ -278,6 +281,8 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const sessionRenameRef = useRef<HTMLInputElement>(null)
   const sectionRenameRef = useRef<HTMLInputElement>(null)
   const newSectionInputRef = useRef<HTMLInputElement>(null)
+  const newMenuRef = useRef<HTMLDivElement>(null)
+  useClickOutside(newMenuRef, () => setShowNewMenu(false))
   // Read current collapse state inside the stable ([]) keydown effect below.
   const collapsedRef = useRef(collapsed)
   collapsedRef.current = collapsed
@@ -870,22 +875,47 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
         {/* The header icon buttons became labelled toolbar buttons here; the
             pin-panel button retired with the fly-out. The tour anchor lives on
             the Saved TAB (always mounted), not here. */}
-        <div className="px-2 pb-1.5 flex gap-1.5 shrink-0">
+        {/* One central + New button (#483) — what to create is the second
+            click's question, so the two answers live in a menu, not the row. */}
+        <div ref={newMenuRef} className="px-2 pb-1.5 flex justify-center shrink-0 relative">
           <button
-            data-testid="new-config-button"
-            onClick={() => setShowNewDialog(true)}
-            className="h-7 px-2.5 rounded-md bg-blue/20 border border-blue/45 text-blue text-[11px] font-semibold flex items-center gap-1 hover:bg-blue/30 transition-colors focus-ring"
-            title="New config (Ctrl+T)"
+            data-testid="new-button"
+            onClick={() => setShowNewMenu((v) => !v)}
+            aria-expanded={showNewMenu}
+            aria-haspopup="menu"
+            className="h-7 px-4 rounded-md bg-blue/20 border border-blue/45 text-blue text-[11px] font-semibold flex items-center gap-1 hover:bg-blue/30 transition-colors focus-ring"
+            title="New config (Ctrl+T) or section"
           >
-            <span className="font-extrabold">+</span> New config
+            <span className="font-extrabold">+</span> New
           </button>
-          <button
-            onClick={() => { setShowNewSectionInput(true); setTimeout(() => newSectionInputRef.current?.focus(), 0) }}
-            className="h-7 px-2.5 rounded-md bg-surface0 border border-surface1 text-subtext1 text-[11px] font-semibold flex items-center gap-1 hover:bg-surface1 transition-colors focus-ring"
-            title="New section"
-          >
-            <span className="font-extrabold">+</span> Section
-          </button>
+          {showNewMenu && (
+            <div
+              role="menu"
+              data-testid="new-menu"
+              className="absolute top-full left-1/2 -translate-x-1/2 z-50 rounded-lg shadow-xl py-1 min-w-[150px]"
+              style={{ background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)' }}
+            >
+              <button
+                role="menuitem"
+                data-testid="new-menu-config"
+                onClick={() => { setShowNewMenu(false); setShowNewDialog(true) }}
+                className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--surface-overlay)] transition-colors flex items-center justify-between gap-3"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                Config
+                <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>Ctrl+T</span>
+              </button>
+              <button
+                role="menuitem"
+                data-testid="new-menu-section"
+                onClick={() => { setShowNewMenu(false); setShowNewSectionInput(true); setTimeout(() => newSectionInputRef.current?.focus(), 0) }}
+                className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--surface-overlay)] transition-colors"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                Section
+              </button>
+            </div>
+          )}
         </div>
 
         {/* The scrolling launcher list — sections, groups, loose configs. */}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -283,6 +283,12 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   const newSectionInputRef = useRef<HTMLInputElement>(null)
   const newMenuRef = useRef<HTMLDivElement>(null)
   useClickOutside(newMenuRef, () => setShowNewMenu(false))
+  // The menu's DOM unmounts with the Saved body (tab switch, rail collapse) —
+  // both reachable keyboard-only, where no outside mousedown fires. Without
+  // this the state latches and the menu reappears unrequested (#483 review).
+  useEffect(() => {
+    if (panelTab !== 'saved' || collapsed) setShowNewMenu(false)
+  }, [panelTab, collapsed])
   // Read current collapse state inside the stable ([]) keydown effect below.
   const collapsedRef = useRef(collapsed)
   collapsedRef.current = collapsed

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -833,7 +833,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
           }`}
           data-testid="panel-tab-saved"
           /* The tour's "Saved configs live here" anchor: on the always-mounted
-             tab, NOT the "+ New config" button inside the Saved body — the
+             tab, NOT the "+ New" button inside the Saved body — the
              panel defaults to Running, and an unresolvable selector makes
              GuidedTour.available() silently skip the step. */
           data-tour="new-config"

--- a/src/renderer/training-steps.ts
+++ b/src/renderer/training-steps.ts
@@ -57,7 +57,7 @@ export const trainingSteps: TrainingStep[] = [
       'Local or SSH -- one config form, full Claude support either way',
     ],
     howToTrigger: [
-      { label: 'Create', value: 'Saved tab → + New config' },
+      { label: 'Create', value: 'Saved tab → + New → Config' },
       { label: 'Edit', value: 'Hover a config → pencil icon' },
       { label: 'Pin', value: 'Right-click a config → Pin to Quick Start' },
     ],
@@ -169,7 +169,7 @@ export const trainingSteps: TrainingStep[] = [
       '**Tokenomics** segments Codex spend automatically alongside Claude, per-day and per-model',
     ],
     howToTrigger: [
-      { label: 'Spawn', value: 'New config -> provider card -> Codex' },
+      { label: 'Spawn', value: '+ New -> Config -> provider card -> Codex' },
       { label: 'Auth', value: 'Settings -> Codex -> Login' },
       { label: 'Model', value: 'Edit the Codex config -> model' },
     ],

--- a/tests/e2e/model-picker.spec.ts
+++ b/tests/e2e/model-picker.spec.ts
@@ -68,9 +68,10 @@ async function openDialog() {
     await expect(page.locator('text=New saved config')).toHaveCount(0)
   }
   // Two-mode panel: open the Saved tab first (the panel defaults to Running),
-  // then the launcher's "+ New config" button.
+  // then the central "+ New" button's Config option (#483).
   await page.locator('[data-testid="panel-tab-saved"]').click()
-  await page.locator('[data-testid="new-config-button"]').click()
+  await page.locator('[data-testid="new-button"]').click()
+  await page.locator('[data-testid="new-menu-config"]').click()
   await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
 }
 

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -114,7 +114,7 @@ test.describe('Sidebar Navigation', () => {
     await expect(runningTab).toHaveAttribute('aria-selected', 'true')
   })
 
-  test('Saved tab reveals the launcher (+ New config); Running returns to sessions', async () => {
+  test('Saved tab reveals the launcher (+ New); Running returns to sessions', async () => {
     const sidebar = page.locator('aside')
     if (!await sidebar.isVisible().catch(() => false)) {
       test.skip()

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -123,7 +123,7 @@ test.describe('Sidebar Navigation', () => {
 
     await sidebar.locator('[data-testid="panel-tab-saved"]').click()
     await expect(sidebar.locator('[data-testid="saved-tab"]')).toBeVisible()
-    await expect(sidebar.locator('[data-testid="new-config-button"]')).toBeVisible()
+    await expect(sidebar.locator('[data-testid="new-button"]')).toBeVisible()
 
     await sidebar.locator('[data-testid="panel-tab-running"]').click()
     await expect(sidebar.locator('[data-testid="running-tab"]')).toBeVisible()

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -43,9 +43,10 @@ async function openDialog() {
     await expect(page.locator('text=New saved config')).toHaveCount(0)
   }
   // Two-mode panel: open the Saved tab first (the panel defaults to Running),
-  // then the launcher's "+ New config" button.
+  // then the central "+ New" button's Config option (#483).
   await page.locator('[data-testid="panel-tab-saved"]').click()
-  await page.locator('[data-testid="new-config-button"]').click()
+  await page.locator('[data-testid="new-button"]').click()
+  await page.locator('[data-testid="new-menu-config"]').click()
   await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
 }
 

--- a/tests/e2e/session-restore.spec.ts
+++ b/tests/e2e/session-restore.spec.ts
@@ -186,9 +186,10 @@ test('fail-open: a CORRUPT primary with NO usable .bak boots clean (no wedge, no
 /** Create + launch a Terminal x Local session named SESSION_NAME in workDir. */
 async function createTerminalSession(page: Page): Promise<void> {
   // Two-mode panel: open the Saved tab first (the panel defaults to Running),
-  // then the launcher's "+ New config" button.
+  // then the central "+ New" button's Config option (#483).
   await page.locator('[data-testid="panel-tab-saved"]').click()
-  await page.locator('[data-testid="new-config-button"]').click()
+  await page.locator('[data-testid="new-button"]').click()
+  await page.locator('[data-testid="new-menu-config"]').click()
   await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
 
   await page

--- a/tests/unit/renderer/dialog-palette-retired.test.ts
+++ b/tests/unit/renderer/dialog-palette-retired.test.ts
@@ -136,6 +136,10 @@ const PARTIAL_MAX: Record<string, { max: number; what: string }> = {
     max: 3,
     what: 'the account overflow popover (already on E5; the hits are footer chrome)',
   },
+  'components/Sidebar.tsx': {
+    max: 52,
+    what: 'the + New menu (#483) — the menu itself is token-clean (role="menu" is what pulled the file in); the hits are the surrounding sidebar chrome, out of #360\'s dialog scope',
+  },
 }
 
 const EXCLUDED = new Set([

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -30,6 +30,9 @@ vi.mock('../../../src/renderer/stores/cloudAgentStore', () => ({ useCloudAgentSt
 vi.mock('../../../src/renderer/stores/conductorMcpStore', () => ({ useConductorMcpStore: (sel: any) => sel({ browserRunning: false, serverRunning: true }) }))
 vi.mock('../../../src/renderer/stores/appMetaStore', () => ({ useAppMetaStore: (sel: any) => sel({ meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }) }))
 ;(globalThis as any).window.electronAPI = { update: { check: () => Promise.resolve(false), onAvailable: () => () => {}, getVersion: () => Promise.resolve('') } }
+// The New menu's Config action opens the real dialog — heavy and store-hungry;
+// the menu's own behaviour is what's under test.
+vi.mock('../../../src/renderer/components/SessionDialog', () => ({ default: () => React.createElement('div', { 'data-testid': 'session-dialog' }) }))
 
 const { default: Sidebar } = await import('../../../src/renderer/components/Sidebar')
 
@@ -70,12 +73,36 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     expect(tabs().saved!.getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('[data-testid="saved-tab"]')).toBeTruthy()
     expect(container.querySelector('[data-testid="running-tab"]')).toBeNull()
-    const newConfig = container.querySelector('[data-testid="new-config-button"]')
-    expect(newConfig).toBeTruthy()
-    expect(newConfig!.textContent).toMatch(/new config/i)
-    // The old fly-out disclosure is gone with the overlay it opened.
-    const disclosure = Array.from(container.querySelectorAll('button')).find(b => b.getAttribute('aria-expanded') !== null)
-    expect(disclosure).toBeUndefined()
+    // One central + New button (#483): the two creations live in its menu.
+    const newButton = container.querySelector('[data-testid="new-button"]')
+    expect(newButton).toBeTruthy()
+    expect(newButton!.textContent).toMatch(/new/i)
+    expect(container.querySelector('[data-testid="new-menu"]')).toBeNull()
+    // The old fly-out disclosure stays gone — the only expander is the New menu button.
+    const disclosures = Array.from(container.querySelectorAll('button')).filter(b => b.getAttribute('aria-expanded') !== null)
+    expect(disclosures).toEqual([newButton])
+  })
+
+  it('the New menu offers Config and Section, and each option does its job (#483)', () => {
+    render()
+    act(() => { tabs().saved!.click() })
+    const newButton = () => container.querySelector('[data-testid="new-button"]') as HTMLButtonElement
+
+    act(() => { newButton().click() })
+    expect(newButton().getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-testid="new-menu-config"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="new-menu-section"]')).toBeTruthy()
+
+    // Section: menu closes, the inline section-name input appears.
+    act(() => { (container.querySelector('[data-testid="new-menu-section"]') as HTMLButtonElement).click() })
+    expect(container.querySelector('[data-testid="new-menu"]')).toBeNull()
+    expect(container.querySelector('input[placeholder="Section name"]')).toBeTruthy()
+
+    // Config: menu closes, the New Config dialog opens.
+    act(() => { newButton().click() })
+    act(() => { (container.querySelector('[data-testid="new-menu-config"]') as HTMLButtonElement).click() })
+    expect(container.querySelector('[data-testid="new-menu"]')).toBeNull()
+    expect(container.querySelector('[data-testid="session-dialog"]')).toBeTruthy()
   })
 
   it('clicking Running returns to the session list', () => {

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -28,7 +28,15 @@ vi.mock('../../../src/renderer/stores/configStore', () => {
 vi.mock('../../../src/renderer/stores/insightsStore', () => ({ useInsightsStore: (sel: any) => sel({ status: null, statusMessage: null }) }))
 vi.mock('../../../src/renderer/stores/cloudAgentStore', () => ({ useCloudAgentStore: (sel: any) => sel({ agents: [] }) }))
 vi.mock('../../../src/renderer/stores/conductorMcpStore', () => ({ useConductorMcpStore: (sel: any) => sel({ browserRunning: false, serverRunning: true }) }))
-vi.mock('../../../src/renderer/stores/appMetaStore', () => ({ useAppMetaStore: (sel: any) => sel({ meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }) }))
+vi.mock('../../../src/renderer/stores/appMetaStore', () => {
+  // getState included: Sidebar's document-level keydown handler (Ctrl+T
+  // suppression during onboarding) reads it, and the menu-dismissal test
+  // dispatches real keydowns at the document.
+  const STATE = { meta: { hasCreatedFirstConfig: true, firstRunCardDismissed: true }, update: () => {} }
+  const useAppMetaStore: any = (sel: any) => sel(STATE)
+  useAppMetaStore.getState = () => STATE
+  return { useAppMetaStore }
+})
 ;(globalThis as any).window.electronAPI = { update: { check: () => Promise.resolve(false), onAvailable: () => () => {}, getVersion: () => Promise.resolve('') } }
 // The New menu's Config action opens the real dialog — heavy and store-hungry;
 // the menu's own behaviour is what's under test.
@@ -83,7 +91,7 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     expect(disclosures).toEqual([newButton])
   })
 
-  it('the New menu offers Config and Section, and each option does its job (#483)', () => {
+  it('the New menu offers Config and Section, and each option does its job (#483)', async () => {
     render()
     act(() => { tabs().saved!.click() })
     const newButton = () => container.querySelector('[data-testid="new-button"]') as HTMLButtonElement
@@ -93,16 +101,48 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     expect(container.querySelector('[data-testid="new-menu-config"]')).toBeTruthy()
     expect(container.querySelector('[data-testid="new-menu-section"]')).toBeTruthy()
 
-    // Section: menu closes, the inline section-name input appears.
+    // Section: menu closes, the inline section-name input appears and takes
+    // focus (the focus hop rides a setTimeout(0) — flush it before asserting).
     act(() => { (container.querySelector('[data-testid="new-menu-section"]') as HTMLButtonElement).click() })
     expect(container.querySelector('[data-testid="new-menu"]')).toBeNull()
-    expect(container.querySelector('input[placeholder="Section name"]')).toBeTruthy()
+    const sectionInput = container.querySelector('input[placeholder="Section name"]')
+    expect(sectionInput).toBeTruthy()
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)) })
+    expect(document.activeElement).toBe(sectionInput)
 
     // Config: menu closes, the New Config dialog opens.
     act(() => { newButton().click() })
     act(() => { (container.querySelector('[data-testid="new-menu-config"]') as HTMLButtonElement).click() })
     expect(container.querySelector('[data-testid="new-menu"]')).toBeNull()
     expect(container.querySelector('[data-testid="session-dialog"]')).toBeTruthy()
+  })
+
+  it('the New menu dismisses on outside mousedown, Escape, and tab switch (#483)', () => {
+    render()
+    act(() => { tabs().saved!.click() })
+    const newButton = () => container.querySelector('[data-testid="new-button"]') as HTMLButtonElement
+    const menu = () => container.querySelector('[data-testid="new-menu"]')
+
+    // Outside mousedown (useClickOutside listens on mousedown, not click).
+    act(() => { newButton().click() })
+    expect(menu()).toBeTruthy()
+    act(() => { document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })) })
+    expect(menu()).toBeNull()
+
+    // Escape.
+    act(() => { newButton().click() })
+    expect(menu()).toBeTruthy()
+    act(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })) })
+    expect(menu()).toBeNull()
+
+    // Leaving the Saved body (keyboard-only path — no mousedown fires): the
+    // state must not latch and resurface the menu unrequested on return.
+    act(() => { newButton().click() })
+    expect(menu()).toBeTruthy()
+    act(() => { tabs().running!.click() })
+    act(() => { tabs().saved!.click() })
+    expect(menu()).toBeNull()
+    expect(newButton().getAttribute('aria-expanded')).toBe('false')
   })
 
   it('clicking Running returns to the session list', () => {

--- a/tests/unit/renderer/sidebar-panel-tabs.test.ts
+++ b/tests/unit/renderer/sidebar-panel-tabs.test.ts
@@ -75,7 +75,7 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     expect(container.querySelector('[data-testid="saved-tab"]')).toBeNull()
   })
 
-  it('clicking Saved switches mode: the launcher (search + New config) replaces the session list', () => {
+  it('clicking Saved switches mode: the launcher (search + New) replaces the session list', () => {
     render()
     act(() => { tabs().saved!.click() })
     expect(tabs().saved!.getAttribute('aria-selected')).toBe('true')
@@ -143,6 +143,13 @@ describe('Sidebar panel tabs (two-mode left panel)', () => {
     act(() => { tabs().saved!.click() })
     expect(menu()).toBeNull()
     expect(newButton().getAttribute('aria-expanded')).toBe('false')
+
+    // Same latch via the other keyboard-only unmount: collapsing to the rail.
+    act(() => { newButton().click() })
+    expect(menu()).toBeTruthy()
+    act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {}, collapsed: true } as any)))
+    act(() => root.render(React.createElement(Sidebar, { currentView: 'sessions', onViewChange: () => {} } as any)))
+    expect(menu()).toBeNull()
   })
 
   it('clicking Running returns to the session list', () => {


### PR DESCRIPTION
Fixes #483 (owner request 2026-08-25, screenshot on the issue).

The Saved tab's two side-by-side buttons — `+ New config` and `+ Section` — become **one centered `+ New` button**; clicking it opens a small menu with the two options:

- **Config** (with the Ctrl+T hint; Ctrl+T itself still opens the dialog directly)
- **Section** (closes the menu, opens the inline section-name input, focuses it)

Details:
- Menu follows the established ConfigContextMenu recipe (`--surface-raised` / `--border-subtle` / `--surface-overlay` tokens), `role="menu"`/`menuitem`, `aria-expanded`/`aria-haspopup` on the button, click-outside + Escape dismiss via the existing `useClickOutside` hook.
- `role="menu"` pulls `Sidebar.tsx` into the #360 palette guard's broad dialog scan; the file joins `PARTIAL_MAX` at its current chrome count (52) with a reason — the new menu itself is token-clean and adds zero palette hits, so the ceiling polices regressions exactly as designed.
- Testids: `new-button`, `new-menu`, `new-menu-config`, `new-menu-section` (`new-config-button` is gone). The four e2e specs that used it now click New → Config; the sidebar unit suite pins the menu contract (opens, both options work, the only `aria-expanded` control in Saved is this button).

Full unit run: 8331 passed; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)