### PR TITLE
fix(terminal): hand-pulled repaint + geometry re-sync for console-direct splice damage

### DIFF
--- a/CONTEXT.d/2026-08-25-503-terminal-resync.md
+++ b/CONTEXT.d/2026-08-25-503-terminal-resync.md
@@ -1,0 +1,46 @@
+# 2026-08-25 — #503: console-direct splice damage, and the hand-pulled re-sync
+
+Owner report, live mid-session: an ssh host-key prompt bled through a Claude
+Code turn — prompt text mid-transcript, spinner fragments fused into output
+lines, still there in scrollback.
+
+## The split that decided the fix
+
+The splices sat **in scrollback**, and scrollback is populated only by bytes
+that came down the pty stream — which places the merge UPSTREAM of us and
+distinguishes this from the #379 class (whose damage never passes through the
+stream and is invisible to xterm). Mechanism: Windows OpenSSH opens the console
+device directly (`CONIN$`/`CONOUT$`) for its host-key prompt, conhost merges
+those writes with the TUI's concurrent cursor-addressed repaints, and ConPTY —
+a screen-scraper — re-emits the merged buffer as VT.
+
+So: **history is unfixable by physics** (the bytes really arrived spliced);
+what IS fixable is the TUI live-region desync that persists afterwards and
+keeps garbling every later delta-repaint. The repair is the proven post-resume
+nudge — shrink one row, restore, let the TUI re-lay-out at reconfirmed
+geometry — plus the strong repaint for our own stale cells.
+
+No auto-trigger exists: the spliced bytes carry no signature, the writer is a
+descendant of claude inside the pty (invisible to the command bar's
+`expectBleed` seam, which probes only lines typed in the bar), and main does
+not walk pty process trees. Hence a hand-pulled cord: **Ctrl+Alt+R** (capture
+phase + AltGr-guarded, the Ctrl+Alt+G reasoning) and **"Repaint terminal"** in
+the terminal context menu, both through the #379 repaint registry
+(`requestResync`, falling back to the plain settle repaint on stub
+registrations).
+
+## What the review round surfaced (PR #506)
+
+- **Persisted `keyboardShortcuts` maps never gain new defaults** — the hook's
+  `|| DEFAULT_SHORTCUTS` fired only when the whole object was missing, so
+  every pre-existing user would have had the new chord dead (and this likely
+  explains residual "Ctrl+Alt+G does nothing" reports post-#399). Both
+  handlers now merge over the defaults, the way StageEmptyState always did.
+- The chord now repairs **the terminal it was pressed in** (DOM-ancestry
+  lookup via `data-terminal-session`) — the partner shell registers under
+  `${id}-partner`, and the active-session fallback alone would have nudged a
+  hidden pty.
+- `e.repeat` is ignored — a held chord auto-repeats ~16Hz and each fire is a
+  pty resize pair.
+- `dispose()` restores LIVE geometry, not the fire-time capture, so a user
+  resize inside the 60ms shrink window survives an unmount race.

--- a/CONTEXT.d/2026-08-25-503-terminal-resync.md
+++ b/CONTEXT.d/2026-08-25-503-terminal-resync.md
@@ -31,16 +31,24 @@ registrations).
 
 ## What the review round surfaced (PR #506)
 
