### PR TITLE
fix(resume): recover conversations orphaned by a pruned worktree cwd (#535)

### DIFF
--- a/CONTEXT.d/2026-08-26-535-worktree-resume-orphan.md
+++ b/CONTEXT.d/2026-08-26-535-worktree-resume-orphan.md
@@ -1,0 +1,31 @@
+## 2026-08-26 -- #535 resume orphan recovery for pruned worktree cwds
+
+Sessions that ran in a git worktree lost their conversation on resume once the worktree was
+pruned. The durable session->conversation map (#480/#488) records the worktree path as the
+resume cwd; after the worktree is removed (session-guard / loop lifecycle, ADR-012 / #522)
+resolveResumeLaunch stats the dead cwd, returns null (correct fail-open, added by #397/#413's
+Fix 1 -- never retargets HOME), and CCC opens a fresh session. The transcript survives, orphaned
+in the worktree's mangled ~/.claude/projects folder (that tree is separate from the git worktree
+on disk), unreachable because no surviving cwd mangles to that folder.
+
+Confirmed against live data: session `aai-core | INSIGHTS FU` (uuid 6070b52c...) present in the
+morning session-state backup, gone after restart; its 2.9 MB transcript intact under
+`...projects\C--Users-severson-aai-core--claude-worktrees-session-2026-08-26-retrofix\`; the
+worktree absent from `git worktree list`. The fallback surfaced the worktree name
+(`session-2026-08-26-retrofix`) as the session label.
+
+Fix: new pure `recoverOrphanResumeLaunch(target, survivingCwd, deps)` in spawn-claude-command.ts,
+wired into pty-manager's resume else-branch. When (and only when) the target cwd is MISSING, the
+surviving configured cwd exists + is a dir + is not home/ancestor, and the orphan transcript
+exists inside projectsRoot, it relocates `<uuid>.jsonl` into the surviving cwd's mangled folder
+(keep-larger on collision, per #131/#132; rename with copy+unlink cross-device fallback) and
+resumes there. Fails CLOSED to null (existing fresh fallback) on any other condition. Guards:
+UUID_RE re-validation, projectsRoot containment (defense-in-depth vs a bad mangle), isHomeOrAncestor
+refusal, orphan-only gate (target cwd must be gone). New per-reason drop log at the null branch.
+
+Gate: 44/44 in tests/unit/main/spawn-resume-command.test.ts (12 new), typecheck clean (3 tsconfigs),
+full unit suite 8330 pass (9 unrelated vitest worker-pool startup timeouts under local resource
+contention -- flakes; the named file passes 32/32 in isolation; CI is the real gate).
+
+Related still-open follow-ups: #536 (sync CCC session name into the JSONL/session), and #397
+Phases 4-5. Refs #480 #397 #131 #522.

--- a/CONTEXT.d/2026-08-26-535-worktree-resume-orphan.md
+++ b/CONTEXT.d/2026-08-26-535-worktree-resume-orphan.md
@@ -27,5 +27,17 @@ Gate: 44/44 in tests/unit/main/spawn-resume-command.test.ts (12 new), typecheck 
 full unit suite 8330 pass (9 unrelated vitest worker-pool startup timeouts under local resource
 contention -- flakes; the named file passes 32/32 in isolation; CI is the real gate).
 
+Adversarial review (ADR-009, PTY resume argv + fs moves): 4 attackers (injection/traversal,
+bypass, fail-open, platform-parity). Injection, path traversal, home-escape, projectsRoot
+containment and isHomeOrAncestor all held. Two MAJORs found and fixed, then re-attacked (both hold):
+(1) keep-larger let a planted duplicate (source selected via the untrusted target.cwd) OVERWRITE a
+live destination transcript on a size compare -> fix: never overwrite; relocate ONLY into an empty
+dest slot, resume in place otherwise (removed sizeOf/keep-larger). (2) the copy fallback could leave
+a truncated file at the real <uuid>.jsonl name -> the heuristic binder's *.jsonl scan could
+cross-bind it -> fix: copy to a same-dir temp `<dst>.partial-<pid>` then atomic rename into place,
+remove temp on failure (fail closed to null), warn on an un-removable source. Residual INFO: a
+self-targeted TOCTOU on the dest with no attacker-controlled input and no privilege gain (optional
+COPYFILE_EXCL hardening noted, not required). Verdict PASS, 0 open. 15 unit tests (45/45 file green).
+
 Related still-open follow-ups: #536 (sync CCC session name into the JSONL/session), and #397
 Phases 4-5. Refs #480 #397 #131 #522.

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -2984,11 +2984,12 @@ export function spawnPty(
           const recovered = recoverOrphanResumeLaunch(effectiveTarget, resolvedCwd, {
             existsSync: fs.existsSync,
             statSync: (p) => fs.statSync(p),
-            sizeOf: (p) => fs.statSync(p).size,
             mkdirp: (dir) => { fs.mkdirSync(dir, { recursive: true }) },
             renameFile: (src, dst) => { fs.renameSync(src, dst) },
             copyFile: (src, dst) => { fs.copyFileSync(src, dst) },
             removeFile: (p) => { fs.rmSync(p, { force: true }) },
+            pid: () => process.pid,
+            warn: (msg) => { logWarn(msg) },
             homedir: os.homedir,
             mangleCwdToProjectDir,
             projectsRoot: path.join(os.homedir(), '.claude', 'projects'),

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -15,7 +15,7 @@ import { logPtyOutput, isDebugModeEnabled } from './debug-capture'
 import { shouldRegisterRun } from './logging/should-register-run'
 import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service'
 import { resolveResumeTargetFromTranscript, mangleCwdToProjectDir } from './logging/transcript-discovery'
-import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath, quoteArgForShell, modelFlag } from './spawn-claude-command'
+import { buildClaudeLaunchCommand, resolveResumeLaunch, recoverOrphanResumeLaunch, buildResumeTranscriptPath, quoteArgForShell, modelFlag } from './spawn-claude-command'
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
@@ -2977,7 +2977,33 @@ export function spawnPty(
           resumeUuidForBind = launch.resumeUuid
           logInfo(`[pty] T8b exact resume for ${sessionId}: uuid=${resumeUuid} cwd=${claudeCwd} (was ${resolvedCwd})`)
         } else {
-          logInfo(`[pty] T8b resume target dropped for ${sessionId} (fail-open existence check) — uuid=${effectiveTarget.uuid}`)
+          // #535: the exact gate failed. When the ONLY reason is a deleted
+          // worktree cwd, the conversation transcript still exists under the
+          // worktree's mangled project folder — relocate it into the surviving
+          // configured cwd's folder and resume there rather than opening fresh.
+          const recovered = recoverOrphanResumeLaunch(effectiveTarget, resolvedCwd, {
+            existsSync: fs.existsSync,
+            statSync: (p) => fs.statSync(p),
+            sizeOf: (p) => fs.statSync(p).size,
+            mkdirp: (dir) => { fs.mkdirSync(dir, { recursive: true }) },
+            renameFile: (src, dst) => { fs.renameSync(src, dst) },
+            copyFile: (src, dst) => { fs.copyFileSync(src, dst) },
+            removeFile: (p) => { fs.rmSync(p, { force: true }) },
+            homedir: os.homedir,
+            mangleCwdToProjectDir,
+            projectsRoot: path.join(os.homedir(), '.claude', 'projects'),
+            isHomeOrAncestor,
+            ensureCompanionDir: (projectDir, uuid) => { ensureCompanionDir(projectDir, uuid, nodeFsCompanionDeps) },
+          })
+          if (recovered) {
+            resumeUuid = recovered.resumeUuid
+            claudeCwd = recovered.claudeCwd
+            effectiveLaunchCwd = claudeCwd
+            resumeUuidForBind = recovered.resumeUuid
+            logInfo(`[pty] T8b ORPHAN-RECOVERED resume for ${sessionId}: uuid=${resumeUuid} relocated to cwd=${claudeCwd} (dead worktree was ${effectiveTarget.cwd})`)
+          } else {
+            logInfo(`[pty] T8b resume target dropped for ${sessionId} (fail-open existence check; no orphan recovery) — uuid=${effectiveTarget.uuid} cwd=${effectiveTarget.cwd}`)
+          }
         }
       }
 

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -241,6 +241,147 @@ export function resolveResumeLaunch(
 }
 
 // ---------------------------------------------------------------------------
+// recoverOrphanResumeLaunch — resume a conversation whose worktree cwd is gone (#535)
+// ---------------------------------------------------------------------------
+
+/**
+ * Injectable deps for {@link recoverOrphanResumeLaunch}. Production wraps node
+ * fs/os + path-utils; tests pass in-memory fakes so the relocation logic is
+ * unit-testable WITHOUT touching disk.
+ */
+export interface RecoverOrphanDeps {
+  existsSync: (p: string) => boolean
+  statSync: (p: string) => { isDirectory: () => boolean }
+  /** Byte size of a file (used for the keep-larger collision rule). */
+  sizeOf: (p: string) => number
+  /** Recursively create a directory (mkdir -p). */
+  mkdirp: (dir: string) => void
+  /** Move a file (rename); may throw on cross-device, caller falls back to copy. */
+  renameFile: (src: string, dst: string) => void
+  /** Copy a file (cross-device fallback for renameFile). */
+  copyFile: (src: string, dst: string) => void
+  /** Best-effort unlink after a copy fallback; must not throw fatally. */
+  removeFile: (p: string) => void
+  homedir: () => string
+  mangleCwdToProjectDir: (cwd: string) => string
+  /** Canonical `~/.claude/projects` root. */
+  projectsRoot: string
+  /** True when `cwd` IS or is an ANCESTOR of the user's home dir — never relocate there. */
+  isHomeOrAncestor: (cwd: string) => boolean
+  ensureCompanionDir: (projectDir: string, uuid: string) => void
+}
+
+/**
+ * Recover a resume whose ORIGINAL cwd (a git worktree) has been deleted (#535).
+ *
+ * {@link resolveResumeLaunch} deliberately returns null when the captured cwd
+ * is gone — it never retargets homedir. But a session that ran in a worktree
+ * created by session-guard / the loop system (ADR-012 / #522) has its transcript
+ * written under the worktree's mangled project folder, which SURVIVES the
+ * worktree deletion (the `~/.claude/projects/<mangle>/…` tree is a separate
+ * location from the git worktree on disk). The conversation is therefore intact
+ * but unreachable: `claude --resume <uuid>` looks in `<mangle(launchCwd)>/`, and
+ * no surviving cwd mangles to the dead worktree's folder.
+ *
+ * This recovers it by RELOCATING the orphaned `<uuid>.jsonl` into the surviving
+ * cwd's (the session's configured repo root) mangled folder, then resuming there.
+ *
+ * Applies ONLY to the genuine orphan case, and fails CLOSED to null (→ caller's
+ * fresh fallback) on anything else. ALL must hold:
+ *   - target present, uuid matches the canonical UUID format;
+ *   - the target's RAW cwd is MISSING (this is what makes it an orphan — if it
+ *     exists, resolveResumeLaunch's null was for another reason; do not relocate);
+ *   - `survivingCwd` exists, is a directory, and is NOT home or an ancestor of it
+ *     (never relocate a transcript into ~/.claude/projects/<mangle(home)>);
+ *   - the orphan transcript `projectsRoot/<mangle(targetCwd)>/<uuid>.jsonl` exists
+ *     and resolves INSIDE projectsRoot (containment — defense in depth);
+ *   - the destination path also resolves INSIDE projectsRoot.
+ *
+ * Collision rule (matches #131/#132): if a transcript already exists at the
+ * destination, keep the LARGER file (transcripts only grow → never lose history)
+ * — if the existing dest is at least as large, resume it in place without moving.
+ *
+ * Returns `{ resumeUuid, claudeCwd }` (claudeCwd = the surviving cwd) or null.
+ */
+export function recoverOrphanResumeLaunch(
+  target: ResumeTarget | undefined,
+  survivingCwd: string,
+  deps: RecoverOrphanDeps,
+): { resumeUuid: string; claudeCwd: string } | null {
+  try {
+    if (!target || !target.uuid || !target.cwd) return null
+    if (!UUID_RE.test(target.uuid)) return null
+    if (!survivingCwd) return null
+
+    const home = deps.homedir()
+
+    // Expand a leading `~` in the target cwd the same way resolveResumeLaunch does.
+    let rawTargetCwd: string
+    if (target.cwd === '~') rawTargetCwd = home
+    else if (target.cwd.startsWith('~/') || target.cwd.startsWith('~\\')) rawTargetCwd = nodePath.join(home, target.cwd.slice(2))
+    else rawTargetCwd = nodePath.resolve(target.cwd)
+
+    // ORPHAN GATE: recovery applies ONLY when the original cwd is gone. If it
+    // still exists, resolveResumeLaunch failed for another reason (e.g. the
+    // transcript was pruned) and relocating would be wrong.
+    if (deps.existsSync(rawTargetCwd)) return null
+
+    // The surviving cwd must be a real directory and MUST NOT be home/an ancestor.
+    const survivingResolved = nodePath.resolve(survivingCwd)
+    if (!deps.existsSync(survivingResolved)) return null
+    if (!deps.statSync(survivingResolved).isDirectory()) return null
+    if (deps.isHomeOrAncestor(survivingResolved)) return null
+
+    const rootWithSep = deps.projectsRoot.endsWith(nodePath.sep) ? deps.projectsRoot : deps.projectsRoot + nodePath.sep
+    const contained = (p: string): boolean => p === deps.projectsRoot || p.startsWith(rootWithSep)
+
+    const orphanDir = nodePath.resolve(nodePath.join(deps.projectsRoot, deps.mangleCwdToProjectDir(target.cwd)))
+    const orphanTranscript = nodePath.join(orphanDir, `${target.uuid}.jsonl`)
+    if (!contained(orphanDir)) return null
+    if (!deps.existsSync(orphanTranscript)) return null
+
+    const destDir = nodePath.resolve(nodePath.join(deps.projectsRoot, deps.mangleCwdToProjectDir(survivingResolved)))
+    const destTranscript = nodePath.join(destDir, `${target.uuid}.jsonl`)
+    if (!contained(destDir)) return null
+
+    // Nothing to do if the source already sits in the destination folder (the
+    // surviving cwd happens to mangle to the same place). Resume as-is.
+    if (destTranscript !== orphanTranscript) {
+      if (deps.existsSync(destTranscript)) {
+        // Keep-larger: a bigger file at the destination already holds >= history.
+        const destSize = deps.sizeOf(destTranscript)
+        const orphanSize = deps.sizeOf(orphanTranscript)
+        if (orphanSize > destSize) {
+          deps.mkdirp(destDir)
+          relocate(orphanTranscript, destTranscript, deps)
+        }
+        // else: destination is at least as large — resume it in place.
+      } else {
+        deps.mkdirp(destDir)
+        relocate(orphanTranscript, destTranscript, deps)
+      }
+    }
+
+    try { deps.ensureCompanionDir(destDir, target.uuid) } catch { /* best-effort */ }
+
+    return { resumeUuid: target.uuid, claudeCwd: survivingResolved }
+  } catch {
+    return null
+  }
+}
+
+/** Move src→dst, preferring an atomic rename, falling back to copy+unlink. */
+function relocate(src: string, dst: string, deps: RecoverOrphanDeps): void {
+  try {
+    deps.renameFile(src, dst)
+  } catch {
+    // Cross-device or locked: copy then best-effort remove the original.
+    deps.copyFile(src, dst)
+    try { deps.removeFile(src) } catch { /* best-effort */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // buildResumeTranscriptPath — deterministic resume-bind path (Part A)
 // ---------------------------------------------------------------------------
 

--- a/src/main/spawn-claude-command.ts
+++ b/src/main/spawn-claude-command.ts
@@ -252,16 +252,18 @@ export function resolveResumeLaunch(
 export interface RecoverOrphanDeps {
   existsSync: (p: string) => boolean
   statSync: (p: string) => { isDirectory: () => boolean }
-  /** Byte size of a file (used for the keep-larger collision rule). */
-  sizeOf: (p: string) => number
   /** Recursively create a directory (mkdir -p). */
   mkdirp: (dir: string) => void
   /** Move a file (rename); may throw on cross-device, caller falls back to copy. */
   renameFile: (src: string, dst: string) => void
   /** Copy a file (cross-device fallback for renameFile). */
   copyFile: (src: string, dst: string) => void
-  /** Best-effort unlink after a copy fallback; must not throw fatally. */
+  /** Best-effort unlink; must not throw fatally. */
   removeFile: (p: string) => void
+  /** Current process id — makes the copy-fallback temp name unique. */
+  pid: () => number
+  /** Non-fatal diagnostic (e.g. a source that could not be removed post-copy). */
+  warn: (msg: string) => void
   homedir: () => string
   mangleCwdToProjectDir: (cwd: string) => string
   /** Canonical `~/.claude/projects` root. */
@@ -297,9 +299,12 @@ export interface RecoverOrphanDeps {
  *     and resolves INSIDE projectsRoot (containment — defense in depth);
  *   - the destination path also resolves INSIDE projectsRoot.
  *
- * Collision rule (matches #131/#132): if a transcript already exists at the
- * destination, keep the LARGER file (transcripts only grow → never lose history)
- * — if the existing dest is at least as large, resume it in place without moving.
+ * Collision rule (adversarial review #535): if a transcript ALREADY exists at
+ * the destination, that IS the conversation for this uuid in this project —
+ * resume it IN PLACE and NEVER overwrite it. The orphan source path is derived
+ * from `target.cwd` (transcript content, not a trusted value), so a size-compare
+ * "keep-larger" overwrite would let a planted duplicate clobber a live, possibly
+ * different conversation. Relocation only ever writes into an EMPTY dest slot.
  *
  * Returns `{ resumeUuid, claudeCwd }` (claudeCwd = the surviving cwd) or null.
  */
@@ -344,22 +349,13 @@ export function recoverOrphanResumeLaunch(
     const destTranscript = nodePath.join(destDir, `${target.uuid}.jsonl`)
     if (!contained(destDir)) return null
 
-    // Nothing to do if the source already sits in the destination folder (the
-    // surviving cwd happens to mangle to the same place). Resume as-is.
-    if (destTranscript !== orphanTranscript) {
-      if (deps.existsSync(destTranscript)) {
-        // Keep-larger: a bigger file at the destination already holds >= history.
-        const destSize = deps.sizeOf(destTranscript)
-        const orphanSize = deps.sizeOf(orphanTranscript)
-        if (orphanSize > destSize) {
-          deps.mkdirp(destDir)
-          relocate(orphanTranscript, destTranscript, deps)
-        }
-        // else: destination is at least as large — resume it in place.
-      } else {
-        deps.mkdirp(destDir)
-        relocate(orphanTranscript, destTranscript, deps)
-      }
+    // Relocate ONLY into an empty destination slot. If the source already sits
+    // in the destination folder (the surviving cwd mangles to the same place), or
+    // a transcript for this uuid already exists there, resume in place and move
+    // nothing — never overwrite a live transcript (see the collision rule above).
+    if (destTranscript !== orphanTranscript && !deps.existsSync(destTranscript)) {
+      deps.mkdirp(destDir)
+      relocate(orphanTranscript, destTranscript, deps)
     }
 
     try { deps.ensureCompanionDir(destDir, target.uuid) } catch { /* best-effort */ }
@@ -370,14 +366,37 @@ export function recoverOrphanResumeLaunch(
   }
 }
 
-/** Move src→dst, preferring an atomic rename, falling back to copy+unlink. */
+/**
+ * Move src→dst. Caller guarantees dst does not yet exist.
+ *
+ * Prefer an atomic same-name rename. On cross-device (EXDEV) or a locked source,
+ * copy to a SAME-DIRECTORY temp sibling and rename THAT into place — so a partial
+ * copy never lands at the `<uuid>.jsonl` name the heuristic binder scans (adv
+ * review #535). The temp is a sibling of dst, so the final rename is same-device.
+ * On any copy failure the partial temp is removed before the error propagates
+ * (the outer catch in recoverOrphanResumeLaunch then fails the recovery closed).
+ * A source that cannot be unlinked after a successful copy is a non-fatal leak —
+ * warn, do not throw (resume already has a correct destination).
+ */
 function relocate(src: string, dst: string, deps: RecoverOrphanDeps): void {
   try {
     deps.renameFile(src, dst)
+    return
   } catch {
-    // Cross-device or locked: copy then best-effort remove the original.
-    deps.copyFile(src, dst)
-    try { deps.removeFile(src) } catch { /* best-effort */ }
+    // fall through to the copy fallback
+  }
+  const tmp = `${dst}.partial-${deps.pid()}`
+  try {
+    deps.copyFile(src, tmp)
+    deps.renameFile(tmp, dst)
+  } catch (e) {
+    try { deps.removeFile(tmp) } catch { /* best-effort cleanup */ }
+    throw e
+  }
+  try {
+    deps.removeFile(src)
+  } catch {
+    deps.warn(`[resume] orphan recovery: copied transcript to ${dst} but could not remove the source ${src} (left in place)`)
   }
 }
 

--- a/tests/unit/main/spawn-resume-command.test.ts
+++ b/tests/unit/main/spawn-resume-command.test.ts
@@ -424,33 +424,38 @@ describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
     removeFile: ReturnType<typeof vi.fn>
     mkdirp: ReturnType<typeof vi.fn>
     ensureCompanionDir: ReturnType<typeof vi.fn>
+    warn: ReturnType<typeof vi.fn>
   }
+  const PID = 4242
   function makeDeps(opts: {
     existsPaths?: Set<string>
     dirPaths?: Set<string>
-    sizes?: Map<string, number>
     isHomeOrAncestor?: (cwd: string) => boolean
     mangleCwdToProjectDir?: (cwd: string) => string
-    renameThrows?: boolean
+    renameFile?: (src: string, dst: string) => void
+    copyFile?: (src: string, dst: string) => void
+    removeFile?: (p: string) => void
     projectsRoot?: string
   } = {}): { deps: any; spies: Spies } {
     const exists = opts.existsPaths
     const dirs = opts.dirPaths
     const spies: Spies = {
-      renameFile: vi.fn(() => { if (opts.renameThrows) throw new Error('EXDEV') }),
-      copyFile: vi.fn(),
-      removeFile: vi.fn(),
+      renameFile: vi.fn(opts.renameFile),
+      copyFile: vi.fn(opts.copyFile),
+      removeFile: vi.fn(opts.removeFile),
       mkdirp: vi.fn(),
       ensureCompanionDir: vi.fn(),
+      warn: vi.fn(),
     }
     const deps = {
       existsSync: (p: string) => (exists ? exists.has(p) : true),
       statSync: (p: string) => ({ isDirectory: () => (dirs ? dirs.has(p) : true) }),
-      sizeOf: (p: string) => (opts.sizes ? (opts.sizes.get(p) ?? 0) : 0),
       mkdirp: spies.mkdirp,
       renameFile: spies.renameFile,
       copyFile: spies.copyFile,
       removeFile: spies.removeFile,
+      pid: () => PID,
+      warn: spies.warn,
       homedir: () => HOME,
       mangleCwdToProjectDir: opts.mangleCwdToProjectDir ?? mangle,
       projectsRoot: opts.projectsRoot ?? PROJECTS_ROOT,
@@ -459,6 +464,7 @@ describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
     }
     return { deps, spies }
   }
+  const destTranscriptPath = () => path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`)
 
   it('happy path: dead worktree + surviving cwd + orphan transcript → relocates and resumes in surviving cwd', () => {
     // Everything exists EXCEPT the dead worktree dir; dest folder has no transcript yet.
@@ -513,33 +519,55 @@ describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
     expect(recoverOrphanResumeLaunch({ uuid: '$(rm -rf /)', cwd: DEAD_WT }, SURVIVING, deps)).toBeNull()
   })
 
-  it('keep-larger: existing destination transcript is larger → resume in place, no relocate', () => {
-    const destTranscript = path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`)
-    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT), destTranscript])
-    const sizes = new Map<string, number>([[transcriptOf(DEAD_WT), 100], [destTranscript, 500]])
-    const { deps, spies } = makeDeps({ existsPaths, sizes })
+  it('SECURITY (adv #535): an existing destination transcript is NEVER overwritten — resume in place', () => {
+    // The orphan source path derives from target.cwd (transcript content, not
+    // trusted). If a transcript for this uuid already exists at the destination,
+    // that IS the conversation — resume it, move nothing, whatever the sizes.
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT), destTranscriptPath()])
+    const { deps, spies } = makeDeps({ existsPaths })
     const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
     expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
     expect(spies.renameFile).not.toHaveBeenCalled()
+    expect(spies.copyFile).not.toHaveBeenCalled()
   })
 
-  it('keep-larger: orphan is larger than the existing destination → relocates over it', () => {
-    const destTranscript = path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`)
-    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT), destTranscript])
-    const sizes = new Map<string, number>([[transcriptOf(DEAD_WT), 999], [destTranscript, 10]])
-    const { deps, spies } = makeDeps({ existsPaths, sizes })
-    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
-    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
-    expect(spies.renameFile).toHaveBeenCalledWith(transcriptOf(DEAD_WT), destTranscript)
-  })
-
-  it('cross-device rename → falls back to copy + remove, still resumes', () => {
+  it('cross-device rename → copies to a SAME-DIR temp, renames temp→dst, removes source (no partial at the uuid name)', () => {
+    const dst = destTranscriptPath()
+    const tmp = `${dst}.partial-${PID}`
+    // The initial same-name rename throws EXDEV; the temp→dst rename succeeds.
+    const renameFile = vi.fn((src: string, d: string) => { if (d === dst && src === transcriptOf(DEAD_WT)) throw new Error('EXDEV') })
     const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
-    const { deps, spies } = makeDeps({ existsPaths, renameThrows: true })
+    const { deps, spies } = makeDeps({ existsPaths, renameFile })
     const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
     expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
-    expect(spies.copyFile).toHaveBeenCalledTimes(1)
-    expect(spies.removeFile).toHaveBeenCalledTimes(1)
+    expect(spies.copyFile).toHaveBeenCalledWith(transcriptOf(DEAD_WT), tmp)
+    expect(spies.renameFile).toHaveBeenCalledWith(tmp, dst)
+    expect(spies.removeFile).toHaveBeenCalledWith(transcriptOf(DEAD_WT))
+  })
+
+  it('partial copy (copyFile throws) → removes the temp and fails CLOSED to null (no file at the uuid name)', () => {
+    const dst = destTranscriptPath()
+    const tmp = `${dst}.partial-${PID}`
+    const renameFile = vi.fn((_src: string, d: string) => { if (d === dst) throw new Error('EXDEV') })
+    const copyFile = vi.fn(() => { throw new Error('ENOSPC') })
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
+    const { deps, spies } = makeDeps({ existsPaths, renameFile, copyFile })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toBeNull()                                   // fail closed → caller launches fresh
+    expect(spies.removeFile).toHaveBeenCalledWith(tmp)       // partial temp cleaned up
+    // dst (the <uuid>.jsonl name the heuristic binder scans) was never written
+    expect(spies.renameFile).not.toHaveBeenCalledWith(tmp, dst)
+  })
+
+  it('source unlink fails after a successful copy → WARNS and still resumes (non-fatal leak)', () => {
+    const dst = destTranscriptPath()
+    const renameFile = vi.fn((src: string, d: string) => { if (d === dst && src === transcriptOf(DEAD_WT)) throw new Error('EXDEV') })
+    const removeFile = vi.fn((p: string) => { if (p === transcriptOf(DEAD_WT)) throw new Error('EBUSY') })
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
+    const { deps, spies } = makeDeps({ existsPaths, renameFile, removeFile })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
+    expect(spies.warn).toHaveBeenCalledTimes(1)
   })
 
   it('containment: a mangle that escapes projectsRoot is refused (defense in depth)', () => {
@@ -557,8 +585,8 @@ describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
     const deps = {
       existsSync: () => { throw new Error('boom') },
       statSync: () => ({ isDirectory: () => true }),
-      sizeOf: () => 0,
       mkdirp: vi.fn(), renameFile: vi.fn(), copyFile: vi.fn(), removeFile: vi.fn(),
+      pid: () => 1, warn: vi.fn(),
       homedir: () => HOME, mangleCwdToProjectDir: mangle, projectsRoot: PROJECTS_ROOT,
       isHomeOrAncestor: () => false, ensureCompanionDir: vi.fn(),
     }

--- a/tests/unit/main/spawn-resume-command.test.ts
+++ b/tests/unit/main/spawn-resume-command.test.ts
@@ -410,11 +410,18 @@ describe('resolveResumeLaunch — gate', () => {
 // that orphaned transcript into the surviving configured cwd's folder and resumes
 // there. It must fire ONLY for the genuine orphan case and fail CLOSED to null.
 describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
-  const HOME = 'C:\\Users\\jane'
+  // Build paths from an ABSOLUTE, cross-platform base (os.tmpdir()) so the
+  // projectsRoot-containment check (which compares a path.resolve()d absolute
+  // path against projectsRoot) behaves identically on win32 and POSIX. Windows
+  // path literals like 'F:\\repo' are NOT absolute on POSIX — path.resolve()
+  // prepends the cwd there, breaking the startsWith() containment and failing
+  // these tests only on the macOS CI leg (the #535 review's cross-platform trap).
+  const HOME = path.join(os.tmpdir(), 'ccc535-home')
   const PROJECTS_ROOT = path.join(HOME, '.claude', 'projects')
   const T_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
-  const DEAD_WT = 'F:\\repo\\.claude\\worktrees\\session-x'   // pruned worktree
-  const SURVIVING = 'F:\\repo'                                 // configured repo root, still present
+  const REPO = path.join(os.tmpdir(), 'ccc535-repo')
+  const DEAD_WT = path.join(REPO, '.claude', 'worktrees', 'session-x')  // pruned worktree
+  const SURVIVING = REPO                                                // configured repo root, still present
   const mangle = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, '-')
   const transcriptOf = (cwd: string) => path.join(PROJECTS_ROOT, mangle(cwd), `${T_UUID}.jsonl`)
 

--- a/tests/unit/main/spawn-resume-command.test.ts
+++ b/tests/unit/main/spawn-resume-command.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as os from 'os'
 import * as path from 'path'
-import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath } from '../../../src/main/spawn-claude-command'
+import { buildClaudeLaunchCommand, resolveResumeLaunch, recoverOrphanResumeLaunch, buildResumeTranscriptPath } from '../../../src/main/spawn-claude-command'
 
 const CWD = 'F:\\proj\\worktree'
 const CLAUDE = 'C:\\bin\\claude.cmd'
@@ -397,6 +397,172 @@ describe('resolveResumeLaunch — gate', () => {
   it('FIX 4: a canonical uuid still passes the new guard (no regression)', () => {
     const out = resolveResumeLaunch({ uuid: T_UUID, cwd: REAL_CWD }, makeDeps())
     expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(REAL_CWD) })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// recoverOrphanResumeLaunch — resume across a pruned worktree cwd (#535)
+// ---------------------------------------------------------------------------
+//
+// When a session ran in a git worktree that has since been deleted,
+// resolveResumeLaunch returns null (the raw cwd is gone) but the transcript
+// still lives under the worktree's mangled project folder. This helper relocates
+// that orphaned transcript into the surviving configured cwd's folder and resumes
+// there. It must fire ONLY for the genuine orphan case and fail CLOSED to null.
+describe('recoverOrphanResumeLaunch — pruned-worktree recovery', () => {
+  const HOME = 'C:\\Users\\jane'
+  const PROJECTS_ROOT = path.join(HOME, '.claude', 'projects')
+  const T_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+  const DEAD_WT = 'F:\\repo\\.claude\\worktrees\\session-x'   // pruned worktree
+  const SURVIVING = 'F:\\repo'                                 // configured repo root, still present
+  const mangle = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, '-')
+  const transcriptOf = (cwd: string) => path.join(PROJECTS_ROOT, mangle(cwd), `${T_UUID}.jsonl`)
+
+  interface Spies {
+    renameFile: ReturnType<typeof vi.fn>
+    copyFile: ReturnType<typeof vi.fn>
+    removeFile: ReturnType<typeof vi.fn>
+    mkdirp: ReturnType<typeof vi.fn>
+    ensureCompanionDir: ReturnType<typeof vi.fn>
+  }
+  function makeDeps(opts: {
+    existsPaths?: Set<string>
+    dirPaths?: Set<string>
+    sizes?: Map<string, number>
+    isHomeOrAncestor?: (cwd: string) => boolean
+    mangleCwdToProjectDir?: (cwd: string) => string
+    renameThrows?: boolean
+    projectsRoot?: string
+  } = {}): { deps: any; spies: Spies } {
+    const exists = opts.existsPaths
+    const dirs = opts.dirPaths
+    const spies: Spies = {
+      renameFile: vi.fn(() => { if (opts.renameThrows) throw new Error('EXDEV') }),
+      copyFile: vi.fn(),
+      removeFile: vi.fn(),
+      mkdirp: vi.fn(),
+      ensureCompanionDir: vi.fn(),
+    }
+    const deps = {
+      existsSync: (p: string) => (exists ? exists.has(p) : true),
+      statSync: (p: string) => ({ isDirectory: () => (dirs ? dirs.has(p) : true) }),
+      sizeOf: (p: string) => (opts.sizes ? (opts.sizes.get(p) ?? 0) : 0),
+      mkdirp: spies.mkdirp,
+      renameFile: spies.renameFile,
+      copyFile: spies.copyFile,
+      removeFile: spies.removeFile,
+      homedir: () => HOME,
+      mangleCwdToProjectDir: opts.mangleCwdToProjectDir ?? mangle,
+      projectsRoot: opts.projectsRoot ?? PROJECTS_ROOT,
+      isHomeOrAncestor: opts.isHomeOrAncestor ?? (() => false),
+      ensureCompanionDir: spies.ensureCompanionDir,
+    }
+    return { deps, spies }
+  }
+
+  it('happy path: dead worktree + surviving cwd + orphan transcript → relocates and resumes in surviving cwd', () => {
+    // Everything exists EXCEPT the dead worktree dir; dest folder has no transcript yet.
+    const existsPaths = new Set<string>([
+      path.resolve(SURVIVING),
+      transcriptOf(DEAD_WT),
+      // DEAD_WT absent (pruned); dest transcript absent
+    ])
+    const { deps, spies } = makeDeps({ existsPaths, dirPaths: new Set([path.resolve(SURVIVING)]) })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
+    expect(spies.mkdirp).toHaveBeenCalledWith(path.resolve(path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)))))
+    expect(spies.renameFile).toHaveBeenCalledWith(transcriptOf(DEAD_WT), path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`))
+    expect(spies.ensureCompanionDir).toHaveBeenCalledTimes(1)
+  })
+
+  it('NOT an orphan: the target cwd still exists → null, relocates nothing', () => {
+    const existsPaths = new Set<string>([
+      path.resolve(SURVIVING),
+      path.resolve(DEAD_WT),          // still present → resolveResumeLaunch failed for another reason
+      transcriptOf(DEAD_WT),
+    ])
+    const { deps, spies } = makeDeps({ existsPaths })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toBeNull()
+    expect(spies.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('refuses to relocate into home or an ancestor of home', () => {
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
+    const { deps, spies } = makeDeps({ existsPaths, isHomeOrAncestor: () => true })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toBeNull()
+    expect(spies.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('surviving cwd missing → null', () => {
+    const existsPaths = new Set<string>([transcriptOf(DEAD_WT)]) // SURVIVING absent
+    const { deps } = makeDeps({ existsPaths })
+    expect(recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)).toBeNull()
+  })
+
+  it('orphan transcript missing → null (no conversation to recover)', () => {
+    const existsPaths = new Set<string>([path.resolve(SURVIVING)]) // transcript absent
+    const { deps, spies } = makeDeps({ existsPaths })
+    expect(recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)).toBeNull()
+    expect(spies.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('non-UUID uuid → null, builds no path', () => {
+    const { deps } = makeDeps()
+    expect(recoverOrphanResumeLaunch({ uuid: '$(rm -rf /)', cwd: DEAD_WT }, SURVIVING, deps)).toBeNull()
+  })
+
+  it('keep-larger: existing destination transcript is larger → resume in place, no relocate', () => {
+    const destTranscript = path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`)
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT), destTranscript])
+    const sizes = new Map<string, number>([[transcriptOf(DEAD_WT), 100], [destTranscript, 500]])
+    const { deps, spies } = makeDeps({ existsPaths, sizes })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
+    expect(spies.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('keep-larger: orphan is larger than the existing destination → relocates over it', () => {
+    const destTranscript = path.join(PROJECTS_ROOT, mangle(path.resolve(SURVIVING)), `${T_UUID}.jsonl`)
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT), destTranscript])
+    const sizes = new Map<string, number>([[transcriptOf(DEAD_WT), 999], [destTranscript, 10]])
+    const { deps, spies } = makeDeps({ existsPaths, sizes })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
+    expect(spies.renameFile).toHaveBeenCalledWith(transcriptOf(DEAD_WT), destTranscript)
+  })
+
+  it('cross-device rename → falls back to copy + remove, still resumes', () => {
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
+    const { deps, spies } = makeDeps({ existsPaths, renameThrows: true })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toEqual({ resumeUuid: T_UUID, claudeCwd: path.resolve(SURVIVING) })
+    expect(spies.copyFile).toHaveBeenCalledTimes(1)
+    expect(spies.removeFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('containment: a mangle that escapes projectsRoot is refused (defense in depth)', () => {
+    // A malicious/buggy mangle returning a traversal must not let the move touch
+    // a path outside ~/.claude/projects.
+    const evilMangle = () => '..\\..\\Windows\\System32'
+    const existsPaths = new Set<string>([path.resolve(SURVIVING), transcriptOf(DEAD_WT)])
+    const { deps, spies } = makeDeps({ existsPaths, mangleCwdToProjectDir: evilMangle })
+    const out = recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)
+    expect(out).toBeNull()
+    expect(spies.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('fails open (null) when a dep throws', () => {
+    const deps = {
+      existsSync: () => { throw new Error('boom') },
+      statSync: () => ({ isDirectory: () => true }),
+      sizeOf: () => 0,
+      mkdirp: vi.fn(), renameFile: vi.fn(), copyFile: vi.fn(), removeFile: vi.fn(),
+      homedir: () => HOME, mangleCwdToProjectDir: mangle, projectsRoot: PROJECTS_ROOT,
+      isHomeOrAncestor: () => false, ensureCompanionDir: vi.fn(),
+    }
+    expect(recoverOrphanResumeLaunch({ uuid: T_UUID, cwd: DEAD_WT }, SURVIVING, deps)).toBeNull()
   })
 })
 


### PR DESCRIPTION
Closes #535. **release-2.2.** Refs #480 #397 #131 #522.

Recovers a conversation whose **git worktree cwd was pruned** — the gap left open after the
durable session->conversation map (#480/#488) and the durability umbrella (#397/#413), both of
which fail-open to a fresh session but never *recover* the orphan.

## Why (verified against live data, 2026-08-26)

A real session `aai-core | INSIGHTS FU` (uuid `6070b52c…`) vanished on restart. Its 2.9 MB
transcript was intact under the worktree's mangled projects folder
(`…\C--Users-severson-aai-core--claude-worktrees-session-2026-08-26-retrofix\`), but the worktree
was gone from `git worktree list` and `session-state.json` recorded the resume cwd as the parent
repo. `resolveResumeLaunch` correctly returns null on the missing cwd (#397 Fix 1 — never HOME),
so CCC opened a fresh session and surfaced the worktree name (`session-2026-08-26-retrofix`) as the
label. Systemic for worktree-driven flows: the loop system (#522) and session-guard create and
destroy worktrees constantly, orphaning a transcript each time.

## What

- **`recoverOrphanResumeLaunch(target, survivingCwd, deps)`** (pure, injectable-deps, next to
  `resolveResumeLaunch`): when — and only when — the target cwd is MISSING, the surviving
  configured cwd exists + is a dir + is not home/ancestor, and the orphan `<uuid>.jsonl` exists
  inside `projectsRoot`, it relocates the transcript into the surviving cwd's mangled folder and
  resumes there. Fails **closed** to null (existing fresh fallback) on anything else.
- Wired into pty-manager's resume drop-branch, with a per-reason diagnostic log
  (`ORPHAN-RECOVERED` / drop reason).

## Security — ADR-009 adversarial review: PASS

Touches the PTY resume argv (uuid) + filesystem moves under `~/.claude/projects` → full pass
(4 independent attackers: injection/traversal, bypass, fail-open, platform-parity). Injection,
path traversal, home-escape, `projectsRoot` containment and `isHomeOrAncestor` all held. **Two
MAJORs found, fixed, and re-attacked (both hold):**

1. keep-larger let a planted duplicate — source selected via the untrusted `target.cwd` (transcript
   content) — **overwrite a live destination transcript** on a size compare. Fixed: **never
   overwrite**; relocate only into an EMPTY dest slot, resume in place otherwise (removed
   `sizeOf`/keep-larger).
2. the copy fallback could leave a **truncated file at the real `<uuid>.jsonl` name**, which the
   heuristic binder's `*.jsonl` scan could cross-bind to a fresh session. Fixed: copy to a same-dir
   temp `<dst>.partial-<pid>`, then atomic rename into place; remove temp on failure (fail closed);
   warn on an un-removable source.

Residual INFO only: a self-targeted TOCTOU on the dest with no attacker-controlled input and no
privilege gain (optional `COPYFILE_EXCL` hardening noted, not required).

## Gate

- `npm run typecheck` clean (3 tsconfigs)
- `npx vitest run tests/unit/main/spawn-resume-command.test.ts` — 45/45 (15 new authority/relocation guards)
- full unit suite green (a few vitest worker-pool startup timeouts under local load are flakes; CI is the gate)

## NOT done — gates the MERGE, not this PR

Resume behavior is desktop-observable → apply `desktop-tested` after a human (or a Playwright
`_electron` e2e) confirms an orphaned session resumes. A human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
