### PR TITLE
feat(command-bar): add an Artifacts button beside Browser (#501)

### DIFF
--- a/CONTEXT.d/2026-08-25-501-artifacts-command-bar-button.md
+++ b/CONTEXT.d/2026-08-25-501-artifacts-command-bar-button.md
@@ -1,0 +1,38 @@
+## 2026-08-25 -- #501 Artifacts button in the command bar
+
+**What.** Added an `artifacts` core tool to the command bar, beside Browser. It
+opens the current account's artifacts on claude.ai via the existing
+`accountWeb.openArtifacts(profileId)` IPC -- the same action the Sidebar's
+per-session menu already exposes. Previously that was the ONLY entry point.
+
+**How.**
+- `commandBarStore.ts`: `'artifacts'` added to `CORE_TOOL_IDS` (after `browser`),
+  so hide/show + the settings "Core tools" list pick it up generically.
+- `CommandBar.tsx`: an inline action button (modelled on Partner/Snap, not a
+  pane tool) rendered right after Browser, gated `!hiddenHere.has('artifacts') &&
+  artifactsApplicable`. Applicability mirrors the Sidebar: local, non-shell, with
+  a resolvable profile (`session.profileId ?? primary`). Click -> openArtifacts,
+  surfacing a failure the way the Sidebar does. Also a right-click menu entry.
+- `CustomCommandsTab.tsx`: the settings `TOOL_LABEL` (a `Record<CoreToolId>`)
+  gained `artifacts` (required, or typecheck breaks) + a caveat note.
+- `tipsStore.ts`: registered `artifacts.opened` in `DIRECT_FEATURE_IDS` so the
+  trackUsage-id prune guard passes.
+
+**Not security-sensitive.** Renderer-only; reuses an existing IPC. No new
+IPC/preload/PTY/credential surface -> no adversarial-review trigger (ADR-009).
+
+**Tests.** `commandbar-artifacts-button.test.tsx` (renders for an applicable
+session, opens the resolved profile on click, primary fallback, hidden for
+shell-only / no-profile / SSH). Updated `custom-commands-tab.test.ts`'s hardcoded
+`CORE_TOOL_IDS` assertion. Full unit suite green locally (8357).
+
+**Local limit.** This box cannot build `better-sqlite3` for Electron (node-gyp
+emits a Utility project), so the full app / e2e cannot run here; validated via
+unit + typecheck + build. CI builds native on its runners.
+
+**Follow-up (not merge-blocking).** A tips-library entry + Feature-Guide mention
+per the release user-facing-surface sweep.
+
+**Gates.** Human desktop-test (`desktop-tested`) + green CI before merge.
+
+**Ref:** #501.

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useCommandStore, CustomCommand, CommandSection } from '../stores/commandStore'
 import { bandMembers, type CommandBand } from '../lib/command-bands'
 import { useSessionStore } from '../stores/sessionStore'
+import { useAccountProfilesStore } from '../stores/accountProfilesStore'
 import { useCommandBarStore, type CoreToolId, type CommandBarOverflow, type HiddenCoreTools } from '../stores/commandBarStore'
 import { useExcalidrawStore } from '../stores/excalidrawStore'
 import { useLogsStore } from '../stores/useLogsStore'
@@ -90,7 +91,7 @@ function PermissionsPresetDropdown({ value, onChange }: { value: CodexPreset; on
   )
 }
 
-const TOOL_LABEL: Record<CoreToolId, string> = { snap: 'Snap', canvas: 'Canvas', logs: 'Logs', browser: 'Browser', partner: 'Partner', notes: 'Notes' }
+const TOOL_LABEL: Record<CoreToolId, string> = { snap: 'Snap', canvas: 'Canvas', logs: 'Logs', browser: 'Browser', artifacts: 'Artifacts', partner: 'Partner', notes: 'Notes' }
 const NO_HIDDEN: HiddenCoreTools = { everywhere: [], bySession: {} }
 
 interface Props {
@@ -209,6 +210,23 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
     () => sessionCapabilities(session ?? ({ provider: 'claude', sessionType, shellOnly: mainPaneIsShell, configId } as never)),
     [session, sessionType, mainPaneIsShell, configId],
   )
