### PR TITLE
feat(sessions): carry the CCC session name onto the transcript via a sidecar (#536)

### DIFF
--- a/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
+++ b/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
@@ -29,5 +29,16 @@ label -- existing behaviour).
 Known follow-up: #535's transcript relocation does not yet move the sidecar (a relocated transcript
 falls back to the session-state name). Minor; note for a later pass.
 
-Gate: 62 targeted tests (20 new sidecar unit tests + picker readSidecarName cases); binder+logging
-suites 236 pass; typecheck clean (3 tsconfigs). Refs #480 #130 #535.
+Adversarial review (ADR-009: renderer->main IPC + fs write under ~/.claude/projects + picker parse):
+3 attackers. Injection (JSON.stringify + name-only reads), path containment (binder-canonicalized
+paths), transcript-corruption and fail-open all held. Findings fixed:
+- MEDIUM pendingNames unbounded leak (forgetSessionName had no prod caller; renderer can pass any
+  sessionId) -> retire on endRun AND after onExactBind writes, plus a hard 512-entry LRU cap.
+- MEDIUM stale-name bleed onto the next conversation after /clear -> same retire-on-onExactBind fix.
+- MEDIUM blank rename could not clear + a generic config label got promoted to the picker's bold
+  primary -> the renderer now sends the user's OWN customName (empty = cleared) beside configLabel;
+  the handler writes the sidecar from customName (blank removes it).
+- MINOR rename-time write used a heuristic-inclusive path (sibling mislabel in the ~20s pre-exact
+  window) -> use getExactResumeTarget (exact-only); the pre-bind case is covered by onExactBind.
+Verdict after fixes: PASS. Gate: 328 targeted tests (sidecar + picker + store + binder + logging),
+typecheck clean (3 tsconfigs). Refs #480 #130 #535.

--- a/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
+++ b/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
@@ -40,5 +40,9 @@ paths), transcript-corruption and fail-open all held. Findings fixed:
   the handler writes the sidecar from customName (blank removes it).
 - MINOR rename-time write used a heuristic-inclusive path (sibling mislabel in the ~20s pre-exact
   window) -> use getExactResumeTarget (exact-only); the pre-bind case is covered by onExactBind.
-Verdict after fixes: PASS. Gate: 328 targeted tests (sidecar + picker + store + binder + logging),
-typecheck clean (3 tsconfigs). Refs #480 #130 #535.
+Re-attack found one residual: the rename-AFTER-bind path still re-primed the registry (bled on the
+next /clear). Fixed: when already bound, write directly AND forgetSessionName; only remember when
+not yet bound. Guarded by logs2-ipc-handlers tests (bound -> write+forget, not-bound -> remember,
+blank -> '' write, omitted customName -> configLabel fallback). Verdict after round 2: PASS.
+Gate: 123 tests (handler + sidecar + store + picker) + binder/logging suites, typecheck clean
+(3 tsconfigs). Refs #480 #130 #535.

--- a/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
+++ b/CONTEXT.d/2026-08-26-536-session-name-sidecar.md
@@ -1,0 +1,33 @@
+## 2026-08-26 -- #536 carry the CCC session name onto the transcript (sidecar)
+
+A session's display name (customName, set by the left-hand rename) lived only in CCC's stores --
+never on the transcript. The resume picker mapped names via a uuid->customName map read back from
+session-state.json (last-writer-wins, collides when sessions share a folder), and a diagnostic had
+to cross-reference session-state by uuid to tell which transcript was which.
+
+Chosen mechanism (user decision): a CCC-owned SIDECAR, not a line inside Claude's JSONL. Writing
+into `<uuid>.jsonl` risks breaking Claude's own resume parse (#535 territory); a sibling
+`<uuid>.ccc-name.json` couples to nothing Claude reads, survives worktree/cross-account moves, and
+the picker prefers it over the fragile session-state map.
+
+Implementation:
+- `src/main/logging/session-name-sidecar.ts` (new): pure `sidecarPathFor` / `writeNameSidecar` /
+  `readNameSidecar` (injectable I/O, best-effort, JSON.stringify-escaped name, blank name REMOVES
+  the sidecar) + a pending-name registry (`rememberSessionName`/`getRememberedName`/`forget`) that
+  bridges "renamed before the transcript is bound".
+- Rename IPC (`logs2-handlers.ts` LOGS2_RENAME_SESSION): remember the name; write the sidecar now if
+  the session is already bound (`getTranscriptBinder().getLatestTranscriptPath`).
+- Binder exact bind: new `onExactBind(sessionId, canonicalPath)` dep (sibling of #480's `persist`);
+  `logging-service.ts` wires it to write the remembered name once the path is known.
+- Picker (`scripts/resume-picker.js`): new `readSidecarName(conv.filePath)`, preferred over
+  `loadWorkNames` at the label site.
+
+Best-effort throughout: a name is never worth throwing into a rename/spawn/bind path; every read is
+fail-safe -> null. Un-renamed sessions write no sidecar (picker falls back to the session-state
+label -- existing behaviour).
+
+Known follow-up: #535's transcript relocation does not yet move the sidecar (a relocated transcript
+falls back to the session-state name). Minor; note for a later pass.
+
+Gate: 62 targeted tests (20 new sidecar unit tests + picker readSidecarName cases); binder+logging
+suites 236 pass; typecheck clean (3 tsconfigs). Refs #480 #130 #535.

--- a/scripts/resume-picker.js
+++ b/scripts/resume-picker.js
@@ -458,6 +458,22 @@ function loadWorkNames(configDir) {
   return map
 }
 
