### PR TITLE
fix(logging): bound the uncaughtException EPIPE loop + enforce the log rotation cap (#487)

### DIFF
--- a/CONTEXT.d/2026-08-24-487-debug-logger-epipe-loop.md
+++ b/CONTEXT.d/2026-08-24-487-debug-logger-epipe-loop.md
@@ -1,0 +1,80 @@
+## 2026-08-24 -- #487 debug-logger EPIPE crash-loop + unbounded app.log growth
+
+Confirmed both premises against src/main/debug-logger.ts before touching it:
+
+- A) the uncaughtException handler called logError() BEFORE the EPIPE/EIO
+  check, so a broken stdout/stderr pipe could re-enter the handler.
+- B) getStream() only rotated on stream CREATION, never re-checking size on an
+  already-open stream, so a hot logger grew app.log past MAX_LOG_SIZE (10MB)
+  without bound (matches the observed 68GB app.log.1, 2h19m of identical
+  EPIPE lines).
+
+Fixes, all in src/main/debug-logger.ts:
+
+- Reordered the uncaughtException handler: EPIPE/EIO is checked FIRST and
+  writes straight to the file stream (never console), before any logError
+  call. Added a re-entrancy guard (`inUncaughtExceptionHandler`) so the
+  handler cannot recurse into itself even if something inside it re-triggers
+  uncaughtException.
+- Mirrored the same EPIPE/EIO-first suppression in unhandledRejection (it had
+  none at all -- a second, unguarded entry point into the same class of bug).
+- Wrapped every console.* call in logInfo/logWarn/logError in try/catch, and
+  added no-op 'error' handlers on process.stdout/stderr, so a broken pipe
+  degrades to a silent no-op instead of feeding the exception machinery.
+- Replaced the stream-creation-only rotation check with a running byte
+  counter (`streamBytes`, tracked in-process rather than via
+  WriteStream.bytesWritten, which lags actual writes) checked on every write;
+  crossing MAX_LOG_SIZE ends the stream so the next write reopens through the
+  existing rotateIfNeeded() path.
+- Added an 'error' listener on the log stream itself so a write failure
+  (ENOSPC/EBADF/permission loss) can no longer surface as an unhandled
+  'error' event -> uncaughtException -> another failing write (a second,
+  distinct crash-loop entry point the audit found).
+
+Also fixed, same audit pass (all confirmed against current code, not audit
+text alone):
+
+- tests/e2e/helpers/electron-app.ts: closeIsolatedApp now tree-kills the
+  Electron process (taskkill /T /F on Windows; process group SIGKILL
+  elsewhere) before removing its temp data dir, since a plain root-process
+  kill leaves node-pty's shell (+ conhost) alive holding handles inside that
+  dir -- the actual mechanism behind the 68GB leak surviving cleanup. rmSync
+  now retries (maxRetries/retryDelay) and warns with the leaked path + size
+  on final failure instead of a silent catch. Added a best-effort sweep of
+  stale ccc-e2e-* temp dirs (>1h old) at the start of each run so a leak
+  survives at most one run.
+- tests/e2e/session-dialog-permutations.spec.ts: the PTY-launching spec's
+  probeDir cleanup moved from mid-test (racing the still-live shell that owns
+  it as cwd) to afterAll, after closeIsolatedApp's tree-kill.
+- src/main/codex-review-mcp-tool.ts: the per-review mkdtemp tmpDir was never
+  removed on ANY path, including every early-return error path. Wrapped in
+  try/finally with rmSync in the finally.
+- src/main/channel-attachments.ts / channel-ledger.ts: attachments/ had no
+  retention while the ledger already rotated at 30 days. Added
+  reapAttachments() (age derived from the base-36-timestamp filename, no
+  stat() needed) and wired it into rotateLedgers() on the same window.
+
+Deferred (confirmed in-audit but out of scope for this fix -- separate
+tickets): the ssh-shim remote trace-log cap (needs a remote redeploy);
+rotateLedgers() itself is still never called anywhere (a pre-existing dead
+retention path, unrelated to the attachments fix above); screenshot
+auto-delete defaulting to "keep forever"; tokenomics tk_files/tk_events
+retention; Logs v2 transcript DB retention; insights archive pruning; vision
+CDP profile dir cleanup; tokenomics worker postMessage try/catch;
+tests/e2e/desktop-import.spec.ts's own rmSync hardening (that file exists
+only on feat/209-desktop-chat-import, not yet on beta -- nothing to fix here
+until it lands).
+
+Tests: tests/unit/main/debug-logger-epipe-loop.test.ts (new) covers both
+premises directly -- a throwing/reentrant console.error is bounded to one
+real invocation, and a >15MB write burst on one long-lived stream rotates
+(current file stays under the cap, a .1 file appears). Also added
+tests/unit/channel-attachments.test.ts for reapAttachments, and updated
+tests/unit/channel-ledger.test.ts's channel-storage mock for the new
+channelsDir() call rotateLedgers now makes.
+
+Note while testing: a vi.mock(path, async () => vi.importActual(...)) wrapper
+memoizes its result independent of vi.resetModules() -- a second dynamic
+import() in a later test silently returns the FIRST test's already-
+initialized module instance. Use vi.unmock() instead when a suite needs a
+truly fresh module per test.

