### PR TITLE
fix(logging): durable, cross-safe session-conversation tracking (#480)

### DIFF
--- a/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
+++ b/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
@@ -39,4 +39,31 @@ tests updated for the new `bindOnce` arg and the durable-first handler.
 **Gates.** Touches PTY resume + IPC -> /adversarial-review required before merge
 (ADR-009). Human approval + desktop test before merge.
 
+### Adversarial review (round 1) -- verdict PASS after fixes
+
+Four independent attacker lenses (injection, cross/ownership, blast-radius,
+design/coverage/platform). Injection: NONE (uuid triple-validated by anchored
+UUID_RE before argv; cwd quote-escaped + existence-gated; SQL parameterized).
+
+One MAJOR found and fixed: the durable table accumulated one row per session and
+was read on resume keyed only by sessionId, so after an app restart two cards
+could both resume the same uuid. Fix: `upsertSessionConversation` runs in a
+transaction that evicts every OTHER session's row for the same uuid first --
+one uuid maps to at most one durable session (handoff transfers ownership).
+
+Two LOW fixes: (1) the ownership-refusal check now runs BEFORE `cancelHeuristic`,
+so a refused bind keeps its heuristic fallback armed; (2) `getResumeTarget`
+prefers the LIVE exact bind and falls back to the durable record only after a
+restart, closing a /clear-then-quit staleness window.
+
+Intended trade-off (documented, not fixed): a session that NEVER received an
+exact hook bind (hooks disabled / gateway bind failure) loses app-relaunch resume
+-- the heuristic net is deliberately removed from the resume path because it is
+the exact source of the cross. Default config (hooks on) is unaffected.
+
+Re-attack (round 2, two fresh lenses): PASS -- MAJOR proven closed (attacker
+reverted the eviction, saw the guard test fail, restored), reorder proven to hold
+rotation / dedupe / refusal / heuristic invariants. Regression tests added for
+every fix (fail-on-revert verified).
+
 **Ref:** #480.

--- a/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
+++ b/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
@@ -1,0 +1,42 @@
+## 2026-08-25 -- #480 durable, cross-safe session->conversation tracking
+
+**Problem.** When several cards run in one repo directory, an in-session Restart
+could resume a SIBLING card's Claude conversation. Root cause: the transcript
+binder's heuristic fallback (`transcript-discovery.ts` `bindOnce`) scans the
+shared mangled-cwd project folder and picks the newest `.jsonl`, which can belong
+to another live card; `getLatestTranscriptPath` then fed that into the restart
+resume in `pty-manager.ts`. Evidence: one run was attributed three overlapping
+transcripts (two written concurrently) -- impossible for a single session.
+
+**Fix (fix-forward, four parts).**
+
+1. Exact-only resume. New `binder.getExactResumeTarget(sessionId)` returns the
+   bound path ONLY when the bind is EXACT (authenticated hook / statusline).
+   `pty-manager` restart capture now uses it instead of `getLatestTranscriptPath`
+   -- a heuristic guess is never a resume source. No exact bind => `resume=none`
+   (fresh start), which is safer than reopening a stranger.
+2. Ownership guard. The binder keeps a uuid->sessionId reverse index for exact
+   binds. A second LIVE session cannot steal a uuid another live session owns
+   (the bind is refused); the reservation releases on `endRun` / on a /clear
+   rotation so a genuine handoff still re-binds.
+3. Heuristic exclusion. `bindOnce` takes an `excludeUuids` set; the binder passes
+   the uuids owned by OTHER live sessions so the newest-file scan skips them.
+4. Durable map. New `session_conversation(sessionId PK, uuid, path, confidence,
+   updatedAt)` table in `transcripts.db`, upserted on every exact bind via a new
+   worker message. `resume-handlers` `getResumeTarget` now reads the durable
+   record first, then the live exact bind -- one crash-durable source for both
+   the close-all relaunch path and in-session restart.
+
+**Not changed.** The app-relaunch resume via persisted `resumeUuid`
+(`buildSessionStateWithResumeTargets`) already worked; it now shares the same
+exact-only source.
+
+**Tests.** New `transcript-binder-ownership.test.ts` (exact-only, ownership
+guard, handoff, heuristic exclusion, /clear rotation); discovery exclusion cases;
+`transcripts-db.native.test.ts` durable-map cases. Existing binder + resume-IPC
+tests updated for the new `bindOnce` arg and the durable-first handler.
+
+**Gates.** Touches PTY resume + IPC -> /adversarial-review required before merge
+(ADR-009). Human approval + desktop test before merge.
+
+**Ref:** #480.

--- a/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
+++ b/CONTEXT.d/2026-08-25-480-durable-conversation-tracking.md
@@ -66,4 +66,31 @@ reverted the eviction, saw the guard test fail, restored), reorder proven to hol
 rotation / dedupe / refusal / heuristic invariants. Regression tests added for
 every fix (fail-on-revert verified).
 
+### Hooks-off fallback + adversarial round 2 (BLOCKER + MAJOR)
+
+Added a fallback (user-requested): when hooks are OFF no exact bind can arrive,
+so the resume paths fall back to the heuristic bind AND warn -- best-effort
+resume for a config with no authenticated source. Gated by a new
+`isExactBindSourceActive()` in `src/main/hooks/index.ts`.
+
+A focused attacker on that gate found two holes, both fixed:
+
+- BLOCKER: a SECOND enrichment path (`session-resume-enrich.ts`, wired in
+  `index.ts`, the `session:save` / exit-flush choke point) still stamped
+  resumeUuid from the heuristic `getLatestTranscriptPath` with NO gate, and
+  OVERWROTE the renderer's gated value -- so the same-repo cross survived on the
+  relaunch path even with hooks on. Fix: route that path through
+  `getExactResumeTarget` + the same gated heuristic fallback.
+- MAJOR: `isExactBindSourceActive()` keyed on the live `gateway.listening` flag,
+  which blips false during gateway startup / crash-backoff / manual restart, so
+  the fallback unlocked in the default (hooks-on) config during those windows.
+  Fix: key ONLY on the `hooksEnabled` SETTING.
+
+Round-2 re-attack after the fixes: PASS. One MINOR (documented, by design): a
+permanently-failed gateway with hooks ON gives fresh resume rather than a
+heuristic guess -- fails safe, and the durable table still recovers any session
+that achieved an exact bind once. Regression tests: `exact-bind-gate.test.ts`,
+`enrich-cross-attack-480.test.ts`, plus hooks-on/off cases in
+`session-resume-enrich.test.ts` and `resume-ipc-handlers.test.ts`.
+
 **Ref:** #480.

--- a/src/main/hooks/index.ts
+++ b/src/main/hooks/index.ts
@@ -1,5 +1,6 @@
 import type { HookEvent, HooksGatewayStatus } from '../../shared/hook-types'
 import type { RingBufferEntry } from './hooks-types'
+import { readConfig } from '../config-manager'
 
 /** The gateway surface consumers use via getGateway(). Implemented by both the
  *  in-process HooksGateway and the out-of-process HooksGatewayProxy, so either can
@@ -23,6 +24,31 @@ export function setGateway(gw: HooksGatewayLike): void {
 
 export function getGateway(): HooksGatewayLike | null {
   return singleton
+}
+
+/**
+ * #480: can an EXACT transcript bind ever arrive for a session? Keyed ONLY on the
+ * `hooksEnabled` SETTING — not the live `gateway.status().listening`, which blips
+ * false during gateway startup / crash-backoff / manual restart. Keying on the
+ * transient flag would unlock the cross-prone heuristic fallback in the DEFAULT
+ * (hooks-on) config during those windows (adversarial round 2, MAJOR). When hooks
+ * are enabled, an authenticated SessionStart hook WILL report the transcript_path
+ * once the gateway settles, so the resume paths stay exact-only (no cross).
+ *
+ * When this is FALSE (hooks disabled by the user) no exact bind can ever arrive,
+ * so the resume paths fall back to the heuristic (newest-file) bind AND warn:
+ * best-effort resume that can cross if several cards share one repo folder — the
+ * deliberate trade for a config that has no authenticated source at all.
+ *
+ * Edge case (by design): if hooks are ENABLED but the gateway can NEVER bind
+ * (e.g. a permanently-taken port), an exact bind never arrives yet this stays
+ * TRUE, so such a session gets a FRESH resume rather than a heuristic guess. That
+ * fails safe (never a cross) and is preferred over reintroducing the race; after
+ * an app restart the durable session_conversation table still recovers any
+ * session that achieved an exact bind at least once.
+ */
+export function isExactBindSourceActive(): boolean {
+  return readConfig<{ hooksEnabled?: boolean }>('settings')?.hooksEnabled !== false
 }
 
 export { HooksGateway } from './hooks-gateway'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,7 +74,7 @@ import { readClipboardImageWithRetry } from './clipboard-image'
 import { readClipboardTextWithRetry } from './clipboard-text'
 import { readClipboardImageFilePath, type PasteableImage } from './clipboard-file'
 import { HooksGateway } from './hooks/hooks-gateway'
-import { setGateway, getGateway } from './hooks'
+import { setGateway, getGateway, isExactBindSourceActive } from './hooks'
 import { ServiceSupervisor } from './services/service-supervisor'
 import { forkHooksChild } from './services/fork-hooks-child'
 import { start as startLoopStallMonitor, stop as stopLoopStallMonitor } from './services/loop-stall-monitor'
