### PR TITLE
fix(canvas): submit hand-back owns pane state — no double flip against a racing click

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -54,6 +54,13 @@ Landed so far, each through the canvas loop where the owner reviewed:
   CanvasSubjectPicker, canvas-scoping the armed keys, and the one-click
   draft-note delete.
 
+- **#478**: the submit-triggered auto-return raced the user's own pane toggle
+  (toggle landing = double flip). The hand-back moved into excalidrawStore
+  (`beginSubmitReturn`): the landing CLOSES rather than toggles, the pane
+  toggles disable for the 1200ms beat, the panel's early-leave cancels first,
+  and the store timer survives the panel its landing unmounts. Mutation-proven
+  (toggle landing reds the race test).
+
 Canvas findings the loop itself surfaced, filed for this same release:
 **#470** (review rounds stack per superseded ready version; requirements for
 the round state machine captured on the issue), **#476** (subject-level

--- a/src/renderer/components/AgentCanvasButton.tsx
+++ b/src/renderer/components/AgentCanvasButton.tsx
@@ -29,6 +29,10 @@ interface Props {
 export default function AgentCanvasButton({ sessionId }: Props) {
   const isOpen = useExcalidrawStore((s) => !!s.bySessionId[sessionId]?.isOpen)
   const togglePane = useExcalidrawStore((s) => s.togglePane)
+  // #478: while the submit-triggered hand-back is in flight it is the only
+  // driver of pane state — this toggle disables for the beat, then reads
+  // "Canvas" again once the landing closes the pane.
+  const returning = useExcalidrawStore((s) => !!s.submitReturnBySession[sessionId])
   const queue = useCanvasQueue(sessionId)
   const [queueOpen, setQueueOpen] = React.useState(false)
 
@@ -88,7 +92,8 @@ export default function AgentCanvasButton({ sessionId }: Props) {
           if (!isOpen) trackUsage('canvas.opened')
           togglePane(sessionId)
         }}
-        className={`relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border whitespace-nowrap shrink-0 transition-colors ${
+        disabled={returning}
+        className={`relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border whitespace-nowrap shrink-0 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
           isOpen
             ? 'bg-mauve/20 border-mauve/70 text-mauve hover:bg-mauve/30'
             : waiting
@@ -97,11 +102,13 @@ export default function AgentCanvasButton({ sessionId }: Props) {
         }`}
         style={!isOpen && waiting ? warnStyle : undefined}
         title={
-          isOpen
-            ? 'Back to the terminal (closes the Agent Canvas)'
-            : waiting
-              ? `${queue} canvas${queue === 1 ? '' : 'es'} waiting on your review — click the count for the list, right-click to dismiss all`
-              : 'Open Agent Canvas'
+          returning
+            ? 'Returning to the terminal…'
+            : isOpen
+              ? 'Back to the terminal (closes the Agent Canvas)'
+              : waiting
+                ? `${queue} canvas${queue === 1 ? '' : 'es'} waiting on your review — click the count for the list, right-click to dismiss all`
+                : 'Open Agent Canvas'
         }
         data-testid="canvas-button"
         data-waiting={waiting ? 'true' : undefined}

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -308,6 +308,9 @@ const MARQUEE_MIN_PX = 8
 
 function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versions, onOpenLibrary, isActive }: SurfaceProps) {
   const togglePane = useExcalidrawStore((s) => s.togglePane)
+  // #478: the submit hand-back in flight — the close control disables so the
+  // submit-triggered transition is the only driver of pane state.
+  const returning = useExcalidrawStore((s) => !!s.submitReturnBySession[sessionId])
   const mode = useCanvasStore((s) => s.bySessionId[sessionId]?.interactionMode ?? 'browse')
   const setInteractionMode = useCanvasStore((s) => s.setInteractionMode)
   const setActiveVersion = useCanvasStore((s) => s.setActiveVersion)
@@ -1432,9 +1435,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
         </div>
         <button
           onClick={() => togglePane(sessionId)}
+          disabled={returning}
           aria-label="Close Agent Canvas"
-          title="Close Agent Canvas"
-          className="shrink-0 p-[5px] rounded leading-none text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-panel)] transition-colors focus-ring"
+          title={returning ? 'Returning to the terminal…' : 'Close Agent Canvas'}
+          className="shrink-0 p-[5px] rounded leading-none text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-panel)] transition-colors focus-ring disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden="true">
             <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />

--- a/src/renderer/components/CanvasNotesPanel.tsx
+++ b/src/renderer/components/CanvasNotesPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from '../stores/canvasReviewStore'
 import { PAGE_REPORTED_MARK, PAGE_REPORTED_TITLE } from '../canvas/page-reported'
 import { useArmedConfirm } from '../hooks/useArmedConfirm'
+import { useExcalidrawStore } from '../stores/excalidrawStore'
 import { imageFileFromClipboard, pastedImageToPng } from '../utils/canvasPasteImage'
 
 interface Props {
@@ -191,10 +192,10 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [justSubmitted, setJustSubmitted] = useState<{ id: string; count: number } | null>(null)
-  /** Pending auto-return, cleared on unmount so a torn-down panel cannot toggle
-   *  a pane that no longer belongs to it. */
-  const returnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => () => { if (returnTimerRef.current) clearTimeout(returnTimerRef.current) }, [])
+  // The auto-return timer moved into excalidrawStore with #478
+  // (beginSubmitReturn) — the landing must outlive this panel, since the
+  // landing itself is what unmounts it, and it CLOSES rather than toggles so
+  // it can never reopen a pane something else already closed.
 
   /** Notes with a variant approval in flight — one marker per click, never one
    *  per state-read (see resolveOne). */
@@ -624,10 +625,11 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
       // and the Canvas button pulses again the moment the agent re-renders,
       // which is what brings them back. The manual control stays for anyone who
       // wants to leave sooner.
-      returnTimerRef.current = setTimeout(() => {
-        returnTimerRef.current = null
-        onReturnToTerminal()
-      }, 1200)
+      // #478: the hand-off lives in the store, which lands it by CLOSING the
+      // pane (never toggling) and flags the session so the pane toggles
+      // disable meanwhile — a user click racing this window cannot double-flip
+      // the pane. The store timer also survives this panel unmounting.
+      useExcalidrawStore.getState().beginSubmitReturn(sessionId)
     } finally {
       setSubmitting(false)
     }
@@ -1252,7 +1254,9 @@ export default function CanvasNotesPanel({ sessionId, version, getGlassApi, onRe
             <div className="flex-1" />
             <button
               onClick={() => {
-                if (returnTimerRef.current) { clearTimeout(returnTimerRef.current); returnTimerRef.current = null }
+                // Leaving EARLY is race-safe by construction: cancel the
+                // store's pending landing first, then do the one navigation.
+                useExcalidrawStore.getState().cancelSubmitReturn(sessionId)
                 onReturnToTerminal()
               }}
               className="px-2 py-1 text-[11px] rounded border border-blue/50 text-blue hover:bg-blue/10"

--- a/src/renderer/stores/excalidrawStore.ts
+++ b/src/renderer/stores/excalidrawStore.ts
@@ -40,12 +40,25 @@ interface PersistedShape {
 
 interface State {
   bySessionId: Record<string, ExcalidrawSessionState>
+  /** Sessions whose submit-triggered return-to-terminal is in flight (#478).
+   *  While set, the submit transition is the ONLY driver of pane state: the
+   *  toggles disable, and the landing CLOSES rather than toggles, so a user
+   *  click racing the timer cannot double-flip the pane. Volatile — never
+   *  persisted. */
+  submitReturnBySession: Record<string, boolean>
 }
 
 interface Actions {
   hydrate: (data: PersistedShape) => void
   togglePane: (sessionId: string) => void
   setOpen: (sessionId: string, open: boolean) => void
+  /** Arm the submit hand-off (#478): mark the session in flight and schedule
+   *  the landing. On fire the pane is CLOSED if still open — never toggled,
+   *  so a pane something else already closed stays closed. */
+  beginSubmitReturn: (sessionId: string, delayMs?: number) => void
+  /** Leave early / tear down: clear the flag and the pending landing without
+   *  touching pane state (the caller does its own navigation). */
+  cancelSubmitReturn: (sessionId: string) => void
   newDrawing: (sessionId: string, name?: string) => string
   selectDrawing: (sessionId: string, drawingId: string) => void
   renameDrawing: (sessionId: string, drawingId: string, newName: string) => void
@@ -66,7 +79,7 @@ const defaultState = (): ExcalidrawSessionState => ({
   isOpen: false,
 })
 
-const persist = (state: State, immediate = false) => {
+const persist = (state: Pick<State, 'bySessionId'>, immediate = false) => {
   // Strip the volatile `isOpen` flag — pane visibility shouldn't carry
   // across app restarts (we always restore with everything closed).
   const persisted: PersistedShape = { bySessionId: {} }
@@ -89,8 +102,55 @@ const nextUntitledName = (drawings: ExcalidrawDrawing[]): string => {
   return `Untitled ${Date.now()}`
 }
 
+/** Pending submit-return landings, outside the store state — timer handles are
+ *  not renderable data. Keyed like the flag; begin replaces, cancel clears. */
+const submitReturnTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/** How long the post-submit confirmation stays up before the hand-back (#478).
+ *  Long enough to read as deliberate, short enough not to strand the user. */
+export const SUBMIT_RETURN_DELAY_MS = 1200
+
 export const useExcalidrawStore = create<State & Actions>((set, get) => ({
   bySessionId: {},
+  submitReturnBySession: {},
+
+  beginSubmitReturn: (sessionId, delayMs = SUBMIT_RETURN_DELAY_MS) => {
+    const prior = submitReturnTimers.get(sessionId)
+    if (prior) clearTimeout(prior)
+    set((s) => ({ submitReturnBySession: { ...s.submitReturnBySession, [sessionId]: true } }))
+    submitReturnTimers.set(
+      sessionId,
+      setTimeout(() => {
+        submitReturnTimers.delete(sessionId)
+        const flags = { ...get().submitReturnBySession }
+        delete flags[sessionId]
+        const cur = get().bySessionId[sessionId]
+        // CLOSE, never toggle: if anything else closed the pane inside the
+        // window, a toggle here would REOPEN it — the double-flip this exists
+        // to prevent.
+        if (cur?.isOpen) {
+          set((s) => ({
+            submitReturnBySession: flags,
+            bySessionId: { ...s.bySessionId, [sessionId]: { ...cur, isOpen: false } },
+          }))
+        } else {
+          set({ submitReturnBySession: flags })
+        }
+      }, delayMs),
+    )
+  },
+
+  cancelSubmitReturn: (sessionId) => {
+    const prior = submitReturnTimers.get(sessionId)
+    if (prior) clearTimeout(prior)
+    submitReturnTimers.delete(sessionId)
+    if (!get().submitReturnBySession[sessionId]) return
+    set((s) => {
+      const flags = { ...s.submitReturnBySession }
+      delete flags[sessionId]
+      return { submitReturnBySession: flags }
+    })
+  },
 
   hydrate: (data) => {
     const next: Record<string, ExcalidrawSessionState> = {}
@@ -128,7 +188,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
     }
-    const newState: State = {
+    const newState: Pick<State, 'bySessionId'> = {
       bySessionId: {
         ...get().bySessionId,
         [sessionId]: {
@@ -145,7 +205,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
 
   selectDrawing: (sessionId, drawingId) => {
     const cur = get().bySessionId[sessionId] ?? defaultState()
-    const next: State = {
+    const next: Pick<State, 'bySessionId'> = {
       bySessionId: {
         ...get().bySessionId,
         [sessionId]: { ...cur, activeDrawingId: drawingId },
@@ -159,7 +219,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
     const cur = get().bySessionId[sessionId] ?? defaultState()
     const trimmed = newName.trim()
     if (!trimmed) return
-    const next: State = {
+    const next: Pick<State, 'bySessionId'> = {
       bySessionId: {
         ...get().bySessionId,
         [sessionId]: {
@@ -177,7 +237,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
   deleteDrawing: (sessionId, drawingId) => {
     const cur = get().bySessionId[sessionId] ?? defaultState()
     const remaining = cur.drawings.filter((d) => d.id !== drawingId)
-    const next: State = {
+    const next: Pick<State, 'bySessionId'> = {
       bySessionId: {
         ...get().bySessionId,
         [sessionId]: {
@@ -196,7 +256,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
   updateScene: (sessionId, drawingId, scene) => {
     const cur = get().bySessionId[sessionId] ?? defaultState()
     if (!cur.drawings.some((d) => d.id === drawingId)) return
-    const next: State = {
+    const next: Pick<State, 'bySessionId'> = {
       bySessionId: {
         ...get().bySessionId,
         [sessionId]: {
@@ -212,11 +272,11 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
   },
 
   reset: (sessionId) => {
+    get().cancelSubmitReturn(sessionId)
     const next = { ...get().bySessionId }
     delete next[sessionId]
-    const ns: State = { bySessionId: next }
-    set(ns)
-    persist(ns, true)
+    set({ bySessionId: next })
+    persist({ bySessionId: next }, true)
   },
 
   reconcile: (liveSessionIds) => {
@@ -228,7 +288,7 @@ export const useExcalidrawStore = create<State & Actions>((set, get) => ({
     for (const [sid, s] of Object.entries(current)) {
       if (live.has(sid)) next[sid] = s
     }
-    const ns: State = { bySessionId: next }
+    const ns: Pick<State, 'bySessionId'> = { bySessionId: next }
     set(ns)
     persist(ns, true)
   },

--- a/tests/unit/renderer/canvas-submit-return-race.test.tsx
+++ b/tests/unit/renderer/canvas-submit-return-race.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+//
+// #478: submitting a review auto-returns the user to the terminal after a
+// short confirmation beat. If the user also clicks a pane toggle inside that
+// window, the two pushes raced — a toggle-based landing REOPENED the pane the
+// user had just closed (double flip / flicker). The rule now: while the
+// submit hand-back is in flight it is the ONLY driver of pane state — the
+// landing lives in the store, CLOSES rather than toggles, and the pane
+// toggles disable for the beat.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import AgentCanvasButton from '../../../src/renderer/components/AgentCanvasButton'
+import { useExcalidrawStore, SUBMIT_RETURN_DELAY_MS } from '../../../src/renderer/stores/excalidrawStore'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const SID = 'session-race'
+
+;(globalThis as any).window.electronAPI = {
+  ...((globalThis as any).window?.electronAPI ?? {}),
+  canvas: {
+    ...((globalThis as any).window?.electronAPI?.canvas ?? {}),
+    onChanged: () => () => {},
+    getState: vi.fn().mockResolvedValue(null),
+    reviewGetState: vi.fn().mockResolvedValue(null),
+    listAll: vi.fn().mockResolvedValue([]),
+  },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  useExcalidrawStore.getState().cancelSubmitReturn(SID)
+  useExcalidrawStore.getState().setOpen(SID, false)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const flag = () => !!useExcalidrawStore.getState().submitReturnBySession[SID]
+const open = () => !!useExcalidrawStore.getState().bySessionId[SID]?.isOpen
+
+describe('the store-owned submit hand-back', () => {
+  it('flags the session, then lands by closing the pane and clearing the flag', () => {
+    useExcalidrawStore.getState().setOpen(SID, true)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+    expect(flag()).toBe(true)
+    expect(open()).toBe(true)
+
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS)
+    expect(open()).toBe(false)
+    expect(flag()).toBe(false)
+  })
+
+  it('THE RACE: a pane closed inside the window is not reopened by the landing', () => {
+    // The old shape: the landing called togglePane, so a user click that had
+    // already closed the pane got it flipped back open.
+    useExcalidrawStore.getState().setOpen(SID, true)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+    useExcalidrawStore.getState().togglePane(SID) // the user's racing close
+    expect(open()).toBe(false)
+
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS)
+    expect(open()).toBe(false) // stays closed — no double flip
+    expect(flag()).toBe(false)
+  })
+
+  it('cancel clears the flag and the landing never fires', () => {
+    useExcalidrawStore.getState().setOpen(SID, true)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+    useExcalidrawStore.getState().cancelSubmitReturn(SID)
+    expect(flag()).toBe(false)
+
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS * 2)
+    // The early-leaver navigated themselves; the store must not close (or
+    // reopen) anything afterwards.
+    expect(open()).toBe(true)
+  })
+
+  it('re-arming replaces the pending landing instead of stacking two', () => {
+    useExcalidrawStore.getState().setOpen(SID, true)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS - 100)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+
+    // The first deadline passes — replaced, so nothing lands yet.
+    vi.advanceTimersByTime(100)
+    expect(open()).toBe(true)
+    expect(flag()).toBe(true)
+
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS)
+    expect(open()).toBe(false)
+    expect(flag()).toBe(false)
+  })
+
+  it('reset cancels an in-flight hand-back with the session', () => {
+    useExcalidrawStore.getState().setOpen(SID, true)
+    useExcalidrawStore.getState().beginSubmitReturn(SID)
+    useExcalidrawStore.getState().reset(SID)
+    expect(flag()).toBe(false)
+    vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS * 2)
+    // The session state is gone; the landing must not resurrect it.
+    expect(useExcalidrawStore.getState().bySessionId[SID]).toBeUndefined()
+  })
+})
+
+describe('the pane toggles disable while the hand-back is in flight', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('the command-bar Canvas button is disabled for the beat, then usable again', () => {
+    useExcalidrawStore.getState().setOpen(SID, true)
+    act(() => { root.render(<AgentCanvasButton sessionId={SID} />) })
+    const btn = container.querySelector('[data-testid="canvas-button"]') as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+
+    act(() => { useExcalidrawStore.getState().beginSubmitReturn(SID) })
+    expect(btn.disabled).toBe(true)
+    expect(btn.title).toBe('Returning to the terminal…')
+
+    act(() => { vi.advanceTimersByTime(SUBMIT_RETURN_DELAY_MS) })
+    expect(btn.disabled).toBe(false)
+    // Landed: the pane is closed and the toggle reads as the way back in.
+    expect(open()).toBe(false)
+  })
+
+  it('the pane close control and the panel wiring carry the contract (source pin)', () => {
+    // Mounting CanvasSurface / the full submit flow is out of proportion here;
+    // pin the wiring the way the shortcut suite pins data-shortcut-capture.
+    const fs = require('node:fs') as typeof import('node:fs')
+    const path = require('node:path') as typeof import('node:path')
+    const pane = fs.readFileSync(path.resolve(__dirname, '../../../src/renderer/components/AgentCanvasPane.tsx'), 'utf8')
+    expect(pane).toMatch(/disabled=\{returning\}\s*\n\s*aria-label="Close Agent Canvas"/)
+    const panel = fs.readFileSync(path.resolve(__dirname, '../../../src/renderer/components/CanvasNotesPanel.tsx'), 'utf8')
+    expect(panel).toContain('beginSubmitReturn(sessionId)')
+    expect(panel).toContain('cancelSubmitReturn(sessionId)')
+  })
+})


### PR DESCRIPTION
Fixes #478.

## The race

After **Submit review**, the panel armed a local 1200ms timer whose landing called `togglePane`. A user clicking any pane toggle inside that window closed the pane first — and the landing then **toggled it back open** (the double flip / flicker from the owner's rc.2 pass).

## The rule (as the issue put it: the submit-triggered transition is the only driver of pane state while in flight)

The hand-back moved into `excalidrawStore`:

- **`beginSubmitReturn(sessionId)`** flags the session and schedules the landing. The landing **closes, never toggles** — a pane anything else already closed stays closed.
- **The pane toggles disable** for the beat: the command-bar Canvas button and the pane's ✕ read *"Returning to the terminal…"*, then reset to normal once the landing puts the user back (the button reads **Canvas** again — the issue's requested end state).
- The panel's own **"Return to terminal"** early-leave stays enabled — it is race-safe by construction (cancels the pending landing, then does the one navigation).
- The store-held timer **survives the panel unmounting** (the landing is what unmounts it); `reset()` cancels it with the session.

## Tests

7 new: the flag→land→close sequence; **THE RACE** (a pane closed inside the window is not reopened — mutation-proven: reverting the landing to a toggle reds exactly this test); cancel semantics; re-arm replaces rather than stacks; reset cancels; the command-bar button disabled through a full beat (fake timers); and a source pin for the pane ✕ + panel wiring.

Full suite 8438 passed / typecheck clean. Renderer-only, no ADR-009 surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