--- a/CONTEXT.d/2026-08-25-487-e2e-stale-sweep.md
+++ b/CONTEXT.d/2026-08-25-487-e2e-stale-sweep.md
@@ -1,0 +1,33 @@
+## 2026-08-25 -- #487 e2e: stale-dir sweep coverage (tests/e2e/debug-log-bounded.spec.ts)
+
+Added `tests/e2e/debug-log-bounded.spec.ts` covering the deterministic half of the
+#487 helpers/electron-app.ts teardown hardening: `sweepStaleTempDirs()`. It launches
+the real packaged app and asserts a pre-existing `ccc-e2e-*` dir with a >1h-old mtime
+(a simulated leak from a crashed prior run) is GONE after launch, while a
+current-mtime `ccc-e2e-*` dir SURVIVES (age guard never nukes a live run's data dir).
+Both fixtures are created at module load so they exist before the process's
+once-per-process sweep at the first `launchIsolatedApp` -- robust standalone and in
+the full serial suite.
+
+Credibility (mutation-verified): commenting out the `sweepStaleTempDirs()` call in
+launchIsolatedApp makes the stale dir survive -> the spec fails on that assertion.
+Reverting restores green. Deterministic (pure fs), ~230ms, Windows-gated.
+
+Deliberately NOT shipped -- the process-tree-kill teardown assertion. The other half
+of the fix (`taskkill /T` so a surviving node-pty shell can't hold the dataDir open)
+is not credibly reliable as an in-window e2e: shell-only sessions spawn PowerShell
+under ConPTY (useConpty:true), which reparents the shell out of Electron's process
+tree, so whether the dataDir is freed after teardown is dominated by the RACE between
+the orphaned shell's natural death and the rmSync window, not by tree-kill vs
+root-only kill. Measured directly: idle shell flipped pass/leak across runs on BOTH
+the fixed and the reverted teardown; a shell pinned alive made BOTH clean. No config
+failed reliably on old AND passed reliably on the fix -> any such assertion would be
+flaky, worse than none.
+
+Deliberately unit-only -- app.log rotation + the EPIPE/EIO crash-loop suppression.
+Crossing the 10MB MAX_LOG_SIZE cap through the real app in one window is not a credible
+runtime, and the unbounded-growth failure shape needs a long-lived orphaned window an
+in-window e2e can't create. Covered, mutation-verified, in
+tests/unit/main/debug-logger-epipe-loop.test.ts (hot-stream rotation, sync-burst
+rotation race, single-record truncation, uncaughtException re-entrancy, stream-error
+reopen).

--- a/CONTEXT.d/2026-08-25-487-round1-adversarial-fixes.md
+++ b/CONTEXT.d/2026-08-25-487-round1-adversarial-fixes.md
@@ -1,0 +1,65 @@
+## 2026-08-25 -- #487 round-1 adversarial review: rotation race, attachment-reap false positives, coverage gaps
+
+Round-1 adversarial review of the #487 logging/disk fix (969bad1b) found the
+rotation fix and the attachment reaper each had a real remaining hole, plus
+three coverage gaps where existing correct behavior had no dedicated test.
+Fixed all in the same branch (fix/487-logging-epipe-loop), all in
+src/main/debug-logger.ts and src/main/channel-attachments.ts:
+
+- BLOCKER -- rotation still defeated by a synchronous write burst: the
+  original fix rotated by ending the stream and letting the NEXT write's
+  openStream() re-derive the decision from fs.statSync(). That stat lags the
+  prior stream's async flush; a tight loop with no `await` could cross
+  MAX_LOG_SIZE many times before the OS ever wrote anything out, so
+  statSync() kept seeing a small/pre-flush size, skipped rotation, AND
+  reseeded `streamBytes` from that same stale number -- the counter never
+  reached the cap again. Root fix: an in-process `mustRotate` flag, set the
+  instant the byte counter crosses the cap, honoured UNCONDITIONALLY on the
+  next open (never re-derived from a stat). Also had to open the log file's
+  fd SYNCHRONOUSLY (fs.openSync, handed to createWriteStream) instead of
+  letting the stream open it asynchronously -- otherwise, in a truly
+  synchronous burst (zero yields), the file might not exist on disk yet when
+  the rotate step ran, making the rename a silent no-op and converging every
+  "rotated" stream instance back onto the same growing file.
+- MINOR -- a single formatted record bigger than the whole cap
+  (logError('y'.repeat(50MB))) used to write in full before the running-total
+  check ever ran. Added a 256KB single-record cap (truncate + marker) applied
+  before the record reaches the stream.
+- BLOCKER -- channel-attachments.ts reapAttachments() still deleted
+  non-timestamp files: the whole-string base36 guard let any all-base36 stem
+  ("logo", "note", "icon", "README", and case-insensitively "Thumbs.db")
+  parse via parseInt(stem, 36) into a small 1970-ish number, so `ts < cutoff`
+  was true and it got deleted -- guaranteed real-world victim on Windows:
+  Thumbs.db. Added a round-trip check (`ts.toString(36) === stem.toLowerCase()`)
+  and a plausible-epoch bound (>= 2020-01-01, <= now); a stem failing either
+  check is skipped, never deleted.
+- Coverage gap -- the existing reentrancy-guard test only drove reentry
+  through the NON-suppressed branch (console.error on a non-EPIPE error),
+  which never actually exercises the guard against the SUPPRESSED (EPIPE)
+  branch's own write path recursing. Removing the guard didn't fail that
+  test. Added a test that drives a reentrant EPIPE through
+  writeToLog()->stream.write() itself; it fails when the guard is removed
+  (confirmed by reverting on a scratch copy).
+- Coverage gap -- the log stream's own 'error' listener (nulls the cached
+  stream so the next write reopens) had no direct test. Added one; confirmed
+  it fails when that listener is removed.
+- Coverage gap -- codex-review-mcp-tool.ts's per-call tmpDir cleanup
+  (try/finally rmSync) had tests only for error paths that happened to
+  exercise it incidentally, not a direct assertion. Added a success-path and
+  an error-return-path test that each capture the actual tmpDir the tool
+  created and assert it's gone afterward; confirmed both fail when the
+  finally block's rmSync is removed.
+
+Deferred (unchanged from the original fix's note): rotateLedgers() is still
+never called anywhere in production -- reapAttachments() is unit-tested
+directly instead, per the round-1 review's own instruction not to wire that
+dead path up as part of this fix.
+
+Verification: every new/changed regression test was confirmed to FAIL against
+a scratch revert of its corresponding fix (statSync-based rotation restored,
+record-cap removed, reapAttachments' round-trip/epoch checks removed, the
+reentrancy guard's `if (inUncaughtExceptionHandler) return` removed, the
+stream 'error' listener removed, and the codex-review finally block's rmSync
+removed) before being confirmed to PASS against the fixed code. `npm run
+typecheck` clean; full `npx vitest run` (734 files, 8357 tests): 8326 passed,
+29 skipped, 2 todo, 0 failed.

--- a/src/main/channel-attachments.ts
+++ b/src/main/channel-attachments.ts
@@ -1,15 +1,23 @@
 // src/main/channel-attachments.ts
-import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { channelsDir } from './channel-storage'
 
 // 2 MB decoded cap -- allows base64 overhead over the spec's 1 MB post-encode image limit.
 const MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024
 
+// Matches channel-ledger.ts's own retention window, so an attachment never
+// outlives (or is reaped much before) the ledger record that references it.
+const ATTACHMENT_RETENTION_DAYS = 30
+
+function attachmentsDir(): string {
+  return join(channelsDir(), 'attachments')
+}
+
 // Persists a data URL (or raw base64) to conductor-channels/attachments/<id>.<ext>
 // and returns the absolute path. CC reads files reliably; we never embed base64.
 export function persistAttachment(dataUrl: string, ext: 'png' | 'txt'): string {
-  const dir = join(channelsDir(), 'attachments')
+  const dir = attachmentsDir()
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
   const base64 = dataUrl.includes(',') ? dataUrl.split(',')[1] : dataUrl
   const buffer = Buffer.from(base64, 'base64')
@@ -17,4 +25,66 @@ export function persistAttachment(dataUrl: string, ext: 'png' | 'txt'): string {
   const path = join(dir, `${Date.now().toString(36)}.${ext}`)
   writeFileSync(path, buffer)
   return path
+}
+
+/**
+ * Deletes attachments older than `retentionDays`. The ledger files that
+ * reference them already rotate (channel-ledger.ts rotateLedgers, 30-day
+ * default) but the attachments themselves were exempt, so screenshot-heavy
+ * channel traffic grew `attachments/` without bound (#487 audit).
+ *
+ * The filename IS a base-36 `Date.now()` (see persistAttachment above), so age
+ * is derived from the name -- no per-file stat() needed. A name that doesn't
+ * parse as our timestamp format is left alone rather than guessed at.
+ *
+ * The whole-string base36 guard below is NOT sufficient by itself (round-1
+ * adversarial finding, BLOCKER): any all-base36 stem -- "logo", "note",
+ * "icon", "Thumbs", "README" -- still parses via parseInt(stem, 36) into some
+ * number, and every one of those happens to land in 1970, so `ts < cutoff`
+ * was true and the file was deleted. Guaranteed real-world victim on Windows:
+ * Thumbs.db. Two further checks are required before a stem is trusted as OUR
+ * timestamp: it must ROUND-TRIP back to itself (rejects any stem that parsed
+ * but isn't actually the canonical base-36 encoding of its own value, and
+ * -- by comparing against the lowercased stem -- the case-insensitive hole
+ * the old regex's `/i` flag left open), and it must fall inside a PLAUSIBLE
+ * epoch-ms window (this repo postdates 2020; nothing genuine is ever
+ * millions of ms since epoch, which is what a short English word parses to).
+ * A stem that fails either check is left alone, never deleted.
+ */
+const MIN_PLAUSIBLE_TIMESTAMP_MS = Date.UTC(2020, 0, 1)
+
+export function reapAttachments(now: Date = new Date(), retentionDays: number = ATTACHMENT_RETENTION_DAYS): void {
+  const dir = attachmentsDir()
+  if (!existsSync(dir)) return
+  const cutoff = now.getTime() - retentionDays * 86_400_000
+  let names: string[]
+  try {
+    names = readdirSync(dir)
+  } catch {
+    return
+  }
+  for (const name of names) {
+    const dotIndex = name.lastIndexOf('.')
+    const stem = dotIndex === -1 ? name : name.slice(0, dotIndex)
+    // parseInt(str, 36) parses only a leading valid-base36 PREFIX and ignores
+    // the rest -- "not-a-timestamp" would silently parse as "not" and return a
+    // small, very-old-looking number. Require the whole stem to be base36
+    // first, or an unrelated filename could be misread as an ancient
+    // timestamp and deleted.
+    if (!/^[0-9a-z]+$/i.test(stem)) continue
+    const ts = parseInt(stem, 36)
+    if (!Number.isFinite(ts)) continue
+    // Round-trip: reject any stem that parses but isn't ACTUALLY the
+    // canonical lowercase base-36 encoding of `ts` (coincidental words,
+    // leading zeros, mixed case).
+    if (ts.toString(36) !== stem.toLowerCase()) continue
+    // Plausibility bound: reject anything outside a sane epoch-ms window
+    // (before 2020, or in the future relative to `now`) -- this is what
+    // actually stops "logo"/"note"/"Thumbs"/"README", all of which round-trip
+    // cleanly but parse to a handful of days/minutes/hours after 1970-01-01.
+    if (ts < MIN_PLAUSIBLE_TIMESTAMP_MS || ts > now.getTime()) continue
+    if (ts < cutoff) {
+      try { unlinkSync(join(dir, name)) } catch { /* best effort */ }
+    }
+  }
 }

--- a/src/main/channel-ledger.ts
+++ b/src/main/channel-ledger.ts
@@ -2,6 +2,7 @@
 import type { LedgerRecord } from '../shared/channel-types'
 import { appendLine, listFiles, deleteFile } from './channel-storage'
 import { redactHookPayload } from './hooks/hook-payload-redactor'
+import { reapAttachments } from './channel-attachments'
 
 let seq = 0
 function newId(): string { return `${Date.now().toString(36)}-${(seq++).toString(36)}` }
@@ -33,6 +34,9 @@ export function appendLedger(input: LedgerInput): string {
 const LEDGER_RE = /^(\d{4})-(\d{2})-(\d{2})\.jsonl$/
 
 // Deletes ledger files older than `retentionDays`. Non-ledger files are ignored.
+// Also reaps attachments/ on the same retention window (#487 audit) -- the
+// ledger rotates but the attachments a record's `attachmentPath` points at were
+// exempt, so screenshot-heavy channel traffic grew that dir without bound.
 export function rotateLedgers(now: Date = new Date(), retentionDays = 30): void {
   const cutoff = now.getTime() - retentionDays * 86_400_000
   for (const name of listFiles()) {
@@ -41,4 +45,5 @@ export function rotateLedgers(now: Date = new Date(), retentionDays = 30): void 
     const fileTime = Date.UTC(+m[1], +m[2] - 1, +m[3])
     if (fileTime < cutoff) deleteFile(name)
   }
+  reapAttachments(now, retentionDays)
 }

--- a/src/main/codex-review-mcp-tool.ts
+++ b/src/main/codex-review-mcp-tool.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, existsSync, statSync } from 'fs'
+import { mkdtempSync, readFileSync, existsSync, statSync, rmSync } from 'fs'
 import { join } from 'path'
 import * as path from 'path'
 import { tmpdir } from 'os'
@@ -214,73 +214,82 @@ export async function runCodexReview(
     }
   }
 
-  // 4. Tmpfile for last-message capture
+  // 4. Tmpfile for last-message capture. Never removed anywhere below this
+  // point in the original code -- including every early-return error path
+  // (timeout, non-zero exit, missing tmpfile) -- so one dir + up to ~50KB
+  // review.md leaked into %TEMP% per invocation, forever (#487 audit).
+  // try/finally below guarantees cleanup on every path, including a throw.
   const tmpDir = mkdtempSync(join(tmpdir(), 'ccc-codex-review-'))
   const tmpfile = join(tmpDir, 'review.md')
-
-  // 5. Build argv
-  const argv = buildArgv(args, resolvedCwd, tmpfile)
-
-  // P7.7.9: log spawn args so the debug log shows exactly what flags were
-  // passed to codex on each invocation. Useful when diagnosing future CLI
-  // drift or argv-construction regressions.
-  logInfo('[codex-review] spawning: codex ' + argv.join(' '))
-
-  // 6. Spawn streaming. P7.7.15: honour caller-supplied timeoutSeconds when
-  // provided; zod already clamped it to [TIMEOUT_SECONDS_MIN, TIMEOUT_SECONDS_MAX].
-  const timeoutMs = args.timeoutSeconds != null ? args.timeoutSeconds * 1000 : REVIEW_TIMEOUT_MS
-  let observed: TokenCountObserved | null = null
-  const result = await runCodexStreaming(argv, {
-    timeoutMs,
-    cwd: resolvedCwd,
-    onStdoutLine: (line: string) => {
-      const parsedLine = parseTokenCountLine(line)
-      if (parsedLine) observed = parsedLine
-    },
-  })
-
-  // 7. Error mapping
-  if (result.timedOut) {
-    return { isError: true, text: `Codex review timed out after ${formatTimeoutForMessage(timeoutMs)}. Try a smaller scope (e.g. mode: "paths") or raise timeoutSeconds (max ${TIMEOUT_SECONDS_MAX}).` }
-  }
-  if (result.code !== 0) {
-    const excerpt = (result.stderr || '').slice(0, 500)
-    return { isError: true, text: `Codex review failed (exit ${result.code}): ${excerpt}${formatFooter(observed)}` }
-  }
-
-  // 8. Read tmpfile
-  if (!existsSync(tmpfile)) {
-    return { isError: true, text: 'Codex review produced no output (tmpfile missing).' }
-  }
-  let review = readFileSync(tmpfile, 'utf-8')
-  if (statSync(tmpfile).size > MAX_DIFF_BYTES) {
-    review = '[review truncated -- output exceeded 50KB]\n\n' + review.slice(-MAX_DIFF_BYTES)
-  }
-
-  // 9. Record usage
-  if (observed) {
-    const obsInner = observed as TokenCountObserved
-    recordReview(cccSessionId, {
-      inputTokens: obsInner.inputTokens,
-      outputTokens: obsInner.outputTokens,
-      rateLimit: obsInner.rateLimit,
-    })
-  }
-
-  // Emit internal event so channel rules (Codex Routing) can forward the
-  // review to the PR author session. Best-effort: never breaks the review result.
   try {
-    // Count numbered list items or "issue:" lines as a rough finding count.
-    const findingCount = (review.match(/^\s*\d+\./gm) ?? []).length || 1
-    emitCodexReviewComplete({
-      prNumber: undefined,
-      authorSessionId: cccSessionId,
-      findingCount,
-      findings: review.slice(0, 500),
-    })
-  } catch { /* channels emit is best-effort */ }
+    // 5. Build argv
+    const argv = buildArgv(args, resolvedCwd, tmpfile)
 
-  return { isError: false, text: review + formatFooter(observed) }
+    // P7.7.9: log spawn args so the debug log shows exactly what flags were
+    // passed to codex on each invocation. Useful when diagnosing future CLI
+    // drift or argv-construction regressions.
+    logInfo('[codex-review] spawning: codex ' + argv.join(' '))
+
+    // 6. Spawn streaming. P7.7.15: honour caller-supplied timeoutSeconds when
+    // provided; zod already clamped it to [TIMEOUT_SECONDS_MIN, TIMEOUT_SECONDS_MAX].
+    const timeoutMs = args.timeoutSeconds != null ? args.timeoutSeconds * 1000 : REVIEW_TIMEOUT_MS
+    let observed: TokenCountObserved | null = null
+    const result = await runCodexStreaming(argv, {
+      timeoutMs,
+      cwd: resolvedCwd,
+      onStdoutLine: (line: string) => {
+        const parsedLine = parseTokenCountLine(line)
+        if (parsedLine) observed = parsedLine
+      },
+    })
+
+    // 7. Error mapping
+    if (result.timedOut) {
+      return { isError: true, text: `Codex review timed out after ${formatTimeoutForMessage(timeoutMs)}. Try a smaller scope (e.g. mode: "paths") or raise timeoutSeconds (max ${TIMEOUT_SECONDS_MAX}).` }
+    }
+    if (result.code !== 0) {
+      const excerpt = (result.stderr || '').slice(0, 500)
+      return { isError: true, text: `Codex review failed (exit ${result.code}): ${excerpt}${formatFooter(observed)}` }
+    }
+
+    // 8. Read tmpfile
+    if (!existsSync(tmpfile)) {
+      return { isError: true, text: 'Codex review produced no output (tmpfile missing).' }
+    }
+    let review = readFileSync(tmpfile, 'utf-8')
+    if (statSync(tmpfile).size > MAX_DIFF_BYTES) {
+      review = '[review truncated -- output exceeded 50KB]\n\n' + review.slice(-MAX_DIFF_BYTES)
+    }
+
+    // 9. Record usage
+    if (observed) {
+      const obsInner = observed as TokenCountObserved
+      recordReview(cccSessionId, {
+        inputTokens: obsInner.inputTokens,
+        outputTokens: obsInner.outputTokens,
+        rateLimit: obsInner.rateLimit,
+      })
+    }
+
+    // Emit internal event so channel rules (Codex Routing) can forward the
+    // review to the PR author session. Best-effort: never breaks the review result.
+    try {
+      // Count numbered list items or "issue:" lines as a rough finding count.
+      const findingCount = (review.match(/^\s*\d+\./gm) ?? []).length || 1
+      emitCodexReviewComplete({
+        prNumber: undefined,
+        authorSessionId: cccSessionId,
+        findingCount,
+        findings: review.slice(0, 500),
+      })
+    } catch { /* channels emit is best-effort */ }
+
+    return { isError: false, text: review + formatFooter(observed) }
+  } finally {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3 })
+    } catch { /* best effort -- a stray dir here is a slow leak, not correctness */ }
+  }
 }
 
 /** Register the codex_review tool on a conductor-mcp-server McpServer instance.

--- a/src/main/debug-logger.ts
+++ b/src/main/debug-logger.ts
@@ -20,8 +20,31 @@ function getLogFilePath(): string {
   return LOG_FILE
 }
 const MAX_LOG_SIZE = 10 * 1024 * 1024 // 10MB
+// Bounds a single formatted record (round-1 adversarial finding, MINOR): a
+// single huge logError() call used to write past MAX_LOG_SIZE in one shot
+// before the running-total check ever ran. Generous enough for a real stack
+// trace; small enough that no single call can blow the rotation budget.
+const MAX_RECORD_BYTES = 256 * 1024 // 256KB
 
 let logStream: fs.WriteStream | null = null
+// Bytes written to `logStream` since it was opened, seeded from the on-disk
+// size of any pre-existing file at open time. Checked on every write (#487-B):
+// a long-lived stream that only rotated at CREATION time never re-checked size,
+// so a hot logger grew app.log without bound (observed: a 68GB app.log.1).
+// Tracked in-process rather than via WriteStream.bytesWritten, which only
+// counts bytes the OS has actually flushed and can lag a burst of writes.
+let streamBytes = 0
+// Set synchronously by writeToLog the instant `streamBytes` crosses the cap.
+// openStream() honours this UNCONDITIONALLY on the next reopen (round-1
+// adversarial finding, BLOCKER): re-deriving the rotate decision from
+// fs.statSync() races the prior stream's async flush -- a synchronous write
+// burst (no await) could cross the cap, end() the stream, and have the very
+// next write's statSync() still see the pre-flush (smaller) on-disk size, so
+// it skipped rotation AND reseeded `streamBytes` from that stale, too-small
+// number -- the counter then never reached the cap again. This flag makes the
+// in-process byte counter authoritative: rotation is a deterministic
+// consequence of OUR OWN decision, never a re-read of a racing stat.
+let mustRotate = false
 let verboseMode = false
 // Sticky channel-level baseline (beta builds default verbose ON). Kept separate
 // from the debug toggle so turning debug mode off can't silence beta verbose
@@ -63,36 +86,100 @@ function ensureLogDir() {
   }
 }
 
+// Renames logFile -> .1, cascading any existing .1/.2 up to .3 (oldest
+// dropped). Renaming does not disturb a still-open WriteStream fd pointed at
+// that inode (true on POSIX always, and on Windows because Node opens files
+// with FILE_SHARE_DELETE) -- so this is safe to call even while a just-ended
+// stream is still flushing its last buffered bytes to the now-renamed file.
+function rotateLogFiles(logFile: string) {
+  const rot3 = `${logFile}.3`
+  const rot2 = `${logFile}.2`
+  const rot1 = `${logFile}.1`
+  try { if (fs.existsSync(rot3)) fs.unlinkSync(rot3) } catch { /* ignore */ }
+  try { if (fs.existsSync(rot2)) fs.renameSync(rot2, rot3) } catch { /* ignore */ }
+  try { if (fs.existsSync(rot1)) fs.renameSync(rot1, rot2) } catch { /* ignore */ }
+  try { if (fs.existsSync(logFile)) fs.renameSync(logFile, rot1) } catch { /* ignore */ }
+}
+
+/** Cold-start-only stat-based rotation: used ONLY when this process has no
+ *  in-process byte-count history to trust (the very first stream this process
+ *  opens), to catch a file a PRIOR process left oversized. Never used to
+ *  decide rotation for a stream WE ourselves just closed -- see `mustRotate`. */
 function rotateIfNeeded() {
   try {
     const logFile = getLogFilePath()
     if (fs.existsSync(logFile)) {
       const stat = fs.statSync(logFile)
       if (stat.size > MAX_LOG_SIZE) {
-        // Close existing stream
         if (logStream) {
           logStream.end()
           logStream = null
         }
-        // Keep up to 3 rotated logs
-        const rot3 = `${logFile}.3`
-        const rot2 = `${logFile}.2`
-        const rot1 = `${logFile}.1`
-        try { if (fs.existsSync(rot3)) fs.unlinkSync(rot3) } catch { /* ignore */ }
-        try { if (fs.existsSync(rot2)) fs.renameSync(rot2, rot3) } catch { /* ignore */ }
-        try { if (fs.existsSync(rot1)) fs.renameSync(rot1, rot2) } catch { /* ignore */ }
-        fs.renameSync(logFile, rot1)
+        rotateLogFiles(logFile)
       }
     }
   } catch { /* ignore */ }
 }
 
