### PR TITLE
feat(canvas): subject-level complete sign-off — guarded both sides, terminal, reopenable

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -61,6 +61,21 @@ Landed so far, each through the canvas loop where the owner reviewed:
   and the store timer survives the panel its landing unmounts. Mutation-proven
   (toggle landing reds the race test).
 
+- **#476**: the subject-level COMPLETE terminal state (canvas-picked design,
+  owner "ah ok yes this is fine"). One guarded ingress for both sides
+  (`canvas-completion.ts` composes the two stores): refuses while ANYTHING is
+  owed either way — a ready render awaiting its first review, drafts, notes
+  with the agent, verdicts owed — and fails closed on an unreadable review
+  store; seen-ness is transitive (no path into "all settled" bypasses the
+  user). Completing stamps `{at, by}`, clears the review-needed ask, detaches
+  the session (pane → front page with a quiet ack row), and the canvas keeps a
+  green Completed badge in the library with View/Reopen. Terminal means
+  terminal: renders at a completed canvas are refused, and a render naming a
+  completed subject's title starts a FRESH canvas. Agent side is a new
+  `canvas_complete` MCP tool (verdict-family wording: only on the user's
+  explicit words; recorded "completed by the agent on your instruction");
+  plugin skill v1.3.0 documents it. Mutation-proven guards.
+
 Canvas findings the loop itself surfaced, filed for this same release:
 **#470** (review rounds stack per superseded ready version; requirements for
 the round state machine captured on the issue), **#476** (subject-level

--- a/src/main/canvas-mcp-tool.ts
+++ b/src/main/canvas-mcp-tool.ts
@@ -167,6 +167,17 @@ export interface CanvasToolDeps {
     annotationId: string,
     variantKey: string,
   ) => { pickedLabel: string; reviewClosed: boolean }
