### PR TITLE
build(release): 2.1.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.5",
+  "version": "2.1.0-rc.6",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump for the rc.6 cut. Ships the #540 bundle already on beta: What's New on every beta prerelease, the sleep moon, the active-session green context-bar sweep, the canvas show-and-tell lane, the command-chip focus fix, and a canvas reload-heal fix. Changelog (changelog.ts + CHANGELOG.md) already landed with #540; this is the package.json version line only.

Release gate for 2.1.0-rc.6 PASSES locally (milestone #8 exists with no outstanding issues; model registry covers all 10 supported models).