### PR TITLE
feat(accounts): setting for which account a resumed session uses

### DIFF
--- a/CONTEXT.d/2026-08-25-rc3-ui-round.md
+++ b/CONTEXT.d/2026-08-25-rc3-ui-round.md
@@ -76,6 +76,13 @@ Landed so far, each through the canvas loop where the owner reviewed:
   explicit words; recorded "completed by the agent on your instruction");
   plugin skill v1.3.0 documents it. Mutation-proven guards.
 
+Later rc.3 milestone items (owner goodnight/triage list, built after the canvas
+cluster):
+- **#449** (PR #510): plan X-Ray lock drawn as SVG, not the emoji (repo no-emoji rule).
+- **#448** (PR #511): re-pinned the first-launch e2e to the #441 multi-page What's New showcase (PREV_VERSION was older than commandBar's sinceVersion, so the run pulled a setup step and the notes-run assertions failed — invisibly, no Playwright CI).
+- **#447** (PR #512): usage snapshot on account switch (was unwired); fetchOne fires with `noRefresh` so it never rotates the token the respawn is about to use. ADR-009 adversarial PASS. Follow-ups #515.
+- **#446** (PR #516): `resumeAccountMode` setting (ask vs auto-last, default auto-last) in Settings → Accounts. Auto-last = today's silent continue-under-last (#76); 'ask' skips the predetermined mark so the existing gate opens per restored session. Resume-gate Cancel keeps the session (spawns saved account) instead of discarding it, and a deleted pinned account pre-selects a real one.
+
 Canvas findings the loop itself surfaced, filed for this same release:
 **#470** (review rounds stack per superseded ready version; requirements for
 the round state machine captured on the issue), **#476** (subject-level

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -83,7 +83,7 @@ import AutoDetectBanner from './components/github/AutoDetectBanner'
 import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import type { SessionState, SavedSession } from './types/electron'
 import { buildSessionState, buildSessionStateWithResumeTargets, markRestoredSessionsPredetermined } from './session-persistence'
-import { resolveResumeAccountMode } from './utils/sessionLaunch'
+import { shouldPredetermineRestoredAccount } from './utils/sessionLaunch'
 import { useSessionAutosave, cancelSessionAutosave } from './hooks/useSessionAutosave'
 
 // Re-export ViewType from its canonical location for backwards compatibility
