### PR TITLE
fix(canvas): double-click-proof the notes panel's two bulk confirms

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -38,6 +38,22 @@ Landed so far, each through the canvas loop where the owner reviewed:
   body unmounting (tab switch / rail collapse), and the guided-tour +
   Feature-Guide copy that still said "+ New config" now names the menu path.
 
+- **#470** (PR #490): superseded review rounds settle instead of stacking the
+  queue — a real terminal state (`closedBy: 'supersede'`, panel row "settled by
+  your later review") applied by a sweep that runs inside the four mutations
+  able to create the settled-debt shape; the pill counts owing canvases max 1
+  per canvas. Adversarial pass (ADR-009, store change) found the sweep could
+  ride past the seen-barrier — fixed: `isAgentCloseable`-gated, per-artifact
+  scoped, triage-shielded, reopen-shielded. Owner verifies live in rc.3;
+  merged on the review record.
+- **#485** (PR #504): the two CanvasNotesPanel bulk confirms ("Close all
+  waiting on me", "Dismiss the rest") joined the #456 `useArmedConfirm`
+  pattern — guard keyed by armed round id / `'all'`. The new tests exposed a
+  latent dangling-`act()` in the Q-6 lock test that had been poisoning any
+  test placed after it. Review follow-up filed: a fifth unguarded confirm in
+  CanvasSubjectPicker, canvas-scoping the armed keys, and the one-click
+  draft-note delete.
+
 Canvas findings the loop itself surfaced, filed for this same release:
 **#470** (review rounds stack per superseded ready version; requirements for
 the round state machine captured on the issue), **#476** (subject-level

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -12,6 +12,7 @@ import {
   type ReviewGroup,
 } from '../stores/canvasReviewStore'
 import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
