### PR TITLE
build(release): 2.1.0-rc.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.6",
+  "version": "2.1.0-rc.7",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump for the rc.7 cut. Ships the working-session pill + README feature refresh from #542 (already on beta); changelog landed there. package.json version line only.