+// ── CCC name sidecar (#536) ─────────────────────────────────────────
+// A CCC-owned `<uuid>.ccc-name.json` sibling of the transcript carries the
+// user's session name durably — written by main on rename / exact-bind. Prefer
+// it over loadWorkNames(): the sidecar sits next to the exact transcript, so it
+// survives the session-state.json last-writer-wins uuid->name collision and any
+// worktree / cross-account move of the projects tree. FAIL-SAFE → null.
+function readSidecarName(transcriptFilePath) {
+  try {
+    if (typeof transcriptFilePath !== 'string' || !transcriptFilePath.endsWith('.jsonl')) return null
+    const p = transcriptFilePath.slice(0, -'.jsonl'.length) + '.ccc-name.json'
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'))
+    const name = parsed && typeof parsed.name === 'string' ? parsed.name.trim() : ''
+    return name || null
+  } catch { return null }
+}
+
 // ── Main ────────────────────────────────────────────────────────────
 async function main() {
   const cwd = process.cwd()
@@ -504,7 +520,7 @@ async function main() {
   for (let i = 0; i < conversations.length; i++) {
     const conv = conversations[i]
     const num = String(i + 1).padStart(2)
-    const workName = workNames.get(conv.sessionId)
+    const workName = readSidecarName(conv.filePath) || workNames.get(conv.sessionId)
     // Best available label, most→least useful: the user's own work name, then
     // Claude's AI title, then the first real user message, then the last prompt,
     // then the most recent user message. "(continued session)" only when the
@@ -720,6 +736,7 @@ module.exports = {
   parseConversation,
   computeLayoutWidth,
   loadWorkNames,
+  readSidecarName,
   sanitizeMessageText,
 }
 

--- a/src/main/ipc/logs2-handlers.ts
+++ b/src/main/ipc/logs2-handlers.ts
@@ -71,7 +71,7 @@ const searchSchema = z
 const deleteSlotSchema = z.object({ scope: scopeSchema }).strict()
 
 const renameSessionSchema = z
-  .object({ sessionId: z.string().min(1).max(200), configLabel: z.string().max(200) })
+  .object({ sessionId: z.string().min(1).max(200), configLabel: z.string().max(200), customName: z.string().max(200).optional() })
   .strict()
 
 const ingestStatusSchema = z.object({ sessionId: z.string().min(1).max(200) }).strict()
@@ -134,15 +134,19 @@ export function registerLogs2Handlers(getWindow: () => BrowserWindow | null): vo
   // logs/history tab reflects the custom work name durably. Fire-and-forget post
   // (buffered in the supervisor); no-op when logging is disabled.
   ipcMain.handle(IPC.LOGS2_RENAME_SESSION, async (_e, args: unknown) => {
-    const { sessionId, configLabel } = renameSessionSchema.parse(args)
+    const { sessionId, configLabel, customName } = renameSessionSchema.parse(args)
     getLogSupervisor()?.renameRun(sessionId, configLabel)
-    // #536: carry the name onto the transcript so it survives outside CCC and
-    // identifies the conversation on resume. Remember it (the exact-bind callback
-    // writes it once the transcript path is known), and write the sidecar now if
-    // the session is already bound. Best-effort — never fail the rename.
-    rememberSessionName(sessionId, configLabel)
-    const boundPath = getTranscriptBinder()?.getLatestTranscriptPath(sessionId)
-    if (boundPath) writeNameSidecar(boundPath, configLabel, nodeNameSidecarDeps)
+    // #536: carry the user's OWN work name (customName, NOT the generic config
+    // label) onto the transcript so it survives outside CCC and identifies the
+    // conversation on resume. An empty customName is a real "cleared" signal and
+    // removes the sidecar. Older preload builds omit customName → fall back to
+    // configLabel. Remember it (the exact-bind callback writes it once the path is
+    // known), and write now only against an EXACT bind — never a heuristic guess
+    // (which in a shared folder could be a sibling card's transcript). Best-effort.
+    const nameForSidecar = customName ?? configLabel
+    rememberSessionName(sessionId, nameForSidecar)
+    const exactPath = getTranscriptBinder()?.getExactResumeTarget(sessionId)
+    if (exactPath) writeNameSidecar(exactPath, nameForSidecar, nodeNameSidecarDeps)
     return { ok: true }
   })
 

--- a/src/main/ipc/logs2-handlers.ts
+++ b/src/main/ipc/logs2-handlers.ts
@@ -21,7 +21,8 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { z } from 'zod'
 import { IPC } from '../../shared/ipc-channels'
-import { getLogSupervisor } from '../logging/logging-service'
+import { getLogSupervisor, getTranscriptBinder } from '../logging/logging-service'
+import { rememberSessionName, writeNameSidecar, nodeNameSidecarDeps } from '../logging/session-name-sidecar'
 
 // ---------------------------------------------------------------------------
 // Bounds + Zod schemas
@@ -135,6 +136,13 @@ export function registerLogs2Handlers(getWindow: () => BrowserWindow | null): vo
   ipcMain.handle(IPC.LOGS2_RENAME_SESSION, async (_e, args: unknown) => {
     const { sessionId, configLabel } = renameSessionSchema.parse(args)
     getLogSupervisor()?.renameRun(sessionId, configLabel)
+    // #536: carry the name onto the transcript so it survives outside CCC and
+    // identifies the conversation on resume. Remember it (the exact-bind callback
+    // writes it once the transcript path is known), and write the sidecar now if
+    // the session is already bound. Best-effort — never fail the rename.
+    rememberSessionName(sessionId, configLabel)
+    const boundPath = getTranscriptBinder()?.getLatestTranscriptPath(sessionId)
+    if (boundPath) writeNameSidecar(boundPath, configLabel, nodeNameSidecarDeps)
     return { ok: true }
   })
 

--- a/src/main/ipc/logs2-handlers.ts
+++ b/src/main/ipc/logs2-handlers.ts
@@ -22,7 +22,7 @@ import { ipcMain, BrowserWindow } from 'electron'
 import { z } from 'zod'
 import { IPC } from '../../shared/ipc-channels'
 import { getLogSupervisor, getTranscriptBinder } from '../logging/logging-service'
-import { rememberSessionName, writeNameSidecar, nodeNameSidecarDeps } from '../logging/session-name-sidecar'
+import { rememberSessionName, forgetSessionName, writeNameSidecar, nodeNameSidecarDeps } from '../logging/session-name-sidecar'
 
 // ---------------------------------------------------------------------------
 // Bounds + Zod schemas
@@ -144,9 +144,18 @@ export function registerLogs2Handlers(getWindow: () => BrowserWindow | null): vo
     // known), and write now only against an EXACT bind — never a heuristic guess
     // (which in a shared folder could be a sibling card's transcript). Best-effort.
     const nameForSidecar = customName ?? configLabel
-    rememberSessionName(sessionId, nameForSidecar)
     const exactPath = getTranscriptBinder()?.getExactResumeTarget(sessionId)
-    if (exactPath) writeNameSidecar(exactPath, nameForSidecar, nodeNameSidecarDeps)
+    if (exactPath) {
+      // Already bound: write directly and DO NOT keep a pending entry — a lingering
+      // one would bleed this name onto the next conversation this session binds
+      // after a /clear rotates the uuid (adv review #536).
+      writeNameSidecar(exactPath, nameForSidecar, nodeNameSidecarDeps)
+      forgetSessionName(sessionId)
+    } else {
+      // Not bound yet: remember so onExactBind writes it once the path is known
+      // (a blank name clears the pending entry).
+      rememberSessionName(sessionId, nameForSidecar)
+    }
     return { ok: true }
   })
 

--- a/src/main/logging/logging-service.ts
+++ b/src/main/logging/logging-service.ts
@@ -25,7 +25,7 @@ import { makeTranscriptBinder } from './transcript-binder'
 import type { TranscriptBinder } from './transcript-binder'
 import { readConfig } from '../config-manager'
 import { logInfo } from '../debug-logger'
-import { getRememberedName, writeNameSidecar, nodeNameSidecarDeps } from './session-name-sidecar'
+import { getRememberedName, forgetSessionName, writeNameSidecar, nodeNameSidecarDeps } from './session-name-sidecar'
 
 // Module-level singleton. Null until initLogging() runs, and stays null when
 // logging is disabled (no fork, no worker, no native dep loaded).
@@ -69,10 +69,15 @@ export function initLogging(opts: {
     log: logInfo,
     persist: (sessionId, path, uuid) => sup.persistSessionConversation(sessionId, path, uuid),
     // #536: when the exact transcript path becomes known, flush any CCC name that
-    // was set for this session (e.g. renamed before the bind) to its sidecar.
+    // was set for this session (e.g. renamed before the bind) to its sidecar, then
+    // RETIRE the pending entry. Retiring here (a) stops the name bleeding onto the
+    // next conversation this card binds after a /clear rotates the uuid, and
+    // (b) bounds the registry — a later rename writes directly via the now-known
+    // exact path and needs no pending entry.
     onExactBind: (sessionId, path) => {
       const name = getRememberedName(sessionId)
       if (name) writeNameSidecar(path, name, nodeNameSidecarDeps)
+      forgetSessionName(sessionId)
     },
   })
 }

