### PR TITLE
feat(sidebar): number multiple live sessions of one config in the running list

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -31,7 +31,7 @@ import GroupHeader from './sidebar/GroupHeader'
 import SessionSectionHeader from './sidebar/SessionSectionHeader'
 import SessionGroupHeader from './sidebar/SessionGroupHeader'
 import UngroupedSessionsHeader from './sidebar/UngroupedSessionsHeader'
-import { runningConfigCounts } from './sidebar/savedConfigsView'
+import { runningConfigCounts, sessionInstanceOrdinals } from './sidebar/savedConfigsView'
 import AskConductorDock from './sidebar/AskConductorDock'
 import QuickStartPanel from './sidebar/QuickStartPanel'
 import { resolveDefaultPanelTab, resolveSidebarWidth, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX, launchableInGroup, launchableInSection, type PanelTab } from './sidebar/sessionsPanelState'
@@ -259,6 +259,9 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
   // delete guard read these; launch-all skips anything counted (bring-up).
   // `sessions` already excludes the Ask session.
   const runningCounts = useMemo(() => runningConfigCounts(sessions), [sessions])
+  // Per-session instance ordinal (#454), same input array as the counts so the
+  // two always agree. Only same-config 2+ instances get a number.
+  const sessionOrdinals = useMemo(() => sessionInstanceOrdinals(sessions), [sessions])
   const [dragConfigId, setDragConfigId] = useState<string | null>(null)
   const [dragOverConfigId, setDragOverConfigId] = useState<string | null>(null)
   // The LOOSE configs: in no group and no section (a stale id pointing at a
@@ -769,6 +772,7 @@ export default function Sidebar({ currentView, onViewChange, collapsed, onShowAc
         onContextMenu={(e) => { e.preventDefault(); refreshWebOnly(session.profileId ?? primaryProfileId); void refreshWebSessions(session.profileId ?? primaryProfileId); setSessionContextMenu({ sessionId: session.id, x: e.clientX, y: e.clientY }) }}
         isSelected={selectedSessionIds.has(session.id)}
         isFocused={focusedSessionIndex === flatIndex}
+        ordinal={sessionOrdinals.get(session.id)}
       />
     )
   }

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -25,6 +25,10 @@ interface SessionRowProps {
   onContextMenu: (e: React.MouseEvent) => void
   isSelected?: boolean
   isFocused?: boolean
+  /** 1-based instance number among live sessions of the SAME config (#454),
+   *  present only when that config has 2+ instances. Rendered as a muted "#2"
+   *  after the name so otherwise-identical rows are tellable apart. */
+  ordinal?: number
 }
 
 // Map store SessionStatus -> UI SessionState (see ui/StatusDot). error wins over
@@ -47,7 +51,7 @@ function meterClass(pct: number): string {
   return 'meter-neutral'
 }
 