-- **Persisted `keyboardShortcuts` maps never gain new defaults** — the hook's
-  `|| DEFAULT_SHORTCUTS` fired only when the whole object was missing, so
-  every pre-existing user would have had the new chord dead (and this likely
-  explains residual "Ctrl+Alt+G does nothing" reports post-#399). Both
-  handlers now merge over the defaults, the way StageEmptyState always did.
-- The chord now repairs **the terminal it was pressed in** (DOM-ancestry
-  lookup via `data-terminal-session`) — the partner shell registers under
-  `${id}-partner`, and the active-session fallback alone would have nudged a
-  hidden pty.
-- `e.repeat` is ignored — a held chord auto-repeats ~16Hz and each fire is a
-  pty resize pair.
+- **Persisted `keyboardShortcuts` maps never gained new defaults** — root
+  cause in `settingsStore.hydrate`, whose deep-merge covered statusLine/
+  terminal/conductorTools/watchdog but not keyboardShortcuts, so every
+  substituting consumer had new chords dead for existing users (Sidebar's #124
+  per-key `renameSession` patch was this same bug; residual "Ctrl+Alt+G does
+  nothing" reports post-#399 likely were too). Fixed IN hydrate for every
+  consumer; the two hook handlers also merge locally as defense in depth. A
+  hand-cleared `""` binding survives the merge (falsy → `matchesShortcut`
+  declines) — only a hand-deleted key resurrects its default.
+- The chord repairs **the terminal it was pressed in** (DOM ancestry via
+  `data-terminal-session`); with focus outside any terminal it targets the
+  pane actually on screen (`data-terminal-active` — `isActive` is true for at
+  most one TerminalView); the bare active id is the last resort. The partner
+  shell registers under `${id}-partner`, and the active-session id alone
+  would have nudged a hidden pty.
+- Key-repeats are **consumed without acting** — for both chords. Round 2
+  caught that a bare `if (e.repeat) return` before preventDefault let xterm
+  encode the held chord as ESC+ctrl-char straight into the pty; and each
+  glyph-capture fire is a disk write + Explorer reveal.
 - `dispose()` restores LIVE geometry, not the fire-time capture, so a user
   resize inside the 60ms shrink window survives an unmount race.

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -94,7 +94,7 @@ export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPast
           type="button"
           className={itemClass}
           onClick={onRepaint}
-          title="Redraw the terminal and re-confirm its size — for when something printed over the pane and the text stays garbled"
+          title="Re-confirms the terminal size and redraws — stops NEW garbling after something printed over the pane. Lines already written stay as they arrived."
           data-testid="terminal-ctx-repaint"
         >
           <span>Repaint terminal</span>

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -14,10 +14,13 @@ interface Props {
   hasSelection: boolean
   onCopy: () => void
   onPaste: () => void
+  /** Repaint + geometry re-sync (#503) — the rescue for a pane something wrote
+   *  over (an ssh host-key prompt, a console-attached tool). */
+  onRepaint: () => void
   onClose: () => void
 }
 
-export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPaste, onClose }: Props) {
+export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPaste, onRepaint, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Clamp into the viewport after first paint (below-right of the pointer when
@@ -85,6 +88,17 @@ export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPast
         <button type="button" className={itemClass} onClick={onPaste}>
           <span>Paste</span>
           <span style={{ color: 'var(--text-muted)' }}>Ctrl+V</span>
+        </button>
+        <div className="my-1 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
+        <button
+          type="button"
+          className={itemClass}
+          onClick={onRepaint}
+          title="Redraw the terminal and re-confirm its size — for when something printed over the pane and the text stays garbled"
+          data-testid="terminal-ctx-repaint"
+        >
+          <span>Repaint terminal</span>
+          <span style={{ color: 'var(--text-muted)' }}>Ctrl+Alt+R</span>
         </button>
       </div>
     </div>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -1306,8 +1306,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     // data-terminal-session: lets the Ctrl+Alt+R capture handler resolve WHICH
     // terminal the chord was pressed in by DOM ancestry (#503) — the partner
     // pane and alt panes register under their own keys, and the active session
-    // id alone would nudge a hidden pty.
-    <div className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative" style={{ minHeight: 0 }} data-terminal-session={sessionId}>
+    // id alone would nudge a hidden pty. data-terminal-active marks the one
+    // pane that is actually on screen (isActive is true for at most one
+    // TerminalView — main and partner exclude each other), the handler's
+    // fallback when focus sits outside any terminal.
+    <div
+      className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative"
+      style={{ minHeight: 0 }}
+      data-terminal-session={sessionId}
+      data-terminal-active={isActive ? '' : undefined}
+    >
       {needsLogin && (
         <div className="bg-blue/10 border-b border-blue/30 text-lavender text-xs px-3 py-1.5 shrink-0">
           Setting up a new account. Run claude, type /login, and choose the account. We&apos;ll detect it automatically.

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -1303,7 +1303,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   }
 
   return (
-    <div className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative" style={{ minHeight: 0 }}>
+    // data-terminal-session: lets the Ctrl+Alt+R capture handler resolve WHICH
+    // terminal the chord was pressed in by DOM ancestry (#503) — the partner
+    // pane and alt panes register under their own keys, and the active session
+    // id alone would nudge a hidden pty.
+    <div className="flex-1 flex flex-col titlebar-no-drag overflow-hidden relative" style={{ minHeight: 0 }} data-terminal-session={sessionId}>
       {needsLogin && (
         <div className="bg-blue/10 border-b border-blue/30 text-lavender text-xs px-3 py-1.5 shrink-0">
           Setting up a new account. Run claude, type /login, and choose the account. We&apos;ll detect it automatically.

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -31,7 +31,8 @@ import TerminalContextMenu from './TerminalContextMenu'
 import { decideFollow } from '../utils/terminalScroll'
 import { getTerminalTheme } from './terminal/terminalTheme'
 import { installTerminalKeybindings } from './terminal/terminalKeybindings'
-import { registerRepainter } from './terminal/repaintRegistry'
+import { registerRepainter, requestResync } from './terminal/repaintRegistry'
+import { createGeometryResync, type GeometryResync } from './terminal/geometryResync'
 import { useSettingsStore, DEFAULT_TERMINAL_SETTINGS, gpuRenderingEnabled } from '../stores/settingsStore'
 import { usePasteHintStore } from '../stores/pasteHintStore'
 import { installInputDiagnostics, describeBytes } from '../utils/inputDiagnostics'
@@ -414,6 +415,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     let unsubData: (() => void) | null = null
     let unsubExit: (() => void) | null = null
     let disposeKeybindings: (() => void) | null = null
+    let geometryResync: GeometryResync | null = null
     let handleContextMenu: ((e: MouseEvent) => void) | null = null
     let handlePaste: ((e: ClipboardEvent) => void) | null = null
     let disposed = false
@@ -609,8 +611,27 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // That text never passes through the pty stream, so xterm cannot know its
       // model is stale — only an unconditional repaint puts the two back in
       // agreement.
+      //
+      // #503 adds resync: the shrink→restore geometry nudge (same shape as the
+      // post-resume one below) followed by the strong repaint, hand-pulled via
+      // Ctrl+Alt+R / the context menu for splice damage a repaint alone cannot
+      // fix — a console-direct writer (ssh's host-key prompt) can leave the
+      // TUI's live region desynced from the real rows, and only the TUI
+      // re-laying-out at reconfirmed geometry repairs that.
+      geometryResync = createGeometryResync({
+        getGeometry: () => ({ cols: term?.cols ?? 0, rows: term?.rows ?? 0 }),
+        resizePty: (c, r) => {
+          ptyResizeCount += 1
+          try { window.electronAPI.pty.resize(sessionId, c, r) } catch { /* main gone */ }
+        },
+        refresh: () => { try { term?.refresh(0, (term?.rows ?? 1) - 1) } catch { /* disposed */ } },
+        settleStrong: () => repainter?.settleStrong(),
+        isBusy: () => resumeNudgeShrunk,
+        onRestore: (c, r) => { lastSentCols = c; lastSentRows = r },
+      })
       unregisterRepainter = registerRepainter(sessionId, {
         settleStrong: (quietMs, intervalMs) => repainter?.settleStrong(quietMs, intervalMs),
+        resync: () => { geometryResync?.fire() },
       })
 
       // #119: cursor options passed to the Terminal constructor do NOT reliably
@@ -1230,6 +1251,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       if (handlePaste) container.removeEventListener('paste', handlePaste, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)
       unregisterRepainter?.()
+      geometryResync?.dispose()
       repainter?.dispose()
       if (repainterRef.current === repainter) repainterRef.current = null
       resizeObserver?.disconnect()
@@ -1331,6 +1353,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           hasSelection={ctxMenu.hasSelection}
           onCopy={ctxMenuCopy}
           onPaste={ctxMenuPaste}
+          onRepaint={() => {
+            requestResync(sessionId)
+            closeCtxMenu()
+          }}
           onClose={closeCtxMenu}
         />
       )}

--- a/src/renderer/components/terminal/geometryResync.ts
+++ b/src/renderer/components/terminal/geometryResync.ts
@@ -92,8 +92,19 @@ export function createGeometryResync(deps: GeometryResyncDeps): GeometryResync {
       restoreTimer = null
     }
     if (shrunkFrom) {
+      // Prefer LIVE geometry, same rule as the restore: a user resize can land
+      // inside the shrink window, and the pty outlives this view — restoring
+      // the stale capture would leave it at the pre-resize size. The capture
+      // is only the fallback for a term already disposed under us.
+      let target = shrunkFrom
       try {
-        deps.resizePty(shrunkFrom.cols, shrunkFrom.rows)
+        const g = deps.getGeometry()
+        if (g.cols > 0 && g.rows > 0) target = g
+      } catch {
+        /* term disposed first — the capture will do */
+      }
+      try {
+        deps.resizePty(target.cols, target.rows)
       } catch {
         /* main gone mid-teardown */
       }

--- a/src/renderer/components/terminal/geometryResync.ts
+++ b/src/renderer/components/terminal/geometryResync.ts
@@ -1,0 +1,105 @@
+/**
+ * User-invoked terminal repaint + geometry re-sync (#503).
+ *
+ * When a console-attached child of the pty's own process tree writes to the
+ * console device directly — Windows OpenSSH does exactly this for its host-key
+ * prompt, opening CONIN$/CONOUT$ around its redirected stdio — conhost merges
+ * those writes with the TUI's concurrent cursor-addressed repaints and ConPTY
+ * emits the spliced result. Two kinds of damage come out of that:
+ *
+ *  - Rows already scrolled into history hold the spliced text. Those bytes
+ *    really arrived that way; nothing downstream can un-write them.
+ *  - The TUI's live region can stay desynced from the real rows afterwards,
+ *    garbling every later delta-repaint. THIS is repairable: the same
+ *    shrink-by-one-row → restore nudge the post-resume path uses makes the
+ *    program re-lay-out its whole TUI at reconfirmed geometry, and a strong
+ *    repaint then redraws our own stale cells.
+ *
+ * There is no signal to auto-detect the splice on (the bytes are
+ * indistinguishable from ordinary output), so this is a hand-pulled cord:
+ * Ctrl+Alt+R and the terminal context menu, via the repaint registry.
+ *
+ * Deps-injected like staleGlyphRepaint so the sequence is testable without a
+ * live terminal.
+ */
+
+/** How long the pty stays shrunk before the restore half fires — long enough
+ *  for the resize to reach conpty, short enough to read as a flicker. Same
+ *  figure the post-resume nudge settled on. */
+export const RESYNC_RESTORE_DELAY_MS = 60
+
+export interface GeometryResyncDeps {
+  /** Read AT CALL TIME, both on fire and on restore — a real user resize can
+   *  land inside the shrink window, and restoring a stale capture would stomp
+   *  it (see the post-resume nudge's identical rule). */
+  getGeometry: () => { cols: number; rows: number }
+  resizePty: (cols: number, rows: number) => void
+  /** Repaint every row of the live viewport. */
+  refresh: () => void
+  /** The atlas-clearing settle sweep, for GPU-side stale cells. */
+  settleStrong: () => void
+  /** True while some other geometry jiggle is in flight (the post-resume
+   *  nudge); firing under it would fight over the restore. */
+  isBusy?: () => boolean
+  /** Bookkeeping hook: the restore's geometry became the last one sent. */
+  onRestore?: (cols: number, rows: number) => void
+  setTimer?: (cb: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
+}
+
+export interface GeometryResync {
+  /** Run one shrink→restore→repaint cycle. False when it declined: disposed,
+   *  a cycle already in flight, another jiggle busy, or geometry too small to
+   *  shrink (rows must survive -1). */
+  fire: () => boolean
+  /** Cancel a pending restore and, if the pty is still shrunk, put it back —
+   *  a remount must not inherit a one-row-short terminal. */
+  dispose: () => void
+}
+
+export function createGeometryResync(deps: GeometryResyncDeps): GeometryResync {
+  const setTimer = deps.setTimer ?? ((cb: () => void, ms: number) => setTimeout(cb, ms))
+  const clearTimer = deps.clearTimer ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>))
+  let restoreTimer: unknown = null
+  let shrunkFrom: { cols: number; rows: number } | null = null
+  let disposed = false
+
+  const fire = (): boolean => {
+    if (disposed || restoreTimer !== null || deps.isBusy?.()) return false
+    const { cols, rows } = deps.getGeometry()
+    if (cols <= 0 || rows <= 2) return false
+    shrunkFrom = { cols, rows }
+    deps.resizePty(cols, rows - 1)
+    restoreTimer = setTimer(() => {
+      restoreTimer = null
+      shrunkFrom = null
+      if (disposed) return
+      const g = deps.getGeometry()
+      if (g.cols > 0 && g.rows > 0) {
+        deps.resizePty(g.cols, g.rows)
+        deps.onRestore?.(g.cols, g.rows)
+      }
+      deps.refresh()
+      deps.settleStrong()
+    }, RESYNC_RESTORE_DELAY_MS)
+    return true
+  }
+
+  const dispose = (): void => {
+    disposed = true
+    if (restoreTimer !== null) {
+      clearTimer(restoreTimer)
+      restoreTimer = null
+    }
+    if (shrunkFrom) {
+      try {
+        deps.resizePty(shrunkFrom.cols, shrunkFrom.rows)
+      } catch {
+        /* main gone mid-teardown */
+      }
+      shrunkFrom = null
+    }
+  }
+
+  return { fire, dispose }
+}

--- a/src/renderer/components/terminal/repaintRegistry.ts
+++ b/src/renderer/components/terminal/repaintRegistry.ts
@@ -26,6 +26,14 @@
 export interface SessionRepainter {
   /** Wait for output to go quiet, then clear the atlas and repaint every row. */
   settleStrong: (quietMs?: number, intervalMs?: number) => void
+  /**
+   * Full repaint + geometry re-sync (#503): the shrink→restore pty nudge that
+   * makes the TUI re-lay-out, then the strong repaint. For damage a repaint
+   * alone cannot fix — a console-direct writer (ssh's host-key prompt) left
+   * the TUI's live region desynced from the real rows. Optional: registered
+   * by TerminalView; absent only in stub registrations.
+   */
+  resync?: () => void
 }
 
 const repainters = new Map<string, SessionRepainter>()
@@ -53,6 +61,24 @@ export function requestSettleRepaint(sessionId: string): boolean {
   if (!repainter) return false
   try {
     repainter.settleStrong()
+    return true
+  } catch {
+    // A terminal disposed between the lookup and the call. Nothing to repair.
+    return false
+  }
+}
+
+/**
+ * Ask a session's terminal for the full repaint + geometry re-sync (#503).
+ * Falls back to the plain settle repaint when the registration predates the
+ * resync (a stub), and no-ops without a live terminal, like the above.
+ */
+export function requestResync(sessionId: string): boolean {
+  const repainter = repainters.get(sessionId)
+  if (!repainter) return false
+  try {
+    if (repainter.resync) repainter.resync()
+    else repainter.settleStrong()
     return true
   } catch {
     // A terminal disposed between the lookup and the call. Nothing to repair.

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -4,6 +4,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { requestCloseSession } from '../stores/sshCloseStore'
 import { matchesShortcut, DEFAULT_SHORTCUTS } from '../utils/shortcuts'
 import { captureGlyphDiagnostic } from '../utils/glyphDiagnostic'
+import { requestResync } from '../components/terminal/repaintRegistry'
 import { sendImageToSession } from '../utils/imageTransfer'
 import { usePasteHintStore } from '../stores/pasteHintStore'
 import { useAppMetaStore } from '../stores/appMetaStore'
@@ -141,6 +142,15 @@ export function useKeyboardShortcuts(
         e.preventDefault()
         e.stopPropagation()
         void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
+      }
+      // Repaint + geometry re-sync (#503): pressed while staring at a pane
+      // something printed over — same capture-phase + AltGr reasoning as the
+      // glyph capture above.
+      if (matchesShortcut(e, shortcuts.repaintTerminal) && !e.getModifierState?.('AltGraph')) {
+        e.preventDefault()
+        e.stopPropagation()
+        const sid = useSessionStore.getState().activeSessionId
+        if (sid) requestResync(sid)
       }
     }
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -146,26 +146,33 @@ export function useKeyboardShortcuts(
       // pre-release map must not leave newer chords dead.
       const shortcuts = { ...DEFAULT_SHORTCUTS, ...(useSettingsStore.getState().settings.keyboardShortcuts || {}) }
       if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
+        // Consume repeats but never act on them: each fire is a disk write +
+        // Explorer reveal, and an unconsumed repeat would stream the chord's
+        // xterm encoding (ESC + ctrl-char) into the pty instead.
         e.preventDefault()
         e.stopPropagation()
+        if (e.repeat) return
         void captureGlyphDiagnostic(useSessionStore.getState().activeSessionId)
       }
       // Repaint + geometry re-sync (#503): pressed while staring at a pane
       // something printed over — same capture-phase + AltGr reasoning as the
       // glyph capture above.
       if (matchesShortcut(e, shortcuts.repaintTerminal) && !e.getModifierState?.('AltGraph')) {
-        // Held chord auto-repeats ~16Hz; unlike the read-only capture above,
-        // this one WRITES (a pty resize pair per fire) — one press, one nudge.
-        if (e.repeat) return
+        // Same repeat rule: consumed, not acted on — a held chord auto-repeats
+        // ~16Hz and each fire is a pty resize pair.
         e.preventDefault()
         e.stopPropagation()
+        if (e.repeat) return
         // Repair the terminal the chord was pressed IN, resolved by DOM
         // ancestry: the focused pane may be the partner shell or an alt pane,
         // registered under its own key — the active session id alone would
-        // nudge a hidden pty. Fall back to it only when focus is outside any
-        // terminal.
+        // nudge a hidden pty. With focus outside any terminal, the pane
+        // actually on screen (data-terminal-active — at most one) is the
+        // target; the bare active id is the last resort.
         const from = (e.target as Element | null)?.closest?.('[data-terminal-session]')
-        const sid = from?.getAttribute('data-terminal-session') || useSessionStore.getState().activeSessionId
+        const sid = from?.getAttribute('data-terminal-session')
+          || document.querySelector('[data-terminal-session][data-terminal-active]')?.getAttribute('data-terminal-session')
+          || useSessionStore.getState().activeSessionId
         if (sid) requestResync(sid)
       }
     }

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -47,7 +47,12 @@ export function useKeyboardShortcuts(
       // sessions, paste into a hidden prompt), so suppress them until the
       // flow settles. Same gate expression as App.tsx's bootGate input.
       if (deriveOnboarding(useAppMetaStore.getState().meta, {}).due) return
-      const shortcuts = useSettingsStore.getState().settings.keyboardShortcuts || DEFAULT_SHORTCUTS
+      // MERGE over the defaults, never substitute: a persisted map predating a
+      // release lacks that release's new actions, and `|| DEFAULT_SHORTCUTS`
+      // only helps when the whole object is absent — every existing user would
+      // have the new chord silently dead (#503 review; StageEmptyState already
+      // merges this way).
+      const shortcuts = { ...DEFAULT_SHORTCUTS, ...(useSettingsStore.getState().settings.keyboardShortcuts || {}) }
 
       // Close current tab: a page tab closes the page; a session tab routes
       // through the End-vs-Leave-running choice.
@@ -137,7 +142,9 @@ export function useKeyboardShortcuts(
       // reveal — instead of reporting a match). Those boxes carry
       // data-shortcut-capture; yield to them.
       if ((e.target as Element | null)?.closest?.('[data-shortcut-capture]')) return
-      const shortcuts = useSettingsStore.getState().settings.keyboardShortcuts || DEFAULT_SHORTCUTS
+      // Merge over defaults for the same reason as handleKeyDown: a persisted
+      // pre-release map must not leave newer chords dead.
+      const shortcuts = { ...DEFAULT_SHORTCUTS, ...(useSettingsStore.getState().settings.keyboardShortcuts || {}) }
       if (matchesShortcut(e, shortcuts.captureGlyphDiagnostic) && !e.getModifierState?.('AltGraph')) {
         e.preventDefault()
         e.stopPropagation()
@@ -147,9 +154,18 @@ export function useKeyboardShortcuts(
       // something printed over — same capture-phase + AltGr reasoning as the
       // glyph capture above.
       if (matchesShortcut(e, shortcuts.repaintTerminal) && !e.getModifierState?.('AltGraph')) {
+        // Held chord auto-repeats ~16Hz; unlike the read-only capture above,
+        // this one WRITES (a pty resize pair per fire) — one press, one nudge.
+        if (e.repeat) return
         e.preventDefault()
         e.stopPropagation()
-        const sid = useSessionStore.getState().activeSessionId
+        // Repair the terminal the chord was pressed IN, resolved by DOM
+        // ancestry: the focused pane may be the partner shell or an alt pane,
+        // registered under its own key — the active session id alone would
+        // nudge a hidden pty. Fall back to it only when focus is outside any
+        // terminal.
+        const from = (e.target as Element | null)?.closest?.('[data-terminal-session]')
+        const sid = from?.getAttribute('data-terminal-session') || useSessionStore.getState().activeSessionId
         if (sid) requestResync(sid)
       }
     }

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -463,6 +463,11 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       terminal: { ...DEFAULT_TERMINAL_SETTINGS, ...(settings.terminal || {}) },
       conductorTools: { ...DEFAULT_CONDUCTOR_TOOLS, ...(settings.conductorTools || {}) },
       watchdog: { ...DEFAULT_WATCHDOG_SETTINGS, ...(settings.watchdog || {}) },
+      // keyboardShortcuts joined the deep-merge with #503: a persisted map
+      // predating a release lacks that release's new actions, and every
+      // consumer that substituted the whole object had its new chords dead
+      // (the Sidebar #124 renameSession patch was this same bug).
+      keyboardShortcuts: { ...DEFAULT_SHORTCUTS, ...(settings.keyboardShortcuts || {}) },
       typography: migrateTypography(settings),
     }
     const font = migrateV2Font(merged)

--- a/src/renderer/utils/shortcuts.ts
+++ b/src/renderer/utils/shortcuts.ts
@@ -51,6 +51,7 @@ export const DEFAULT_SHORTCUTS: Record<string, string> = {
   pasteImage: 'Alt+V',
   renameSession: 'F2',
   captureGlyphDiagnostic: 'Ctrl+Alt+G',
+  repaintTerminal: 'Ctrl+Alt+R',
 }
 
 /** Human-readable labels for shortcut actions */
@@ -63,4 +64,5 @@ export const SHORTCUT_LABELS: Record<string, string> = {
   pasteImage: 'Paste clipboard image',
   renameSession: 'Rename session',
   captureGlyphDiagnostic: 'Capture glyph diagnostic',
+  repaintTerminal: 'Repaint terminal',
 }

--- a/tests/unit/geometry-resync.test.ts
+++ b/tests/unit/geometry-resync.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createGeometryResync,
+  RESYNC_RESTORE_DELAY_MS,
+  type GeometryResyncDeps,
+} from '../../src/renderer/components/terminal/geometryResync'
+
+// #503: the hand-pulled repaint + geometry re-sync. A console-direct writer
+// (ssh's host-key prompt) can leave the TUI's live region desynced from the
+// real rows; the shrink→restore nudge makes the TUI re-lay-out, and the strong
+// repaint clears our own stale cells. These pin the exact sequence, the
+// at-fire-time geometry re-read, the decline paths, and the unmount restore.
+
+type Timer = { cb: () => void; ms: number; cleared: boolean }
+
+function harness(overrides: Partial<GeometryResyncDeps> = {}) {
+  const timers: Timer[] = []
+  const calls: string[] = []
+  let geometry = { cols: 120, rows: 40 }
+  const deps: GeometryResyncDeps = {
+    getGeometry: () => ({ ...geometry }),
+    resizePty: (c, r) => calls.push(`resize ${c}x${r}`),
+    refresh: () => calls.push('refresh'),
+    settleStrong: () => calls.push('settleStrong'),
+    setTimer: (cb, ms) => {
+      const t: Timer = { cb, ms, cleared: false }
+      timers.push(t)
+      return t
+    },
+    clearTimer: (h) => { (h as Timer).cleared = true },
+    ...overrides,
+  }
+  return {
+    resync: createGeometryResync(deps),
+    calls,
+    timers,
+    setGeometry: (g: { cols: number; rows: number }) => { geometry = g },
+    firePending: () => {
+      for (const t of timers.splice(0)) if (!t.cleared) t.cb()
+    },
+  }
+}
+
+describe('createGeometryResync', () => {
+  it('shrinks by one row, then restores, repaints, and settles — in that order', () => {
+    const h = harness()
+    expect(h.resync.fire()).toBe(true)
+    expect(h.calls).toEqual(['resize 120x39'])
+    expect(h.timers[0].ms).toBe(RESYNC_RESTORE_DELAY_MS)
+
+    h.firePending()
+    expect(h.calls).toEqual(['resize 120x39', 'resize 120x40', 'refresh', 'settleStrong'])
+  })
+
+  it('re-reads geometry at restore time — a user resize inside the window wins', () => {
+    const h = harness()
+    h.resync.fire()
+    // The user resizes the window while the pty sits one row short.
+    h.setGeometry({ cols: 200, rows: 60 })
+    h.firePending()
+    expect(h.calls).toContain('resize 200x60')
+    expect(h.calls).not.toContain('resize 120x40')
+  })
+
+  it('reports the restored geometry through onRestore', () => {
+    const restored: Array<[number, number]> = []
+    const h = harness({ onRestore: (c, r) => restored.push([c, r]) })
+    h.resync.fire()
+    h.firePending()
+    expect(restored).toEqual([[120, 40]])
+  })
+
+  it('declines while a cycle is already in flight, and can fire again after', () => {
+    const h = harness()
+    expect(h.resync.fire()).toBe(true)
+    expect(h.resync.fire()).toBe(false)
+    h.firePending()
+    expect(h.resync.fire()).toBe(true)
+  })
+
+  it('declines while another jiggle is busy (the post-resume nudge)', () => {
+    let busy = true
+    const h = harness({ isBusy: () => busy })
+    expect(h.resync.fire()).toBe(false)
+    expect(h.calls).toEqual([])
+    busy = false
+    expect(h.resync.fire()).toBe(true)
+  })
+
+  it('declines on geometry too small to shrink', () => {
+    const h = harness()
+    h.setGeometry({ cols: 80, rows: 2 })
+    expect(h.resync.fire()).toBe(false)
+    h.setGeometry({ cols: 0, rows: 40 })
+    expect(h.resync.fire()).toBe(false)
+    expect(h.calls).toEqual([])
+  })
+
+  it('dispose mid-shrink restores the pty so a remount does not inherit one row short', () => {
+    const h = harness()
+    h.resync.fire()
+    h.resync.dispose()
+    expect(h.timers[0].cleared).toBe(true)
+    expect(h.calls).toEqual(['resize 120x39', 'resize 120x40'])
+    // And a fire after dispose is dead.
+    expect(h.resync.fire()).toBe(false)
+  })
+
+  it('dispose with nothing in flight touches nothing', () => {
+    const h = harness()
+    h.resync.dispose()
+    expect(h.calls).toEqual([])
+  })
+
+  it('a restore firing after dispose does nothing', () => {
+    // The timer seam let the callback survive clearTimer; the disposed flag
+    // must still gate it.
+    const h = harness({ clearTimer: () => { /* deliberately leaky */ } })
+    h.resync.fire()
+    h.resync.dispose()
+    const after = h.calls.length
+    h.firePending()
+    expect(h.calls.length).toBe(after)
+  })
+})

--- a/tests/unit/geometry-resync.test.ts
+++ b/tests/unit/geometry-resync.test.ts
@@ -106,6 +106,30 @@ describe('createGeometryResync', () => {
     expect(h.resync.fire()).toBe(false)
   })
 
+  it('dispose restores LIVE geometry — a user resize inside the window survives the unmount race', () => {
+    const h = harness()
+    h.resync.fire()
+    // The pty outlives the view; restoring the stale capture would leave it
+    // at the pre-resize size.
+    h.setGeometry({ cols: 200, rows: 60 })
+    h.resync.dispose()
+    expect(h.calls).toEqual(['resize 120x39', 'resize 200x60'])
+  })
+
+  it('dispose falls back to the fire-time capture when the term is already gone', () => {
+    let fired = false
+    const h = harness({
+      getGeometry: () => {
+        if (fired) throw new Error('disposed')
+        fired = true
+        return { cols: 120, rows: 40 }
+      },
+    })
+    h.resync.fire()
+    h.resync.dispose()
+    expect(h.calls).toEqual(['resize 120x39', 'resize 120x40'])
+  })
+
   it('dispose with nothing in flight touches nothing', () => {
     const h = harness()
     h.resync.dispose()

--- a/tests/unit/renderer/keyboard-glyph-capture.test.tsx
+++ b/tests/unit/renderer/keyboard-glyph-capture.test.tsx
@@ -23,6 +23,10 @@ const captureGlyphDiagnostic = vi.fn(async () => ({ ok: true }))
 vi.mock('../../../src/renderer/utils/glyphDiagnostic', () => ({
   captureGlyphDiagnostic: (...args: unknown[]) => captureGlyphDiagnostic(...args),
 }))
+const requestResync = vi.fn(() => true)
+vi.mock('../../../src/renderer/components/terminal/repaintRegistry', () => ({
+  requestResync: (...args: unknown[]) => requestResync(...args),
+}))
 
 const { useKeyboardShortcuts } = await import('../../../src/renderer/hooks/useKeyboardShortcuts')
 const { useSessionStore } = await import('../../../src/renderer/stores/sessionStore')
@@ -39,6 +43,7 @@ let root: Root
 
 beforeEach(() => {
   captureGlyphDiagnostic.mockClear()
+  requestResync.mockClear()
   useSessionStore.setState({ sessions: [], activeSessionId: 's1', renamingSessionId: null } as any)
   useSettingsStore.setState({ settings: { keyboardShortcuts: DEFAULT_SHORTCUTS } as any })
   container = document.createElement('div')
@@ -109,5 +114,71 @@ describe('Ctrl+Alt+G glyph capture survives xterm (#374, beta.17 silence)', () =
     // Load-bearing now the listener runs BEFORE xterm: the event must reach
     // the terminal unprevented so AltGr text entry still types.
     expect(e.defaultPrevented).toBe(false)
+  })
+})
+
+/** A keydown for Ctrl+Alt+R (#503), with the same knobs plus key-repeat. */
+function chordR(opts: { altGraph?: boolean; repeat?: boolean } = {}): KeyboardEvent {
+  const e = new KeyboardEvent('keydown', {
+    key: 'r', ctrlKey: true, altKey: true, repeat: opts.repeat ?? false, bubbles: true, cancelable: true,
+  })
+  Object.defineProperty(e, 'getModifierState', { value: (m: string) => (m === 'AltGraph' ? (opts.altGraph ?? false) : false) })
+  return e
+}
+
+describe('Ctrl+Alt+R repaint + re-sync (#503)', () => {
+  it('fires even when xterm-style handling stops propagation at its textarea', () => {
+    const term = document.createElement('textarea')
+    container.appendChild(term)
+    term.addEventListener('keydown', (e) => { e.stopPropagation(); e.preventDefault() }, true)
+    act(() => { term.dispatchEvent(chordR()) })
+    expect(requestResync).toHaveBeenCalledTimes(1)
+  })
+
+  it('repairs the terminal the chord was pressed IN, resolved by DOM ancestry', () => {
+    // The partner shell registers under `${id}-partner` and stays mounted while
+    // hidden — the active session id alone would nudge the hidden main pty.
+    const pane = document.createElement('div')
+    pane.setAttribute('data-terminal-session', 's1-partner')
+    const term = document.createElement('textarea')
+    pane.appendChild(term)
+    container.appendChild(pane)
+    act(() => { term.dispatchEvent(chordR()) })
+    expect(requestResync).toHaveBeenCalledWith('s1-partner')
+  })
+
+  it('falls back to the active session when focus is outside any terminal', () => {
+    act(() => { window.dispatchEvent(chordR()) })
+    expect(requestResync).toHaveBeenCalledWith('s1')
+  })
+
+  it('ignores key-repeat — a held chord must not storm the pty with resizes', () => {
+    act(() => { window.dispatchEvent(chordR({ repeat: true })) })
+    expect(requestResync).not.toHaveBeenCalled()
+  })
+
+  it('the AltGr guard holds here too', () => {
+    const e = chordR({ altGraph: true })
+    act(() => { window.dispatchEvent(e) })
+    expect(requestResync).not.toHaveBeenCalled()
+    expect(e.defaultPrevented).toBe(false)
+  })
+
+  it('yields to the Settings shortcut recorder / Test box', () => {
+    const box = document.createElement('div')
+    box.setAttribute('data-shortcut-capture', '')
+    container.appendChild(box)
+    act(() => { box.dispatchEvent(chordR()) })
+    expect(requestResync).not.toHaveBeenCalled()
+  })
+
+  it('still fires for a user whose persisted shortcut map predates the chord', () => {
+    // The hydration shape that killed new chords: a saved keyboardShortcuts
+    // object from an older release has no repaintTerminal key, and a plain
+    // `|| DEFAULT_SHORTCUTS` substitution never fires because the object
+    // EXISTS. The handler must merge over the defaults instead.
+    useSettingsStore.setState({ settings: { keyboardShortcuts: { closeSession: 'Ctrl+W' } } as any })
+    act(() => { window.dispatchEvent(chordR()) })
+    expect(requestResync).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/renderer/keyboard-glyph-capture.test.tsx
+++ b/tests/unit/renderer/keyboard-glyph-capture.test.tsx
@@ -147,14 +147,49 @@ describe('Ctrl+Alt+R repaint + re-sync (#503)', () => {
     expect(requestResync).toHaveBeenCalledWith('s1-partner')
   })
 
-  it('falls back to the active session when focus is outside any terminal', () => {
+  it('with focus outside any terminal, targets the pane actually on screen', () => {
+    // The partner pane is showing (it carries data-terminal-active); the user
+    // clicks the command bar, then presses the chord. Ancestry misses, but the
+    // marked pane — not the hidden main pty — must win.
+    const pane = document.createElement('div')
+    pane.setAttribute('data-terminal-session', 's1-partner')
+    pane.setAttribute('data-terminal-active', '')
+    container.appendChild(pane)
+    act(() => { window.dispatchEvent(chordR()) })
+    expect(requestResync).toHaveBeenCalledWith('s1-partner')
+  })
+
+  it('falls back to the active session id with no terminal marked at all', () => {
     act(() => { window.dispatchEvent(chordR()) })
     expect(requestResync).toHaveBeenCalledWith('s1')
   })
 
-  it('ignores key-repeat — a held chord must not storm the pty with resizes', () => {
-    act(() => { window.dispatchEvent(chordR({ repeat: true })) })
+  it('TerminalView actually emits both attributes the resolution keys on', () => {
+    // Same contract shape as the data-shortcut-capture test above: the handler
+    // honours the attributes, and TerminalView must CARRY them — deleting them
+    // silently degrades the chord to the last-resort fallback, suite green.
+    const fs = require('node:fs') as typeof import('node:fs')
+    const path = require('node:path') as typeof import('node:path')
+    const src = fs.readFileSync(path.resolve(__dirname, '../../../src/renderer/components/TerminalView.tsx'), 'utf8')
+    expect(src).toMatch(/data-terminal-session=\{sessionId\}/)
+    expect(src).toMatch(/data-terminal-active=\{isActive/)
+  })
+
+  it('consumes key-repeat without acting — no resync storm, nothing leaks to xterm', () => {
+    // An UNCONSUMED repeat reaches xterm, which encodes Ctrl+Alt+R as
+    // ESC+\x12 straight into the pty — worse than the storm it avoids.
+    const e = chordR({ repeat: true })
+    act(() => { window.dispatchEvent(e) })
     expect(requestResync).not.toHaveBeenCalled()
+    expect(e.defaultPrevented).toBe(true)
+  })
+
+  it('the glyph chord consumes its repeats too — each fire is a disk write', () => {
+    const e = chord()
+    Object.defineProperty(e, 'repeat', { value: true })
+    act(() => { window.dispatchEvent(e) })
+    expect(captureGlyphDiagnostic).not.toHaveBeenCalled()
+    expect(e.defaultPrevented).toBe(true)
   })
 
   it('the AltGr guard holds here too', () => {

--- a/tests/unit/renderer/terminal-context-menu.test.tsx
+++ b/tests/unit/renderer/terminal-context-menu.test.tsx
@@ -31,6 +31,7 @@ function renderMenu(over: Partial<React.ComponentProps<typeof TerminalContextMen
     hasSelection: false,
     onCopy: noop,
     onPaste: noop,
+    onRepaint: noop,
     onClose: noop,
     ...over,
   }
@@ -75,6 +76,22 @@ describe('TerminalContextMenu', () => {
     expect(onPaste).not.toHaveBeenCalled() // rendering the menu never pastes
     act(() => { buttonByText(r.container, 'Paste').click() })
     expect(onPaste).toHaveBeenCalledTimes(1)
+    r.unmount()
+  })
+
+  it('fires onRepaint from the Repaint row, and only from it (#503)', () => {
+    const onRepaint = vi.fn()
+    const onCopy = vi.fn()
+    const onPaste = vi.fn()
+    const r = renderMenu({ hasSelection: true, onRepaint, onCopy, onPaste })
+    const row = r.container.querySelector('[data-testid="terminal-ctx-repaint"]') as HTMLButtonElement
+    expect(row).toBeTruthy()
+    // Always enabled — the rescue must be reachable exactly when the pane is a mess.
+    expect(row.disabled).toBe(false)
+    act(() => { row.click() })
+    expect(onRepaint).toHaveBeenCalledTimes(1)
+    expect(onCopy).not.toHaveBeenCalled()
+    expect(onPaste).not.toHaveBeenCalled()
     r.unmount()
   })
 

--- a/tests/unit/repaint-registry.test.ts
+++ b/tests/unit/repaint-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   registerRepainter,
   requestSettleRepaint,
+  requestResync,
   scheduleBleedRepaints,
   __clearRepaintRegistry,
   BLEED_REPAINT_DELAYS_MS,
@@ -51,6 +52,38 @@ describe('repaintRegistry', () => {
     registerRepainter('s1', { settleStrong: () => { throw new Error('disposed') } })
     expect(() => requestSettleRepaint('s1')).not.toThrow()
     expect(requestSettleRepaint('s1')).toBe(false)
+  })
+})
+
+// #503: the resync request — the geometry-nudge repaint for console-direct
+// splice damage, routed the same way.
+describe('requestResync', () => {
+  beforeEach(() => __clearRepaintRegistry())
+
+  it('routes to the registered resync, not the plain repaint', () => {
+    const settleStrong = vi.fn()
+    const resync = vi.fn()
+    registerRepainter('s1', { settleStrong, resync })
+    expect(requestResync('s1')).toBe(true)
+    expect(resync).toHaveBeenCalledTimes(1)
+    expect(settleStrong).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the plain repaint on a stub without resync', () => {
+    const settleStrong = vi.fn()
+    registerRepainter('s1', { settleStrong })
+    expect(requestResync('s1')).toBe(true)
+    expect(settleStrong).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op for a session with no terminal', () => {
+    expect(requestResync('nobody')).toBe(false)
+  })
+
+  it('survives a terminal disposed between lookup and call', () => {
+    registerRepainter('s1', { settleStrong: vi.fn(), resync: () => { throw new Error('disposed') } })
+    expect(() => requestResync('s1')).not.toThrow()
+    expect(requestResync('s1')).toBe(false)
   })
 })
 

--- a/tests/unit/stores/settingsStore.test.ts
+++ b/tests/unit/stores/settingsStore.test.ts
@@ -32,6 +32,22 @@ describe('settingsStore', () => {
       expect(state.settings.terminalFontSize).toBe(13)
     })
 
+    it('a shortcut map predating a release picks up the new chords (#503)', () => {
+      // The shape that kept new chords dead: a persisted keyboardShortcuts
+      // object EXISTS but lacks keys added since it was saved, and a consumer
+      // substituting the whole object never sees the new defaults. hydrate
+      // owns the merge now; a user's own binding still wins, and a
+      // hand-cleared "" survives as cleared (falsy never matches a chord).
+      useSettingsStore.getState().hydrate({
+        keyboardShortcuts: { closeSession: 'Ctrl+Q', pasteImage: '' },
+      } as any)
+      const map = useSettingsStore.getState().settings.keyboardShortcuts!
+      expect(map.repaintTerminal).toBe('Ctrl+Alt+R')
+      expect(map.captureGlyphDiagnostic).toBe('Ctrl+Alt+G')
+      expect(map.closeSession).toBe('Ctrl+Q')
+      expect(map.pasteImage).toBe('')
+    })
+
     it('fully overrides when all keys provided', () => {
       useSettingsStore.getState().hydrate({
         defaultModel: 'haiku',


### PR DESCRIPTION
Fixes #503 (the fixable half — see the scope note).

## Root cause

Windows OpenSSH opens the console device (`CONIN$`/`CONOUT$`) directly for its host-key prompt, bypassing the tool's captured stdio. conhost merges those writes with the TUI's concurrent cursor-addressed repaints, and **ConPTY emits the spliced result down the pty stream** — the owner's screenshot shows the splices *in scrollback*, which only pty-stream bytes can reach. Two kinds of damage:

1. **History**: spliced rows already scrolled up. The bytes really arrived interleaved; nothing downstream of conhost can un-write them. Out of scope by physics.
2. **Ongoing garble**: the TUI's live region can stay desynced from the real rows afterwards, corrupting every later delta-repaint. **This is the fixable half** — the same shrink-one-row → restore geometry nudge the post-resume corruption fix uses forces the TUI to fully re-lay-out, and a strong repaint clears our own stale cells.

There is no byte signature to auto-detect the splice on (it is indistinguishable from ordinary output), so the repair is a hand-pulled cord.

## What ships

- **`geometryResync.ts`** (new, deps-injected like `staleGlyphRepaint`): shrink `rows-1` → 60ms → restore at **at-fire-time** geometry (a user resize inside the window wins — same rule as the resume nudge) → `refresh` → `settleStrong`. Declines while the post-resume nudge is mid-jiggle; `dispose()` restores a shrunk pty so a remount never inherits one row short.
- **Repaint registry** (#379 fix E) gains `resync` + `requestResync(sessionId)`, falling back to the plain settle repaint on a registration without it.
- **Ctrl+Alt+R** — capture-phase + AltGr-guarded, exactly the Ctrl+Alt+G reasoning (it is pressed while the corrupted terminal has focus, where xterm eats bubbling keydowns). Configurable; appears in Settings automatically via `SHORTCUT_LABELS`.
- **"Repaint terminal"** row in the terminal right-click menu, with the shortcut hint.

## Tests

13 new: the full sequence order, at-restore-time geometry re-read, `onRestore` bookkeeping, in-flight/busy/too-small declines, dispose-mid-shrink restore, post-dispose timer leak gate (mutation-proven — deleting the disposed gate reds it), and the registry routing/fallback/no-terminal/disposed cases.

Full suite 8412 passed / typecheck clean.

Not ADR-009 security-sensitive: renderer-only, no IPC surface change (`pty.resize` is an existing channel used by the resume nudge on the same call shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