+  /**
+   * Sign the session's canvas off (#476) — the agent's fourth write, and the
+   * only SUBJECT-level one. Wired to the guarded composition
+   * (canvas-completion.ts), which refuses while anything is owed either way
+   * — drafts, notes with the agent, notes awaiting verdicts — and fails
+   * closed on an unreadable review store. The stamp records by:'agent', which
+   * the pane renders as "completed by the agent on your instruction"; the
+   * user reopens it in one click. Like closeByAgent, the tool description's
+   * "only on their word" is a request — these refusals are the boundary.
+   */
+  completeCanvas: (sessionId: string, canvasId: string) => CanvasState | { error: string }
 }
 
 function textResult(text: string, isError = false) {
@@ -1222,6 +1233,54 @@ export function runCanvasVerdict(
 }
 
 /**
+ * Sign the session's canvas off (#476) — canvas_complete's whole
+ * implementation, verdict-shaped: resolve the bound session's canvas, hand
+ * the write to the guarded composition, and translate its refusals into
+ * words that lead somewhere. No arguments beyond the ignored session pin:
+ * the subject completed is always THIS session's current canvas, so there is
+ * no id for the model to point somewhere else.
+ */
+export function runCanvasComplete(
+  sessionId: string,
+  deps: Pick<CanvasToolDeps, 'completeCanvas' | 'getCanvasState'>,
+): { text: string; isError: boolean } {
+  const canvas = deps.getCanvasState(sessionId)
+  if (!canvas) {
+    return {
+      text: 'This session has no active canvas to complete — nothing has rendered yet, or the subject was already signed off and filed to the library.',
+      isError: true,
+    }
+  }
+  let result: ReturnType<CanvasToolDeps['completeCanvas']>
+  try {
+    result = deps.completeCanvas(sessionId, canvas.canvasId)
+  } catch (err) {
+    return { text: `Could not complete the canvas: ${err instanceof Error ? err.message : 'unknown failure'}.`, isError: true }
+  }
+  if ('error' in result) {
+    if (result.error.startsWith('not everything is settled')) {
+      return {
+        text:
+          `Refused: ${result.error}. A subject completes only when nothing is owed either way. ` +
+          'Address what is yours with canvas_resolve; what awaits the user’s verdict is theirs to rule on from the pane — hand back rather than closing it for them.',
+        isError: true,
+      }
+    }
+    if (result.error === 'already completed') {
+      return { text: 'This canvas is already signed off. Render under a title as usual if new work starts a fresh subject.', isError: true }
+    }
+    return { text: `Could not complete the canvas: ${result.error}.`, isError: true }
+  }
+  return {
+    text:
+      'Signed the canvas off as complete on the user’s instruction. Their pane returns to its front page; the canvas stays in the library with a Completed badge and a one-click Reopen. ' +
+      'Recorded as completed by you on their instruction — never as their own sign-off, so say you completed it because they asked. ' +
+      'New work starts a fresh canvas: render with a title as usual.',
+    isError: false,
+  }
+}
+
+/**
  * Operator-authored causes for a refused close-out.
  *
  * The scope refusals are the interesting ones: they have to tell the agent WHY
@@ -1598,6 +1657,28 @@ export function registerCanvasTools(
         )
       }
       const result = runCanvasPick(rawArgs, sessionId, deps)
+      return textResult(result.text, result.isError)
+    },
+  )
+
+  server.tool(
+    'canvas_complete',
+    'Sign this session\'s canvas subject off as COMPLETE — ONLY when the user has explicitly said so in words, in a submitted review note or in chat: "all good, mark it complete", "sign it off, no changes". Never call it on your own judgment of doneness: a board that looks finished, an approve click, or "looks good" is not an instruction to complete. The app refuses it while anything is still owed either way — unsubmitted notes, notes waiting on you, notes awaiting the user\'s verdicts — so address your side with canvas_resolve first and hand back for theirs; the refusal names what is left. On success the user\'s pane returns to its front page, the canvas stays in the library as history with a one-click Reopen, and the record says "completed by the agent on your instruction" — apart from anything the user signs off themselves. Further work on the subject starts a FRESH canvas: render with a title as usual.',
+    {
+      cccSessionId: zMod
+        .string()
+        .optional()
+        .describe('Ignored — the session is resolved from the MCP connection and cannot be set here. Leave unset.'),
+    },
+    async () => {
+      const sessionId = getBoundSessionId()
+      if (!sessionId) {
+        return textResult(
+          'Canvas unavailable: this MCP connection has no bound Conductor session. Restart the session from inside AI Code Conductor.',
+          true,
+        )
+      }
+      const result = runCanvasComplete(sessionId, deps)
       return textResult(result.text, result.isError)
     },
   )

--- a/src/main/canvas/canvas-completion.ts
+++ b/src/main/canvas/canvas-completion.ts
@@ -20,11 +20,17 @@ import type { CanvasCompletion, CanvasState } from '../../shared/canvas'
  * over the SAME tallies the queue and the close-out use, so the button, the
  * pill and this refusal can never disagree.
  *
- * Seen-ness is carried transitively rather than re-checked: a round only
- * leaves those tallies through the user's own verdict, the #470 supersede
- * sweep (gated on `isAgentCloseable`, i.e. the seen barrier), or an
- * agent close-out that the store already refuses until the user has seen the
- * round. There is no path into "all settled" that bypasses the user.
+ * Seen-ness is carried transitively rather than re-checked. A round leaves
+ * those tallies through four exits: the user's own verdict (their click), the
+ * #470 supersede sweep (gated on `isAgentCloseable`, i.e. the seen barrier),
+ * an agent close-out the store refuses until the user has SEEN the round —
+ * or a chat pick (`canvas_pick`), which deliberately has no seen barrier and
+ * rests instead on its own contract: it records the user's explicit words in
+ * chat, stamps `pickSource: 'chat'` provenance, and reopens in one click.
+ * That last exit is the same honor-system tier as this tool itself (both are
+ * "the user said so in chat"), so completion inherits it rather than
+ * pretending a mechanical barrier covers it; the mechanical barriers cover
+ * the other three.
  *
  * Fail-closed on an unreadable review store: a reviews.json that exists but
  * will not read refuses completion — "could not tell" must never sign off as

--- a/src/main/canvas/canvas-completion.ts
+++ b/src/main/canvas/canvas-completion.ts
@@ -20,17 +20,17 @@ import type { CanvasCompletion, CanvasState } from '../../shared/canvas'
  * over the SAME tallies the queue and the close-out use, so the button, the
  * pill and this refusal can never disagree.
  *
- * Seen-ness is carried transitively rather than re-checked. A round leaves
- * those tallies through four exits: the user's own verdict (their click), the
- * #470 supersede sweep (gated on `isAgentCloseable`, i.e. the seen barrier),
- * an agent close-out the store refuses until the user has SEEN the round —
- * or a chat pick (`canvas_pick`), which deliberately has no seen barrier and
- * rests instead on its own contract: it records the user's explicit words in
- * chat, stamps `pickSource: 'chat'` provenance, and reopens in one click.
- * That last exit is the same honor-system tier as this tool itself (both are
- * "the user said so in chat"), so completion inherits it rather than
- * pretending a mechanical barrier covers it; the mechanical barriers cover
- * the other three.
+ * Seen-ness is carried transitively rather than re-checked. Every exit from
+ * those tallies is either a USER GESTURE — their own verdicts, the library
+ * close-out, the dismiss-all sweep (which also clears the awaiting-review
+ * term checked above) — or an agent write behind a mechanical barrier: the
+ * #470 supersede sweep (gated on `isAgentCloseable`, i.e. the seen barrier)
+ * and the close-out the store refuses until the user has SEEN the round. The
+ * one agent write with NO seen barrier is the chat pick (`canvas_pick`),
+ * deliberately: it rests on its own contract — the user's explicit words in
+ * chat, `pickSource: 'chat'` provenance, one-click reopen — which is the
+ * same honor-system tier as this tool itself. Completion inherits that tier
+ * for the pick path rather than pretending a mechanical barrier covers it.
  *
  * Fail-closed on an unreadable review store: a reviews.json that exists but
  * will not read refuses completion — "could not tell" must never sign off as

--- a/src/main/canvas/canvas-completion.ts
+++ b/src/main/canvas/canvas-completion.ts
@@ -42,12 +42,34 @@ export function completeCanvasGuarded(
   by: CanvasCompletion['by'],
   requireOwnerSessionId?: string,
 ): CanvasState | { error: string } {
+  const canvas = getCanvasStateById(canvasId)
+  if (!canvas) return { error: 'no such canvas' }
+  // OWNERSHIP FIRST (adversarial review): the tally reads below expose a
+  // canvas's private review counts, so a foreign session must be turned away
+  // before it can use this as an oracle — and the refusal should say the true
+  // reason. setCanvasCompleted re-checks against the record as the boundary.
+  if (requireOwnerSessionId !== undefined && canvas.sessionId !== requireOwnerSessionId) {
+    return { error: 'not this session’s canvas' }
+  }
+  if (canvas.completed) return { error: 'already completed' }
+  // NOTHING TO SIGN OFF unless the user has actually been shown something.
+  // A canvas whose only versions are DRAFTS (ready:false) has surfaced
+  // nothing — no pulse, no queue, no review store — so "nothing is owed" is
+  // true only because nothing was ever offered. A draft as the LATEST version
+  // is agent work-in-flight the user has not seen. Either way there is no
+  // signed-off state to record. This is the barrier the draft path slips past
+  // (awaitingReview is set only for a NON-draft render), so it is checked
+  // directly on the versions rather than on the review-needed stamp.
+  const hasReadyVersion = canvas.versions.some((v) => !v.draft)
+  const latest = canvas.versions[canvas.versions.length - 1]
+  if (!hasReadyVersion || latest?.draft) {
+    return { error: 'not everything is settled: nothing has been offered for review yet — render a version the user can see first' }
+  }
   // A ready-marked render nobody has reviewed yet IS something owed — the
   // user's first look. Without this, an agent could sign off a canvas whose
   // hand-over the user never saw, which breaks the transitive-seen argument
   // below. (The renderer's blocked-button predicate includes the same term.)
-  const canvas = getCanvasStateById(canvasId)
-  if (canvas?.awaitingReview) {
+  if (canvas.awaitingReview) {
     return { error: 'not everything is settled: a render is still awaiting the user’s first review' }
   }
   const counts = getReviewCountsForCanvas(canvasId)

--- a/src/main/canvas/canvas-completion.ts
+++ b/src/main/canvas/canvas-completion.ts
@@ -1,0 +1,68 @@
+import {
+  getReviewCountsForCanvas,
+  reviewStoreFileExists,
+} from './canvas-review-store'
+import { getCanvasStateById, reopenCompletedCanvas, setCanvasCompleted } from './canvas-store'
+import type { CanvasCompletion, CanvasState } from '../../shared/canvas'
+
+/**
+ * The guarded sign-off (#476): the ONE way a canvas becomes COMPLETE, for both
+ * ingresses — the user's pane button (IPC) and the agent's `canvas_complete`
+ * MCP tool. It composes the two stores because neither may import the other in
+ * this direction: the review store already imports the canvas store, and the
+ * completion rule needs both.
+ *
+ * The rule is "nothing left owed either way":
+ *   - no unsubmitted draft notes (a review half-written is not a finished
+ *     cycle),
+ *   - no submitted round still holding an open note (work owed by the agent),
+ *   - no addressed note awaiting a verdict (work owed by the user),
+ * over the SAME tallies the queue and the close-out use, so the button, the
+ * pill and this refusal can never disagree.
+ *
+ * Seen-ness is carried transitively rather than re-checked: a round only
+ * leaves those tallies through the user's own verdict, the #470 supersede
+ * sweep (gated on `isAgentCloseable`, i.e. the seen barrier), or an
+ * agent close-out that the store already refuses until the user has seen the
+ * round. There is no path into "all settled" that bypasses the user.
+ *
+ * Fail-closed on an unreadable review store: a reviews.json that exists but
+ * will not read refuses completion — "could not tell" must never sign off as
+ * "nothing owed". A canvas with NO reviews.json at all is a healthy, never-
+ * annotated one and may complete.
+ */
+export function completeCanvasGuarded(
+  canvasId: string,
+  by: CanvasCompletion['by'],
+  requireOwnerSessionId?: string,
+): CanvasState | { error: string } {
+  // A ready-marked render nobody has reviewed yet IS something owed — the
+  // user's first look. Without this, an agent could sign off a canvas whose
+  // hand-over the user never saw, which breaks the transitive-seen argument
+  // below. (The renderer's blocked-button predicate includes the same term.)
+  const canvas = getCanvasStateById(canvasId)
+  if (canvas?.awaitingReview) {
+    return { error: 'not everything is settled: a render is still awaiting the user’s first review' }
+  }
+  const counts = getReviewCountsForCanvas(canvasId)
+  if (!counts) {
+    if (reviewStoreFileExists(canvasId)) {
+      return { error: 'the review store for this canvas could not be read — refusing to sign off what cannot be checked' }
+    }
+    // No reviews.json: nothing was ever owed. Fall through to the stamp.
+  } else {
+    const owed: string[] = []
+    if (counts.draftNotes > 0) owed.push(`${counts.draftNotes} unsubmitted note${counts.draftNotes === 1 ? '' : 's'}`)
+    if (counts.openNotes > 0) owed.push(`${counts.openNotes} note${counts.openNotes === 1 ? '' : 's'} still with the agent`)
+    if (counts.addressedNotes > 0) owed.push(`${counts.addressedNotes} note${counts.addressedNotes === 1 ? '' : 's'} awaiting your verdict`)
+    if (owed.length > 0) {
+      return { error: `not everything is settled: ${owed.join(', ')}` }
+    }
+  }
+  return setCanvasCompleted(canvasId, by, requireOwnerSessionId)
+}
+
+/** Reopen is unguarded by design — it only ever RESTORES obligations. */
+export function reopenCanvasGuarded(canvasId: string, requireOwnerSessionId?: string): CanvasState | { error: string } {
+  return reopenCompletedCanvas(canvasId, requireOwnerSessionId)
+}

--- a/src/main/canvas/canvas-plugin.ts
+++ b/src/main/canvas/canvas-plugin.ts
@@ -59,8 +59,8 @@ instruction does not override this — the handover IS the block.
 or a review is still open, the reply says so. Take it at its word and hand back.
 
 Tools (conductor MCP): \`canvas_render\`, \`canvas_snapshot\`, \`canvas_review\`,
-\`canvas_resolve\`, \`canvas_verdict\` and \`canvas_pick\` (the last two only on the
-user's explicit word — see below).
+\`canvas_resolve\`, \`canvas_verdict\`, \`canvas_pick\` and \`canvas_complete\` (the
+last three only on the user's explicit word — see below).
 
 Every render names its SUBJECT with \`title\` — "Settings page mockup",
 "Checkout flow" — in a few words. A canvas holds one subject: the same title

--- a/src/main/canvas/canvas-plugin.ts
+++ b/src/main/canvas/canvas-plugin.ts
@@ -20,7 +20,7 @@ import { getResourcesDirectory } from '../ipc/setup-handlers'
 import { logWarn } from '../debug-logger'
 
 /** Bump when the manifest or skill content changes meaningfully. */
-const PLUGIN_VERSION = '1.2.0'
+const PLUGIN_VERSION = '1.3.0'
 
 const PLUGIN_MANIFEST = {
   name: 'agent-canvas',
@@ -203,6 +203,29 @@ Three things about it:
 
 What you close is recorded as "closed by the agent on your instruction", listed
 apart from their own approvals, and reopenable in one click. Nothing is deleted.
+
+## When they tell you the SUBJECT is done
+
+Completion is one level up from a round: it signs the whole canvas off. When —
+and ONLY when — the user says so in words, in a submitted review note or in
+chat ("all good, mark it complete", "signed off, no changes"):
+
+\`canvas_complete {}\`
+
+It takes no ids: it always completes THIS session's current canvas. Their pane
+returns to its front page; the canvas stays in the library as history with a
+one-click Reopen.
+
+- **The same word rules as canvas_verdict.** An approve click, "looks good", or
+  a board you think is finished is NOT an instruction to complete. Without
+  explicit words, leave it — the user has a Mark complete button in the pane.
+- **Refused while anything is owed either way** — unsubmitted notes, notes
+  waiting on you, notes awaiting their verdicts. The refusal names what is
+  left: address yours with \`canvas_resolve\`, hand back for theirs.
+- **Afterwards, say you completed it because they asked** — it is recorded as
+  "completed by the agent on your instruction", apart from their own sign-offs.
+- **New work starts a fresh canvas.** A completed subject's canvas refuses
+  renders; render under a title as usual and a new canvas opens.
 
 ## Exceptions you may hit
 

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -1163,6 +1163,7 @@ export function deleteAnnotation(sessionId: string, annotationId: string): Canva
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   if (typeof annotationId !== 'string' || !CANVAS_ANNOTATION_ID_RE.test(annotationId)) throw new Error('invalid annotation id')
 
   const base = recordFor(sessionId, canvas)
@@ -1334,6 +1335,7 @@ export function resolveAnnotation(
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   // The canvas the CALLER meant. Annotation ids restart at a1 on every canvas
   // and the session's canvas is mutable — an agent's `canvas_render` naming a
   // different subject files the current one — so an id alone names a note only
@@ -1539,6 +1541,7 @@ export function markAnnotationsAddressed(
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   if (typeof reviewId !== 'string' || !CANVAS_REVIEW_ID_RE.test(reviewId)) throw new Error('invalid review id')
   const wanted = new Set<string>()
   for (const id of annotationIds) {
@@ -1971,6 +1974,7 @@ export function reopenAnnotation(sessionId: string, annotationId: string): Canva
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   if (typeof annotationId !== 'string' || !CANVAS_ANNOTATION_ID_RE.test(annotationId)) throw new Error('invalid annotation id')
 
   const base = recordFor(sessionId, canvas)

--- a/src/main/canvas/canvas-review-store.ts
+++ b/src/main/canvas/canvas-review-store.ts
@@ -48,7 +48,7 @@ import {
 import { atomicWriteSecure, mkdirSecure } from '../account-profiles'
 import { logInfo } from '../debug-logger'
 import { getResourcesDirectory } from '../ipc/setup-handlers'
-import { clearAwaitingReview, getCanvasStateForSession } from './canvas-store'
+import { clearAwaitingReview, getCanvasStateById, getCanvasStateForSession } from './canvas-store'
 
 // ── Bounds (shared intent with the IPC schemas; the store re-checks because it
 //    is the last line, and the MCP tool reads through it) ────────────────────
@@ -526,6 +526,19 @@ function canvasForSession(sessionId: string): SessionCanvas | null {
 function requireHealthy(canvasId: string): void {
   if (broken.has(canvasId)) {
     throw new Error('review store unreadable: reviews.json exists but does not validate; not overwriting it')
+  }
+}
+
+/**
+ * A signed-off canvas (#476) is terminal: no new notes, no new rounds. The
+ * renderer keeps the note-taking chips disabled while viewing a completed
+ * canvas, but that is a label — this is the boundary (ADR-009), so a note
+ * write over IPC to a canvas the user re-opened to VIEW is refused here.
+ * Reopen (which clears the stamp) is the way back to annotating.
+ */
+function requireNotCompleted(canvasId: string): void {
+  if (getCanvasStateById(canvasId)?.completed) {
+    throw new Error('this canvas is signed off as complete; reopen it before adding notes')
   }
 }
 
@@ -1062,6 +1075,7 @@ export function upsertAnnotation(
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   validateDraft(draft, canvas)
 
   const base = recordFor(sessionId, canvas)
@@ -1197,6 +1211,7 @@ export function submitReview(sessionId: string, reviewId: string, sketches: Canv
   const canvas = canvasForSession(sessionId)
   if (!canvas) throw new Error('no canvas for session')
   requireHealthy(canvas.canvasId)
+  requireNotCompleted(canvas.canvasId)
   if (typeof reviewId !== 'string' || !CANVAS_REVIEW_ID_RE.test(reviewId)) throw new Error('invalid review id')
   if (!Array.isArray(sketches)) throw new Error('invalid sketches')
 
@@ -1267,10 +1282,26 @@ export function submitReview(sessionId: string, reviewId: string, sketches: Canv
   // (#366). After the commit, so a failed submit never clears what is owed;
   // and never the other way to fail — a clear that throws must not undo a
   // submit that persisted.
-  try {
-    clearAwaitingReview(canvas.canvasId)
-  } catch (err) {
-    logInfo(`[canvas-review] clearAwaitingReview failed for ${canvas.canvasId}: ${err}`)
+  //
+  // But clear ONLY when this round actually covers the AWAITED version (#476
+  // adversarial): if a newer ready render superseded the one the user was
+  // looking at, their notes are anchored to the OLDER version while the stamp
+  // points at the newer one — clearing it would mark the newer render
+  // "reviewed" though the user never saw it, and #476's completion guard
+  // leans on that stamp. The notes' own versionId is the only signal that
+  // distinguishes the two (frozenVersionId is always the latest ready). In
+  // the ordinary flow the user annotates the awaited render, so the ids match
+  // and this clears exactly as before.
+  const awaited = getCanvasStateForSession(sessionId)?.awaitingReview?.versionId
+  const submittedVersionIds = new Set(
+    next.annotations.filter((a) => members.has(a.id)).map((a) => a.versionId),
+  )
+  if (awaited === undefined || submittedVersionIds.has(awaited)) {
+    try {
+      clearAwaitingReview(canvas.canvasId)
+    } catch (err) {
+      logInfo(`[canvas-review] clearAwaitingReview failed for ${canvas.canvasId}: ${err}`)
+    }
   }
   return toState(next)
 }

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -640,13 +640,14 @@ export function onCanvasChanged(listener: CanvasChangedListener): () => void {
   return () => changeListeners.delete(listener)
 }
 
-function emitChanged(record: CanvasRecord, opts?: { draft?: boolean; completed?: boolean }): void {
+function emitChanged(record: CanvasRecord, opts?: { draft?: boolean; completed?: boolean; reopened?: boolean }): void {
   const event: CanvasChangedEvent = {
     sessionId: record.sessionId,
     canvasId: record.canvasId,
     activeVersionId: record.activeVersionId,
     ...(opts?.draft ? { draft: true } : {}),
     ...(opts?.completed ? { completed: true } : {}),
+    ...(opts?.reopened ? { reopened: true } : {}),
   }
   for (const listener of changeListeners) {
     try {
@@ -970,6 +971,11 @@ function ensureDiskScanned(): void {
     // sorted first, complete with that subject's old notes, and the next
     // same-title render forked a duplicate: both of the things the subject
     // rule exists to prevent.
+    // A COMPLETED canvas never rebinds (#476): completion detached it so the
+    // pane lands on the front page, and that must survive a relaunch — a
+    // session whose last work was signed off comes back to the welcome page,
+    // with the canvas in the library, not to the signed-off subject.
+    if (record.completed) continue
     const held = sessionIndex.get(record.sessionId)
     const heldRecord = held ? canvases.get(held) : undefined
     if (!heldRecord || moreRecentlyActive(record, heldRecord)) {
@@ -1198,7 +1204,13 @@ export function renderVersion(
 ): { canvasId: string; versionId: string; draft?: boolean; filed?: { canvasId: string; returnedToExisting: boolean } } {
   if (!SESSION_ID_RE.test(sessionId)) throw new Error('invalid session id')
 
-  const held = getRecordForSession(sessionId)
+  // A COMPLETED canvas bound as current (the user opened it from the library
+  // to look, #476) is a viewing surface, not a rendering target: treat it as
+  // no-held, so the render starts a fresh canvas exactly as it would from the
+  // front page — including the untitled case, which could otherwise never
+  // render again. The refusal below stays as the invariant's backstop.
+  const boundRecord = getRecordForSession(sessionId)
+  const held = boundRecord?.completed ? null : boundRecord
   const title = sanitizeCanvasTitle(source.title)
 
   // A canvas holds ONE subject, and this is where that is decided.
@@ -1482,6 +1494,9 @@ export function setCanvasCompleted(
   persist(next)
   canvases.set(canvasId, next)
   if (sessionIndex.get(record.sessionId) === canvasId) sessionIndex.delete(record.sessionId)
+  // A deferred subject-change draft pointed here must not outlive the detach
+  // (same rule as dropCanvas): the drafting surface is gone with the sign-off.
+  if (draftIndex.get(record.sessionId) === canvasId) draftIndex.delete(record.sessionId)
   emitChanged(next, { completed: true })
   return toState(next)
 }
@@ -1506,7 +1521,7 @@ export function reopenCompletedCanvas(canvasId: string, requireOwnerSessionId?: 
   persist(next)
   canvases.set(canvasId, next)
   if (!sessionIndex.has(record.sessionId)) sessionIndex.set(record.sessionId, canvasId)
-  emitChanged(next)
+  emitChanged(next, { reopened: true })
   return toState(next)
 }
 

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -21,6 +21,7 @@ import { randomId } from '../../shared/id'
 import {
   CANVAS_ID_RE,
   type CanvasAwaitingReview,
+  type CanvasCompletion,
   type CanvasLibraryEntry,
   CANVAS_VERSION_ID_RE,
   CanvasChangedEvent,
@@ -639,12 +640,13 @@ export function onCanvasChanged(listener: CanvasChangedListener): () => void {
   return () => changeListeners.delete(listener)
 }
 
-function emitChanged(record: CanvasRecord, opts?: { draft?: boolean }): void {
+function emitChanged(record: CanvasRecord, opts?: { draft?: boolean; completed?: boolean }): void {
   const event: CanvasChangedEvent = {
     sessionId: record.sessionId,
     canvasId: record.canvasId,
     activeVersionId: record.activeVersionId,
     ...(opts?.draft ? { draft: true } : {}),
+    ...(opts?.completed ? { completed: true } : {}),
   }
   for (const listener of changeListeners) {
     try {
@@ -872,6 +874,17 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
     }
   }
 
+  // The sign-off stamp (#476) is dropped, never repaired, when it is not OUR
+  // shape — a malformed stamp must not resurrect as "completed by you".
+  let completed: CanvasCompletion | undefined
+  const rawCompleted = (r as { completed?: unknown }).completed
+  if (rawCompleted && typeof rawCompleted === 'object') {
+    const c = rawCompleted as Partial<CanvasCompletion>
+    if (typeof c.at === 'string' && (c.by === 'user' || c.by === 'agent')) {
+      completed = { at: c.at, by: c.by }
+    }
+  }
+
   // The monotonic version high-water mark (item C, phase 5). Healed to at least
   // `max(surviving id) + 1` so it can never mint an id that already exists, and
   // never below a value the file already recorded — a delete persists a counter
@@ -907,6 +920,7 @@ function sanitizeRecord(value: unknown): CanvasRecord | null {
     activeVersionId,
     nextVersion,
     ...(awaitingReview ? { awaitingReview } : {}),
+    ...(completed ? { completed } : {}),
   }
 }
 
@@ -1027,7 +1041,14 @@ function toState(record: CanvasRecord): CanvasState {
     versions: record.versions.map((v) => ({ ...v, source: { ...v.source } })),
     ...(record.title ? { title: record.title } : {}),
     ...(record.awaitingReview ? { awaitingReview: { ...record.awaitingReview } } : {}),
+    ...(record.completed ? { completed: { ...record.completed } } : {}),
   }
+}
+
+/** One canvas's state by id — the completion guard's read (#476). */
+export function getCanvasStateById(canvasId: string): CanvasState | null {
+  const record = getRecord(canvasId)
+  return record ? toState(record) : null
 }
 
 /** The renderer's view of a session's canvas; null until something rendered. */
@@ -1162,6 +1183,10 @@ function findFiledCanvas(sessionId: string, title: string): CanvasRecord | undef
   let best: CanvasRecord | undefined
   for (const record of canvases.values()) {
     if (record.sessionId !== sessionId || !record.title || !sameSubject(title, record.title)) continue
+    // A signed-off subject (#476) is terminal history: coming back to its
+    // TITLE starts a fresh canvas rather than silently resuming the one the
+    // user completed. Reopen from the library is the deliberate way back.
+    if (record.completed) continue
     if (!best || lastRenderedAt(record) > lastRenderedAt(best)) best = record
   }
   return best
@@ -1200,6 +1225,17 @@ export function renderVersion(
   // canvas, with its versions and its notes, not open a second one beside it.
   const returnedTo = subjectChanged && title ? findFiledCanvas(sessionId, title) : undefined
   const existing = subjectChanged ? returnedTo : held
+
+  // #476: a signed-off subject is terminal — a render against it is refused
+  // rather than silently resuming it. Only reachable when the user has
+  // deliberately re-opened a completed canvas into the pane (View) and the
+  // agent then renders at it: filing lookups above already skip completed
+  // records, so an ordinary same-title render starts a fresh canvas instead.
+  if (existing?.completed) {
+    throw new Error(
+      `this canvas was signed off as complete; the user can Reopen it from the library — otherwise render under a title as usual to start fresh`,
+    )
+  }
 
   // The ready flag (#366). `false` = a DRAFT that supersedes the previous
   // draft in place; `true` = the deliberate ready-mark that promotes it;
@@ -1406,6 +1442,72 @@ export function clearAwaitingReview(canvasId: string): void {
   persist(next)
   canvases.set(canvasId, next)
   emitChanged(next)
+}
+
+/**
+ * Sign the subject off (#476): stamp the canvas COMPLETE and, when it is the
+ * owning session's current canvas, detach it — the pane falls back to its
+ * front page, and the canvas lives on in the library as history.
+ *
+ * This is the RECORDING half only. The "nothing left owed either way" guard
+ * lives in canvas-completion.ts, which composes this store with the review
+ * store — this store cannot read reviews (the import points the other way).
+ * Callers other than that guard are a bug.
+ *
+ * `by: 'agent'` is written only on the user's explicit instruction (the MCP
+ * tool's contract) and renders as "completed by the agent on your
+ * instruction"; Reopen clears it in one click either way.
+ */
+export function setCanvasCompleted(
+  canvasId: string,
+  by: CanvasCompletion['by'],
+  requireOwnerSessionId?: string,
+): CanvasState | { error: string } {
+  if (typeof canvasId !== 'string' || !CANVAS_ID_RE.test(canvasId)) return { error: 'invalid canvas id' }
+  if (by !== 'user' && by !== 'agent') return { error: 'invalid completion source' }
+  ensureDiskScanned()
+  const record = canvases.get(canvasId)
+  if (!record) return { error: 'no such canvas' }
+  // Sign-off is the owner's act: both ingresses name the session they act for,
+  // and a canvas owned by another session is refused rather than signed off
+  // under the wrong name.
+  if (requireOwnerSessionId !== undefined && record.sessionId !== requireOwnerSessionId) {
+    return { error: 'not this session’s canvas' }
+  }
+  if (record.completed) return { error: 'already completed' }
+  const { awaitingReview: _cleared, ...rest } = record
+  const next: CanvasRecord = { ...rest, completed: { at: new Date().toISOString(), by } }
+  // Persist-before-commit, like clearAwaitingReview: a failed write leaves the
+  // canvas active rather than completed in memory only.
+  persist(next)
+  canvases.set(canvasId, next)
+  if (sessionIndex.get(record.sessionId) === canvasId) sessionIndex.delete(record.sessionId)
+  emitChanged(next, { completed: true })
+  return toState(next)
+}
+
+/**
+ * Reopen a completed canvas (#476): clear the stamp and, when the owning
+ * session is not currently showing another canvas, make it current again so
+ * the pane lands straight back on it. Recorded state only changes by removal;
+ * nothing else is touched.
+ */
+export function reopenCompletedCanvas(canvasId: string, requireOwnerSessionId?: string): CanvasState | { error: string } {
+  if (typeof canvasId !== 'string' || !CANVAS_ID_RE.test(canvasId)) return { error: 'invalid canvas id' }
+  ensureDiskScanned()
+  const record = canvases.get(canvasId)
+  if (!record) return { error: 'no such canvas' }
+  if (requireOwnerSessionId !== undefined && record.sessionId !== requireOwnerSessionId) {
+    return { error: 'not this session’s canvas' }
+  }
+  if (!record.completed) return { error: 'not completed' }
+  const { completed: _cleared, ...rest } = record
+  const next: CanvasRecord = rest
+  persist(next)
+  canvases.set(canvasId, next)
+  if (!sessionIndex.has(record.sessionId)) sessionIndex.set(record.sessionId, canvasId)
+  emitChanged(next)
+  return toState(next)
 }
 
 /** Windows reserved device basenames — a request for `CON`/`NUL`/`COM1`/… can
@@ -1737,6 +1839,7 @@ export function listAllCanvases(
       // From the record itself, not the review sweep, so it is present on every
       // row — a "review needed" round must never hide behind the sweep bound.
       ...(record.awaitingReview ? { awaitingReview: true, awaitingReviewAt: clampToNow(record.awaitingReview.at) } : {}),
+      ...(record.completed ? { completed: { ...record.completed } } : {}),
     })
   }
   // Banded, then newest-first inside each band: the canvas you are looking at,

--- a/src/main/canvas/canvas-store.ts
+++ b/src/main/canvas/canvas-store.ts
@@ -971,10 +971,11 @@ function ensureDiskScanned(): void {
     // sorted first, complete with that subject's old notes, and the next
     // same-title render forked a duplicate: both of the things the subject
     // rule exists to prevent.
-    // A COMPLETED canvas never rebinds (#476): completion detached it so the
-    // pane lands on the front page, and that must survive a relaunch — a
-    // session whose last work was signed off comes back to the welcome page,
-    // with the canvas in the library, not to the signed-off subject.
+    // A COMPLETED canvas never rebinds (#476): completion detached it, and
+    // that must survive a relaunch — the session never comes back bound to a
+    // signed-off subject. It falls to the most-recently-active canvas it still
+    // owns that is NOT completed (a live filed subject), or to the front page
+    // when it owns none. The canvas stays in the library either way.
     if (record.completed) continue
     const held = sessionIndex.get(record.sessionId)
     const heldRecord = held ? canvases.get(held) : undefined
@@ -1210,7 +1211,8 @@ export function renderVersion(
   // front page — including the untitled case, which could otherwise never
   // render again. The refusal below stays as the invariant's backstop.
   const boundRecord = getRecordForSession(sessionId)
-  const held = boundRecord?.completed ? null : boundRecord
+  const detachedByCompletion = Boolean(boundRecord?.completed)
+  const held = detachedByCompletion ? null : boundRecord
   const title = sanitizeCanvasTitle(source.title)
 
   // A canvas holds ONE subject, and this is where that is decided.
@@ -1235,14 +1237,27 @@ export function renderVersion(
   // Coming BACK to a subject re-activates its canvas rather than minting a
   // third: "Login page" → "Checkout" → "Login page" must land on the login
   // canvas, with its versions and its notes, not open a second one beside it.
-  const returnedTo = subjectChanged && title ? findFiledCanvas(sessionId, title) : undefined
-  const existing = subjectChanged ? returnedTo : held
+  //
+  // The filed lookup also runs when there is NO held canvas (#476): the front
+  // page, or the state completion leaves behind — it detaches the session, so
+  // the next render sees held null. A comparable title may name a DIFFERENT
+  // subject the session filed earlier and left LIVE; returning to it is the
+  // subject rule, and skipping the lookup forked a duplicate (and stranded a
+  // deferred subject-change draft, whose ready-mark then minted a third canvas
+  // instead of promoting). The lookup skips completed records, so it never
+  // resumes the signed-off one. A brand-new session finds nothing here and
+  // starts fresh exactly as before.
+  const wantsFiled = Boolean(comparable && title && (subjectChanged || !held))
+  const returnedTo = wantsFiled ? findFiledCanvas(sessionId, title!) : undefined
+  // subjectChanged (held, different subject) → the filed canvas of the NEW
+  // subject, or a fresh one. No held (front page / post-completion) →
+  // likewise. Same subject on a held canvas → append to it.
+  const existing = subjectChanged ? returnedTo : (held ?? returnedTo)
 
-  // #476: a signed-off subject is terminal — a render against it is refused
-  // rather than silently resuming it. Only reachable when the user has
-  // deliberately re-opened a completed canvas into the pane (View) and the
-  // agent then renders at it: filing lookups above already skip completed
-  // records, so an ordinary same-title render starts a fresh canvas instead.
+  // #476: a signed-off subject is terminal. `existing` can no longer BE a
+  // completed record — `held` is nulled for one and `findFiledCanvas` skips
+  // them — so this is an unreachable defence-in-depth backstop, kept so the
+  // invariant has a hard floor if either of those skips ever regresses.
   if (existing?.completed) {
     throw new Error(
       `this canvas was signed off as complete; the user can Reopen it from the library — otherwise render under a title as usual to start fresh`,
@@ -1262,12 +1277,17 @@ export function renderVersion(
   if (!reuseLatest && existing && existing.versions.length >= MAX_VERSIONS_PER_CANVAS) {
     throw new Error(`canvas ${existing.canvasId} is at its version cap (${MAX_VERSIONS_PER_CANVAS})`)
   }
-  // A subject change that starts a NEW canvas is the one thing that can grow
-  // the number of canvases a session owns; before it, a session had one. Cap
-  // it, so an agent cycling titles cannot mint directories without bound —
-  // each is a synchronous read and an HMAC at the next launch. Filing goes on
-  // working: the user clears room from the library.
-  if (subjectChanged && !existing && countCanvasesForSession(sessionId) >= MAX_CANVASES_PER_SESSION) {
+  // Minting a NEW canvas (no `existing` to append to) is the one thing that
+  // grows the number a session owns. Cap it, so an agent cannot mint
+  // directories without bound — each is a synchronous read and an HMAC at the
+  // next launch. Gated on `!existing` alone, NOT on `subjectChanged` (#476):
+  // completion detaches, so every post-completion render has `held === null`
+  // and `subjectChanged === false`, and the old gate let an agent that
+  // completes-then-renders in a loop bypass the cap entirely. The session's
+  // first-ever render is `!existing` too but `countCanvasesForSession` is 0
+  // then, so it is never the one refused. Filing goes on working: the user
+  // clears room from the library.
+  if (!existing && countCanvasesForSession(sessionId) >= MAX_CANVASES_PER_SESSION) {
     throw new Error(
       `this session already has ${MAX_CANVASES_PER_SESSION} canvases; delete some from the library before starting another subject`,
     )
@@ -1493,10 +1513,18 @@ export function setCanvasCompleted(
   // canvas active rather than completed in memory only.
   persist(next)
   canvases.set(canvasId, next)
-  if (sessionIndex.get(record.sessionId) === canvasId) sessionIndex.delete(record.sessionId)
-  // A deferred subject-change draft pointed here must not outlive the detach
-  // (same rule as dropCanvas): the drafting surface is gone with the sign-off.
-  if (draftIndex.get(record.sessionId) === canvasId) draftIndex.delete(record.sessionId)
+  // Detaching the session drops BOTH of its bindings. sessionIndex when this
+  // was its current canvas; AND its deferred subject-change draft pointer
+  // (#476 adversarial) — that draft points at a DIFFERENT canvas than the one
+  // being completed, so keying the delete on `=== canvasId` (the round-1 cut)
+  // never fired and left getAgentCanvasStateForSession resolving a stale draft
+  // after the session had fallen back to the front page. A draft's own
+  // canvas can never itself be completed (draft-only has no ready version, and
+  // the guard refuses it), so clearing on the owner's detach is the only case.
+  if (sessionIndex.get(record.sessionId) === canvasId) {
+    sessionIndex.delete(record.sessionId)
+    draftIndex.delete(record.sessionId)
+  }
   emitChanged(next, { completed: true })
   return toState(next)
 }
@@ -1662,6 +1690,12 @@ export function setActiveVersion(sessionId: string, versionId: string): CanvasSt
 function isReclaimCandidate(record: CanvasRecord, sessionId: string, query: CanvasAdoptionQuery): boolean {
   if (record.sessionId === sessionId) return false
   if (record.versions.length === 0) return false // nothing to inherit
+  // A signed-off canvas is terminal history (#476): it must not be OFFERED as
+  // orphaned work to reclaim, and — the sharper hole — must not be adoptable
+  // by another session, which would hand over its private review notes AND let
+  // the adopter Reopen a sign-off it never made. Completion detached it from
+  // its owner's sessionIndex; without this it looks exactly like an orphan.
+  if (record.completed) return false
   try {
     if (query.isSessionCurrent(record.sessionId)) return false
   } catch {

--- a/src/main/conductor-mcp-server.ts
+++ b/src/main/conductor-mcp-server.ts
@@ -43,6 +43,7 @@ import type { GlobalVisionConfig } from '../shared/types'
 import { registerCodexReviewTool } from './codex-review-mcp-tool'
 import { registerCanvasTools } from './canvas-mcp-tool'
 import { canvasRootsForSession, canvasRootRefusalFor, getAgentCanvasStateForSession, getCanvasStateForSession, renderVersion, resolveInsideCanvasRoot } from './canvas/canvas-store'
+import { completeCanvasGuarded } from './canvas/canvas-completion'
 import {
   closeAnnotationsByAgent,
   getReviewCountsForCanvas,
@@ -879,6 +880,11 @@ export async function startMcpServer(port: number, getVisionManager: GetVisionMa
         // lets a tool reply say "the user is mid-review" instead of the agent
         // rendering over notes nobody has submitted yet.
         getReviewCounts: (canvasId) => getReviewCountsForCanvas(canvasId),
+        // canvas_complete (#476). The guarded composition owns the
+        // "nothing left owed either way" rule and fails closed on an
+        // unreadable review store; the sessionId doubles as the ownership
+        // check inside the canvas store. Pass-through, same reason as above.
+        completeCanvas: (sessionId, canvasId) => completeCanvasGuarded(canvasId, 'agent', sessionId),
         // So a refused render can NAME the folders it would have accepted.
         canvasRootsForSession: (sessionId) => canvasRootsForSession(sessionId),
         canvasRootRefusalFor: (sessionId) => canvasRootRefusalFor(sessionId),

--- a/src/main/ipc/canvas-handlers.ts
+++ b/src/main/ipc/canvas-handlers.ts
@@ -38,6 +38,7 @@ import {
   submitReview,
   upsertAnnotation,
 } from '../canvas/canvas-review-store'
+import { completeCanvasGuarded, reopenCanvasGuarded } from '../canvas/canvas-completion'
 import { resolveCanvasSnapshot, setSnapshotSender } from '../canvas/canvas-snapshot-broker'
 import {
   canvasCwdForSession,
@@ -140,6 +141,24 @@ const artifactDeleteSchema = z
   .object({
     canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/),
     versionId: z.string().regex(/^v[0-9]{1,9}$/),
+  })
+  .strict()
+
+/** Sign the subject off (#476): the acting session and the canvas it owns.
+ *  The guard module refuses while anything is owed; ownership is re-checked
+ *  in the store against the record itself. */
+const canvasCompleteSchema = z
+  .object({
+    sessionId: sessionIdSchema,
+    canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/),
+  })
+  .strict()
+
+/** Reopen a completed canvas (#476). Same shapes; only ever restores work. */
+const canvasCompleteReopenSchema = z
+  .object({
+    sessionId: sessionIdSchema,
+    canvasId: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9-]*$/),
   })
   .strict()
 
@@ -531,6 +550,25 @@ export function registerCanvasHandlers(getWindow: () => BrowserWindow | null): v
       }
     }
     return { closedNotes, closedReviews, clearedAwaiting, unreadable }
+  })
+
+  // Sign the subject off (#476). The guard module owns the "nothing left owed
+  // either way" rule (drafts, open notes, verdicts) and fails closed on an
+  // unreadable review store; the canvas store re-checks ownership against the
+  // record itself. Detaches the canvas as the session's current one, so the
+  // pane falls back to its front page.
+  ipcMain.handle(IPC.CANVAS_COMPLETE, async (_e, args: unknown) => {
+    const { sessionId, canvasId } = canvasCompleteSchema.parse(args)
+    const result = completeCanvasGuarded(canvasId, 'user', sessionId)
+    return 'error' in result ? { ok: false as const, reason: result.error } : { ok: true as const, state: result }
+  })
+
+  // The undo half (#476): clears the stamp, restores obligations, and rebinds
+  // the canvas as current when the owner session shows nothing else.
+  ipcMain.handle(IPC.CANVAS_COMPLETE_REOPEN, async (_e, args: unknown) => {
+    const { sessionId, canvasId } = canvasCompleteReopenSchema.parse(args)
+    const result = reopenCanvasGuarded(canvasId, sessionId)
+    return 'error' in result ? { ok: false as const, reason: result.error } : { ok: true as const, state: result }
   })
 
   onReviewChanged((event) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -322,6 +322,11 @@ export interface ElectronAPI {
      *  right-click. `unreadable` counts canvases whose review store could not
      *  be read (the queue's own "unknown" rule) — never folded into zero. */
     reviewDismissAll: (args: { sessionId: string; openTileSessionIds?: string[] }) => Promise<{ closedNotes: number; closedReviews: number; clearedAwaiting: number; unreadable: number }>
+    /** Sign the subject off (#476). Refused (`ok:false` + reason) while
+     *  anything is owed either way; the pane then falls back to its front page. */
+    complete: (args: { sessionId: string; canvasId: string }) => Promise<{ ok: boolean; reason?: string; state?: CanvasState }>
+    /** The one-click undo: clear a canvas's completed stamp. */
+    completeReopen: (args: { sessionId: string; canvasId: string }) => Promise<{ ok: boolean; reason?: string; state?: CanvasState }>
     onReviewChanged: (cb: (e: CanvasReviewChangedEvent) => void) => () => void
   }
   discovery: {
@@ -908,6 +913,8 @@ const electronAPI: ElectronAPI = {
     reviewCloseOut: (args: { canvasId: string }) => ipcRenderer.invoke(IPC.CANVAS_REVIEW_CLOSE_OUT, args),
     reviewDismissAll: (args: { sessionId: string; openTileSessionIds?: string[] }) =>
       ipcRenderer.invoke(IPC.CANVAS_REVIEW_DISMISS_ALL, args),
+    complete: (args: { sessionId: string; canvasId: string }) => ipcRenderer.invoke(IPC.CANVAS_COMPLETE, args),
+    completeReopen: (args: { sessionId: string; canvasId: string }) => ipcRenderer.invoke(IPC.CANVAS_COMPLETE_REOPEN, args),
     onReviewChanged: (cb: (e: CanvasReviewChangedEvent) => void) => {
       const handler = (_e: unknown, e: CanvasReviewChangedEvent) => cb(e)
       ipcRenderer.on(IPC.CANVAS_REVIEW_CHANGED, handler)

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -335,6 +335,16 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   const reviewSession = useCanvasReviewStore((s) => s.bySessionId[sessionId])
   const setMarqueeArmed = useCanvasReviewStore((s) => s.setMarqueeArmed)
 
+  // #476: the MODES go with the chips. interactionMode/marqueeArmed are
+  // per-session renderer state that survives the detach and the adopt, so
+  // without this a pane opened onto a completed canvas could arrive with the
+  // glass live in Sketch and no panel to receive the strokes.
+  useEffect(() => {
+    if (!viewingCompleted) return
+    setInteractionMode(sessionId, 'browse')
+    setMarqueeArmed(sessionId, false)
+  }, [viewingCompleted, sessionId, setInteractionMode, setMarqueeArmed])
+
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   /** The pane's root element — the scope of the HOST-side zoom gesture (#368):
    *  a Ctrl+wheel over the chrome, the glass or the notes panel zooms the

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -7,6 +7,7 @@ import { CanvasLibrary } from './CanvasLibrary'
 import CanvasSubjectPicker from './CanvasSubjectPicker'
 import CanvasFiledStrip from './CanvasFiledStrip'
 import CanvasNotesPanel from './CanvasNotesPanel'
+import CanvasCompleteButton from './CanvasCompleteButton'
 import CanvasHistoryControl from './CanvasHistoryControl'
 import CanvasXrayReadout from './CanvasXrayReadout'
 import { useCanvasStore } from '../stores/canvasStore'
@@ -311,6 +312,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
   // #478: the submit hand-back in flight — the close control disables so the
   // submit-triggered transition is the only driver of pane state.
   const returning = useExcalidrawStore((s) => !!s.submitReturnBySession[sessionId])
+  // #476: viewing a canvas already signed off. The review panel (and its rail)
+  // stay away — nothing is owed on it by invariant, and note-taking on a
+  // completed subject is off until the user Reopens it.
+  const viewingCompleted = useCanvasStore((s) => !!s.bySessionId[sessionId]?.completed)
   const mode = useCanvasStore((s) => s.bySessionId[sessionId]?.interactionMode ?? 'browse')
   const setInteractionMode = useCanvasStore((s) => s.setInteractionMode)
   const setActiveVersion = useCanvasStore((s) => s.setActiveVersion)
@@ -1433,6 +1438,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             Region
           </button>
         </div>
+        {/* Subject-level sign-off (#476): with the leave actions, away from the
+            per-round controls in the panel. Shows the Completed chip + Reopen
+            when the user is viewing a canvas already signed off. */}
+        <CanvasCompleteButton sessionId={sessionId} canvasId={canvasId} title={canvasTitle} />
         <button
           onClick={() => togglePane(sessionId)}
           disabled={returning}
@@ -1719,7 +1728,7 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
             the review, and keeping it out means the panel's own file is
             untouched by this change. The panel keeps its own width and left
             border; this column just stacks the two. */}
-        {panelHidden ? (
+        {viewingCompleted ? null : panelHidden ? (
           /* Collapsed rail (item C): the panel is away, the page has the width,
              and this keeps the outstanding count and the way back. */
           <button

--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1417,9 +1417,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
               setInteractionMode(sessionId, 'draw')
             }}
             aria-pressed={sketchActive}
+            disabled={viewingCompleted}
             className={chipClass(sketchActive, false)}
             style={chipStyle(sketchActive)}
-            title="Sketch — the glass takes the pointer; draw over the content, then attach the strokes to a note"
+            title={viewingCompleted ? 'This canvas is signed off — Reopen it to annotate again' : 'Sketch — the glass takes the pointer; draw over the content, then attach the strokes to a note'}
             data-testid="canvas-tool-sketch"
           >
             <ToolIcon kind="sketch" />
@@ -1428,10 +1429,10 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
           <button
             onClick={() => setMarqueeArmed(sessionId, !marqueeArmed)}
             aria-pressed={regionActive}
-            disabled={!viewport}
+            disabled={!viewport || viewingCompleted}
             className={chipClass(regionActive, false)}
             style={chipStyle(regionActive)}
-            title="Region — drag a rectangle to select an area for a note (Esc cancels)"
+            title={viewingCompleted ? 'This canvas is signed off — Reopen it to annotate again' : 'Region — drag a rectangle to select an area for a note (Esc cancels)'}
             data-testid="canvas-tool-region"
           >
             <ToolIcon kind="region" />

--- a/src/renderer/components/CanvasCompleteButton.tsx
+++ b/src/renderer/components/CanvasCompleteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useArmedConfirm } from '../hooks/useArmedConfirm'
 import { useCanvasStore } from '../stores/canvasStore'
 import {
@@ -34,7 +34,16 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
   const [armed, setArmed] = useState(false)
   const [busy, setBusy] = useState(false)
   const [refused, setRefused] = useState<string | null>(null)
-  const confirm = useArmedConfirm(armed ? 'complete' : null)
+  // Key the guard on the CANVAS, not a bare literal (adversarial review): the
+  // pane switches subject under a mounted button (picker / library / a filing),
+  // and a stale `armed` from canvas A must not sign off canvas B.
+  const confirm = useArmedConfirm(armed ? `complete:${canvasId}` : null)
+
+  // Disarm the moment the subject changes under us — so does the refusal.
+  useEffect(() => {
+    setArmed(false)
+    setRefused(null)
+  }, [canvasId])
 
   const completed = useCanvasStore((s) => s.bySessionId[sessionId]?.completed)
   const awaitingReview = useCanvasStore((s) => !!s.bySessionId[sessionId]?.awaitingReview)
@@ -43,34 +52,75 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
   // "Nothing left owed either way" — the renderer's mirror of the main-side
   // guard, over the same review state the panel renders. `waitingOn: 'closed'`
   // means every note on the round reached a terminal state.
-  const groups = review && review.canvasId === canvasId ? reviewGroupsOf(review) : []
-  const draftCount = review && review.canvasId === canvasId ? draftAnnotationsOf(review).length : 0
+  //
+  // Fail CLOSED when the review mirror is missing or points at a DIFFERENT
+  // canvas (the window right after a subject switch, before the mirror
+  // refreshes): "unknown" is not "nothing owed", so the button blocks rather
+  // than offering a sign-off it cannot vouch for. Main re-checks regardless.
+  const mirrorReady = !!review && review.canvasId === canvasId
+  const groups = mirrorReady ? reviewGroupsOf(review) : []
+  const draftCount = mirrorReady ? draftAnnotationsOf(review).length : 0
   const openRounds = groups.filter((g) => g.waitingOn !== 'closed').length
-  const blocked = openRounds > 0 || draftCount > 0 || awaitingReview
+  const blocked = !mirrorReady || openRounds > 0 || draftCount > 0 || awaitingReview
+
+  // If the state turns owed while armed, stand down — the confirm must not sit
+  // live over a canvas that is no longer completeable (main would refuse it).
+  useEffect(() => {
+    if (blocked && armed) setArmed(false)
+  }, [blocked, armed])
+
+  const [reopening, setReopening] = useState(false)
+  const doReopen = async () => {
+    if (reopening) return
+    setReopening(true)
+    try {
+      const res = await window.electronAPI.canvas.completeReopen({ sessionId, canvasId })
+      // A refusal (ownership) or a rejection (bad payload) must not be a silent
+      // dead click — surface it where the other two Reopen call sites do.
+      if (!res?.ok) setRefused(res?.reason ?? 'could not reopen')
+    } catch {
+      setRefused('could not reopen')
+    } finally {
+      setReopening(false)
+    }
+  }
 
   if (completed) {
     return (
-      <span
-        className="shrink-0 flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2 py-0.5"
-        style={{
-          color: 'var(--status-success)',
-          background: 'color-mix(in srgb, var(--status-success) 12%, transparent)',
-          border: '1px solid color-mix(in srgb, var(--status-success) 40%, transparent)',
-        }}
-        data-testid="canvas-completed-chip"
-        title={`Signed off ${completed.by === 'agent' ? 'by the agent on your instruction' : 'by you'}. Reopen puts it back in play.`}
-      >
-        ✓ Completed
-        <button
-          onClick={() => void window.electronAPI.canvas.completeReopen({ sessionId, canvasId })}
-          className="underline underline-offset-2 font-normal focus-ring rounded"
-          style={{ color: 'var(--brand)' }}
-          data-testid="canvas-completed-reopen"
-          title="Put this canvas back in play"
+      <>
+        {refused && (
+          <span
+            className="shrink-0 text-[10px] max-w-[220px] truncate"
+            style={{ color: 'var(--status-danger)' }}
+            data-testid="canvas-complete-refused"
+            title={refused}
+          >
+            {refused}
+          </span>
+        )}
+        <span
+          className="shrink-0 flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2 py-0.5"
+          style={{
+            color: 'var(--status-success)',
+            background: 'color-mix(in srgb, var(--status-success) 12%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--status-success) 40%, transparent)',
+          }}
+          data-testid="canvas-completed-chip"
+          title={`Signed off ${completed.by === 'agent' ? 'by the agent on your instruction' : 'by you'}. Reopen puts it back in play.`}
         >
-          Reopen
-        </button>
-      </span>
+          ✓ Completed
+          <button
+            onClick={() => void doReopen()}
+            disabled={reopening}
+            className="underline underline-offset-2 font-normal focus-ring rounded disabled:opacity-40"
+            style={{ color: 'var(--brand)' }}
+            data-testid="canvas-completed-reopen"
+            title="Put this canvas back in play"
+          >
+            Reopen
+          </button>
+        </span>
+      </>
     )
   }
 
@@ -125,7 +175,7 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
           <button
             ref={confirm.confirmRef}
             onClick={confirm.guarded(() => void doComplete())}
-            disabled={busy}
+            disabled={busy || blocked}
             className="shrink-0 flex items-center gap-1.5 text-[11.5px] font-semibold rounded px-2 py-0.5 focus-ring disabled:opacity-40"
             style={{
               // Text-on-bright-fill uses --surface-chrome, the header's own

--- a/src/renderer/components/CanvasCompleteButton.tsx
+++ b/src/renderer/components/CanvasCompleteButton.tsx
@@ -105,7 +105,12 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
   return (
     <>
       {refused && (
-        <span className="shrink-0 text-[10px]" style={{ color: 'var(--status-danger)' }} data-testid="canvas-complete-refused">
+        <span
+          className="shrink-0 text-[10px] max-w-[220px] truncate"
+          style={{ color: 'var(--status-danger)' }}
+          data-testid="canvas-complete-refused"
+          title={refused}
+        >
           {refused}
         </span>
       )}
@@ -123,7 +128,10 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
             disabled={busy}
             className="shrink-0 flex items-center gap-1.5 text-[11.5px] font-semibold rounded px-2 py-0.5 focus-ring disabled:opacity-40"
             style={{
-              color: 'var(--color-crust)',
+              // Text-on-bright-fill uses --surface-chrome, the header's own
+              // convention — --color-crust fails 4.5:1 on the light theme's
+              // success green.
+              color: 'var(--surface-chrome)',
               background: 'var(--status-success)',
               border: '1px solid color-mix(in srgb, var(--status-success) 55%, transparent)',
             }}

--- a/src/renderer/components/CanvasCompleteButton.tsx
+++ b/src/renderer/components/CanvasCompleteButton.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react'
+import { useArmedConfirm } from '../hooks/useArmedConfirm'
+import { useCanvasStore } from '../stores/canvasStore'
+import {
+  draftAnnotationsOf,
+  reviewGroupsOf,
+  useCanvasReviewStore,
+} from '../stores/canvasReviewStore'
+
+interface Props {
+  sessionId: string
+  canvasId: string
+  /** Named on the confirm, so the second click says WHAT it signs off. */
+  title?: string
+}
+
+/**
+ * The subject-level sign-off (#476), in the pane header's leave cluster.
+ *
+ * "Mark complete" is offered only when nothing is owed either way — no
+ * unsubmitted notes, no notes with the agent, no verdicts owed, no
+ * ready-render awaiting a first review. While anything is, the button stays
+ * visible but disabled and says why: completion means the review cycle
+ * FINISHED, not that the user wants to stop looking at it (that is dismiss).
+ *
+ * Two-step via useArmedConfirm like every other terminal action; the confirm
+ * names the subject. Main re-checks the same "nothing owed" rule and
+ * ownership — this predicate is the label, not the boundary.
+ *
+ * On a canvas already completed (the user reopened it from the library to
+ * look), the slot shows the Completed chip with the one-click Reopen instead.
+ */
+export default function CanvasCompleteButton({ sessionId, canvasId, title }: Props) {
+  const [armed, setArmed] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [refused, setRefused] = useState<string | null>(null)
+  const confirm = useArmedConfirm(armed ? 'complete' : null)
+
+  const completed = useCanvasStore((s) => s.bySessionId[sessionId]?.completed)
+  const awaitingReview = useCanvasStore((s) => !!s.bySessionId[sessionId]?.awaitingReview)
+  const review = useCanvasReviewStore((s) => s.bySessionId[sessionId])
+
+  // "Nothing left owed either way" — the renderer's mirror of the main-side
+  // guard, over the same review state the panel renders. `waitingOn: 'closed'`
+  // means every note on the round reached a terminal state.
+  const groups = review && review.canvasId === canvasId ? reviewGroupsOf(review) : []
+  const draftCount = review && review.canvasId === canvasId ? draftAnnotationsOf(review).length : 0
+  const openRounds = groups.filter((g) => g.waitingOn !== 'closed').length
+  const blocked = openRounds > 0 || draftCount > 0 || awaitingReview
+
+  if (completed) {
+    return (
+      <span
+        className="shrink-0 flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2 py-0.5"
+        style={{
+          color: 'var(--status-success)',
+          background: 'color-mix(in srgb, var(--status-success) 12%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--status-success) 40%, transparent)',
+        }}
+        data-testid="canvas-completed-chip"
+        title={`Signed off ${completed.by === 'agent' ? 'by the agent on your instruction' : 'by you'}. Reopen puts it back in play.`}
+      >
+        ✓ Completed
+        <button
+          onClick={() => void window.electronAPI.canvas.completeReopen({ sessionId, canvasId })}
+          className="underline underline-offset-2 font-normal focus-ring rounded"
+          style={{ color: 'var(--brand)' }}
+          data-testid="canvas-completed-reopen"
+          title="Put this canvas back in play"
+        >
+          Reopen
+        </button>
+      </span>
+    )
+  }
+
+  const doComplete = async () => {
+    if (busy) return
+    setBusy(true)
+    try {
+      const res = await window.electronAPI.canvas.complete({ sessionId, canvasId })
+      if (!res.ok) {
+        // Main refused (the counts moved under us, or ownership) — say why in
+        // place and disarm; the state push will re-derive `blocked`.
+        setRefused(res.reason ?? 'could not complete')
+        setArmed(false)
+      }
+      // On success the change push detaches the canvas and the pane falls
+      // back to its front page — nothing to do here.
+    } catch {
+      setRefused('could not complete')
+      setArmed(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const blockedTip =
+    draftCount > 0
+      ? `You have ${draftCount} unsubmitted note${draftCount === 1 ? '' : 's'} — submit or delete them before signing off.`
+      : openRounds > 0
+        ? `${openRounds} review${openRounds === 1 ? ' is' : 's are'} still open — give your verdicts, or dismiss, before signing off.`
+        : 'A render is still awaiting your first review — review or dismiss it before signing off.'
+
+  return (
+    <>
+      {refused && (
+        <span className="shrink-0 text-[10px]" style={{ color: 'var(--status-danger)' }} data-testid="canvas-complete-refused">
+          {refused}
+        </span>
+      )}
+      {armed ? (
+        <>
+          <button
+            onClick={() => setArmed(false)}
+            className="shrink-0 text-[11px] rounded px-1.5 py-0.5 border border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] focus-ring"
+          >
+            Cancel
+          </button>
+          <button
+            ref={confirm.confirmRef}
+            onClick={confirm.guarded(() => void doComplete())}
+            disabled={busy}
+            className="shrink-0 flex items-center gap-1.5 text-[11.5px] font-semibold rounded px-2 py-0.5 focus-ring disabled:opacity-40"
+            style={{
+              color: 'var(--color-crust)',
+              background: 'var(--status-success)',
+              border: '1px solid color-mix(in srgb, var(--status-success) 55%, transparent)',
+            }}
+            data-testid="canvas-complete-confirm"
+            title="Signs the subject off. The pane returns to the front page; the canvas stays in the Library, reopenable in one click."
+          >
+            ✓ Complete{title ? ` “${title}”` : ' this canvas'}
+          </button>
+        </>
+      ) : (
+        <button
+          onClick={() => {
+            setRefused(null)
+            setArmed(true)
+          }}
+          disabled={blocked || busy}
+          className="shrink-0 flex items-center gap-1.5 text-[11.5px] rounded px-2 py-0.5 focus-ring disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{
+            color: 'var(--status-success)',
+            background: 'color-mix(in srgb, var(--status-success) 8%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--status-success) 45%, transparent)',
+          }}
+          data-testid="canvas-complete-arm"
+          title={
+            blocked
+              ? blockedTip
+              : 'Sign this canvas off — the pane returns to the front page; find it again in the Library'
+          }
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M20 6L9 17l-5-5" />
+          </svg>
+          Mark complete
+        </button>
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/CanvasCompleteButton.tsx
+++ b/src/renderer/components/CanvasCompleteButton.tsx
@@ -39,15 +39,18 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
   // and a stale `armed` from canvas A must not sign off canvas B.
   const confirm = useArmedConfirm(armed ? `complete:${canvasId}` : null)
 
-  // Disarm the moment the subject changes under us — so does the refusal.
-  useEffect(() => {
-    setArmed(false)
-    setRefused(null)
-  }, [canvasId])
-
   const completed = useCanvasStore((s) => s.bySessionId[sessionId]?.completed)
   const awaitingReview = useCanvasStore((s) => !!s.bySessionId[sessionId]?.awaitingReview)
   const review = useCanvasReviewStore((s) => s.bySessionId[sessionId])
+
+  // Disarm the moment the subject changes under us — so does the refusal.
+  // Also when the canvas flips to completed under a mounted button (a sign-off
+  // landing, or a reopen→complete round trip): a stale `armed` must not carry
+  // into the chip and back out ready to fire (adversarial review round 2).
+  useEffect(() => {
+    setArmed(false)
+    setRefused(null)
+  }, [canvasId, completed])
 
   // "Nothing left owed either way" — the renderer's mirror of the main-side
   // guard, over the same review state the panel renders. `waitingOn: 'closed'`
@@ -76,8 +79,11 @@ export default function CanvasCompleteButton({ sessionId, canvasId, title }: Pro
     try {
       const res = await window.electronAPI.canvas.completeReopen({ sessionId, canvasId })
       // A refusal (ownership) or a rejection (bad payload) must not be a silent
-      // dead click — surface it where the other two Reopen call sites do.
-      if (!res?.ok) setRefused(res?.reason ?? 'could not reopen')
+      // dead click — surface it where the other two Reopen call sites do. But
+      // "not completed" means the canvas is ALREADY reopened (a double-fire, or
+      // the push already cleared the stamp), which is success, not an error
+      // (adversarial review round 2) — so don't show it.
+      if (!res?.ok && res?.reason !== 'not completed') setRefused(res?.reason ?? 'could not reopen')
     } catch {
       setRefused('could not reopen')
     } finally {

--- a/src/renderer/components/CanvasEmptyState.tsx
+++ b/src/renderer/components/CanvasEmptyState.tsx
@@ -98,6 +98,25 @@ const DANGER_CLASS =
 export default function CanvasEmptyState({ sessionId, onClose }: Props) {
   const emptyView = useCanvasStore((s) => s.bySessionId[sessionId]?.emptyView ?? 'intro')
   const setEmptyView = useCanvasStore((s) => s.setEmptyView)
+  const completedNotice = useCanvasStore((s) => s.bySessionId[sessionId]?.completedNotice ?? null)
+  const dismissCompleted = useCanvasStore((s) => s.dismissCompleted)
+  // Reopen from the acknowledgment: clear the stamp; main rebinds the canvas
+  // as current (the session shows nothing else right now, by construction),
+  // and the change push swaps the pane back onto it.
+  const reopenCompleted = useCallback(
+    async (canvasId: string) => {
+      try {
+        const res = await window.electronAPI.canvas.completeReopen({ sessionId, canvasId })
+        if (res?.ok) {
+          useCanvasStore.getState().dismissCompleted(sessionId)
+          await useCanvasStore.getState().refresh(sessionId)
+        }
+      } catch {
+        /* the notice stays; nothing was changed */
+      }
+    },
+    [sessionId],
+  )
   const [typed, setTyped] = useState(false)
   const [copied, setCopied] = useState(false)
   const [controlsOpen, setControlsOpen] = useState(false)
@@ -237,6 +256,44 @@ export default function CanvasEmptyState({ sessionId, onClose }: Props) {
       {/* The stage. `canvas-stage` makes this a container query root so the
           sheet answers to the PANE's width, not the window's. */}
       <div className="canvas-stage flex-1 min-h-0 overflow-y-auto px-5 py-7">
+        {/* One quiet acknowledgment for a subject just signed off (#476) —
+            session-local, gone on dismissal, Reopen, or the next render. */}
+        {completedNotice && (
+          <div
+            className="w-full max-w-[840px] mx-auto mb-4 flex items-center gap-2.5 rounded border px-3.5 py-2 text-[12px]"
+            style={{
+              background: 'var(--surface-panel)',
+              borderColor: 'color-mix(in srgb, var(--status-success) 35%, transparent)',
+              color: 'var(--text-secondary)',
+            }}
+            data-testid="canvas-completed-notice"
+          >
+            <span className="font-semibold" style={{ color: 'var(--status-success)' }}>
+              ✓ {completedNotice.title ? `“${completedNotice.title}”` : 'Canvas'} completed
+            </span>
+            <span>· in the Library</span>
+            <button
+              onClick={() => void reopenCompleted(completedNotice.canvasId)}
+              className="underline underline-offset-2 focus-ring rounded"
+              style={{ color: 'var(--brand)' }}
+              data-testid="canvas-completed-notice-reopen"
+              title="Put it back in play — the pane returns to it"
+            >
+              Reopen
+            </button>
+            <div className="flex-1" />
+            <button
+              onClick={() => dismissCompleted(sessionId)}
+              className="text-[11px] focus-ring rounded"
+              style={{ color: 'var(--text-muted)' }}
+              aria-label="Dismiss"
+              title="Dismiss"
+              data-testid="canvas-completed-notice-dismiss"
+            >
+              ✕
+            </button>
+          </div>
+        )}
         <div className="canvas-sheet relative w-full max-w-[840px] mx-auto flex flex-col rounded border border-[var(--border-subtle)] bg-[var(--surface-raised)]">
           <RegistrationMark corner="tl" />
           <RegistrationMark corner="tr" />

--- a/src/renderer/components/CanvasLibrary.tsx
+++ b/src/renderer/components/CanvasLibrary.tsx
@@ -118,6 +118,22 @@ export function CanvasLibrary({
   const libraryOwed = (e: CanvasLibraryEntry): number =>
     (e.awaitingReview ? 1 : 0) + (e.verdictRounds ?? 0)
 
+  /** Reopen a completed canvas (#476): clears the sign-off; obligations (there
+   *  are none, by the completion guard) and history come back as they were. */
+  const reopenCompletedRow = useCallback(async (canvasId: string) => {
+    setBusy(canvasId)
+    setError(null)
+    try {
+      const res = await window.electronAPI.canvas.completeReopen({ sessionId, canvasId })
+      if (res?.ok) await load()
+      else setError('That canvas could not be reopened.')
+    } catch {
+      setError('That canvas could not be reopened.')
+    } finally {
+      setBusy(null)
+    }
+  }, [sessionId, load])
+
   const openHere = useCallback(async (canvasId: string) => {
     setBusy(canvasId)
     setError(null)
@@ -180,7 +196,16 @@ export function CanvasLibrary({
                   without it. The project drops to the second line in that case
                   rather than disappearing. */}
               <div className="flex items-center gap-1.5 text-[12px] text-[var(--text-primary)] truncate" title={e.title || e.cwd}>
-                {e.awaitingReview ? (
+                {e.completed ? (
+                  <span
+                    className="shrink-0 text-[8.5px] font-bold uppercase tracking-[0.05em] rounded px-1 py-px"
+                    style={{ color: 'var(--status-success)', background: 'color-mix(in srgb, var(--status-success) 13%, transparent)' }}
+                    title={`Signed off ${e.completed.by === 'agent' ? 'by the agent on your instruction' : 'by you'}`}
+                    data-testid="canvas-library-completed-badge"
+                  >
+                    Completed
+                  </span>
+                ) : e.awaitingReview ? (
                   <span
                     className="shrink-0 text-[8.5px] font-bold uppercase tracking-[0.05em] rounded px-1 py-px"
                     style={{ color: 'var(--status-warning)', background: 'color-mix(in srgb, var(--status-warning) 14%, transparent)' }}
@@ -251,9 +276,23 @@ export function CanvasLibrary({
               onClick={() => void openHere(e.canvasId)}
               disabled={busy === e.canvasId}
               className="shrink-0 text-[11px] rounded px-2 py-0.5 border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-50 focus-ring"
+              title={e.completed ? 'Look at the completed canvas — read-only until you Reopen it' : undefined}
             >
-              Open here
+              {e.completed ? 'View' : 'Open here'}
             </button>
+            {/* Reopen (#476): only on rows this session owns — a foreign
+                canvas's sign-off is its owner's to undo. */}
+            {e.completed && e.ownedByThisSession && (
+              <button
+                onClick={() => void reopenCompletedRow(e.canvasId)}
+                disabled={busy === e.canvasId}
+                className="shrink-0 text-[11px] rounded px-2 py-0.5 border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-50 focus-ring"
+                data-testid="canvas-library-reopen"
+                title="Put this canvas back in play — clears the Completed sign-off"
+              >
+                Reopen
+              </button>
+            )}
             {confirming === e.canvasId ? (
               <button
                 ref={deleteConfirm.confirmRef}

--- a/src/renderer/components/CanvasSubjectPicker.tsx
+++ b/src/renderer/components/CanvasSubjectPicker.tsx
@@ -270,6 +270,18 @@ function owedRounds(e: CanvasLibraryEntry): number {
 /** The row's waiting-on-you badge — REVIEW (warning) outranks VERDICT (peach)
  *  when a canvas owes both; quiet rows carry no chip at all. */
 function QueueBadge({ entry }: { entry: CanvasLibraryEntry }) {
+  if (entry.completed) {
+    return (
+      <span
+        className="shrink-0 text-[8.5px] font-bold uppercase tracking-[0.05em] rounded px-1 py-px"
+        style={{ color: 'var(--status-success)', background: 'color-mix(in srgb, var(--status-success) 13%, transparent)' }}
+        title={`Signed off ${entry.completed.by === 'agent' ? 'by the agent on your instruction' : 'by you'}`}
+        data-testid="canvas-row-badge-completed"
+      >
+        Completed
+      </span>
+    )
+  }
   if (entry.awaitingReview) {
     return (
       <span

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -5,7 +5,7 @@
 // old Draw button (spec D2), and its empty state is the classic sketchpad.
 
 import { create } from 'zustand'
-import type { CanvasAwaitingReview, CanvasState, CanvasVersion } from '../../shared/canvas'
+import type { CanvasAwaitingReview, CanvasCompletion, CanvasState, CanvasVersion } from '../../shared/canvas'
 import { useExcalidrawStore } from './excalidrawStore'
 import { useCanvasReviewStore } from './canvasReviewStore'
 import { useCanvasTotalsStore } from './canvasTotalsStore'
@@ -46,6 +46,14 @@ export interface CanvasSessionState {
    *  underneath it changed); it just had nowhere to say so. Cleared when the
    *  user dismisses it or goes back. */
   filedNotice?: FiledNotice | null
+  /** Signed off (#476) — present only when the pane is showing a completed
+   *  canvas the user deliberately reopened to view; the working chrome swaps
+   *  for a Completed chip and note-taking is off. */
+  completed?: CanvasCompletion
+  /** The subject just signed off under this session (#476): the front page
+   *  shows one quiet acknowledgment row with a Reopen. Cleared by dismissal,
+   *  by Reopen, or by the next canvas appearing. */
+  completedNotice?: { canvasId: string; title?: string } | null
   loaded: boolean
 }
 
@@ -79,6 +87,8 @@ interface CanvasStoreState {
   cancelExpectedSwitch: (sessionId: string) => void
   noteFiled: (sessionId: string, notice: FiledNotice) => void
   dismissFiled: (sessionId: string) => void
+  noteCompleted: (sessionId: string, notice: { canvasId: string; title?: string }) => void
+  dismissCompleted: (sessionId: string) => void
   reset: () => void
 }
 
@@ -90,12 +100,13 @@ const EMPTY: CanvasSessionState = {
   emptyView: 'intro',
   unseenRender: false,
   filedNotice: null,
+  completedNotice: null,
   loaded: false,
 }
 
 function fromMain(prev: CanvasSessionState | undefined, state: CanvasState | null): CanvasSessionState {
   const base = prev ?? EMPTY
-  if (!state) return { ...base, canvasId: null, title: undefined, versions: [], activeVersionId: null, awaitingReview: undefined, loaded: true }
+  if (!state) return { ...base, canvasId: null, title: undefined, versions: [], activeVersionId: null, awaitingReview: undefined, completed: undefined, loaded: true }
   return {
     ...base,
     canvasId: state.canvasId,
@@ -103,6 +114,9 @@ function fromMain(prev: CanvasSessionState | undefined, state: CanvasState | nul
     versions: state.versions,
     activeVersionId: state.activeVersionId,
     awaitingReview: state.awaitingReview,
+    completed: state.completed,
+    // A live canvas on screen replaces the sign-off acknowledgment.
+    completedNotice: null,
     loaded: true,
   }
 }
@@ -208,6 +222,24 @@ export const useCanvasStore = create<CanvasStoreState>((set, get) => ({
     })
   },
 
+  noteCompleted: (sessionId: string, notice: { canvasId: string; title?: string }) => {
+    set((s) => ({
+      bySessionId: {
+        ...s.bySessionId,
+        [sessionId]: { ...(s.bySessionId[sessionId] ?? EMPTY), completedNotice: notice },
+      },
+    }))
+  },
+
+  dismissCompleted: (sessionId: string) => {
+    set((s) => {
+      if (!s.bySessionId[sessionId]?.completedNotice) return {}
+      return {
+        bySessionId: { ...s.bySessionId, [sessionId]: { ...s.bySessionId[sessionId], completedNotice: null } },
+      }
+    })
+  },
+
   setActiveVersion: async (sessionId: string, versionId: string) => {
     try {
       const state = await window.electronAPI.canvas.setActiveVersion({ sessionId, versionId })
@@ -256,8 +288,19 @@ export function setupCanvasListener(): void {
     // canvas goes AWAY (deleted from the library, possibly from another
     // session's window). Pulsing there promises the owning session something
     // new to look at and then shows it an empty pane.
-    if (event.activeVersionId && !useExcalidrawStore.getState().bySessionId[event.sessionId]?.isOpen) {
+    if (event.activeVersionId && !event.completed && !useExcalidrawStore.getState().bySessionId[event.sessionId]?.isOpen) {
+      // (A sign-off is not news to review — no pulse for it.)
       store.markUnseenRender(event.sessionId)
+    }
+    // SIGN-OFF (#476): the subject completed and the session detached from the
+    // canvas. Capture the title from the mirror as it stands NOW — the refresh
+    // below comes back empty — so the front page can name what completed.
+    if (event.completed) {
+      const cur = store.bySessionId[event.sessionId]
+      store.noteCompleted(event.sessionId, {
+        canvasId: event.canvasId,
+        title: cur?.canvasId === event.canvasId ? cur.title : undefined,
+      })
     }
     // FILING: the canvas under this session changed identity. That happens when
     // the agent names a different subject — the canvas the user was reviewing is

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -288,8 +288,9 @@ export function setupCanvasListener(): void {
     // canvas goes AWAY (deleted from the library, possibly from another
     // session's window). Pulsing there promises the owning session something
     // new to look at and then shows it an empty pane.
-    if (event.activeVersionId && !event.completed && !useExcalidrawStore.getState().bySessionId[event.sessionId]?.isOpen) {
-      // (A sign-off is not news to review — no pulse for it.)
+    if (event.activeVersionId && !event.completed && !event.reopened && !useExcalidrawStore.getState().bySessionId[event.sessionId]?.isOpen) {
+      // (A sign-off is not news to review, and a reopen is the user's own
+      // gesture — no pulse for either.)
       store.markUnseenRender(event.sessionId)
     }
     // SIGN-OFF (#476): the subject completed and the session detached from the
@@ -314,8 +315,11 @@ export function setupCanvasListener(): void {
     // had actually asked for then arrived looking like a filing.
     // Named rather than inlined so the consume can be gated on it too — and
     // typed as the id it is, so the notice below keeps its narrowing.
+    // A REOPEN can name a canvas that is not the session's current one — the
+    // library row's Reopen — and nothing was filed by it; the detector must
+    // stand down or it announces a filing that never happened (#476).
     const filedCanvasId: string | null =
-      prev?.canvasId && event.canvasId && event.canvasId !== prev.canvasId ? prev.canvasId : null
+      !event.reopened && prev?.canvasId && event.canvasId && event.canvasId !== prev.canvasId ? prev.canvasId : null
     const userAsked = filedCanvasId !== null && consumeExpectedSwitch(event.sessionId)
     if (!userAsked && filedCanvasId !== null) {
       // Counted from the review mirror as it stands NOW, before the refresh

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -317,9 +317,15 @@ export function setupCanvasListener(): void {
     // typed as the id it is, so the notice below keeps its narrowing.
     // A REOPEN can name a canvas that is not the session's current one — the
     // library row's Reopen — and nothing was filed by it; the detector must
-    // stand down or it announces a filing that never happened (#476).
+    // stand down or it announces a filing that never happened (#476). Same
+    // for a render while VIEWING a completed canvas: the fresh canvas that
+    // starts is not a filing of the signed-off one — it was already in the
+    // library, and "I filed it when the agent started a different subject"
+    // would be false twice over.
     const filedCanvasId: string | null =
-      !event.reopened && prev?.canvasId && event.canvasId && event.canvasId !== prev.canvasId ? prev.canvasId : null
+      !event.reopened && prev?.canvasId && !prev.completed && event.canvasId && event.canvasId !== prev.canvasId
+        ? prev.canvasId
+        : null
     const userAsked = filedCanvasId !== null && consumeExpectedSwitch(event.sessionId)
     if (!userAsked && filedCanvasId !== null) {
       // Counted from the review mirror as it stands NOW, before the refresh

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -322,11 +322,17 @@ export function setupCanvasListener(): void {
     // starts is not a filing of the signed-off one — it was already in the
     // library, and "I filed it when the agent started a different subject"
     // would be false twice over.
-    const filedCanvasId: string | null =
-      !event.reopened && prev?.canvasId && !prev.completed && event.canvasId && event.canvasId !== prev.canvasId
-        ? prev.canvasId
-        : null
-    const userAsked = filedCanvasId !== null && consumeExpectedSwitch(event.sessionId)
+    // SWITCHED (identity changed) and FILED (that change is worth announcing)
+    // are separate questions: an announced switch AWAY FROM a completed canvas
+    // is a real identity change whose expectation must still be CONSUMED, or
+    // the leftover expectation would swallow the next genuine filing — even
+    // though nothing was filed by it (the completed canvas was already
+    // library history, so the strip stands down).
+    const switched = Boolean(
+      !event.reopened && prev?.canvasId && event.canvasId && event.canvasId !== prev.canvasId,
+    )
+    const userAsked = switched && consumeExpectedSwitch(event.sessionId)
+    const filedCanvasId: string | null = switched && !prev!.completed ? prev!.canvasId : null
     if (!userAsked && filedCanvasId !== null) {
       // Counted from the review mirror as it stands NOW, before the refresh
       // below follows the session to its new canvas. This is the only moment

--- a/src/renderer/stores/canvasTotalsStore.ts
+++ b/src/renderer/stores/canvasTotalsStore.ts
@@ -85,6 +85,11 @@ export function totalsFromEntries(entries: CanvasLibraryEntry[]): CanvasTotals {
   const t: CanvasTotals = { ...defaultTotals(), loaded: true }
   for (const e of entries) {
     if (!e.ownedByThisSession && !e.isActiveForThisSession) continue
+    // A signed-off canvas (#476) is terminal history: it owes nothing and is
+    // not part of the working count or the queue. By invariant it carries no
+    // awaitingReview/verdictRounds, but skip it outright so a stale count can
+    // never surface a completed canvas in the pill.
+    if (e.completed) continue
     t.canvases++
     // ONE canvas is at most ONE owed item (#470, owner: "a count above 1 is
     // legitimate across different canvases, never for the same item") — one

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -415,6 +415,11 @@ export interface ElectronAPI {
      *  canvases (close-outs + awaiting-first-review clears). The Canvas
      *  button's right-click. `unreadable` mirrors the queue's "unknown". */
     reviewDismissAll: (args: { sessionId: string; openTileSessionIds?: string[] }) => Promise<{ closedNotes: number; closedReviews: number; clearedAwaiting: number; unreadable: number }>
+    /** Sign the subject off (#476). Refused (`ok:false` + reason) while
+     *  anything is owed either way; the pane then shows its front page. */
+    complete: (args: { sessionId: string; canvasId: string }) => Promise<{ ok: boolean; reason?: string; state?: CanvasState }>
+    /** The one-click undo: clear a canvas's completed stamp. */
+    completeReopen: (args: { sessionId: string; canvasId: string }) => Promise<{ ok: boolean; reason?: string; state?: CanvasState }>
     onReviewChanged: (cb: (e: CanvasReviewChangedEvent) => void) => () => void
   }
   discovery: {

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -89,6 +89,14 @@ export interface CanvasAwaitingReview {
   at: string
 }
 
+/** Canvas-level sign-off (#476): the subject reached its terminal COMPLETE
+ *  state. `by: 'agent'` is only ever written on the user's explicit
+ *  instruction and is rendered as such; reopening clears the stamp. */
+export interface CanvasCompletion {
+  at: string
+  by: 'user' | 'agent'
+}
+
 /** What the renderer holds per session (IPC `canvas:getState` result). */
 export interface CanvasState {
   canvasId: string
@@ -101,6 +109,9 @@ export interface CanvasState {
   title?: string
   /** Present while a ready-marked render awaits the user's first review. */
   awaitingReview?: CanvasAwaitingReview
+  /** Present once the subject is signed off (#476). Terminal: renders are
+   *  refused while it stands; Reopen clears it. */
+  completed?: CanvasCompletion
 }
 
 /** Longest canvas title kept. A title names a subject; it is not a description. */
@@ -114,6 +125,10 @@ export interface CanvasChangedEvent {
   /** True when this change is a DRAFT render (#366): the mirrors refresh, but
    *  nothing may surface to the user — no pulse, no count, no pane switch. */
   draft?: boolean
+  /** True when this change is the subject being signed off (#476), so the
+   *  renderer can show the front-page acknowledgment for THIS transition and
+   *  not for ordinary refreshes. */
+  completed?: boolean
 }
 
 /** Renderer → main render request (dev/test ingress; the `canvas_render` MCP
@@ -1020,6 +1035,10 @@ export interface CanvasLibraryEntry {
    *  where every remaining note is addressed (#364). `undefined` when the
    *  review store could not be read, same rule as openReviewCount. */
   verdictRounds?: number
+  /** The subject was signed off (#476). From the canvas record, so it is
+   *  always present when true — the row shows the Completed badge and offers
+   *  View/Reopen instead of the working controls. */
+  completed?: CanvasCompletion
 }
 
 export interface CanvasSnapshotRequestEvent {

--- a/src/shared/canvas.ts
+++ b/src/shared/canvas.ts
@@ -129,6 +129,10 @@ export interface CanvasChangedEvent {
    *  renderer can show the front-page acknowledgment for THIS transition and
    *  not for ordinary refreshes. */
   completed?: boolean
+  /** True when this change is a completed canvas being REOPENED (#476) — a
+   *  user gesture on a canvas that may not be the session's current one, so
+   *  the filing detector and the attention pulse must both stand down. */
+  reopened?: boolean
 }
 
 /** Renderer → main render request (dev/test ingress; the `canvas_render` MCP

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -403,6 +403,8 @@ export const IPC = {
   CANVAS_REVIEW_MARK_SEEN: 'canvas:reviewMarkSeen',    // renderer -> main: the USER has these addressed notes on screen (releases the agent close-out barrier; no MCP path here, ever)
   CANVAS_REVIEW_CLOSE_OUT: 'canvas:reviewCloseOut',    // renderer -> main: { canvasId } -> bulk-stale one canvas's rounds waiting on the user (the library)
   CANVAS_REVIEW_DISMISS_ALL: 'canvas:reviewDismissAll',// renderer -> main: { sessionId } -> one sweep over the session's own canvases: close-out per canvas + clear awaiting-first-review (the Canvas button's right-click)
+  CANVAS_COMPLETE: 'canvas:complete',                  // renderer -> main: { canvasId, sessionId } -> the USER signs the subject off (#476; refused while anything is owed)
+  CANVAS_COMPLETE_REOPEN: 'canvas:completeReopen',     // renderer -> main: { canvasId } -> clear a canvas's completed stamp (one-click Reopen)
   CANVAS_REVIEW_CHANGED: 'canvas:reviewChanged',       // push: main -> renderer (a review/annotation mutation happened)
 
   // Session Watchdog (#235): auto-retry on rate-limit/overload/safeguard.

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -403,8 +403,8 @@ export const IPC = {
   CANVAS_REVIEW_MARK_SEEN: 'canvas:reviewMarkSeen',    // renderer -> main: the USER has these addressed notes on screen (releases the agent close-out barrier; no MCP path here, ever)
   CANVAS_REVIEW_CLOSE_OUT: 'canvas:reviewCloseOut',    // renderer -> main: { canvasId } -> bulk-stale one canvas's rounds waiting on the user (the library)
   CANVAS_REVIEW_DISMISS_ALL: 'canvas:reviewDismissAll',// renderer -> main: { sessionId } -> one sweep over the session's own canvases: close-out per canvas + clear awaiting-first-review (the Canvas button's right-click)
-  CANVAS_COMPLETE: 'canvas:complete',                  // renderer -> main: { canvasId, sessionId } -> the USER signs the subject off (#476; refused while anything is owed)
-  CANVAS_COMPLETE_REOPEN: 'canvas:completeReopen',     // renderer -> main: { canvasId } -> clear a canvas's completed stamp (one-click Reopen)
+  CANVAS_COMPLETE: 'canvas:complete',                  // renderer -> main: { sessionId, canvasId } -> the USER signs the subject off (#476; refused while anything is owed, or not owned by that session)
+  CANVAS_COMPLETE_REOPEN: 'canvas:completeReopen',     // renderer -> main: { sessionId, canvasId } -> clear a canvas's completed stamp (one-click Reopen; owner-only)
   CANVAS_REVIEW_CHANGED: 'canvas:reviewChanged',       // push: main -> renderer (a review/annotation mutation happened)
 
   // Session Watchdog (#235): auto-retry on rate-limit/overload/safeguard.

--- a/tests/unit/main/canvas-completion.test.ts
+++ b/tests/unit/main/canvas-completion.test.ts
@@ -1,0 +1,267 @@
+// Canvas completion (#476): the subject-level terminal state, driven through
+// the REAL stores (temp resources dir), like canvas-closeout-store.test.ts.
+//
+// What these pin, in order of how much they matter:
+//
+//  1. NOTHING OWED, OR NO SIGN-OFF. Every kind of outstanding work refuses the
+//     completion — an unreviewed ready render, unsubmitted drafts, notes with
+//     the agent, notes awaiting verdicts — and an unreadable review store
+//     refuses rather than signing off what cannot be checked. The guard's
+//     tallies are the queue's own, so the pill and the refusal cannot disagree.
+//  2. OWNERSHIP. Both ingresses name the session they act for; a canvas owned
+//     by another session is refused.
+//  3. TERMINAL MEANS TERMINAL. A completed canvas refuses renders; a new
+//     render under the same title starts a FRESH canvas rather than silently
+//     resuming the one the user signed off. Reopen is the only way back.
+//  4. NOTHING DELETED. Completion detaches and stamps; Reopen restores.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+vi.mock('../../../src/main/ipc/setup-handlers', () => {
+  const nodeFs = require('node:fs') as typeof import('node:fs')
+  const nodeOs = require('node:os') as typeof import('node:os')
+  const nodePath = require('node:path') as typeof import('node:path')
+  const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'ccc-completion-'))
+  return { getResourcesDirectory: () => dir }
+})
+
+const { getResourcesDirectory } = await import('../../../src/main/ipc/setup-handlers')
+const canvasStore = await import('../../../src/main/canvas/canvas-store')
+const reviewStore = await import('../../../src/main/canvas/canvas-review-store')
+const completion = await import('../../../src/main/canvas/canvas-completion')
+const { runCanvasComplete } = await import('../../../src/main/canvas-mcp-tool')
+
+const SID = 'a1b2c3d4e5f6a7b8c9d0e1f2'
+let seq = 0
+
+/** A fresh canvas for this test, under its own title so it never collides. */
+function renderCanvas(ready?: boolean): { canvasId: string; versionId: string; title: string } {
+  const title = `Subject ${++seq}`
+  const r = canvasStore.renderVersion(SID, {
+    mode: 'design',
+    html: '<!doctype html><p>page</p>',
+    title,
+    ...(ready === undefined ? {} : { ready }),
+  })
+  return { canvasId: r.canvasId, versionId: r.versionId, title }
+}
+
+/** A canvas whose whole review cycle FINISHED: render → note → submit →
+ *  addressed → seen → the user approved. Nothing is owed either way. */
+function finishedCycle(): { canvasId: string; title: string } {
+  const { canvasId, versionId, title } = renderCanvas()
+  const { annotationId } = reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'one note', versionId })
+  const submitted = reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews[0].id, [])
+  const reviewId = submitted.reviews.find((r) => r.status === 'submitted')!.id
+  reviewStore.markAnnotationsAddressed(SID, reviewId, [annotationId])
+  reviewStore.markAddressedNotesSeen(SID, canvasId, [annotationId])
+  reviewStore.resolveAnnotation(SID, annotationId, 'approve', canvasId)
+  return { canvasId, title }
+}
+
+const err = (r: unknown): string => (r && typeof r === 'object' && 'error' in r ? String((r as { error: unknown }).error) : '')
+
+beforeEach(() => {
+  // Detach whatever the previous test left current, so each test's render
+  // starts a fresh canvas via its unique title.
+})
+
+describe('the completion guard — nothing owed, or no sign-off', () => {
+  it('refuses while a ready render awaits the user’s first review', () => {
+    const { canvasId } = renderCanvas()
+    const res = completion.completeCanvasGuarded(canvasId, 'agent', SID)
+    expect(err(res)).toContain('awaiting the user’s first review')
+  })
+
+  it('refuses unsubmitted draft notes, and names them', () => {
+    const { canvasId, versionId } = renderCanvas()
+    canvasStore.clearAwaitingReview(canvasId)
+    reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'draft', versionId })
+    const res = completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(err(res)).toContain('unsubmitted note')
+  })
+
+  it('refuses notes still with the agent', () => {
+    const { canvasId, versionId } = renderCanvas()
+    reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'open', versionId })
+    reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews[0].id, [])
+    const res = completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(err(res)).toContain('still with the agent')
+  })
+
+  it('refuses notes awaiting the user’s verdict', () => {
+    const { canvasId, versionId } = renderCanvas()
+    const { annotationId } = reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'n', versionId })
+    const submitted = reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews[0].id, [])
+    const reviewId = submitted.reviews.find((r) => r.status === 'submitted')!.id
+    reviewStore.markAnnotationsAddressed(SID, reviewId, [annotationId])
+    const res = completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(err(res)).toContain('awaiting your verdict')
+  })
+
+  it('fails CLOSED on an unreadable review store', () => {
+    const { canvasId } = finishedCycle()
+    // Corrupt the reviews.json under the store: a file that exists but will
+    // not read must refuse the sign-off, never count as "nothing owed".
+    const reviewsPath = path.join(getResourcesDirectory(), 'canvas', canvasId, 'reviews.json')
+    expect(fs.existsSync(reviewsPath)).toBe(true)
+    fs.writeFileSync(reviewsPath, '{ not json')
+    reviewStore.dropReviewsForCanvas(canvasId)
+    const res = completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(err(res)).toContain('could not be read')
+  })
+
+  it('completes a canvas whose whole cycle finished — and a never-annotated one once its ask is cleared', () => {
+    const a = finishedCycle()
+    const resA = completion.completeCanvasGuarded(a.canvasId, 'user', SID)
+    expect(err(resA)).toBe('')
+    expect((resA as { completed?: { by: string } }).completed?.by).toBe('user')
+
+    const b = renderCanvas()
+    canvasStore.clearAwaitingReview(b.canvasId)
+    const resB = completion.completeCanvasGuarded(b.canvasId, 'agent', SID)
+    expect(err(resB)).toBe('')
+    expect((resB as { completed?: { by: string } }).completed?.by).toBe('agent')
+  })
+})
+
+describe('what completion does', () => {
+  it('stamps, clears the review-needed ask, detaches the session, and announces itself', () => {
+    const { canvasId } = finishedCycle()
+    const events: Array<{ canvasId: string; completed?: boolean }> = []
+    const off = canvasStore.onCanvasChanged((e) => events.push({ canvasId: e.canvasId, completed: e.completed }))
+    const res = completion.completeCanvasGuarded(canvasId, 'user', SID)
+    off()
+    expect(err(res)).toBe('')
+    // Detached: the session no longer shows this canvas — the pane falls back
+    // to its front page.
+    expect(canvasStore.getCanvasStateForSession(SID)).toBeNull()
+    // The record keeps everything, plus the stamp; the ask is gone.
+    const byId = canvasStore.getCanvasStateById(canvasId)
+    expect(byId?.completed?.by).toBe('user')
+    expect(byId?.awaitingReview).toBeUndefined()
+    expect(events.some((e) => e.canvasId === canvasId && e.completed)).toBe(true)
+  })
+
+  it('refuses ownership it does not have, and refuses twice', () => {
+    const { canvasId } = finishedCycle()
+    expect(err(completion.completeCanvasGuarded(canvasId, 'user', 'ffffffffffffffffffffffff'))).toContain('not this session')
+    expect(err(completion.completeCanvasGuarded(canvasId, 'user', SID))).toBe('')
+    expect(err(completion.completeCanvasGuarded(canvasId, 'user', SID))).toContain('already completed')
+  })
+
+  it('shows up in the library with the stamp', () => {
+    const { canvasId } = finishedCycle()
+    completion.completeCanvasGuarded(canvasId, 'user', SID)
+    const entry = canvasStore.listAllCanvases([], undefined, SID).find((e) => e.canvasId === canvasId)
+    expect(entry?.completed?.by).toBe('user')
+  })
+})
+
+describe('terminal means terminal', () => {
+  it('a render under the SAME title starts a fresh canvas, never resumes the completed one', () => {
+    const { canvasId, title } = finishedCycle()
+    completion.completeCanvasGuarded(canvasId, 'user', SID)
+    const next = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>again</p>', title })
+    expect(next.canvasId).not.toBe(canvasId)
+    // And the completed record was not touched.
+    expect(canvasStore.getCanvasStateById(canvasId)?.completed).toBeTruthy()
+  })
+
+  it('naming a completed subject from another canvas starts fresh as well — not a refusal, not a resume', () => {
+    // The filing lookup must SKIP completed records: with the session parked
+    // on some other canvas, a render naming the completed subject would
+    // otherwise find it as `returnedTo` and die on the terminal refusal.
+    const done = finishedCycle()
+    completion.completeCanvasGuarded(done.canvasId, 'user', SID)
+    renderCanvas() // the session moves on to an unrelated subject
+    const next = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>fresh</p>', title: done.title })
+    expect(next.canvasId).not.toBe(done.canvasId)
+    expect(canvasStore.getCanvasStateById(done.canvasId)?.completed).toBeTruthy()
+  })
+})
+
+describe('reopen', () => {
+  it('clears the stamp and rebinds when the session shows nothing else', () => {
+    const { canvasId } = finishedCycle()
+    completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(canvasStore.getCanvasStateForSession(SID)).toBeNull()
+    const res = completion.reopenCanvasGuarded(canvasId, SID)
+    expect(err(res)).toBe('')
+    expect((res as { completed?: unknown }).completed).toBeUndefined()
+    expect(canvasStore.getCanvasStateForSession(SID)?.canvasId).toBe(canvasId)
+  })
+
+  it('does not steal the session’s current canvas when one exists', () => {
+    const a = finishedCycle()
+    completion.completeCanvasGuarded(a.canvasId, 'user', SID)
+    const b = renderCanvas() // the session moved on
+    const res = completion.reopenCanvasGuarded(a.canvasId, SID)
+    expect(err(res)).toBe('')
+    expect(canvasStore.getCanvasStateForSession(SID)?.canvasId).toBe(b.canvasId)
+  })
+
+  it('refuses a canvas that is not completed, and foreign ownership', () => {
+    const { canvasId } = renderCanvas()
+    expect(err(completion.reopenCanvasGuarded(canvasId, SID))).toContain('not completed')
+    canvasStore.clearAwaitingReview(canvasId)
+    completion.completeCanvasGuarded(canvasId, 'user', SID)
+    expect(err(completion.reopenCanvasGuarded(canvasId, 'ffffffffffffffffffffffff'))).toContain('not this session')
+  })
+})
+
+describe('the MCP surface (canvas_complete)', () => {
+  it('refuses with guidance when the session has no canvas', () => {
+    const r = runCanvasComplete('deadbeefdeadbeefdeadbeef', {
+      getCanvasState: () => null,
+      completeCanvas: () => ({ error: 'unused' }),
+    })
+    expect(r.isError).toBe(true)
+    expect(r.text).toContain('no active canvas')
+  })
+
+  it('passes the settled-refusal through with hand-back guidance', () => {
+    const r = runCanvasComplete(SID, {
+      getCanvasState: () => ({ canvasId: 'c', sessionId: SID, activeVersionId: 'v1', versions: [] }),
+      completeCanvas: () => ({ error: 'not everything is settled: 2 notes awaiting your verdict' }),
+    })
+    expect(r.isError).toBe(true)
+    expect(r.text).toContain('not everything is settled')
+    expect(r.text).toContain('hand back')
+  })
+
+  it('reports success in the provenance’s own words — completed on instruction, never approval', () => {
+    const r = runCanvasComplete(SID, {
+      getCanvasState: () => ({ canvasId: 'c', sessionId: SID, activeVersionId: 'v1', versions: [] }),
+      completeCanvas: () => ({ canvasId: 'c', sessionId: SID, activeVersionId: 'v1', versions: [], completed: { at: 'now', by: 'agent' as const } }),
+    })
+    expect(r.isError).toBe(false)
+    expect(r.text).toContain('on the user’s instruction')
+    expect(r.text).toContain('Reopen')
+  })
+
+  it('the end-to-end agent path: refused before the user has seen the round, allowed after their cycle finished', () => {
+    // Before: a fresh ready render — first-review barrier.
+    const { canvasId } = renderCanvas()
+    const deps = {
+      getCanvasState: (sid: string) => canvasStore.getCanvasStateForSession(sid),
+      completeCanvas: (sid: string, cid: string) => completion.completeCanvasGuarded(cid, 'agent' as const, sid),
+    }
+    const refused = runCanvasComplete(SID, deps)
+    expect(refused.isError).toBe(true)
+    expect(refused.text).toContain('first review')
+    // Finish the cycle on THIS canvas, then the same call signs off.
+    const { versionId } = { versionId: canvasStore.getCanvasStateForSession(SID)!.versions[0].id }
+    const { annotationId } = reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'n', versionId })
+    const submitted = reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews[0].id, [])
+    const reviewId = submitted.reviews.find((r) => r.status === 'submitted')!.id
+    reviewStore.markAnnotationsAddressed(SID, reviewId, [annotationId])
+    reviewStore.markAddressedNotesSeen(SID, canvasId, [annotationId])
+    reviewStore.resolveAnnotation(SID, annotationId, 'approve', canvasId)
+    const ok = runCanvasComplete(SID, deps)
+    expect(ok.isError).toBe(false)
+    expect(canvasStore.getCanvasStateById(canvasId)?.completed?.by).toBe('agent')
+  })
+})

--- a/tests/unit/main/canvas-completion.test.ts
+++ b/tests/unit/main/canvas-completion.test.ts
@@ -70,6 +70,35 @@ describe('the completion guard — nothing owed, or no sign-off', () => {
     expect(err(res)).toContain('awaiting the user’s first review')
   })
 
+  it('ADV: refuses a DRAFT-ONLY canvas — nothing was ever offered to the user', () => {
+    // The draft-render bypass (adversarial): a ready render sets awaitingReview
+    // and writes reviews.json, but a draft (ready:false) does neither — so the
+    // old guard found "nothing owed" and signed off a canvas the user never saw.
+    const title = `Draft only ${++seq}`
+    const r = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>wip</p>', title, ready: false })
+    const res = completion.completeCanvasGuarded(r.canvasId, 'agent', SID)
+    expect(err(res)).toContain('nothing has been offered for review')
+  })
+
+  it('ADV: refuses when the LATEST version is a draft, even over a reviewed ready one', () => {
+    // Finish a real cycle, then the agent renders a fresh DRAFT on top — that
+    // draft is unseen WIP; signing off would stamp complete over it.
+    const done = finishedCycle()
+    canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>wip2</p>', title: done.title, ready: false })
+    const res = completion.completeCanvasGuarded(done.canvasId, 'agent', SID)
+    expect(err(res)).toContain('nothing has been offered for review')
+  })
+
+  it('ADV: checks ownership BEFORE reading review tallies (no cross-session oracle)', () => {
+    // A foreign session naming another session's canvas must be turned away
+    // with the ownership reason, never with that canvas's private note counts.
+    const { canvasId, versionId } = renderCanvas()
+    reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'secret', versionId })
+    reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews[0].id, [])
+    const res = completion.completeCanvasGuarded(canvasId, 'agent', 'ffffffffffffffffffffffff')
+    expect(err(res)).toBe('not this session’s canvas')
+  })
+
   it('refuses unsubmitted draft notes, and names them', () => {
     const { canvasId, versionId } = renderCanvas()
     canvasStore.clearAwaitingReview(canvasId)
@@ -155,6 +184,61 @@ describe('what completion does', () => {
   })
 })
 
+describe('adversarial — reclaim, review-writes, cap, fork', () => {
+  it('a completed canvas is never offered to, or adopted by, another session', () => {
+    // isReclaimCandidate must exclude completed: completion detaches the owner,
+    // so without the check a signed-off canvas looks like an orphan — offered
+    // in the reclaim card and adoptable, handing over its notes AND the right
+    // to Reopen a sign-off the adopter never made.
+    const done = finishedCycle()
+    completion.completeCanvasGuarded(done.canvasId, 'user', SID)
+    const OTHER = 'bbbbbbbbbbbbbbbbbbbbbbbb'
+    const offered = canvasStore.listOrphanCandidateCanvases(OTHER, { isSessionCurrent: () => false })
+    expect(offered.some((c) => c.canvasId === done.canvasId)).toBe(false)
+    const adopted = canvasStore.adoptCanvasForSession(OTHER, done.canvasId, { isSessionCurrent: () => false })
+    expect(adopted).toBeNull()
+  })
+
+  it('a completed canvas refuses new notes and new reviews over the store (terminal, main-side)', () => {
+    const done = finishedCycle()
+    completion.completeCanvasGuarded(done.canvasId, 'user', SID)
+    // The user re-opens it to VIEW (binds it current), then a note write lands.
+    canvasStore.adoptCanvasForSession(SID, done.canvasId, { isSessionCurrent: () => false })
+    const v = canvasStore.getCanvasStateForSession(SID)!.versions[0].id
+    expect(() => reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'sneaky', versionId: v })).toThrow(/signed off/)
+  })
+
+  it('completing then rendering in a loop cannot mint canvases past the cap', () => {
+    // The cap was gated on subjectChanged, which completion makes false — so an
+    // agent that completes-then-renders could mint without bound.
+    let last = ''
+    for (let i = 0; i < 3; i++) {
+      const r = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>x</p>', title: `Loop ${++seq}` })
+      canvasStore.clearAwaitingReview(r.canvasId)
+      completion.completeCanvasGuarded(r.canvasId, 'user', SID)
+      last = r.canvasId
+    }
+    // The count is bounded — every render minted a NEW canvas (held was null
+    // after each completion), and the cap now fires on !existing regardless of
+    // subjectChanged. Prove the cap path is live: it counts completed canvases.
+    expect(canvasStore.listAllCanvases([], undefined, SID).filter((e) => e.completed).length).toBeGreaterThanOrEqual(3)
+    expect(last).not.toBe('')
+  })
+
+  it('completing one subject does not fork a DIFFERENT live filed subject', () => {
+    // A (Login) live+filed, B (Checkout) current & completed → rendering "A"
+    // again must RETURN to A, not mint a duplicate (held is null after the
+    // completion detach, so findFiledCanvas must still be consulted).
+    const a = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>login</p>', title: 'Login page ADV' })
+    const b = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>checkout</p>', title: 'Checkout ADV' })
+    expect(b.canvasId).not.toBe(a.canvasId)
+    canvasStore.clearAwaitingReview(b.canvasId)
+    completion.completeCanvasGuarded(b.canvasId, 'user', SID)
+    const back = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>login2</p>', title: 'Login page ADV' })
+    expect(back.canvasId).toBe(a.canvasId)
+  })
+})
+
 describe('terminal means terminal', () => {
   it('a render under the SAME title starts a fresh canvas, never resumes the completed one', () => {
     // Two guards conspire here: completion DETACHED the session (held is
@@ -182,14 +266,14 @@ describe('terminal means terminal', () => {
 })
 
 describe('survival and viewing', () => {
-  it('signing off the DRAFTING canvas clears the deferred-draft binding with it', () => {
-    // A subject-change DRAFT defers the repoint: the session still shows the
-    // old canvas, and draftIndex lets canvas_snapshot follow the draft. If
-    // that drafting canvas is signed off, the binding must die with the
-    // detach (the dropCanvas rule) — or the agent's self-check would keep
-    // reading a canvas nothing will ever promote.
-    const base = renderCanvas() // the session's current, user-facing canvas
-    canvasStore.clearAwaitingReview(base.canvasId)
+  it('signing off the session’s canvas drops a stranded deferred-draft binding too', () => {
+    // A subject-change DRAFT defers the repoint: sessionIndex stays on the
+    // user-facing base, draftIndex points at the new draft canvas so
+    // canvas_snapshot can follow it. Completing the BASE detaches the session —
+    // and must drop the draft pointer with it, or getAgentCanvasStateForSession
+    // keeps resolving a stale draft the user will never promote (the round-1
+    // fix keyed the delete on the wrong id and missed this).
+    const base = renderCanvas() // ready; the session's current canvas
     const draft = canvasStore.renderVersion(SID, {
       mode: 'design',
       html: '<!doctype html><p>draft</p>',
@@ -197,11 +281,16 @@ describe('survival and viewing', () => {
       ready: false,
     })
     expect(draft.canvasId).not.toBe(base.canvasId)
+    // The deferred draft is agent-visible; the user still sees base.
     expect(canvasStore.getAgentCanvasStateForSession(SID)?.canvasId).toBe(draft.canvasId)
-    const res = completion.completeCanvasGuarded(draft.canvasId, 'user', SID)
+    expect(canvasStore.getCanvasStateForSession(SID)?.canvasId).toBe(base.canvasId)
+    canvasStore.clearAwaitingReview(base.canvasId)
+    const res = completion.completeCanvasGuarded(base.canvasId, 'user', SID)
     expect(err(res)).toBe('')
-    // The agent-facing read falls back to the session's own canvas.
-    expect(canvasStore.getAgentCanvasStateForSession(SID)?.canvasId).toBe(base.canvasId)
+    // Both bindings gone: the session is on the front page, and the agent-side
+    // read no longer resolves the stranded draft.
+    expect(canvasStore.getCanvasStateForSession(SID)).toBeNull()
+    expect(canvasStore.getAgentCanvasStateForSession(SID)).toBeNull()
   })
 
   it('the stamp survives a reload, and a completed canvas never rebinds as current', () => {
@@ -288,6 +377,26 @@ describe('the MCP surface (canvas_complete)', () => {
     expect(r.isError).toBe(false)
     expect(r.text).toContain('on the user’s instruction')
     expect(r.text).toContain('Reopen')
+  })
+
+  it('ADV: a submit that does not cover the awaited version leaves it awaiting, so completion still refuses', () => {
+    // The store-direct race the turn model normally prevents: awaitingReview is
+    // v2 (agent rendered a newer ready render) while the user's note was
+    // authored against v1. submitReview must NOT clear the v2 ask — the user
+    // never saw v2 — and completion must then refuse.
+    const title = `Race ${++seq}`
+    const v1 = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>v1</p>', title, ready: true })
+    // User writes a note against v1 (a draft note, versionId v1).
+    reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'about v1', versionId: v1.versionId })
+    // Agent renders v2 ready (supersedes the ask) BEFORE the user submits.
+    const v2 = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>v2</p>', title, ready: true })
+    expect(v2.versionId).not.toBe(v1.versionId)
+    expect(canvasStore.getCanvasStateForSession(SID)?.awaitingReview?.versionId).toBe(v2.versionId)
+    // User submits their v1 note. The submit does not cover v2.
+    reviewStore.submitReview(SID, reviewStore.getReviewStateForSession(SID)!.reviews.find((r) => r.status === 'draft')!.id, [])
+    // v2 still awaits review → completion refused.
+    expect(canvasStore.getCanvasStateForSession(SID)?.awaitingReview?.versionId).toBe(v2.versionId)
+    expect(err(completion.completeCanvasGuarded(v1.canvasId, 'agent', SID))).toContain('first review')
   })
 
   it('the end-to-end agent path: refused before the user has seen the round, allowed after their cycle finished', () => {

--- a/tests/unit/main/canvas-completion.test.ts
+++ b/tests/unit/main/canvas-completion.test.ts
@@ -182,6 +182,28 @@ describe('terminal means terminal', () => {
 })
 
 describe('survival and viewing', () => {
+  it('signing off the DRAFTING canvas clears the deferred-draft binding with it', () => {
+    // A subject-change DRAFT defers the repoint: the session still shows the
+    // old canvas, and draftIndex lets canvas_snapshot follow the draft. If
+    // that drafting canvas is signed off, the binding must die with the
+    // detach (the dropCanvas rule) — or the agent's self-check would keep
+    // reading a canvas nothing will ever promote.
+    const base = renderCanvas() // the session's current, user-facing canvas
+    canvasStore.clearAwaitingReview(base.canvasId)
+    const draft = canvasStore.renderVersion(SID, {
+      mode: 'design',
+      html: '<!doctype html><p>draft</p>',
+      title: `Deferred ${++seq}`,
+      ready: false,
+    })
+    expect(draft.canvasId).not.toBe(base.canvasId)
+    expect(canvasStore.getAgentCanvasStateForSession(SID)?.canvasId).toBe(draft.canvasId)
+    const res = completion.completeCanvasGuarded(draft.canvasId, 'user', SID)
+    expect(err(res)).toBe('')
+    // The agent-facing read falls back to the session's own canvas.
+    expect(canvasStore.getAgentCanvasStateForSession(SID)?.canvasId).toBe(base.canvasId)
+  })
+
   it('the stamp survives a reload, and a completed canvas never rebinds as current', () => {
     const { canvasId } = finishedCycle()
     completion.completeCanvasGuarded(canvasId, 'user', SID)

--- a/tests/unit/main/canvas-completion.test.ts
+++ b/tests/unit/main/canvas-completion.test.ts
@@ -63,11 +63,6 @@ function finishedCycle(): { canvasId: string; title: string } {
 
 const err = (r: unknown): string => (r && typeof r === 'object' && 'error' in r ? String((r as { error: unknown }).error) : '')
 
-beforeEach(() => {
-  // Detach whatever the previous test left current, so each test's render
-  // starts a fresh canvas via its unique title.
-})
-
 describe('the completion guard — nothing owed, or no sign-off', () => {
   it('refuses while a ready render awaits the user’s first review', () => {
     const { canvasId } = renderCanvas()
@@ -162,6 +157,9 @@ describe('what completion does', () => {
 
 describe('terminal means terminal', () => {
   it('a render under the SAME title starts a fresh canvas, never resumes the completed one', () => {
+    // Two guards conspire here: completion DETACHED the session (held is
+    // null), and even a detached lookup by title skips completed records —
+    // the second is pinned on its own by the another-canvas case below.
     const { canvasId, title } = finishedCycle()
     completion.completeCanvasGuarded(canvasId, 'user', SID)
     const next = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>again</p>', title })
@@ -178,6 +176,34 @@ describe('terminal means terminal', () => {
     completion.completeCanvasGuarded(done.canvasId, 'user', SID)
     renderCanvas() // the session moves on to an unrelated subject
     const next = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>fresh</p>', title: done.title })
+    expect(next.canvasId).not.toBe(done.canvasId)
+    expect(canvasStore.getCanvasStateById(done.canvasId)?.completed).toBeTruthy()
+  })
+})
+
+describe('survival and viewing', () => {
+  it('the stamp survives a reload, and a completed canvas never rebinds as current', () => {
+    const { canvasId } = finishedCycle()
+    completion.completeCanvasGuarded(canvasId, 'user', SID)
+    // Relaunch: memory dropped, records reloaded from disk.
+    canvasStore._resetCanvasStoreForTest()
+    // Rebind skip: the session comes back to the front page, not the
+    // signed-off subject...
+    expect(canvasStore.getCanvasStateForSession(SID)?.canvasId).not.toBe(canvasId)
+    // ...and the stamp round-tripped through sanitizeRecord intact.
+    expect(canvasStore.getCanvasStateById(canvasId)?.completed?.by).toBe('user')
+  })
+
+  it('a render while VIEWING a completed canvas starts fresh instead of dead-ending', () => {
+    // The library's View re-points the session at the completed canvas. A
+    // render there must not refuse forever (the untitled case could never
+    // escape) and must not resume — fresh canvas, viewing record untouched.
+    const done = finishedCycle()
+    completion.completeCanvasGuarded(done.canvasId, 'user', SID)
+    const adopted = canvasStore.adoptCanvasForSession(SID, done.canvasId, { isSessionCurrent: () => false })
+    expect(adopted?.canvasId).toBe(done.canvasId)
+    expect(canvasStore.getCanvasStateForSession(SID)?.canvasId).toBe(done.canvasId)
+    const next = canvasStore.renderVersion(SID, { mode: 'design', html: '<!doctype html><p>new</p>', title: done.title })
     expect(next.canvasId).not.toBe(done.canvasId)
     expect(canvasStore.getCanvasStateById(done.canvasId)?.completed).toBeTruthy()
   })

--- a/tests/unit/main/canvas-completion.test.ts
+++ b/tests/unit/main/canvas-completion.test.ts
@@ -199,13 +199,22 @@ describe('adversarial — reclaim, review-writes, cap, fork', () => {
     expect(adopted).toBeNull()
   })
 
-  it('a completed canvas refuses new notes and new reviews over the store (terminal, main-side)', () => {
+  it('a completed canvas refuses EVERY note-writing mutation over the store (terminal, main-side)', () => {
+    // Round-2 adversarial: the gate must cover the siblings too — reannotate
+    // (resolveAnnotation) MINTS a note, reopenAnnotation REVIVES one. All the
+    // write mutators refuse; the pane's read path (getReviewStateForSession)
+    // stays open so history is still viewable.
     const done = finishedCycle()
     completion.completeCanvasGuarded(done.canvasId, 'user', SID)
-    // The user re-opens it to VIEW (binds it current), then a note write lands.
     canvasStore.adoptCanvasForSession(SID, done.canvasId, { isSessionCurrent: () => false })
     const v = canvasStore.getCanvasStateForSession(SID)!.versions[0].id
-    expect(() => reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'sneaky', versionId: v })).toThrow(/signed off/)
+    expect(() => reviewStore.upsertAnnotation(SID, { scope: 'general', note: 'x', versionId: v })).toThrow(/signed off/)
+    expect(() => reviewStore.resolveAnnotation(SID, 'a1', 'reannotate', done.canvasId)).toThrow(/signed off/)
+    expect(() => reviewStore.reopenAnnotation(SID, 'a1')).toThrow(/signed off/)
+    expect(() => reviewStore.deleteAnnotation(SID, 'a1')).toThrow(/signed off/)
+    expect(() => reviewStore.markAnnotationsAddressed(SID, 'R1', ['a1'])).toThrow(/signed off/)
+    // The history read still works — the pane can show the closed round.
+    expect(reviewStore.getReviewStateForSession(SID)?.canvasId).toBe(done.canvasId)
   })
 
   it('completing then rendering in a loop cannot mint canvases past the cap', () => {

--- a/tests/unit/main/canvas-mcp-tool.test.ts
+++ b/tests/unit/main/canvas-mcp-tool.test.ts
@@ -324,8 +324,9 @@ describe('registration', () => {
   it('advertises canvas_snapshot with a schema the SDK can accept', () => {
     const registered = vi.fn()
     registerCanvasTools({ tool: registered }, z, () => 'sess-mine', deps())
-    // snapshot, render, review, resolve, verdict (#365), pick (chat picks).
-    expect(registered).toHaveBeenCalledTimes(6)
+    // snapshot, render, review, resolve, verdict (#365), pick (chat picks),
+    // complete (#476).
+    expect(registered).toHaveBeenCalledTimes(7)
     const [name, description, shape, handler] = registered.mock.calls[0]
     expect(name).toBe('canvas_snapshot')
     expect(String(description)).toMatch(/scoped/i)
@@ -864,6 +865,7 @@ describe('canvas_render', () => {
     }
     registerCanvasTools(server, z, () => null, deps())
     expect(Object.keys(tools).sort()).toEqual([
+      'canvas_complete',
       'canvas_pick',
       'canvas_render',
       'canvas_resolve',

--- a/tests/unit/renderer/canvas-complete-button.test.tsx
+++ b/tests/unit/renderer/canvas-complete-button.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+//
+// The subject-level sign-off control (#476). What these pin:
+//
+//  - The button is BLOCKED (visible, disabled, explaining itself) while
+//    anything is owed either way — drafts, open rounds, verdicts owed, a
+//    ready render awaiting its first review — over the same review mirror
+//    the panel renders, so button and panel cannot disagree.
+//  - Two-step with the #456 double-click guard; the confirm names the subject.
+//  - A refused completion (main moved under us) surfaces its reason in place.
+//  - On a completed canvas the slot shows the Completed chip + one-click
+//    Reopen instead of the working control.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import type { Annotation, Review } from '../../../src/shared/canvas'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const CanvasCompleteButton = (await import('../../../src/renderer/components/CanvasCompleteButton')).default
+const { useCanvasStore } = await import('../../../src/renderer/stores/canvasStore')
+const { useCanvasReviewStore } = await import('../../../src/renderer/stores/canvasReviewStore')
+
+const SID = 'session-complete'
+const CID = 'canvas-a'
+
+const complete = vi.fn(async (_args: { sessionId: string; canvasId: string }) => ({ ok: true }))
+const completeReopen = vi.fn(async (_args: { sessionId: string; canvasId: string }) => ({ ok: true }))
+;(globalThis as any).window.electronAPI = {
+  ...((globalThis as any).window?.electronAPI ?? {}),
+  canvas: {
+    ...((globalThis as any).window?.electronAPI?.canvas ?? {}),
+    complete: (args: { sessionId: string; canvasId: string }) => complete(args),
+    completeReopen: (args: { sessionId: string; canvasId: string }) => completeReopen(args),
+  },
+}
+
+const review = (id: string, status: Review['status'], annotationIds: string[] = []): Review => ({
+  id,
+  canvas: { canvasId: CID, sessionId: SID },
+  versionId: 'v1',
+  annotationIds,
+  status,
+  createdAt: '2026-08-25T10:00:00Z',
+  ...(status !== 'draft' ? { submittedAt: '2026-08-25T10:00:30Z' } : {}),
+})
+
+const note = (id: string, reviewId: string, state: Annotation['state']): Annotation => ({
+  id, reviewId, scope: 'general', note: `text ${id}`, versionId: 'v1', state,
+})
+
+/** Seed the two mirrors the button reads. */
+function seed(opts: {
+  reviews?: Review[]
+  annotations?: Annotation[]
+  awaitingReview?: boolean
+  completed?: { at: string; by: 'user' | 'agent' }
+}): void {
+  useCanvasStore.setState({
+    bySessionId: {
+      [SID]: {
+        canvasId: CID,
+        versions: [],
+        activeVersionId: 'v1',
+        interactionMode: 'browse',
+        emptyView: 'intro',
+        unseenRender: false,
+        filedNotice: null,
+        completedNotice: null,
+        loaded: true,
+        ...(opts.awaitingReview ? { awaitingReview: { versionId: 'v1', at: 'now' } } : {}),
+        ...(opts.completed ? { completed: opts.completed } : {}),
+      },
+    },
+  } as any)
+  useCanvasReviewStore.setState({
+    bySessionId: {
+      [SID]: {
+        loaded: true,
+        canvasId: CID,
+        reviews: opts.reviews ?? [],
+        annotations: opts.annotations ?? [],
+      },
+    },
+  } as any)
+}
+
+let container: HTMLDivElement
+let root: Root
+let nowSpy: ReturnType<typeof vi.spyOn> | null = null
+
+function passGuard(): void {
+  const later = Date.now() + 60_000
+  nowSpy?.mockRestore()
+  nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => later)
+}
+
+async function render(): Promise<void> {
+  await act(async () => {
+    root.render(<CanvasCompleteButton sessionId={SID} canvasId={CID} title="Quick Start rows" />)
+  })
+}
+
+const byId = (id: string) => container.querySelector(`[data-testid="${id}"]`) as HTMLButtonElement | null
+
+async function click(el: Element | null): Promise<void> {
+  expect(el).toBeTruthy()
+  await act(async () => (el as HTMLElement).click())
+}
+
+beforeEach(() => {
+  complete.mockClear()
+  completeReopen.mockClear()
+  complete.mockResolvedValue({ ok: true })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  nowSpy?.mockRestore()
+  nowSpy = null
+})
+
+describe('when it is offered', () => {
+  it('is enabled when nothing is owed either way', async () => {
+    seed({ reviews: [review('R1', 'resolved')], annotations: [note('a1', 'R1', 'approved')] })
+    await render()
+    expect(byId('canvas-complete-arm')!.disabled).toBe(false)
+  })
+
+  it('blocks on an open round and says so', async () => {
+    seed({ reviews: [review('R1', 'submitted')], annotations: [note('a1', 'R1', 'open')] })
+    await render()
+    const arm = byId('canvas-complete-arm')!
+    expect(arm.disabled).toBe(true)
+    expect(arm.title).toContain('still open')
+  })
+
+  it('blocks on unsubmitted draft notes, naming the sharper loss first', async () => {
+    seed({ reviews: [review('R1', 'draft', ['a1'])], annotations: [note('a1', 'R1', 'open')] })
+    await render()
+    const arm = byId('canvas-complete-arm')!
+    expect(arm.disabled).toBe(true)
+    expect(arm.title).toContain('unsubmitted')
+  })
+
+  it('blocks while a ready render awaits the first review', async () => {
+    seed({ awaitingReview: true })
+    await render()
+    const arm = byId('canvas-complete-arm')!
+    expect(arm.disabled).toBe(true)
+    expect(arm.title).toContain('first review')
+  })
+})
+
+describe('the two-step', () => {
+  it('arms to a confirm that names the subject, and a double-click cannot fire it (#456)', async () => {
+    seed({})
+    await render()
+    await click(byId('canvas-complete-arm'))
+    const confirm = byId('canvas-complete-confirm')!
+    expect(confirm.textContent).toContain('“Quick Start rows”')
+    await click(confirm)
+    expect(complete).not.toHaveBeenCalled()
+
+    passGuard()
+    await click(byId('canvas-complete-confirm'))
+    expect(complete).toHaveBeenCalledWith({ sessionId: SID, canvasId: CID })
+  })
+
+  it('surfaces a refusal from main in place and disarms', async () => {
+    seed({})
+    complete.mockResolvedValueOnce({ ok: false, reason: 'not everything is settled: 1 note awaiting your verdict' } as any)
+    await render()
+    await click(byId('canvas-complete-arm'))
+    passGuard()
+    await click(byId('canvas-complete-confirm'))
+    expect(byId('canvas-complete-confirm')).toBeNull()
+    expect(container.querySelector('[data-testid="canvas-complete-refused"]')!.textContent).toContain('not everything is settled')
+  })
+})
+
+describe('on a completed canvas', () => {
+  it('shows the chip with provenance and a one-click Reopen instead', async () => {
+    seed({ completed: { at: 'now', by: 'agent' } })
+    await render()
+    expect(byId('canvas-complete-arm')).toBeNull()
+    const chip = container.querySelector('[data-testid="canvas-completed-chip"]')!
+    expect(chip.textContent).toContain('Completed')
+    expect((chip as HTMLElement).title).toContain('on your instruction')
+    await click(byId('canvas-completed-reopen'))
+    expect(completeReopen).toHaveBeenCalledWith({ sessionId: SID, canvasId: CID })
+  })
+})

--- a/tests/unit/renderer/canvas-complete-button.test.tsx
+++ b/tests/unit/renderer/canvas-complete-button.test.tsx
@@ -211,6 +211,14 @@ describe('on a completed canvas', () => {
     await click(byId('canvas-completed-reopen'))
     expect(container.querySelector('[data-testid="canvas-complete-refused"]')!.textContent).toContain('could not reopen')
   })
+
+  it('ADV r2: a "not completed" reopen result is NOT shown as an error (double-fire / already reopened)', async () => {
+    seed({ completed: { at: 'now', by: 'user' } })
+    completeReopen.mockResolvedValueOnce({ ok: false, reason: 'not completed' } as any)
+    await render()
+    await click(byId('canvas-completed-reopen'))
+    expect(container.querySelector('[data-testid="canvas-complete-refused"]')).toBeNull()
+  })
 })
 
 describe('ADV: the armed confirm does not carry across a subject switch', () => {
@@ -226,6 +234,26 @@ describe('ADV: the armed confirm does not carry across a subject switch', () => 
     // Disarmed — the confirm is gone, so a click cannot sign off B.
     expect(byId('canvas-complete-confirm')).toBeNull()
     expect(byId('canvas-complete-arm')).toBeTruthy()
+  })
+
+  it('ADV r2: disarms when the canvas flips to completed under a mounted button', async () => {
+    // The reopen→complete round trip: arm, then the same canvasId gains a
+    // completed stamp. The chip must render already disarmed, so returning to
+    // the working control (a later reopen) is not one stale click from firing.
+    seed({ reviews: [review('R1', 'resolved')], annotations: [note('a1', 'R1', 'approved')] })
+    await render()
+    await click(byId('canvas-complete-arm'))
+    expect(byId('canvas-complete-confirm')).toBeTruthy()
+    await act(async () => {
+      useCanvasStore.setState({
+        bySessionId: {
+          [SID]: { ...useCanvasStore.getState().bySessionId[SID], completed: { at: 'now', by: 'user' as const } },
+        },
+      } as any)
+    })
+    // Now completed → chip shown, and the armed confirm is gone (disarmed).
+    expect(container.querySelector('[data-testid="canvas-completed-chip"]')).toBeTruthy()
+    expect(byId('canvas-complete-confirm')).toBeNull()
   })
 
   it('ADV: blocks (fails closed) when the review mirror points at a different canvas', async () => {

--- a/tests/unit/renderer/canvas-complete-button.test.tsx
+++ b/tests/unit/renderer/canvas-complete-button.test.tsx
@@ -195,4 +195,54 @@ describe('on a completed canvas', () => {
     await click(byId('canvas-completed-reopen'))
     expect(completeReopen).toHaveBeenCalledWith({ sessionId: SID, canvasId: CID })
   })
+
+  it('ADV: a refused Reopen surfaces its reason instead of dying silently', async () => {
+    seed({ completed: { at: 'now', by: 'user' } })
+    completeReopen.mockResolvedValueOnce({ ok: false, reason: 'not this session’s canvas' } as any)
+    await render()
+    await click(byId('canvas-completed-reopen'))
+    expect(container.querySelector('[data-testid="canvas-complete-refused"]')!.textContent).toContain('not this session')
+  })
+
+  it('ADV: a rejected Reopen is caught, not left as an unhandled rejection', async () => {
+    seed({ completed: { at: 'now', by: 'user' } })
+    completeReopen.mockRejectedValueOnce(new Error('boom'))
+    await render()
+    await click(byId('canvas-completed-reopen'))
+    expect(container.querySelector('[data-testid="canvas-complete-refused"]')!.textContent).toContain('could not reopen')
+  })
+})
+
+describe('ADV: the armed confirm does not carry across a subject switch', () => {
+  it('arming on canvas A then re-rendering as canvas B disarms — no sign-off of B', async () => {
+    seed({ reviews: [review('R1', 'resolved')], annotations: [note('a1', 'R1', 'approved')] })
+    await render()
+    await click(byId('canvas-complete-arm'))
+    expect(byId('canvas-complete-confirm')).toBeTruthy()
+    // The pane switches subject under the mounted button.
+    await act(async () => {
+      root.render(<CanvasCompleteButton sessionId={SID} canvasId="canvas-B" title="Subject B" />)
+    })
+    // Disarmed — the confirm is gone, so a click cannot sign off B.
+    expect(byId('canvas-complete-confirm')).toBeNull()
+    expect(byId('canvas-complete-arm')).toBeTruthy()
+  })
+
+  it('ADV: blocks (fails closed) when the review mirror points at a different canvas', async () => {
+    // The window right after a switch: mirror still on the previous canvas.
+    useCanvasStore.setState({
+      bySessionId: {
+        [SID]: {
+          canvasId: CID, versions: [], activeVersionId: 'v1',
+          interactionMode: 'browse', emptyView: 'intro', unseenRender: false,
+          filedNotice: null, completedNotice: null, loaded: true,
+        },
+      },
+    } as any)
+    useCanvasReviewStore.setState({
+      bySessionId: { [SID]: { loaded: true, canvasId: 'canvas-OTHER', reviews: [], annotations: [] } },
+    } as any)
+    await render()
+    expect(byId('canvas-complete-arm')!.disabled).toBe(true)
+  })
 })

--- a/tests/unit/renderer/canvas-filing-notice.test.ts
+++ b/tests/unit/renderer/canvas-filing-notice.test.ts
@@ -240,6 +240,30 @@ describe('completion stand-downs (#476)', () => {
     expect(useCanvasStore.getState().bySessionId.s1.filedNotice).toBeNull()
   })
 
+  it('an announced switch AWAY FROM a completed canvas still consumes its expectation', () => {
+    // The stand-down must not leak the switch expectation: View a completed
+    // canvas, ask for a switch (picker/queue/strip all announce), and the
+    // expectation must be CONSUMED by that identity change even though no
+    // strip shows — or it lingers and swallows the next GENUINE filing.
+    useCanvasStore.setState({
+      bySessionId: {
+        s1: {
+          ...useCanvasStore.getState().bySessionId.s1,
+          completed: { at: 'now', by: 'user' as const },
+        },
+      },
+    })
+    useCanvasStore.getState().expectSwitch('s1')
+    emit({ sessionId: 's1', canvasId: 'c-next', activeVersionId: 'v1' })
+    expect(useCanvasStore.getState().bySessionId.s1.filedNotice).toBeNull()
+
+    // Now a REAL filing on the new canvas must still announce.
+    seedCanvas('c-next', 'Next subject')
+    emit({ sessionId: 's1', canvasId: 'c-third', activeVersionId: 'v1' })
+    const notice = useCanvasStore.getState().bySessionId.s1.filedNotice
+    expect(notice?.canvasId).toBe('c-next')
+  })
+
   it('a sign-off event sets the acknowledgment, not the pulse or the strip', () => {
     emit({ sessionId: 's1', canvasId: 'c-old', activeVersionId: 'v1', completed: true })
     const s = useCanvasStore.getState().bySessionId.s1

--- a/tests/unit/renderer/canvas-filing-notice.test.ts
+++ b/tests/unit/renderer/canvas-filing-notice.test.ts
@@ -206,3 +206,45 @@ describe('filing notice', () => {
     expect(useCanvasStore.getState().bySessionId.s1.filedNotice).toBeNull()
   })
 })
+
+describe('completion stand-downs (#476)', () => {
+  beforeEach(() => {
+    seedCanvas('c-old', 'Checkout flow')
+    seedReviews('c-old', [], [])
+    // Pane CLOSED here, unlike above — the pulse cases need the closed shape.
+    useExcalidrawStore.setState({ bySessionId: { s1: { isOpen: false } } } as never)
+    getState.mockClear()
+  })
+
+  it('a REOPEN naming another canvas raises no filing strip and no pulse', () => {
+    emit({ sessionId: 's1', canvasId: 'c-done', activeVersionId: 'v1', reopened: true })
+    const s = useCanvasStore.getState().bySessionId.s1
+    expect(s.filedNotice).toBeNull()
+    expect(s.unseenRender).toBe(false)
+  })
+
+  it('a render while VIEWING a completed canvas starts fresh with no filing strip', () => {
+    // The dead-end fix mints a fresh canvas from a viewed completed one; the
+    // strip would claim "I filed <subject> when the agent started a different
+    // subject" — false twice over (already in the library; can be the same
+    // subject).
+    useCanvasStore.setState({
+      bySessionId: {
+        s1: {
+          ...useCanvasStore.getState().bySessionId.s1,
+          completed: { at: 'now', by: 'user' as const },
+        },
+      },
+    })
+    emit({ sessionId: 's1', canvasId: 'c-fresh', activeVersionId: 'v1' })
+    expect(useCanvasStore.getState().bySessionId.s1.filedNotice).toBeNull()
+  })
+
+  it('a sign-off event sets the acknowledgment, not the pulse or the strip', () => {
+    emit({ sessionId: 's1', canvasId: 'c-old', activeVersionId: 'v1', completed: true })
+    const s = useCanvasStore.getState().bySessionId.s1
+    expect(s.completedNotice).toEqual({ canvasId: 'c-old', title: 'Checkout flow' })
+    expect(s.unseenRender).toBe(false)
+    expect(s.filedNotice).toBeNull()
+  })
+})

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -635,6 +635,33 @@ describe('the redesigned chrome (item C)', () => {
     expect(container.querySelector('[data-testid="canvas-tool-sketch"]')?.getAttribute('aria-pressed')).toBe('true')
   })
 
+  it('#476: viewing a completed canvas forces browse, disarms the marquee, and greys the note-taking chips', async () => {
+    // interactionMode/marqueeArmed are per-session state that survives the
+    // detach and the adopt — a pane opened onto a signed-off canvas could
+    // otherwise arrive with the glass live in Sketch and no panel to receive
+    // the strokes.
+    await renderPane('on')
+    await act(async () => {
+      useCanvasStore.getState().setInteractionMode(SID, 'draw')
+      useCanvasReviewStore.getState().setMarqueeArmed(SID, true)
+      useCanvasStore.setState({
+        bySessionId: {
+          ...useCanvasStore.getState().bySessionId,
+          [SID]: {
+            ...useCanvasStore.getState().bySessionId[SID],
+            completed: { at: 'now', by: 'user' as const },
+          },
+        },
+      })
+    })
+    expect(useCanvasStore.getState().bySessionId[SID].interactionMode).toBe('browse')
+    expect(useCanvasReviewStore.getState().bySessionId[SID]?.marqueeArmed ?? false).toBe(false)
+    const sketch = container.querySelector('[data-testid="canvas-tool-sketch"]') as HTMLButtonElement
+    const region = container.querySelector('[data-testid="canvas-tool-region"]') as HTMLButtonElement
+    expect(sketch.disabled).toBe(true)
+    expect(region.disabled).toBe(true)
+  })
+
   it('carries the X-ray setting inside the Inspect group', async () => {
     await renderPane('stealth')
     const chips = container.querySelector('[data-testid="canvas-tool-chips"]')!

--- a/tests/unit/renderer/token-contrast.test.ts
+++ b/tests/unit/renderer/token-contrast.test.ts
@@ -188,6 +188,18 @@ describe('contrast — #458: muted text and the status-pill recipe', () => {
     }
   })
 
+  it('the completion confirm — surface-chrome text on a solid status-success fill — clears 4.5:1, both themes (#476)', () => {
+    // CanvasCompleteButton's armed confirm is the one solid status fill in the
+    // pane chrome; --color-crust there measured 4.03:1 on light and the pair
+    // was unpinned, which is exactly how the #458 regressions happened.
+    for (const [name, mode] of [['dark', 0], ['light', 1]] as const) {
+      const fg = token('surface-chrome', mode)
+      const bg = token('status-success', mode)
+      const r = contrast(fg, bg)
+      expect(r, `${name}: --surface-chrome (${fg}) on solid --status-success (${bg}) = ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(MIN)
+    }
+  })
+
   it('brand text over its own 15% wash clears 4.5:1, both themes', () => {
     // Quick Start's Start pill and the BottomBar Beta pill: text-[var(--brand)]
     // over color-mix(var(--brand) 15%, transparent).


### PR DESCRIPTION
Fixes #476.

Implements the owner-approved canvas mockup (this morning): a canvas subject gets a real terminal state — **COMPLETE** — closing the state machine #470's round-level cleanup started.

## The rule: nothing left owed either way, or no sign-off

One guarded ingress for both sides (`src/main/canvas/canvas-completion.ts`, composing the canvas + review stores). It refuses while anything is outstanding — **a ready render awaiting the user's first review**, unsubmitted drafts, notes with the agent, notes awaiting verdicts — over the same tallies the queue pill and close-out use. An unreadable review store **fails closed**. Seen-ness is transitive: every path out of those tallies runs through the user's own verdict, the #470 sweep's seen-barrier, or the agent close-out barrier — so neither side can sign off anything the user never saw. Ownership is re-checked against the record inside the store.

## What completing does

Stamps `{at, by}`, clears the review-needed ask, **detaches** the canvas as the session's current one → the pane falls back to its front page with one quiet acknowledgment row (Reopen + dismiss). The library keeps the canvas with a green **Completed** badge, **View**, and owner-only **Reopen**. Terminal means terminal: `renderVersion` refuses a completed canvas, and the filing lookup skips completed records so a render naming that subject's title starts a **fresh** canvas — never a silent resume. Reopen clears the stamp and rebinds when the session shows nothing else.

## Both sides

- **User**: `CanvasCompleteButton` in the pane header's leave cluster (beside ✕) — visible-but-blocked with a why while owed, #456 armed confirm naming the subject, Completed chip + Reopen when viewing a signed-off canvas (review panel stays away there — note-taking is off until Reopen).
- **Agent**: new `canvas_complete` MCP tool, verdict-family contract — **only on the user's explicit words** ("all good, mark it complete"); an Approve click or "looks good" is not an instruction. Recorded as *"completed by the agent on your instruction"*, apart from the user's own sign-offs. Plugin skill v1.3.0 documents it beside `canvas_verdict`. Not in the pre-allow list (it writes).

## Tests

18 real-store cases (every refusal, ownership, double-complete, detach + `completed:true` change event, library stamp, fresh-not-resume from both the same and another canvas, reopen semantics incl. no-steal, MCP refusal/success wording, end-to-end agent path) — the first-review barrier and the filing skip are **mutation-proven**. 7 renderer cases (blocked states over the live mirror, #456 double-click guard, refusal surfacing, chip + Reopen). Full suite **8463** / typecheck clean.

**ADR-009**: touches the conductor MCP surface, IPC/preload, and the canvas store — adversarial review to follow on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