--- a/src/main/logging/logging-service.ts
+++ b/src/main/logging/logging-service.ts
@@ -25,6 +25,7 @@ import { makeTranscriptBinder } from './transcript-binder'
 import type { TranscriptBinder } from './transcript-binder'
 import { readConfig } from '../config-manager'
 import { logInfo } from '../debug-logger'
+import { getRememberedName, writeNameSidecar, nodeNameSidecarDeps } from './session-name-sidecar'
 
 // Module-level singleton. Null until initLogging() runs, and stays null when
 // logging is disabled (no fork, no worker, no native dep loaded).
@@ -67,6 +68,12 @@ export function initLogging(opts: {
     supervisor: sup,
     log: logInfo,
     persist: (sessionId, path, uuid) => sup.persistSessionConversation(sessionId, path, uuid),
+    // #536: when the exact transcript path becomes known, flush any CCC name that
+    // was set for this session (e.g. renamed before the bind) to its sidecar.
+    onExactBind: (sessionId, path) => {
+      const name = getRememberedName(sessionId)
+      if (name) writeNameSidecar(path, name, nodeNameSidecarDeps)
+    },
   })
 }
 

--- a/src/main/logging/session-name-sidecar.ts
+++ b/src/main/logging/session-name-sidecar.ts
@@ -79,11 +79,27 @@ export function readNameSidecar(transcriptPath: string, deps: Pick<NameSidecarDe
 
 const pendingNames = new Map<string, string>()
 
+/**
+ * Hard cap on remembered names. The rename IPC is reachable by the (less-trusted)
+ * renderer with an arbitrary sessionId, so without a bound a compromised renderer
+ * could grow this map without limit. Entries are retired on exact-bind and on
+ * endRun; the cap is a belt-and-suspenders backstop that evicts the oldest entry
+ * (Map preserves insertion order) so the map can never grow unbounded regardless.
+ */
+const MAX_PENDING_NAMES = 512
+
 /** Record the latest display name for a CCC session (empty string = cleared). */
 export function rememberSessionName(sessionId: string, name: string): void {
   const trimmed = typeof name === 'string' ? name.trim() : ''
-  if (trimmed) pendingNames.set(sessionId, trimmed)
-  else pendingNames.delete(sessionId)
+  if (!trimmed) { pendingNames.delete(sessionId); return }
+  // Re-insert last (refresh recency) and evict the oldest over the cap.
+  pendingNames.delete(sessionId)
+  pendingNames.set(sessionId, trimmed)
+  while (pendingNames.size > MAX_PENDING_NAMES) {
+    const oldest = pendingNames.keys().next().value
+    if (oldest === undefined) break
+    pendingNames.delete(oldest)
+  }
 }
 
 /** The remembered name for a session, or null. */

--- a/src/main/logging/session-name-sidecar.ts
+++ b/src/main/logging/session-name-sidecar.ts
@@ -1,0 +1,105 @@
+/**
+ * session-name-sidecar.ts — carry a CCC session's display name across to the
+ * transcript on disk, so the name survives outside CCC and identifies which
+ * conversation is which during a resume (#536).
+ *
+ * WHY a sidecar and NOT a line inside Claude's `<uuid>.jsonl`: Claude owns that
+ * transcript's format and rewrites it on resume — appending to it risks breaking
+ * the very resume we protect (#535). Instead we write a CCC-owned sibling file
+ * `<uuid>.ccc-name.json` next to the transcript. It couples to nothing Claude
+ * parses, survives worktree/cross-account moves of the projects tree, and the
+ * resume-picker reads it in preference to the fragile last-writer-wins
+ * uuid->customName map it derives from session-state.json.
+ *
+ * Every operation is BEST-EFFORT: a name is a convenience, never worth throwing
+ * into a spawn / rename / bind path. All I/O is injected so the logic is
+ * unit-testable without disk. No default export (project convention).
+ */
+
+import * as fs from 'node:fs'
+
+/** The sidecar file for a `<uuid>.jsonl` transcript, or null if the path is not a transcript. */
+export function sidecarPathFor(transcriptPath: string): string | null {
+  if (typeof transcriptPath !== 'string' || !transcriptPath.endsWith('.jsonl')) return null
+  return `${transcriptPath.slice(0, -'.jsonl'.length)}.ccc-name.json`
+}
+
+export interface NameSidecarDeps {
+  writeFile: (p: string, data: string) => void
+  readFile: (p: string) => string
+  removeFile: (p: string) => void
+  /** Epoch ms; injected so tests are deterministic. */
+  now: () => number
+}
+
+/**
+ * Write (or clear) the sidecar next to a transcript. An empty/blank name REMOVES
+ * the sidecar (a rename back to the default should not leave a stale name). Never
+ * throws — a failure just means the picker falls back to its session-state map.
+ */
+export function writeNameSidecar(transcriptPath: string, name: string, deps: NameSidecarDeps): void {
+  try {
+    const p = sidecarPathFor(transcriptPath)
+    if (!p) return
+    const trimmed = typeof name === 'string' ? name.trim() : ''
+    if (!trimmed) {
+      try { deps.removeFile(p) } catch { /* best-effort: nothing to clear */ }
+      return
+    }
+    // JSON.stringify escapes every control/quote character in the name, so an
+    // arbitrary user rename cannot break the file or inject structure.
+    deps.writeFile(p, JSON.stringify({ name: trimmed, updatedAt: deps.now() }))
+  } catch {
+    /* best-effort: a name is never worth throwing */
+  }
+}
+
+/** Read the CCC name from a transcript's sidecar, or null (missing / bad / blank). Never throws. */
+export function readNameSidecar(transcriptPath: string, deps: Pick<NameSidecarDeps, 'readFile'>): string | null {
+  try {
+    const p = sidecarPathFor(transcriptPath)
+    if (!p) return null
+    const parsed = JSON.parse(deps.readFile(p))
+    const name = parsed && typeof parsed.name === 'string' ? parsed.name.trim() : ''
+    return name || null
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pending-name registry — bridges "renamed before the transcript is bound"
+// ---------------------------------------------------------------------------
+//
+// A rename can land before the binder knows this session's transcript path (the
+// exact bind arrives ~20s in, or later). We remember the latest name per CCC
+// sessionId; the rename handler writes the sidecar immediately when a path is
+// already known, and the binder's exact-bind callback writes it (from this
+// registry) the moment the path becomes known. Last write wins, by design.
+
+const pendingNames = new Map<string, string>()
+
+/** Record the latest display name for a CCC session (empty string = cleared). */
+export function rememberSessionName(sessionId: string, name: string): void {
+  const trimmed = typeof name === 'string' ? name.trim() : ''
+  if (trimmed) pendingNames.set(sessionId, trimmed)
+  else pendingNames.delete(sessionId)
+}
+
+/** The remembered name for a session, or null. */
+export function getRememberedName(sessionId: string): string | null {
+  return pendingNames.get(sessionId) ?? null
+}
+
+/** Drop a session's remembered name (call when the run ends). */
+export function forgetSessionName(sessionId: string): void {
+  pendingNames.delete(sessionId)
+}
+
+/** Production I/O: node fs, real clock. Injected into the write/read helpers at the call sites. */
+export const nodeNameSidecarDeps: NameSidecarDeps = {
+  writeFile: (p, data) => { fs.writeFileSync(p, data, 'utf-8') },
+  readFile: (p) => fs.readFileSync(p, 'utf-8'),
+  removeFile: (p) => { fs.rmSync(p, { force: true }) },
+  now: () => Date.now(),
+}

--- a/src/main/logging/transcript-binder.ts
+++ b/src/main/logging/transcript-binder.ts
@@ -88,6 +88,13 @@ export interface TranscriptBinderDeps {
    * the transcripts.db worker). Defaults to a no-op.
    */
   persist?: (sessionId: string, canonicalPath: string, uuid: string) => void
+  /**
+   * #536: fired on every committed EXACT bind with the canonical transcript
+   * path, so a name remembered for this session (before its transcript was
+   * known) can be written to the `<uuid>.ccc-name.json` sidecar the moment the
+   * path becomes available. Fire-and-forget; keeps the binder pure. No-op default.
+   */
+  onExactBind?: (sessionId: string, canonicalPath: string) => void
 }
 
 const DEFAULT_DEBOUNCE_MS = 250
@@ -145,6 +152,7 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
   const heuristicRetryCap = deps.heuristicRetryCap ?? DEFAULT_HEURISTIC_RETRY_CAP
   const log = deps.log ?? (() => { /* no-op */ })
   const persist = deps.persist ?? (() => { /* no-op */ })
+  const onExactBind = deps.onExactBind ?? (() => { /* no-op */ })
 
   const sessions = new Map<string, SessionState>()
 
@@ -299,6 +307,8 @@ export function makeTranscriptBinder(deps: TranscriptBinderDeps): TranscriptBind
     // #480: durable record, keyed by sessionId, of the exact conversation — the
     // authenticated source of truth for restart resume.
     if (uuid) persist(sessionId, canonical, uuid)
+    // #536: the transcript path is now known — write any pending CCC name sidecar.
+    onExactBind(sessionId, canonical)
     log(`[binder] exact bind committed sid=${sessionId} path=${canonical}`)
   }
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -17,6 +17,7 @@ import { getLogSupervisor, getTranscriptBinder } from './logging/logging-service
 import { resolveResumeTargetFromTranscript, mangleCwdToProjectDir } from './logging/transcript-discovery'
 import { buildClaudeLaunchCommand, resolveResumeLaunch, buildResumeTranscriptPath, quoteArgForShell, modelFlag } from './spawn-claude-command'
 import { ensureCompanionDir, nodeFsCompanionDeps } from './logging/companion-dir'
+import { forgetSessionName } from './logging/session-name-sidecar'
 import { logInfo, logDebug, logError, logWarn } from './debug-logger'
 import { writeCliSetupPty, getResourcesDirectory } from './ipc/setup-handlers'
 import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand, buildRemoteTmuxKillCommand, getWindowsRemoteSetupCommand, buildWindowsClaudeCommand } from './providers/claude/ssh-shim'
