### PR TITLE
fix(canvas): draw the plan X-Ray lock instead of the emoji

### DIFF
--- a/src/renderer/components/AgentCanvasPane.tsx
+++ b/src/renderer/components/AgentCanvasPane.tsx
@@ -1415,8 +1415,14 @@ function CanvasSurface({ sessionId, canvasId, title: canvasTitle, version, versi
                 )
               })}
               {planLocked && (
-                <span className="px-1.5 leading-none text-[10px]" style={{ color: 'var(--text-muted)' }} aria-hidden>
-                  🔒
+                // A DRAWN padlock, not the lock emoji (#449): the repo's rule
+                // is no emoji in JSX — they render inconsistently across
+                // platforms and esbuild rejects the \u{...} escape form anyway.
+                <span className="px-1.5 inline-flex items-center" style={{ color: 'var(--text-muted)' }} aria-hidden>
+                  <svg width="9" height="11" viewBox="0 0 10 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="1.5" y="5" width="7" height="6" rx="1.2" />
+                    <path d="M3.2 5V3.4a1.8 1.8 0 0 1 3.6 0V5" />
+                  </svg>
                 </span>
               )}
             </div>

--- a/tests/unit/renderer/canvas-xray-pane.test.tsx
+++ b/tests/unit/renderer/canvas-xray-pane.test.tsx
@@ -662,6 +662,21 @@ describe('the redesigned chrome (item C)', () => {
     expect(region.disabled).toBe(true)
   })
 
+  it('#449: a PLAN locks X-Ray to Stealth with a DRAWN padlock, never the emoji', async () => {
+    const planState = {
+      ...STATE,
+      versions: [{ id: 'v1', mode: 'plan', createdAt: '2026-08-14T10:00:00Z', source: { mode: 'plan', entry: 'index.html' } }],
+    } as CanvasState
+    ;(window as any).electronAPI.canvas.getState.mockResolvedValueOnce(planState)
+    await renderPane('on')
+    const xray = container.querySelector('[data-testid="canvas-xray-mode"]')!
+    // The lock is an <svg>, and there is no astral-plane emoji in the group.
+    expect(xray.querySelector('svg')).toBeTruthy()
+    expect(/\u{1F512}/u.test(xray.textContent ?? '')).toBe(false)
+    // And the segments are inert on a plan.
+    expect((xray.querySelector('[data-testid="canvas-xray-off"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
   it('carries the X-ray setting inside the Inspect group', async () => {
     await renderPane('stealth')
     const chips = container.querySelector('[data-testid="canvas-tool-chips"]')!


### PR DESCRIPTION
Fixes #449. The plan-locked X-Ray segment rendered a literal lock emoji in JSX (against the no-emoji/draw-marks convention). Now a small inline SVG padlock; plan-mode render test pins svg-present + no lock emoji. Trivial cosmetic swap — Double Review trivial-edit exception. Suite 8487 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)