+/** Opens a fresh log stream. Rotation is decided ONE OF TWO ways, never both:
+ *
+ *  - `mustRotate` set (writeToLog crossed MAX_LOG_SIZE on the PRIOR stream):
+ *    rotate UNCONDITIONALLY and reset `streamBytes` to 0. Deliberately does
+ *    NOT re-derive this decision from fs.statSync() -- that stat can lag the
+ *    prior stream's async flush (a synchronous write burst crosses the cap
+ *    well before the OS has written it out), which used to both skip
+ *    rotation and reseed `streamBytes` from the stale, too-small on-disk
+ *    size, so the counter never reached the cap again (#487 round-1 BLOCKER).
+ *
+ *  - Cold start (no `mustRotate`, i.e. the first stream this process opens):
+ *    no in-process history exists yet, so fall back to a stat-based check for
+ *    a file a prior process left oversized, and seed `streamBytes` from disk
+ *    -- there is nothing else to seed it from at this point. */
+function openStream(): fs.WriteStream {
+  ensureLogDir()
+  const filePath = getLogFilePath()
+  if (mustRotate) {
+    rotateLogFiles(filePath)
+    mustRotate = false
+    streamBytes = 0
+  } else {
+    rotateIfNeeded()
+    let existingSize = 0
+    try { existingSize = fs.statSync(filePath).size } catch { /* file doesn't exist yet */ }
+    streamBytes = existingSize
+  }
+  // Open the fd SYNCHRONOUSLY and hand it to createWriteStream, instead of
+  // letting the stream open it internally (which is asynchronous -- Node
+  // schedules the actual open() syscall on the libuv threadpool and only
+  // creates the on-disk file once that completes). In a genuinely synchronous
+  // write burst (no await, no setImmediate) the event loop never turns, so an
+  // async-opened file may not exist on disk yet even after many writes have
+  // been queued into the stream's internal buffer -- which made the
+  // rotateLogFiles() rename above a silent no-op the first time this ran
+  // (fs.existsSync(filePath) was false), and every subsequent "rotated"
+  // stream kept opening the SAME still-nonexistent path, so all of them
+  // converged on one growing file once the opens finally settled (#487
+  // round-1 BLOCKER, synchronous-burst case). Opening the fd here makes file
+  // existence unconditional and immediate, so the NEXT crossing's
+  // rotateLogFiles() can always find and rename the real file.
+  const fd = fs.openSync(filePath, 'a')
+  const stream = fs.createWriteStream(filePath, { fd })
+  // A stream-level write failure (ENOSPC, EBADF, permission loss) must never be
+  // left as an unhandled 'error' event -- that becomes an uncaughtException,
+  // which (before this fix) re-entered logError -> getStream -> another failing
+  // write, a second crash-loop entry point distinct from #487-A (audit, high).
+  // Deliberately does NOT call logError: logging the failure is exactly the
+  // write that just failed.
+  stream.on('error', () => {
+    if (logStream === stream) logStream = null
+  })
+  return stream
+}
+
 function getStream(): fs.WriteStream | null {
   if (logStream && !logStream.destroyed) return logStream
   try {
-    ensureLogDir()
-    rotateIfNeeded()
-    logStream = fs.createWriteStream(getLogFilePath(), { flags: 'a' })
+    logStream = openStream()
     return logStream
   } catch {
     // If data directory resolution fails, fall back to console-only logging
@@ -137,11 +224,40 @@ function formatMessage(level: string, ...args: unknown[]): string {
   return `[${timestamp}] [${level}] ${message}\n`
 }
 
+/**
+ * Single write sink for every log level. Tracks bytes written to the CURRENT
+ * stream instance and rotates the instant the running total crosses
+ * MAX_LOG_SIZE (#487-B), instead of only re-checking size when a new stream
+ * happens to get created. Ending the stream here, nulling it out, and setting
+ * `mustRotate` means the very next call reopens via getStream() ->
+ * openStream(), which rotates the now-oversized file UNCONDITIONALLY (not via
+ * a racing statSync) before appending further.
+ */
+function writeToLog(formatted: string): void {
+  const stream = getStream()
+  if (!stream) return
+  let toWrite = formatted
+  if (Buffer.byteLength(toWrite) > MAX_RECORD_BYTES) {
+    // A single absurdly large record (round-1 adversarial finding, MINOR)
+    // must never itself exceed the rotation budget -- truncate before it
+    // ever reaches stream.write(), not after.
+    const marker = '...[truncated]\n'
+    const budget = MAX_RECORD_BYTES - Buffer.byteLength(marker)
+    toWrite = Buffer.from(toWrite, 'utf8').subarray(0, budget).toString('utf8') + marker
+  }
+  stream.write(toWrite)
+  streamBytes += Buffer.byteLength(toWrite)
+  if (streamBytes >= MAX_LOG_SIZE) {
+    mustRotate = true
+    stream.end()
+    if (logStream === stream) logStream = null
+  }
+}
+
 /** Only writes when verbose/debug mode is enabled */
 export function logDebug(...args: unknown[]): void {
   if (!verboseMode) return
-  const stream = getStream()
-  stream?.write(formatMessage('DEBUG', ...args))
+  writeToLog(formatMessage('DEBUG', ...args))
 }
 
 /** Per-event hot-path diagnostics (every hook request, etc.). Writes ONLY in
@@ -149,26 +265,24 @@ export function logDebug(...args: unknown[]): void {
  *  the hot path unless explicitly opted in. */
 export function logTrace(...args: unknown[]): void {
   if (!traceMode) return
-  const stream = getStream()
-  stream?.write(formatMessage('TRACE', ...args))
+  writeToLog(formatMessage('TRACE', ...args))
 }
 
 export function logInfo(...args: unknown[]): void {
-  const stream = getStream()
-  stream?.write(formatMessage('INFO', ...args))
-  console.log(...args)
+  writeToLog(formatMessage('INFO', ...args))
+  // A broken stdout pipe must never escape as a thrown exception from inside a
+  // logging call (#487 audit): the file line above already landed.
+  try { console.log(...args) } catch { /* stdout gone */ }
 }
 
 export function logWarn(...args: unknown[]): void {
-  const stream = getStream()
-  stream?.write(formatMessage('WARN', ...args))
-  console.warn(...args)
+  writeToLog(formatMessage('WARN', ...args))
+  try { console.warn(...args) } catch { /* stderr gone */ }
 }
 
 export function logError(...args: unknown[]): void {
-  const stream = getStream()
-  stream?.write(formatMessage('ERROR', ...args))
-  console.error(...args)
+  writeToLog(formatMessage('ERROR', ...args))
+  try { console.error(...args) } catch { /* stderr gone */ }
 }
 
 export function getLogDir(): string {
@@ -182,19 +296,57 @@ export function closeDebugLogger(): void {
   }
 }
 
+// Re-entrancy guard for the uncaughtException handler below (#487-A). Scoped to
+// the synchronous body of ONE invocation: if handling the current exception
+// somehow re-triggers the same handler before it returns (the historical bug --
+// logError -> console.error -> throws EPIPE -> Node re-emits uncaughtException
+// -> handler runs again -> repeat), the re-entrant call returns immediately
+// instead of logging and rethrowing again. Reset in `finally` so a LATER,
+// unrelated exception is still handled normally.
+let inUncaughtExceptionHandler = false
+
 // Capture unhandled errors
 export function installGlobalErrorHandlers(): void {
+  // A handled stream 'error' event never becomes an uncaughtException, so
+  // console.* on a broken pipe degrades to a silent no-op instead of feeding
+  // the exception machinery below at all (#487 audit, medium). Belt-and-
+  // suspenders with the try/catch around each console.* call above.
+  process.stdout.on('error', () => { /* broken pipe: drop it, file logging continues */ })
+  process.stderr.on('error', () => { /* same */ })
+
   process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
-    logError('Uncaught exception:', err)
-    // Suppress EPIPE/EIO from PTY
-    if (err.code === 'EPIPE' || err.code === 'EIO') {
-      return
+    if (inUncaughtExceptionHandler) return
+    inUncaughtExceptionHandler = true
+    try {
+      // EPIPE/EIO from a dead PTY/stdout pipe FIRST, and BEFORE any console
+      // write -- logging through logError (which calls console.error) on a
+      // broken pipe was exactly what re-emitted the next EPIPE as a fresh
+      // uncaughtException (#487-A). Write straight to the file stream instead.
+      if (err.code === 'EPIPE' || err.code === 'EIO') {
+        try {
+          writeToLog(formatMessage('ERROR', 'Uncaught exception (suppressed):', err))
+        } catch { /* never let the handler throw */ }
+        return
+      }
+      logError('Uncaught exception:', err)
+      // For other errors, still throw to crash properly
+      throw err
+    } finally {
+      inUncaughtExceptionHandler = false
     }
-    // For other errors, still throw to crash properly
-    throw err
   })
 
   process.on('unhandledRejection', (reason) => {
+    // Second broken-pipe entry point (#487 audit, high): an unhandled rejection
+    // occurring while stdout/stderr is broken hit the same unguarded
+    // logError -> console.error path with no suppression at all.
+    const code = (reason as NodeJS.ErrnoException | null | undefined)?.code
+    if (code === 'EPIPE' || code === 'EIO') {
+      try {
+        writeToLog(formatMessage('ERROR', 'Unhandled rejection (suppressed):', reason))
+      } catch { /* never let the handler throw */ }
+      return
+    }
     logError('Unhandled rejection:', reason)
   })
 }

--- a/tests/e2e/debug-log-bounded.spec.ts
+++ b/tests/e2e/debug-log-bounded.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E for the #487 logging/disk fix — the STALE-DIR SWEEP half of the
+ * helpers/electron-app.ts teardown hardening.
+ *
+ * #487's disk symptom was leaked isolated data dirs accumulating FOREVER: a run
+ * whose teardown could not fully remove its mkdtemp dir (a node-pty shell still
+ * holding a handle on Windows) left the multi-GB dir behind, and nothing ever
+ * cleaned it up — one run's leak became permanent, and they piled up. The fix
+ * added `sweepStaleTempDirs()`: at the first `launchIsolatedApp` in a test
+ * process it removes any `ccc-e2e-*` dir in the OS temp root older than 1h,
+ * so a leaked dir survives at most one run instead of forever — while leaving
+ * a RECENT dir (an in-flight run's live data dir) untouched.
+ *
+ * This spec proves both halves of that behaviour, deterministically (pure fs —
+ * no process/PTY timing to race):
+ *
+ *   - A pre-existing `ccc-e2e-*` dir with an OLD mtime (simulating a leak from a
+ *     crashed prior run) is GONE after launch — the sweep removed it.
+ *   - A pre-existing `ccc-e2e-*` dir with a CURRENT mtime SURVIVES — the age
+ *     guard must never nuke a run's live data dir.
+ *
+ * Both fixture dirs are created at MODULE LOAD (before any test body runs, hence
+ * before the process's first `launchIsolatedApp`), because the sweep is
+ * once-per-process and fires at that first launch. That ordering makes the
+ * assertion hold whether this spec runs alone (its own beforeAll launch sweeps)
+ * or inside the full serial suite (an earlier spec's first launch sweeps — the
+ * stale fixture is already present from module load either way).
+ *
+ * CREDIBILITY (mutation-verified): commenting out the `sweepStaleTempDirs()`
+ * call in launchIsolatedApp makes the OLD dir SURVIVE the launch → the first
+ * assertion fails. Verified — see the PR notes / CONTEXT.d fragment.
+ *
+ * WHY NOT the process-tree-kill teardown assertion (attempted, deliberately not
+ * shipped): the fix's other half is a `taskkill /T` process-tree kill so a
+ * surviving node-pty shell can't hold the dataDir open. That is NOT credibly
+ * reliable as an in-window e2e on Windows: shell-only sessions spawn PowerShell
+ * under ConPTY (useConpty:true), which reparents the shell out of Electron's
+ * process tree, and whether the dataDir is freed after teardown is dominated by
+ * the RACE between the orphaned shell's natural death (when the pseudoconsole
+ * tears down) and the rmSync window — not deterministically by tree-kill vs
+ * root-only kill. Measured directly: with the shell idle it flipped
+ * pass/leak across runs on BOTH the fixed and the reverted teardown; pinning
+ * the shell alive made BOTH clean. No configuration failed reliably on old AND
+ * passed reliably on the fix, so any such assertion would be flaky — worse than
+ * none. That path stays covered by the harness itself (the sweep here catches
+ * whatever a racy teardown leaves) and by the run-over-run absence of leaked
+ * dirs.
+ *
+ * WHY NOT an in-app app.log ROTATION assertion (unit-only): driving the real app
+ * across the 10MB MAX_LOG_SIZE cap in a single test window is not achievable in
+ * a credible runtime, and the unbounded-growth failure shape needs a long-lived
+ * ORPHANED window to appear — exactly what an in-window e2e cannot create.
+ * Rotation on a hot long-lived stream, the synchronous-burst rotation race,
+ * single-record truncation, the uncaughtException re-entrancy guard and
+ * stream-error reopen are all covered, mutation-verified, in
+ * tests/unit/main/debug-logger-epipe-loop.test.ts.
+ *
+ * Windows-only: the leak this sweep backstops is the Windows PTY-handle case,
+ * and this repo's e2e runs on Windows.
+ */
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+
+// Created at MODULE LOAD so they exist before the process's first
+// launchIsolatedApp (the sweep is once-per-process and fires there).
+const rand = Math.random().toString(36).slice(2, 8)
+// A leaked dir from a "prior crashed run": old mtime → the sweep must remove it.
+const staleDir = path.join(os.tmpdir(), `ccc-e2e-STALE-${rand}`)
+// A recent dir (an in-flight run's live data dir): the sweep must keep it.
+const freshDir = path.join(os.tmpdir(), `ccc-e2e-FRESH-${rand}`)
+
+try {
+  // Give the stale fixture some content (mirrors a real leaked data dir) so the
+  // sweep is exercised on a non-empty tree, then age its mtime past the 1h cap.
+  fs.mkdirSync(path.join(staleDir, 'debug'), { recursive: true })
+  fs.writeFileSync(path.join(staleDir, 'debug', 'app.log'), 'x'.repeat(4096))
+  const old = Date.now() - TWO_HOURS_MS
+  fs.utimesSync(staleDir, old / 1000, old / 1000)
+
+  fs.mkdirSync(freshDir, { recursive: true })
+  fs.writeFileSync(path.join(freshDir, 'marker'), 'live')
+} catch {
+  /* creation failure surfaces as a missing-precondition assertion below */
+}
+
+let ctx: IsolatedApp
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000)
+  ctx = await launchIsolatedApp()
+})
+
+test.afterAll(async () => {
+  try {
+    await closeIsolatedApp(ctx)
+  } catch {
+    /* already closed */
+  }
+  for (const d of [staleDir, freshDir]) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+    } catch {
+      /* best effort */
+    }
+  }
+})
+
+test('sweeps a stale leaked e2e data dir on launch, keeps a recent one (#487)', async () => {
+  test.skip(process.platform !== 'win32', 'the leak this sweep backstops is the Windows PTY-handle case')
+
+  // Precondition: the fresh fixture was created (the stale one may already be
+  // gone if an earlier spec launched first — that is the swept state we assert).
+  expect(fs.existsSync(freshDir), 'fresh fixture dir was not created').toBe(true)
+
+  // The stale, >1h-old leaked dir must have been swept by sweepStaleTempDirs()
+  // at the process's first launch.
+  expect(
+    fs.existsSync(staleDir),
+    `stale leaked dir was NOT swept (still present): ${staleDir}`,
+  ).toBe(false)
+
+  // The recent dir must be untouched — the age guard must never remove a run's
+  // live data dir.
+  expect(
+    fs.existsSync(freshDir),
+    `recent dir was wrongly swept (age guard failed): ${freshDir}`,
+  ).toBe(true)
+
+  // Desktop-gate evidence: the app running normally after the sweep.
+  await shot(ctx.page, '01-app-running-after-stale-sweep')
+})
+
+// ───────────────────────────────────────────────────────────────── helpers
+
+/** Capture desktop-gate evidence: write the PNG to the test output dir AND
+ *  attach it by path (shows inline in the report). */
+async function shot(p: IsolatedApp['page'], name: string): Promise<void> {
+  const file = test.info().outputPath(`${name}.png`)
+  await p.screenshot({ path: file })
+  await test.info().attach(name, { path: file, contentType: 'image/png' })
+}

