### PR TITLE
docs(surface): add artifacts button tip and feature-guide mention (#513)

### DIFF
--- a/src/renderer/tips-library.ts
+++ b/src/renderer/tips-library.ts
@@ -369,6 +369,20 @@ export const TIPS_LIBRARY: Tip[] = [
   },
 
   {
+    id: 'tip.artifacts-button',
+    category: 'productivity',
+    complexity: 'simple',
+    priority: 45,
+    variants: {
+      primary: {
+        shortText: 'Open your account artifacts from the command bar',
+        title: 'The Artifacts Button',
+        body: 'Next to **Browser** in the command bar, the **Artifacts** button opens this account\'s artifacts on claude.ai in one click -- no digging through the sidebar menu.\n\n• Shows for a local session signed into an account; a terminal-only session hides it.\n• Uses the session\'s account (or your primary), so each account opens its own artifacts.\n• Right-click it to open artifacts or hide the button, like the other core tools.',
+      },
+    },
+  },
+
+  {
     id: 'tip.webview-freeze',
     category: 'productivity',
     complexity: 'intermediate',

--- a/src/shared/app-knowledge.ts
+++ b/src/shared/app-knowledge.ts
@@ -71,7 +71,7 @@ export const APP_KNOWLEDGE_SECTIONS: AppKnowledgeSection[] = [
   {
     id: 'draw',
     title: 'Canvas, Snap, and the webview',
-    body: `Inside a session you can swap the terminal for a webview pane (Web), freeze that page into the Excalidraw scratchpad to sketch over it (Freeze), or take a Snap screenshot that lands in the conversation. The alternative pane replaces the terminal while it is open, and closing it brings the terminal straight back.`,
+    body: `Inside a session you can swap the terminal for a webview pane (Web), freeze that page into the Excalidraw scratchpad to sketch over it (Freeze), or take a Snap screenshot that lands in the conversation. The alternative pane replaces the terminal while it is open, and closing it brings the terminal straight back. Next to Browser, the Artifacts button opens this account's artifacts on claude.ai in one click; it appears for a local session signed into an account and uses that session's account.`,
   },
   {
     id: 'sentinel',


### PR DESCRIPTION
Follow-ups to #501 (Artifacts command-bar button). Fixes #513.

## Included (copy / user-facing surface)
- **Tips library** — a discovery tip "The Artifacts Button" (`tip.artifacts-button`, no `requires`, so it teaches the button exists).
- **Feature Guide / Ask Conductor** — the Artifacts button is mentioned in the "Canvas, Snap, and the webview" app-knowledge section.

## Intentionally NOT included: a positive command-bar e2e (with rationale)
The third follow-up — seed an account and drive the actual button click in e2e — is deferred as a deliberate engineering call, not an oversight:
- The button only renders for a **local, non-shell** session with an account, so a positive e2e must spawn a **real `claude` session** and navigate the account gate. That is flaky/heavy in the isolated harness, and the CI matrix has **no e2e step**, so it would not run as a gate anyway.
- The button's render + applicability + click→`accountWeb.openArtifacts` logic is already covered deterministically by the unit test `commandbar-artifacts-button.test.tsx` (5 cases), and the tool's presence in the real app is covered by `artifacts-button.spec.ts` (Settings row).
- Adding a spawn-dependent, non-gating, flaky test would violate "a test that cannot fail reliably is worse than none."

If you want the heavy version regardless, say so and I'll build the account-seeded, claude-spawning positive spec.

## Not security-sensitive
Renderer copy only. No IPC/PTY/credential surface.

## Tests
Full renderer + shared suites green (3009). Typecheck clean. Tip/knowledge guard tests pass.

## Gate
Copy-only, no behavior to exercise beyond the unit-tested content — candidate for `skip-desktop-test`; deferring that call to the reviewer.