@@ -698,7 +698,7 @@ export default function App() {
       // marking is skipped so the picker opens per restored session
       // (pre-selecting that saved account). With <2 profiles the gate is inert
       // regardless, so the branch only bites a genuine multi-account user.
-      if (resolveResumeAccountMode(useSettingsStore.getState().settings.resumeAccountMode) === 'auto-last') {
+      if (shouldPredetermineRestoredAccount(useSettingsStore.getState().settings.resumeAccountMode)) {
         markRestoredSessionsPredetermined(restoredSessions.map((s) => s.id))
       }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -83,6 +83,7 @@ import AutoDetectBanner from './components/github/AutoDetectBanner'
 import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import type { SessionState, SavedSession } from './types/electron'
 import { buildSessionState, buildSessionStateWithResumeTargets, markRestoredSessionsPredetermined } from './session-persistence'
+import { resolveResumeAccountMode } from './utils/sessionLaunch'
 import { useSessionAutosave, cancelSessionAutosave } from './hooks/useSessionAutosave'
 
 // Re-export ViewType from its canonical location for backwards compatibility
@@ -688,13 +689,18 @@ export default function App() {
         }
       }
 
-      // Relaunch must CONTINUE each session under the same account it was closed
-      // on (issue #76). The account is already determined (persisted profileId),
-      // so -- like in-session Restart/Recover/Switch -- mark the restored sessions
-      // predetermined BEFORE the store restore mounts their TerminalViews, so each
-      // spawn skips the pre-spawn AccountLaunchGate re-prompt and respawns under
-      // its saved account.
-      markRestoredSessionsPredetermined(restoredSessions.map((s) => s.id))
+      // Relaunch continues each session under the account it was closed on
+      // (issue #76): the account is already determined (persisted profileId),
+      // so — like in-session Restart/Recover/Switch — mark the restored sessions
+      // predetermined BEFORE the store restore mounts their TerminalViews, so
+      // each spawn skips the pre-spawn AccountLaunchGate and respawns under its
+      // saved account. #446: this is the DEFAULT ('auto-last'); under 'ask' the
+      // marking is skipped so the picker opens per restored session
+      // (pre-selecting that saved account). With <2 profiles the gate is inert
+      // regardless, so the branch only bites a genuine multi-account user.
+      if (resolveResumeAccountMode(useSettingsStore.getState().settings.resumeAccountMode) === 'auto-last') {
+        markRestoredSessionsPredetermined(restoredSessions.map((s) => s.id))
+      }
 
       useSessionStore.getState().restoreSessions(restoredSessions, savedState.activeSessionId)
       // Per-session "hide this tool" entries key on session ids, which persist

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -84,6 +84,7 @@ import { handleAutoDetectAccept } from './utils/githubAutoDetectAccept'
 import type { SessionState, SavedSession } from './types/electron'
 import { buildSessionState, buildSessionStateWithResumeTargets, markRestoredSessionsPredetermined } from './session-persistence'
 import { shouldPredetermineRestoredAccount } from './utils/sessionLaunch'
+import { useAccountGateStore } from './stores/accountGateStore'
 import { useSessionAutosave, cancelSessionAutosave } from './hooks/useSessionAutosave'
 
 // Re-export ViewType from its canonical location for backwards compatibility
@@ -698,8 +699,14 @@ export default function App() {
       // marking is skipped so the picker opens per restored session
       // (pre-selecting that saved account). With <2 profiles the gate is inert
       // regardless, so the branch only bites a genuine multi-account user.
+      // Mark them RESTORED regardless of mode (#446): "was restored" is a
+      // property of the session, and it is what lets a cancelled resume-gate
+      // keep the session rather than discard it. Only the predetermined mark
+      // (which SKIPS the gate) is mode-conditional.
+      const restoredIds = restoredSessions.map((s) => s.id)
+      useAccountGateStore.getState().markRestored(restoredIds)
       if (shouldPredetermineRestoredAccount(useSettingsStore.getState().settings.resumeAccountMode)) {
-        markRestoredSessionsPredetermined(restoredSessions.map((s) => s.id))
+        markRestoredSessionsPredetermined(restoredIds)
       }
 
       useSessionStore.getState().restoreSessions(restoredSessions, savedState.activeSessionId)

--- a/src/renderer/components/AccountLaunchGate.tsx
+++ b/src/renderer/components/AccountLaunchGate.tsx
@@ -27,6 +27,10 @@ export default function AccountLaunchGate() {
   const pending = useAccountGateStore((s) => s.queue[0] ?? null)
   const resolveChoice = useAccountGateStore((s) => s.resolveChoice)
   const cancelChoice = useAccountGateStore((s) => s.cancelChoice)
+  // #446: on a RESTORED session (the 'ask' resume path) Cancel keeps the
+  // session and continues under its saved account — it does NOT discard the
+  // tab the way it does for a brand-new launch — so the button says so.
+  const isRestore = useAccountGateStore((s) => s.restored.includes(pending?.sessionId ?? ''))
   const profiles = useAccountProfilesStore((s) => s.profiles)
   const accountAliases = useSettingsStore((s) => s.settings.accountAliases)
   const accountColourOverrides = useSettingsStore((s) => s.settings.accountColourOverrides)
@@ -188,9 +192,11 @@ export default function AccountLaunchGate() {
             variant="secondary"
             onClick={cancelChoice}
             testId="account-launch-cancel"
-            title="Don't launch; close this session tab"
+            title={isRestore
+              ? 'Keep this session and continue under its last account'
+              : "Don't launch; close this session tab"}
           >
-            Cancel
+            {isRestore ? 'Keep last account' : 'Cancel'}
           </DialogButton>
           <DialogButton
             variant="primary"

--- a/src/renderer/components/AccountLaunchGate.tsx
+++ b/src/renderer/components/AccountLaunchGate.tsx
@@ -44,9 +44,14 @@ export default function AccountLaunchGate() {
   const activeSelectable = profiles.filter(isSelectable)
   const selectableProfiles = activeSelectable.length > 0 ? activeSelectable : profiles
   // Pre-select: the session's pinned profile, else primary, else the first
-  // selectable (never an inactive account).
+  // selectable (never an inactive account). The pinned id is honoured only if
+  // it still EXISTS (#446): the 'ask' resume path routes an already-pinned
+  // profileId through this gate, and a session pinned to a since-DELETED account
+  // would otherwise pre-select an id with no matching <option> — a blank
+  // dropdown. A missing pin falls through to primary/first, same as no pin.
+  const pinnedStillExists = !!pending?.currentProfileId && profiles.some((p) => p.id === pending.currentProfileId)
   const defaultSelectedId = () =>
-    pending?.currentProfileId ?? profiles.find((p) => p.isPrimary)?.id ?? selectableProfiles[0]?.id ?? ''
+    (pinnedStillExists ? pending!.currentProfileId : undefined) ?? profiles.find((p) => p.isPrimary)?.id ?? selectableProfiles[0]?.id ?? ''
   const [selected, setSelected] = useState<string>(defaultSelectedId())
 
   // Re-seed the selection each time a new session reaches the head of the queue.

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -19,6 +19,7 @@ import HooksGatewaySection from './github/config/HooksGatewaySection'
 import PageFrame from './PageFrame'
 import { SectionLabel } from './ui/SectionLabel'
 import { resolveDefaultPanelTab, type PanelTab } from './sidebar/sessionsPanelState'
+import { resolveResumeAccountMode } from '../utils/sessionLaunch'
 import { Kbd } from './ui/Kbd'
 import { trackUsage } from '../stores/tipsStore'
 import { useAddAccount } from '../hooks/useAddAccount'
@@ -569,7 +570,28 @@ export default function SettingsPage({ initialTab, onNavigateToSessions, onUpdat
           )}
 
           {activeTab === 'accounts' && (
-            <AccountsPanel onAdd={handleAddAccount} />
+            <>
+              {/* #446: which account a RESUMED session (app-relaunch restore)
+                  runs under. Only meaningful with 2+ accounts; default keeps
+                  today's silent continue-under-last behaviour. */}
+              <Section title="Resuming sessions" icon={<path d="M8 3a5 5 0 1 0 4.5 2.8M8 3V1M8 3l2 1.2" stroke="currentColor" strokeWidth="1.2" fill="none" strokeLinecap="round" />}>
+                <Field label="Account for a resumed session">
+                  <select
+                    value={resolveResumeAccountMode(settings.resumeAccountMode)}
+                    onChange={(e) => save({ resumeAccountMode: e.target.value as 'ask' | 'auto-last' })}
+                    className="bg-crust/60 border border-surface0/80 rounded-lg px-3 py-2 text-sm text-text w-full focus:outline-none focus:border-blue/50 transition-colors"
+                    data-ux-id="settings-resume-account-mode"
+                  >
+                    <option value="auto-last">Auto-resume last — the account it ran under (default)</option>
+                    <option value="ask">Ask each time — pick the account when a session resumes</option>
+                  </select>
+                </Field>
+                <p className="text-[11px] text-overlay0 mt-1">
+                  Only matters when you have two or more accounts. Applies when the app restarts and restores your sessions.
+                </p>
+              </Section>
+              <AccountsPanel onAdd={handleAddAccount} />
+            </>
           )}
 
           {activeTab === 'statusline' && (

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -790,10 +790,19 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               .requestChoice(sessionId, session?.label || '', session?.profileId)
               .then((chosen) => {
                 if (chosen === GATE_CANCELLED) {
-                  // User aborted the launch: no PTY exists yet (the gate blocks
-                  // before doSpawn), so closing is just removing the tab. The
-                  // tab is gone for good, so its browser profile goes with it —
-                  // a no-op for a session that never opened a pane (#371).
+                  // Cancel means different things for a NEW tab vs a RESUME
+                  // (#446). A session that already ran under an account
+                  // (session.profileId set) only reaches this gate on the
+                  // 'ask' resume path — cancelling there must NOT throw away a
+                  // session the user just chose to restore, so fall back to its
+                  // saved account and spawn (the same fail-open as .catch
+                  // below). A brand-new tab has no saved account and nothing to
+                  // keep, so cancel still discards it (its browser profile goes
+                  // with it — a no-op for a pane that never opened, #371).
+                  if (session?.profileId) {
+                    doSpawn(session.profileId)
+                    return
+                  }
                   forgetSessionBrowserProfile(sessionId)
                   useSessionStore.getState().removeSession(sessionId)
                   return

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -791,16 +791,23 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               .then((chosen) => {
                 if (chosen === GATE_CANCELLED) {
                   // Cancel means different things for a NEW tab vs a RESUME
-                  // (#446). A session that already ran under an account
-                  // (session.profileId set) only reaches this gate on the
-                  // 'ask' resume path — cancelling there must NOT throw away a
-                  // session the user just chose to restore, so fall back to its
-                  // saved account and spawn (the same fail-open as .catch
-                  // below). A brand-new tab has no saved account and nothing to
-                  // keep, so cancel still discards it (its browser profile goes
-                  // with it — a no-op for a pane that never opened, #371).
-                  if (session?.profileId) {
-                    doSpawn(session.profileId)
+                  // (#446). A session RESTORED this run only reaches this gate
+                  // on the 'ask' resume path, and cancelling there must NOT
+                  // throw away a session the user chose to restore — continue
+                  // under its saved account instead. The signal is "was
+                  // restored" (gate store), not session.profileId, which
+                  // cannot tell a resume from a fresh tab (legacy
+                  // config.profileId can pin a new tab; a single-account resume
+                  // carries no pin). A brand-new tab is discarded as before
+                  // (its browser profile goes with it — a no-op for a pane that
+                  // never opened, #371).
+                  if (gate.wasRestored(sessionId)) {
+                    // Same !disposed handling as the success path: if the view
+                    // is gone, mark predetermined so the remount spawns the
+                    // saved account without re-prompting (never spawn a PTY for
+                    // a torn-down view).
+                    if (!disposed) doSpawn(session?.profileId)
+                    else gate.markPredetermined(sessionId)
                     return
                   }
                   forgetSessionBrowserProfile(sessionId)

--- a/src/renderer/session-persistence.ts
+++ b/src/renderer/session-persistence.ts
@@ -139,6 +139,12 @@ export async function buildSessionStateWithResumeTargets(): Promise<SessionState
  * flag is set before each spawn effect reads consumePredetermined(). The flag is
  * consumed only on the gate-eligible path, so it is a harmless no-op for
  * single-account / shell-only / Codex / SSH restores.
+ *
+ * #446: the caller (App restore) now runs this CONDITIONALLY —
+ * `shouldPredetermineRestoredAccount(settings.resumeAccountMode)`. It is the
+ * default ('auto-last'); under 'ask' the caller skips it so the gate opens per
+ * restored session. This function itself is unchanged: it always marks what it
+ * is given.
  */
 export function markRestoredSessionsPredetermined(sessionIds: string[]): void {
   const gate = useAccountGateStore.getState()

--- a/src/renderer/stores/accountGateStore.ts
+++ b/src/renderer/stores/accountGateStore.ts
@@ -26,6 +26,13 @@ interface AccountGateState {
   queue: PendingAccountGate[]
   /** Sessions whose next spawn already has an explicit account (restart/switch). */
   predetermined: string[]
+  /** Sessions RESTORED this app-run (#446). A property of the session, not of
+   *  the resume-account setting, so it is marked in BOTH modes. It is what
+   *  makes a cancelled resume-gate keep the session (continue under its saved
+   *  account) instead of discarding it the way a cancelled NEW-tab gate does —
+   *  session.profileId cannot tell the two apart (legacy config.profileId, and
+   *  single-account sessions that carry no pin). Never persisted. */
+  restored: string[]
 
   /** Enqueue a choice request; resolves when the modal is answered. */
   requestChoice: (
@@ -43,11 +50,16 @@ interface AccountGateState {
   markPredetermined: (sessionId: string) => void
   /** Read + clear the predetermined flag for a session. */
   consumePredetermined: (sessionId: string) => boolean
+  /** Mark sessions as restored-this-run (#446). Idempotent. */
+  markRestored: (sessionIds: string[]) => void
+  /** Was this session restored this app-run? (Not consumed — a lasting fact.) */
+  wasRestored: (sessionId: string) => boolean
 }
 
 export const useAccountGateStore = create<AccountGateState>((set, get) => ({
   queue: [],
   predetermined: [],
+  restored: [],
 
   requestChoice: (sessionId, sessionLabel, currentProfileId) =>
     new Promise<GateChoice>((resolve) => {
@@ -83,4 +95,12 @@ export const useAccountGateStore = create<AccountGateState>((set, get) => ({
     if (had) set((s) => ({ predetermined: s.predetermined.filter((id) => id !== sessionId) }))
     return had
   },
+
+  markRestored: (sessionIds) =>
+    set((s) => {
+      const add = sessionIds.filter((id) => !s.restored.includes(id))
+      return add.length ? { restored: [...s.restored, ...add] } : s
+    }),
+
+  wasRestored: (sessionId) => get().restored.includes(sessionId),
 }))

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -220,6 +220,13 @@ export interface AppSettings {
    *  shape on upgrade. Minimal mode reads the SAME footerHiddenUsageBuckets
    *  denylist, so hiding Fable there drops its dot here. */
   footerAccountDisplay?: 'meters' | 'dots'
+  /** Which Claude account a RESUMED session (an app-relaunch restore) runs
+   *  under (#446). 'auto-last' continues silently under the account it ran
+   *  under; 'ask' opens the account picker per restored session. Absent =>
+   *  'auto-last' (via resolveResumeAccountMode), so no existing install
+   *  changes on upgrade. Inert for anyone with fewer than two account
+   *  profiles — there is nothing to pick. */
+  resumeAccountMode?: 'ask' | 'auto-last'
   updateChannel: UpdateChannel
   /** True once the user has explicitly picked an update channel (onboarding
    *  Transparency recap, or Settings -> General). Absent/false means

--- a/src/renderer/utils/sessionLaunch.ts
+++ b/src/renderer/utils/sessionLaunch.ts
@@ -55,6 +55,20 @@ export function canSwitchAccountForSession(opts: {
 }
 
 /**
+ * How a RESUMED session (an app-relaunch restore) chooses its account (#446).
+ *   - 'auto-last' (default): continue silently under the account the session
+ *     ran under — restored sessions are marked predetermined, no gate.
+ *   - 'ask': the account picker opens per restored session (pre-selecting the
+ *     last account), by NOT marking it predetermined.
+ * Absent or unrecognised => 'auto-last', so no existing install changes on
+ * upgrade. Resolver-based default (the settings enum convention here), not a
+ * DEFAULT_SETTINGS entry.
+ */
+export function resolveResumeAccountMode(value: unknown): 'ask' | 'auto-last' {
+  return value === 'ask' ? 'ask' : 'auto-last'
+}
+
+/**
  * Render a PTY-spawn failure into a readable, single-line terminal message.
  *
  * The renderer used to fire `pty.spawn` without catching, so a main-process

--- a/src/renderer/utils/sessionLaunch.ts
+++ b/src/renderer/utils/sessionLaunch.ts
@@ -69,6 +69,17 @@ export function resolveResumeAccountMode(value: unknown): 'ask' | 'auto-last' {
 }
 
 /**
+ * Whether an app-relaunch restore should mark its sessions predetermined —
+ * i.e. continue silently under the saved account (#446). True in 'auto-last'
+ * (the default), false in 'ask' (let the gate open per restored session).
+ * Extracted so the App restore branch is pinned by a unit test rather than
+ * living only in App.tsx (which is not unit-testable).
+ */
+export function shouldPredetermineRestoredAccount(resumeAccountMode: unknown): boolean {
+  return resolveResumeAccountMode(resumeAccountMode) === 'auto-last'
+}
+
+/**
  * Render a PTY-spawn failure into a readable, single-line terminal message.
  *
  * The renderer used to fire `pty.spawn` without catching, so a main-process

--- a/tests/unit/renderer/account-gate-store.test.ts
+++ b/tests/unit/renderer/account-gate-store.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { useAccountGateStore } from '../../../src/renderer/stores/accountGateStore'
 
 function reset() {
-  useAccountGateStore.setState({ queue: [], predetermined: [] })
+  useAccountGateStore.setState({ queue: [], predetermined: [], restored: [] })
 }
 
 describe('accountGateStore', () => {
@@ -71,5 +71,27 @@ describe('accountGateStore', () => {
     store.markPredetermined('s1')
     store.markPredetermined('s1')
     expect(useAccountGateStore.getState().predetermined.filter((id) => id === 's1')).toHaveLength(1)
+  })
+
+  it('restored (#446): markRestored sets a LASTING flag (not consumed by reads)', () => {
+    const store = useAccountGateStore.getState()
+    expect(store.wasRestored('s1')).toBe(false)
+    store.markRestored(['s1', 's2'])
+    // Read twice — unlike predetermined, wasRestored does not clear.
+    expect(useAccountGateStore.getState().wasRestored('s1')).toBe(true)
+    expect(useAccountGateStore.getState().wasRestored('s1')).toBe(true)
+    expect(useAccountGateStore.getState().wasRestored('s2')).toBe(true)
+    expect(useAccountGateStore.getState().wasRestored('s3')).toBe(false)
+  })
+
+  it('markRestored is idempotent and independent of predetermined', () => {
+    const store = useAccountGateStore.getState()
+    store.markRestored(['s1'])
+    store.markRestored(['s1'])
+    expect(useAccountGateStore.getState().restored.filter((id) => id === 's1')).toHaveLength(1)
+    // Consuming predetermined does not touch the restored flag.
+    store.markPredetermined('s1')
+    useAccountGateStore.getState().consumePredetermined('s1')
+    expect(useAccountGateStore.getState().wasRestored('s1')).toBe(true)
   })
 })

--- a/tests/unit/renderer/account-launch-gate-lastused.test.tsx
+++ b/tests/unit/renderer/account-launch-gate-lastused.test.tsx
@@ -9,7 +9,7 @@ import { act } from 'react'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
-const gateState: any = { queue: [], resolveChoice: vi.fn(), cancelChoice: vi.fn() }
+const gateState: any = { queue: [], restored: [], resolveChoice: vi.fn(), cancelChoice: vi.fn() }
 const profilesState: any = { profiles: [] }
 const settingsState: any = { settings: { accountAliases: {}, accountColourOverrides: {}, lastUsedAccountId: undefined } }
 
@@ -32,6 +32,7 @@ beforeEach(() => {
   root = createRoot(container)
   gateState.resolveChoice = vi.fn()
   gateState.queue = [{ sessionId: 's1', sessionLabel: 'web', currentProfileId: undefined, resolve: () => {} }]
+  gateState.restored = []
   profilesState.profiles = []
   settingsState.settings = { accountAliases: {}, accountColourOverrides: {}, lastUsedAccountId: undefined }
 })
@@ -94,6 +95,18 @@ describe('AccountLaunchGate — Last used line', () => {
     const launchBtn = Array.from(container.querySelectorAll('button')).find((b) => /launch|start/i.test(b.textContent || '')) as HTMLButtonElement
     act(() => launchBtn.click())
     expect(gateState.resolveChoice).toHaveBeenCalledWith('primary')
+  })
+
+  it('#446: the secondary button reads "Keep last account" on a RESTORED session, "Cancel" otherwise', () => {
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p2', accountEmail: 'p2@b.co' })]
+    // Fresh session (not restored): Cancel/discard wording.
+    render()
+    expect(q('[data-testid="account-launch-cancel"]')!.textContent).toContain('Cancel')
+    act(() => root.unmount()); root = createRoot(container)
+    // Restored session: keep-and-continue wording.
+    gateState.restored = ['s1']
+    render()
+    expect(q('[data-testid="account-launch-cancel"]')!.textContent).toContain('Keep last account')
   })
 
   it('Use → then Launch resolves the gate with an ACTIVE last-used account', () => {

--- a/tests/unit/renderer/account-launch-gate-lastused.test.tsx
+++ b/tests/unit/renderer/account-launch-gate-lastused.test.tsx
@@ -79,6 +79,23 @@ describe('AccountLaunchGate — Last used line', () => {
     expect(q('[data-testid="account-launch-lastused"]')).toBeNull()
   })
 
+  it('#446: a session pinned to a DELETED account pre-selects a real account, not blank', () => {
+    // The 'ask' resume path routes an already-pinned profileId through this
+    // gate; if that account was deleted, the pre-select must fall through to
+    // primary rather than pointing at a non-existent <option> (a blank picker
+    // that then launches a dead id).
+    profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-other', accountEmail: 'o@b.co' })]
+    gateState.queue = [{ sessionId: 's1', sessionLabel: 'web', currentProfileId: 'deleted-acct', resolve: () => {} }]
+    render()
+    const select = q('[data-testid="account-launch-select"]') as HTMLSelectElement | null
+    expect(select).not.toBeNull()
+    expect(select!.value).toBe('primary') // fell through to primary, not '' or the dead id
+    // Launch resolves a REAL account.
+    const launchBtn = Array.from(container.querySelectorAll('button')).find((b) => /launch|start/i.test(b.textContent || '')) as HTMLButtonElement
+    act(() => launchBtn.click())
+    expect(gateState.resolveChoice).toHaveBeenCalledWith('primary')
+  })
+
   it('Use → then Launch resolves the gate with an ACTIVE last-used account', () => {
     profilesState.profiles = [profile({ id: 'primary', isPrimary: true }), profile({ id: 'p-active', accountEmail: 'used@b.co' })]
     settingsState.settings.lastUsedAccountId = 'p-active'

--- a/tests/unit/renderer/session-launch.test.ts
+++ b/tests/unit/renderer/session-launch.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/renderer/session-launch.test.ts
 import { describe, it, expect } from 'vitest'
-import { shouldGateAccountChoice, canSwitchAccountForSession, formatSpawnError } from '../../../src/renderer/utils/sessionLaunch'
+import { shouldGateAccountChoice, canSwitchAccountForSession, formatSpawnError, resolveResumeAccountMode } from '../../../src/renderer/utils/sessionLaunch'
 
 describe('shouldGateAccountChoice', () => {
   it('gates a Claude session with >= 2 account profiles', () => {
@@ -23,6 +23,17 @@ describe('shouldGateAccountChoice', () => {
   })
   it('does NOT gate an SSH session even if provider is Claude (remote host uses its own login)', () => {
     expect(shouldGateAccountChoice({ hasSession: true, profileCount: 2, provider: 'claude', isSsh: true })).toBe(false)
+  })
+})
+
+describe('resolveResumeAccountMode (#446)', () => {
+  it("returns 'ask' only for the exact string 'ask'", () => {
+    expect(resolveResumeAccountMode('ask')).toBe('ask')
+  })
+  it("defaults to 'auto-last' for absent/unknown/legacy values", () => {
+    for (const v of [undefined, null, '', 'auto-last', 'AUTO', 'Ask', 1, {}, true]) {
+      expect(resolveResumeAccountMode(v)).toBe('auto-last')
+    }
   })
 })
 

--- a/tests/unit/renderer/session-launch.test.ts
+++ b/tests/unit/renderer/session-launch.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/renderer/session-launch.test.ts
 import { describe, it, expect } from 'vitest'
-import { shouldGateAccountChoice, canSwitchAccountForSession, formatSpawnError, resolveResumeAccountMode } from '../../../src/renderer/utils/sessionLaunch'
+import { shouldGateAccountChoice, canSwitchAccountForSession, formatSpawnError, resolveResumeAccountMode, shouldPredetermineRestoredAccount } from '../../../src/renderer/utils/sessionLaunch'
 
 describe('shouldGateAccountChoice', () => {
   it('gates a Claude session with >= 2 account profiles', () => {
@@ -34,6 +34,17 @@ describe('resolveResumeAccountMode (#446)', () => {
     for (const v of [undefined, null, '', 'auto-last', 'AUTO', 'Ask', 1, {}, true]) {
       expect(resolveResumeAccountMode(v)).toBe('auto-last')
     }
+  })
+})
+
+describe('shouldPredetermineRestoredAccount (#446)', () => {
+  it('predetermines (auto-last) by default and for any non-ask value', () => {
+    for (const v of [undefined, null, 'auto-last', 'anything', 1]) {
+      expect(shouldPredetermineRestoredAccount(v)).toBe(true)
+    }
+  })
+  it("does NOT predetermine under 'ask' (the gate opens per restored session)", () => {
+    expect(shouldPredetermineRestoredAccount('ask')).toBe(false)
   })
 })
 


### PR DESCRIPTION
Fixes #446. Adds resumeAccountMode ('ask' | 'auto-last', default auto-last) in Settings → Accounts. Auto-last = today's silent continue-under-last (#76); 'ask' skips the predetermined mark so the existing AccountLaunchGate opens per restored session (pre-selecting the saved account) — no new picker UI. Scoped to the app-relaunch restore path; inert with <2 profiles. Resolver-default convention; tests cover resolveResumeAccountMode. Suite 8498 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)