--- a/tests/e2e/helpers/electron-app.ts
+++ b/tests/e2e/helpers/electron-app.ts
@@ -16,11 +16,60 @@ import { _electron as electron, ElectronApplication, Page } from '@playwright/te
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+import { execFileSync } from 'child_process'
 import { emptyGitHubConfig } from '../../../src/shared/github-constants'
 import { currentTrainingVersion } from '../../../src/renderer/training-steps'
 import { STEPS, ONBOARDING_VERSION } from '../../../src/renderer/onboarding/steps'
 
 const APP_PATH = path.resolve(__dirname, '../../../out/main/index.js')
+
+// A leaked dir survives at most one run instead of forever: best-effort sweep
+// of stale ccc-e2e-* dirs (this helper's own prefix, and desktop-import's
+// ccc-e2e-import-* / the probe spec's ccc-e2e-probe-*) left behind by a run
+// whose teardown couldn't fully clean up (a PTY-owned handle on Windows -- see
+// closeIsolatedApp below). Runs once per process, at first launch.
+const STALE_DIR_MAX_AGE_MS = 60 * 60 * 1000 // 1h
+let staleSweepDone = false
+function sweepStaleTempDirs(): void {
+  if (staleSweepDone) return
+  staleSweepDone = true
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(os.tmpdir())
+  } catch {
+    return
+  }
+  const now = Date.now()
+  for (const name of entries) {
+    if (!name.startsWith('ccc-e2e-')) continue
+    const full = path.join(os.tmpdir(), name)
+    try {
+      const stat = fs.statSync(full)
+      if (now - stat.mtimeMs < STALE_DIR_MAX_AGE_MS) continue
+      fs.rmSync(full, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 })
+    } catch {
+      /* best effort -- a dir still in active use by another worker is fine to skip */
+    }
+  }
+}
+
+/** Tree-kill the whole Electron process group. On Windows, `.process().kill()`
+ *  terminates only the root process -- a node-pty child (shell + conhost)
+ *  reparents and survives, keeping open handles inside dataDir (including the
+ *  debug log the app writes there), which is exactly what made the dataDir
+ *  rmSync below fail silently and leak multi-GB temp dirs (#487 audit). */
+function killProcessTree(pid: number | undefined): void {
+  if (!pid) return
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore', timeout: 10000 })
+    } else {
+      process.kill(-pid, 'SIGKILL')
+    }
+  } catch {
+    /* already gone, or never had children -- either way, nothing left to kill */
+  }
+}
 
 export interface IsolatedApp {
   app: ElectronApplication
@@ -91,6 +140,7 @@ function seedCleanConfig(dataDir: string): void {
 }
 
 export async function launchIsolatedApp(): Promise<IsolatedApp> {
+  sweepStaleTempDirs()
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-e2e-'))
   seedCleanConfig(dataDir)
   const app = await electron.launch({
@@ -131,6 +181,12 @@ export async function closeIsolatedApp(a: IsolatedApp | undefined): Promise<void
   // A graceful close can hang indefinitely when the test left a live PTY session
   // running (the shell keeps the app alive), which blows the afterAll hook
   // timeout and fails an otherwise-passing run. Race it, then kill.
+  let pid: number | undefined
+  try {
+    pid = a.app.process().pid
+  } catch {
+    /* process already gone */
+  }
   try {
     await Promise.race([
       a.app.close(),
@@ -139,15 +195,52 @@ export async function closeIsolatedApp(a: IsolatedApp | undefined): Promise<void
   } catch {
     /* ignore */
   }
+  // Tree-kill: a plain root-process kill leaves node-pty's shell (+ conhost on
+  // Windows) alive, still holding handles inside dataDir (#487 audit).
+  killProcessTree(pid)
   try {
     a.app.process().kill()
   } catch {
     /* already gone */
   }
   // Remove ONLY the unique mkdtemp dir we created — never a parent/shared path.
+  // Retry across the brief window where a just-killed shell's handle (or
+  // Windows' own conhost teardown) hasn't released the directory yet; on final
+  // failure, warn with the leaked path and its size instead of swallowing it --
+  // a silent catch here is exactly what let a leaked dir go unnoticed and
+  // accumulate forever (#487 audit).
   try {
-    fs.rmSync(a.dataDir, { recursive: true, force: true })
+    fs.rmSync(a.dataDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 })
+  } catch (err) {
+    const size = dirSizeBestEffort(a.dataDir)
+    console.warn(
+      `[e2e] failed to remove isolated data dir ${a.dataDir}` +
+        `${size != null ? ` (~${(size / (1024 * 1024)).toFixed(1)} MB leaked)` : ''}: ${(err as Error).message}`,
+    )
+  }
+}
+
+/** Best-effort recursive size of a directory, for the leak warning above. Never
+ *  throws -- an inaccessible file just doesn't count toward the total. */
+function dirSizeBestEffort(dir: string): number | null {
+  let total = 0
+  const stack = [dir]
+  try {
+    while (stack.length) {
+      const cur = stack.pop() as string
+      for (const name of fs.readdirSync(cur)) {
+        const full = path.join(cur, name)
+        try {
+          const stat = fs.statSync(full)
+          if (stat.isDirectory()) stack.push(full)
+          else total += stat.size
+        } catch {
+          /* skip files that vanish mid-walk or refuse a stat */
+        }
+      }
+    }
+    return total
   } catch {
-    /* ignore */
+    return null
   }
 }

--- a/tests/e2e/session-dialog-permutations.spec.ts
+++ b/tests/e2e/session-dialog-permutations.spec.ts
@@ -17,6 +17,10 @@ import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/elec
 
 let ctx: IsolatedApp
 let page: IsolatedApp['page']
+// Set by the PTY-launching spec below; cleaned up in afterAll, AFTER
+// closeIsolatedApp's tree-kill has torn down the shell that owns it (#487
+// audit: cleaning it up in-test raced the still-live shell and always failed).
+let probeDirToClean: string | undefined
 
 test.beforeAll(async () => {
   ctx = await launchIsolatedApp()
@@ -27,6 +31,13 @@ test.afterAll(async () => {
   // Tearing down with a live PTY session can exceed the 30s hook default.
   test.setTimeout(120000)
   await closeIsolatedApp(ctx)
+  if (probeDirToClean) {
+    try {
+      fs.rmSync(probeDirToClean, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 })
+    } catch (err) {
+      console.warn(`[e2e] failed to remove probe dir ${probeDirToClean}: ${(err as Error).message}`)
+    }
+  }
 })
 
 /**
@@ -163,6 +174,7 @@ test.describe('Terminal-only config actually runs its command', () => {
     // as a real argv element, not just as pixels) and immune to xterm rendering
     // to a canvas, where there is no DOM text to read.
     const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-e2e-probe-'))
+    probeDirToClean = probeDir
     const probeJs = path.join(probeDir, 'probe.js')
     const probeOut = path.join(probeDir, 'argv.txt')
     fs.writeFileSync(
@@ -196,8 +208,8 @@ test.describe('Terminal-only config actually runs its command', () => {
     expect(shown).toContain('--token|E2E-SECRET-9f3a')
     // …and it ran in the configured working directory (the cd landed first).
     expect(shown.toLowerCase()).toContain(probeDir.toLowerCase())
-    // Best-effort: the spawned shell is still live with this as its cwd, so
-    // Windows holds a lock on it. Leaving a temp dir behind must not fail the run.
-    try { fs.rmSync(probeDir, { recursive: true, force: true }) } catch { /* shell still owns it */ }
+    // Cleanup happens in afterAll, AFTER the app (and its still-live shell) is
+    // torn down -- see probeDirToClean above. Doing it here always raced the
+    // shell that still owns probeDir as its cwd.
   })
 })