@@ -3427,6 +3428,9 @@ export function spawnPty(
       // Logs v2 (Task 8): cancel any pending heuristic timer + clear the binder's
       // per-session bind state so a reused sessionId (restart) binds fresh.
       getTranscriptBinder()?.endRun(sessionId)
+      // #536: retire any remembered CCC name so a renamed-but-never-bound session
+      // does not leak an entry in the pending-name registry for the process life.
+      forgetSessionName(sessionId)
       getPtyIntegrityMonitor()?.endSession(sessionId)
       // (watchdog teardown now lives UNCONDITIONALLY in cleanupSessionResources
       //  below — see FINDING 1 — so the restart-race stale exit tears it down too)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -230,7 +230,7 @@ export interface ElectronAPI {
     search: (args: { query: string; limit?: number }) => Promise<unknown[]>
     deleteSlot: (args: { scope: { configId: string } | { sessionId: string } }) =>
       Promise<{ deletedRuns: number; deletedMessages: number }>
-    renameSession: (args: { sessionId: string; configLabel: string }) => Promise<{ ok: boolean }>
+    renameSession: (args: { sessionId: string; configLabel: string; customName?: string }) => Promise<{ ok: boolean }>
     clearAll: () => Promise<{ deletedRuns: number; deletedMessages: number }>
     ingestStatus: (args: { sessionId: string }) => Promise<{
       transcripts: { path: string; status: string; ord: number }[]
@@ -863,7 +863,7 @@ const electronAPI: ElectronAPI = {
     search: (args: { query: string; limit?: number }) => ipcRenderer.invoke(IPC.LOGS2_SEARCH, args),
     deleteSlot: (args: { scope: { configId: string } | { sessionId: string } }) =>
       ipcRenderer.invoke(IPC.LOGS2_DELETE_SLOT, args),
-    renameSession: (args: { sessionId: string; configLabel: string }) =>
+    renameSession: (args: { sessionId: string; configLabel: string; customName?: string }) =>
       ipcRenderer.invoke(IPC.LOGS2_RENAME_SESSION, args),
     clearAll: () => ipcRenderer.invoke(IPC.LOGS2_CLEAR_ALL),
     ingestStatus: (args: { sessionId: string }) => ipcRenderer.invoke(IPC.LOGS2_INGEST_STATUS, args),

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -278,7 +278,11 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     const s = get().sessions.find((x) => x.id === id)
     const effective = trimmed || s?.label || ''
     try {
-      window.electronAPI?.logs2?.renameSession?.({ sessionId: id, configLabel: effective })
+      // configLabel = the effective display name for the logs DB (falls back to
+      // the config label). customName = the user's OWN work name only (empty when
+      // cleared) — #536 writes it to the transcript sidecar, so a blank rename
+      // clears the sidecar and a generic config label never becomes a "work name".
+      window.electronAPI?.logs2?.renameSession?.({ sessionId: id, configLabel: effective, customName: trimmed })
     } catch { /* logging off / preload absent */ }
   }
 }))

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -330,7 +330,7 @@ export interface ElectronAPI {
     }>>
     deleteSlot: (args: { scope: { configId: string } | { sessionId: string } }) =>
       Promise<{ deletedRuns: number; deletedMessages: number }>