@@ -119,7 +119,13 @@ installGlobalErrorHandlers()
 // binder is read lazily per call — it may init after this module loads.
 const sessionDurability = createSessionDurability({
   enrichDeps: {
+    // #480: exact bind is the source of truth; the heuristic path is used only as
+    // the hooks-off fallback (gated by isExactBindSourceActive) so this main-side
+    // enrichment can never persist a cross-prone heuristic guess in the default
+    // (hooks-on) config — matching the resume-handlers IPC.
+    getExactResumeTarget: (id) => getTranscriptBinder()?.getExactResumeTarget(id) ?? null,
     getLatestTranscriptPath: (id) => getTranscriptBinder()?.getLatestTranscriptPath(id) ?? null,
+    isExactBindSourceActive,
     resolveResumeTargetFromTranscript,
   },
   save: saveSessionState,

--- a/src/main/ipc/resume-handlers.ts
+++ b/src/main/ipc/resume-handlers.ts
@@ -14,6 +14,8 @@ import { z } from 'zod'
 import { IPC } from '../../shared/ipc-channels'
 import { getTranscriptBinder, getLogSupervisor } from '../logging/logging-service'
 import { resolveResumeTargetFromTranscript } from '../logging/transcript-discovery'
+import { isExactBindSourceActive } from '../hooks'
+import { logWarn } from '../debug-logger'
 
 const sessionIdSchema = z.string().min(1).max(200)
 
@@ -45,6 +47,17 @@ export function registerResumeHandlers(): void {
           if (row?.path) path = row.path
         } catch {
           /* durable lookup is best-effort; a miss simply yields null (fresh) */
+        }
+      }
+      // #480 hooks-off fallback: when no EXACT source can arrive (hooks disabled
+      // or gateway down), fall back to the heuristic bind and WARN, so a
+      // hooks-off user still gets app-relaunch resume. Best-effort: it can cross
+      // if several cards share one repo folder — the trade the exact-only path
+      // makes for the default (hooks-on) config.
+      if (!path && !isExactBindSourceActive()) {
+        path = getTranscriptBinder()?.getLatestTranscriptPath(sessionId) ?? null
+        if (path) {
+          logWarn(`[resume] #480 hooks-off fallback for ${sessionId}: hooks inactive, using heuristic bind (best-effort; may cross if multiple cards share this repo)`)
         }
       }
       if (!path) return null

--- a/src/main/ipc/resume-handlers.ts
+++ b/src/main/ipc/resume-handlers.ts
@@ -29,17 +29,24 @@ export function registerResumeHandlers(): void {
     try {
       sessionIdSchema.parse(sessionId)
       let path: string | null = null
-      // Prefer the durable record.
-      try {
-        const rows = await getLogSupervisor()?.query('session-conversation', { sessionId })
-        const row = rows?.[0] as { path?: string } | undefined
-        if (row?.path) path = row.path
-      } catch {
-        /* durable lookup is best-effort; fall through to the live exact bind */
+      // Prefer the LIVE exact bind. During a live session — including the
+      // graceful close-all save that enriches session-state — it is the freshest
+      // authoritative source, so a /clear rotation that has not yet flushed to
+      // the durable table cannot make us persist a staler uuid (adversarial
+      // round 1). Never getLatestTranscriptPath, which also returns heuristic
+      // binds.
+      path = getTranscriptBinder()?.getExactResumeTarget(sessionId) ?? null
+      // Fall back to the durable record — the source after an app restart, when
+      // the in-memory bind is gone.
+      if (!path) {
+        try {
+          const rows = await getLogSupervisor()?.query('session-conversation', { sessionId })
+          const row = rows?.[0] as { path?: string } | undefined
+          if (row?.path) path = row.path
+        } catch {
+          /* durable lookup is best-effort; a miss simply yields null (fresh) */
+        }
       }
-      // Fall back to the live EXACT bind (never getLatestTranscriptPath, which
-      // also returns heuristic binds).
-      if (!path) path = getTranscriptBinder()?.getExactResumeTarget(sessionId) ?? null
       if (!path) return null
       return resolveResumeTargetFromTranscript(path)
     } catch {

--- a/src/main/ipc/resume-handlers.ts
+++ b/src/main/ipc/resume-handlers.ts
@@ -12,21 +12,36 @@
 import { ipcMain } from 'electron'
 import { z } from 'zod'
 import { IPC } from '../../shared/ipc-channels'
-import { getTranscriptBinder } from '../logging/logging-service'
+import { getTranscriptBinder, getLogSupervisor } from '../logging/logging-service'
 import { resolveResumeTargetFromTranscript } from '../logging/transcript-discovery'
 
 const sessionIdSchema = z.string().min(1).max(200)
 
 export function registerResumeHandlers(): void {
-  // T8b (bug #5): resolve a session's exact-conversation resume target from the
-  // latest bound transcript. Returns {uuid,cwd} or null. Fully fail-safe (any
-  // miss => null) so the renderer's save-time enrichment simply omits the field.
+  // T8b (bug #5) + #480: resolve a session's exact-conversation resume target.
+  // Source of truth is the durable session_conversation map (survives restart /
+  // crash), written on every authenticated EXACT bind; the live EXACT bind is the
+  // fallback. A heuristic (newest-file) guess is NEVER used — that folder scan is
+  // what resumed a sibling card's conversation for same-repo sessions. Returns
+  // {uuid,cwd} or null; fully fail-safe (any miss => null) so the renderer's
+  // save-time enrichment simply omits the field.
   ipcMain.handle(IPC.LOGS_GET_RESUME_TARGET, async (_e, sessionId: string) => {
     try {
       sessionIdSchema.parse(sessionId)
-      const latest = getTranscriptBinder()?.getLatestTranscriptPath(sessionId)
-      if (!latest) return null
-      return resolveResumeTargetFromTranscript(latest)
+      let path: string | null = null
+      // Prefer the durable record.
+      try {
+        const rows = await getLogSupervisor()?.query('session-conversation', { sessionId })
+        const row = rows?.[0] as { path?: string } | undefined
+        if (row?.path) path = row.path
+      } catch {
+        /* durable lookup is best-effort; fall through to the live exact bind */
+      }
+      // Fall back to the live EXACT bind (never getLatestTranscriptPath, which
+      // also returns heuristic binds).
+      if (!path) path = getTranscriptBinder()?.getExactResumeTarget(sessionId) ?? null
+      if (!path) return null
+      return resolveResumeTargetFromTranscript(path)
     } catch {
       return null
     }

--- a/src/main/logging/log-supervisor.ts
+++ b/src/main/logging/log-supervisor.ts
@@ -285,7 +285,7 @@ export class LogSupervisor {
   /** #480: durably record the EXACT conversation a session is on (keyed by AICC
    *  sessionId). Fire-and-forget; buffered while the worker is down like every
    *  other lifecycle message. This is the authoritative source restart resume
-   *  reads back via the `resume-target-by-session` query. */
+   *  reads back via the `session-conversation` query. */
   persistSessionConversation(sessionId: string, path: string, uuid: string): void {
     this.enqueueOrSend({ type: 'session-conversation-upsert', sessionId, path, uuid, updatedAt: Date.now() })
   }

--- a/src/main/logging/log-supervisor.ts
+++ b/src/main/logging/log-supervisor.ts
@@ -64,6 +64,7 @@ type BufferedMessage =
   | Extract<ToTranscriptsWorker, { type: 'run-account' }>
   | Extract<ToTranscriptsWorker, { type: 'run-rename' }>
   | Extract<ToTranscriptsWorker, { type: 'transcript-bind' }>
+  | Extract<ToTranscriptsWorker, { type: 'session-conversation-upsert' }>
 
 interface QueuedItem {
   msg: BufferedMessage
@@ -279,6 +280,14 @@ export class LogSupervisor {
    *  starts tailing it immediately. */
   bindTranscript(sessionId: string, path: string, confidence: 'exact' | 'heuristic', sourceVersion?: string): void {
     this.enqueueOrSend({ type: 'transcript-bind', sessionId, path, confidence, sourceVersion })
+  }
+
+  /** #480: durably record the EXACT conversation a session is on (keyed by AICC
+   *  sessionId). Fire-and-forget; buffered while the worker is down like every
+   *  other lifecycle message. This is the authoritative source restart resume
+   *  reads back via the `resume-target-by-session` query. */
+  persistSessionConversation(sessionId: string, path: string, uuid: string): void {
+    this.enqueueOrSend({ type: 'session-conversation-upsert', sessionId, path, uuid, updatedAt: Date.now() })
   }
 
   /** Subscribe to the worker's new-messages fan-out. Returns an unsubscribe. */

--- a/src/main/logging/log-worker-transport.ts
+++ b/src/main/logging/log-worker-transport.ts
@@ -45,6 +45,16 @@ export type ToTranscriptsWorker =
       confidence: 'exact' | 'heuristic'
       sourceVersion?: string
     }
+  | {
+      // #480: durable session->conversation mapping, written on every EXACT bind.
+      // Independent of the runs/transcripts index so restart resume has a single
+      // authoritative, crash-durable source keyed by AICC sessionId.
+      type: 'session-conversation-upsert'
+      sessionId: string
+      path: string
+      uuid: string
+      updatedAt: number
+    }
   | { type: 'query'; id: number; kind: string; args: Record<string, unknown> }
   | { type: 'shutdown' }
 

--- a/src/main/logging/logging-service.ts
+++ b/src/main/logging/logging-service.ts
@@ -61,7 +61,13 @@ export function initLogging(opts: {
   // real ~/.claude/projects heuristic binder (defaults inside makeTranscriptBinder).
   // Diagnostics flow to the main app.log via the injected logInfo (paths only) so
   // first-/resumed-session bind failures are visible after the fact.
-  _binder = makeTranscriptBinder({ supervisor: sup, log: logInfo })
+  // #480: `persist` writes the durable session->conversation record on every
+  // exact bind, so restart resume has a crash-durable authoritative source.
+  _binder = makeTranscriptBinder({
+    supervisor: sup,
+    log: logInfo,
+    persist: (sessionId, path, uuid) => sup.persistSessionConversation(sessionId, path, uuid),
+  })
 }
 
 /** The supervisor, for run lifecycle + diagnostics + the read path. Null when disabled. */

--- a/src/main/logging/transcript-binder.ts
+++ b/src/main/logging/transcript-binder.ts
@@ -32,7 +32,7 @@
  * No Electron imports — pure node + injected deps, so it unit-tests without any
  * Electron ABI. No default export (project convention).
  */
-import { canonicalizeTranscriptPath, makeHeuristicBinder } from './transcript-discovery'
+import { canonicalizeTranscriptPath, makeHeuristicBinder, UUID_RE } from './transcript-discovery'
 import type { DiscoveryBinding } from './transcript-discovery'
 
 /** The minimal supervisor surface the binder needs (LogSupervisor satisfies it). */
@@ -42,7 +42,7 @@ export interface TranscriptBinderSupervisor {
 
 /** The heuristic-binder surface (makeHeuristicBinder() satisfies it). */
 export interface TranscriptHeuristicBinder {
-  bindOnce(sessionId: string, cwd: string, startedAtMs: number): DiscoveryBinding | null
+  bindOnce(sessionId: string, cwd: string, startedAtMs: number, excludeUuids?: ReadonlySet<string>): DiscoveryBinding | null
   /**
    * Drop the heuristic binder's permanent per-sessionId success cache so the
    * next bindOnce rescans. endRun calls this so a reused sessionId (in-session
@@ -80,6 +80,14 @@ export interface TranscriptBinderDeps {
    * constructing the binder; tests pass a spy. Defaults to a no-op.
    */
   log?: (msg: string) => void
+  /**
+   * #480: durable session→conversation sink. Called on every committed EXACT
+   * bind with the canonical transcript path + its conversation uuid, so the
+   * mapping survives an app restart / crash independently of the in-memory
+   * state. Fire-and-forget; the binder stays pure (the supervisor forwards it to
+   * the transcripts.db worker). Defaults to a no-op.
+   */
+  persist?: (sessionId: string, canonicalPath: string, uuid: string) => void
 }
 
 const DEFAULT_DEBOUNCE_MS = 250
@@ -102,6 +110,9 @@ interface SessionState {
   /** The cwd + startedAt captured at registerRun, reused by heuristic retries. */
   heuristicCwd: string | null
   heuristicStartedAtMs: number
+  /** #480: the conversation uuid this session currently owns (exact bind only),
+   *  used to release the ownership reservation on rebind / endRun. */
+  ownedUuid: string | null
 }
 
 export interface TranscriptBinder {
@@ -113,6 +124,14 @@ export interface TranscriptBinder {
   endRun(sessionId: string): void
   /** Latest canonical transcript path bound for the session, or null. (T8b) */
   getLatestTranscriptPath(sessionId: string): string | null
+  /**
+   * #480: the canonical transcript path bound for the session ONLY when the bind
+   * is EXACT (authenticated hook / statusline). Returns null for a heuristic
+   * bind or no bind. Restart resume uses THIS — never a heuristic guess — so a
+   * shared-folder scan can no longer resume a sibling card's conversation. A
+   * null here means "start fresh", which is safer than resuming a stranger.
+   */
+  getExactResumeTarget(sessionId: string): string | null
 }
 
 export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBinder {
@@ -125,8 +144,44 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
   const heuristicDelayMs = deps.heuristicDelayMs ?? DEFAULT_HEURISTIC_DELAY_MS
   const heuristicRetryCap = deps.heuristicRetryCap ?? DEFAULT_HEURISTIC_RETRY_CAP
   const log = deps.log ?? (() => { /* no-op */ })
+  const persist = deps.persist ?? (() => { /* no-op */ })
 
   const sessions = new Map<string, SessionState>()
+
+  // #480: reverse index conversation-uuid -> owning sessionId, for EXACT binds
+  // only. Enforces "one conversation belongs to at most one live session": an
+  // exact bind that would steal a uuid already held by a DIFFERENT live session
+  // is refused, and the heuristic scan is told to skip every uuid in here that
+  // belongs to another session.
+  const uuidOwners = new Map<string, string>()
+
+  /** Extract the conversation uuid (transcript basename stem) from a canonical
+   *  path, or null when the stem is not a uuid. */
+  function uuidFromPath(canonicalPath: string): string | null {
+    const slash = Math.max(canonicalPath.lastIndexOf('/'), canonicalPath.lastIndexOf('\\'))
+    const base = slash >= 0 ? canonicalPath.slice(slash + 1) : canonicalPath
+    const stem = base.endsWith('.jsonl') ? base.slice(0, -'.jsonl'.length) : base
+    return UUID_RE.test(stem) ? stem : null
+  }
+
+  /** Release the uuid this session currently owns (if any) from the reverse
+   *  index, but only when the index still points at THIS session. */
+  function releaseOwnership(sessionId: string, s: SessionState): void {
+    if (s.ownedUuid && uuidOwners.get(s.ownedUuid) === sessionId) {
+      uuidOwners.delete(s.ownedUuid)
+    }
+    s.ownedUuid = null
+  }
+
+  /** The set of uuids EXACT-owned by sessions OTHER than `sessionId` — passed to
+   *  the heuristic scan so it never binds a sibling's conversation. */
+  function uuidsOwnedByOthers(sessionId: string): ReadonlySet<string> {
+    const out = new Set<string>()
+    for (const [uuid, owner] of uuidOwners) {
+      if (owner !== sessionId) out.add(uuid)
+    }
+    return out
+  }
 
   function getOrCreate(sessionId: string): SessionState {
     let s = sessions.get(sessionId)
@@ -134,6 +189,7 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
       s = {
         boundPath: null, boundConfidence: null, debounceHandle: null, pendingRaw: null,
         heuristicHandle: null, heuristicRetriesLeft: 0, heuristicCwd: null, heuristicStartedAtMs: 0,
+        ownedUuid: null,
       }
       sessions.set(sessionId, s)
     }
@@ -162,7 +218,9 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
     if (cur.boundConfidence === 'exact') return
     const cwd = cur.heuristicCwd
     if (cwd === null) return
-    const binding = heuristicBinder.bindOnce(sessionId, cwd, cur.heuristicStartedAtMs)
+    // #480: exclude conversations already exact-owned by other live sessions so
+    // the newest-file scan cannot claim a sibling card's transcript.
+    const binding = heuristicBinder.bindOnce(sessionId, cwd, cur.heuristicStartedAtMs, uuidsOwnedByOthers(sessionId))
     if (!binding) {
       // Nothing found yet. Re-arm another attempt if retries remain; a later exact
       // notification can still bind in the meantime.
@@ -208,9 +266,33 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
     // exact below, so we only short-circuit when confidence also matches.)
     if (s.boundPath === canonical && s.boundConfidence === 'exact') return
 
+    // #480 ownership guard: a conversation belongs to at most one LIVE session.
+    // If another still-live session already owns this uuid, refuse the bind
+    // rather than steal it — this is exactly the same-cwd cross that resumed a
+    // sibling card's conversation. `sessions.has(owner)` gates on "still live"
+    // so a released uuid (previous owner ended) is freely re-claimable.
+    const uuid = uuidFromPath(canonical)
+    if (uuid) {
+      const owner = uuidOwners.get(uuid)
+      if (owner && owner !== sessionId && sessions.has(owner)) {
+        log(`[binder] exact bind REFUSED sid=${sessionId} uuid=${uuid} ownedBy=${owner}`)
+        return
+      }
+    }
+    // Release a different uuid this session previously owned (e.g. /clear rotated
+    // the conversation) before claiming the new one.
+    if (s.ownedUuid && s.ownedUuid !== uuid) releaseOwnership(sessionId, s)
+
     s.boundPath = canonical
     s.boundConfidence = 'exact'
+    if (uuid) {
+      uuidOwners.set(uuid, sessionId)
+      s.ownedUuid = uuid
+    }
     supervisor.bindTranscript(sessionId, canonical, 'exact')
+    // #480: durable record, keyed by sessionId, of the exact conversation — the
+    // authenticated source of truth for restart resume.
+    if (uuid) persist(sessionId, canonical, uuid)
     log(`[binder] exact bind committed sid=${sessionId} path=${canonical}`)
   }
 
@@ -259,6 +341,9 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
       if (!s) return
       if (s.debounceHandle !== null) clearTimer(s.debounceHandle)
       cancelHeuristic(s)
+      // #480: release the conversation-uuid reservation so the same conversation
+      // can be re-owned by whichever session resumes it next (handoff / restart).
+      releaseOwnership(sessionId, s)
       // Drop ALL per-session state so a reused sessionId (restart) binds fresh
       // rather than being deduped against a stale prior bind. Combined with the
       // heuristicBinder.forget above, "bind fresh on restart" now holds for both
@@ -268,6 +353,11 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
 
     getLatestTranscriptPath(sessionId: string): string | null {
       return sessions.get(sessionId)?.boundPath ?? null
+    },
+
+    getExactResumeTarget(sessionId: string): string | null {
+      const s = sessions.get(sessionId)
+      return s && s.boundConfidence === 'exact' ? s.boundPath : null
     },
   }
 }

--- a/src/main/logging/transcript-binder.ts
+++ b/src/main/logging/transcript-binder.ts
@@ -257,6 +257,25 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
       return   // non-transcript path — ignore
     }
 
+    // #480 ownership guard: a conversation belongs to at most one LIVE session.
+    // If another still-live session already owns this uuid, refuse the bind
+    // rather than steal it — this is exactly the same-cwd cross that resumed a
+    // sibling card's conversation. `sessions.has(owner)` gates on "still live"
+    // so a released uuid (previous owner ended) is freely re-claimable.
+    //
+    // Checked BEFORE cancelHeuristic (adversarial round 1): a refused bind must
+    // NOT disarm this session's heuristic fallback — otherwise a transient uuid
+    // collision would leave the loser with neither an exact nor a heuristic bind
+    // and its transcript would never be tailed.
+    const uuid = uuidFromPath(canonical)
+    if (uuid) {
+      const owner = uuidOwners.get(uuid)
+      if (owner && owner !== sessionId && sessions.has(owner)) {
+        log(`[binder] exact bind REFUSED sid=${sessionId} uuid=${uuid} ownedBy=${owner}`)
+        return
+      }
+    }
+
     // An exact source always wins. Cancel any still-pending heuristic fallback (and
     // its retries) so it can't later re-bind on top of the exact path.
     cancelHeuristic(s)
@@ -266,19 +285,6 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
     // exact below, so we only short-circuit when confidence also matches.)
     if (s.boundPath === canonical && s.boundConfidence === 'exact') return
 
-    // #480 ownership guard: a conversation belongs to at most one LIVE session.
-    // If another still-live session already owns this uuid, refuse the bind
-    // rather than steal it — this is exactly the same-cwd cross that resumed a
-    // sibling card's conversation. `sessions.has(owner)` gates on "still live"
-    // so a released uuid (previous owner ended) is freely re-claimable.
-    const uuid = uuidFromPath(canonical)
-    if (uuid) {
-      const owner = uuidOwners.get(uuid)
-      if (owner && owner !== sessionId && sessions.has(owner)) {
-        log(`[binder] exact bind REFUSED sid=${sessionId} uuid=${uuid} ownedBy=${owner}`)
-        return
-      }
-    }
     // Release a different uuid this session previously owned (e.g. /clear rotated
     // the conversation) before claiming the new one.
     if (s.ownedUuid && s.ownedUuid !== uuid) releaseOwnership(sessionId, s)

--- a/src/main/logging/transcript-discovery.ts
+++ b/src/main/logging/transcript-discovery.ts
@@ -304,8 +304,18 @@ interface HeuristicBinder {
    * BIND-ONCE: a given sessionId gets AT MOST one successful heuristic binding
    * ever (in-memory Map). Repeat calls for the same sessionId return the SAME
    * stored binding (or null if first call failed — failures may retry).
+   *
+   * `excludeUuids` (#480): conversation uuids already EXACT-bound to a DIFFERENT
+   * live session. The scan skips those `.jsonl` files so a fresh card in a shared
+   * repo folder cannot heuristically claim a sibling card's conversation — the
+   * root cause of cross-session resume. Omitted / empty = scan everything (legacy).
    */
-  bindOnce(sessionId: string, cwd: string, startedAtMs: number): DiscoveryBinding | null
+  bindOnce(
+    sessionId: string,
+    cwd: string,
+    startedAtMs: number,
+    excludeUuids?: ReadonlySet<string>,
+  ): DiscoveryBinding | null
 
   /**
    * Drops the permanent success-cache entry for a sessionId so the NEXT
@@ -345,10 +355,23 @@ export function makeHeuristicBinder(deps?: HeuristicBinderDeps): HeuristicBinder
   const successCache = new Map<string, DiscoveryBinding>()
 
   return {
-    bindOnce(sessionId: string, cwd: string, startedAtMs: number): DiscoveryBinding | null {
+    bindOnce(
+      sessionId: string,
+      cwd: string,
+      startedAtMs: number,
+      excludeUuids?: ReadonlySet<string>,
+    ): DiscoveryBinding | null {
       // Return existing successful binding immediately.
       const cached = successCache.get(sessionId)
       if (cached !== undefined) return cached
+
+      // #480: skip transcripts already owned (exact) by another live session so a
+      // fresh card in a shared repo folder never claims a sibling's conversation.
+      const isExcluded = (name: string): boolean => {
+        if (!excludeUuids || excludeUuids.size === 0) return false
+        const stem = name.endsWith('.jsonl') ? name.slice(0, -'.jsonl'.length) : name
+        return excludeUuids.has(stem)
+      }
 
       // Determine the project directory for this cwd.
       const mangled = mangleCwdToProjectDir(cwd)
@@ -372,6 +395,7 @@ export function makeHeuristicBinder(deps?: HeuristicBinderDeps): HeuristicBinder
       let bestMtime = -Infinity
 
       for (const name of jsonlFiles) {
+        if (isExcluded(name)) continue
         const full = path.join(projDir, name)
         let mtime: number
         try {

--- a/src/main/logging/transcripts-db.ts
+++ b/src/main/logging/transcripts-db.ts
@@ -820,6 +820,20 @@ export function openTranscriptsDb(dbPath: string): TranscriptsDb {
       uuid = excluded.uuid, path = excluded.path,
       confidence = excluded.confidence, updatedAt = excluded.updatedAt
   `)
+  // #480 (adversarial round 1): a conversation uuid must map to at most ONE
+  // durable session, or two cards could both `--resume <uuid>` after an app
+  // restart (the in-memory ownership guard is empty at boot). A new owner for a
+  // uuid evicts every other session's durable row for it — last-writer-wins on
+  // uuid — so a legitimate handoff transfers ownership instead of accumulating.
+  const stmtEvictOtherOwnersOfUuid: Statement = sqlite.prepare(
+    `DELETE FROM session_conversation WHERE uuid = @uuid AND sessionId <> @sessionId`,
+  )
+  const runUpsertSessionConversation = sqlite.transaction(
+    (row: { sessionId: string; uuid: string; path: string; updatedAt: number }) => {
+      stmtEvictOtherOwnersOfUuid.run(row)
+      stmtUpsertSessionConversation.run(row)
+    },
+  )
   const stmtGetSessionConversation: Statement = sqlite.prepare(
     `SELECT uuid, path, updatedAt FROM session_conversation WHERE sessionId = ?`,
   )
@@ -1025,7 +1039,7 @@ export function openTranscriptsDb(dbPath: string): TranscriptsDb {
     },
 
     upsertSessionConversation(row) {
-      stmtUpsertSessionConversation.run(row)
+      runUpsertSessionConversation(row)
     },
 
     getSessionConversation(sessionId: string) {

--- a/src/main/logging/transcripts-db.ts
+++ b/src/main/logging/transcripts-db.ts
@@ -268,6 +268,20 @@ export interface TranscriptsDb {
    */
   sessionConfig(sessionId: string): { configId: string | null } | null
 
+  /**
+   * #480: upsert the durable session -> conversation record. Called on every
+   * EXACT bind. Last write wins (a /clear rotation updates the row to the new
+   * uuid). `updatedAt` is supplied by the caller (main-process clock).
+   */
+  upsertSessionConversation(row: { sessionId: string; uuid: string; path: string; updatedAt: number }): void
+
+  /**
+   * #480: read the durable conversation for a sessionId, or null. Restart resume
+   * resolves {uuid, cwd} from this path when the in-memory exact bind is absent
+   * (e.g. after an app relaunch).
+   */
+  getSessionConversation(sessionId: string): { uuid: string; path: string; updatedAt: number } | null
+
   close(): void
 }
 
@@ -346,6 +360,20 @@ CREATE TABLE IF NOT EXISTS meta (
   value TEXT NOT NULL
 );
 INSERT OR IGNORE INTO meta(key, value) VALUES ('schemaVersion', '1');
+
+-- #480: durable session -> conversation map. One row per AICC sessionId,
+-- upserted on every EXACT (authenticated) transcript bind. This is the
+-- authoritative, crash-durable source restart resume reads back, independent of
+-- the runs/transcripts index (which cross-attributes conversations among cards
+-- that share one repo folder). Keyed by sessionId so each card resolves to the
+-- conversation the hook confirmed for IT, never a sibling's newest file.
+CREATE TABLE IF NOT EXISTS session_conversation (
+  sessionId  TEXT PRIMARY KEY,
+  uuid       TEXT NOT NULL,
+  path       TEXT NOT NULL,
+  confidence TEXT NOT NULL DEFAULT 'exact',
+  updatedAt  INTEGER NOT NULL
+);
 `
 
 // ---------------------------------------------------------------------------
@@ -784,6 +812,17 @@ export function openTranscriptsDb(dbPath: string): TranscriptsDb {
   const stmtCountMessagesForRun: Statement = sqlite.prepare(
     `SELECT COUNT(*) AS c FROM messages WHERE runId = ?`,
   )
+  // #480: durable session -> conversation map.
+  const stmtUpsertSessionConversation: Statement = sqlite.prepare(`
+    INSERT INTO session_conversation(sessionId, uuid, path, confidence, updatedAt)
+    VALUES (@sessionId, @uuid, @path, 'exact', @updatedAt)
+    ON CONFLICT(sessionId) DO UPDATE SET
+      uuid = excluded.uuid, path = excluded.path,
+      confidence = excluded.confidence, updatedAt = excluded.updatedAt
+  `)
+  const stmtGetSessionConversation: Statement = sqlite.prepare(
+    `SELECT uuid, path, updatedAt FROM session_conversation WHERE sessionId = ?`,
+  )
 
   // ---------------------------------------------------------------------------
   // TranscriptsDb implementation
@@ -982,6 +1021,17 @@ export function openTranscriptsDb(dbPath: string): TranscriptsDb {
 
     sessionConfig(sessionId: string) {
       const row = stmtSessionConfig.get(sessionId) as { configId: string | null } | undefined
+      return row ?? null
+    },
+
+    upsertSessionConversation(row) {
+      stmtUpsertSessionConversation.run(row)
+    },
+
+    getSessionConversation(sessionId: string) {
+      const row = stmtGetSessionConversation.get(sessionId) as
+        | { uuid: string; path: string; updatedAt: number }
+        | undefined
       return row ?? null
     },
 

--- a/src/main/logging/transcripts-worker.ts
+++ b/src/main/logging/transcripts-worker.ts
@@ -475,6 +475,13 @@ export function createTranscriptsWorker(
         rows = res ? [res] : []
         break
       }
+      case 'session-conversation': {
+        // #480: durable session -> conversation lookup for restart resume.
+        const sessionId = typeof args.sessionId === 'string' ? args.sessionId : ''
+        const res = sessionId ? db!.getSessionConversation(sessionId) : null
+        rows = res ? [res] : []
+        break
+      }
       default:
         // Poison guard: an unknown kind answers with a correlated error, never a crash.
         post({ type: 'error', id, message: `unknown query kind: ${kind}` })
@@ -599,6 +606,18 @@ export function createTranscriptsWorker(
         }
         return
       }
+
+      case 'session-conversation-upsert':
+        // #480: durable, run-independent session -> conversation record. Does NOT
+        // require an open run (unlike transcript-bind), so it survives even when
+        // the run row is missing — it is keyed by sessionId, not runId.
+        db.upsertSessionConversation({
+          sessionId: msg.sessionId,
+          uuid: msg.uuid,
+          path: msg.path,
+          updatedAt: msg.updatedAt,
+        })
+        return
 
       case 'query':
         handleQuery(msg.id, msg.kind, msg.args)

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1028,7 +1028,13 @@ export function spawnPty(
   let capturedResumeTarget: { uuid: string; cwd: string } | null = null
   if (!options?.ssh && !options?.shellOnly && (options?.provider ?? 'claude') === 'claude') {
     try {
-      const latest = getTranscriptBinder()?.getLatestTranscriptPath(sessionId)
+      // #480: resume ONLY from an EXACT (authenticated) bind. The previous
+      // getLatestTranscriptPath() also returned heuristic binds — a newest-file
+      // scan of the shared per-repo transcript folder — which resumed a SIBLING
+      // card's conversation when several cards ran in one repo. An exact-only
+      // capture means "resume the conversation the hook confirmed for THIS
+      // session, or start fresh"; a fresh start beats reopening a stranger.
+      const latest = getTranscriptBinder()?.getExactResumeTarget(sessionId)
       if (latest) {
         capturedResumeTarget = resolveResumeTargetFromTranscript(latest)
       }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -33,7 +33,7 @@ import { buildTerminalLaunchLine } from './terminal-launch-line'
 import { dispatchSSHStatuslineUpdate, cleanupStatusFile } from './statusline-watcher'
 import { forgetSession } from './background-context'
 import { decorateStatuslineWithColour } from './account-color'
-import { getGateway } from './hooks'
+import { getGateway, isExactBindSourceActive } from './hooks'
 import { injectHooks } from './hooks/session-hooks-writer'
 import {
   writeLocalSessionSettings,
@@ -1034,7 +1034,18 @@ export function spawnPty(
       // card's conversation when several cards ran in one repo. An exact-only
       // capture means "resume the conversation the hook confirmed for THIS
       // session, or start fresh"; a fresh start beats reopening a stranger.
-      const latest = getTranscriptBinder()?.getExactResumeTarget(sessionId)
+      const binder = getTranscriptBinder()
+      let latest = binder?.getExactResumeTarget(sessionId) ?? null
+      // Hooks-off fallback: when no EXACT source can ever arrive (hooks disabled
+      // or gateway down), fall back to the heuristic bind and WARN. In that
+      // degraded config there is no authenticated source, so best-effort resume
+      // beats never resuming — but it can cross if cards share a repo folder.
+      if (!latest && !isExactBindSourceActive()) {
+        latest = binder?.getLatestTranscriptPath(sessionId) ?? null
+        if (latest) {
+          logWarn(`[pty] #480 hooks-off resume fallback for ${sessionId}: hooks inactive, using heuristic bind ${latest} (best-effort; may cross if multiple cards share this repo)`)
+        }
+      }
       if (latest) {
         capturedResumeTarget = resolveResumeTargetFromTranscript(latest)
       }

--- a/src/main/session-resume-enrich.ts
+++ b/src/main/session-resume-enrich.ts
@@ -22,8 +22,22 @@
 import type { SessionState } from './session-state'
 
 export interface ResumeEnrichDeps {
-  /** The binder's latest canonical transcript path for a session, or null. */
+  /**
+   * #480: the binder's EXACT (authenticated) transcript path for a session, or
+   * null. This is the source of truth — never the heuristic newest-file scan,
+   * which cross-attributes conversations among cards that share one repo folder.
+   */
+  getExactResumeTarget: (sessionId: string) => string | null
+  /**
+   * #480: the heuristic-inclusive latest path, used ONLY as the hooks-off
+   * fallback (when no exact source can ever arrive).
+   */
   getLatestTranscriptPath: (sessionId: string) => string | null
+  /**
+   * #480: is an exact bind possible (hooks enabled)? When false, fall back to the
+   * heuristic path so a hooks-off user still gets a resumable record.
+   */
+  isExactBindSourceActive: () => boolean
   /** Derive {uuid, cwd} from a transcript path, or null on any failure. */
   resolveResumeTargetFromTranscript: (transcriptPath: string) => { uuid: string; cwd: string } | null
 }
@@ -52,7 +66,13 @@ export function enrichSessionStateWithResumeTargets(
     try {
       if (!s || s.shellOnly) continue
       if ((s.provider ?? 'claude') !== 'claude') continue
-      const latest = deps.getLatestTranscriptPath(s.id)
+      // #480: EXACT bind only — this must not persist a heuristic (cross-prone)
+      // guess. The hooks-off fallback re-enables the heuristic only when no
+      // authenticated source can arrive.
+      let latest = deps.getExactResumeTarget(s.id)
+      if (!latest && !deps.isExactBindSourceActive()) {
+        latest = deps.getLatestTranscriptPath(s.id)
+      }
       if (!latest) continue
       const target = deps.resolveResumeTargetFromTranscript(latest)
       if (target && target.uuid && target.cwd) {

--- a/tests/e2e/session-resume-tracking.spec.ts
+++ b/tests/e2e/session-resume-tracking.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * E2E (#480): durable, cross-safe session->conversation tracking, validated in the
+ * REAL packaged app.
+ *
+ * Scope — what e2e can honestly assert here:
+ *   1. The new `session_conversation` durable table ships and is created when the
+ *      packaged app opens transcripts.db at startup (the DDL runs for real, not
+ *      only under the unit `openTranscriptsDb`).
+ *   2. The Restart action — the exact user gesture that used to resume the wrong
+ *      conversation — runs end-to-end in the app without crashing, and the session
+ *      returns healthy.
+ *
+ * NOT here (covered by unit + native suites, which need no real `claude`):
+ *   - The exact-only resume / ownership-guard / eviction LOGIC. Proving a real
+ *     cross would require two live `claude` conversations writing transcripts and
+ *     firing authenticated hooks — absent in CI. That correctness lives in
+ *     transcript-binder-ownership / transcripts-db.native / resume-ipc-handlers.
+ *
+ * better-sqlite3 is built for Electron's ABI and cannot be required from the
+ * plain-node Playwright runner, so the schema check scans the DB file bytes for
+ * the table's CREATE SQL — SQLite stores it as plaintext in sqlite_master.
+ */
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+const SESSION_NAME = 'E2E Resume 480'
+
+async function shot(page: import('@playwright/test').Page, name: string): Promise<void> {
+  const file = test.info().outputPath(`${name}.png`)
+  await page.screenshot({ path: file })
+  await test.info().attach(name, { path: file, contentType: 'image/png' })
+}
+
+/** True if any of the sqlite files (main + WAL) contains the given ASCII needle. */
+function dbFilesContain(dataDir: string, needle: string): boolean {
+  const base = path.join(dataDir, 'transcripts.db')
+  for (const f of [base, `${base}-wal`, `${base}-shm`]) {
+    try {
+      if (fs.existsSync(f) && fs.readFileSync(f).includes(Buffer.from(needle, 'ascii'))) return true
+    } catch {
+      /* ignore unreadable / locked */
+    }
+  }
+  return false
+}
+
+test.describe('#480 durable session-conversation tracking (packaged app)', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('the app ships and creates the session_conversation durable table', async () => {
+    test.setTimeout(90000)
+    let a: IsolatedApp | undefined
+    try {
+      a = await launchIsolatedApp()
+      // The logging worker opens transcripts.db at startup and runs the DDL.
+      await expect
+        .poll(() => fs.existsSync(path.join(a!.dataDir, 'transcripts.db')), { timeout: 30000, intervals: [300] })
+        .toBe(true)
+      // The #480 table's CREATE SQL is stored as plaintext in sqlite_master.
+      await expect
+        .poll(() => dbFilesContain(a!.dataDir, 'session_conversation'), { timeout: 30000, intervals: [300] })
+        .toBe(true)
+      await shot(a.page, '480-01-app-booted')
+    } finally {
+      await closeIsolatedApp(a)
+    }
+  })
+
+  test('Restart on a live session returns it healthy (no crash)', async () => {
+    test.setTimeout(120000)
+    let a: IsolatedApp | undefined
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-e2e-480-work-'))
+    try {
+      a = await launchIsolatedApp()
+      const page = a.page
+
+      // Create a Terminal x Local session (no real `claude` binary needed).
+      await page.locator('[data-testid="panel-tab-saved"]').click()
+      await page.locator('[data-testid="new-config-button"]').click()
+      await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
+      await page.locator('[role="radiogroup"][aria-label="Provider"] label:has(input[value="terminal"])').click()
+      await page.locator('[role="radiogroup"][aria-label="Where it runs"] label:has(input[value="local"])').click()
+      await page.locator('input[placeholder*="home folder"]').first().fill(workDir)
+      await page.locator('input[placeholder="e.g. App Dev"]').fill(SESSION_NAME)
+      await page.locator('button:has-text("Create config")').click()
+
+      const card = page.locator('.session-card').filter({ hasText: SESSION_NAME }).first()
+      await expect(card).toBeVisible({ timeout: 30000 })
+      await shot(page, '480-02-session-created')
+
+      // Click Restart (the gesture that used to resume the wrong conversation).
+      const restart = page.locator('button[title="Restart session"]').first()
+      await expect(restart).toBeVisible({ timeout: 15000 })
+      await restart.click()
+
+      // The session card returns and the shell stays healthy (no crash / blank).
+      await expect(card).toBeVisible({ timeout: 30000 })
+      await expect(page.locator('[data-tour="new-config"]').first()).toBeVisible()
+      await shot(page, '480-03-after-restart')
+    } finally {
+      await closeIsolatedApp(a)
+      try { fs.rmSync(workDir, { recursive: true, force: true }) } catch { /* ignore */ }
+    }
+  })
+})

--- a/tests/unit/logging/transcript-binder-ownership.test.ts
+++ b/tests/unit/logging/transcript-binder-ownership.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #480 — durable, cross-safe session→conversation binding.
+ *
+ * These tests cover the three guarantees added to the binder so two cards
+ * sharing one repo folder can never resume each other's conversation:
+ *   1. exact-only resume target (getExactResumeTarget) — a heuristic bind is
+ *      NOT a resume source;
+ *   2. an ownership guard — one conversation uuid belongs to at most one LIVE
+ *      session; a second live session cannot steal it;
+ *   3. the heuristic scan is told which uuids other live sessions own, and the
+ *      durable `persist` sink fires on every exact bind.
+ *
+ * Plain vitest (no native deps): supervisor / heuristic binder / persist are
+ * stubs; canonicalize is injected. Paths are already-canonical and end in a real
+ * UUID so the binder's uuid extraction activates.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { makeTranscriptBinder } from '../../../src/main/logging/transcript-binder'
+import type { TranscriptBinderDeps, TranscriptHeuristicBinder } from '../../../src/main/logging/transcript-binder'
+import type { DiscoveryBinding } from '../../../src/main/logging/transcript-discovery'
+
+const UUID_X = '11111111-1111-4111-8111-111111111111'
+const UUID_Y = '22222222-2222-4222-8222-222222222222'
+const pathFor = (uuid: string) => `/home/.claude/projects/proj/${uuid}.jsonl`
+
+interface BindCall { sessionId: string; path: string; confidence: 'exact' | 'heuristic' }
+interface PersistCall { sessionId: string; path: string; uuid: string }
+
+function makeFakeTimers() {
+  let nowMs = 0
+  let nextId = 1
+  const timers = new Map<number, { fireAt: number; cb: () => void }>()
+  return {
+    setTimer: (cb: () => void, ms: number): number => { const id = nextId++; timers.set(id, { fireAt: nowMs + ms, cb }); return id },
+    clearTimer: (id: number): void => { timers.delete(id) },
+    advance(ms: number): void {
+      nowMs += ms
+      const due = [...timers.entries()].filter(([, t]) => t.fireAt <= nowMs).sort((a, b) => a[1].fireAt - b[1].fireAt)
+      for (const [id, t] of due) if (timers.has(id)) { timers.delete(id); t.cb() }
+    },
+  }
+}
+
+/** A heuristic binder whose result is scripted per call and that records the
+ *  excludeUuids set it was handed. */
+function makeScriptedHeuristic(result: (cwd: string) => DiscoveryBinding | null) {
+  const calls: Array<{ sessionId: string; exclude: ReadonlySet<string> | undefined }> = []
+  const hb: TranscriptHeuristicBinder = {
+    bindOnce: vi.fn((sessionId, cwd, _startedAtMs, exclude) => {
+      calls.push({ sessionId, exclude })
+      return result(cwd)
+    }),
+    forget: vi.fn(),
+  }
+  return { hb, calls }
+}
+
+function makeHarness(overrides?: Partial<TranscriptBinderDeps>) {
+  const binds: BindCall[] = []
+  const persists: PersistCall[] = []
+  const timers = makeFakeTimers()
+  const deps: TranscriptBinderDeps = {
+    supervisor: { bindTranscript: (sessionId, path, confidence) => { binds.push({ sessionId, path, confidence }) } },
+    canonicalize: (p: string) => (p.includes('.jsonl') ? p : null),
+    heuristicBinder: { bindOnce: vi.fn(() => null), forget: vi.fn() },
+    persist: (sessionId, path, uuid) => { persists.push({ sessionId, path, uuid }) },
+    setTimer: timers.setTimer,
+    clearTimer: timers.clearTimer,
+    debounceMs: 100,
+    heuristicDelayMs: 20_000,
+    ...overrides,
+  }
+  const binder = makeTranscriptBinder(deps)
+  return { binder, binds, persists, timers }
+}
+
+describe('#480 exact-only resume target', () => {
+  it('exposes an exact bind via getExactResumeTarget', () => {
+    const { binder, timers } = makeHarness()
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
+    expect(binder.getLatestTranscriptPath('s1')).toBe(pathFor(UUID_X))
+  })
+
+  it('does NOT expose a heuristic bind as a resume target', () => {
+    const heuristic = makeScriptedHeuristic(() => ({ path: pathFor(UUID_X), confidence: 'heuristic' }))
+    const { binder, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    binder.registerRun('s1', '/repo', 0)
+    timers.advance(20_000) // fire the heuristic fallback
+    // Latest path is the heuristic one, but it is NOT an exact resume source.
+    expect(binder.getLatestTranscriptPath('s1')).toBe(pathFor(UUID_X))
+    expect(binder.getExactResumeTarget('s1')).toBeNull()
+  })
+
+  it('persists the durable record on every exact bind', () => {
+    const { binder, persists, timers } = makeHarness()
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    expect(persists).toEqual([{ sessionId: 's1', path: pathFor(UUID_X), uuid: UUID_X }])
+  })
+})
+
+describe('#480 ownership guard — one conversation, one live session', () => {
+  it('refuses a second LIVE session from stealing a bound conversation', () => {
+    const { binder, binds, persists, timers } = makeHarness()
+    // s1 binds conversation X.
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // s2 (also live) tries to bind the SAME conversation X.
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    // s2 is refused: no bind, no persist, no resume target.
+    expect(binder.getExactResumeTarget('s2')).toBeNull()
+    expect(binds.filter((b) => b.sessionId === 's2')).toHaveLength(0)
+    expect(persists.filter((p) => p.sessionId === 's2')).toHaveLength(0)
+    // s1 keeps ownership.
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
+  })
+
+  it('lets the next session re-claim a conversation after the owner ends (handoff)', () => {
+    const { binder, timers } = makeHarness()
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    binder.endRun('s1') // owner releases the reservation
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBe(pathFor(UUID_X))
+  })
+})
+
+describe('#480 heuristic scan excludes conversations owned by others', () => {
+  it('passes the other-owned uuids to bindOnce', () => {
+    const heuristic = makeScriptedHeuristic(() => null)
+    const { binder, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    // s1 exact-owns X.
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // s2 starts a run; its heuristic fallback must exclude X.
+    binder.registerRun('s2', '/repo', 0)
+    timers.advance(20_000)
+    const s2call = heuristic.calls.find((c) => c.sessionId === 's2')
+    expect(s2call).toBeDefined()
+    expect(s2call!.exclude && [...s2call!.exclude]).toContain(UUID_X)
+  })
+
+  it('a /clear rotation to a new uuid releases the old reservation', () => {
+    const { binder, timers } = makeHarness()
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // Same session rotates to conversation Y.
+    binder.notifyTranscriptPath('s1', pathFor(UUID_Y))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_Y))
+    // X is free again: a different live session may now claim it.
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBe(pathFor(UUID_X))
+  })
+})

--- a/tests/unit/logging/transcript-binder-ownership.test.ts
+++ b/tests/unit/logging/transcript-binder-ownership.test.ts
@@ -120,6 +120,28 @@ describe('#480 ownership guard — one conversation, one live session', () => {
     expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
   })
 
+  it('a refused bind does NOT disarm the loser\'s heuristic fallback', () => {
+    // Adversarial round 1: cancelHeuristic must run AFTER the ownership refusal,
+    // else a transient uuid collision leaves the loser with neither an exact nor
+    // a heuristic bind and its transcript is never tailed.
+    const heuristic = makeScriptedHeuristic(() => null)
+    const { binder, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    // s1 (live) exact-owns X.
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // s2 starts a run (arms its heuristic) then tries to bind X -> refused.
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100) // debounce -> commitExact refuses (X owned by live s1)
+    expect(binder.getExactResumeTarget('s2')).toBeNull()
+    const before = heuristic.calls.filter((c) => c.sessionId === 's2').length
+    // The refusal must have LEFT s2's heuristic timer armed: it still fires.
+    timers.advance(20_000)
+    const after = heuristic.calls.filter((c) => c.sessionId === 's2').length
+    expect(after).toBeGreaterThan(before)
+  })
+
   it('lets the next session re-claim a conversation after the owner ends (handoff)', () => {
     const { binder, timers } = makeHarness()
     binder.registerRun('s1', '/repo', 0)
@@ -130,6 +152,110 @@ describe('#480 ownership guard — one conversation, one live session', () => {
     binder.notifyTranscriptPath('s2', pathFor(UUID_X))
     timers.advance(100)
     expect(binder.getExactResumeTarget('s2')).toBe(pathFor(UUID_X))
+  })
+})
+
+describe('#480 REORDER attacker — guard-first invariants', () => {
+  // H1: /clear rotation with guard now BEFORE dedupe + cancelHeuristic.
+  it('H1 rotation X->Y releases X, claims Y, and X is re-claimable by a live session', () => {
+    const heuristic = makeScriptedHeuristic(() => null)
+    const { binder, binds, persists, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
+    // rotate to Y
+    binder.notifyTranscriptPath('s1', pathFor(UUID_Y))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_Y))
+    // heuristic timer for s1 was cancelled by the exact binds (never fires)
+    timers.advance(20_000)
+    expect(heuristic.calls.filter((c) => c.sessionId === 's1')).toHaveLength(0)
+    // X is now free: a different LIVE session claims it (proves release happened)
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBe(pathFor(UUID_X))
+    // persist fired for X(s1), Y(s1), X(s2) — three exact commits, no churn dupes
+    expect(persists).toEqual([
+      { sessionId: 's1', path: pathFor(UUID_X), uuid: UUID_X },
+      { sessionId: 's1', path: pathFor(UUID_Y), uuid: UUID_Y },
+      { sessionId: 's2', path: pathFor(UUID_X), uuid: UUID_X },
+    ])
+    expect(binds.map((b) => `${b.sessionId}:${b.confidence}`)).toEqual(['s1:exact', 's1:exact', 's2:exact'])
+  })
+
+  // H2: identical exact re-notify of SAME path/session short-circuits — no churn,
+  // guard must NOT refuse the session's own re-bind (owner === sessionId).
+  it('H2 identical re-notify short-circuits: no duplicate bind, no duplicate persist', () => {
+    const { binder, binds, persists, timers } = makeHarness()
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binds).toHaveLength(1)
+    expect(persists).toHaveLength(1)
+    // same path, same session, again
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // still exactly one bind + one persist — dedupe held despite guard-first
+    expect(binds).toHaveLength(1)
+    expect(persists).toHaveLength(1)
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
+  })
+
+  // H4: a REFUSED session keeps its heuristic timer AND heuristic can later bind a
+  // DIFFERENT file — but that heuristic bind must NEVER claim ownership or persist.
+  it('H4 refused session heuristic-binds a different file without ownership/persist', () => {
+    const OTHER = '33333333-3333-4333-8333-333333333333'
+    const heuristic = makeScriptedHeuristic(() => ({ path: pathFor(OTHER), confidence: 'heuristic' }))
+    const { binder, binds, persists, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    // s1 exact-owns X
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    // s2 arms heuristic, then is refused X
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBeNull()
+    // s2 heuristic fires -> binds OTHER (heuristic confidence)
+    timers.advance(20_000)
+    expect(binds.filter((b) => b.sessionId === 's2')).toEqual([
+      { sessionId: 's2', path: pathFor(OTHER), confidence: 'heuristic' },
+    ])
+    // heuristic path never persists and never becomes a resume target
+    expect(persists.filter((p) => p.sessionId === 's2')).toHaveLength(0)
+    expect(binder.getExactResumeTarget('s2')).toBeNull()
+    expect(binder.getLatestTranscriptPath('s2')).toBe(pathFor(OTHER))
+    // ownership of OTHER was NOT claimed by s2's heuristic: a live s3 can exact-bind OTHER
+    binder.registerRun('s3', '/repo', 0)
+    binder.notifyTranscriptPath('s3', pathFor(OTHER))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s3')).toBe(pathFor(OTHER))
+  })
+
+  // H5: registerRun after a refusal leaves state consistent — s2 owned nothing, a
+  // fresh run re-arms cleanly and can later exact-bind a free uuid.
+  it('H5 registerRun after refusal keeps state consistent', () => {
+    const OTHER = '44444444-4444-4444-8444-444444444444'
+    const heuristic = makeScriptedHeuristic(() => null)
+    const { binder, binds, persists, timers } = makeHarness({ heuristicBinder: heuristic.hb })
+    binder.registerRun('s1', '/repo', 0)
+    binder.notifyTranscriptPath('s1', pathFor(UUID_X))
+    timers.advance(100)
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(UUID_X))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBeNull()
+    // s2 restarts (registerRun again) then binds a FREE uuid — must succeed
+    binder.registerRun('s2', '/repo', 0)
+    binder.notifyTranscriptPath('s2', pathFor(OTHER))
+    timers.advance(100)
+    expect(binder.getExactResumeTarget('s2')).toBe(pathFor(OTHER))
+    // s1 still owns X untouched
+    expect(binder.getExactResumeTarget('s1')).toBe(pathFor(UUID_X))
+    expect(persists.filter((p) => p.sessionId === 's2')).toEqual([
+      { sessionId: 's2', path: pathFor(OTHER), uuid: OTHER },
+    ])
   })
 })
 

--- a/tests/unit/logging/transcript-binder.test.ts
+++ b/tests/unit/logging/transcript-binder.test.ts
@@ -138,7 +138,9 @@ describe('transcript-binder — heuristic fallback', () => {
     binder.registerRun('s1', 'F:\\proj', 1_000)
     expect(binds).toHaveLength(0)
     timers.advance(20_000)
-    expect(heuristicBinder.bindOnce).toHaveBeenCalledWith('s1', 'F:\\proj', 1_000)
+    // #480: the binder now also passes the set of uuids owned by other live
+    // sessions so the scan can skip them (empty here — no other exact owner).
+    expect(heuristicBinder.bindOnce).toHaveBeenCalledWith('s1', 'F:\\proj', 1_000, expect.any(Set))
     expect(binds).toEqual([
       { sessionId: 's1', path: '/home/.claude/projects/proj/heur.jsonl', confidence: 'heuristic' },
     ])

--- a/tests/unit/logging/transcript-discovery.test.ts
+++ b/tests/unit/logging/transcript-discovery.test.ts
@@ -259,6 +259,38 @@ describe('makeHeuristicBinder', () => {
     expect(binding!.path).toBe(path.normalize(newestPath))
   })
 
+  it('#480 skips a .jsonl whose uuid is owned by another session (no cross)', () => {
+    const root = makeTmpProjectsRoot()
+    const cwd = 'F:\\shared-repo'
+    const projDir = path.join(root, mangleCwdToProjectDir(cwd))
+    fs.mkdirSync(projDir, { recursive: true })
+    const startedAt = 1_000_000
+    const SIBLING = '11111111-1111-4111-8111-111111111111'
+    const MINE = '22222222-2222-4222-8222-222222222222'
+    // The sibling's conversation is the NEWEST file — it would win a plain scan.
+    writeJsonl(projDir, `${SIBLING}.jsonl`, startedAt + 10_000)
+    // Mine is older but still in-window.
+    const minePath = writeJsonl(projDir, `${MINE}.jsonl`, startedAt + 1_000)
+
+    const binder = makeHeuristicBinder({ projectsRoot: root })
+    const binding = binder.bindOnce('sess-x', cwd, startedAt, new Set([SIBLING]))
+    expect(binding).not.toBeNull()
+    expect(binding!.path).toBe(path.normalize(minePath))
+  })
+
+  it('#480 returns null rather than cross when the only in-window file is excluded', () => {
+    const root = makeTmpProjectsRoot()
+    const cwd = 'F:\\solo-sibling'
+    const projDir = path.join(root, mangleCwdToProjectDir(cwd))
+    fs.mkdirSync(projDir, { recursive: true })
+    const startedAt = 1_000_000
+    const SIBLING = '33333333-3333-4333-8333-333333333333'
+    writeJsonl(projDir, `${SIBLING}.jsonl`, startedAt + 5_000)
+
+    const binder = makeHeuristicBinder({ projectsRoot: root })
+    expect(binder.bindOnce('sess-y', cwd, startedAt, new Set([SIBLING]))).toBeNull()
+  })
+
   it('ignores .jsonl files older than startedAtMs - 60_000', () => {
     const root = makeTmpProjectsRoot()
     const cwd = 'F:\\old-project'

--- a/tests/unit/logging/transcripts-db.native.test.ts
+++ b/tests/unit/logging/transcripts-db.native.test.ts
@@ -885,4 +885,39 @@ describe('transcripts-db', () => {
       expect(db.sessionConfig('nope')).toBeNull()
     })
   })
+
+  describe('#480 durable session_conversation map', () => {
+    it('upserts and reads back the exact conversation for a session', () => {
+      const p = '/home/.claude/projects/proj/11111111-1111-4111-8111-111111111111.jsonl'
+      db.upsertSessionConversation({ sessionId: 's1', uuid: '11111111-1111-4111-8111-111111111111', path: p, updatedAt: 100 })
+      expect(db.getSessionConversation('s1')).toEqual({
+        uuid: '11111111-1111-4111-8111-111111111111', path: p, updatedAt: 100,
+      })
+    })
+
+    it('is last-write-wins per session (a /clear rotation replaces the row)', () => {
+      const p1 = '/home/.claude/projects/proj/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl'
+      const p2 = '/home/.claude/projects/proj/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl'
+      db.upsertSessionConversation({ sessionId: 's1', uuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', path: p1, updatedAt: 100 })
+      db.upsertSessionConversation({ sessionId: 's1', uuid: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', path: p2, updatedAt: 200 })
+      expect(db.getSessionConversation('s1')).toEqual({
+        uuid: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', path: p2, updatedAt: 200,
+      })
+    })
+
+    it('keeps distinct sessions independent and returns null for unknown ones', () => {
+      db.upsertSessionConversation({ sessionId: 's1', uuid: '11111111-1111-4111-8111-111111111111', path: '/p/1.jsonl', updatedAt: 1 })
+      db.upsertSessionConversation({ sessionId: 's2', uuid: '22222222-2222-4222-8222-222222222222', path: '/p/2.jsonl', updatedAt: 2 })
+      expect(db.getSessionConversation('s1')?.uuid).toBe('11111111-1111-4111-8111-111111111111')
+      expect(db.getSessionConversation('s2')?.uuid).toBe('22222222-2222-4222-8222-222222222222')
+      expect(db.getSessionConversation('nope')).toBeNull()
+    })
+
+    it('does NOT require an open run (survives a missing run row)', () => {
+      // No insertRun for 's-orphan' — the durable map is keyed by sessionId, not runId.
+      const p = '/home/.claude/projects/proj/cccccccc-cccc-4ccc-8ccc-cccccccccccc.jsonl'
+      db.upsertSessionConversation({ sessionId: 's-orphan', uuid: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', path: p, updatedAt: 5 })
+      expect(db.getSessionConversation('s-orphan')?.path).toBe(p)
+    })
+  })
 })

--- a/tests/unit/logging/transcripts-db.native.test.ts
+++ b/tests/unit/logging/transcripts-db.native.test.ts
@@ -919,5 +919,36 @@ describe('transcripts-db', () => {
       db.upsertSessionConversation({ sessionId: 's-orphan', uuid: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', path: p, updatedAt: 5 })
       expect(db.getSessionConversation('s-orphan')?.path).toBe(p)
     })
+
+    it('maps a uuid to at most one session — a new owner evicts the prior row', () => {
+      // Adversarial round 1: without eviction, two durable rows would point at
+      // the same conversation and both cards would `--resume` it after a restart.
+      const uuid = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+      const p = `/home/.claude/projects/proj/${uuid}.jsonl`
+      db.upsertSessionConversation({ sessionId: 'sA', uuid, path: p, updatedAt: 1 })
+      db.upsertSessionConversation({ sessionId: 'sB', uuid, path: p, updatedAt: 2 }) // handoff
+      expect(db.getSessionConversation('sA')).toBeNull() // stale row evicted
+      expect(db.getSessionConversation('sB')?.uuid).toBe(uuid)
+      // A different uuid for the same session is unaffected by the eviction rule.
+      db.upsertSessionConversation({ sessionId: 'sA', uuid: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee', path: '/p/e.jsonl', updatedAt: 3 })
+      expect(db.getSessionConversation('sA')?.uuid).toBe('eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee')
+      expect(db.getSessionConversation('sB')?.uuid).toBe(uuid)
+    })
+
+    it('recreates the table on open for a pre-existing DB (IF NOT EXISTS migration)', () => {
+      // Simulate a DB written before #480: drop the table, reopen via the real
+      // opener, and confirm the DDL restores it and round-trips.
+      db.close()
+      const raw = new Database(dbPath)
+      raw.exec('DROP TABLE session_conversation')
+      raw.close()
+      const db2 = openTranscriptsDb(dbPath)
+      try {
+        db2.upsertSessionConversation({ sessionId: 's', uuid: 'ffffffff-ffff-4fff-8fff-ffffffffffff', path: '/p/f.jsonl', updatedAt: 1 })
+        expect(db2.getSessionConversation('s')?.uuid).toBe('ffffffff-ffff-4fff-8fff-ffffffffffff')
+      } finally {
+        db2.close()
+      }
+    })
   })
 })

--- a/tests/unit/main/canvas-root-provenance.test.ts
+++ b/tests/unit/main/canvas-root-provenance.test.ts
@@ -94,7 +94,12 @@ vi.mock('../../../src/main/logging/transcript-discovery', async (importOriginal)
 vi.mock('../../../src/main/logging/logging-service', () => ({
   getLogSupervisor: () => null,
   getTranscriptBinder: () =>
-    h.bindTranscript ? { getLatestTranscriptPath: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl' } : null,
+    h.bindTranscript ? {
+      getLatestTranscriptPath: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl',
+      // #480: restart resume now reads the EXACT bind; mirror the path so this
+      // exercises the same resume the test intends.
+      getExactResumeTarget: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl',
+    } : null,
 }))
 
 vi.mock('../../../src/main/conductor-mcp-server', () => ({
@@ -124,7 +129,7 @@ vi.mock('../../../src/main/vision-manager', () => ({
 }))
 
 vi.mock('../../../src/main/canvas/canvas-plugin', () => ({ ensureCanvasPlugin: () => null }))
-vi.mock('../../../src/main/hooks', () => ({ getGateway: () => null }))
+vi.mock('../../../src/main/hooks', () => ({ getGateway: () => null, isExactBindSourceActive: () => true }))
 vi.mock('../../../src/main/hooks/session-hooks-writer', () => ({ injectHooks: () => {} }))
 vi.mock('../../../src/main/hooks/per-session-settings', () => ({
   writeLocalSessionSettings: () => null,

--- a/tests/unit/main/canvas-worktree-spawn.test.ts
+++ b/tests/unit/main/canvas-worktree-spawn.test.ts
@@ -86,7 +86,12 @@ vi.mock('../../../src/main/logging/transcript-discovery', async (importOriginal)
 vi.mock('../../../src/main/logging/logging-service', () => ({
   getLogSupervisor: () => null,
   getTranscriptBinder: () =>
-    h.bindTranscript ? { getLatestTranscriptPath: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl' } : null,
+    h.bindTranscript ? {
+      getLatestTranscriptPath: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl',
+      // #480: restart resume now reads the EXACT bind; mirror the path so this
+      // exercises the same resume the test intends.
+      getExactResumeTarget: () => '/transcripts/11111111-2222-3333-4444-555555555555.jsonl',
+    } : null,
 }))
 
 vi.mock('../../../src/main/conductor-mcp-server', () => ({
@@ -119,7 +124,7 @@ vi.mock('../../../src/main/vision-manager', () => ({
 }))
 
 vi.mock('../../../src/main/canvas/canvas-plugin', () => ({ ensureCanvasPlugin: () => null }))
-vi.mock('../../../src/main/hooks', () => ({ getGateway: () => null }))
+vi.mock('../../../src/main/hooks', () => ({ getGateway: () => null, isExactBindSourceActive: () => true }))
 vi.mock('../../../src/main/hooks/session-hooks-writer', () => ({ injectHooks: () => {} }))
 vi.mock('../../../src/main/hooks/per-session-settings', () => ({
   writeLocalSessionSettings: () => null,

--- a/tests/unit/main/enrich-cross-attack-480.test.ts
+++ b/tests/unit/main/enrich-cross-attack-480.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { enrichSessionStateWithResumeTargets } from '../../../src/main/session-resume-enrich'
+import type { ResumeEnrichDeps } from '../../../src/main/session-resume-enrich'
+import type { SessionState } from '../../../src/main/session-state'
+
+// #480 adversarial round 2 re-check (attacker): two same-repo cards, hooks ON,
+// with NO exact bind and ONLY a shared heuristic bind (the newest .jsonl in the
+// per-repo folder). The main enrich path must NOT stamp the same conversation
+// uuid on both cards — that was the same-repo cross that survived on the relaunch
+// (enrich) path. Deps are shaped EXACTLY as src/main/index.ts wires them.
+
+function state(sessions: any[]): SessionState {
+  return { sessions, activeSessionId: sessions[0]?.id, savedAt: 1 } as unknown as SessionState
+}
+
+// Both same-repo cards resolve, via the heuristic newest-file scan, to the SAME
+// sibling transcript — the concrete cross.
+const SHARED_HEUR = '/repo/proj/9f9f9f9f-1111-2222-3333-444444444444.jsonl'
+const CROSS_UUID = '9f9f9f9f-1111-2222-3333-444444444444'
+
+/** Deps mirroring src/main/index.ts createSessionDurability wiring:
+ *  getExactResumeTarget -> binder exact map (null: nothing authenticated yet),
+ *  getLatestTranscriptPath -> binder heuristic newest-file scan (shared sibling),
+ *  isExactBindSourceActive -> real hook gate (hooks ON => true),
+ *  resolveResumeTargetFromTranscript -> uuid from transcript basename. */
+function prodDeps(hooksEnabled: boolean): ResumeEnrichDeps & { _getLatest: ReturnType<typeof vi.fn> } {
+  const getLatest = vi.fn((_id: string): string | null => SHARED_HEUR)
+  return {
+    getExactResumeTarget: (_id: string) => null,
+    getLatestTranscriptPath: (id: string) => getLatest(id),
+    isExactBindSourceActive: () => hooksEnabled,
+    resolveResumeTargetFromTranscript: (p: string) => ({
+      uuid: p.split('/').pop()!.replace(/\.jsonl$/i, ''),
+      cwd: '/repo/proj',
+    }),
+    _getLatest: getLatest,
+  }
+}
+
+describe('#480 cross attack — main enrich, hooks ON, two same-repo cards', () => {
+  it('does NOT stamp the same heuristic uuid on two same-repo cards (hooks on)', () => {
+    const deps = prodDeps(true)
+    const s = state([
+      { id: 'cardA', provider: 'claude', cwd: '/repo/proj' },
+      { id: 'cardB', provider: 'claude', cwd: '/repo/proj' },
+    ])
+    enrichSessionStateWithResumeTargets(s, deps)
+
+    // Heuristic path must never be consulted while hooks are on.
+    expect(deps._getLatest).not.toHaveBeenCalled()
+    // Neither card gets a resume uuid — a fresh start beats reopening a stranger.
+    expect(s.sessions[0].resumeUuid).toBeUndefined()
+    expect(s.sessions[1].resumeUuid).toBeUndefined()
+    // Explicitly: they are NOT both the crossed sibling uuid.
+    expect(s.sessions[0].resumeUuid).not.toBe(CROSS_UUID)
+    expect(s.sessions[1].resumeUuid).not.toBe(CROSS_UUID)
+  })
+
+  it('control: hooks OFF DOES fall back to the (crossing) heuristic — the documented trade', () => {
+    const deps = prodDeps(false)
+    const s = state([
+      { id: 'cardA', provider: 'claude', cwd: '/repo/proj' },
+      { id: 'cardB', provider: 'claude', cwd: '/repo/proj' },
+    ])
+    enrichSessionStateWithResumeTargets(s, deps)
+    // With no authenticated source at all, both cross to the sibling — expected.
+    expect(s.sessions[0].resumeUuid).toBe(CROSS_UUID)
+    expect(s.sessions[1].resumeUuid).toBe(CROSS_UUID)
+  })
+})

--- a/tests/unit/main/exact-bind-gate.test.ts
+++ b/tests/unit/main/exact-bind-gate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// #480: `isExactBindSourceActive()` gates the (cross-prone) heuristic resume
+// fallback. It keys ONLY on the `hooksEnabled` setting — NOT the live
+// gateway.listening flag, which blips false during gateway startup / crash-
+// backoff / manual restart. Keying on the transient flag would unlock the
+// fallback in the DEFAULT (hooks-on) config during those windows and let two
+// same-repo cards cross (adversarial round 2, MAJOR). These tests pin that.
+
+const readConfigSpy = vi.fn<(key: string) => unknown>()
+vi.mock('../../../src/main/config-manager', () => ({
+  readConfig: (key: string) => readConfigSpy(key),
+}))
+
+import { isExactBindSourceActive, setGateway } from '../../../src/main/hooks'
+import type { HooksGatewayLike } from '../../../src/main/hooks'
+import type { HooksGatewayStatus } from '../../../src/shared/hook-types'
+
+function fakeGateway(status: HooksGatewayStatus): HooksGatewayLike {
+  return {
+    registerSession: () => '',
+    unregisterSession: () => {},
+    getBuffer: () => [],
+    status: () => status,
+    start: async () => status,
+    stop: async () => {},
+    setPermissionGateActive: () => {},
+    subscribe: () => () => {},
+  } as unknown as HooksGatewayLike
+}
+
+describe('#480 gate: isExactBindSourceActive()', () => {
+  beforeEach(() => {
+    readConfigSpy.mockReset()
+  })
+
+  it('defaults TRUE when the settings file is absent (config null)', () => {
+    readConfigSpy.mockReturnValue(null)
+    expect(isExactBindSourceActive()).toBe(true)
+  })
+
+  it('defaults TRUE when the key is absent from an existing settings object', () => {
+    readConfigSpy.mockReturnValue({ somethingElse: 1 })
+    expect(isExactBindSourceActive()).toBe(true)
+  })
+
+  it('stays TRUE with hooks enabled even while the gateway is NOT listening (no race unlock)', () => {
+    readConfigSpy.mockReturnValue({ hooksEnabled: true })
+    // Transient states the supervisor/proxy legitimately produce with hooks ON.
+    setGateway(fakeGateway({ enabled: true, listening: false, port: null }))
+    expect(isExactBindSourceActive()).toBe(true) // exact source WILL arrive once it settles
+  })
+
+  it('stays TRUE with hooks enabled even when the gateway singleton is null (pre-init)', () => {
+    readConfigSpy.mockReturnValue({ hooksEnabled: true })
+    // @ts-expect-error deliberately clear the singleton to model pre-init
+    setGateway(null)
+    expect(isExactBindSourceActive()).toBe(true)
+  })
+
+  it('is FALSE only when the user disabled hooks (the intended fallback case)', () => {
+    readConfigSpy.mockReturnValue({ hooksEnabled: false })
+    setGateway(fakeGateway({ enabled: true, listening: true, port: 5 }))
+    expect(isExactBindSourceActive()).toBe(false)
+  })
+
+  it('propagates a readConfig throw — consumers wrap it and fail safe', () => {
+    readConfigSpy.mockImplementation(() => { throw new Error('no resources dir') })
+    expect(() => isExactBindSourceActive()).toThrow()
+  })
+})

--- a/tests/unit/main/resume-ipc-handlers.test.ts
+++ b/tests/unit/main/resume-ipc-handlers.test.ts
@@ -11,11 +11,22 @@ vi.mock('electron', () => ({
 // supervisor query) and falls back to the live EXACT bind — never a heuristic
 // guess. Mock both accessors.
 const getExactResumeTargetSpy = vi.fn<(id: string) => string | null>()
+const getLatestTranscriptPathSpy = vi.fn<(id: string) => string | null>()
 const querySpy = vi.fn<(kind: string, args: Record<string, unknown>) => Promise<unknown[]>>()
 vi.mock('../../../src/main/logging/logging-service', () => ({
-  getTranscriptBinder: () => ({ getExactResumeTarget: getExactResumeTargetSpy }),
+  getTranscriptBinder: () => ({
+    getExactResumeTarget: getExactResumeTargetSpy,
+    getLatestTranscriptPath: getLatestTranscriptPathSpy,
+  }),
   getLogSupervisor: () => ({ query: querySpy }),
 }))
+
+// #480: the hooks-off fallback gate — exact-only when hooks are active.
+const isExactBindSourceActiveSpy = vi.fn<() => boolean>()
+vi.mock('../../../src/main/hooks', () => ({
+  isExactBindSourceActive: () => isExactBindSourceActiveSpy(),
+}))
+vi.mock('../../../src/main/debug-logger', () => ({ logWarn: () => {} }))
 
 // Stub the pure resolver so the handler test stays a pure IPC test.
 const resolveSpy = vi.fn<(p: string) => { uuid: string; cwd: string } | null>()
@@ -31,8 +42,12 @@ describe('resume IPC handler (getResumeTarget)', () => {
   beforeEach(() => {
     handlers.clear()
     getExactResumeTargetSpy.mockReset()
+    getLatestTranscriptPathSpy.mockReset()
+    getLatestTranscriptPathSpy.mockReturnValue(null)
     querySpy.mockReset()
     querySpy.mockResolvedValue([]) // durable miss by default
+    isExactBindSourceActiveSpy.mockReset()
+    isExactBindSourceActiveSpy.mockReturnValue(true) // hooks active => exact-only, no fallback
     resolveSpy.mockReset()
     registerResumeHandlers()
   })
@@ -70,6 +85,27 @@ describe('resume IPC handler (getResumeTarget)', () => {
     getExactResumeTargetSpy.mockReturnValue(null)
     querySpy.mockRejectedValue(new Error('worker down'))
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(out).toBeNull()
+  })
+
+  it('hooks-off: falls back to the heuristic bind and still resolves', async () => {
+    isExactBindSourceActiveSpy.mockReturnValue(false)
+    getExactResumeTargetSpy.mockReturnValue(null)
+    querySpy.mockResolvedValue([])
+    getLatestTranscriptPathSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
+    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
+    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(getLatestTranscriptPathSpy).toHaveBeenCalledWith('s1')
+    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
+  })
+
+  it('hooks-on: never falls back to the heuristic (exact-only, no cross)', async () => {
+    isExactBindSourceActiveSpy.mockReturnValue(true)
+    getExactResumeTargetSpy.mockReturnValue(null)
+    querySpy.mockResolvedValue([])
+    getLatestTranscriptPathSpy.mockReturnValue('/home/.claude/projects/p/sibling.jsonl')
+    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(getLatestTranscriptPathSpy).not.toHaveBeenCalled()
     expect(out).toBeNull()
   })
 

--- a/tests/unit/main/resume-ipc-handlers.test.ts
+++ b/tests/unit/main/resume-ipc-handlers.test.ts
@@ -7,10 +7,14 @@ vi.mock('electron', () => ({
   ipcMain: { handle: (ch: string, fn: (...a: any[]) => any) => handlers.set(ch, fn) },
 }))
 
-// Mock the binder accessor; the spy records the sessionId it is asked about.
-const getLatestTranscriptPathSpy = vi.fn<(id: string) => string | null>()
+// #480: the handler now prefers the durable session_conversation record (via the
+// supervisor query) and falls back to the live EXACT bind — never a heuristic
+// guess. Mock both accessors.
+const getExactResumeTargetSpy = vi.fn<(id: string) => string | null>()
+const querySpy = vi.fn<(kind: string, args: Record<string, unknown>) => Promise<unknown[]>>()
 vi.mock('../../../src/main/logging/logging-service', () => ({
-  getTranscriptBinder: () => ({ getLatestTranscriptPath: getLatestTranscriptPathSpy }),
+  getTranscriptBinder: () => ({ getExactResumeTarget: getExactResumeTargetSpy }),
+  getLogSupervisor: () => ({ query: querySpy }),
 }))
 
 // Stub the pure resolver so the handler test stays a pure IPC test.
@@ -26,25 +30,48 @@ const invoke = (ch: string, ...args: any[]) => handlers.get(ch)!({} as any, ...a
 describe('resume IPC handler (getResumeTarget)', () => {
   beforeEach(() => {
     handlers.clear()
-    getLatestTranscriptPathSpy.mockReset()
+    getExactResumeTargetSpy.mockReset()
+    querySpy.mockReset()
+    querySpy.mockResolvedValue([]) // durable miss by default
     resolveSpy.mockReset()
     registerResumeHandlers()
   })
 
-  it('resolves {uuid,cwd} from the latest bound transcript', async () => {
-    getLatestTranscriptPathSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
+  it('prefers the durable session_conversation record', async () => {
+    querySpy.mockResolvedValue([{ uuid: 'u', path: '/home/.claude/projects/p/u.jsonl' }])
     resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
-    expect(getLatestTranscriptPathSpy).toHaveBeenCalledWith('s1')
+    expect(querySpy).toHaveBeenCalledWith('session-conversation', { sessionId: 's1' })
+    expect(resolveSpy).toHaveBeenCalledWith('/home/.claude/projects/p/u.jsonl')
+    // The durable hit means we never consult the live bind.
+    expect(getExactResumeTargetSpy).not.toHaveBeenCalled()
+    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
+  })
+
+  it('falls back to the live EXACT bind when the durable record is absent', async () => {
+    querySpy.mockResolvedValue([])
+    getExactResumeTargetSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
+    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
+    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(getExactResumeTargetSpy).toHaveBeenCalledWith('s1')
     expect(resolveSpy).toHaveBeenCalledWith('/home/.claude/projects/p/u.jsonl')
     expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
   })
 
-  it('returns null when no transcript is bound', async () => {
-    getLatestTranscriptPathSpy.mockReturnValue(null)
+  it('returns null when neither the durable record nor an exact bind exists', async () => {
+    querySpy.mockResolvedValue([])
+    getExactResumeTargetSpy.mockReturnValue(null)
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
     expect(out).toBeNull()
     expect(resolveSpy).not.toHaveBeenCalled()
+  })
+
+  it('survives a durable-query rejection and still tries the exact bind', async () => {
+    querySpy.mockRejectedValue(new Error('worker down'))
+    getExactResumeTargetSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
+    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
+    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
   })
 
   it('is fail-safe (returns null) on an invalid sessionId', async () => {

--- a/tests/unit/main/resume-ipc-handlers.test.ts
+++ b/tests/unit/main/resume-ipc-handlers.test.ts
@@ -37,41 +37,40 @@ describe('resume IPC handler (getResumeTarget)', () => {
     registerResumeHandlers()
   })
 
-  it('prefers the durable session_conversation record', async () => {
+  it('prefers the LIVE exact bind (freshest during a live session)', async () => {
+    getExactResumeTargetSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
+    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
+    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
+    expect(getExactResumeTargetSpy).toHaveBeenCalledWith('s1')
+    // The live hit means we never consult the durable table.
+    expect(querySpy).not.toHaveBeenCalled()
+    expect(resolveSpy).toHaveBeenCalledWith('/home/.claude/projects/p/u.jsonl')
+    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
+  })
+
+  it('falls back to the durable record after a restart (no live bind)', async () => {
+    getExactResumeTargetSpy.mockReturnValue(null)
     querySpy.mockResolvedValue([{ uuid: 'u', path: '/home/.claude/projects/p/u.jsonl' }])
     resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
     expect(querySpy).toHaveBeenCalledWith('session-conversation', { sessionId: 's1' })
     expect(resolveSpy).toHaveBeenCalledWith('/home/.claude/projects/p/u.jsonl')
-    // The durable hit means we never consult the live bind.
-    expect(getExactResumeTargetSpy).not.toHaveBeenCalled()
     expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
   })
 
-  it('falls back to the live EXACT bind when the durable record is absent', async () => {
-    querySpy.mockResolvedValue([])
-    getExactResumeTargetSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
-    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
-    const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
-    expect(getExactResumeTargetSpy).toHaveBeenCalledWith('s1')
-    expect(resolveSpy).toHaveBeenCalledWith('/home/.claude/projects/p/u.jsonl')
-    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
-  })
-
-  it('returns null when neither the durable record nor an exact bind exists', async () => {
-    querySpy.mockResolvedValue([])
+  it('returns null when neither the live bind nor the durable record exists', async () => {
     getExactResumeTargetSpy.mockReturnValue(null)
+    querySpy.mockResolvedValue([])
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
     expect(out).toBeNull()
     expect(resolveSpy).not.toHaveBeenCalled()
   })
 
-  it('survives a durable-query rejection and still tries the exact bind', async () => {
+  it('survives a durable-query rejection (returns fresh, never throws)', async () => {
+    getExactResumeTargetSpy.mockReturnValue(null)
     querySpy.mockRejectedValue(new Error('worker down'))
-    getExactResumeTargetSpy.mockReturnValue('/home/.claude/projects/p/u.jsonl')
-    resolveSpy.mockReturnValue({ uuid: 'u', cwd: 'F:/wt' })
     const out = await invoke(IPC.LOGS_GET_RESUME_TARGET, 's1')
-    expect(out).toEqual({ uuid: 'u', cwd: 'F:/wt' })
+    expect(out).toBeNull()
   })
 
   it('is fail-safe (returns null) on an invalid sessionId', async () => {

--- a/tests/unit/main/session-durability.test.ts
+++ b/tests/unit/main/session-durability.test.ts
@@ -11,7 +11,10 @@ const target = { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', cwd: 'C:/p' }
 function make(saveImpl?: (s: SessionState) => boolean, log?: (m: string) => void) {
   const save = vi.fn(saveImpl ?? (() => true))
   const enrichDeps = {
+    // #480: exact bind is the source; heuristic is the hooks-off fallback only.
+    getExactResumeTarget: () => '/x/f.jsonl',
     getLatestTranscriptPath: () => '/x/f.jsonl',
+    isExactBindSourceActive: () => true,
     resolveResumeTargetFromTranscript: () => target,
   }
   const d = createSessionDurability({ enrichDeps, save, log })

--- a/tests/unit/main/session-resume-enrich.test.ts
+++ b/tests/unit/main/session-resume-enrich.test.ts
@@ -1,74 +1,92 @@
 import { describe, it, expect, vi } from 'vitest'
 import { enrichSessionStateWithResumeTargets } from '../../../src/main/session-resume-enrich'
+import type { ResumeEnrichDeps } from '../../../src/main/session-resume-enrich'
 import type { SessionState } from '../../../src/main/session-state'
 
 // #397 Group 1: main-side enrichment is the single write choke point that stamps
 // each Claude session's exact-conversation resume target, so EVERY renderer writer
-// (autosave, account flush, GitHub flush, Save-&-Close) persists a resumable
-// record — not only the graceful-close path. These tests pin the fail-safe rules.
+// persists a resumable record — not only the graceful-close path.
+// #480: it must use the EXACT bind (never the heuristic), with a hooks-off
+// fallback, so it can never persist a cross-prone guess in the default config.
 
 function state(sessions: any[]): SessionState {
   return { sessions, activeSessionId: sessions[0]?.id, savedAt: 1 } as unknown as SessionState
 }
 
 const okTarget = { uuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', cwd: 'C:/proj' }
+const EXACT = '/x/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+const HEUR = '/x/heuristic-sibling.jsonl'
+
+/** Default deps: hooks ON, an exact path available, and a heuristic path that
+ *  MUST NOT be consulted while hooks are on. Override per test. */
+function mkDeps(over: Partial<ResumeEnrichDeps> = {}): ResumeEnrichDeps {
+  return {
+    getExactResumeTarget: () => EXACT,
+    getLatestTranscriptPath: () => HEUR,
+    isExactBindSourceActive: () => true,
+    resolveResumeTargetFromTranscript: () => okTarget,
+    ...over,
+  }
+}
 
 describe('enrichSessionStateWithResumeTargets', () => {
-  it('stamps uuid+cwd on a Claude session from the binder', () => {
+  it('stamps uuid+cwd on a Claude session from the EXACT bind', () => {
     const s = state([{ id: 's1', provider: 'claude' }])
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: () => '/x/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl',
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
+    enrichSessionStateWithResumeTargets(s, mkDeps())
     expect(s.sessions[0]).toMatchObject({ resumeUuid: okTarget.uuid, resumeCwd: okTarget.cwd })
   })
 
   it('treats an absent provider as claude (default) and enriches it', () => {
     const s = state([{ id: 's1' }])
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: () => '/x/f.jsonl',
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
+    enrichSessionStateWithResumeTargets(s, mkDeps())
+    expect(s.sessions[0].resumeUuid).toBe(okTarget.uuid)
+  })
+
+  it('#480 hooks-on: NEVER consults the heuristic path (no cross)', () => {
+    const s = state([{ id: 's1', provider: 'claude' }])
+    const getLatest = vi.fn(() => HEUR)
+    enrichSessionStateWithResumeTargets(s, mkDeps({ getExactResumeTarget: () => null, getLatestTranscriptPath: getLatest }))
+    expect(getLatest).not.toHaveBeenCalled()
+    expect(s.sessions[0].resumeUuid).toBeUndefined()
+  })
+
+  it('#480 hooks-off: falls back to the heuristic path', () => {
+    const s = state([{ id: 's1', provider: 'claude' }])
+    const getLatest = vi.fn(() => HEUR)
+    enrichSessionStateWithResumeTargets(s, mkDeps({
+      getExactResumeTarget: () => null,
+      isExactBindSourceActive: () => false,
+      getLatestTranscriptPath: getLatest,
+    }))
+    expect(getLatest).toHaveBeenCalledWith('s1')
     expect(s.sessions[0].resumeUuid).toBe(okTarget.uuid)
   })
 
   it('skips shell-only sessions', () => {
     const s = state([{ id: 's1', provider: 'claude', shellOnly: true }])
-    const getLatest = vi.fn(() => '/x/f.jsonl')
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: getLatest,
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
-    expect(getLatest).not.toHaveBeenCalled()
+    const getExact = vi.fn(() => EXACT)
+    enrichSessionStateWithResumeTargets(s, mkDeps({ getExactResumeTarget: getExact }))
+    expect(getExact).not.toHaveBeenCalled()
     expect(s.sessions[0].resumeUuid).toBeUndefined()
   })
 
   it('skips non-Claude (codex) sessions', () => {
     const s = state([{ id: 's1', provider: 'codex' }])
-    const getLatest = vi.fn(() => '/x/f.jsonl')
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: getLatest,
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
-    expect(getLatest).not.toHaveBeenCalled()
+    const getExact = vi.fn(() => EXACT)
+    enrichSessionStateWithResumeTargets(s, mkDeps({ getExactResumeTarget: getExact }))
+    expect(getExact).not.toHaveBeenCalled()
     expect(s.sessions[0].resumeUuid).toBeUndefined()
   })
 
-  it('KEEPS the existing target when the binder has no path (logging off)', () => {
+  it('KEEPS the existing target when there is no exact bind (hooks on, no fallback)', () => {
     const s = state([{ id: 's1', provider: 'claude', resumeUuid: 'old-uuid', resumeCwd: 'C:/old' }])
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: () => null,
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
+    enrichSessionStateWithResumeTargets(s, mkDeps({ getExactResumeTarget: () => null }))
     expect(s.sessions[0]).toMatchObject({ resumeUuid: 'old-uuid', resumeCwd: 'C:/old' })
   })
 
   it('KEEPS the existing target when the transcript does not resolve a target', () => {
     const s = state([{ id: 's1', provider: 'claude', resumeUuid: 'old-uuid', resumeCwd: 'C:/old' }])
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: () => '/x/f.jsonl',
-      resolveResumeTargetFromTranscript: () => null,
-    })
+    enrichSessionStateWithResumeTargets(s, mkDeps({ resolveResumeTargetFromTranscript: () => null }))
     expect(s.sessions[0]).toMatchObject({ resumeUuid: 'old-uuid', resumeCwd: 'C:/old' })
   })
 
@@ -77,22 +95,18 @@ describe('enrichSessionStateWithResumeTargets', () => {
       { id: 'bad', provider: 'claude', resumeUuid: 'keep' },
       { id: 'good', provider: 'claude' },
     ])
-    enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: (id) => {
+    enrichSessionStateWithResumeTargets(s, mkDeps({
+      getExactResumeTarget: (id) => {
         if (id === 'bad') throw new Error('binder blew up')
-        return '/x/f.jsonl'
+        return EXACT
       },
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })
+    }))
     expect(s.sessions[0].resumeUuid).toBe('keep')          // untouched despite the throw
     expect(s.sessions[1].resumeUuid).toBe(okTarget.uuid)   // later session still enriched
   })
 
   it('is a whole no-op on a non-array sessions field', () => {
     const s = { sessions: undefined, savedAt: 1 } as unknown as SessionState
-    expect(() => enrichSessionStateWithResumeTargets(s, {
-      getLatestTranscriptPath: () => '/x/f.jsonl',
-      resolveResumeTargetFromTranscript: () => okTarget,
-    })).not.toThrow()
+    expect(() => enrichSessionStateWithResumeTargets(s, mkDeps())).not.toThrow()
   })
 })


### PR DESCRIPTION
Fixes #480.

## Problem

When several cards run in one repo directory, an in-session **Restart** (and app relaunch) could resume the **wrong Claude Code conversation** — a sibling card's transcript. Root cause: the transcript binder's heuristic fallback picks the newest `.jsonl` in the shared per-repo project folder, which can belong to another live card, and the resume path trusted it.

## Fix

1. **Exact-only resume.** Restart resume uses only the authenticated (hook-reported) exact bind — never the newest-file heuristic. No exact bind → fresh start (safer than reopening a stranger).
2. **Ownership guard.** A conversation uuid maps to at most one live session; a second live session cannot steal it; released on `endRun` / `/clear` for a genuine handoff.
3. **Heuristic exclusion.** The fallback scan skips uuids owned by other live sessions.
4. **Durable map.** New `session_conversation` table in `transcripts.db`, written on every exact bind, single-owner-per-uuid (a handoff evicts the prior row). Both the in-session restart and the close-all relaunch read this one crash-durable source.
5. **Hooks-off fallback (gated + warned).** When hooks are disabled (no authenticated source can arrive), resume falls back to the heuristic bind and logs a warning — best-effort for that config only. Gated on the `hooksEnabled` setting so a transient gateway blip never unlocks it in the default config.

## Adversarial review (ADR-009): PASS

Touches the PTY resume path + IPC, so `/adversarial-review` was run (independent attacker sub-agents, two fix→re-attack rounds). Findings, all fixed:

- **MAJOR** — the durable table could re-cross two cards after an app restart (row-per-session, never evicted) → now single-owner-per-uuid.
- **BLOCKER** — a second enrichment path (`session-resume-enrich`) was un-gated and overwrote the renderer's correct value with a heuristic guess → now exact-only + gated.
- **MAJOR** — the fallback gate keyed on the transient `gateway.listening` flag → now keys only on the `hooksEnabled` setting.
- Plus LOW fixes: refusal no longer disarms the heuristic; live bind preferred over durable.

Injection lens: NONE (uuid triple-validated by anchored regex before argv; cwd quote-escaped + existence-gated; SQL parameterized). One MINOR left by design: a permanently-failed gateway with hooks on gives a fresh resume (fails safe).

## Tests

266 non-native + 71 native pass; new tests are fail-on-revert verified (ownership guard, exact-only resume, durable single-owner + migration, hooks-on/off fallback, gate). `tsc` clean.

## Gates

- Desktop-tested by the operator (two same-repo cards; restart resumes the right conversation).
- Human review + merge per ADR-025.