+
+  // #501: the Artifacts core tool opens this account's artifacts on claude.ai via
+  // the existing accountWeb.openArtifacts IPC (the Sidebar's per-session action).
+  // It applies only to a local, non-shell session that resolves to an account
+  // profile (its own, else the primary) — the same guard the Sidebar uses.
+  const primaryProfileId = useAccountProfilesStore((s) => s.profiles.find((p) => p.isPrimary)?.id)
+  const artifactsProfileId = session?.profileId ?? primaryProfileId
+  const artifactsApplicable =
+    !!session && !session.shellOnly && session.sessionType === 'local' && !!artifactsProfileId
+  const openArtifacts = useCallback(() => {
+    if (!artifactsProfileId) return
+    trackUsage('artifacts.opened')
+    void window.electronAPI.accountWeb
+      ?.openArtifacts?.(artifactsProfileId)
+      .then((r) => { if (r && !r.ok) alert(`Could not open artifacts for this account: ${r.error}`) })
+      .catch(() => alert('Could not open artifacts — the app could not reach the account window.'))
+  }, [artifactsProfileId])
 
   const visibleCommands = useMemo(
     () => commands.filter((c) => c.scope === 'global' || (c.scope === 'config' && c.configId === configId)),
@@ -765,6 +783,22 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           {!hiddenHere.has('canvas') && coreWrap('canvas', <AgentCanvasButton sessionId={sessionId} />)}
           {!hiddenHere.has('logs') && coreWrap('logs', <LogsButton sessionId={sessionId} structuralReason={caps.logsEmptyReason} remoteHost={caps.remoteHost} />)}
           {!hiddenHere.has('browser') && coreWrap('browser', <WebviewButton sessionId={webviewKey} />)}
+          {!hiddenHere.has('artifacts') && artifactsApplicable && coreWrap('artifacts', (
+            <button
+              type="button"
+              onClick={openArtifacts}
+              className="relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring bg-surface0/60 border-surface1/80 hover:bg-surface1 text-overlay1 hover:text-text"
+              title="Open this account's artifacts on claude.ai"
+              aria-label="Open artifacts"
+              data-testid="artifacts-open"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" />
+                <rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+              Artifacts
+            </button>
+          ))}
           {partnerEnabled && onTogglePartner && !hiddenHere.has('partner') && coreWrap('partner', (
             <button
               onClick={onTogglePartner}
@@ -886,6 +920,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
             : menu.tool === 'canvas' ? 'Agent Canvas · reviews and mock-ups'
             : menu.tool === 'snap' ? `a screenshot, sent to ${caps.agentName || 'the agent'}`
             : menu.tool === 'notes' ? 'encrypted notes · Global and this config'
+            : menu.tool === 'artifacts' ? 'this account\'s artifacts on claude.ai'
             : 'the browser pane'}
           ownActions={
             menu.tool === 'partner' && onTogglePartner ? [{ label: isPartnerActive ? 'Back to the main terminal' : 'Open partner shell', onClick: () => { setMenu(null); onTogglePartner() }, testId: 'menu-partner-toggle' }]
@@ -898,6 +933,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
                 { label: `Dismiss everything waiting on me (${canvasQueue})…`, onClick: () => { setMenu(null); setConfirm({ kind: 'canvas-dismiss' }) }, testId: 'menu-canvas-dismiss-all' },
                 { label: `Show what's waiting (${canvasQueue})`, onClick: () => { setMenu(null); window.dispatchEvent(new CustomEvent('ccc:canvasShowQueue', { detail: { sessionId } })) }, testId: 'menu-canvas-show-queue' },
               ]
+            : menu.tool === 'artifacts' ? [{ label: 'Open artifacts', onClick: () => { setMenu(null); openArtifacts() }, testId: 'menu-artifacts-open' }]
             : undefined}
           onHide={(where) => requestHide(menu.tool, where)}
           onClose={() => setMenu(null)}

--- a/src/renderer/components/settings/CustomCommandsTab.tsx
+++ b/src/renderer/components/settings/CustomCommandsTab.tsx
@@ -25,10 +25,11 @@ import CommandDialog from '../CommandDialog'
  * operations, a sections panel, a secrets list, import/export.
  */
 
-const TOOL_LABEL: Record<CoreToolId, string> = { snap: 'Snap', canvas: 'Canvas', logs: 'Logs', browser: 'Browser', partner: 'Partner', notes: 'Notes' }
+const TOOL_LABEL: Record<CoreToolId, string> = { snap: 'Snap', canvas: 'Canvas', logs: 'Logs', browser: 'Browser', artifacts: 'Artifacts', partner: 'Partner', notes: 'Notes' }
 const TOOL_NOTE: Partial<Record<CoreToolId, string>> = {
   snap: 'not in terminal-only sessions',
   logs: 'also needs General → Index conversation logs',
+  artifacts: 'local sessions with an account only',
 }
 
 function Card({ title, sub, children, testId }: { title: string; sub?: string; children: React.ReactNode; testId?: string }) {

--- a/src/renderer/stores/commandBarStore.ts
+++ b/src/renderer/stores/commandBarStore.ts
@@ -12,7 +12,7 @@ import { saveConfigDebounced, saveConfigNow } from '../utils/config-saver'
 
 /** The fixed tools in the Core band. A future tool is appended here and appears
  *  by default: hide state is a denylist, absent = shown. */
-export const CORE_TOOL_IDS = ['snap', 'canvas', 'logs', 'browser', 'partner', 'notes'] as const
+export const CORE_TOOL_IDS = ['snap', 'canvas', 'logs', 'browser', 'artifacts', 'partner', 'notes'] as const
 export type CoreToolId = typeof CORE_TOOL_IDS[number]
 
 /** One row and fold the rest (default), or wrap to at most a second row then fold. */

--- a/src/renderer/stores/tipsStore.ts
+++ b/src/renderer/stores/tipsStore.ts
@@ -98,6 +98,7 @@ const DIRECT_FEATURE_IDS: readonly string[] = [
   'commands.ctrl-click-args',
   'security.encrypted-notes',
   'webview.opened',
+  'artifacts.opened',
   'productivity.statusline-config',
   'github.signed-in',
   'github.panel-toggled',

--- a/tests/e2e/artifacts-button.spec.ts
+++ b/tests/e2e/artifacts-button.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E (#501): the Artifacts core tool ships in the real packaged app.
+ *
+ * The command-bar button itself only shows for a local, non-shell session that
+ * resolves to an account profile — a state the isolated e2e harness (no accounts,
+ * no real `claude`) cannot reach, and one the unit test
+ * (commandbar-artifacts-button.test.tsx) covers deterministically. What e2e CAN
+ * prove here, without a session or account, is that the new core tool is
+ * registered and surfaces in the app's UI: Settings → Custom Commands → Core
+ * tools lists one row per CORE_TOOL_ID, so an "Artifacts" row appearing there is
+ * proof the tool shipped and integrated (alongside the existing Browser row).
+ */
+import { test, expect } from '@playwright/test'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+let ctx: IsolatedApp
+let page: IsolatedApp['page']
+
+test.beforeAll(async () => {
+  test.setTimeout(90000)
+  ctx = await launchIsolatedApp()
+  page = ctx.page
+})
+
+test.afterAll(async () => {
+  await closeIsolatedApp(ctx)
+})
+
+test.describe('#501 Artifacts core tool (packaged app)', () => {
+  test('appears in Settings → Custom Commands → Core tools, beside Browser', async () => {
+    test.setTimeout(60000)
+    // Open Settings by its accessible name (robust to nav re-ordering).
+    await page.getByRole('button', { name: 'Settings', exact: true }).click()
+    await page.waitForTimeout(400)
+
+    // Switch to the Custom Commands tab.
+    await page.getByRole('button', { name: 'Custom Commands' }).click()
+    await expect(page.locator('[data-testid="custom-commands-tab"]')).toBeVisible({ timeout: 10000 })
+
+    // Non-vacuous: an existing core tool row is present...
+    await expect(page.locator('[data-testid="settings-core-browser"]')).toBeVisible()
+    // ...and the new Artifacts row shipped alongside it.
+    const artifacts = page.locator('[data-testid="settings-core-artifacts"]')
+    await expect(artifacts).toBeVisible()
+    await expect(artifacts).toHaveText(/Artifacts/i)
+
+    await page.screenshot({ path: test.info().outputPath('501-artifacts-core-tool.png') })
+    await test.info().attach('501-artifacts-core-tool', { path: test.info().outputPath('501-artifacts-core-tool.png'), contentType: 'image/png' })
+  })
+})

--- a/tests/unit/renderer/commandbar-artifacts-button.test.tsx
+++ b/tests/unit/renderer/commandbar-artifacts-button.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+/**
+ * #501: the Artifacts core-tool button in the command bar. It opens the current
+ * account's artifacts via the existing accountWeb.openArtifacts IPC (the Sidebar's
+ * per-session action), and appears only for a local, non-shell session that
+ * resolves to an account profile.
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+// The session under test — overwritten per test before render.
+let SESSION: Record<string, unknown> = {}
+let PROFILES: Array<Record<string, unknown>> = []
+
+vi.mock('../../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: (sel: any) => sel({ sessions: [SESSION], activeSessionId: SESSION.id, updateSession: vi.fn() }),
+}))
+vi.mock('../../../src/renderer/stores/accountProfilesStore', () => ({
+  useAccountProfilesStore: (sel: any) => sel({ profiles: PROFILES }),
+}))
+vi.mock('../../../src/renderer/stores/commandStore', () => ({
+  useCommandStore: () => ({
+    commands: [], sections: [],
+    addCommand: vi.fn(), updateCommand: vi.fn(), removeCommand: vi.fn(), reorderCommands: vi.fn(),
+    updateSection: vi.fn(), removeSection: vi.fn(), reorderSections: vi.fn(),
+  }),
+}))
+vi.mock('../../../src/renderer/stores/commandBarStore', () => ({
+  useCommandBarStore: (sel: any) => sel({ state: { collapsedSectionIds: [] }, toggleSection: vi.fn() }),
+}))
+const webviewState = { startActivation: vi.fn(() => 0), markAvailable: vi.fn(), markFailed: vi.fn(), navigate: vi.fn(), bySessionId: {} }
+vi.mock('../../../src/renderer/stores/webviewStore', () => ({
+  useWebviewStore: Object.assign((sel: any) => sel(webviewState), { getState: () => webviewState }),
+  pollUrlForContent: vi.fn(() => Promise.resolve(false)),
+  probeWebviewUrls: vi.fn(() => Promise.resolve(false)),
+}))
+const trackUsage = vi.fn()
+vi.mock('../../../src/renderer/stores/tipsStore', () => ({ trackUsage: (...a: unknown[]) => trackUsage(...a) }))
+vi.mock('../../../src/renderer/utils/id', () => ({ generateId: () => 'test-id' }))
+vi.mock('../../../src/renderer/components/ScreenshotButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/AgentCanvasButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/LogsButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/WebviewButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/CommandDialog', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/PasteHint', () => ({ default: () => null }))
+
+const openArtifacts = vi.fn(() => Promise.resolve({ ok: true as const }))
+;(globalThis as any).window.electronAPI = {
+  ...(globalThis as any).window.electronAPI,
+  pty: { write: vi.fn() },
+  accountWeb: { openArtifacts },
+}
+;(globalThis as any).window.alert = vi.fn()
+
+const { default: CommandBar } = await import('../../../src/renderer/components/CommandBar')
+
+let container: HTMLDivElement
+let root: Root
+beforeEach(() => {
+  openArtifacts.mockClear(); trackUsage.mockClear()
+  PROFILES = []
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+const render = () => {
+  act(() => { root.render(React.createElement(CommandBar, { sessionId: 's-1', parentSessionId: 's-1', configId: 'cfg' } as never)) })
+}
+const artifactsBtn = () => container.querySelector('[data-testid="artifacts-open"]') as HTMLButtonElement | null
+
+describe('#501 Artifacts command-bar button', () => {
+  it('renders for a local, non-shell session with a profile and opens that account on click', () => {
+    SESSION = { id: 's-1', label: 't', workingDirectory: '/', sessionType: 'local', provider: 'claude', profileId: 'prof-1' }
+    render()
+    const b = artifactsBtn()
+    expect(b).not.toBeNull()
+    expect(b!.textContent).toContain('Artifacts')
+    act(() => { b!.click() })
+    expect(openArtifacts).toHaveBeenCalledWith('prof-1')
+    expect(trackUsage).toHaveBeenCalledWith('artifacts.opened')
+  })
+
+  it('falls back to the primary profile when the session has none', () => {
+    SESSION = { id: 's-1', label: 't', workingDirectory: '/', sessionType: 'local', provider: 'claude' }
+    PROFILES = [{ id: 'prim', isPrimary: true }, { id: 'other', isPrimary: false }]
+    render()
+    act(() => { artifactsBtn()!.click() })
+    expect(openArtifacts).toHaveBeenCalledWith('prim')
+  })
+
+  it('is hidden for a shell-only session', () => {
+    SESSION = { id: 's-1', label: 't', workingDirectory: '/', sessionType: 'local', provider: 'claude', profileId: 'prof-1', shellOnly: true }
+    render()
+    expect(artifactsBtn()).toBeNull()
+  })
+
+  it('is hidden for a session with no resolvable profile', () => {
+    SESSION = { id: 's-1', label: 't', workingDirectory: '/', sessionType: 'local', provider: 'claude' }
+    PROFILES = [] // no primary either
+    render()
+    expect(artifactsBtn()).toBeNull()
+  })
+
+  it('is hidden for a non-local (SSH) session', () => {
+    SESSION = { id: 's-1', label: 't', workingDirectory: '/', sessionType: 'ssh', provider: 'claude', profileId: 'prof-1' }
+    render()
+    expect(artifactsBtn()).toBeNull()
+  })
+})

--- a/tests/unit/renderer/custom-commands-tab.test.tsx
+++ b/tests/unit/renderer/custom-commands-tab.test.tsx
@@ -220,7 +220,7 @@ describe('Command bar card -- writes the shared commandBarStore', () => {
 describe('Core tools card -- where hidden tools come back', () => {
   it('lists one row per Core tool, each "Shown" by default; Snap and Logs carry their caveats', () => {
     render()
-    expect(CORE_TOOL_IDS).toEqual(['snap', 'canvas', 'logs', 'browser', 'partner', 'notes'])
+    expect(CORE_TOOL_IDS).toEqual(['snap', 'canvas', 'logs', 'browser', 'artifacts', 'partner', 'notes'])
     for (const tool of CORE_TOOL_IDS) {
       expect(byTestId(`settings-core-${tool}`), `row for ${tool}`).not.toBeNull()
       expect(must(`settings-core-${tool}-status`).textContent?.startsWith('Shown'), `${tool} status`).toBe(true)


### PR DESCRIPTION
Fixes #501.

## What

Adds an **Artifacts** button to the command bar, right after Browser. It opens the current account's artifacts on claude.ai via the existing `accountWeb.openArtifacts(profileId)` IPC — until now reachable only from the Sidebar's per-session menu.

## How

- `commandBarStore.ts` — `artifacts` added to `CORE_TOOL_IDS` (after `browser`), so hide/show and the settings "Core tools" list pick it up generically.
- `CommandBar.tsx` — an inline action button (modelled on Partner/Snap — it opens a window, it is not a pane), rendered after Browser and gated to a **local, non-shell** session that resolves to an account profile (`session.profileId ?? primary`, mirroring the Sidebar guard). Click opens artifacts and surfaces a failure the way the Sidebar does; a right-click menu entry is included.
- `CustomCommandsTab.tsx` — the settings `TOOL_LABEL` (`Record<CoreToolId>`) gains `artifacts` (+ a caveat note).
- `tipsStore.ts` — `artifacts.opened` registered so the trackUsage-id prune guard passes.

## Not security-sensitive

Renderer-only; reuses the existing `accountWeb.openArtifacts` IPC. No new IPC/preload/PTY/credential/updater surface, so no adversarial-review trigger (ADR-009).

## Tests

`commandbar-artifacts-button.test.tsx` — renders for an applicable session, opens the resolved profile on click, primary-profile fallback, and is hidden for shell-only / no-profile / SSH sessions. Updated the hardcoded `CORE_TOOL_IDS` assertion in `custom-commands-tab`. Full unit suite green locally (8357 pass); typecheck + build clean.

Local note: this workstation cannot compile `better-sqlite3` for Electron (node-gyp emits a Utility project), so the full app/e2e was not run locally — validated by unit + typecheck + build; CI builds native on its runners.

## Follow-up (not merge-blocking)

A tips-library entry + Feature-Guide mention per the release user-facing-surface sweep.

## Gates

Human desktop-test (`desktop-tested`) + green CI before merge.