-    renameSession: (args: { sessionId: string; configLabel: string }) => Promise<{ ok: boolean }>
+    renameSession: (args: { sessionId: string; configLabel: string; customName?: string }) => Promise<{ ok: boolean }>
     clearAll: () => Promise<{ deletedRuns: number; deletedMessages: number }>
     ingestStatus: (args: { sessionId: string }) => Promise<{
       transcripts: { path: string; status: string; ord: number }[]

--- a/tests/unit/main/logs2-ipc-handlers.test.ts
+++ b/tests/unit/main/logs2-ipc-handlers.test.ts
@@ -16,9 +16,22 @@ const onNewMessagesSpy = vi.fn((cb: (e: { sessionId: string; configId: string | 
   return () => { newMessagesCb = null }
 })
 let supervisorPresent = true
+let exactPathForRename: string | null = null
+const renameRunSpy = vi.fn()
 vi.mock('../../../src/main/logging/logging-service', () => ({
-  getLogSupervisor: () => (supervisorPresent ? { query: querySpy, onNewMessages: onNewMessagesSpy } : null),
+  getLogSupervisor: () => (supervisorPresent ? { query: querySpy, onNewMessages: onNewMessagesSpy, renameRun: renameRunSpy } : null),
+  getTranscriptBinder: () => ({ getExactResumeTarget: (_sid: string) => exactPathForRename }),
 }))
+
+// Spy on the sidecar module so the rename handler's write/remember/forget calls
+// are observable (#536).
+const sidecar = vi.hoisted(() => ({
+  rememberSessionName: vi.fn(),
+  forgetSessionName: vi.fn(),
+  writeNameSidecar: vi.fn(),
+  nodeNameSidecarDeps: {},
+}))
+vi.mock('../../../src/main/logging/session-name-sidecar', () => sidecar)
 
 import { registerLogs2Handlers } from '../../../src/main/ipc/logs2-handlers'
 
@@ -34,6 +47,11 @@ describe('logs2 IPC handlers', () => {
     onNewMessagesSpy.mockClear()
     newMessagesCb = null
     supervisorPresent = true
+    exactPathForRename = null
+    renameRunSpy.mockReset()
+    sidecar.rememberSessionName.mockReset()
+    sidecar.forgetSessionName.mockReset()
+    sidecar.writeNameSidecar.mockReset()
     sent = []
     const win = {
       isDestroyed: () => false,
@@ -230,5 +248,39 @@ describe('logs2 IPC handlers', () => {
     supervisorPresent = false
     registerLogs2Handlers(getWindow)
     expect(onNewMessagesSpy).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // #536 — rename carries the name onto the transcript via the sidecar
+  // -------------------------------------------------------------------------
+
+  it('rename while BOUND writes the sidecar with customName and RETIRES the pending entry (no /clear bleed)', async () => {
+    exactPathForRename = 'C:\\p\\aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+    await invoke(IPC.LOGS2_RENAME_SESSION, { sessionId: 's1', configLabel: 'Config A', customName: 'Auth Bug' })
+    expect(renameRunSpy).toHaveBeenCalledWith('s1', 'Config A')
+    expect(sidecar.writeNameSidecar).toHaveBeenCalledWith(exactPathForRename, 'Auth Bug', sidecar.nodeNameSidecarDeps)
+    // The critical regression guard: an already-bound rename must NOT leave a
+    // pending entry, or it bleeds onto the next conversation after a /clear.
+    expect(sidecar.forgetSessionName).toHaveBeenCalledWith('s1')
+    expect(sidecar.rememberSessionName).not.toHaveBeenCalled()
+  })
+
+  it('rename while NOT bound remembers the name (onExactBind writes it later), no direct write', async () => {
+    exactPathForRename = null
+    await invoke(IPC.LOGS2_RENAME_SESSION, { sessionId: 's2', configLabel: 'Config A', customName: 'Docs sweep' })
+    expect(sidecar.rememberSessionName).toHaveBeenCalledWith('s2', 'Docs sweep')
+    expect(sidecar.writeNameSidecar).not.toHaveBeenCalled()
+  })
+
+  it('a blank customName is the cleared signal (empty string, not the config label)', async () => {
+    exactPathForRename = 'C:\\p\\aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+    await invoke(IPC.LOGS2_RENAME_SESSION, { sessionId: 's3', configLabel: 'Config A', customName: '' })
+    expect(sidecar.writeNameSidecar).toHaveBeenCalledWith(exactPathForRename, '', sidecar.nodeNameSidecarDeps)
+  })
+
+  it('back-compat: an omitted customName falls back to configLabel', async () => {
+    exactPathForRename = null
+    await invoke(IPC.LOGS2_RENAME_SESSION, { sessionId: 's4', configLabel: 'Config A' })
+    expect(sidecar.rememberSessionName).toHaveBeenCalledWith('s4', 'Config A')
   })
 })

--- a/tests/unit/main/session-name-sidecar.test.ts
+++ b/tests/unit/main/session-name-sidecar.test.ts
@@ -126,4 +126,15 @@ describe('pending-name registry', () => {
   it('unknown session → null', () => {
     expect(getRememberedName('nope')).toBeNull()
   })
+
+  it('is bounded: past the cap the OLDEST entries are evicted (renderer cannot grow it without limit)', () => {
+    // The rename IPC is renderer-reachable with an arbitrary sessionId; the map
+    // must never grow unbounded even if entries are never retired.
+    const N = 700 // > MAX_PENDING_NAMES (512)
+    for (let i = 0; i < N; i++) rememberSessionName(`leak-${i}`, `name-${i}`)
+    // The earliest inserted entries were evicted; the most recent survive.
+    expect(getRememberedName('leak-0')).toBeNull()
+    expect(getRememberedName(`leak-${N - 1}`)).toBe(`name-${N - 1}`)
+    for (let i = 0; i < N; i++) forgetSessionName(`leak-${i}`)
+  })
 })

--- a/tests/unit/main/session-name-sidecar.test.ts
+++ b/tests/unit/main/session-name-sidecar.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for session-name-sidecar (#536) — the pure name-carry helpers.
+ * All I/O is injected; no disk. Covers path derivation, write/clear, read,
+ * injection safety (JSON.stringify), best-effort no-throw, and the pending-name
+ * registry that bridges "renamed before the transcript is bound".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  sidecarPathFor,
+  writeNameSidecar,
+  readNameSidecar,
+  rememberSessionName,
+  getRememberedName,
+  forgetSessionName,
+} from '../../../src/main/logging/session-name-sidecar'
+
+const TRANSCRIPT = 'C:\\Users\\jane\\.claude\\projects\\F--repo\\aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'
+const SIDECAR = 'C:\\Users\\jane\\.claude\\projects\\F--repo\\aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.ccc-name.json'
+
+function makeDeps(over: Partial<{ writeFile: any; readFile: any; removeFile: any; now: any }> = {}) {
+  return {
+    writeFile: vi.fn(over.writeFile),
+    readFile: vi.fn(over.readFile ?? (() => { throw new Error('ENOENT') })),
+    removeFile: vi.fn(over.removeFile),
+    now: over.now ?? (() => 1700000000000),
+  }
+}
+
+describe('sidecarPathFor', () => {
+  it('maps <uuid>.jsonl → <uuid>.ccc-name.json', () => {
+    expect(sidecarPathFor(TRANSCRIPT)).toBe(SIDECAR)
+  })
+  it('returns null for a non-.jsonl path', () => {
+    expect(sidecarPathFor('C:\\x\\notes.txt')).toBeNull()
+    expect(sidecarPathFor('C:\\x\\file.jsonl.bak')).toBeNull()
+  })
+  it('returns null for a non-string', () => {
+    // @ts-expect-error deliberately wrong type
+    expect(sidecarPathFor(undefined)).toBeNull()
+  })
+})
+
+describe('writeNameSidecar', () => {
+  it('writes {name, updatedAt} JSON to the sidecar path', () => {
+    const deps = makeDeps()
+    writeNameSidecar(TRANSCRIPT, '  aai-core | INSIGHTS FU  ', deps)
+    expect(deps.writeFile).toHaveBeenCalledTimes(1)
+    const [p, data] = deps.writeFile.mock.calls[0]
+    expect(p).toBe(SIDECAR)
+    expect(JSON.parse(data)).toEqual({ name: 'aai-core | INSIGHTS FU', updatedAt: 1700000000000 })
+  })
+
+  it('an empty / blank name REMOVES the sidecar (rename back to default clears it)', () => {
+    const deps = makeDeps()
+    writeNameSidecar(TRANSCRIPT, '   ', deps)
+    expect(deps.removeFile).toHaveBeenCalledWith(SIDECAR)
+    expect(deps.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('a non-transcript path is a no-op', () => {
+    const deps = makeDeps()
+    writeNameSidecar('C:\\x\\notes.txt', 'name', deps)
+    expect(deps.writeFile).not.toHaveBeenCalled()
+    expect(deps.removeFile).not.toHaveBeenCalled()
+  })
+
+  it('injection: a name with quotes / newlines / structure is escaped by JSON.stringify (no breakout)', () => {
+    const deps = makeDeps()
+    const evil = '", "updatedAt": 0, "x": "\n}{ evil'
+    writeNameSidecar(TRANSCRIPT, evil, deps)
+    const [, data] = deps.writeFile.mock.calls[0]
+    // Round-trips to exactly the name; no extra keys, no structure injected.
+    expect(JSON.parse(data)).toEqual({ name: evil.trim(), updatedAt: 1700000000000 })
+  })
+
+  it('best-effort: a throwing writeFile does not propagate', () => {
+    const deps = makeDeps({ writeFile: () => { throw new Error('EACCES') } })
+    expect(() => writeNameSidecar(TRANSCRIPT, 'name', deps)).not.toThrow()
+  })
+
+  it('best-effort: a throwing removeFile (clearing) does not propagate', () => {
+    const deps = makeDeps({ removeFile: () => { throw new Error('EBUSY') } })
+    expect(() => writeNameSidecar(TRANSCRIPT, '', deps)).not.toThrow()
+  })
+})
+
+describe('readNameSidecar', () => {
+  it('returns the trimmed name from a valid sidecar', () => {
+    const deps = { readFile: () => JSON.stringify({ name: '  my work  ', updatedAt: 1 }) }
+    expect(readNameSidecar(TRANSCRIPT, deps)).toBe('my work')
+  })
+  it('returns null for a blank name', () => {
+    const deps = { readFile: () => JSON.stringify({ name: '   ' }) }
+    expect(readNameSidecar(TRANSCRIPT, deps)).toBeNull()
+  })
+  it('returns null on missing file / bad JSON', () => {
+    expect(readNameSidecar(TRANSCRIPT, { readFile: () => { throw new Error('ENOENT') } })).toBeNull()
+    expect(readNameSidecar(TRANSCRIPT, { readFile: () => 'not json' })).toBeNull()
+  })
+  it('returns null for a non-transcript path (never reads)', () => {
+    const readFile = vi.fn(() => '{"name":"x"}')
+    expect(readNameSidecar('C:\\x\\notes.txt', { readFile })).toBeNull()
+    expect(readFile).not.toHaveBeenCalled()
+  })
+})
+
+describe('pending-name registry', () => {
+  beforeEach(() => { forgetSessionName('sid1'); forgetSessionName('sid2') })
+
+  it('remembers and reads back the latest name', () => {
+    rememberSessionName('sid1', '  work A  ')
+    expect(getRememberedName('sid1')).toBe('work A')
+    rememberSessionName('sid1', 'work B')
+    expect(getRememberedName('sid1')).toBe('work B')
+  })
+  it('a blank name clears the remembered entry', () => {
+    rememberSessionName('sid1', 'work')
+    rememberSessionName('sid1', '   ')
+    expect(getRememberedName('sid1')).toBeNull()
+  })
+  it('forget drops the entry', () => {
+    rememberSessionName('sid2', 'work')
+    forgetSessionName('sid2')
+    expect(getRememberedName('sid2')).toBeNull()
+  })
+  it('unknown session → null', () => {
+    expect(getRememberedName('nope')).toBeNull()
+  })
+})

--- a/tests/unit/scripts/resume-picker.test.ts
+++ b/tests/unit/scripts/resume-picker.test.ts
@@ -23,6 +23,7 @@ const picker = require('../../../scripts/resume-picker.js') as {
   ensureCompanionDir: (projectDir: string, uuid: string) => boolean
   computeLayoutWidth: (columns: number | undefined) => number
   loadWorkNames: (configDir: string | undefined) => Map<string, string>
+  readSidecarName: (transcriptFilePath: string) => string | null
   sanitizeMessageText: (raw: unknown) => string | null
 }
 
@@ -477,5 +478,29 @@ describe('resume-picker loadWorkNames', () => {
     expect(picker.loadWorkNames(dir).size).toBe(0) // no file written yet
     writeFileSync(join(dir, 'session-state.json'), '{ not json', 'utf-8')
     expect(picker.loadWorkNames(dir).size).toBe(0)
+  })
+})
+
+// ── readSidecarName (#536: name carried onto the transcript) ─────────
+describe('resume-picker readSidecarName', () => {
+  let dir: string
+  const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccc-sidecar-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+  const transcript = () => join(dir, `${UUID}.jsonl`)
+  const sidecar = () => join(dir, `${UUID}.ccc-name.json`)
+
+  it('reads the trimmed name from <uuid>.ccc-name.json beside the transcript', () => {
+    writeFileSync(sidecar(), JSON.stringify({ name: '  aai-core | INSIGHTS FU  ', updatedAt: 1 }), 'utf-8')
+    expect(picker.readSidecarName(transcript())).toBe('aai-core | INSIGHTS FU')
+  })
+
+  it('fail-safe: missing sidecar, bad JSON, blank name, or non-.jsonl path → null', () => {
+    expect(picker.readSidecarName(transcript())).toBeNull()          // no sidecar
+    writeFileSync(sidecar(), '{ not json', 'utf-8')
+    expect(picker.readSidecarName(transcript())).toBeNull()          // bad JSON
+    writeFileSync(sidecar(), JSON.stringify({ name: '   ' }), 'utf-8')
+    expect(picker.readSidecarName(transcript())).toBeNull()          // blank
+    expect(picker.readSidecarName(join(dir, 'notes.txt'))).toBeNull() // not a transcript
   })
 })

--- a/tests/unit/stores/sessionStore.test.ts
+++ b/tests/unit/stores/sessionStore.test.ts
@@ -265,11 +265,15 @@ describe('sessionStore', () => {
       useSessionStore.getState().addSession(makeSession({ id: 'a', label: 'Config A' }))
 
       useSessionStore.getState().renameSession('a', 'Boot perf')
-      expect(renameSessionIpc).toHaveBeenCalledWith({ sessionId: 'a', configLabel: 'Boot perf' })
+      // #536: customName (the user's own work name) rides alongside configLabel so
+      // the transcript sidecar carries the work name, never the generic config label.
+      expect(renameSessionIpc).toHaveBeenCalledWith({ sessionId: 'a', configLabel: 'Boot perf', customName: 'Boot perf' })
 
       // Blank => effective label falls back to the config label.
       useSessionStore.getState().renameSession('a', '   ')
-      expect(renameSessionIpc).toHaveBeenLastCalledWith({ sessionId: 'a', configLabel: 'Config A' })
+      // A blank rename sends an EMPTY customName — the real "cleared" signal that
+      // removes the sidecar — while configLabel still falls back to the label.
+      expect(renameSessionIpc).toHaveBeenLastCalledWith({ sessionId: 'a', configLabel: 'Config A', customName: '' })
 
       delete (globalThis as any).window
     })


### PR DESCRIPTION
Closes #536. **release-2.2.** Refs #480 #130 #535.

Carries the CCC session name (the left-hand `customName`) onto the transcript on disk, so the name
survives outside CCC and identifies which conversation is loading on resume.

## Mechanism — a sidecar, NOT a line in Claude's JSONL

Writing into `<uuid>.jsonl` would couple to Claude's own transcript format and risk breaking the
resume it owns (the exact thing #535 fixes). Instead this writes a CCC-owned sibling
`<uuid>.ccc-name.json`. It couples to nothing Claude parses, survives worktree/cross-account moves
of the projects tree, and the resume-picker reads it in preference to the fragile last-writer-wins
`uuid → customName` map it derives from `session-state.json`.

## What

- **`src/main/logging/session-name-sidecar.ts`** — pure, best-effort `sidecarPathFor` /
  `writeNameSidecar` / `readNameSidecar` (injectable I/O, `JSON.stringify`-escaped name, blank name
  REMOVES the sidecar) + a bounded pending-name registry that bridges "renamed before the transcript
  is bound".
- **Rename IPC** (`logs2-handlers.ts`) — writes the sidecar from the user's own `customName` against
  an EXACT bind; remembers it when not yet bound. The renderer now sends `customName` (empty =
  cleared) beside `configLabel`.
- **Binder** — new `onExactBind` hook (sibling of #480's `persist`) flushes a remembered name once
  the transcript path is known, then retires the entry.
- **Picker** (`resume-picker.js`) — `readSidecarName(conv.filePath)`, preferred over the
  session-state map.

Best-effort throughout: a name is never worth throwing into a rename/spawn/bind path; every read is
fail-safe → null. Un-renamed sessions write no sidecar (picker falls back to existing behaviour).

## Security — ADR-009 adversarial review: PASS

Touches the renderer→main IPC boundary, an fs write under `~/.claude/projects`, and the picker
parse → full pass (3 attackers: injection, IPC/state, fail-open). Injection (`JSON.stringify` +
name-only reads), path containment (binder-canonicalized paths), transcript-corruption and
fail-open all held. **Findings found and fixed (two rounds):**

1. MEDIUM — `pendingNames` unbounded leak (renderer-reachable sessionId; `forgetSessionName` had no
   prod caller) → retire on `endRun` and after `onExactBind`, plus a 512-entry LRU cap.
2. MEDIUM — a renamed name bled onto the next conversation after `/clear` → retire on bind AND on the
   rename-after-bind path (round-2 residual, now guarded by handler tests).
3. MEDIUM — a blank rename could not clear, and a generic config label was promoted to the picker's
   primary → the renderer sends the user's own `customName` (empty = cleared); sidecar written from it.
4. MINOR — rename-time write used a heuristic-inclusive path (sibling mislabel window) →
   `getExactResumeTarget` (exact-only); the pre-bind case is covered by `onExactBind`.

## Gate

- `npm run typecheck` clean (3 tsconfigs)
- targeted suites green: `session-name-sidecar` (21), `logs2-ipc-handlers` (rename cases),
  `resume-picker` (readSidecarName), `sessionStore` (payload), binder + logging (236)
- full unit suite green locally (a few vitest worker-pool startup timeouts under local load are
  flakes; CI is the gate)

## NOT done — gates the MERGE, not this PR

Name-on-resume is desktop-observable → apply `desktop-tested` after a human (or a Playwright
`_electron` e2e) confirms a renamed session shows its name in the picker. Known minor follow-up:
#535's transcript relocation does not yet move the sidecar (relocated transcript falls back to the
session-state name). A human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