-export default function SessionRow({ session, isActive, needsAttention, isRenaming, renameValue, renameRef, onRenameChange, onRenameFinish, onRenameCancel, onClick, onContextMenu, isSelected, isFocused }: SessionRowProps) {
+export default function SessionRow({ session, isActive, needsAttention, isRenaming, renameValue, renameRef, onRenameChange, onRenameFinish, onRenameCancel, onClick, onContextMenu, isSelected, isFocused, ordinal }: SessionRowProps) {
   const theme = useResolvedTheme()
   const identity = resolveIdentityColor(session.identityColorKey ?? bucketLegacyColorToKey(session.color), theme)
   const st = toSessionState(session.status, needsAttention)
@@ -139,6 +143,15 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
           deliberately or add min-w-0 + flex-shrink rules at that point. */}
       <span className="nm relative z-10 row-start-1 flex items-center gap-1.5">
         <span className="text-[13px] truncate" style={{ fontWeight: isActive ? 700 : 600 }} title={session.customName?.trim() ? `${session.customName.trim()} · ${session.label}` : session.label}>{session.customName?.trim() || session.label}</span>
+        {ordinal !== undefined && (
+          <span
+            className="shrink-0 text-[11px] tabular-nums text-[var(--text-muted)]"
+            title={`Instance ${ordinal} of this config`}
+            data-testid="session-row-ordinal"
+          >
+            #{ordinal}
+          </span>
+        )}
       </span>
 
       {/* Line 1, col 3: status pill only. The account colour dot lives on line 3

--- a/src/renderer/components/sidebar/savedConfigsView.ts
+++ b/src/renderer/components/sidebar/savedConfigsView.ts
@@ -23,3 +23,40 @@ export function runningConfigCounts(sessions: ReadonlyArray<Pick<Session, 'confi
   return counts
 }
 
+/**
+ * A 1-based instance ordinal per session id, ONLY for sessions whose config has
+ * two or more live instances (#454). Three sessions of "App Dev" become #1/#2/#3
+ * so the otherwise-identical rows (same label, same identity colour) are
+ * navigable; a config with a single live session gets no ordinal (nothing to
+ * disambiguate).
+ *
+ * Ordered by ARRAY position, not createdAt: createdAt is not persisted and every
+ * session restored on relaunch is stamped the same instant (App.tsx), so a
+ * createdAt sort is non-deterministic after a restart, whereas array order is
+ * creation order in-run and survives restore. (Known wart: an in-session
+ * Restart removes+re-adds the record, moving it to the end — a restarted
+ * instance renumbers to the highest ordinal. Acceptable: the numbers stay
+ * unique and stable until the next Restart, and the pill's "open the latest"
+ * already selects that same last-in-array instance.)
+ *
+ * Derived, never baked into `label`: the label is copied into logs, the SSH
+ * close dialog and session-state.json, and is overridden by `customName` at
+ * every display site — an ordinal belongs only in the row, computed live.
+ */
+export function sessionInstanceOrdinals(
+  sessions: ReadonlyArray<Pick<Session, 'id' | 'configId' | 'kind'>>,
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  const running = sessions.filter((s) => s.kind !== 'ask' && !!s.configId)
+  const totals = new Map<string, number>()
+  for (const s of running) totals.set(s.configId!, (totals.get(s.configId!) ?? 0) + 1)
+  const ordinals = new Map<string, number>()
+  for (const s of running) {
+    if ((totals.get(s.configId!) ?? 0) < 2) continue // single instance: no ordinal
+    const n = (counts.get(s.configId!) ?? 0) + 1
+    counts.set(s.configId!, n)
+    ordinals.set(s.id, n)
+  }
+  return ordinals
+}
+

--- a/tests/unit/renderer/session-instance-ordinals.test.ts
+++ b/tests/unit/renderer/session-instance-ordinals.test.ts
@@ -1,0 +1,40 @@
+// #454: multiple live sessions of one config get a 1-based instance ordinal so
+// the otherwise-identical Running rows are tellable apart. Single-instance
+// configs get none.
+import { describe, it, expect } from 'vitest'
+import { sessionInstanceOrdinals } from '../../../src/renderer/components/sidebar/savedConfigsView'
+
+type S = { id: string; configId?: string; kind?: 'ask' }
+const s = (id: string, configId?: string, kind?: 'ask'): S => ({ id, configId, kind })
+
+describe('sessionInstanceOrdinals (#454)', () => {
+  it('numbers same-config siblings 1..N in array order', () => {
+    const m = sessionInstanceOrdinals([s('a', 'cfg1'), s('b', 'cfg1'), s('c', 'cfg1')])
+    expect(m.get('a')).toBe(1)
+    expect(m.get('b')).toBe(2)
+    expect(m.get('c')).toBe(3)
+  })
+
+  it('gives NO ordinal to a config with a single live instance', () => {
+    const m = sessionInstanceOrdinals([s('a', 'cfg1'), s('b', 'cfg2')])
+    expect(m.has('a')).toBe(false)
+    expect(m.has('b')).toBe(false)
+  })
+
+  it('numbers each config independently', () => {
+    const m = sessionInstanceOrdinals([s('a', 'cfg1'), s('b', 'cfg2'), s('c', 'cfg1'), s('d', 'cfg2')])
+    expect([m.get('a'), m.get('c')]).toEqual([1, 2]) // cfg1
+    expect([m.get('b'), m.get('d')]).toEqual([1, 2]) // cfg2
+  })
+
+  it('skips Ask sessions and config-less sessions entirely', () => {
+    const m = sessionInstanceOrdinals([s('ask', undefined, 'ask'), s('ask2', undefined, 'ask'), s('none'), s('none2')])
+    expect(m.size).toBe(0)
+  })
+
+  it('an Ask session sharing nothing does not perturb a real config’s numbering', () => {
+    const m = sessionInstanceOrdinals([s('a', 'cfg1'), s('ask', undefined, 'ask'), s('b', 'cfg1')])
+    expect(m.get('a')).toBe(1)
+    expect(m.get('b')).toBe(2)
+  })
+})

--- a/tests/unit/renderer/sessionrow-card.test.ts
+++ b/tests/unit/renderer/sessionrow-card.test.ts
@@ -46,6 +46,15 @@ describe('SessionRow card', () => {
   beforeEach(() => { container = document.createElement('div'); document.body.appendChild(container); root = createRoot(container) })
   afterEach(() => { act(() => root.unmount()); container.remove() })
 
+  it('#454: renders the instance ordinal when given one, and omits it otherwise', () => {
+    render(root, { label: 'App Dev' }, { ordinal: 2 })
+    const o = container.querySelector('[data-testid="session-row-ordinal"]')
+    expect(o?.textContent).toBe('#2')
+    act(() => root.unmount()); root = createRoot(container)
+    render(root, { label: 'App Dev' }) // no ordinal prop
+    expect(container.querySelector('[data-testid="session-row-ordinal"]')).toBeNull()
+  })
+
   it('does NOT render a Claude provider badge for the default (claude) provider', () => {
     render(root, { provider: 'claude' })
     expect(container.querySelector('[title="Claude is working"]')).toBeNull()


### PR DESCRIPTION
Closes #454.

Three live instances of one saved config ("App Dev" ×3) rendered three identical rows. Each same-config live session now gets a 1-based instance ordinal rendered as a muted `#2` / `#3` suffix after the name; a config with a single live session shows none.

## Design notes

- **Derived at render, never baked into `session.label`** — the label flows into logs, the SSH close dialog, and `session-state.json`, and is overridden by `customName` at every display site.
- **Ordered by array position, not `createdAt`** — `createdAt` is not persisted and is stamped identically for all sessions on relaunch, so it is non-deterministic post-restart; array order is creation order in-run and survives restore.
- Pure helper `sessionInstanceOrdinals` in `savedConfigsView.ts` beside `runningConfigCounts`, fed the same array and memoized in `Sidebar`, so the pill count and row ordinals always agree.
- Ask-Conductor / config-less sessions are skipped.

## Tests

- Helper: per-config independent numbering, single-instance omission, Ask/config-less skipped.
- `SessionRow` render: shows `#N` with the prop, omits it without.

Full suite 8510 green + typecheck clean at 87f8a342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