--- a/tests/unit/channel-attachments.test.ts
+++ b/tests/unit/channel-attachments.test.ts
@@ -1,0 +1,104 @@
+// tests/unit/channel-attachments.test.ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { vi } from 'vitest'
+
+let channelsRoot: string
+vi.mock('../../src/main/channel-storage', () => ({
+  channelsDir: () => channelsRoot,
+}))
+
+import { persistAttachment, reapAttachments } from '../../src/main/channel-attachments'
+
+function attachmentsDir(): string {
+  return path.join(channelsRoot, 'attachments')
+}
+
+describe('channel-attachments: reapAttachments (#487 audit)', () => {
+  beforeEach(() => {
+    channelsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-attachments-test-'))
+  })
+
+  it('persistAttachment writes into <channelsDir>/attachments', () => {
+    const p = persistAttachment('data:image/png;base64,AAAA', 'png')
+    expect(fs.existsSync(p)).toBe(true)
+    expect(path.dirname(p)).toBe(attachmentsDir())
+  })
+
+  it('no-ops when attachments/ does not exist yet', () => {
+    expect(() => reapAttachments()).not.toThrow()
+  })
+
+  it('deletes attachments older than retentionDays, keeps newer ones', () => {
+    const dir = attachmentsDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const now = Date.now()
+    const oldTs = now - 40 * 86_400_000 // 40 days old
+    const newTs = now - 1 * 86_400_000 // 1 day old
+    const oldFile = path.join(dir, `${oldTs.toString(36)}.png`)
+    const newFile = path.join(dir, `${newTs.toString(36)}.png`)
+    fs.writeFileSync(oldFile, Buffer.from('old'))
+    fs.writeFileSync(newFile, Buffer.from('new'))
+
+    reapAttachments(new Date(now), 30)
+
+    expect(fs.existsSync(oldFile)).toBe(false)
+    expect(fs.existsSync(newFile)).toBe(true)
+  })
+
+  it('leaves non-timestamp filenames alone', () => {
+    const dir = attachmentsDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const strange = path.join(dir, 'not-a-timestamp.png')
+    fs.writeFileSync(strange, Buffer.from('x'))
+
+    reapAttachments(new Date(), 30)
+
+    expect(fs.existsSync(strange)).toBe(true)
+  })
+
+  // Round-1 adversarial finding (BLOCKER): the old whole-string base36 guard
+  // still let any all-base36 STEM through parseInt(stem, 36) -- "logo",
+  // "note", "icon", "README" (and, case-insensitively, "Thumbs.db") all parse
+  // cleanly to a small number that lands in 1970, so `ts < cutoff` was true
+  // and every one of them got deleted. Thumbs.db is a guaranteed real-world
+  // victim on Windows. These must all SURVIVE a reap.
+  it('#487 round-1: never deletes non-timestamp base36-coincidental filenames (Thumbs.db et al.)', () => {
+    const dir = attachmentsDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const victims = ['Thumbs.db', 'logo.png', 'note.txt', 'README.txt', 'icon.png']
+    for (const v of victims) {
+      fs.writeFileSync(path.join(dir, v), Buffer.from('keep me'))
+    }
+
+    reapAttachments(new Date(), 30)
+
+    for (const v of victims) {
+      expect(fs.existsSync(path.join(dir, v))).toBe(true)
+    }
+  })
+
+  // Companion positive case: a GENUINE Date.now().toString(36)-named file
+  // older than retention must still be deleted, and one at/after the cutoff
+  // must still be kept -- the plausibility/round-trip checks must not turn
+  // into a blanket "never delete anything" regression.
+  it('#487 round-1: still deletes a genuine expired timestamp file, keeps one at cutoff', () => {
+    const dir = attachmentsDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const now = Date.now()
+    const retentionDays = 30
+    const expiredTs = now - 40 * 86_400_000 // 40 days old -- past retention
+    const atCutoffTs = now - retentionDays * 86_400_000 // exactly at cutoff -- kept
+    const expiredFile = path.join(dir, `${expiredTs.toString(36)}.png`)
+    const atCutoffFile = path.join(dir, `${atCutoffTs.toString(36)}.png`)
+    fs.writeFileSync(expiredFile, Buffer.from('old'))
+    fs.writeFileSync(atCutoffFile, Buffer.from('boundary'))
+
+    reapAttachments(new Date(now), retentionDays)
+
+    expect(fs.existsSync(expiredFile)).toBe(false)
+    expect(fs.existsSync(atCutoffFile)).toBe(true)
+  })
+})

