### PR TITLE
feat(ask): slim ask conductor session + browser pane clear

### DIFF
--- a/src/main/logging/should-register-run.ts
+++ b/src/main/logging/should-register-run.ts
@@ -22,6 +22,12 @@
  *                                         the remote host; nothing local to tail
  *                                         (same `options.ssh` signal the OSC
  *                                         sentinel SSH statusline branch keys on).
+ *  - NOT an Ask Conductor session       — the help session is an ephemeral
+ *                                         utility surface (#465): its chatter
+ *                                         must not fill the Logs index. Claude's
+ *                                         own transcripts still exist, so the
+ *                                         header's "Past discussions" resume
+ *                                         path is unaffected.
  *  - per-config loggingEnabled !== false  — DEFAULT-TRUE (undefined => ON).
  *  - global  loggingEnabled !== false     — DEFAULT-TRUE (undefined => ON).
  *
@@ -32,6 +38,8 @@ export function shouldRegisterRun(
     provider?: 'claude' | 'codex'
     shellOnly?: boolean
     ssh?: unknown
+    /** The Ask Conductor help session (#465). Never logged. */
+    isAsk?: boolean
     /** Per-config logging opt-out. DEFAULT-TRUE: only `false` disables. */
     loggingEnabled?: boolean
   },
@@ -42,6 +50,7 @@ export function shouldRegisterRun(
   if (opts.provider !== 'claude') return false
   if (opts.shellOnly) return false
   if (opts.ssh) return false
+  if (opts.isAsk === true) return false
   if (opts.loggingEnabled === false) return false
   if (settings.loggingEnabled === false) return false
   return true

--- a/src/main/tokenomics/tokenomics-service.ts
+++ b/src/main/tokenomics/tokenomics-service.ts
@@ -35,7 +35,10 @@ function loadConfigDims(): TkConfigDim[] {
   // Ask Conductor 'help' bucket (#465). The matcher is longest-prefix, so this
   // synthetic dim only ever claims spend from inside `<resources>/help` itself;
   // it cannot shadow a real config (and getResourcesDirectory never throws —
-  // it falls back under the data directory before the user picks one).
+  // it falls back under the data directory before the user picks one). Known
+  // edge, shared with every saved config: the worker's isJunkCwd runs first,
+  // so a resources dir under a junk-flagged segment (temp/, windows/) sends
+  // this spend to "External / no config" instead. Fails safe, never wrong.
   dims.push({ configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: join(getResourcesDirectory(), 'help') })
   return dims
 }

--- a/src/main/tokenomics/tokenomics-service.ts
+++ b/src/main/tokenomics/tokenomics-service.ts
@@ -5,8 +5,19 @@ import { forkTokenomicsWorker } from './fork-tokenomics-worker'
 import { getAllPricing, fetchModelPricing } from './tk-pricing'
 import { readConfig } from '../config-manager'
 import { onRegistryReload } from '../model-registry-service'
-import { getDataDirectory } from '../data-paths'
+import { getDataDirectory, getResourcesDirectory } from '../data-paths'
 import type { TkConfigDim } from './tk-types'
+
+/**
+ * Reserved attribution id for the Ask Conductor help session (#465). Its spend
+ * is real but it is not project work, so it must not pollute the "External /
+ * no config" bucket the cost views use for unrecognised spend. The help
+ * session's cwd is the staged `<resources>/help` workspace, so a synthetic
+ * config dim pointing there lets the ordinary cwd->config matcher file it
+ * under its own labeled row. Saved-config ids are crypto-random hex
+ * (shared/id.ts), so this literal can never collide with one.
+ */
+export const TK_HELP_CONFIG_ID = '__ask-help__'
 
 let _sup: TokenomicsSupervisor | null = null
 let _unsubReload: (() => void) | null = null
@@ -18,9 +29,15 @@ interface SavedConfigRecord { id: string; label: string; workingDirectory?: stri
 
 function loadConfigDims(): TkConfigDim[] {
   const configs = readConfig<SavedConfigRecord[]>('configs') ?? []
-  return configs
+  const dims = configs
     .filter((c): c is SavedConfigRecord & { workingDirectory: string } => !!c.workingDirectory)
     .map((c) => ({ configId: c.id, label: c.label, workingDirectory: c.workingDirectory }))
+  // Ask Conductor 'help' bucket (#465). The matcher is longest-prefix, so this
+  // synthetic dim only ever claims spend from inside `<resources>/help` itself;
+  // it cannot shadow a real config (and getResourcesDirectory never throws —
+  // it falls back under the data directory before the user picks one).
+  dims.push({ configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: join(getResourcesDirectory(), 'help') })
+  return dims
 }
 
 export function initTokenomics(opts: { emit: (channel: string, payload: unknown) => void }): void {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -879,6 +879,9 @@ export default function App() {
         {(() => {
           const gi = activeSession.githubIntegration
           const shouldShow =
+            // The Ask help session carries no GitHub surface at all (#465) —
+            // its cwd is the staged help workspace, not a project.
+            activeSession.kind !== 'ask' &&
             !gi?.enabled &&
             !gi?.repoUrl &&
             !gi?.dismissedAutoDetect &&
@@ -1092,7 +1095,11 @@ export default function App() {
               has the same Close button in the same corner (the desktop proof
               for item 26 found the FAB intercepting its clicks), so it is
               suppressed there too. */}
+          {/* #465: never for the Ask help session — this gate removes the FAB,
+              the rail AND the Ctrl+/ toggle (the listener lives inside the
+              panel), which is the whole GitHub surface. */}
           {activeSession
+            && activeSession.kind !== 'ask'
             && !excalidrawBySession[activeSession.id]?.isOpen
             && !webviewBySession[activeSession.id]?.isOpen && (
             <GitHubPanel sessionId={activeSession.id} />
@@ -1114,7 +1121,9 @@ export default function App() {
             sessionId={activeSession.id}
             configId={activeSession.configId}
             sessionType={activeSession.sessionType === 'ssh' ? 'ssh' : 'local'}
-            partnerEnabled={true}
+            // #465: the Ask help session has no partner shell — it is a help
+            // surface, not a workspace. Every other session keeps it.
+            partnerEnabled={activeSession.kind !== 'ask'}
             isPartnerActive={partnerActive.has(activeSession.id)}
             onTogglePartner={() => togglePartner(activeSession.id)}
             partnerSessionId={activeSession.id + '-partner'}

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -749,7 +749,10 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
         data-testid="command-row"
         data-overflow={overflowMode}
       >
-        {/* Add — far left, prominent (owner). Click adds a command; the caret offers the rest. */}
+        {/* Add — far left, prominent (owner). Click adds a command; the caret
+            offers the rest. Not on the Ask session (#465): its bar carries no
+            command bands, so there is nothing an Add could add to. */}
+        {!caps.isAsk && (
         <span className="inline-flex items-stretch rounded-md border shrink-0 overflow-hidden" style={{ borderColor: 'color-mix(in srgb, var(--brand) 55%, transparent)', background: 'color-mix(in srgb, var(--brand) 16%, transparent)' }} data-testid="command-add">
           <button
             type="button"
@@ -776,14 +779,19 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
             <svg width="9" height="9" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden><path d="M2.5 4l2.5 2.5L7.5 4" /></svg>
           </button>
         </span>
+        )}
 
-        {/* Core — the fixed tools. Components, never data, never drop targets. */}
+        {/* Core — the fixed tools. Components, never data, never drop targets.
+            The Ask session (#465) keeps only Snap and Canvas: it is a slim help
+            surface, so the project-facing tools — Logs (its runs are not
+            indexed), Browser, Artifacts (a claude.ai surface), Partner and the
+            encrypted Notes — never render there. */}
         <div role="toolbar" aria-label="Session tools" className="flex items-center gap-1 shrink-0" data-testid="command-band-core" onDragOver={(e) => { if (dragId) { e.dataTransfer.dropEffect = 'none' } }}>
           {!hiddenHere.has('snap') && caps.canSendImageToAgent && coreWrap('snap', <ScreenshotButton sessionId={sessionId} sessionType={sessionType} />)}
           {!hiddenHere.has('canvas') && coreWrap('canvas', <AgentCanvasButton sessionId={sessionId} />)}
-          {!hiddenHere.has('logs') && coreWrap('logs', <LogsButton sessionId={sessionId} structuralReason={caps.logsEmptyReason} remoteHost={caps.remoteHost} />)}
-          {!hiddenHere.has('browser') && coreWrap('browser', <WebviewButton sessionId={webviewKey} />)}
-          {!hiddenHere.has('artifacts') && artifactsApplicable && coreWrap('artifacts', (
+          {!caps.isAsk && !hiddenHere.has('logs') && coreWrap('logs', <LogsButton sessionId={sessionId} structuralReason={caps.logsEmptyReason} remoteHost={caps.remoteHost} />)}
+          {!caps.isAsk && !hiddenHere.has('browser') && coreWrap('browser', <WebviewButton sessionId={webviewKey} />)}
+          {!caps.isAsk && !hiddenHere.has('artifacts') && artifactsApplicable && coreWrap('artifacts', (
             <button
               type="button"
               onClick={openArtifacts}
@@ -799,7 +807,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
               Artifacts
             </button>
           ))}
-          {partnerEnabled && onTogglePartner && !hiddenHere.has('partner') && coreWrap('partner', (
+          {!caps.isAsk && partnerEnabled && onTogglePartner && !hiddenHere.has('partner') && coreWrap('partner', (
             <button
               onClick={onTogglePartner}
               className={`relative flex items-center gap-1.5 px-2 h-7 text-xs rounded border transition-colors whitespace-nowrap shrink-0 focus-ring ${
@@ -822,7 +830,7 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
             </button>
           ))}
           {/* The encrypted notes, moved here from the session header (D10): one lock, a quiet count. */}
-          {!hiddenHere.has('notes') && coreWrap('notes', <NotesTool ref={notesRef} configId={configId} configName={configName} />)}
+          {!caps.isAsk && !hiddenHere.has('notes') && coreWrap('notes', <NotesTool ref={notesRef} configId={configId} configName={configName} />)}
         </div>
 
         {/* Codex keeps its two session pills -- session controls, not commands. */}
@@ -840,7 +848,9 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
           </>
         )}
 
-        {plans.map(renderBand)}
+        {/* #465: no command bands on the Ask session — the user's Global and
+            per-config buttons are workspace tooling, not help-session tooling. */}
+        {!caps.isAsk && plans.map(renderBand)}
         <div className="flex-1 min-w-[4px]" />
       </div>
 

--- a/src/renderer/components/CommandBar.tsx
+++ b/src/renderer/components/CommandBar.tsx
@@ -970,8 +970,8 @@ export default function CommandBar({ sessionId, configId, sessionType = 'local',
         <BarMenu
           x={menu.x} y={menu.y} overflow={overflowMode}
           hiddenTools={Array.from(hiddenHere).map((t) => ({ tool: t, label: TOOL_LABEL[t] }))}
-          onAddCommand={() => { setMenu(null); setShowDialog({ scope: configId ? 'config' : 'global' }) }}
-          onAddSection={() => { setSectionInput({ x: menu.x, y: menu.y, band: configId ? 'config' : 'global' }); setMenu(null) }}
+          onAddCommand={caps.isAsk ? undefined : () => { setMenu(null); setShowDialog({ scope: configId ? 'config' : 'global' }) }}
+          onAddSection={caps.isAsk ? undefined : () => { setSectionInput({ x: menu.x, y: menu.y, band: configId ? 'config' : 'global' }); setMenu(null) }}
           onOverflow={(v) => { setMenu(null); setOverflow?.(v) }}
           onShowTool={(tool) => { setMenu(null); showCoreTool?.(tool, hidden.everywhere?.includes(tool) ? 'everywhere' : 'session', webviewKey) }}
           onManage={() => { setMenu(null); openSettingsTab('commands') }}

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -208,11 +208,14 @@ function SessionAuthPills({ session }: { session: Session }) {
     if (applies && !isAsk && profileId) void refresh(profileId)
   }, [applies, isAsk, profileId, refresh, session.id])
 
-  const gitHub = <SessionGitHubPill session={session} />
+  // Never a GitHub pill on the Ask session (#465) — structural, so even a
+  // stray githubIntegration on the record (there is no path that sets one,
+  // the auto-detect banner is gated) could not paint it.
+  const gitHub = isAsk ? null : <SessionGitHubPill session={session} />
   if (!applies || !profileId) {
     // Non-Claude sessions still show the GitHub pill (with its own leading
     // separator) so the right cluster stays consistent.
-    return session.githubIntegration?.repoSlug
+    return !isAsk && session.githubIntegration?.repoSlug
       ? (<><div className="w-px h-4 bg-surface1 shrink-0" />{gitHub}</>)
       : null
   }

--- a/src/renderer/components/SessionHeader.tsx
+++ b/src/renderer/components/SessionHeader.tsx
@@ -193,6 +193,11 @@ function SessionAuthPills({ session }: { session: Session }) {
   // web session. SSH (remote creds), Codex (not profile-scoped) and shell-only
   // sessions show nothing — same gate the context-menu auth items use.
   const applies = !session.shellOnly && session.sessionType === 'local' && (session.provider ?? 'claude') === 'claude'
+  // The Ask help session (#465) keeps ONLY the account pill: it still runs as an
+  // account (that requirement predates this), but the claude.ai / Claude Code
+  // auth pills and the GitHub pill are workspace chrome a help surface does not
+  // carry — and with no auth pills to feed, the status fetch is skipped too.
+  const isAsk = session.kind === 'ask'
   const profileId = session.profileId ?? primary?.id
   const profile = useAccountProfilesStore((s) => (profileId ? s.profiles.find((p) => p.id === profileId) : undefined))
   const status = useAccountAuthStore((s) => (profileId ? s.byProfile[profileId] : undefined))
@@ -200,8 +205,8 @@ function SessionAuthPills({ session }: { session: Session }) {
   React.useEffect(() => {
     // This header renders only the ACTIVE session, so mounting/param-change is
     // "on activate". Re-fetch when the session or its account changes.
-    if (applies && profileId) void refresh(profileId)
-  }, [applies, profileId, refresh, session.id])
+    if (applies && !isAsk && profileId) void refresh(profileId)
+  }, [applies, isAsk, profileId, refresh, session.id])
 
   const gitHub = <SessionGitHubPill session={session} />
   if (!applies || !profileId) {
@@ -236,6 +241,19 @@ function SessionAuthPills({ session }: { session: Session }) {
     resolveAccountColourKey(email, accountColourOverrides, profile?.colourKey),
     theme,
   )
+
+  // Slim Ask header (#465): the account pill alone. Everything below this point
+  // is auth-status wording for pills the Ask session does not render.
+  if (isAsk) {
+    return (
+      <HeaderPill
+        label={accountName}
+        tone={accountTone}
+        title={email ? `Account: ${email}` : 'This session’s Claude account'}
+        testId="session-pill-account"
+      />
+    )
+  }
 
   // A green dot = all good, no word; the word appears only when action is needed
   // (signed out / not connected / expired / unknown), mirroring the title bar.

--- a/src/renderer/components/WebviewPane.tsx
+++ b/src/renderer/components/WebviewPane.tsx
@@ -150,10 +150,18 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
         openInFlight = false
         if (cancelled) return
         if (ok) {
-          viewReadyRef.current = true
           // The URL may have moved on while the IPC was in flight.
           const latest = useWebviewStore.getState().bySessionId[sessionId]?.currentUrl
-          if (latest && latest !== url) void window.electronAPI.webview.navigate(sessionId, latest)
+          if (!latest) {
+            // Cleared while the open was in flight (#481): destroy the view this
+            // round trip just created and stay unready — the blank start page is
+            // what the user asked for, and the native view would paint over it.
+            viewReadyRef.current = false
+            void window.electronAPI.webview.close(sessionId).catch(() => { /* noop */ })
+            return
+          }
+          viewReadyRef.current = true
+          if (latest !== url) void window.electronAPI.webview.navigate(sessionId, latest)
         } else {
           setOpen(sessionId, false)
         }

--- a/src/renderer/components/WebviewPane.tsx
+++ b/src/renderer/components/WebviewPane.tsx
@@ -161,7 +161,14 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
             return
           }
           viewReadyRef.current = true
-          if (latest !== url) void window.electronAPI.webview.navigate(sessionId, latest)
+          // Clear-then-navigate inside this one round trip: the view this open
+          // created was destroyed by the Clear, so the compensating navigate
+          // fails — fall back to a fresh open instead of discarding the result.
+          if (latest !== url) {
+            void window.electronAPI.webview.navigate(sessionId, latest).then((navOk) => {
+              if (!navOk) { viewReadyRef.current = false; tryOpenRef.current?.() }
+            }).catch(() => { /* noop */ })
+          }
         } else {
           setOpen(sessionId, false)
         }

--- a/src/renderer/components/WebviewPane.tsx
+++ b/src/renderer/components/WebviewPane.tsx
@@ -58,6 +58,7 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
   const navigate = useWebviewStore((s) => s.navigate)
   const setPage = useWebviewStore((s) => s.setPage)
   const setHomeUrl = useWebviewStore((s) => s.setHomeUrl)
+  const clearPage = useWebviewStore((s) => s.clearPage)
 
   const configId = useSessionStore((s) => s.sessions.find((x) => x.id === sessionId)?.configId)
   const favourites = useBrowserStore((s) => s.favourites)
@@ -105,9 +106,11 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
   }, [sessionId, setPage])
 
   // The pane opened on its start page but this session has a home: go there.
+  // NOT after an explicit Clear (#481) — the user asked for the start page,
+  // and auto-homing would make the Clear button a no-op for anyone with a home.
   useEffect(() => {
-    if (state?.isOpen && !currentUrl && home) navigate(sessionId, home)
-  }, [state?.isOpen, currentUrl, home, sessionId, navigate])
+    if (state?.isOpen && !currentUrl && home && !state.atStartPage) navigate(sessionId, home)
+  }, [state?.isOpen, currentUrl, home, sessionId, navigate, state?.atStartPage])
 
   const measure = useCallback((): Bounds | null => {
     const el = containerRef.current
@@ -257,6 +260,15 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
     }
   }
   const handleReload = () => { void window.electronAPI.webview.reload(sessionId) }
+  const handleClear = () => {
+    // Destroy the native view FIRST: it paints above every HTML layer, so with
+    // it alive the start page would render underneath and never be seen. The
+    // ready flag drops with it; the next navigate recreates a fresh view (the
+    // same path the unmount cleanup + reopen uses).
+    viewReadyRef.current = false
+    void window.electronAPI.webview.close(sessionId).catch(() => { /* noop */ })
+    clearPage(sessionId)
+  }
   const handleFreeze = async () => {
     const image = await window.electronAPI.webview.capture(sessionId)
     if (image) setFrozenImage(image)
@@ -366,6 +378,9 @@ export default function WebviewPane({ sessionId, isActive }: Props) {
         </button>
         <button onClick={handleOpenExternal} disabled={!shownUrl} className={`${toolBtn} ${toolBtnIdle}`} title="Open in your real browser" aria-label="Open in your real browser" data-testid="browser-open-external">{Icon.external}</button>
         <div className="w-px h-4 bg-[var(--border-strong)] mx-0.5" />
+        {/* Clear (#481): back to the start page without closing the pane. The
+            only other way off a page was Close — which hides the whole pane. */}
+        <button onClick={handleClear} disabled={!currentUrl} className="px-2 py-0.5 text-xs rounded border border-[var(--border-subtle)] bg-[var(--surface-panel)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--text-primary)] transition-colors disabled:opacity-35" title="Clear the page — back to the start page" data-testid="browser-clear">Clear</button>
         <button onClick={handleFreeze} disabled={!currentUrl} className="px-2 py-0.5 text-xs rounded border border-[var(--border-subtle)] bg-[var(--surface-panel)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--text-primary)] transition-colors disabled:opacity-35" title="Freeze + annotate with Excalidraw">Freeze</button>
         <button onClick={handleClose} className="px-2 py-0.5 text-xs rounded border border-[var(--border-subtle)] bg-[var(--surface-panel)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--text-primary)] transition-colors" title="Back to the terminal" data-testid="browser-close">Close</button>
       </div>

--- a/src/renderer/components/command-bar/menus.tsx
+++ b/src/renderer/components/command-bar/menus.tsx
@@ -363,15 +363,17 @@ export function SectionMenu(p: {
 
 export function BarMenu(p: {
   x: number; y: number; overflow: CommandBarOverflow; hiddenTools: Array<{ tool: CoreToolId; label: string }>
-  onAddCommand: () => void; onAddSection: () => void; onOverflow: (v: CommandBarOverflow) => void
+  /** Absent on the slim Ask bar (#465): it renders no bands, so a command
+   *  added from here would be created and never appear — a dead end. */
+  onAddCommand?: () => void; onAddSection?: () => void; onOverflow: (v: CommandBarOverflow) => void
   onShowTool: (tool: CoreToolId) => void; onManage: () => void; onHideBar: () => void
   onClose: () => void; returnFocusTo?: HTMLElement | null
 }) {
   return (
     <Menu x={p.x} y={p.y} onClose={p.onClose} ariaLabel="Command bar menu" returnFocusTo={p.returnFocusTo} testId="bar-menu">
-      <MenuItem onClick={p.onAddCommand} icon={I.plus} testId="bar-add-command">Add command…</MenuItem>
-      <MenuItem onClick={p.onAddSection} icon={I.lines} testId="bar-add-section">Add section…</MenuItem>
-      <MenuRule />
+      {p.onAddCommand && <MenuItem onClick={p.onAddCommand} icon={I.plus} testId="bar-add-command">Add command…</MenuItem>}
+      {p.onAddSection && <MenuItem onClick={p.onAddSection} icon={I.lines} testId="bar-add-section">Add section…</MenuItem>}
+      {(p.onAddCommand || p.onAddSection) && <MenuRule />}
       <MenuItem onClick={() => p.onOverflow('fold')} testId="bar-overflow-fold">{p.overflow === 'fold' ? '● ' : '○ '}One row — fold the rest</MenuItem>
       <MenuItem onClick={() => p.onOverflow('wrap2')} testId="bar-overflow-wrap2">{p.overflow === 'wrap2' ? '● ' : '○ '}Two rows, then fold</MenuItem>
       <MenuItem icon={I.eyeoff} testId="bar-show-hidden" disabled={p.hiddenTools.length === 0} hint={p.hiddenTools.length ? String(p.hiddenTools.length) : 'none'} submenu={

--- a/src/renderer/stores/webviewStore.ts
+++ b/src/renderer/stores/webviewStore.ts
@@ -57,6 +57,13 @@ export interface WebviewSessionState {
    *  the persisted per-config home lives in browserStore). */
   homeUrl: string | null
   /**
+   * True only after an explicit Clear (#481): the user asked for the START
+   * page, so the pane's "opened blank with a home set -> go home" convenience
+   * must not immediately bounce them back to the home page. Any navigation
+   * or watch activation clears it.
+   */
+  atStartPage: boolean
+  /**
    * Monotonically-incremented per session on every `startActivation`.
    * Long-running pollers capture this token and pass it back to
    * `markAvailable` / `markFailed` so a stale poll can't overwrite a
@@ -101,6 +108,9 @@ interface Actions {
    *  home and "open a page" commands all come through here. The caller has
    *  already normalised + validated (shared/browser-url). */
   navigate: (sessionId: string, url: string) => void
+  /** Clear the pane back to its start page (#481): drops the requested URL and
+   *  the page report, keeps the pane open. The caller closes the native view. */
+  clearPage: (sessionId: string) => void
   /** Main's report of where the view actually is. */
   setPage: (state: WebviewNavState) => void
   /** Session-scoped home (not persisted). */
@@ -124,6 +134,7 @@ const defaultState = (): WebviewSessionState => ({
   isOpen: false,
   page: null,
   homeUrl: null,
+  atStartPage: false,
   activationId: 0,
 })
 
@@ -150,6 +161,7 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
           currentUrl: url,
           navSeq: cur.navSeq + 1,
           loadedAt: null,
+          atStartPage: false,
           activationId: nextToken,
         },
       },
@@ -168,7 +180,10 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
             ...prev,
             status: 'available',
             watchUrl: url,
-            currentUrl: prev.currentUrl ?? url,
+            // After an explicit Clear (#481) the blank pane is deliberate: a
+            // background re-probe must not point it anywhere. An explicit watch
+            // press comes through startActivation, which resets the flag.
+            currentUrl: prev.atStartPage ? prev.currentUrl : (prev.currentUrl ?? url),
             loadedAt: Date.now(),
           },
         },
@@ -214,7 +229,19 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       bySessionId: {
         ...s.bySessionId,
-        [sessionId]: { ...cur, currentUrl: url, navSeq: cur.navSeq + 1, isOpen: true },
+        [sessionId]: { ...cur, currentUrl: url, navSeq: cur.navSeq + 1, isOpen: true, atStartPage: false },
+      },
+    }))
+  },
+  clearPage: (sessionId) => {
+    const cur = get().bySessionId[sessionId]
+    // Nothing to clear for a session whose pane has no state; and `page` must
+    // go too — the address bar and star read page.url ahead of currentUrl.
+    if (!cur) return
+    set((s) => ({
+      bySessionId: {
+        ...s.bySessionId,
+        [sessionId]: { ...cur, currentUrl: null, page: null, atStartPage: true },
       },
     }))
   },
@@ -223,6 +250,9 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
     // A report for a session whose pane has never existed is a stale event
     // from a view that has since been torn down; there is nothing to update.
     if (!cur) return
+    // Same for a view Clear just closed (#481): a late navigation report must
+    // not repopulate `page` under the start page (the address bar reads it).
+    if (cur.atStartPage) return
     set((s) => ({
       bySessionId: {
         ...s.bySessionId,

--- a/src/renderer/stores/webviewStore.ts
+++ b/src/renderer/stores/webviewStore.ts
@@ -59,8 +59,9 @@ export interface WebviewSessionState {
   /**
    * True only after an explicit Clear (#481): the user asked for the START
    * page, so the pane's "opened blank with a home set -> go home" convenience
-   * must not immediately bounce them back to the home page. Any navigation
-   * or watch activation clears it.
+   * must not immediately bounce them back to the home page. Any navigation,
+   * watch activation, or fresh pane open clears it — the Clear applied to
+   * that viewing, not to the session forever.
    */
   atStartPage: boolean
   /**
@@ -205,13 +206,15 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
   },
   // Flip `isOpen` only — status (idle/pending/available/failed) is
   // owned by activation / probe / poll callers and unaffected by
-  // showing or hiding the pane.
+  // showing or hiding the pane. Opening ANEW forgets a previous Clear
+  // (#481): the explicit "show me the start page" applied to that viewing;
+  // a fresh open gets the ordinary go-home convenience back.
   togglePane: (sessionId) => {
     const cur = get().bySessionId[sessionId] || defaultState()
     set((s) => ({
       bySessionId: {
         ...s.bySessionId,
-        [sessionId]: { ...cur, isOpen: !cur.isOpen },
+        [sessionId]: { ...cur, isOpen: !cur.isOpen, atStartPage: cur.isOpen ? cur.atStartPage : false },
       },
     }))
   },
@@ -220,7 +223,7 @@ export const useWebviewStore = create<State & Actions>((set, get) => ({
     set((s) => ({
       bySessionId: {
         ...s.bySessionId,
-        [sessionId]: { ...cur, isOpen: open },
+        [sessionId]: { ...cur, isOpen: open, atStartPage: open && !cur.isOpen ? false : cur.atStartPage },
       },
     }))
   },

--- a/tests/unit/logging/should-register-run.test.ts
+++ b/tests/unit/logging/should-register-run.test.ts
@@ -63,6 +63,15 @@ describe('shouldRegisterRun', () => {
     expect(shouldRegisterRun({ provider: 'claude' }, { loggingEnabled: true })).toBe(true)
   })
 
+  it('does NOT register the Ask Conductor help session (#465)', () => {
+    expect(shouldRegisterRun({ provider: 'claude', isAsk: true }, {})).toBe(false)
+  })
+
+  it('still registers when isAsk is explicitly false or absent', () => {
+    expect(shouldRegisterRun({ provider: 'claude', isAsk: false }, {})).toBe(true)
+    expect(shouldRegisterRun({ provider: 'claude' }, {})).toBe(true)
+  })
+
   it('does NOT register an SSH codex shell-only mix (any single exclusion is enough)', () => {
     expect(
       shouldRegisterRun(

--- a/tests/unit/renderer/ask-slim-command-bar.test.tsx
+++ b/tests/unit/renderer/ask-slim-command-bar.test.tsx
@@ -149,4 +149,27 @@ describe('the Ask session bar is slim (#465)', () => {
     expect(byTestId('core-tool-partner')).not.toBeNull()
     expect(byTestId('core-tool-notes')).not.toBeNull()
   })
+
+  it('the bar right-click menu offers no Add entries on the Ask bar (they would create unreachable commands)', async () => {
+    await render()
+    act(() => {
+      byTestId('command-bar')!.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 40, clientY: 20 }))
+    })
+    expect(byTestId('bar-menu')).not.toBeNull()
+    expect(byTestId('bar-add-command')).toBeNull()
+    expect(byTestId('bar-add-section')).toBeNull()
+    // The rest of the menu (overflow, show hidden tools, manage, hide) survives.
+    expect(byTestId('bar-overflow-fold')).not.toBeNull()
+    expect(byTestId('bar-manage')).not.toBeNull()
+  })
+
+  it('…and keeps them on an ordinary bar', async () => {
+    SESSIONS = [NORMAL_SESSION]
+    await render({ configId: 'cfg' })
+    act(() => {
+      byTestId('command-bar')!.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 40, clientY: 20 }))
+    })
+    expect(byTestId('bar-add-command')).not.toBeNull()
+    expect(byTestId('bar-add-section')).not.toBeNull()
+  })
 })

--- a/tests/unit/renderer/ask-slim-command-bar.test.tsx
+++ b/tests/unit/renderer/ask-slim-command-bar.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+/**
+ * The slim Ask Conductor command bar (#465).
+ *
+ * The Ask session is a help surface, not a workspace: its bar keeps ONLY Snap
+ * and Canvas. Everything project-facing — the Add split chip, the Global and
+ * Session command bands, Logs, Browser, Artifacts, Partner and the encrypted
+ * Notes — must not render there, and the same props on an ordinary session
+ * must keep all of it (so the gate is `kind: 'ask'`, not a side effect of the
+ * missing config).
+ */
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const ASK_SESSION = {
+  id: 'ask-1', label: 'Ask Conductor', kind: 'ask', workingDirectory: '/res/help',
+  color: '#5d8bf0', sessionType: 'local', provider: 'claude', model: '',
+}
+const NORMAL_SESSION = {
+  id: 'ask-1', label: 'My config', workingDirectory: '/proj', color: '#89b4fa',
+  sessionType: 'local', provider: 'claude', model: 'sonnet', configId: 'cfg',
+}
+let SESSIONS: Array<Record<string, unknown>> = [ASK_SESSION]
+
+const COMMANDS = [
+  { id: 'g1', label: 'Explain', prompt: 'explain this', scope: 'global' as const, order: 0 },
+  { id: 'c1', label: 'Test', prompt: 'npm test', scope: 'config' as const, configId: 'cfg', target: 'partner' as const, order: 0 },
+]
+
+vi.mock('../../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: (sel: any) => sel({ sessions: SESSIONS, activeSessionId: 'ask-1', updateSession: vi.fn() }),
+}))
+vi.mock('../../../src/renderer/stores/commandStore', () => {
+  const state = () => ({
+    commands: COMMANDS, sections: [],
+    addCommand: vi.fn(), updateCommand: vi.fn(), removeCommand: vi.fn(), reorderCommands: vi.fn(),
+    moveCommand: vi.fn(), setCommandSection: vi.fn(), togglePinned: vi.fn(), clearReview: vi.fn(),
+    addSection: vi.fn(), updateSection: vi.fn(), removeSection: vi.fn(), reorderSections: vi.fn(),
+  })
+  const useCommandStore = (sel?: any) => (sel ? sel(state()) : state())
+  useCommandStore.getState = state
+  return { useCommandStore }
+})
+vi.mock('../../../src/renderer/stores/commandBarStore', () => ({
+  useCommandBarStore: (sel: any) => sel({
+    state: { collapsedSectionIds: [], barCollapsed: false, overflow: 'fold', hiddenCoreTools: { everywhere: [], bySession: {} } },
+    toggleSection: vi.fn(), setOverflow: vi.fn(), hideCoreTool: vi.fn(), showCoreTool: vi.fn(), setBarCollapsed: vi.fn(),
+  }),
+}))
+vi.mock('../../../src/renderer/stores/webviewStore', () => {
+  const state = { startActivation: vi.fn(() => 0), markAvailable: vi.fn(), markFailed: vi.fn(), navigate: vi.fn(), setOpen: vi.fn(), bySessionId: {} }
+  const useWebviewStore = (sel: any) => sel(state)
+  useWebviewStore.getState = () => state
+  return {
+    useWebviewStore,
+    pollUrlForContent: vi.fn(() => Promise.resolve(false)),
+    probeWebviewUrls: vi.fn(() => Promise.resolve(false)),
+  }
+})
+vi.mock('../../../src/renderer/stores/tipsStore', () => ({ trackUsage: vi.fn() }))
+vi.mock('../../../src/renderer/utils/id', () => ({ generateId: () => 'test-id' }))
+// Markers so "not drawn" is distinguishable from "drawn empty". The coreWrap
+// testids (core-tool-*) come from CommandBar itself, so absence checks read
+// those; these mocks just keep the heavy components out.
+vi.mock('../../../src/renderer/components/ScreenshotButton', () => ({ default: () => React.createElement('div', { 'data-testid': 'snap-mock' }) }))
+vi.mock('../../../src/renderer/components/AgentCanvasButton', () => ({ default: () => React.createElement('div', { 'data-testid': 'canvas-mock' }) }))
+vi.mock('../../../src/renderer/components/WebviewButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/LogsButton', () => ({ default: () => null }))
+vi.mock('../../../src/renderer/components/CommandDialog', () => ({ default: () => null }))
+
+const notesApi = {
+  list: vi.fn(async () => []), load: vi.fn(async () => ''), save: vi.fn(async () => true),
+  delete: vi.fn(async () => true), reorder: vi.fn(async () => true),
+}
+;(globalThis as any).window.electronAPI = {
+  ...(globalThis as any).window.electronAPI,
+  pty: { write: vi.fn() },
+  credentials: { save: vi.fn(), delete: vi.fn() },
+  notes: notesApi,
+}
+
+const { default: CommandBar } = await import('../../../src/renderer/components/CommandBar')
+const { useAccountProfilesStore } = await import('../../../src/renderer/stores/accountProfilesStore')
+
+let container: HTMLDivElement
+let root: Root
+
+const flush = () => act(async () => { await new Promise((r) => setTimeout(r, 0)) })
+const render = async (props: Record<string, unknown> = {}) => {
+  await act(async () => {
+    root.render(React.createElement(CommandBar, {
+      sessionId: 'ask-1', parentSessionId: 'ask-1',
+      // Partner props DELIBERATELY provided: the Ask bar must suppress the
+      // partner by kind, not merely because App forgot to wire it.
+      partnerEnabled: true, onTogglePartner: vi.fn(), partnerSessionId: 'ask-1-partner',
+      ...props,
+    } as never))
+  })
+  await flush()
+}
+const byTestId = (id: string) => container.querySelector<HTMLElement>(`[data-testid="${id}"]`)
+
+beforeEach(() => {
+  SESSIONS = [ASK_SESSION]
+  // A resolvable primary profile: even with an account the Ask bar must not
+  // grow the Artifacts tool (it is a claude.ai surface).
+  useAccountProfilesStore.setState({ profiles: [{ id: 'p1', isPrimary: true, name: 'Main', accountEmail: 'a@b.c' } as never] })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+describe('the Ask session bar is slim (#465)', () => {
+  it('keeps only Snap and Canvas; no Add, no bands, no Logs/Browser/Artifacts/Partner/Notes', async () => {
+    await render()
+    expect(byTestId('core-tool-snap')).not.toBeNull()
+    expect(byTestId('core-tool-canvas')).not.toBeNull()
+
+    expect(byTestId('command-add')).toBeNull()
+    expect(byTestId('command-band-global')).toBeNull()
+    expect(byTestId('command-band-config')).toBeNull()
+    expect(byTestId('core-tool-logs')).toBeNull()
+    expect(byTestId('core-tool-browser')).toBeNull()
+    expect(byTestId('core-tool-artifacts')).toBeNull()
+    expect(byTestId('core-tool-partner')).toBeNull()
+    expect(byTestId('core-tool-notes')).toBeNull()
+  })
+
+  it('an ordinary session with the SAME props keeps everything (the gate is kind, not the missing config)', async () => {
+    SESSIONS = [NORMAL_SESSION]
+    await render({ configId: 'cfg' })
+    expect(byTestId('command-add')).not.toBeNull()
+    expect(byTestId('command-band-global')).not.toBeNull()
+    expect(byTestId('command-band-config')).not.toBeNull()
+    expect(byTestId('core-tool-snap')).not.toBeNull()
+    expect(byTestId('core-tool-canvas')).not.toBeNull()
+    expect(byTestId('core-tool-logs')).not.toBeNull()
+    expect(byTestId('core-tool-browser')).not.toBeNull()
+    expect(byTestId('core-tool-artifacts')).not.toBeNull()
+    expect(byTestId('core-tool-partner')).not.toBeNull()
+    expect(byTestId('core-tool-notes')).not.toBeNull()
+  })
+})

--- a/tests/unit/renderer/session-header.test.tsx
+++ b/tests/unit/renderer/session-header.test.tsx
@@ -163,3 +163,36 @@ describe('SessionHeader', () => {
     expect(container.textContent).not.toContain('claude.ai')
   })
 })
+
+describe('the slim Ask header (#465)', () => {
+  // AskHeaderLead renders the running app version; vitest has no vite define.
+  beforeEach(() => { (globalThis as any).__APP_VERSION__ = '0.0.0-test' })
+
+  const askSession = (over: Partial<Session> = {}) =>
+    makeSession({ id: 'ask', kind: 'ask', label: 'Ask Conductor', configId: undefined, ...over })
+
+  it('keeps ONLY the account pill: no claude.ai / Claude Code / GitHub pills', () => {
+    useAccountProfilesStore.setState({ profiles: [{ id: 'profile-a', name: 'Work', accountEmail: 'me@work.co' } as any] })
+    render(askSession({ profileId: 'profile-a', provider: 'claude', sessionType: 'local' }))
+    expect(container.querySelector('[data-testid="session-pill-account"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-claudecode"]')).toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-claudeai"]')).toBeNull()
+    expect(container.querySelector('[data-testid="session-pill-github"]')).toBeNull()
+    expect(container.textContent).not.toContain('claude.ai')
+    expect(container.textContent).not.toContain('Claude Code')
+    useAccountProfilesStore.setState({ profiles: [] })
+  })
+
+  it('skips the auth-status fetch entirely (no pills to feed)', () => {
+    useAccountProfilesStore.setState({ profiles: [{ id: 'profile-a', name: 'Work', accountEmail: 'me@work.co' } as any] })
+    render(askSession({ profileId: 'profile-a', provider: 'claude', sessionType: 'local' }))
+    expect(window.electronAPI.accountWeb.status).not.toHaveBeenCalled()
+    useAccountProfilesStore.setState({ profiles: [] })
+  })
+
+  it('still wears the Ask band with its history affordance', () => {
+    render(askSession())
+    expect(container.querySelector('[data-ux-id="ask-band"]')).not.toBeNull()
+    expect(container.querySelector('[data-ux-id="ask-band-history"]')).not.toBeNull()
+  })
+})

--- a/tests/unit/renderer/webview-pane-browser.test.tsx
+++ b/tests/unit/renderer/webview-pane-browser.test.tsx
@@ -229,6 +229,75 @@ describe('with a page loaded', () => {
   })
 })
 
+describe('Clear — back to the start page (#481)', () => {
+  const loaded = async () => {
+    act(() => { useWebviewStore.getState().navigate('s1', 'http://localhost:5173/') })
+    render()
+    await flush()
+    expect(api.open).toHaveBeenCalledTimes(1)
+  }
+
+  it('destroys the native view and shows the start page; the pane stays open', async () => {
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    await flush()
+    expect(api.close).toHaveBeenCalledWith('s1')
+    expect(byTest('browser-start')).not.toBeNull()
+    expect(byTest('browser-viewport')).toBeNull()
+    const st = useWebviewStore.getState().bySessionId['s1']
+    expect(st.currentUrl).toBeNull()
+    expect(st.page).toBeNull()
+    expect(st.isOpen).toBe(true)
+  })
+
+  it('does NOT bounce back to the home page (that would make Clear a no-op for anyone with a home)', async () => {
+    useBrowserStore.getState().setHome('cfg1', 'http://localhost:4000/')
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    await flush()
+    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBeNull()
+    expect(byTest('browser-start')).not.toBeNull()
+    // …and no second native view was created for the suppressed auto-home.
+    expect(api.open).toHaveBeenCalledTimes(1)
+  })
+
+  it('a late navigation report from the closed view cannot repopulate the cleared pane', async () => {
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    act(() => { navHandler!({ sessionId: 's1', url: 'http://localhost:5173/stale', title: '', canGoBack: true, canGoForward: false, loading: false }) })
+    const st = useWebviewStore.getState().bySessionId['s1']
+    expect(st.page).toBeNull()
+    expect(byTest('browser-start')).not.toBeNull()
+  })
+
+  it('a background re-probe marking the watch available cannot yank the user off the start page', async () => {
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    act(() => { useWebviewStore.getState().markAvailable('s1', 'http://localhost:3000/') })
+    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBeNull()
+    expect(byTest('browser-start')).not.toBeNull()
+  })
+
+  it('navigating again after Clear creates a FRESH view (the old one was destroyed)', async () => {
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    await flush()
+    act(() => { type(byTest<HTMLInputElement>('browser-start-address')!, 'localhost:9999') })
+    act(() => { byTest<HTMLButtonElement>('browser-start-go')!.click() })
+    await flush()
+    expect(api.open).toHaveBeenCalledTimes(2)
+    expect(api.open).toHaveBeenLastCalledWith('s1', 'http://localhost:9999/', expect.anything())
+    expect(byTest('browser-viewport')).not.toBeNull()
+  })
+
+  it('is disabled on the start page (nothing to clear)', async () => {
+    open()
+    render()
+    await flush()
+    expect(byTest<HTMLButtonElement>('browser-clear')!.disabled).toBe(true)
+  })
+})
+
 describe('the modern palette (#455)', () => {
   // The pane regressed to the pre-redesign near-black palette once (#455: "the
   // old black UX crept in again"). Detector copied from

--- a/tests/unit/renderer/webview-pane-browser.test.tsx
+++ b/tests/unit/renderer/webview-pane-browser.test.tsx
@@ -296,6 +296,40 @@ describe('Clear — back to the start page (#481)', () => {
     await flush()
     expect(byTest<HTMLButtonElement>('browser-clear')!.disabled).toBe(true)
   })
+
+  it('Clear applies to THIS viewing: close and reopen the pane, and the home convenience is back', async () => {
+    useBrowserStore.getState().setHome('cfg1', 'http://localhost:4000/')
+    await loaded()
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    await flush()
+    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBeNull()
+    // Close the pane, reopen it: the fresh open forgets the Clear and homes.
+    act(() => { useWebviewStore.getState().setOpen('s1', false) })
+    act(() => { useWebviewStore.getState().setOpen('s1', true) })
+    await flush()
+    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBe('http://localhost:4000/')
+  })
+
+  it('Clear while an open is still in flight destroys the late view instead of resurrecting it', async () => {
+    let resolveOpen: (ok: boolean) => void = () => {}
+    api.open.mockImplementationOnce(() => new Promise((r) => { resolveOpen = r }))
+    act(() => { useWebviewStore.getState().navigate('s1', 'http://localhost:5173/') })
+    render()
+    await flush()
+    expect(api.open).toHaveBeenCalledTimes(1)
+    // Clear lands while the open IPC is still out.
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    api.close.mockClear()
+    await act(async () => { resolveOpen(true); await new Promise((r) => setTimeout(r, 0)) })
+    // The resolved open notices the cleared pane and closes the view it made.
+    expect(api.close).toHaveBeenCalledWith('s1')
+    expect(byTest('browser-start')).not.toBeNull()
+    // A later navigate creates a genuinely fresh view.
+    act(() => { type(byTest<HTMLInputElement>('browser-start-address')!, 'localhost:9999') })
+    act(() => { byTest<HTMLButtonElement>('browser-start-go')!.click() })
+    await flush()
+    expect(api.open).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('the modern palette (#455)', () => {

--- a/tests/unit/renderer/webview-pane-browser.test.tsx
+++ b/tests/unit/renderer/webview-pane-browser.test.tsx
@@ -330,6 +330,26 @@ describe('Clear — back to the start page (#481)', () => {
     await flush()
     expect(api.open).toHaveBeenCalledTimes(2)
   })
+
+  it('Clear THEN navigate, both inside one open round trip, still lands the new page (no stuck blank placeholder)', async () => {
+    let resolveOpen: (ok: boolean) => void = () => {}
+    api.open.mockImplementationOnce(() => new Promise((r) => { resolveOpen = r }))
+    act(() => { useWebviewStore.getState().navigate('s1', 'http://localhost:5173/') })
+    render()
+    await flush()
+    expect(api.open).toHaveBeenCalledTimes(1)
+    // Clear, then ask for a NEW page — the first open is still out, so the
+    // second request queues behind openInFlight.
+    act(() => { byTest<HTMLButtonElement>('browser-clear')!.click() })
+    act(() => { useWebviewStore.getState().navigate('s1', 'http://localhost:9999/') })
+    // The compensating navigate targets the view Clear destroyed: it fails.
+    api.navigate.mockResolvedValueOnce(false)
+    await act(async () => { resolveOpen(true); await new Promise((r) => setTimeout(r, 0)) })
+    await flush()
+    // The failed compensation fell back to a fresh open of the new page.
+    expect(api.open).toHaveBeenCalledTimes(2)
+    expect(api.open).toHaveBeenLastCalledWith('s1', 'http://localhost:9999/', expect.anything())
+  })
 })
 
 describe('the modern palette (#455)', () => {

--- a/tests/unit/tokenomics/tokenomics-service.test.ts
+++ b/tests/unit/tokenomics/tokenomics-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join } from 'node:path'
 import { FakeTkWorkerTransport } from '../../../src/main/tokenomics/tk-worker-transport'
 
 const forks: FakeTkWorkerTransport[] = []
@@ -20,7 +21,6 @@ import { initTokenomics, getTokenomicsSupervisor, shutdownTokenomics, refreshTok
 // every configs push, pointing at <resources>/help. Built with join() exactly
 // as the service builds it — a hardcoded 'F:\\resources\\help' would fail the
 // macOS CI leg, where join emits a forward slash.
-import { join } from 'node:path'
 const HELP_DIM = { configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: join('F:\\resources', 'help') }
 
 describe('tokenomics-service', () => {

--- a/tests/unit/tokenomics/tokenomics-service.test.ts
+++ b/tests/unit/tokenomics/tokenomics-service.test.ts
@@ -11,10 +11,14 @@ vi.mock('../../../src/main/tokenomics/fork-tokenomics-worker', () => ({
   },
 }))
 vi.mock('../../../src/main/config-manager', () => ({ readConfig: vi.fn(() => [{ id: 'a', label: 'App', workingDirectory: 'F:\\proj' }]) }))
-vi.mock('../../../src/main/data-paths', () => ({ getDataDirectory: () => 'F:\\data' }))
+vi.mock('../../../src/main/data-paths', () => ({ getDataDirectory: () => 'F:\\data', getResourcesDirectory: () => 'F:\\resources' }))
 vi.mock('../../../src/main/tokenomics/tk-pricing', () => ({ getAllPricing: () => ({}), fetchModelPricing: vi.fn(() => Promise.resolve()) }))
 
-import { initTokenomics, getTokenomicsSupervisor, shutdownTokenomics, refreshTokenomicsConfigs } from '../../../src/main/tokenomics/tokenomics-service'
+import { initTokenomics, getTokenomicsSupervisor, shutdownTokenomics, refreshTokenomicsConfigs, TK_HELP_CONFIG_ID } from '../../../src/main/tokenomics/tokenomics-service'
+
+// The synthetic Ask Conductor dim (#465) rides beside the saved configs on
+// every configs push, pointing at <resources>/help.
+const HELP_DIM = { configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: 'F:\\resources\\help' }
 
 describe('tokenomics-service', () => {
   beforeEach(() => { shutdownTokenomics(); forks.length = 0 })
@@ -26,7 +30,7 @@ describe('tokenomics-service', () => {
     const open = forks[0].workerMessages.find((m) => m.type === 'open') as any
     expect(open).toBeTruthy()
     expect(String(open.dbPath)).toContain('tokenomics.db')
-    expect(open.configs).toEqual([{ configId: 'a', label: 'App', workingDirectory: 'F:\\proj' }])
+    expect(open.configs).toEqual([{ configId: 'a', label: 'App', workingDirectory: 'F:\\proj' }, HELP_DIM])
     expect(getTokenomicsSupervisor()).not.toBeNull()
   })
 
@@ -36,10 +40,12 @@ describe('tokenomics-service', () => {
     expect(getTokenomicsSupervisor()).toBeNull()
   })
 
-  it('refreshTokenomicsConfigs pushes set-configs to the worker', () => {
+  it('refreshTokenomicsConfigs pushes set-configs to the worker (help dim included)', () => {
     initTokenomics({ emit: () => {} })
     forks[0].workerMessages.length = 0
     refreshTokenomicsConfigs()
-    expect(forks[0].workerMessages.some((m) => m.type === 'set-configs')).toBe(true)
+    const setConfigs = forks[0].workerMessages.find((m) => m.type === 'set-configs') as any
+    expect(setConfigs).toBeTruthy()
+    expect(setConfigs.configs).toContainEqual(HELP_DIM)
   })
 })

--- a/tests/unit/tokenomics/tokenomics-service.test.ts
+++ b/tests/unit/tokenomics/tokenomics-service.test.ts
@@ -17,8 +17,11 @@ vi.mock('../../../src/main/tokenomics/tk-pricing', () => ({ getAllPricing: () =>
 import { initTokenomics, getTokenomicsSupervisor, shutdownTokenomics, refreshTokenomicsConfigs, TK_HELP_CONFIG_ID } from '../../../src/main/tokenomics/tokenomics-service'
 
 // The synthetic Ask Conductor dim (#465) rides beside the saved configs on
-// every configs push, pointing at <resources>/help.
-const HELP_DIM = { configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: 'F:\\resources\\help' }
+// every configs push, pointing at <resources>/help. Built with join() exactly
+// as the service builds it — a hardcoded 'F:\\resources\\help' would fail the
+// macOS CI leg, where join emits a forward slash.
+import { join } from 'node:path'
+const HELP_DIM = { configId: TK_HELP_CONFIG_ID, label: 'Ask Conductor', workingDirectory: join('F:\\resources', 'help') }
 
 describe('tokenomics-service', () => {
   beforeEach(() => { shutdownTokenomics(); forks.length = 0 })


### PR DESCRIPTION
Closes #465. Closes #481. (Combined per owner call 2026-08-25: "the browser one in same PR".)

## #465 — slim Ask Conductor session

The Ask help session drops every workspace surface. **Keeps: Snap, Canvas, the statusline strip, the account pill, and the Ask band's "Past discussions".**

| Surface | Change |
|---|---|
| Command bar | No Add chip, no Global/Session bands, no Logs / Browser / Artifacts / Partner / Notes. Gate is `sessionCapabilities.isAsk` (the session's `kind`), not a side effect of the missing config — proven by a same-props control test. |
| GitHub | `GitHubPanel` never renders for ask — one gate removes the FAB, the rail and the Ctrl+/ toggle (the listener lives inside the panel). The auto-detect banner is gated too. |
| Partner | `partnerEnabled` off from App; the bar also suppresses it by kind even when the props are handed in. |
| Header | Ask keeps ONLY the account pill; the claude.ai / Claude Code auth pills and GitHub pill go, and the auth-status fetch is skipped. |
| Logging | `shouldRegisterRun` excludes `isAsk` — help chatter stays out of the Logs index. Claude's own transcripts are untouched, so "Past discussions" (the resume picker path) still works. |
| Tokenomics | A synthetic config dim (`__ask-help__` / "Ask Conductor" / `<resources>/help`) rides beside the saved configs; the ordinary longest-prefix cwd matcher files help spend under its own labeled row instead of "External / no config". |

**Verified already true, deliberately untouched:** Running counts / relaunch pill / launch-all are config-keyed (ask has no config and the sidebar filters `kind === 'ask'`); the main-process watchdog has skipped ask since #266; Sentinel is app-level, never per-session; tips are app-level (sidebar dock), not per-session.

Unlisted core tools (Logs, Notes, Artifacts) are also hidden — the issue's keep-list names exactly Snap and Canvas, Logs would be an empty pane once ask runs are unindexed, and Artifacts is a claude.ai surface. Say the word if any should return.

## #481 — browser pane Clear (minimal scope)

A **Clear** button beside Freeze returns the pane to its start page without closing it. Clear destroys the native WebContentsView first (it paints above all HTML), then clears the requested URL + page report. A new `atStartPage` flag makes the blank pane deliberate:

- the open-with-a-home auto-navigate is suppressed (Clear would otherwise be a no-op for anyone with a home page),
- a late navigation report from the closed view cannot repopulate the address bar,
- a background watch re-probe cannot yank the user off the start page — an explicit watch press still can (`startActivation` resets the flag).

Tabs are the follow-up (issue filed and linked on #481).

## Tests

Slim-bar matrix (ask vs same-props ordinary session), ask header pills + skipped fetch + band survival, `shouldRegisterRun` isAsk cases, help dim in the worker `open`/`set-configs` messages, and the Clear flow (view destroyed, no home bounce, stale report ignored, re-probe ignored, fresh view on next navigate, disabled at start).

Full suite 8523 green + typecheck clean at 3173263a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