+import { useArmedConfirm } from '../hooks/useArmedConfirm'
 import { imageFileFromClipboard, pastedImageToPng } from '../utils/canvasPasteImage'
 
 interface Props {
@@ -252,6 +253,10 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
    *  second does it and says how many. Nothing is deleted either way. */
   const [closeAllArmed, setCloseAllArmed] = useState(false)
   const [closingAll, setClosingAll] = useState(false)
+  // Double-click-proofing (#456, extended here by #485): each confirm kind
+  // guards its own arm moment.
+  const dismissRestConfirm = useArmedConfirm(confirmDismissId)
+  const closeAllConfirm = useArmedConfirm(closeAllArmed ? 'all' : null)
   /** Which rounds have their Closed list expanded. Closed work is kept, not
    *  hidden — but it folds away by default so it does not bury what is live. */
   const [closedOpen, setClosedOpen] = useState<Record<string, boolean>>({})
@@ -770,7 +775,8 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
                 Cancel
               </button>
               <button
-                onClick={() => void closeAllWaiting()}
+                ref={closeAllConfirm.confirmRef}
+                onClick={closeAllConfirm.guarded(() => void closeAllWaiting())}
                 disabled={closingAll}
                 data-testid="close-all-waiting-confirm"
                 className="px-2 py-0.5 text-[10px] font-semibold rounded border border-peach/50 text-peach bg-peach/15 hover:bg-peach/25 disabled:opacity-40 focus-ring"
@@ -996,7 +1002,8 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
                 <div className="flex-1" />
                 {confirmDismissId === group.review.id ? (
                   <button
-                    onClick={() => void resolveGroup(group, 'dismiss')}
+                    ref={dismissRestConfirm.confirmRef}
+                    onClick={dismissRestConfirm.guarded(() => void resolveGroup(group, 'dismiss'))}
                     disabled={actionsLocked}
                     className="px-2 py-0.5 text-[10px] font-semibold rounded border border-red/50 text-red bg-red/15 hover:bg-red/25 disabled:opacity-40"
                     title="Drop these notes without action. They will not come back."

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -1005,7 +1005,7 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
                     ref={dismissRestConfirm.confirmRef}
                     onClick={dismissRestConfirm.guarded(() => void resolveGroup(group, 'dismiss'))}
                     disabled={actionsLocked}
-                    className="px-2 py-0.5 text-[10px] font-semibold rounded border border-red/50 text-red bg-red/15 hover:bg-red/25 disabled:opacity-40"
+                    className="px-2 py-0.5 text-[10px] font-semibold rounded border border-red/50 text-red bg-red/15 hover:bg-red/25 disabled:opacity-40 focus-ring"
                     title="Drop these notes without action. They will not come back."
                     data-testid="review-dismiss-rest-confirm"
                   >

--- a/tests/unit/renderer/canvas-closeout-panel.test.tsx
+++ b/tests/unit/renderer/canvas-closeout-panel.test.tsx
@@ -176,6 +176,16 @@ async function click(el: Element | null): Promise<void> {
   await act(async () => (el as HTMLElement).click())
 }
 
+// #456 (extended by #485): a freshly-armed confirm ignores activation for
+// CONFIRM_GUARD_MS so a double-click cannot arm and fire in one gesture.
+// Deliberate confirms jump a mocked clock past the window instead of waiting.
+let nowSpy: ReturnType<typeof vi.spyOn> | null = null
+function passGuard(): void {
+  const later = Date.now() + 60_000
+  nowSpy?.mockRestore()
+  nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => later)
+}
+
 beforeEach(async () => {
   current = boardWithMixedRounds()
   resolves = []
@@ -190,6 +200,8 @@ beforeEach(async () => {
 afterEach(async () => {
   await act(async () => root.unmount())
   container.remove()
+  nowSpy?.mockRestore()
+  nowSpy = null
 })
 
 describe('close all rounds waiting on me', () => {
@@ -214,6 +226,7 @@ describe('close all rounds waiting on me', () => {
   it('closes them as STALE and never as approved', async () => {
     await render()
     await click(byTestId('close-all-waiting-arm'))
+    passGuard()
     await click(byTestId('close-all-waiting-confirm'))
 
     // Newest round first, which is the order the panel lists them in.
@@ -225,6 +238,7 @@ describe('close all rounds waiting on me', () => {
   it('leaves the round still with the agent untouched', async () => {
     await render()
     await click(byTestId('close-all-waiting-arm'))
+    passGuard()
     await click(byTestId('close-all-waiting-confirm'))
 
     expect(resolves.map((r) => r.annotationId)).not.toContain('a4')
@@ -236,6 +250,7 @@ describe('close all rounds waiting on me', () => {
   it('disappears once nothing is waiting on you any more', async () => {
     await render()
     await click(byTestId('close-all-waiting-arm'))
+    passGuard()
     await click(byTestId('close-all-waiting-confirm'))
     await render()
     // R3 is still with the agent, so it is not "waiting on you" and the bar
@@ -372,6 +387,7 @@ describe('a bulk pass cannot land on the wrong canvas, or race itself', () => {
 
     await render()
     await click(byTestId('close-all-waiting-arm'))
+    passGuard()
     await click(byTestId('close-all-waiting-confirm'))
 
     // One resolve landed on the canvas the ids belonged to; the pass then
@@ -400,8 +416,10 @@ describe('a bulk pass cannot land on the wrong canvas, or race itself', () => {
 
     await render()
     await click(byTestId('close-all-waiting-arm'))
-    // Start the pass but do not let it finish.
-    void act(async () => (byTestId('close-all-waiting-confirm') as HTMLElement).click())
+    passGuard()
+    // Start the pass but do not let it finish. Keep the act() promise: left
+    // dangling, it overlaps every act() in later tests and their renders die.
+    const pass = act(async () => (byTestId('close-all-waiting-confirm') as HTMLElement).click())
     await act(async () => {})
 
     // Assert the controls are PRESENT and disabled — `?? true` on a missing
@@ -414,6 +432,65 @@ describe('a bulk pass cannot land on the wrong canvas, or race itself', () => {
     expect(perNote!.disabled).toBe(true)
 
     if (release) (release as () => void)()
+    await pass
     await act(async () => {})
+  })
+})
+
+describe('double-click-proofing (#456, extended by #485)', () => {
+  it('a double-click cannot arm and fire "Close all waiting on me" in one gesture', async () => {
+    await render()
+    await click(byTestId('close-all-waiting-arm'))
+    await click(byTestId('close-all-waiting-confirm'))
+    expect(resolves).toEqual([])
+    // Still armed — the close-out waits for a deliberate second decision.
+    expect(byTestId('close-all-waiting-confirm')).toBeTruthy()
+
+    passGuard()
+    await click(byTestId('close-all-waiting-confirm'))
+    expect(resolves.map((r) => r.annotationId)).toEqual(['a3', 'a1', 'a2'])
+  })
+
+  it('a double-click cannot arm and fire "Dismiss the rest" in one gesture', async () => {
+    await render()
+    await click(group('R1').querySelector('[data-testid="review-dismiss-rest"]'))
+    await click(group('R1').querySelector('[data-testid="review-dismiss-rest-confirm"]'))
+    expect(resolves).toEqual([])
+    expect(group('R1').querySelector('[data-testid="review-dismiss-rest-confirm"]')).toBeTruthy()
+
+    passGuard()
+    await click(group('R1').querySelector('[data-testid="review-dismiss-rest-confirm"]'))
+    expect(resolves.map((r) => r.annotationId)).toEqual(['a1', 'a2'])
+    expect(resolves.every((r) => r.action === 'dismiss')).toBe(true)
+  })
+
+  it('re-arming on a different round re-stamps the dismiss guard', async () => {
+    // Arm R1, wait out the window, then arm R2: the fresh arm must be guarded
+    // again — the stale R1 stamp must not leave R2's confirm live instantly.
+    current = {
+      canvasId: 'canvas-a',
+      sessionId: SID,
+      reviews: [review('R1', 'submitted', '01'), review('R2', 'submitted', '02')],
+      annotations: [
+        note('a1', 'R1', 'addressed'),
+        note('a2', 'R1', 'addressed'),
+        note('a3', 'R2', 'addressed'),
+        note('a6', 'R2', 'addressed'),
+      ],
+    }
+    await render()
+    await click(group('R1').querySelector('[data-testid="review-dismiss-rest"]'))
+    passGuard()
+    await click(group('R2').querySelector('[data-testid="review-dismiss-rest"]'))
+    await click(group('R2').querySelector('[data-testid="review-dismiss-rest-confirm"]'))
+    expect(resolves).toEqual([])
+  })
+
+  it('arming moves focus onto the confirm — both confirms', async () => {
+    await render()
+    await click(byTestId('close-all-waiting-arm'))
+    expect(document.activeElement).toBe(byTestId('close-all-waiting-confirm'))
+    await click(group('R1').querySelector('[data-testid="review-dismiss-rest"]'))
+    expect(document.activeElement).toBe(group('R1').querySelector('[data-testid="review-dismiss-rest-confirm"]'))
   })
 })

--- a/tests/unit/renderer/canvas-closeout-panel.test.tsx
+++ b/tests/unit/renderer/canvas-closeout-panel.test.tsx
@@ -423,17 +423,22 @@ describe('a bulk pass cannot land on the wrong canvas, or race itself', () => {
     await act(async () => {})
 
     // Assert the controls are PRESENT and disabled — `?? true` on a missing
-    // element would pass this test without the lock existing at all.
-    const accept = group('R1').querySelector('[data-testid="review-accept-as-built"]') as HTMLButtonElement | null
-    const perNote = group('R1').querySelector('[data-testid="note-close-stale"]') as HTMLButtonElement | null
-    expect(accept).toBeTruthy()
-    expect(perNote).toBeTruthy()
-    expect(accept!.disabled).toBe(true)
-    expect(perNote!.disabled).toBe(true)
-
-    if (release) (release as () => void)()
-    await pass
-    await act(async () => {})
+    // element would pass this test without the lock existing at all. The
+    // finally releases the latch even when an assertion throws: an unreleased
+    // pass is the same dangling act() the comment above describes, showing up
+    // only on failure, when cascade noise is most expensive.
+    try {
+      const accept = group('R1').querySelector('[data-testid="review-accept-as-built"]') as HTMLButtonElement | null
+      const perNote = group('R1').querySelector('[data-testid="note-close-stale"]') as HTMLButtonElement | null
+      expect(accept).toBeTruthy()
+      expect(perNote).toBeTruthy()
+      expect(accept!.disabled).toBe(true)
+      expect(perNote!.disabled).toBe(true)
+    } finally {
+      if (release) (release as () => void)()
+      await pass
+      await act(async () => {})
+    }
   })
 })
 


### PR DESCRIPTION
Fixes #485.

## What

The #456 pass (PR #484) double-click-proofed every arm-in-place confirm except the two in `CanvasNotesPanel`:

- **"Close all waiting on me"** → "Close N notes" (the panel-top bulk close-out)
- a round's **"Dismiss the rest"** → "Drop N without action"

Both swap the confirm button into the arm button's flex slot, so a fast double-click — or a held Enter, since arming moves focus — armed and fired in one gesture. These are the two buttons that drop the most notes at once; both are recoverable via Reopen, which is why this waited for its own small PR rather than holding #484.

## How

Two `useArmedConfirm` wirings, exactly the #456 pattern:

- `dismissRestConfirm = useArmedConfirm(confirmDismissId)` — keyed by the armed round's review id, so arming a *different* round re-stamps the guard window.
- `closeAllConfirm = useArmedConfirm(closeAllArmed ? 'all' : null)` — the boolean arm keyed as `'all'`.

Each confirm gets the hook's `confirmRef` (arming focuses the confirm, keeping keyboard flow) and its `onClick` goes through `guarded(...)` (activation inside `CONFIRM_GUARD_MS` of arming is swallowed and re-arms the window, which also defeats key-repeat ride-out).

## Tests

Four new cases in `canvas-closeout-panel.test.tsx`: both gestures blocked-then-deliberate, cross-round re-arm re-stamps the guard, and focus lands on each confirm. **Mutation-proven**: stripping `guarded()` from the two onClicks reds three of the four. Existing deliberate-confirm tests jump a mocked clock past the window, as in the #456 suites.

Also fixes a latent test bug the new block exposed: the Q-6 lock test started `act()` with `void` and never awaited it, so its act overlapped every act() in tests that run after it in the file and their renders died. (Nothing ran after it until now.) The promise is now held and awaited.

Full suite: 8399 passed / typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