--- a/tests/unit/channel-ledger.test.ts
+++ b/tests/unit/channel-ledger.test.ts
@@ -6,6 +6,11 @@ vi.mock('../../src/main/channel-storage', () => ({
   appendLine: (_n: string, line: string) => { lines.push(line) },
   listFiles: () => dirFiles,
   deleteFile: (n: string) => { const i = dirFiles.indexOf(n); if (i >= 0) dirFiles.splice(i, 1) },
+  // rotateLedgers now also reaps attachments/ (#487 audit); channel-attachments.ts
+  // reads channelsDir() to find that dir. Point it at a path that never exists so
+  // reapAttachments's existsSync guard no-ops -- attachment reaping itself is
+  // covered by its own dedicated test.
+  channelsDir: () => '/mock/nonexistent/conductor-channels',
 }))
 vi.mock('../../src/main/hooks/hook-payload-redactor', () => ({
   redactHookPayload: <T>(v: T): T => v,

--- a/tests/unit/main/codex-review-mcp-tool.test.ts
+++ b/tests/unit/main/codex-review-mcp-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, dirname } from 'path'
 
 // Mock auth: BOTH runCodexStreaming and readCodexAuthStatus from the same mock factory.
 // (The module under test imports both from './providers/codex/auth'.)
@@ -379,6 +379,53 @@ describe('codex_review tool', () => {
     expect(result.isError).toBe(true)
     expect(result.text).toContain('no Conductor session id bound')
     expect(runCodexStreaming).not.toHaveBeenCalled()
+  })
+
+  // Round-1 adversarial coverage gap (#487 audit): the per-review mkdtemp
+  // tmpDir must be removed on EVERY path, including a successful review --
+  // not just the error paths the original fix's tests happened to exercise.
+  // Capture the tmpDir the tool actually created (via the --output-last-message
+  // arg) and assert it is gone once runCodexReview resolves.
+  it('#487 round-1: cleans up the per-call tmpDir on a successful review', async () => {
+    let tmpDirCreated = ''
+    runCodexStreaming.mockImplementation(async (args: string[]) => {
+      const i = args.indexOf('--output-last-message')
+      const tmpfile = args[i + 1]
+      tmpDirCreated = dirname(tmpfile)
+      writeFileSync(tmpfile, 'fine', 'utf-8')
+      return { code: 0, stderr: '', timedOut: false }
+    })
+
+    const result = await runCodexReview(
+      { cccSessionId: 'sess-allowed', mode: 'working' },
+      optedIn, gitCwd,
+    )
+
+    expect(result.isError).toBe(false)
+    expect(tmpDirCreated).not.toBe('')
+    expect(existsSync(tmpDirCreated)).toBe(false)
+  })
+
+  // Companion case: an error-RETURN path (non-zero exit, not a throw) must
+  // clean up the tmpDir too -- the try/finally must not be scoped only to the
+  // happy path.
+  it('#487 round-1: cleans up the per-call tmpDir on an error-return path (non-zero exit)', async () => {
+    let tmpDirCreated = ''
+    runCodexStreaming.mockImplementation(async (args: string[]) => {
+      const i = args.indexOf('--output-last-message')
+      const tmpfile = args[i + 1]
+      tmpDirCreated = dirname(tmpfile)
+      return { code: 2, stderr: 'boom', timedOut: false }
+    })
+
+    const result = await runCodexReview(
+      { cccSessionId: 'sess-allowed', mode: 'working' },
+      optedIn, gitCwd,
+    )
+
+    expect(result.isError).toBe(true)
+    expect(tmpDirCreated).not.toBe('')
+    expect(existsSync(tmpDirCreated)).toBe(false)
   })
 })
 

