### PR TITLE
docs: surface SessionLoop aggregation layer in front-door docs (#527)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ Two traps worth knowing before you hit them:
 
 - `.claude/skills/adversarial-review/SKILL.md` — the adversarial review pass required for security-sensitive changes (ADR-009), plus the path table that decides when it applies.
 - `.claude/skills/LoopReady/SKILL.md`, `.claude/skills/StartLoop/SKILL.md` — the model-tiered autonomous-backlog pair (premise-review fan-out → labelled plan → autonomous run to PRs), and `docs/loop-autonomy.md` for the contract a "don't ask" run must respect and the blockers it cannot cross.
+- `.claude/skills/SessionLoop/SKILL.md` + `scripts/loop-tree.mjs` — the AGGREGATION layer (ADR-020, `architecture/decisions/…adr-020…`): when a BATCH of tickets should land as ONE PR, SessionLoop runs StartLoop steps 1‑6 per ticket in its own worktree, the AI merges each finished ticket branch INTO a `loop/<base>/<slug>` integration branch via `loop-tree` (which refuses any non-`loop/*` target — the narrow merge carve-out), then opens ONE squash PR. StartLoop is for unrelated tickets (one PR each); SessionLoop is for a batch (one PR total). The AI never merges the session PR to base — a human does.
 - `docs/security-embargo-runbook.md` — the executable procedure for an unfixed vulnerability: who can do what, the `gh` recipes, the private-fork workflow, and the traps (ADR-011).
 - `docs/agent-conventions.md` — the detailed agent/contributor conventions (hard constraints, IPC channel rules, branching & review).
 - `CONTRIBUTING.md` — contributor mechanics, commit-message format, changelog workflow.

--- a/docs/loop-autonomy.md
+++ b/docs/loop-autonomy.md
@@ -1,20 +1,54 @@
 # The autonomous-loop contract
 
-`/LoopReady` and `/StartLoop` let an unattended "don't ask permission" session take
-the open backlog and drive the runnable part of it to PRs. This is the contract
-that keeps such a run safe, and the honest catalogue of what it can and cannot do.
+`/LoopReady`, `/StartLoop` and `/SessionLoop` let an unattended "don't ask
+permission" session take the open backlog and drive the runnable part of it to
+PRs. This is the contract that keeps such a run safe, and the honest catalogue of
+what it can and cannot do.
 
-## The two skills, in one line each
+## The three skills, in one line each
 
 - **LoopReady** — read-only planner. A cheap Fable agent per open ticket does a
   premise review and emits a readiness record; the ticket is labelled `loop-ready`
   or `loop-needs-human`. No code, no PR, no merge.
-- **StartLoop** — autonomous executor. For each `loop-ready` ticket it re-checks the
-  premise, claims it, implements with opus in its own worktree, runs the gates and
-  (if security-sensitive) an adversarial pass, and opens a PR. **It stops there.**
+- **StartLoop** — autonomous executor for UNRELATED tickets. For each `loop-ready`
+  ticket it re-checks the premise, claims it, implements with opus in its own
+  worktree, runs the gates and (if security-sensitive) an adversarial pass, and
+  opens ONE PR per ticket. **It stops there.**
+- **SessionLoop** — the AGGREGATION layer for a BATCH that should land together
+  (ADR-020). It runs StartLoop steps 1‑6 per ticket, then merges each finished
+  ticket branch INTO a shared `loop/<base>/<slug>` integration branch and opens
+  ONE PR for the whole batch. **It also stops at the PR.** Use StartLoop when
+  tickets are unrelated (N PRs), SessionLoop when one review/merge is better than N.
 
 Model tiering is deliberate: Fable does the cheap, fan-out premise work; opus is
 spent only on execution, only on tickets already vetted as runnable.
+
+## Aggregation: many tickets, one PR (SessionLoop / ADR-020)
+
+The pieces are `.claude/skills/SessionLoop/SKILL.md` (the orchestrator) and
+`scripts/loop-tree.mjs` (the branch/merge primitive). The flow:
+
+```
+loop-tree open --base beta --slug <batch>     # mint loop/<base>/<slug> + a worktree
+session-guard adopt --path <it prints>        # the orchestrator OWNS that worktree
+  # per ticket: StartLoop steps 1-6 in its OWN worktree, then:
+loop-tree integrate --branch <ticket-branch>  # AI merges the ticket branch IN
+loop-tree submit --base beta                  # ONE squash PR, ci-run label, folded list
+  # a HUMAN merges the PR, then:
+loop-tree close --remove-worktree             # prune (refuses until HEAD is in origin/base)
+```
+
+Two invariants make this safe without touching the session-guard isolation model
+(ADR-012 is unchanged):
+
+- **`loop/<base>/<slug>` is a NEW namespace**, distinct from session-guard's
+  per-conversation `session/<base>/<short>`. Per-ticket work stays `feat/<n>-…` /
+  `fix/<n>-…`.
+- **The AI's merge authority is narrow and guarded.** Every mutating `loop-tree`
+  verb refuses unless the current branch is `loop/*` (`assertLoopBranch`), and it
+  only ever merges LOCAL ticket branches in (qualified/remote refs are rejected).
+  The AI merges ticket → `loop/*`; a HUMAN merges the session PR to base. See the
+  carve-out in "The hard boundary" below.
 
 ## The label state machine
 


### PR DESCRIPTION
Closes #527. Follow-up to #522 (ADR-020, merged in #523). **release-2.2.**

The session-integration loop shipped in #523 — ADR-020, the `SessionLoop` skill,
`scripts/loop-tree.mjs`, and the `docs/loop-autonomy.md` merge carve-out — but the two
docs a contributor or agent reads FIRST did not mention it, so the aggregation layer was
effectively undiscoverable.

## What this changes (docs-only)

- **`AGENTS.md`** — "Deeper references" now lists `.claude/skills/SessionLoop/SKILL.md` +
  `scripts/loop-tree.mjs` + ADR-020 alongside LoopReady/StartLoop, with one line
  distinguishing **StartLoop** (one PR per ticket, unrelated work) from **SessionLoop**
  (a batch aggregated into ONE PR).
- **`docs/loop-autonomy.md`** — the overview is now **three** skills (was two); a new
  **"Aggregation: many tickets, one PR (SessionLoop / ADR-020)"** section documents the
  `loop/<base>/<slug>` namespace and the `open → integrate → submit → close` flow, and
  restates the two safety invariants (new namespace, narrow guarded merge authority) that
  keep it inside the ADR-012 isolation model.

## Not touched / gates

- No code, no changelog entry (contributor/agent docs, not user-facing) → `Changelog in
  sync` stays green.
- Docs-only → adversarial review exempt (ADR-009 path table), no GUI surface → apply
  `skip-desktop-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
