### PR TITLE
fix(canvas): superseded review rounds settle instead of stacking the queue

### DIFF
--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -25,6 +25,7 @@ import {
   CANVAS_REVIEW_ID_RE,
   CANVAS_VERSION_ID_RE,
   MAX_ANNOTATION_VARIANTS,
+  artifactRuns,
   MAX_ATTACHMENT_PNG_BYTES,
   isCleanVariantLabel,
   type AddressedBy,
@@ -494,18 +495,31 @@ interface SessionCanvas {
   draftVersionIds: string[]
   /** Non-draft version ids, in render order — what the pane can show. */
   readyVersionIds: string[]
+  /** versionId -> the ARTIFACT (contiguous same-kind run) it belongs to,
+   *  keyed by the run's first version id — the same grouping the history
+   *  picker uses (#470 supersede scoping). A round supersedes only OTHER
+   *  rounds of its own artifact; a plan-artifact ruling must not settle a
+   *  mockup-artifact round that merely shares the canvas. */
+  artifactKeyByVersion: Map<string, string>
 }
 
 function canvasForSession(sessionId: string): SessionCanvas | null {
   if (!SESSION_ID_RE.test(sessionId)) return null
   const state = getCanvasStateForSession(sessionId)
   if (!state) return null
+  const artifactKeyByVersion = new Map<string, string>()
+  for (const run of artifactRuns(state.versions)) {
+    const key = run[0]?.id
+    if (key === undefined) continue
+    for (const v of run) artifactKeyByVersion.set(v.id, key)
+  }
   return {
     canvasId: state.canvasId,
     activeVersionId: state.activeVersionId,
     versionIds: new Set(state.versions.map((v) => v.id)),
     draftVersionIds: state.versions.filter((v) => v.draft).map((v) => v.id),
     readyVersionIds: state.versions.filter((v) => !v.draft).map((v) => v.id),
+    artifactKeyByVersion,
   }
 }
 
@@ -858,13 +872,22 @@ function settleReviewStatus(record: ReviewFileRecord, reviewId: string): void {
  * can create the shape); read paths are untouched, so a record written before
  * this existed reads as before until its canvas's next mutation settles it.
  */
-function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
+function supersededOwedReviewIds(record: ReviewFileRecord, artifactKeyByVersion: Map<string, string>): Set<string> {
   const ord = (id: string): number => Number(id.slice(1))
-  let resolvedMax = 0
+  // A round's artifact — the run its frozen version belongs to. A version not
+  // in the map (should not happen: rounds freeze against ready versions) is
+  // isolated to its own key so it can only ever supersede within itself.
+  const artifactOf = (r: Review): string => artifactKeyByVersion.get(r.versionId) ?? `v:${r.versionId}`
+  // Per ARTIFACT, the highest-ordinal round the USER verifiably ruled on. Per
+  // artifact, not per canvas (review round 2, security lens): a canvas holds
+  // many artifacts (a plan, a mockup, a legacy build), and "the user answered
+  // this more recently" is only true for later rounds of the SAME artifact —
+  // approving a plan says nothing about a mockup's open feedback.
+  const resolvedMaxByArtifact = new Map<string, number>()
   for (const r of record.reviews) {
     if (r.status !== 'resolved') continue
     // Only a round the USER verifiably ruled on anchors supersession. The
-    // sweep's justification is "the user answered this canvas more recently
+    // sweep's justification is "the user answered this artifact more recently
     // than these rounds", and that must be a fact the store can check, not an
     // agent assertion: a round resolved purely through the agent-callable
     // writes (canvas_verdict, canvas_pick — closedBy 'agent') must not let a
@@ -876,12 +899,15 @@ function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
     // written only by the panel's resolve IPC).
     const userRuled = notesOfReview(record, r).some((a) => a.closedBy === 'user' || a.state === 'reannotated')
     if (!userRuled) continue
-    resolvedMax = Math.max(resolvedMax, ord(r.id))
+    const art = artifactOf(r)
+    resolvedMaxByArtifact.set(art, Math.max(resolvedMaxByArtifact.get(art) ?? 0, ord(r.id)))
   }
   const out = new Set<string>()
-  if (resolvedMax === 0) return out
+  if (resolvedMaxByArtifact.size === 0) return out
   for (const r of record.reviews) {
-    if (r.status !== 'submitted' || ord(r.id) >= resolvedMax) continue
+    if (r.status !== 'submitted') continue
+    const anchorMax = resolvedMaxByArtifact.get(artifactOf(r)) ?? 0
+    if (anchorMax === 0 || ord(r.id) >= anchorMax) continue
     const notes = notesOfReview(record, r)
     // A round still holding OPEN notes is the agent's debt and survives whole;
     // one with nothing addressed has nothing owed to settle.
@@ -892,6 +918,25 @@ function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
     // that immediately re-settles it would make Reopen a no-op. Only the
     // user's own verdict ends a reopened note.
     if (notes.some((a) => a.state === 'addressed' && a.reopenedAt !== undefined)) continue
+    // THE SEEN-BARRIER, applied to the automatic sweep (ADR-009 adversarial
+    // pass). This is the load-bearing gate. Without it, `canvas_resolve`
+    // (markAnnotationsAddressed — agent-callable) becomes an unattended
+    // terminal close: the agent addresses a round the user never saw, and if
+    // ANY later round was user-ruled the sweep closes it in the same commit —
+    // the precise chain `isAgentCloseable`/`closeAnnotationsByAgent` refuse by
+    // name. The sweep is that same close reached without naming it, so it must
+    // clear the same bar: every addressed note must be agent-closeable (the
+    // user has SEEN it addressed, or a non-agent addressed it). An
+    // agent-addressed-but-unseen note keeps its round owed until the user's
+    // next glance marks it seen (or they dismiss it) — one look, not a silent
+    // close. This is what makes the panel's "settled by your later review"
+    // true: the notes were on the user's screen before the sweep touched them.
+    if (notes.some((a) => a.state === 'addressed' && !isAgentCloseable(a))) continue
+    // A round the user is THEMSELVES triaging — they have ruled on one of its
+    // notes — is not settled debt. The click that ruled one note is a verdict
+    // on that note, never on its siblings, so a later round resolving must not
+    // sweep the rest of a round the user is actively working through.
+    if (notes.some((a) => a.closedBy === 'user' || a.state === 'reannotated')) continue
     out.add(r.id)
   }
   return out
@@ -912,8 +957,8 @@ function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
  * notes end in a reopenable state, and `canvas_verdict`'s seen-barrier still
  * guards every close the agent asks for by name.
  */
-function settleSupersededRounds(record: ReviewFileRecord): string[] {
-  const doomed = supersededOwedReviewIds(record)
+function settleSupersededRounds(record: ReviewFileRecord, artifactKeyByVersion: Map<string, string>): string[] {
+  const doomed = supersededOwedReviewIds(record, artifactKeyByVersion)
   if (doomed.size === 0) return []
   for (const review of record.reviews) {
     if (!doomed.has(review.id)) continue
@@ -1353,8 +1398,9 @@ export function resolveAnnotation(
   // the action was right, and that verdict is what closes a review.
   settleReviewStatus(next, owner.id)
   // The user just ruled: if that resolved a round, older fully-addressed
-  // rounds of this canvas are settled debt now, not stacked debt (#470).
-  settleSupersededRounds(next)
+  // (and user-seen) rounds of the SAME artifact are settled debt now, not
+  // stacked debt (#470).
+  settleSupersededRounds(next, canvas.artifactKeyByVersion)
 
   commit(next)
   return { state: toState(next), ...(reannotationId ? { reannotationId } : {}) }
@@ -1531,10 +1577,14 @@ export function markAnnotationsAddressed(
   }
   for (const id of wanted) if (!addressed.includes(id) && !skipped.includes(id)) skipped.push(id)
   // The owner's 3→2→3 bounce (#470): addressing the notes of a round whose
-  // canvas already has a LATER resolved round used to push that round back
-  // into "waiting on the user". It is settled in the same commit instead —
-  // the user's ruling on the newer round already answered it.
-  if (addressed.length > 0) settleSupersededRounds(next)
+  // artifact already has a LATER user-ruled round used to push that round
+  // back into "waiting on the user". The sweep collapses it instead — but
+  // ONLY once the user has seen those notes addressed (the seen-barrier in
+  // supersededOwedReviewIds): a note the agent addresses in this very call is
+  // not yet seen, so it stays owed for one glance rather than closing under
+  // the user unattended. That one-glance delay is the deliberate price of not
+  // handing `canvas_resolve` an unattended close past the barrier (ADR-009).
+  if (addressed.length > 0) settleSupersededRounds(next, canvas.artifactKeyByVersion)
   if (addressed.length > 0) commit(next)
   return { state: toState(addressed.length > 0 ? next : base), addressed, skipped }
 }
@@ -1753,9 +1803,11 @@ export function closeAnnotationsByAgent(
   if (closed.length === 0) return { state: toState(base), closed, skipped, reviewClosed: false }
 
   settleReviewStatus(next, review.id)
-  // An instructed close that resolved this round supersedes older
-  // fully-addressed rounds the same way a panel verdict does (#470).
-  settleSupersededRounds(next)
+  // Re-runs the sweep so a legacy record can HEAL on the next agent write; an
+  // agent close never anchors supersession itself (closedBy 'agent' is not
+  // user provenance), so this only ever settles rounds a prior USER ruling
+  // already licensed (#470).
+  settleSupersededRounds(next, canvas.artifactKeyByVersion)
   const reviewClosed = next.reviews.find((r) => r.id === review.id)?.status === 'resolved'
   commit(next)
   return { state: toState(next), closed, skipped, reviewClosed }
@@ -1836,8 +1888,10 @@ export function recordChatPick(
   nextTarget.pickSource = 'chat'
 
   settleReviewStatus(next, review.id)
-  // The user's chat pick is a ruling like any other (#470).
-  settleSupersededRounds(next)
+  // A chat pick is closedBy 'agent', so it never anchors supersession itself;
+  // this re-runs the sweep only so a legacy record heals on the next write
+  // (#470). Same as the instructed-close path above.
+  settleSupersededRounds(next, canvas.artifactKeyByVersion)
   const reviewClosed = next.reviews.find((r) => r.id === review.id)?.status === 'resolved'
   commit(next)
   // The label is store-held and was validated clean at mint; the tool echoes it

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -874,10 +874,23 @@ function settleReviewStatus(record: ReviewFileRecord, reviewId: string): void {
  */
 function supersededOwedReviewIds(record: ReviewFileRecord, artifactKeyByVersion: Map<string, string>): Set<string> {
   const ord = (id: string): number => Number(id.slice(1))
-  // A round's artifact — the run its frozen version belongs to. A version not
-  // in the map (should not happen: rounds freeze against ready versions) is
-  // isolated to its own key so it can only ever supersede within itself.
-  const artifactOf = (r: Review): string => artifactKeyByVersion.get(r.versionId) ?? `v:${r.versionId}`
+  // A round's artifact — derived from its NOTES' versions, not its frozen
+  // version alone. A round can freeze against a version of a DIFFERENT artifact
+  // than its notes point at: the agent's `canvas_render` moves activeVersionId,
+  // and submitReview freezes against active, so a mockup note submitted just
+  // after a plan render freezes on the plan version (re-attack round 2, MAJOR).
+  // Keyed on the frozen version alone, a plan ruling would then stale that
+  // mockup note. So a round belongs to an artifact only when its notes AND its
+  // frozen version all agree; one that spans artifacts is isolated to its own
+  // key (`span:`) — it neither anchors a sweep nor is swept, the fail-closed
+  // side. A version absent from the map keys to `v:<id>` (rounds freeze against
+  // ready versions, so this is the belt, not the norm).
+  const keyOf = (versionId: string): string => artifactKeyByVersion.get(versionId) ?? `v:${versionId}`
+  const artifactOf = (r: Review): string => {
+    const keys = new Set<string>([keyOf(r.versionId)])
+    for (const a of notesOfReview(record, r)) keys.add(keyOf(a.versionId))
+    return keys.size === 1 ? [...keys][0] : `span:${r.id}`
+  }
   // Per ARTIFACT, the highest-ordinal round the USER verifiably ruled on. Per
   // artifact, not per canvas (review round 2, security lens): a canvas holds
   // many artifacts (a plan, a mockup, a legacy build), and "the user answered
@@ -933,10 +946,14 @@ function supersededOwedReviewIds(record: ReviewFileRecord, artifactKeyByVersion:
     // true: the notes were on the user's screen before the sweep touched them.
     if (notes.some((a) => a.state === 'addressed' && !isAgentCloseable(a))) continue
     // A round the user is THEMSELVES triaging — they have ruled on one of its
-    // notes — is not settled debt. The click that ruled one note is a verdict
-    // on that note, never on its siblings, so a later round resolving must not
-    // sweep the rest of a round the user is actively working through.
-    if (notes.some((a) => a.closedBy === 'user' || a.state === 'reannotated')) continue
+    // notes with their own click (closedBy 'user') — is not settled debt. The
+    // click that ruled one note is a verdict on that note, never on its
+    // siblings, so a later round resolving must not sweep the rest of a round
+    // the user is actively working through. A 'reannotated' note is NOT a
+    // shield: the user finished with it and its replacement lives in a newer
+    // round, so its addressed round-mates are ordinary settle-able debt
+    // (re-attack round 2).
+    if (notes.some((a) => a.closedBy === 'user')) continue
     out.add(r.id)
   }
   return out
@@ -1643,6 +1660,12 @@ export function markAddressedNotesSeen(
     seen.push(a.id)
   }
   if (seen.length === 0) return { state: toState(base), seen }
+  // The glance IS the seen-barrier's release, so it is exactly the moment a
+  // round the user had already answered (by ruling a later round) becomes
+  // settle-able (#470 re-attack round 2): run the sweep here so the pill
+  // clears on the look, not one mutation later. Renderer-only path, so this
+  // adds no agent capability — it settles only what the user has now seen.
+  settleSupersededRounds(next, canvas.artifactKeyByVersion)
   commit(next)
   return { state: toState(next), seen }
 }

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -316,6 +316,11 @@ function isValidAnnotation(value: unknown): value is Annotation {
   // than render it. (The pickSource block above already pins the stamp itself
   // to this position, so the two rules together are an iff.)
   if (a.state === 'approved' && a.closedBy === 'agent' && a.pickSource !== 'chat') return false
+  // 'supersede' has exactly one legal position (#470): the sweep writes it
+  // only as stale-from-addressed. Anywhere else — an approved note wearing it,
+  // a dismissal — is a hand-edit laundering provenance the panel would then
+  // present as the store's own settling.
+  if (a.closedBy === 'supersede' && (a.state !== 'stale' || a.closedFrom !== 'addressed')) return false
   return true
 }
 
@@ -848,17 +853,30 @@ function settleReviewStatus(record: ReviewFileRecord, reviewId: string): void {
  *
  * Ordinals ('R3' > 'R1'), not frozen version ids, order the rounds: review
  * numbers are minted monotonically per canvas, so a later round is a later
- * ask even when both froze against the same version. One predicate feeds both
- * readers: the COUNT path excludes these rounds from `verdictRounds` (so the
- * pill is right immediately, even for records written before this existed),
- * and the mutation path (`settleSupersededRounds`) makes the same answer
- * durable on the next write.
+ * ask even when both froze against the same version. The predicate feeds the
+ * MUTATION path only (`settleSupersededRounds` inside the four writes that
+ * can create the shape); read paths are untouched, so a record written before
+ * this existed reads as before until its canvas's next mutation settles it.
  */
 function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
   const ord = (id: string): number => Number(id.slice(1))
   let resolvedMax = 0
   for (const r of record.reviews) {
-    if (r.status === 'resolved') resolvedMax = Math.max(resolvedMax, ord(r.id))
+    if (r.status !== 'resolved') continue
+    // Only a round the USER verifiably ruled on anchors supersession. The
+    // sweep's justification is "the user answered this canvas more recently
+    // than these rounds", and that must be a fact the store can check, not an
+    // agent assertion: a round resolved purely through the agent-callable
+    // writes (canvas_verdict, canvas_pick — closedBy 'agent') must not let a
+    // single canvas_pick transitively settle every older round without the
+    // seen-barrier ever running (review round 1, security lens). The two
+    // provenances no agent path can mint: a note closed by the user's own
+    // panel click (closedBy 'user' — the approved+agent iff rule pins agent
+    // approvals to chat picks), and a re-annotation (state 'reannotated' is
+    // written only by the panel's resolve IPC).
+    const userRuled = notesOfReview(record, r).some((a) => a.closedBy === 'user' || a.state === 'reannotated')
+    if (!userRuled) continue
+    resolvedMax = Math.max(resolvedMax, ord(r.id))
   }
   const out = new Set<string>()
   if (resolvedMax === 0) return out
@@ -887,13 +905,12 @@ function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
  * that a person clicked it), and Reopen puts any note straight back.
  *
  * Runs inside every mutation that can create the shape — a later round
- * resolving (user verdicts, an instructed agent close, a chat pick) or an
- * older round becoming fully addressed after the later round already resolved
- * (`markAnnotationsAddressed`, the owner's 3→2→3 bounce). Deliberately NOT a
- * new agent capability: the trigger is always anchored in a user ruling on a
- * newer round, the notes end in a reopenable state, and the provenance is its
- * own value — `canvas_verdict`'s seen-barrier still guards every close the
- * agent asks for by name.
+ * resolving or an older round becoming fully addressed after the later round
+ * already resolved (`markAnnotationsAddressed`, the owner's 3→2→3 bounce).
+ * Deliberately NOT a new agent capability: the anchor is STORE-VERIFIED user
+ * provenance on the resolved later round (see supersededOwedReviewIds), the
+ * notes end in a reopenable state, and `canvas_verdict`'s seen-barrier still
+ * guards every close the agent asks for by name.
  */
 function settleSupersededRounds(record: ReviewFileRecord): string[] {
   const doomed = supersededOwedReviewIds(record)

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -213,7 +213,7 @@ const ANNOTATION_SCOPES = new Set(['element', 'region', 'general'])
  *  'reannotated' — that one already has a live successor note, and reopening it
  *  would leave two notes claiming the same issue. */
 const REOPENABLE_STATES = new Set(['approved', 'dismissed', 'stale'])
-const CLOSED_BY_VALUES = new Set(['user', 'agent'])
+const CLOSED_BY_VALUES = new Set(['user', 'agent', 'supersede'])
 const CLOSED_FROM_VALUES = new Set(['open', 'addressed'])
 const ADDRESSED_ACTORS = new Set(['agent', 'user'])
 /**
@@ -288,6 +288,10 @@ function isValidAnnotation(value: unknown): value is Annotation {
   // barrier as "just now", i.e. it refuses the close — the fail-closed
   // direction, since the barrier exists to withhold permission.
   if (a.addressedAt !== undefined && !isCleanString(a.addressedAt, 64)) return false
+  // The reopen stamp (#470): same discipline as addressedAt. Its PRESENCE is
+  // what shields a round from the supersede sweep, so a malformed value fails
+  // the record rather than silently dropping the shield.
+  if (a.reopenedAt !== undefined && !isCleanString(a.reopenedAt, 64)) return false
   // The close-out barrier's two inputs, validated hardest of anything here: a
   // hand-edited record that could name a non-agent actor, or set the user's
   // seen flag, would hand `canvas_verdict` the permission it is meant to have
@@ -832,6 +836,81 @@ function settleReviewStatus(record: ReviewFileRecord, reviewId: string): void {
   else if (live && review.status === 'resolved') review.status = 'submitted'
 }
 
+/**
+ * Rounds that are OWED but SUPERSEDED (#470): submitted reviews, fully
+ * addressed (nothing open, something addressed), whose ordinal sits below a
+ * later round the user has already ruled on ('resolved'). The owner's live
+ * session hit the shape this names: three ready versions, a review against
+ * each, and the pill read 3 — then approving the newest round left the two
+ * older fully-addressed rounds counting forever, and re-addressing them
+ * pushed the count back UP. A round the user answered by ruling on a NEWER
+ * round of the same canvas is settled debt, not fresh debt.
+ *
+ * Ordinals ('R3' > 'R1'), not frozen version ids, order the rounds: review
+ * numbers are minted monotonically per canvas, so a later round is a later
+ * ask even when both froze against the same version. One predicate feeds both
+ * readers: the COUNT path excludes these rounds from `verdictRounds` (so the
+ * pill is right immediately, even for records written before this existed),
+ * and the mutation path (`settleSupersededRounds`) makes the same answer
+ * durable on the next write.
+ */
+function supersededOwedReviewIds(record: ReviewFileRecord): Set<string> {
+  const ord = (id: string): number => Number(id.slice(1))
+  let resolvedMax = 0
+  for (const r of record.reviews) {
+    if (r.status === 'resolved') resolvedMax = Math.max(resolvedMax, ord(r.id))
+  }
+  const out = new Set<string>()
+  if (resolvedMax === 0) return out
+  for (const r of record.reviews) {
+    if (r.status !== 'submitted' || ord(r.id) >= resolvedMax) continue
+    const notes = notesOfReview(record, r)
+    // A round still holding OPEN notes is the agent's debt and survives whole;
+    // one with nothing addressed has nothing owed to settle.
+    if (notes.some((a) => a.state === 'open')) continue
+    if (!notes.some((a) => a.state === 'addressed')) continue
+    // A REOPENED note shields its round for good (#470): reopening is the user
+    // deliberately putting a settled note back in play, and an automatic sweep
+    // that immediately re-settles it would make Reopen a no-op. Only the
+    // user's own verdict ends a reopened note.
+    if (notes.some((a) => a.state === 'addressed' && a.reopenedAt !== undefined)) continue
+    out.add(r.id)
+  }
+  return out
+}
+
+/**
+ * Make the supersession durable: every round `supersededOwedReviewIds` names
+ * has its addressed notes moved to 'stale' with `closedBy: 'supersede'` —
+ * the automated form of the dismiss-all sweep the owner used as the
+ * workaround. Nothing is deleted, the row says the store settled it (never
+ * that a person clicked it), and Reopen puts any note straight back.
+ *
+ * Runs inside every mutation that can create the shape — a later round
+ * resolving (user verdicts, an instructed agent close, a chat pick) or an
+ * older round becoming fully addressed after the later round already resolved
+ * (`markAnnotationsAddressed`, the owner's 3→2→3 bounce). Deliberately NOT a
+ * new agent capability: the trigger is always anchored in a user ruling on a
+ * newer round, the notes end in a reopenable state, and the provenance is its
+ * own value — `canvas_verdict`'s seen-barrier still guards every close the
+ * agent asks for by name.
+ */
+function settleSupersededRounds(record: ReviewFileRecord): string[] {
+  const doomed = supersededOwedReviewIds(record)
+  if (doomed.size === 0) return []
+  for (const review of record.reviews) {
+    if (!doomed.has(review.id)) continue
+    for (const a of notesOfReview(record, review)) {
+      if (a.state !== 'addressed') continue
+      a.state = 'stale'
+      a.closedBy = 'supersede'
+      a.closedFrom = 'addressed'
+    }
+    settleReviewStatus(record, review.id)
+  }
+  return [...doomed]
+}
+
 /** Validate a renderer-supplied draft against this canvas. Throws on anything
  *  out of shape — the IPC schema should have caught it, so a throw here is a
  *  bug surfacing, not a user error. */
@@ -1256,6 +1335,9 @@ export function resolveAnnotation(
   // hold it open: the agent has acted, but the user has not yet said whether
   // the action was right, and that verdict is what closes a review.
   settleReviewStatus(next, owner.id)
+  // The user just ruled: if that resolved a round, older fully-addressed
+  // rounds of this canvas are settled debt now, not stacked debt (#470).
+  settleSupersededRounds(next)
 
   commit(next)
   return { state: toState(next), ...(reannotationId ? { reannotationId } : {}) }
@@ -1431,6 +1513,11 @@ export function markAnnotationsAddressed(
     }
   }
   for (const id of wanted) if (!addressed.includes(id) && !skipped.includes(id)) skipped.push(id)
+  // The owner's 3→2→3 bounce (#470): addressing the notes of a round whose
+  // canvas already has a LATER resolved round used to push that round back
+  // into "waiting on the user". It is settled in the same commit instead —
+  // the user's ruling on the newer round already answered it.
+  if (addressed.length > 0) settleSupersededRounds(next)
   if (addressed.length > 0) commit(next)
   return { state: toState(addressed.length > 0 ? next : base), addressed, skipped }
 }
@@ -1649,6 +1736,9 @@ export function closeAnnotationsByAgent(
   if (closed.length === 0) return { state: toState(base), closed, skipped, reviewClosed: false }
 
   settleReviewStatus(next, review.id)
+  // An instructed close that resolved this round supersedes older
+  // fully-addressed rounds the same way a panel verdict does (#470).
+  settleSupersededRounds(next)
   const reviewClosed = next.reviews.find((r) => r.id === review.id)?.status === 'resolved'
   commit(next)
   return { state: toState(next), closed, skipped, reviewClosed }
@@ -1729,6 +1819,8 @@ export function recordChatPick(
   nextTarget.pickSource = 'chat'
 
   settleReviewStatus(next, review.id)
+  // The user's chat pick is a ruling like any other (#470).
+  settleSupersededRounds(next)
   const reviewClosed = next.reviews.find((r) => r.id === review.id)?.status === 'resolved'
   commit(next)
   // The label is store-held and was validated clean at mint; the tool echoes it
@@ -1773,6 +1865,12 @@ export function reopenAnnotation(sessionId: string, annotationId: string): Canva
   // the honest default for those: it waits on the agent, which is where a note
   // sits when nobody has claimed to have acted on it.
   nextTarget.state = nextTarget.closedFrom ?? 'open'
+  // The supersede shield (#470): a reopened note is the user's deliberate
+  // re-ask, and the automatic sweep must never re-settle it — with the stamp,
+  // only their own verdict ends this note. Stamped on EVERY reopen (also one
+  // back to 'open': the agent's re-address keeps the shield, or the sweep
+  // would stale the very work the reopen asked for).
+  nextTarget.reopenedAt = new Date().toISOString()
   delete nextTarget.closedBy
   delete nextTarget.closedFrom
   // A note back to 'open' is one nobody has claimed to have acted on, so the

--- a/src/renderer/components/AgentCanvasButton.tsx
+++ b/src/renderer/components/AgentCanvasButton.tsx
@@ -100,7 +100,7 @@ export default function AgentCanvasButton({ sessionId }: Props) {
           isOpen
             ? 'Back to the terminal (closes the Agent Canvas)'
             : waiting
-              ? `${queue} round${queue === 1 ? '' : 's'} waiting on your review — click the count for the list, right-click to dismiss all`
+              ? `${queue} canvas${queue === 1 ? '' : 'es'} waiting on your review — click the count for the list, right-click to dismiss all`
               : 'Open Agent Canvas'
         }
         data-testid="canvas-button"

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -113,6 +113,10 @@ export function closedLabel(note: Annotation): string {
   if (note.closedBy === 'agent' && note.pickSource === 'chat') return `${verdict} · picked in chat`
   if (note.closedBy === 'agent') return `${verdict} · by the agent on your instruction`
   if (note.closedBy === 'user') return `${verdict} · by you`
+  // The supersede sweep (#470): the store settled it because the user ruled on
+  // a LATER round of this canvas. Nobody clicked this note, and the row must
+  // not read as if somebody did.
+  if (note.closedBy === 'supersede') return `${verdict} · settled by your later review`
   // A record from before close-out existed. Says the verdict and claims
   // nothing about who gave it, which is all that is actually known.
   return verdict

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -1104,11 +1104,11 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           testId="confirm-canvas-dismiss"
           title="Dismiss everything waiting on you?"
           body={<>
-            {canvasQueue} round{canvasQueue === 1 ? '' : 's'} across this session's canvases. Notes the agent
+            {canvasQueue} canvas{canvasQueue === 1 ? '' : 'es'} with rounds waiting on you. Notes the agent
             answered are closed — each keeps a <b>Reopen</b> — and a render still waiting for its first review
             stops asking. Nothing is deleted, and rounds still with the agent are left alone.
           </>}
-          actions={[{ label: `Dismiss ${canvasQueue}`, danger: true, testId: 'confirm-canvas-dismiss-ok', onClick: () => { void doCanvasDismissAll() } }]}
+          actions={[{ label: 'Dismiss all', danger: true, testId: 'confirm-canvas-dismiss-ok', onClick: () => { void doCanvasDismissAll() } }]}
           onCancel={() => setConfirm(null)}
         />
       )}

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -57,8 +57,8 @@ function TabCanvasQueueMark({ sessionId }: { sessionId: string }) {
     <span
       className="shrink-0 w-[7px] h-[7px] rounded-full relative z-10"
       style={{ background: 'var(--status-warning)' }}
-      title={`${queue} canvas round${queue === 1 ? '' : 's'} waiting on you`}
-      aria-label={`${queue} canvas round${queue === 1 ? '' : 's'} waiting on you`}
+      title={`${queue} canvas${queue === 1 ? '' : 'es'} waiting on you`}
+      aria-label={`${queue} canvas${queue === 1 ? '' : 'es'} waiting on you`}
       data-testid="tab-canvas-queue-mark"
     />
   )

--- a/src/renderer/lib/canvasQueue.ts
+++ b/src/renderer/lib/canvasQueue.ts
@@ -20,13 +20,19 @@ export function canvasQueueOf(
   totals: CanvasTotals | undefined,
 ): number {
   const liveLoaded = !!canvasLive?.loaded && !!reviewLive?.loaded
-  const liveQueue = liveLoaded
-    ? (canvasLive?.awaitingReview ? 1 : 0) +
+  // ONE canvas is at most ONE owed item (#470) — here as well as in the sweep.
+  // The live mirrors are where the owner's pill actually read 3: the on-screen
+  // canvas's rounds were counted one per submitted review.
+  let liveOwed = 0
+  if (liveLoaded) {
+    const owedKinds =
+      (canvasLive?.awaitingReview ? 1 : 0) +
       (reviewLive ? reviewGroupsOf(reviewLive).filter((g) => g.waitingOn === 'you').length : 0)
-    : 0
-  if (!totals?.loaded) return liveQueue
+    liveOwed = owedKinds > 0 ? 1 : 0
+  }
+  if (!totals?.loaded) return liveOwed
   const elsewhere = Math.max(0, totals.queue - totals.queueOnActive)
-  return liveLoaded ? elsewhere + liveQueue : totals.queue
+  return liveLoaded ? elsewhere + liveOwed : totals.queue
 }
 
 /** The queue number for one session. Every selector returns a primitive, so
@@ -49,9 +55,10 @@ export function useCanvasQueue(sessionId: string): number {
     return t?.loaded ? t.queueOnActive : undefined
   })
   const liveLoaded = awaiting !== undefined && verdict !== undefined
-  const liveQueue = liveLoaded ? awaiting + verdict : 0
-  if (sweepQueue === undefined || sweepOnActive === undefined) return liveQueue
-  return liveLoaded ? Math.max(0, sweepQueue - sweepOnActive) + liveQueue : sweepQueue
+  // Max 1 for the on-screen canvas (#470), mirroring canvasQueueOf.
+  const liveOwed = liveLoaded ? (awaiting + verdict > 0 ? 1 : 0) : 0
+  if (sweepQueue === undefined || sweepOnActive === undefined) return liveOwed
+  return liveLoaded ? Math.max(0, sweepQueue - sweepOnActive) + liveOwed : sweepQueue
 }
 
 /** The owed rounds for the queue list, newest first, from the sweep. */

--- a/src/renderer/stores/canvasTotalsStore.ts
+++ b/src/renderer/stores/canvasTotalsStore.ts
@@ -37,11 +37,12 @@ export interface CanvasTotals {
   /** Open reviews on the canvas the session is currently showing (0 when unreadable). */
   onActive: number
   /**
-   * THE queue number (#364): rounds waiting on the user across every canvas
-   * this session owns — ready-marked renders awaiting a first review, plus
-   * rounds whose notes all await verdicts. One derivation feeds the Canvas
-   * button, the queue list, the tab mark and the pane lead, so the numbers can
-   * never disagree.
+   * THE queue number (#364, recut in #470): CANVASES waiting on the user —
+   * a canvas counts once whether it owes a first review, verdict rounds, or
+   * both ("a count above 1 is legitimate across different canvases, never for
+   * the same item"). The rows keep the per-kind detail. One derivation feeds
+   * the Canvas button, the queue list, the tab mark and the pane lead, so the
+   * numbers can never disagree.
    */
   queue: number
   /** The sweep's view of the on-screen canvas's share of `queue` — subtracted
@@ -89,8 +90,6 @@ export function totalsFromEntries(entries: CanvasLibraryEntry[]): CanvasTotals {
     // when the review store is unreadable — a hand-over must never disappear
     // behind a broken reviews.json.
     if (e.awaitingReview) {
-      t.queue++
-      if (e.isActiveForThisSession) t.queueOnActive++
       t.queueRows.push({
         canvasId: e.canvasId,
         ...(e.title ? { title: e.title } : {}),
@@ -100,8 +99,6 @@ export function totalsFromEntries(entries: CanvasLibraryEntry[]): CanvasTotals {
       })
     }
     if (e.verdictRounds && e.verdictRounds > 0) {
-      t.queue += e.verdictRounds
-      if (e.isActiveForThisSession) t.queueOnActive += e.verdictRounds
       t.queueRows.push({
         canvasId: e.canvasId,
         ...(e.title ? { title: e.title } : {}),
@@ -110,6 +107,14 @@ export function totalsFromEntries(entries: CanvasLibraryEntry[]): CanvasTotals {
         at: e.lastRenderedAt,
         onActive: !!e.isActiveForThisSession,
       })
+    }
+    // ONE canvas is at most ONE owed item (#470, owner: "a count above 1 is
+    // legitimate across different canvases, never for the same item"). The
+    // rows above keep the detail — what kind, how many rounds — but the
+    // number counts canvases owing, not their internal stacking.
+    if (e.awaitingReview || (e.verdictRounds && e.verdictRounds > 0)) {
+      t.queue++
+      if (e.isActiveForThisSession) t.queueOnActive++
     }
     if (e.openReviewCount === undefined) { t.unknown++; continue }
     t.openReviews += e.openReviewCount

--- a/src/renderer/stores/canvasTotalsStore.ts
+++ b/src/renderer/stores/canvasTotalsStore.ts
@@ -40,7 +40,7 @@ export interface CanvasTotals {
    * THE queue number (#364, recut in #470): CANVASES waiting on the user —
    * a canvas counts once whether it owes a first review, verdict rounds, or
    * both ("a count above 1 is legitimate across different canvases, never for
-   * the same item"). The rows keep the per-kind detail. One derivation feeds
+   * the same item"). One row per owing canvas too. One derivation feeds
    * the Canvas button, the queue list, the tab mark and the pane lead, so the
    * numbers can never disagree.
    */
@@ -48,11 +48,11 @@ export interface CanvasTotals {
   /** The sweep's view of the on-screen canvas's share of `queue` — subtracted
    *  by consumers that read that canvas from the fresher live mirrors. */
   queueOnActive: number
-  /** The owed rounds, one row per kind per canvas, newest first. */
+  /** The owed canvases, one row each, newest first. */
   queueRows: CanvasQueueRow[]
 }
 
-/** One owed round in the queue list. */
+/** One owing canvas in the queue list. */
 export interface CanvasQueueRow {
   canvasId: string
   title?: string

--- a/src/renderer/stores/canvasTotalsStore.ts
+++ b/src/renderer/stores/canvasTotalsStore.ts
@@ -86,35 +86,26 @@ export function totalsFromEntries(entries: CanvasLibraryEntry[]): CanvasTotals {
   for (const e of entries) {
     if (!e.ownedByThisSession && !e.isActiveForThisSession) continue
     t.canvases++
-    // The review-needed half comes from the canvas RECORD, so it counts even
-    // when the review store is unreadable — a hand-over must never disappear
-    // behind a broken reviews.json.
-    if (e.awaitingReview) {
-      t.queueRows.push({
-        canvasId: e.canvasId,
-        ...(e.title ? { title: e.title } : {}),
-        kind: 'review',
-        at: e.awaitingReviewAt ?? e.lastRenderedAt,
-        onActive: !!e.isActiveForThisSession,
-      })
-    }
-    if (e.verdictRounds && e.verdictRounds > 0) {
-      t.queueRows.push({
-        canvasId: e.canvasId,
-        ...(e.title ? { title: e.title } : {}),
-        kind: 'verdict',
-        rounds: e.verdictRounds,
-        at: e.lastRenderedAt,
-        onActive: !!e.isActiveForThisSession,
-      })
-    }
     // ONE canvas is at most ONE owed item (#470, owner: "a count above 1 is
-    // legitimate across different canvases, never for the same item"). The
-    // rows above keep the detail — what kind, how many rounds — but the
-    // number counts canvases owing, not their internal stacking.
-    if (e.awaitingReview || (e.verdictRounds && e.verdictRounds > 0)) {
+    // legitimate across different canvases, never for the same item") — one
+    // row per owing canvas too, so the pill and the list under it agree. A
+    // canvas owing BOTH kinds shows as the ready render (the newest ask); the
+    // verdict detail rides `rounds` when that is the kind. The review-needed
+    // half comes from the canvas RECORD, so it counts even when the review
+    // store is unreadable — a hand-over must never disappear behind a broken
+    // reviews.json.
+    const owesVerdicts = !!e.verdictRounds && e.verdictRounds > 0
+    if (e.awaitingReview || owesVerdicts) {
       t.queue++
       if (e.isActiveForThisSession) t.queueOnActive++
+      t.queueRows.push({
+        canvasId: e.canvasId,
+        ...(e.title ? { title: e.title } : {}),
+        ...(e.awaitingReview
+          ? { kind: 'review' as const, at: e.awaitingReviewAt ?? e.lastRenderedAt }
+          : { kind: 'verdict' as const, rounds: e.verdictRounds, at: e.lastRenderedAt }),
+        onActive: !!e.isActiveForThisSession,
+      })
     }
     if (e.openReviewCount === undefined) { t.unknown++; continue }
     t.openReviews += e.openReviewCount

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -232,7 +232,10 @@ export type AgentCloseVerdict = (typeof AGENT_CLOSE_VERDICTS)[number]
 /** Who moved a note to a terminal state. `agent` means `canvas_verdict` wrote
  *  it on the user's instruction — which the panel says out loud, and lists
  *  apart from the user's own approvals. */
-export type AnnotationClosedBy = 'user' | 'agent'
+/** 'supersede' is the store itself settling an addressed note because the user
+ *  ruled on a LATER round of the same canvas (#470) — neither party clicked
+ *  this particular note, and the row must not claim one did. */
+export type AnnotationClosedBy = 'user' | 'agent' | 'supersede'
 
 /**
  * Who moved a note into `addressed` — the state the agent's close-out
@@ -407,6 +410,14 @@ export interface Annotation {
    * Absent on a note nobody has addressed, and on records written before this.
    */
   addressedAt?: string
+  /**
+   * When the USER last reopened this note (#470). Its presence is what the
+   * supersede sweep reads: a reopened note is the user deliberately putting a
+   * settled thing back in play, so no automatic settle may ever touch its
+   * round again — only their own verdict ends it. Set on every reopen; never
+   * cleared (a terminal note's stamp is inert history).
+   */
+  reopenedAt?: string
   /**
    * WHO moved this note into `addressed`, and from which session.
    *

--- a/tests/unit/main/canvas-review-store.test.ts
+++ b/tests/unit/main/canvas-review-store.test.ts
@@ -671,3 +671,76 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
   })
 })
+
+describe('the supersede sweep is anchored in verifiable USER rulings (#470, security round)', () => {
+  function roundAgainstNewVersion(reviewId: string, note = 'note'): { versionId: string; annotationId: string } {
+    const { versionId } = canvasStore.renderVersion(SID, { mode: 'design', html: `<!doctype html><p>${reviewId}</p>`, ready: true })
+    const { annotationId } = store.upsertAnnotation(SID, { scope: 'general', note, versionId })
+    store.submitReview(SID, reviewId, [])
+    return { versionId, annotationId }
+  }
+
+  it('a round resolved purely by a chat pick (agent-recorded) anchors NOTHING', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const r2 = roundAgainstNewVersion('R2')
+    // The whole chain is agent-side: address with variants, then canvas_pick.
+    store.markAnnotationsAddressed(SID, 'R2', [r2.annotationId], { [r2.annotationId]: ['one', 'two'] })
+    const picked = store.recordChatPick(SID, 'R2', r2.annotationId, 'A')
+    expect(picked.reviewClosed).toBe(true)
+
+    // R1 must NOT be swept: no store-verifiable user ruling exists anywhere.
+    const state = store.getReviewStateForSession(SID)!
+    expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({ state: 'addressed' })
+    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
+    const canvasId = state.canvasId
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(2 - 1) // R1 still owed
+  })
+
+  it('ordinals compare numerically: a user ruling on R10 settles R9', () => {
+    const rounds: Array<{ annotationId: string }> = []
+    for (let i = 1; i <= 10; i++) rounds.push(roundAgainstNewVersion(`R${i}`))
+    for (let i = 0; i < 9; i++) store.markAnnotationsAddressed(SID, `R${i + 1}`, [rounds[i].annotationId])
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    // The USER rules on R10. Lexicographically 'R10' < 'R9'; numerically 10 > 9.
+    store.resolveAnnotation(SID, rounds[9].annotationId, 'approve', canvasId)
+    const state = store.getReviewStateForSession(SID)!
+    expect(state.annotations.find((a) => a.id === rounds[8].annotationId)).toMatchObject({
+      state: 'stale',
+      closedBy: 'supersede',
+    })
+    expect(state.reviews.find((r) => r.id === 'R9')?.status).toBe('resolved')
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
+  })
+
+  it('a hand-edited record cannot launder supersede onto an approval, and a malformed reopenedAt fails the record', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    store.resolveAnnotation(SID, r1.annotationId, 'approve', canvasId)
+
+    const file = path.join(getResourcesDirectory(), 'canvas', canvasId, 'reviews.json')
+    const pristine = fs.readFileSync(file, 'utf8')
+
+    // supersede beside 'approved' — provenance laundering. The record refuses.
+    const forged = JSON.parse(pristine)
+    forged.annotations[0].closedBy = 'supersede'
+    fs.writeFileSync(file, JSON.stringify(forged))
+    store._resetCanvasReviewStoreForTest()
+    expect(store.getReviewStateForSession(SID)?.reviews).toEqual([])
+
+    // A reopenedAt that is not a clean bounded string fails the record too —
+    // the shield must not be silently droppable.
+    const badStamp = JSON.parse(pristine)
+    badStamp.annotations[0].reopenedAt = 'x'.repeat(65)
+    fs.writeFileSync(file, JSON.stringify(badStamp))
+    store._resetCanvasReviewStoreForTest()
+    expect(store.getReviewStateForSession(SID)?.reviews).toEqual([])
+
+    // Control: the pristine record still loads (the two reds above are the
+    // edits, not the harness).
+    fs.writeFileSync(file, pristine)
+    store._resetCanvasReviewStoreForTest()
+    expect(store.getReviewStateForSession(SID)!.reviews).toHaveLength(1)
+  })
+})

--- a/tests/unit/main/canvas-review-store.test.ts
+++ b/tests/unit/main/canvas-review-store.test.ts
@@ -573,10 +573,18 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     store.submitReview(SID, reviewId, [])
     return { versionId, annotationId }
   }
+  /** Address the notes AND mark them seen — the sweep only touches rounds the
+   *  user has actually looked at (the seen-barrier, ADR-009 adversarial pass).
+   *  `markAddressedNotesSeen` is the renderer-only bit no MCP tool can write. */
+  function addressAndSee(reviewId: string, ids: string[]): void {
+    store.markAnnotationsAddressed(SID, reviewId, ids)
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    store.markAddressedNotesSeen(SID, canvasId, ids)
+  }
 
-  it("the user's ruling on a later round settles older fully-addressed rounds", () => {
+  it("the user's ruling on a later round settles older SEEN fully-addressed rounds", () => {
     const r1 = roundAgainstNewVersion('R1')
-    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    addressAndSee('R1', [r1.annotationId])
     const r2 = roundAgainstNewVersion('R2')
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
@@ -590,7 +598,33 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
   })
 
-  it("notes still OPEN survive a later ruling whole — and settle only when addressed (the 3→2→3 bounce)", () => {
+  it('THE SEEN-BARRIER: an agent-addressed-but-UNSEEN round is NEVER swept, even under a user ruling', () => {
+    // The BLOCKER the adversarial pass found: canvas_resolve (agent) addresses
+    // a round the user never saw, and a later user ruling settles it in the
+    // same commit — a close past the seen-barrier canvas_verdict enforces.
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId]) // addressed, NOT seen
+    const r2 = roundAgainstNewVersion('R2')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+
+    store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId) // genuine user ruling on R2
+    const state = store.getReviewStateForSession(SID)!
+    // R1 stays owed — the user has not seen its note addressed, so the agent
+    // cannot close it, by the sweep any more than by canvas_verdict.
+    expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({ state: 'addressed' })
+    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+
+    // The user then glances at R1 (the panel marks it seen). The NEXT ruling —
+    // or any mutation — now settles it: one look, not a silent close.
+    store.markAddressedNotesSeen(SID, canvasId, [r1.annotationId])
+    const r3 = roundAgainstNewVersion('R3')
+    store.resolveAnnotation(SID, r3.annotationId, 'approve', canvasId)
+    expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === r1.annotationId))
+      .toMatchObject({ state: 'stale', closedBy: 'supersede' })
+  })
+
+  it("notes still OPEN survive a later ruling whole — and settle once addressed AND seen (the 3→2→3 bounce)", () => {
     const r1 = roundAgainstNewVersion('R1')
     const r2 = roundAgainstNewVersion('R2')
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
@@ -600,22 +634,65 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(afterRuling.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({ state: 'open' })
     expect(afterRuling.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
 
-    // The agent now addresses it. Before #470 this re-entered "waiting on the
-    // user" and the pill bounced back up; it settles in the same commit instead.
-    const { state } = store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    // The agent addresses it; the user glances at it. Before #470 this
+    // re-entered "waiting on the user" and the pill bounced back up; it settles
+    // once seen instead.
+    addressAndSee('R1', [r1.annotationId])
+    // The seen mark alone does not settle; a mutation runs the sweep. Nudge it
+    // with a fresh ruling on a newer round.
+    const r3 = roundAgainstNewVersion('R3')
+    const { state } = store.resolveAnnotation(SID, r3.annotationId, 'approve', canvasId)
     expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({
       state: 'stale',
       closedBy: 'supersede',
     })
     expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('resolved')
-    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
+  })
+
+  it('a round the user is TRIAGING (ruled on one of its notes) is not swept from under them', () => {
+    // R1 has two notes; the user approves one and leaves the other addressed —
+    // they are working through R1. A later ruling on R2 must not stale the rest.
+    const { versionId: v1 } = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>r1</p>', ready: true })
+    const n1 = store.upsertAnnotation(SID, { scope: 'general', note: 'n1', versionId: v1 }).annotationId
+    const n2 = store.upsertAnnotation(SID, { scope: 'general', note: 'n2', versionId: v1 }).annotationId
+    store.submitReview(SID, 'R1', [])
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    addressAndSee('R1', [n1, n2])
+    store.resolveAnnotation(SID, n1, 'approve', canvasId) // a verdict INSIDE R1
+
+    const r2 = roundAgainstNewVersion('R2')
+    store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
+    // n2 survives — the R1 click ruled n1, not n2.
+    expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === n2))
+      .toMatchObject({ state: 'addressed' })
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+  })
+
+  it('the sweep never crosses ARTIFACTS: a plan ruling does not settle a mockup round', () => {
+    // A design (mockup) round R1, seen+addressed, then a PLAN artifact on the
+    // same canvas. Ruling on the plan says nothing about the mockup's feedback.
+    const { versionId: mockupV } = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mock</p>', ready: true })
+    const m1 = store.upsertAnnotation(SID, { scope: 'general', note: 'mockup note', versionId: mockupV }).annotationId
+    store.submitReview(SID, 'R1', [])
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    addressAndSee('R1', [m1])
+
+    const { versionId: planV } = canvasStore.renderVersion(SID, { mode: 'plan', html: '<!doctype html><p>plan</p>', ready: true })
+    const p1 = store.upsertAnnotation(SID, { scope: 'general', note: 'plan note', versionId: planV }).annotationId
+    store.submitReview(SID, 'R2', [])
+    store.resolveAnnotation(SID, p1, 'approve', canvasId) // rule the PLAN round
+
+    // The mockup round is a different artifact — untouched.
+    expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === m1))
+      .toMatchObject({ state: 'addressed' })
+    expect(store.getReviewStateForSession(SID)!.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
   })
 
   it('nothing settles while no later round has been ruled on', () => {
     const r1 = roundAgainstNewVersion('R1')
-    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    addressAndSee('R1', [r1.annotationId])
     const r2 = roundAgainstNewVersion('R2')
-    store.markAnnotationsAddressed(SID, 'R2', [r2.annotationId])
+    addressAndSee('R2', [r2.annotationId])
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
     // Both rounds await verdicts; neither is superseded by a RULING yet.
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(2)
@@ -635,7 +712,7 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
 
   it('a REOPENED note shields its round — the sweep never undoes an explicit reopen', () => {
     const r1 = roundAgainstNewVersion('R1')
-    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    addressAndSee('R1', [r1.annotationId])
     const r2 = roundAgainstNewVersion('R2')
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
     store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
@@ -657,7 +734,7 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
 
   it('the settled state round-trips: reload from disk accepts closedBy supersede', () => {
     const r1 = roundAgainstNewVersion('R1')
-    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    addressAndSee('R1', [r1.annotationId])
     const r2 = roundAgainstNewVersion('R2')
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
     store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
@@ -700,8 +777,11 @@ describe('the supersede sweep is anchored in verifiable USER rulings (#470, secu
   it('ordinals compare numerically: a user ruling on R10 settles R9', () => {
     const rounds: Array<{ annotationId: string }> = []
     for (let i = 1; i <= 10; i++) rounds.push(roundAgainstNewVersion(`R${i}`))
-    for (let i = 0; i < 9; i++) store.markAnnotationsAddressed(SID, `R${i + 1}`, [rounds[i].annotationId])
     const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    for (let i = 0; i < 9; i++) {
+      store.markAnnotationsAddressed(SID, `R${i + 1}`, [rounds[i].annotationId])
+      store.markAddressedNotesSeen(SID, canvasId, [rounds[i].annotationId])
+    }
     // The USER rules on R10. Lexicographically 'R10' < 'R9'; numerically 10 > 9.
     store.resolveAnnotation(SID, rounds[9].annotationId, 'approve', canvasId)
     const state = store.getReviewStateForSession(SID)!

--- a/tests/unit/main/canvas-review-store.test.ts
+++ b/tests/unit/main/canvas-review-store.test.ts
@@ -615,13 +615,13 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
 
-    // The user then glances at R1 (the panel marks it seen). The NEXT ruling —
-    // or any mutation — now settles it: one look, not a silent close.
+    // The user then glances at R1 (the panel marks it seen). The glance IS the
+    // barrier's release, and the sweep runs on it — the pill clears on the
+    // look, not one mutation later. One look, never a silent close.
     store.markAddressedNotesSeen(SID, canvasId, [r1.annotationId])
-    const r3 = roundAgainstNewVersion('R3')
-    store.resolveAnnotation(SID, r3.annotationId, 'approve', canvasId)
     expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === r1.annotationId))
       .toMatchObject({ state: 'stale', closedBy: 'supersede' })
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
   })
 
   it("notes still OPEN survive a later ruling whole — and settle once addressed AND seen (the 3→2→3 bounce)", () => {
@@ -635,18 +635,16 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(afterRuling.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
 
     // The agent addresses it; the user glances at it. Before #470 this
-    // re-entered "waiting on the user" and the pill bounced back up; it settles
-    // once seen instead.
+    // re-entered "waiting on the user" and the pill bounced back up; the glance
+    // settles it in the same commit (R2 is already resolved above).
     addressAndSee('R1', [r1.annotationId])
-    // The seen mark alone does not settle; a mutation runs the sweep. Nudge it
-    // with a fresh ruling on a newer round.
-    const r3 = roundAgainstNewVersion('R3')
-    const { state } = store.resolveAnnotation(SID, r3.annotationId, 'approve', canvasId)
-    expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({
+    const settled = store.getReviewStateForSession(SID)!
+    expect(settled.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({
       state: 'stale',
       closedBy: 'supersede',
     })
-    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('resolved')
+    expect(settled.reviews.find((r) => r.id === 'R1')?.status).toBe('resolved')
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
   })
 
   it('a round the user is TRIAGING (ruled on one of its notes) is not swept from under them', () => {
@@ -666,6 +664,31 @@ describe('superseded rounds settle instead of stacking (#470)', () => {
     expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === n2))
       .toMatchObject({ state: 'addressed' })
     expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+  })
+
+  it('a round whose NOTE and frozen version disagree on artifact is isolated — a freeze-slip cannot carry a mockup note into a plan ruling', () => {
+    // The re-attack MAJOR: the agent renders a plan BETWEEN the user writing a
+    // mockup note and submitting, so the review freezes against the plan
+    // version while its note points at the mockup. Keyed on the frozen version
+    // alone, a plan ruling would stale the mockup note; keyed on notes+frozen,
+    // the round spans artifacts and is isolated (neither anchors nor is swept).
+    const { versionId: mockupV } = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>mock</p>', ready: true })
+    const m1 = store.upsertAnnotation(SID, { scope: 'general', note: 'mockup note', versionId: mockupV }).annotationId
+    // Agent renders a PLAN, moving activeVersionId, before the user submits.
+    canvasStore.renderVersion(SID, { mode: 'plan', html: '<!doctype html><p>plan</p>', ready: true })
+    store.submitReview(SID, 'R1', []) // freezes against the plan version
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    expect(store.getReviewStateForSession(SID)!.reviews.find((r) => r.id === 'R1')!.versionId)
+      .not.toBe(mockupV) // proves the slip happened
+    addressAndSee('R1', [m1])
+
+    // A later PLAN round, ruled on. R1 spans artifacts → untouched.
+    const { versionId: planV2 } = canvasStore.renderVersion(SID, { mode: 'plan', html: '<!doctype html><p>plan2</p>', ready: true })
+    const p1 = store.upsertAnnotation(SID, { scope: 'general', note: 'plan note', versionId: planV2 }).annotationId
+    store.submitReview(SID, 'R2', [])
+    store.resolveAnnotation(SID, p1, 'approve', canvasId)
+    expect(store.getReviewStateForSession(SID)!.annotations.find((a) => a.id === m1))
+      .toMatchObject({ state: 'addressed' })
   })
 
   it('the sweep never crosses ARTIFACTS: a plan ruling does not settle a mockup round', () => {

--- a/tests/unit/main/canvas-review-store.test.ts
+++ b/tests/unit/main/canvas-review-store.test.ts
@@ -564,3 +564,110 @@ describe('drafts and the notes the user can write (#366, review round 2)', () =>
     expect(state.reviews.find((r) => r.status === 'draft')!.versionId).toBe(ready.versionId)
   })
 })
+
+describe('superseded rounds settle instead of stacking (#470)', () => {
+  /** Render a ready version, note it, submit — one full round. */
+  function roundAgainstNewVersion(reviewId: string, note = 'note'): { versionId: string; annotationId: string } {
+    const { versionId } = canvasStore.renderVersion(SID, { mode: 'design', html: `<!doctype html><p>${reviewId}</p>`, ready: true })
+    const { annotationId } = store.upsertAnnotation(SID, { scope: 'general', note, versionId })
+    store.submitReview(SID, reviewId, [])
+    return { versionId, annotationId }
+  }
+
+  it("the user's ruling on a later round settles older fully-addressed rounds", () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const r2 = roundAgainstNewVersion('R2')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+
+    const { state } = store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
+    // R2 resolved by the verdict; R1 settled by the supersede sweep.
+    expect(state.reviews.find((r) => r.id === 'R2')?.status).toBe('resolved')
+    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('resolved')
+    const settled = state.annotations.find((a) => a.id === r1.annotationId)!
+    expect(settled).toMatchObject({ state: 'stale', closedBy: 'supersede', closedFrom: 'addressed' })
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
+  })
+
+  it("notes still OPEN survive a later ruling whole — and settle only when addressed (the 3→2→3 bounce)", () => {
+    const r1 = roundAgainstNewVersion('R1')
+    const r2 = roundAgainstNewVersion('R2')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+
+    const afterRuling = store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId).state
+    // R1's note was never addressed: the agent's debt survives untouched.
+    expect(afterRuling.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({ state: 'open' })
+    expect(afterRuling.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
+
+    // The agent now addresses it. Before #470 this re-entered "waiting on the
+    // user" and the pill bounced back up; it settles in the same commit instead.
+    const { state } = store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({
+      state: 'stale',
+      closedBy: 'supersede',
+    })
+    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('resolved')
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
+  })
+
+  it('nothing settles while no later round has been ruled on', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const r2 = roundAgainstNewVersion('R2')
+    store.markAnnotationsAddressed(SID, 'R2', [r2.annotationId])
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    // Both rounds await verdicts; neither is superseded by a RULING yet.
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(2)
+    const state = store.getReviewStateForSession(SID)!
+    expect(state.annotations.every((a) => a.state === 'addressed')).toBe(true)
+  })
+
+  it('an EARLIER ruling never settles a LATER addressed round', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    store.resolveAnnotation(SID, r1.annotationId, 'approve', canvasId)
+    const r2 = roundAgainstNewVersion('R2')
+    const { state } = store.markAnnotationsAddressed(SID, 'R2', [r2.annotationId])
+    expect(state.annotations.find((a) => a.id === r2.annotationId)).toMatchObject({ state: 'addressed' })
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+  })
+
+  it('a REOPENED note shields its round — the sweep never undoes an explicit reopen', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const r2 = roundAgainstNewVersion('R2')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
+
+    // R1 settled by the sweep; the user deliberately puts it back in play.
+    const reopened = store.reopenAnnotation(SID, r1.annotationId)
+    const back = reopened.annotations.find((a) => a.id === r1.annotationId)!
+    expect(back.state).toBe('addressed')
+    expect(back.reopenedAt).toBeTruthy()
+    expect(reopened.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
+
+    // A THIRD round is ruled on. The reopened note must survive the sweep.
+    const r3 = roundAgainstNewVersion('R3')
+    const { state } = store.resolveAnnotation(SID, r3.annotationId, 'approve', canvasId)
+    expect(state.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({ state: 'addressed' })
+    expect(state.reviews.find((r) => r.id === 'R1')?.status).toBe('submitted')
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(1)
+  })
+
+  it('the settled state round-trips: reload from disk accepts closedBy supersede', () => {
+    const r1 = roundAgainstNewVersion('R1')
+    store.markAnnotationsAddressed(SID, 'R1', [r1.annotationId])
+    const r2 = roundAgainstNewVersion('R2')
+    const canvasId = store.getReviewStateForSession(SID)!.canvasId
+    store.resolveAnnotation(SID, r2.annotationId, 'approve', canvasId)
+
+    store._resetCanvasReviewStoreForTest()
+    const reloaded = store.getReviewStateForSession(SID)!
+    expect(reloaded.annotations.find((a) => a.id === r1.annotationId)).toMatchObject({
+      state: 'stale',
+      closedBy: 'supersede',
+    })
+    expect(store.getReviewCountsForCanvas(canvasId)?.verdictRounds).toBe(0)
+  })
+})

--- a/tests/unit/renderer/canvas-cross-canvas-count.test.tsx
+++ b/tests/unit/renderer/canvas-cross-canvas-count.test.tsx
@@ -111,12 +111,17 @@ describe('the queue pill spans canvases (#364)', () => {
     render()
     expect(pill()?.textContent).toBe('1')
   })
-  it('the live mirror wins for this canvas when it is fresher than the sweep -- UP', async () => {
-    // Sweep says 1 in total; the mirror already knows a second round landed here.
+  it('rounds stacking on THIS canvas never push it past 1 (#470 — the owner saw 3 for one canvas)', async () => {
+    // The live mirror knows two owed rounds here. One canvas = one owed item;
+    // the second round is detail, not a second debt.
     seedCanvasLive()
     seedMirror([owedRound('R1', 'a1'), owedRound('R2', 'a2')])
     seedTotals({ queue: 1, queueOnActive: 1 })
     render()
+    expect(pill()?.textContent).toBe('1')
+    // A round owed on a DIFFERENT canvas still adds — across canvases the
+    // count may exceed 1.
+    act(() => { seedTotals({ queue: 2, queueOnActive: 1 }) })
     expect(pill()?.textContent).toBe('2')
   })
   it('the live mirror wins for this canvas when it is fresher than the sweep -- DOWN (a verdict here drops the pill before the sweep catches up)', async () => {

--- a/tests/unit/renderer/canvas-open-reviews.test.tsx
+++ b/tests/unit/renderer/canvas-open-reviews.test.tsx
@@ -138,11 +138,11 @@ describe('AgentCanvasButton -- the queue pill (#364, pick B)', () => {
     expect(container.querySelector('[data-testid="reserved-label-current"]')!.textContent).toBe('Review needed')
   })
 
-  it('a ready-marked render counts, and adds to the verdict rounds', () => {
+  it('a ready-marked render and a verdict round on ONE canvas still count 1 (#470)', () => {
     seedCanvas(true)
     seed([review('R1', 'submitted', ['a1'])], [note('a1', 'R1', 'addressed')])
     render()
-    expect(pill()?.textContent).toBe('2')
+    expect(pill()?.textContent).toBe('1')
   })
 
   it('shows nothing when every review is resolved and nothing is ready-marked', () => {

--- a/tests/unit/stores/canvasTotalsStore.test.ts
+++ b/tests/unit/stores/canvasTotalsStore.test.ts
@@ -74,8 +74,10 @@ describe('the queue (#364): review-needed + verdict-owed, one derivation', () =>
     ])
     expect(t.queue).toBe(1)
     expect(t.queueOnActive).toBe(1)
-    // The rows keep the detail: both kinds are listed for the one canvas.
-    expect(t.queueRows).toHaveLength(2)
+    // One row per owing canvas, so the pill and the list agree; the ready
+    // render (the newest ask) is the row shown.
+    expect(t.queueRows).toHaveLength(1)
+    expect(t.queueRows[0]).toMatchObject({ kind: 'review', at: '2026-08-23T10:00:00Z' })
   })
 
   it("someone else's canvas never enters the queue", () => {

--- a/tests/unit/stores/canvasTotalsStore.test.ts
+++ b/tests/unit/stores/canvasTotalsStore.test.ts
@@ -53,25 +53,28 @@ describe('totalsFromEntries', () => {
 })
 
 describe('the queue (#364): review-needed + verdict-owed, one derivation', () => {
-  it('counts a ready-marked canvas once and a verdict canvas per round, and rows them newest first', () => {
+  it('counts each OWING CANVAS once (#470) — verdict rounds stay row detail, never stacking', () => {
     const t = totalsFromEntries([
       entry({ canvasId: 'a', title: 'Tips', ownedByThisSession: true, isActiveForThisSession: true, openReviewCount: 1, awaitingReview: true, awaitingReviewAt: '2026-08-23T10:00:00Z' }),
       entry({ canvasId: 'b', title: 'Sidebar', ownedByThisSession: true, openReviewCount: 1, verdictRounds: 2, lastRenderedAt: '2026-08-23T11:00:00Z' }),
       entry({ canvasId: 'c', ownedByThisSession: true, openReviewCount: 0, verdictRounds: 0 }),
     ])
-    expect(t.queue).toBe(3) // 1 review-needed + 2 verdict rounds
+    // The owner's rule: a count above 1 is legitimate across DIFFERENT
+    // canvases, never for the same one — b's 2 rounds are 1 owing canvas.
+    expect(t.queue).toBe(2)
     expect(t.queueOnActive).toBe(1)
     expect(t.queueRows.map((r) => `${r.canvasId}:${r.kind}`)).toEqual(['b:verdict', 'a:review'])
     expect(t.queueRows[0]).toMatchObject({ rounds: 2, title: 'Sidebar', onActive: false })
     expect(t.queueRows[1]).toMatchObject({ kind: 'review', at: '2026-08-23T10:00:00Z', onActive: true })
   })
 
-  it('a canvas can owe BOTH: a fresh ready round and an older verdict round', () => {
+  it('a canvas owing BOTH — a fresh ready round and an older verdict round — still counts ONCE (#470)', () => {
     const t = totalsFromEntries([
       entry({ canvasId: 'a', ownedByThisSession: true, isActiveForThisSession: true, openReviewCount: 1, awaitingReview: true, awaitingReviewAt: '2026-08-23T10:00:00Z', verdictRounds: 1 }),
     ])
-    expect(t.queue).toBe(2)
-    expect(t.queueOnActive).toBe(2)
+    expect(t.queue).toBe(1)
+    expect(t.queueOnActive).toBe(1)
+    // The rows keep the detail: both kinds are listed for the one canvas.
     expect(t.queueRows).toHaveLength(2)
   })
 


### PR DESCRIPTION
Fixes #470.

## The bug (owner's live rc.2 session)
Each `ready: true` render + review of the SAME canvas left its round counting forever: the pill read **3** for one canvas (one per ready version), approving the newest round only dropped it to 2 (the two older fully-addressed rounds kept counting), and the agent addressing those rounds pushed it **back up** to 3.

## The fix — a real terminal state for superseded rounds
**Store** (`canvas-review-store.ts`): one predicate, `supersededOwedReviewIds`, names the settled-debt shape — a *submitted, fully-addressed* round (nothing open, something addressed) whose ordinal sits below a *later round the user has already ruled on* (`resolved`). `settleSupersededRounds` makes it durable: those addressed notes → `stale` with new provenance **`closedBy: 'supersede'`** — the panel row reads *"settled by your later review"*, claiming nobody's click. Nothing is deleted; Reopen works as ever.

It runs inside exactly the four mutations that can create the shape:
- a panel verdict resolving a round (`resolveAnnotation`),
- an instructed agent close (`closeAnnotationsByAgent` — still behind the seen-barrier),
- a chat pick (`recordChatPick`),
- `markAnnotationsAddressed` — the 3→2→3 bounce: an old round becoming fully addressed AFTER a newer round was ruled on settles **in the same commit** and never re-enters the queue.

Guarantees held:
- **Open notes survive whole** — a round still holding agent debt is never swept (the owner's requirement: notes-in-play survive).
- **Reopen is shielded**: `reopenAnnotation` stamps `reopenedAt`, and a round holding a reopened note is never auto-settled again — only the user's own verdict ends it. Without this the sweep would instantly undo any Reopen.
- **Ordinal boundary**: an *earlier* ruling never settles a *later* addressed round.
- Not a new agent capability: the trigger is always anchored in a user ruling on a newer round; `canvas_verdict`'s provenance barrier is untouched.

**Queue** (`canvasTotalsStore.ts`): the pill now counts **owing canvases, max 1 per canvas** (owner: "a count above 1 is legitimate across different canvases, never for the same item"). The queue rows keep the per-kind detail (review vs verdict, round counts).

**Schema**: `AnnotationClosedBy` gains `'supersede'`; `Annotation` gains `reopenedAt` (validated like `addressedAt`; its presence is the shield). Old records load unchanged.

## Tests
Six new store cases — settle on ruling, the 3→2→3 bounce, open-note survival, ordinal boundary, reopen shield, disk round-trip of the new provenance — plus the totals recut. **Mutation-proven both ways**: disabling the sweep reds 3 tests; deleting the shield check reds the reopen test. Full run: 8343 passed, typecheck green.

Legacy records (like the owner's current stuck canvas) heal on the canvas's next mutation; the dismiss-all sweep remains available meanwhile.

ADR-009: this touches the conductor-MCP-written review store — adversarial review to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)