--- a/tests/unit/main/debug-logger-epipe-loop.test.ts
+++ b/tests/unit/main/debug-logger-epipe-loop.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import type * as DebugLogger from '../../../src/main/debug-logger'
+
+// The global setup.ts mocks debug-logger entirely (to prevent file I/O during
+// other suites). This suite needs the REAL implementation and a real
+// (temp-dir) filesystem, so unmock it -- NOT via a vi.mock(...importActual)
+// wrapper: that memoizes its own result independent of vi.resetModules(),
+// so a SECOND dynamic import() in a later test would silently hand back the
+// first test's already-initialized module (its LOG_DIR cached to a tmpDir
+// afterEach had already deleted) instead of a fresh instance.
+vi.unmock('../../../src/main/debug-logger')
+
+let tmpDir: string
+
+vi.mock('../../../src/main/data-paths', () => ({
+  // debug-logger only calls this lazily inside getLogDirPath() -- reading
+  // `tmpDir` at call time (not at mock-definition time) is required.
+  getDataDirectory: () => tmpDir,
+}))
+
+function logDir(): string {
+  return path.join(tmpDir, 'debug')
+}
+function readLogFile(): string {
+  const f = path.join(logDir(), 'app.log')
+  return fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : ''
+}
+
+/** fs.WriteStream opens (and flushes) asynchronously -- a synchronous write
+ *  call queues data but does not guarantee it has reached disk by the very
+ *  next line. Yield the event loop long enough for that to happen before an
+ *  assertion reads the file back. */
+function flush(ms = 200): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+describe('debug-logger #487: EPIPE/EIO handling and rotation', () => {
+  let mod: typeof DebugLogger
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-debug-logger-test-'))
+    // debug-logger keeps its log-stream state (LOG_DIR, the open stream, the
+    // running byte count) in module-level `let`s. Without a fresh module
+    // instance per test, test N reuses test (N-1)'s cached directory AND its
+    // still-open stream -- which afterEach has already rmSync'd out from
+    // under it, so writes silently vanish into an unlinked, path-less fd.
+    vi.resetModules()
+    mod = await import('../../../src/main/debug-logger')
+  })
+
+  afterEach(() => {
+    // Never let one test's handlers leak into the next, or into the real suite.
+    process.removeAllListeners('uncaughtException')
+    process.removeAllListeners('unhandledRejection')
+    mod.closeDebugLogger()
+    vi.restoreAllMocks()
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best effort */ }
+  })
+
+  it('#487-A: a broken pipe cannot recurse the uncaughtException handler', () => {
+    mod.installGlobalErrorHandlers()
+
+    let consoleErrorCalls = 0
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      consoleErrorCalls++
+      // Simulate the historical bug: writing to a broken stdout/stderr pipe
+      // itself raises a fresh EPIPE, which Node re-emits as another
+      // uncaughtException on the very listeners we're already inside.
+      if (consoleErrorCalls < 25) {
+        const epipe = new Error('write EPIPE') as NodeJS.ErrnoException
+        epipe.code = 'EPIPE'
+        process.emit('uncaughtException', epipe)
+      }
+    })
+
+    const err = new Error('boom') as NodeJS.ErrnoException
+    // Non-EPIPE errors still rethrow to crash properly -- that part of the
+    // contract is unchanged. What matters here is what happens BEFORE the throw.
+    expect(() => process.emit('uncaughtException', err)).toThrow('boom')
+
+    // The re-entrancy guard must stop this at exactly one console.error call:
+    // the reentrant process.emit fired from inside our mock must be swallowed
+    // by the guard before it ever reaches logError/console.error again.
+    expect(consoleErrorCalls).toBe(1)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('#487-A: EPIPE/EIO is suppressed and logged to file WITHOUT touching console', async () => {
+    mod.installGlobalErrorHandlers()
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException
+    epipe.code = 'EPIPE'
+    expect(() => process.emit('uncaughtException', epipe)).not.toThrow()
+    await flush()
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(readLogFile()).toContain('Uncaught exception (suppressed):')
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('#487 (unhandledRejection): EPIPE/EIO reasons are suppressed the same way', async () => {
+    mod.installGlobalErrorHandlers()
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException
+    epipe.code = 'EPIPE'
+    expect(() => process.emit('unhandledRejection', epipe, Promise.resolve())).not.toThrow()
+    await flush()
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(readLogFile()).toContain('Unhandled rejection (suppressed):')
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('a throwing console.log cannot escape logInfo', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {
+      throw new Error('write EPIPE')
+    })
+    expect(() => mod.logInfo('hello')).not.toThrow()
+    await flush()
+    expect(readLogFile()).toContain('hello')
+  })
+
+  it('#487-B: a hot logger rotates instead of growing app.log without bound', async () => {
+    // Never let 15MB of literal 'x's hit the real terminal via console.error.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // One ~1KB message, written well past the 10MB cap, on a single long-lived
+    // stream (no restarts) -- the exact shape of the original bug: the old
+    // getStream() only rotated when a NEW stream was created. Yielding every
+    // few hundred iterations mirrors reality (writes are naturally spaced by
+    // real events) and lets each stream's buffered writes actually reach disk
+    // before rotateIfNeeded() re-checks size against MAX_LOG_SIZE.
+    const line = 'x'.repeat(1024)
+    const target = 10 * 1024 * 1024 // MAX_LOG_SIZE, mirrored here (not exported)
+    const iterations = Math.ceil((target * 1.5) / line.length)
+    for (let i = 0; i < iterations; i++) {
+      mod.logError(line)
+      if (i % 500 === 0) await flush(10)
+    }
+    await flush(300)
+
+    const currentSize = fs.statSync(path.join(logDir(), 'app.log')).size
+    const rotatedPath = path.join(logDir(), 'app.log.1')
+
+    // The live file must have rotated at least once -- it must NOT be anywhere
+    // near the ~15MB actually written, and a .1 rotation file must exist.
+    expect(currentSize).toBeLessThan(target)
+    expect(fs.existsSync(rotatedPath)).toBe(true)
+  })
+
+  // Round-1 adversarial finding (BLOCKER): the #487-B fix above still made
+  // its rotate DECISION by re-deriving from fs.statSync() on the next open --
+  // which lags a WriteStream's async flush. A tight loop with NO await lets
+  // many crossings of MAX_LOG_SIZE happen in the same synchronous tick, well
+  // before the OS has actually written any of it out, so statSync() kept
+  // reporting a small (pre-flush) size: rotation was skipped AND `streamBytes`
+  // was reseeded from that same stale, too-small number, so the running
+  // counter never reached the cap again. Root-fix: rotation is decided by an
+  // in-process flag (`mustRotate`) set synchronously the instant the counter
+  // crosses the cap, and honoured unconditionally on the next open -- never
+  // re-derived from a racing stat.
+  it('#487 round-1 BLOCKER: a synchronous write burst (no await) still rotates deterministically', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const line = 'x'.repeat(1024)
+    const target = 10 * 1024 * 1024 // MAX_LOG_SIZE, mirrored here (not exported)
+    // ~30MB in a row with ZERO awaits -- crosses the cap multiple times inside
+    // one synchronous JS turn, which is exactly the shape that defeated the
+    // stat-based decision (the old code never yields to let a flush land).
+    const iterations = Math.ceil((target * 3) / line.length)
+    for (let i = 0; i < iterations; i++) {
+      mod.logError(line)
+    }
+    // Only NOW give the OS a chance to flush the final, still-open stream.
+    await flush(500)
+
+    const currentSize = fs.statSync(path.join(logDir(), 'app.log')).size
+    const rotatedPath = path.join(logDir(), 'app.log.1')
+
+    expect(currentSize).toBeLessThanOrEqual(target)
+    expect(fs.existsSync(rotatedPath)).toBe(true)
+  })
+
+  // Round-1 adversarial finding (MINOR): a single formatted record bigger than
+  // the whole rotation cap used to be written in full before the
+  // running-total check ever ran (logError('y'.repeat(50MB)) wrote 50MB in one
+  // shot). A single record must be bounded/truncated BEFORE it reaches the
+  // stream.
+  it('#487 round-1 MINOR: a single oversized record is truncated, not written whole', async () => {
+    // Never dump 2MB of literal 'y's to the real terminal via console.error.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const huge = 'y'.repeat(2 * 1024 * 1024) // 2MB in one call
+    mod.logError(huge)
+    await flush()
+
+    const size = fs.statSync(path.join(logDir(), 'app.log')).size
+    // Comfortably above the ~256KB record cap (timestamp/level prefix + the
+    // truncation marker add a little) but nowhere near the 2MB passed in.
+    expect(size).toBeLessThan(300 * 1024)
+    expect(readLogFile()).toContain('[truncated]')
+  })
+
+  // Round-1 adversarial coverage gap: the stream's own 'error' listener
+  // (openStream(), ~debug-logger.ts:114-116) nulls the module's cached stream
+  // so the NEXT write transparently reopens instead of silently going
+  // nowhere. Exercise that branch directly rather than relying on it only
+  // being incidentally covered by the rotation tests above.
+  it('#487 round-1: a stream error nulls logStream and the next write reopens cleanly', async () => {
+    // fs.WriteStream doesn't override the public `write` method (only
+    // `_write`), so this captures the real per-call stream instance while
+    // still performing the actual write -- vi.spyOn can't touch the frozen
+    // `fs` module namespace directly (ESM), but the prototype object itself
+    // is a plain, mutable object (same technique the reentrancy test above
+    // uses successfully).
+    const seenStreams: fs.WriteStream[] = []
+    const originalWrite = fs.WriteStream.prototype.write
+    const writeSpy = vi.spyOn(fs.WriteStream.prototype, 'write').mockImplementation(function (this: fs.WriteStream, ...args: unknown[]) {
+      seenStreams.push(this)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalWrite as any).apply(this, args)
+    })
+
+    mod.logInfo('first')
+    await flush()
+    expect(seenStreams.length).toBeGreaterThanOrEqual(1)
+    const firstStream = seenStreams[0]!
+
+    // Simulate a stream-level write failure (ENOSPC/EBADF/permission loss).
+    expect(() => firstStream.emit('error', new Error('EBADF'))).not.toThrow()
+
+    mod.logInfo('second')
+    await flush()
+
+    // A fresh stream instance must have been used for the second write.
+    const secondStream = seenStreams[seenStreams.length - 1]!
+    expect(secondStream).not.toBe(firstStream)
+    const content = readLogFile()
+    expect(content).toContain('first')
+    expect(content).toContain('second')
+
+    writeSpy.mockRestore()
+  })
+
+  // Round-1 adversarial coverage gap: the existing re-entrancy test above
+  // drives re-entry through the NON-suppressed branch (console.error, on an
+  // error with no .code). Drive it through the SUPPRESSED (EPIPE) branch's
+  // own write path instead -- writeToLog() -> stream.write() -- which is the
+  // scenario the guard's docstring specifically calls out ("the suppressed-
+  // branch write path itself re-enters").
+  it('#487-A round-1: the suppressed-branch write path cannot recurse the handler', () => {
+    mod.installGlobalErrorHandlers()
+
+    let writeCalls = 0
+    const writeSpy = vi.spyOn(fs.WriteStream.prototype, 'write').mockImplementation(function (this: any) {
+      writeCalls++
+      if (writeCalls === 1) {
+        // The write itself re-raises a fresh EPIPE synchronously -- mirrors a
+        // stream 'write' that fails immediately while still inside the
+        // handler's own suppressed-branch write.
+        const epipe = new Error('write EPIPE') as NodeJS.ErrnoException
+        epipe.code = 'EPIPE'
+        process.emit('uncaughtException', epipe)
+      }
+      return true
+    })
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException
+    epipe.code = 'EPIPE'
+    expect(() => process.emit('uncaughtException', epipe)).not.toThrow()
+
+    // With the guard intact, the reentrant emit is swallowed before it can
+    // reach writeToLog() a second time -- exactly one write.
+    expect(writeCalls).toBe(1)
+
+    writeSpy.mockRestore()
+  })
+})

--- a/tests/unit/main/log-record-integrity.test.ts
+++ b/tests/unit/main/log-record-integrity.test.ts
@@ -25,6 +25,12 @@ vi.mock('fs', async () => {
     existsSync: () => true,
     mkdirSync: vi.fn(),
     statSync: () => ({ size: 0 }),
+    // The write path now opens the fd synchronously (fs.openSync) and hands it to
+    // createWriteStream (#487 rotation fix, so a sync burst rotates deterministically).
+    // Mock openSync too: otherwise the REAL openSync runs against a dir mkdirSync
+    // was mocked away, throws ENOENT in a clean env (CI), drops the logger to
+    // console-only, and captures nothing — the formatting under test never runs.
+    openSync: () => 1,
     createWriteStream: () => ({
       write: (chunk: string) => { writes.push(String(chunk)); return true },
       end: vi.fn(),


### PR DESCRIPTION
Fixes #487.

## The bug
Two defects in `src/main/debug-logger.ts` combined into a self-feeding log loop that left a **68 GB** `app.log` (2h19m of identical EPIPE lines):
- **A** — the `uncaughtException` handler logged via `console.error` **before** suppressing EPIPE/EIO, so a broken pipe re-entered the handler forever.
- **B** — `getStream()` only rotated at stream *creation*, so a long-lived logger blew past `MAX_LOG_SIZE` unbounded.

Latent **production** risk (any broken stdout — a parent/terminal closing; CCC launches sessions in PTYs), not e2e-only.

## The fix (+ in-scope extras the audit surfaced)
- **A:** suppress EPIPE/EIO **before** logging; a re-entrancy guard; `try/catch` around every `console.*`; error listeners on `process.stdout/stderr` and the log stream.
- **B:** an authoritative in-process byte counter + a `mustRotate` flag honored unconditionally (no racing `statSync`); synchronous fd open so a no-`await` burst rotates deterministically. Disk now capped at ~40 MB (4×10 MB).
- `unhandledRejection` had the same unguarded EPIPE path — mirrored.
- 256 KB single-record truncation.
- `reapAttachments`: a base36-stem parse could delete any non-timestamp all-base36 file (`Thumbs.db`, `logo.png`) — added a round-trip + `[2020, now]` epoch-window guard.
- codex-review MCP per-review `mkdtemp` leak — `try/finally` cleanup (+ tests).
- e2e teardown tree-kill + stale `ccc-e2e-*` sweep — the root cause of the 68 GB dir surviving cleanup.

## Verification
- Full unit suite green (**8326 passed**); 3-project typecheck clean.
- New **mutation-verified** regression tests for every fix claim (each test shown to fail on the reverted fix).

## Adversarial review (ADR-009): PASS in 2 rounds
Round 1 (4 independent attackers) found **2 real BLOCKERs** — rotation still defeated under a synchronous write burst (60 MB → 62 MB, 0 rotations); `reapAttachments` deleting `Thumbs.db` and any all-base36-named file. Both fixed. Round 2 (fresh attackers) confirmed both fixed with no new gaps, and all round-1 mutation survivors now killed. Audited verdict posted below. Two MINOR notes remain (a huge first arg drops trailing args on truncation; a ±1-byte multibyte record).

## Deferred (separate follow-ups the audit surfaced)
`rotateLedgers` is never called in production (pre-existing dead retention path); screenshot cleanup defaults to keep-forever; tokenomics/transcripts/insights retention; vision CDP profile dirs; ssh-shim remote trace cap; tokenomics-worker `postMessage` `try/catch`.

Desktop-test gate: backend/logging fix with no UI surface — still needs the `desktop-tested` label per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
