### PR TITLE
fix(sidebar): sleep/active indicator fixes — monitors, click-wake, fades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `src/renderer/changelog.ts`. After editing that file, run `npm run changelog`
 > (CI enforces that this file is in sync via `npm run changelog:check`).
 
+## [2.1.0-rc.8] - 2026-08-27
+
+> The session sleep and working indicators settle down. Clicking a sleeping session no longer wakes its moon (only real output does, consistently), sessions running monitors are no longer tagged asleep between triggers, and the moon and working pill now fade in and out instead of popping.
+
+### Changed
+- The sleep moon and the working pill now ease in and out with a soft fade instead of popping, and neighbouring badges slide rather than jump. Reduced-motion setups keep the instant behaviour.
+
+### Fixed
+- Clicking or switching to a sleeping session no longer clears its moon. Opening a session repaints its terminal, and that repaint used to count as the session waking — sometimes, depending on window geometry, which is why the behaviour felt inconsistent. Repaint output around a click, focus change or resize is now recognised for what it is: the moon clears only when the session genuinely produces output again, and a click can no longer quietly push an impending moon back either. The working pill gets the same treatment, so it no longer flashes green on a session switch.
+- Sessions running monitors are no longer marked asleep between triggers. A Claude session with active monitors is quiet by design while it waits; the Watchdog now reads the "N monitors" mode footer and skips the moon for those sessions.
+
 ## [2.1.0-rc.7] - 2026-08-27
 
 > The active-session indicator is easier to catch: a Claude session that is producing output now shows a green "working" pill beside its type badge — a gently pulsing play glyph — as well as the context-bar sweep, so a live session reads at a glance.
@@ -1373,6 +1384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tab attention indicators for waiting prompts
 - Context usage tracking via statusline API
 
+[2.1.0-rc.8]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-rc.8
 [2.1.0-rc.7]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-rc.7
 [2.1.0-rc.6]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-rc.6
 [2.1.0-rc.5]: https://github.com/nubbymong/claude-command-center/releases/tag/v2.1.0-rc.5

--- a/src/main/ipc/service-health-handlers.ts
+++ b/src/main/ipc/service-health-handlers.ts
@@ -54,10 +54,14 @@ export function getMergedDiagnostics(getSup: SupGetter, getPty: PtyGetter, getWa
   const wd = getWatchdog()
   let withWd: DiagnosticsSnapshot = withPty
   if (wd) {
-    const wdSnap = wd.getDiagnosticsSnapshot()
+    // One monitor snapshot per merge: getDiagnosticsSnapshot derives its
+    // ServiceHealth from the same snapshot, and the per-silent-session pane
+    // read it now carries (RC8 hasMonitors) should run once, not twice.
+    const mon = wd.getMonitorSnapshot()
+    const wdSnap = wd.getDiagnosticsSnapshot(mon)
     const log = [...withPty.log, ...wdSnap.log].sort((a, b) => a.ts - b.ts)
     if (log.length > LOG_CAP) log.splice(0, log.length - LOG_CAP)
-    withWd = { ...withPty, services: [...withPty.services, ...wdSnap.services], log, watchdog: wd.getMonitorSnapshot() }
+    withWd = { ...withPty, services: [...withPty.services, ...wdSnap.services], log, watchdog: mon }
   }
 
   // Stamp the MAIN-process event-loop jank onto EVERY service (both delivery

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -3589,6 +3589,18 @@ function isSubmittedPayload(data: string): boolean {
 }
 
 export function writePty(sessionId: string, data: string): void {
+  // Focus-report chunks (RC8): xterm emits the DECSET-1004 focus events
+  // (\x1b[I focus-in, \x1b[O focus-out) as standalone writes when a session
+  // pane gains or loses focus — i.e. on every session click/switch, for BOTH
+  // sides of the switch. Claude Code's TUI enables 1004 and answers with a
+  // small redraw, which must not count as the session "waking" from silence.
+  // Arm the watchdog's activation grace so that redraw is excluded from sleep
+  // bookkeeping. EXACT match only (user keystrokes and pastes never arrive as
+  // exactly one of these two chunks), and the write itself is never altered,
+  // blocked, or delayed by this.
+  if (data === '\x1b[I' || data === '\x1b[O') {
+    getWatchdogManager()?.noteRedrawTrigger(sessionId)
+  }
   // Dedupe guard: suppress identical repeats of submitted payloads within a short window.
   // This protects against double-sends from double-clicks, React effect races, event
   // listeners firing twice, etc. Only applies to "submitted" writes (ending in \r or \n)

--- a/src/main/watchdog/patterns.ts
+++ b/src/main/watchdog/patterns.ts
@@ -127,6 +127,30 @@ export function contentTail(lines: string[], n: number, maxRaw = Infinity): stri
   return lines.slice(start, end)
 }
 
+// --- Active-monitor detection (sleep indicator, RC8) ---
+// A session running periodic monitors is QUIET between triggers BY DESIGN, so
+// the silence-based sleep indicator must not tag it asleep. Claude Code
+// advertises active monitors in the mode footer — persistent bottom furniture
+// anchored under the input box: "⏵⏵ auto mode on · 2 monitors · ← for agents",
+// "⏵⏵ accept edits on · 1 monitor". Two anchors, both required to be in the
+// last few rendered lines (the footer region), so the same text quoted in a
+// tool render higher up the pane cannot suppress a real moon:
+//   - the ⏵⏵ mode footer carrying a monitor count, or
+//   - the interpunct-delimited segment itself ("· N monitors") for renders
+//     where the count rides other footer furniture.
+// Known limit (accepted): if the footer scrolls out of the captured pane the
+// detection lapses until it reprints — but it is bottom furniture, so in
+// practice it is always in the tail.
+const MONITOR_FOOTER_TAIL_LINES = 15
+const MODE_FOOTER_MONITORS = /^\s*⏵⏵.*\b\d+\s+monitors?\b/
+const MONITOR_SEGMENT = /·\s*\d+\s+monitors?\b/
+
+export function hasActiveMonitors(text: string, tailLines = MONITOR_FOOTER_TAIL_LINES): boolean {
+  const lines = stripAnsi(text).split('\n')
+  const tail = lines.slice(Math.max(0, lines.length - tailLines))
+  return tail.some((l) => MODE_FOOTER_MONITORS.test(l) || MONITOR_SEGMENT.test(l))
+}
+
 // Claude Code renders rate limits across multiple lines in its TUI, e.g.:
 //   "⚠ You've hit your limit"
 //   "· resets 3pm (UTC)"

--- a/src/main/watchdog/patterns.ts
+++ b/src/main/watchdog/patterns.ts
@@ -138,9 +138,10 @@ export function contentTail(lines: string[], n: number, maxRaw = Infinity): stri
 //   - the ⏵⏵ mode footer carrying a monitor count, or
 //   - the interpunct-delimited segment itself ("· N monitors") for renders
 //     where the count rides other footer furniture.
-// Known limit (accepted): if the footer scrolls out of the captured pane the
+// Known limits (accepted): if the footer scrolls out of the captured pane the
 // detection lapses until it reprints — but it is bottom furniture, so in
-// practice it is always in the tail.
+// practice it is always in the tail; and a very narrow pane (<~46 cols) can
+// wrap the segment across rows, splitting the match.
 const MONITOR_FOOTER_TAIL_LINES = 15
 const MODE_FOOTER_MONITORS = /^\s*⏵⏵.*\b\d+\s+monitors?\b/
 const MONITOR_SEGMENT = /·\s*\d+\s+monitors?\b/

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -15,6 +15,7 @@ import type { BrowserWindow } from 'electron'
 import { Terminal } from '@xterm/headless'
 import { SessionWatchdog } from './session-watchdog'
 import type { WatchdogAdapter, WatchdogPublicState } from './session-watchdog'
+import { hasActiveMonitors } from './patterns'
 import { getGateway } from '../hooks/index'
 import { readConfig } from '../config-manager'
 import { logInfo, logWarn, logError } from '../debug-logger'
@@ -170,6 +171,20 @@ const MAX_TICK_INTERVAL_MS = 30_000
 // via settings.watchdog.silenceWindowMs; 0 disables silence detection.
 const DEFAULT_SILENCE_WINDOW_MS = 120_000
 
+// Activation grace (RC8): clicking/switching to a session makes its hidden
+// terminal visible, which produces PTY OUTPUT that is a REDRAW, not work — the
+// TUI answers the focus-report events xterm sends (Claude Code enables DECSET
+// 1004; measured: a focus flip draws ~31 bytes) and ConPTY repaints the pane
+// on a changed-geometry resize (~2.6 KB). Both used to count as the session
+// "waking", so a click sometimes cleared the moon and sometimes didn't
+// (geometry-dependent). For this window after such a trigger, output is
+// EXCLUDED from silence bookkeeping: it neither clears a latched silence nor
+// resets the idle clock (which would silently push an impending moon back).
+// Genuine work resuming keeps streaming past the window and wakes normally,
+// at most this much later. The pane still ingests every byte, so detection
+// stays accurate.
+export const ACTIVATION_GRACE_MS = 1_000
+
 export interface WatchdogSessionInfo {
   provider?: string
   ssh?: boolean
@@ -260,6 +275,8 @@ interface Entry {
   lastDataAt: number
   /** Latched silence state (no output for the silence window). */
   silent: boolean
+  /** Until this now(), output is a click-redraw, not a wake (RC8). 0 = none. */
+  graceUntil: number
 }
 
 /** Serialize the pane's last `maxLines` rendered lines (screen + genuinely
@@ -524,7 +541,7 @@ export class WatchdogManager {
       scrollback: HEADLESS_SCROLLBACK,
       allowProposedApi: true,
     })
-    this.entries.set(sessionId, { wd, term, ansiClamp: { residual: '' }, feedTimer: null, lastDataAt: this.now(), silent: false })
+    this.entries.set(sessionId, { wd, term, ansiClamp: { residual: '' }, feedTimer: null, lastDataAt: this.now(), silent: false, graceUntil: 0 })
     if (this.startedAt === null) this.startedAt = this.now()
     this.ensureTickTimer()
     this.ensureHookSubscription()
@@ -549,6 +566,24 @@ export class WatchdogManager {
     try {
       entry.term.resize(cols, rows)
     } catch { /* a mid-write resize throw must not kill the PTY data path */ }
+    // A resize makes ConPTY repaint the pane — redraw output, not the session
+    // waking (RC8). Arm the grace so the repaint is excluded from silence
+    // bookkeeping. This covers both the click-activation resize (hidden
+    // terminal shown at a changed geometry) and a window/sidebar resize over a
+    // sleeping session.
+    entry.graceUntil = this.now() + ACTIVATION_GRACE_MS
+  }
+
+  /** Arm the activation grace for a session (RC8): the next
+   *  ACTIVATION_GRACE_MS of output is a click/focus redraw, not a wake. The
+   *  host calls this when it sees a redraw trigger that is not a resize —
+   *  chiefly the DECSET-1004 focus-report chunks (\x1b[I / \x1b[O) xterm
+   *  writes into the PTY when a session pane gains or loses focus. No-op for
+   *  untracked sessions. */
+  noteRedrawTrigger(sessionId: string): void {
+    const entry = this.entries.get(sessionId)
+    if (!entry) return
+    entry.graceUntil = this.now() + ACTIVATION_GRACE_MS
   }
 
   /** Publish one watchdog state to the renderer (and refresh the services
@@ -617,10 +652,20 @@ export class WatchdogManager {
     // and PUSH the flip: the sleep indicator rides diagnostics pushes, and
     // without this the wake only reached the renderer on the next unrelated
     // heartbeat (with hooks and logging both off, potentially much later).
-    entry.lastDataAt = this.now()
-    if (entry.silent) {
-      entry.silent = false
-      try { this.host.onHealthChange?.() } catch { /* host gone */ }
+    //
+    // EXCEPT inside the activation grace (RC8): output arriving within
+    // ACTIVATION_GRACE_MS of a redraw trigger (focus-report write, resize) is
+    // the TUI repainting for a click, not work resuming. It must neither clear
+    // a latched silence (the click-wake bug) nor reset the idle clock (a click
+    // on a not-yet-silent session would silently push its moon back a full
+    // window). Genuine work keeps streaming past the grace and wakes then.
+    const now = this.now()
+    if (now >= entry.graceUntil) {
+      entry.lastDataAt = now
+      if (entry.silent) {
+        entry.silent = false
+        try { this.host.onHealthChange?.() } catch { /* host gone */ }
+      }
     }
     // RAW bytes into the rendered pane — the terminal's parser is the tail
     // discipline now (#266 BLOCKER-1); no stripping, no manual line caps. Only
@@ -651,6 +696,20 @@ export class WatchdogManager {
     return this.entries.has(sessionId)
   }
 
+  /** Does this entry's rendered pane advertise active monitors in its mode
+   *  footer? Reads the same TAIL_MAX_LINES window getTail uses — readPanePair
+   *  counts raw buffer rows (blank rows below sparse content consume a small
+   *  window) and trims trailing blanks, and hasActiveMonitors then scopes its
+   *  scan to the last 15 rendered lines, so the anchor stays tight. Guarded:
+   *  a pane-read throw must not kill a health push. */
+  private paneHasMonitors(e: Entry): boolean {
+    try {
+      return hasActiveMonitors(readPanePair(e.term, TAIL_MAX_LINES, false).text)
+    } catch {
+      return false
+    }
+  }
+
   /** Per-session monitor state + current throttle, for the services view. */
   getMonitorSnapshot(): WatchdogMonitorSnapshot {
     const now = this.now()
@@ -663,6 +722,12 @@ export class WatchdogManager {
         waitUntil: st.waitUntil,
         silent: e.silent,
         idleMs: Math.max(0, now - e.lastDataAt),
+        // Monitor-aware sleep (RC8): a session with active monitors is quiet
+        // between triggers by design, so the moon skips it. Read only for
+        // SILENT sessions — the only ones the moon consults — and the pane
+        // cannot change while silent (changing requires output), so the read
+        // is stable and cheap here rather than on the per-burst feed path.
+        hasMonitors: e.silent ? this.paneHasMonitors(e) : false,
       }
     })
     return {

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -740,10 +740,11 @@ export class WatchdogManager {
   }
 
   /** ServiceHealth snapshot so the watchdog appears in the services view merge,
-   *  modelled on the logging supervisor's getDiagnosticsSnapshot(). */
-  getDiagnosticsSnapshot(): DiagnosticsSnapshot {
+   *  modelled on the logging supervisor's getDiagnosticsSnapshot(). Callers
+   *  that already hold a monitor snapshot pass it in so the per-silent-session
+   *  pane read (paneHasMonitors) runs once per push, not twice. */
+  getDiagnosticsSnapshot(mon: WatchdogMonitorSnapshot = this.getMonitorSnapshot()): DiagnosticsSnapshot {
     const now = this.now()
-    const mon = this.getMonitorSnapshot()
     const health = createInitialHealth('watchdog', 'Watchdog')
     health.state = this.entries.size > 0 ? 'listening' : 'stopped'
     health.startedAt = this.startedAt

--- a/src/main/watchdog/watchdog-manager.ts
+++ b/src/main/watchdog/watchdog-manager.ts
@@ -724,9 +724,9 @@ export class WatchdogManager {
         idleMs: Math.max(0, now - e.lastDataAt),
         // Monitor-aware sleep (RC8): a session with active monitors is quiet
         // between triggers by design, so the moon skips it. Read only for
-        // SILENT sessions — the only ones the moon consults — and the pane
-        // cannot change while silent (changing requires output), so the read
-        // is stable and cheap here rather than on the per-burst feed path.
+        // SILENT sessions — the only ones the moon consults. While silent the
+        // pane changes only on graced click-redraw output, so reading it per
+        // snapshot (not per feed burst) is both cheap and current.
         hasMonitors: e.silent ? this.paneHasMonitors(e) : false,
       }
     })

--- a/src/renderer/changelog.ts
+++ b/src/renderer/changelog.ts
@@ -21,6 +21,16 @@ export interface ChangelogEntry {
 // a backtick in a comment opens a phantom string and the parse fails.
 export const changelog: ChangelogEntry[] = [
   {
+    version: '2.1.0-rc.8',
+    date: '2026-08-27',
+    highlights: 'The session sleep and working indicators settle down. Clicking a sleeping session no longer wakes its moon (only real output does, consistently), sessions running monitors are no longer tagged asleep between triggers, and the moon and working pill now fade in and out instead of popping.',
+    changes: [
+      { type: 'fix', description: 'Clicking or switching to a sleeping session no longer clears its moon. Opening a session repaints its terminal, and that repaint used to count as the session waking — sometimes, depending on window geometry, which is why the behaviour felt inconsistent. Repaint output around a click, focus change or resize is now recognised for what it is: the moon clears only when the session genuinely produces output again, and a click can no longer quietly push an impending moon back either. The working pill gets the same treatment, so it no longer flashes green on a session switch.' },
+      { type: 'fix', description: 'Sessions running monitors are no longer marked asleep between triggers. A Claude session with active monitors is quiet by design while it waits; the Watchdog now reads the "N monitors" mode footer and skips the moon for those sessions.' },
+      { type: 'improvement', description: 'The sleep moon and the working pill now ease in and out with a soft fade instead of popping, and neighbouring badges slide rather than jump. Reduced-motion setups keep the instant behaviour.' },
+    ],
+  },
+  {
     version: '2.1.0-rc.7',
     date: '2026-08-27',
     highlights: 'The active-session indicator is easier to catch: a Claude session that is producing output now shows a green "working" pill beside its type badge — a gently pulsing play glyph — as well as the context-bar sweep, so a live session reads at a glance.',

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -1163,6 +1163,9 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               // ConPTY repaints the pane on resize — redraw output, not
               // activity. Grace the pill so it doesn't flash (RC8); the main
               // process arms the moon's grace in its own resize handler.
+              // (The resume-nudge and geometryResync resizes deliberately skip
+              // this: they fire in already-streaming flows where the pill is
+              // lit anyway, while the main-side grace still covers the moon.)
               noteActivityGrace(sessionId)
               window.electronAPI.pty.resize(sessionId, cols, rows)
               reportIntegrity()

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -43,6 +43,7 @@ import { useWatchdogSubscription } from '../hooks/useWatchdogSubscription'
 import { useAccountIdentitySubscription } from '../hooks/useAccountIdentitySubscription'
 import { useActiveTabEffect } from '../hooks/useActiveTabEffect'
 import { useCursorLayerVisibility } from '../hooks/useCursorLayerVisibility'
+import { noteActivityGrace } from '../stores/activeStore'
 import type { ProviderId, CodexOptions, TerminalOptions } from '../../shared/types'
 
 // Re-export for consumers
@@ -881,6 +882,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
             `[${sessionId}] pty:write ${shellOnly ? 'shell' : 'claude'} ${describeBytes(data)}`,
           )
         }
+        // Focus-report chunks (RC8): the TUI answers \x1b[I / \x1b[O with a
+        // small redraw. Grace the working pill so a session click/switch does
+        // not flash it — the exact-match twin of the main process's sleep-moon
+        // grace in writePty.
+        if (data === '\x1b[I' || data === '\x1b[O') noteActivityGrace(sessionId)
         window.electronAPI.pty.write(sessionId, data)
       })
 
@@ -1154,6 +1160,10 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               lastSentCols = cols
               lastSentRows = rows
               ptyResizeCount += 1
+              // ConPTY repaints the pane on resize — redraw output, not
+              // activity. Grace the pill so it doesn't flash (RC8); the main
+              // process arms the moon's grace in its own resize handler.
+              noteActivityGrace(sessionId)
               window.electronAPI.pty.resize(sessionId, cols, rows)
               reportIntegrity()
             }

--- a/src/renderer/components/sidebar/Badges.tsx
+++ b/src/renderer/components/sidebar/Badges.tsx
@@ -1,4 +1,46 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
+
+/** How long an exiting chip stays mounted for its fade-out. Slightly over the
+ *  220ms CSS animation so the last frame always paints before unmount. */
+export const FADE_OUT_MS = 240
+
+/**
+ * Soft enter/exit for the presence chips (moon + working pill, RC8): the flags
+ * they key on flip abruptly (a silence latch, a 2.5s output window), and a
+ * chip popping in/out of the badge row reads as flicker. The slot fades AND
+ * collapses its width so neighbours slide rather than jump. On exit it keeps
+ * the LAST-rendered child on screen for the fade — the store value backing the
+ * chip (e.g. the moon's silentSince) is usually gone the frame the flag
+ * clears. Reduced motion: the CSS disables the animations and snaps the exit
+ * state, so chips appear/disappear instantly as before.
+ */
+export function FadeSlot({ show, children }: { show: boolean; children: React.ReactNode }) {
+  const [phase, setPhase] = useState<'in' | 'out' | 'gone'>(show ? 'in' : 'gone')
+  const phaseRef = useRef(phase)
+  phaseRef.current = phase
+  const lastChildren = useRef<React.ReactNode>(null)
+  if (show) lastChildren.current = children
+  useEffect(() => {
+    if (show) {
+      setPhase('in')
+      return
+    }
+    if (phaseRef.current === 'gone') return
+    setPhase('out')
+    const t = setTimeout(() => setPhase('gone'), FADE_OUT_MS)
+    return () => clearTimeout(t)
+  }, [show])
+  if (phase === 'gone') return null
+  return (
+    <span
+      className={`fade-slot ${phase === 'out' ? 'fade-slot-out' : 'fade-slot-in'}`}
+      data-testid="fade-slot"
+      data-phase={phase}
+    >
+      {lastChildren.current}
+    </span>
+  )
+}
 
 export function ClaudeBadge({ needsAttention }: { needsAttention: boolean }) {
   const isWorking = !needsAttention

--- a/src/renderer/components/sidebar/SessionRow.tsx
+++ b/src/renderer/components/sidebar/SessionRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Session } from '../../stores/sessionStore'
-import { MoonBadge, SessionTypeBadge, SshBadge, SshPersistentBadge, WatchdogBadge, WorkingBadge } from './Badges'
+import { FadeSlot, MoonBadge, SessionTypeBadge, SshBadge, SshPersistentBadge, WatchdogBadge, WorkingBadge } from './Badges'
 import { isAsleep, useSleepStore } from '../../stores/sleepStore'
 import { useActiveStore } from '../../stores/activeStore'
 import { type SessionState } from '../ui/StatusDot'
@@ -198,9 +198,15 @@ export default function SessionRow({ session, isActive, needsAttention, isRenami
         {/* Moon BESIDE the type badge (variant B): the type mark stays — the
             moon is additional Watchdog state, not a replacement identity. The
             working pill is its inverse and shares the slot (mutually exclusive:
-            asleep vs. moving). */}
-        {asleep && silentSince != null && <MoonBadge sinceMs={silentSince} />}
-        {showActive && <WorkingBadge />}
+            asleep vs. moving). Both ride a FadeSlot (RC8) so they ease in/out
+            instead of popping — the slot keeps the exiting chip mounted for
+            its fade even after the backing store value clears. */}
+        <FadeSlot show={asleep && silentSince != null}>
+          {silentSince != null && <MoonBadge sinceMs={silentSince} />}
+        </FadeSlot>
+        <FadeSlot show={showActive}>
+          <WorkingBadge />
+        </FadeSlot>
         <SessionTypeBadge kind={session.shellOnly ? 'shell' : (session.provider ?? 'claude') === 'codex' ? 'codex' : 'claude'} />
         <WatchdogBadge watchdog={session.watchdog} />
         {/* Graceful-fail: show effort ONLY once a live tick (statusline / hooks)

--- a/src/renderer/stores/activeStore.ts
+++ b/src/renderer/stores/activeStore.ts
@@ -24,6 +24,14 @@ import { useSessionStore } from './sessionStore'
 export const ACTIVE_WINDOW_MS = 2500
 /** How often the active set is re-derived (the CSS animation is smooth regardless). */
 const TICK_MS = 1000
+/** Activation grace (RC8): after a session click/switch or a terminal resize,
+ *  the TUI repaints (focus-report response, ConPTY redraw) — output that is a
+ *  REDRAW, not work. Chunks within this window of such a trigger are ignored,
+ *  so the pill does not flash on a click. Mirrors the main-process grace the
+ *  Watchdog applies to the sleep moon. A genuinely working session keeps
+ *  streaming past the window, and its ≤1s stamp gap never outlasts the 2.5s
+ *  active window — so a live pill cannot flicker off from the grace itself. */
+export const ACTIVITY_GRACE_MS = 1000
 
 interface ActiveState {
   /** Session ids whose PTY output moved within the last ACTIVE_WINDOW_MS. */
@@ -37,6 +45,19 @@ export const useActiveStore = create<ActiveState>(() => ({ activeIds: new Set<st
 const lastOutputAt = new Map<string, number>()
 // Per-session unsubscribe handles for the pty:data subscriptions we own.
 const dataSubs = new Map<string, () => void>()
+// Per-session grace deadline (epoch ms): chunks before it are click/resize
+// redraws and are not stamped. See ACTIVITY_GRACE_MS.
+const graceUntil = new Map<string, number>()
+
+/** Arm the activation grace for a session: the next ACTIVITY_GRACE_MS of its
+ *  output is treated as a redraw, not activity. TerminalView calls this on the
+ *  SAME triggers the main process graces the sleep moon on — a focus-report
+ *  write (\x1b[I / \x1b[O, sent by xterm when a pane gains or loses focus, so
+ *  both sides of a session switch are covered) and a PTY resize (ConPTY
+ *  repaints on resize). */
+export function noteActivityGrace(sessionId: string): void {
+  graceUntil.set(sessionId, Date.now() + ACTIVITY_GRACE_MS)
+}
 
 function setsEqual(a: Set<string>, b: Set<string>): boolean {
   if (a.size !== b.size) return false
@@ -53,7 +74,11 @@ function reconcile(ids: readonly string[]): void {
   for (const id of live) {
     if (!dataSubs.has(id)) {
       const off = api.onData(id, () => {
-        lastOutputAt.set(id, Date.now())
+        const now = Date.now()
+        // Inside the activation grace this chunk is a click/resize redraw —
+        // never stamp it as activity (RC8).
+        if (now < (graceUntil.get(id) ?? 0)) return
+        lastOutputAt.set(id, now)
       })
       dataSubs.set(id, off)
     }
@@ -63,6 +88,7 @@ function reconcile(ids: readonly string[]): void {
       try { off() } catch { /* listener already gone */ }
       dataSubs.delete(id)
       lastOutputAt.delete(id)
+      graceUntil.delete(id)
     }
   }
 }
@@ -113,6 +139,7 @@ export function teardownActiveListeners(): void {
   for (const [, off] of dataSubs) { try { off() } catch { /* ignore */ } }
   dataSubs.clear()
   lastOutputAt.clear()
+  graceUntil.clear()
   lastIdsKey = ''
   started = false
   useActiveStore.setState({ activeIds: new Set<string>() })

--- a/src/renderer/stores/sleepStore.ts
+++ b/src/renderer/stores/sleepStore.ts
@@ -12,7 +12,12 @@ import type { DiagnosticsSnapshot } from '../../shared/service-health'
  *    sleep visibly, and the renderer runs no clock of its own.
  *  - WAKE is Watchdog-observed activity only. Clicking or selecting a session
  *    changes nothing here — the moon clears when the next health push says the
- *    session is no longer silent.
+ *    session is no longer silent. (The Watchdog itself excludes click-redraw
+ *    output via its activation grace, RC8, so a click cannot wake a session
+ *    through the back door either.)
+ *  - MONITOR sessions never sleep (RC8): a session advertising active
+ *    monitors in its mode footer is quiet between triggers by design; the
+ *    Watchdog flags it (`hasMonitors`) and the moon skips it.
  *  - ATTENTION always outranks the moon (enforced where the moon renders:
  *    `isAsleep` takes needsAttention). A session that stalled WITH a question
  *    shows attention, never sleep.
@@ -33,7 +38,7 @@ interface SleepState {
   /** Bumped when a dismiss grace window elapses, so subscribers re-derive. */
   graceTick: number
   applyWatchdogSessions: (
-    sessions: ReadonlyArray<{ sessionId: string; silent: boolean; idleMs: number }>,
+    sessions: ReadonlyArray<{ sessionId: string; silent: boolean; idleMs: number; hasMonitors?: boolean }>,
     now?: number,
   ) => void
   noteAttentionDismissed: (sessionId: string, now?: number) => void
@@ -65,7 +70,10 @@ export const useSleepStore = create<SleepState>((set, get) => ({
     const prev = get().silentSince
     const next: Record<string, number> = {}
     for (const s of sessions) {
-      if (!s.silent) continue
+      // Monitor sessions are quiet between triggers BY DESIGN (RC8): the
+      // Watchdog flags them from the "· N monitors ·" mode footer, and the
+      // moon skips them even though they are silent by the output clock.
+      if (!s.silent || s.hasMonitors === true) continue
       // Keep the original start across pushes; derive it from idleMs on the
       // flip so "asleep 6m" is honest even when the flip push arrived late.
       next[s.sessionId] = prev[s.sessionId] ?? now - Math.max(0, s.idleMs)

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -450,6 +450,29 @@ input[type="range"] {
   .working-pill { animation: none; }
 }
 
+/* Presence-chip fade (RC8): the moon and working pill enter/exit softly
+   instead of popping. The FadeSlot wrapper fades opacity AND collapses width
+   (overflow hidden) so neighbouring badges slide rather than jump; the 48px
+   max-width comfortably covers the widest chip (moon + hours label). Kept
+   inside the 150-300ms project window. Reduced motion: no animation, and the
+   exit state snaps so a leaving chip vanishes instantly instead of lingering
+   for its unmount timeout. */
+.fade-slot { display: inline-flex; flex-shrink: 0; overflow: hidden; max-width: 48px; }
+.fade-slot-in { animation: fade-slot-in 200ms ease-out; }
+.fade-slot-out { animation: fade-slot-out 220ms ease-in forwards; }
+@keyframes fade-slot-in {
+  from { opacity: 0; max-width: 0; }
+  to   { opacity: 1; max-width: 48px; }
+}
+@keyframes fade-slot-out {
+  from { opacity: 1; max-width: 48px; }
+  to   { opacity: 0; max-width: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fade-slot-in, .fade-slot-out { animation: none; }
+  .fade-slot-out { opacity: 0; max-width: 0; }
+}
+
 /* CommandBar quick-actions strip: expand-in for the command rows when the
    bar is un-collapsed. Kept inside the 150-300ms project window. The rows are
    removed from the DOM when collapsed, so only the open direction animates. */

--- a/src/shared/service-health.ts
+++ b/src/shared/service-health.ts
@@ -44,6 +44,11 @@ export interface WatchdogSessionMonitor {
   silent: boolean
   /** ms since the last PTY chunk for this session. */
   idleMs: number
+  /** True when the session's pane advertises active monitors in its mode
+   *  footer ("… · 2 monitors · …"). A monitor session is quiet between
+   *  triggers BY DESIGN, so the sleep indicator skips it (RC8). Computed only
+   *  for silent sessions — the only ones the moon consults. */
+  hasMonitors?: boolean
 }
 
 /** Snapshot of the whole watchdog subsystem for the services view (#235). */

--- a/tests/unit/main/watchdog/patterns.test.ts
+++ b/tests/unit/main/watchdog/patterns.test.ts
@@ -13,6 +13,7 @@ import {
   isWorking,
   isInternalRetry,
   resumedAfterLimit,
+  hasActiveMonitors,
 } from '../../../../src/main/watchdog/patterns'
 
 // Mirrors upstream claude-auto-retry's DEFAULT_OVERLOAD.patterns / DEFAULT_SAFEGUARD.patterns
@@ -683,5 +684,35 @@ describe('canSendNow (#266 BLOCKER-2 / MAJOR-3) — the send gate, against REAL 
       const draft = box('fix the failing test').join('\n')
       expect(canSendNow(draft, draft)).toEqual({ ok: false, reason: 'draft' })
     })
+  })
+})
+
+describe('hasActiveMonitors (RC8 — monitor sessions never sleep)', () => {
+  it('detects the mode footer carrying a monitor count', () => {
+    expect(hasActiveMonitors('some output\n⏵⏵ auto mode on · 2 monitors · ← for agents')).toBe(true)
+    expect(hasActiveMonitors('x\n  ⏵⏵ accept edits on · 1 monitor')).toBe(true)
+  })
+
+  it('detects the interpunct-delimited segment on other footer furniture', () => {
+    expect(hasActiveMonitors('x\nclaude-fable · 3 monitors · 47%')).toBe(true)
+  })
+
+  it('a plain mode footer without monitors does not match', () => {
+    expect(hasActiveMonitors('x\n⏵⏵ auto mode on (shift+tab to cycle)')).toBe(false)
+  })
+
+  it('prose about monitors does not match (needs the footer/segment anchors)', () => {
+    expect(hasActiveMonitors('I set up 2 monitors for the deploy.\n❯ ')).toBe(false)
+    expect(hasActiveMonitors('the monitors are running\n❯ ')).toBe(false)
+  })
+
+  it('a footer quoted deep in scrollback is outside the tail window', () => {
+    const quoted = '⏵⏵ auto mode on · 2 monitors · ← for agents'
+    const pane = [quoted, ...Array.from({ length: 20 }, (_, i) => `line ${i}`)].join('\n')
+    expect(hasActiveMonitors(pane)).toBe(false)
+  })
+
+  it('reads through ANSI styling', () => {
+    expect(hasActiveMonitors('x\n\x1b[2m⏵⏵ auto mode on · 2 monitors · ← for agents\x1b[0m')).toBe(true)
   })
 })

--- a/tests/unit/main/watchdog/watchdog-throttle-silence.test.ts
+++ b/tests/unit/main/watchdog/watchdog-throttle-silence.test.ts
@@ -142,6 +142,99 @@ describe('watchdog silence detection', () => {
   })
 })
 
+describe('watchdog activation grace (RC8 — a click must not wake a sleeping session)', () => {
+  it('output within the grace neither clears silence nor resets the idle clock', () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 1000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'x')                        // lastDataAt = 0
+    vi.advanceTimersByTime(5000)                 // tick: silent at t=5000
+    expect(m.getMonitorSnapshot().sessions[0].silent).toBe(true)
+    m.noteRedrawTrigger('s1')                    // click: focus-report seen at t=5000
+    m.feedData('s1', 'focus redraw bytes')       // the TUI's click response
+    const s = m.getMonitorSnapshot().sessions[0]
+    expect(s.silent).toBe(true)                  // moon stays
+    expect(s.idleMs).toBe(5000)                  // idle clock untouched
+  })
+
+  it('output after the grace expires wakes the session normally', () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 1000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'x')
+    vi.advanceTimersByTime(5000)                 // silent
+    m.noteRedrawTrigger('s1')                    // grace until t=6000
+    vi.advanceTimersByTime(1500)                 // t=6500, past the grace
+    m.feedData('s1', 'real work resuming')
+    expect(m.getMonitorSnapshot().sessions[0].silent).toBe(false)
+  })
+
+  it('a resize arms the grace too (ConPTY repaints on resize)', () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 1000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'x')
+    vi.advanceTimersByTime(5000)                 // silent
+    m.noteResize('s1', 100, 30)                  // activation resize
+    m.feedData('s1', 'conpty repaint burst')
+    expect(m.getMonitorSnapshot().sessions[0].silent).toBe(true)
+  })
+
+  it('a click on a not-yet-silent session does not push its moon back', () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 6000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'x')                        // lastDataAt = 0
+    vi.advanceTimersByTime(5000)                 // not yet silent (5000 < 6000)
+    m.noteRedrawTrigger('s1')
+    m.feedData('s1', 'click redraw')             // graced: must NOT re-stamp
+    vi.advanceTimersByTime(5000)                 // t=10000: idle 10000 > 6000
+    expect(m.getMonitorSnapshot().sessions[0].silent).toBe(true)
+  })
+
+  it('noteRedrawTrigger on an untracked session is a no-op', () => {
+    const m = new WatchdogManager(makeHost())
+    expect(() => m.noteRedrawTrigger('ghost')).not.toThrow()
+  })
+})
+
+describe('watchdog monitor-mode detection (RC8 — monitor sessions never show the moon)', () => {
+  it('a silent session whose footer advertises monitors reports hasMonitors', async () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 1000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'some output\r\n⏵⏵ auto mode on · 2 monitors · ← for agents')
+    // Async advance: the headless pane's write queue drains on the event loop,
+    // so the sync advance would read an empty pane.
+    await vi.advanceTimersByTimeAsync(5000)      // flush the pane write + flip silent
+    const s = m.getMonitorSnapshot().sessions[0]
+    expect(s.silent).toBe(true)
+    expect(s.hasMonitors).toBe(true)
+  })
+
+  it('a silent session without the monitors footer reports hasMonitors false', async () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 1000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', 'some output\r\n⏵⏵ auto mode on (shift+tab to cycle)')
+    await vi.advanceTimersByTimeAsync(5000)
+    const s = m.getMonitorSnapshot().sessions[0]
+    expect(s.silent).toBe(true)
+    expect(s.hasMonitors).toBe(false)
+  })
+
+  it('a non-silent session skips the pane read (hasMonitors false)', () => {
+    watchdogSettings = { enabled: true, silenceWindowMs: 60_000 }
+    const m = new WatchdogManager(makeHost())
+    m.startWatchdog('s1')
+    m.feedData('s1', '⏵⏵ auto mode on · 2 monitors · ← for agents')
+    vi.advanceTimersByTime(5000)                 // idle 5000 < 60000: not silent
+    const s = m.getMonitorSnapshot().sessions[0]
+    expect(s.silent).toBe(false)
+    expect(s.hasMonitors).toBe(false)
+  })
+})
+
 describe('watchdog services-view snapshots', () => {
   it('reports a watchdog ServiceHealth that is listening when active, stopped when not', () => {
     const m = new WatchdogManager(makeHost())

--- a/tests/unit/pty-manager-watchdog-teardown.test.ts
+++ b/tests/unit/pty-manager-watchdog-teardown.test.ts
@@ -19,11 +19,12 @@ vi.mock('electron', () => ({
 }))
 
 const stopWatchdog = vi.fn()
+const noteRedrawTrigger = vi.fn()
 vi.mock('../../src/main/watchdog/watchdog-manager', () => ({
-  getWatchdogManager: () => ({ stopWatchdog }),
+  getWatchdogManager: () => ({ stopWatchdog, noteRedrawTrigger }),
 }))
 
-const { killPty } = await import('../../src/main/pty-manager')
+const { killPty, writePty } = await import('../../src/main/pty-manager')
 
 describe('pty-manager — watchdog teardown on cleanup (FINDING 1)', () => {
   beforeEach(() => { stopWatchdog.mockClear() })
@@ -33,5 +34,25 @@ describe('pty-manager — watchdog teardown on cleanup (FINDING 1)', () => {
     // exactly the restart/close path that must clear the watcher before respawn.
     killPty('sess-restart-abc')
     expect(stopWatchdog).toHaveBeenCalledWith('sess-restart-abc')
+  })
+})
+
+describe('pty-manager — focus-report writes arm the activation grace (RC8)', () => {
+  beforeEach(() => { noteRedrawTrigger.mockClear() })
+
+  it('the exact \\x1b[I / \\x1b[O chunks arm the grace', () => {
+    writePty('sess-grace', '\x1b[I')
+    expect(noteRedrawTrigger).toHaveBeenCalledWith('sess-grace')
+    noteRedrawTrigger.mockClear()
+    writePty('sess-grace', '\x1b[O')
+    expect(noteRedrawTrigger).toHaveBeenCalledWith('sess-grace')
+  })
+
+  it('ordinary writes never arm it (exact match only)', () => {
+    writePty('sess-grace', 'hello world\r')   // a submitted line
+    writePty('sess-grace', 'a')               // a keystroke
+    writePty('sess-grace', '\x1b[Ix')         // focus report + trailing byte: not the standalone chunk
+    writePty('sess-grace', 'x\x1b[I')         // embedded, not standalone
+    expect(noteRedrawTrigger).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/renderer/active-indicator.test.tsx
+++ b/tests/unit/renderer/active-indicator.test.tsx
@@ -124,10 +124,9 @@ describe('activeStore — derivation from pty:data', () => {
     setupActiveListeners()
     noteActivityGrace('a')               // focus-report/resize seen at t=0
     emit('a')                            // the TUI's redraw response, t=0: graced
-    vi.advanceTimersByTime(ACTIVITY_GRACE_MS - 100) // ticks inside the window
+    vi.advanceTimersByTime(2000)         // ticks at 1000/2000 observe no stamp
     expect(useActiveStore.getState().activeIds.has('a')).toBe(false)
-    vi.advanceTimersByTime(200)          // past the grace
-    emit('a')                            // genuine output now stamps
+    emit('a')                            // t=2000, past the grace: stamps
     vi.advanceTimersByTime(1000)
     expect(useActiveStore.getState().activeIds.has('a')).toBe(true)
   })

--- a/tests/unit/renderer/active-indicator.test.tsx
+++ b/tests/unit/renderer/active-indicator.test.tsx
@@ -39,7 +39,7 @@ const onDataMock = vi.fn((sessionId: string, cb: (d: string) => void) => {
   return () => { set!.delete(cb) }
 })
 
-const { useActiveStore, setupActiveListeners, teardownActiveListeners, ACTIVE_WINDOW_MS } =
+const { useActiveStore, setupActiveListeners, teardownActiveListeners, noteActivityGrace, ACTIVE_WINDOW_MS, ACTIVITY_GRACE_MS } =
   await import('../../../src/renderer/stores/activeStore')
 const { useSessionStore } = await import('../../../src/renderer/stores/sessionStore')
 const { default: SessionRow } = await import('../../../src/renderer/components/sidebar/SessionRow')
@@ -117,6 +117,41 @@ describe('activeStore — derivation from pty:data', () => {
     const first = onDataMock.mock.calls.length
     setupActiveListeners()
     expect(onDataMock.mock.calls.length).toBe(first)
+  })
+
+  it('chunks within the activation grace are ignored — a click-redraw never lights the pill (RC8)', () => {
+    setSessions(['a'])
+    setupActiveListeners()
+    noteActivityGrace('a')               // focus-report/resize seen at t=0
+    emit('a')                            // the TUI's redraw response, t=0: graced
+    vi.advanceTimersByTime(ACTIVITY_GRACE_MS - 100) // ticks inside the window
+    expect(useActiveStore.getState().activeIds.has('a')).toBe(false)
+    vi.advanceTimersByTime(200)          // past the grace
+    emit('a')                            // genuine output now stamps
+    vi.advanceTimersByTime(1000)
+    expect(useActiveStore.getState().activeIds.has('a')).toBe(true)
+  })
+
+  it('the grace is per-session — another session\'s output still counts', () => {
+    setSessions(['a', 'b'])
+    setupActiveListeners()
+    noteActivityGrace('a')
+    emit('a')                            // graced
+    emit('b')                            // not graced
+    vi.advanceTimersByTime(1000)
+    expect(useActiveStore.getState().activeIds.has('a')).toBe(false)
+    expect(useActiveStore.getState().activeIds.has('b')).toBe(true)
+  })
+
+  it('a removed session drops its grace stamp with its subscription', () => {
+    setSessions(['a'])
+    setupActiveListeners()
+    noteActivityGrace('a')
+    setSessions([])                      // reconcile: sub + stamps dropped
+    setSessions(['a'])                   // re-added: fresh subscription
+    emit('a')                            // no stale grace: stamps immediately
+    vi.advanceTimersByTime(1000)
+    expect(useActiveStore.getState().activeIds.has('a')).toBe(true)
   })
 })
 

--- a/tests/unit/renderer/fade-slot.test.tsx
+++ b/tests/unit/renderer/fade-slot.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+/**
+ * FadeSlot (RC8): the presence chips (moon + working pill) enter and exit with
+ * a fade instead of popping. The rules this file holds shut:
+ *  - show=true renders the child; show=false keeps it MOUNTED in the 'out'
+ *    phase for the fade, then unmounts after FADE_OUT_MS.
+ *  - The exiting chip keeps the LAST-rendered child even when the caller's
+ *    children have already collapsed to null (the store value backing the chip
+ *    clears the same frame the flag does).
+ *  - Flipping show back on during the exit cancels the unmount.
+ *  - Initial show=false renders nothing at all.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const { FadeSlot, FADE_OUT_MS } = await import('../../../src/renderer/components/sidebar/Badges')
+
+describe('FadeSlot — presence-chip fade lifecycle', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+  afterEach(() => {
+    act(() => { root.unmount() })
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  const slot = () => container.querySelector('[data-testid="fade-slot"]')
+  const render = (show: boolean, child: React.ReactNode = createElement('i', { 'data-testid': 'chip' }, 'chip')) =>
+    act(() => { root.render(createElement(FadeSlot, { show }, child)) })
+
+  it('renders the child in the "in" phase while shown', () => {
+    render(true)
+    expect(slot()?.getAttribute('data-phase')).toBe('in')
+    expect(container.querySelector('[data-testid="chip"]')).not.toBeNull()
+  })
+
+  it('initial show=false renders nothing', () => {
+    render(false)
+    expect(slot()).toBeNull()
+  })
+
+  it('keeps the chip mounted in the "out" phase for the fade, then unmounts', () => {
+    render(true)
+    render(false)
+    expect(slot()?.getAttribute('data-phase')).toBe('out')
+    expect(container.querySelector('[data-testid="chip"]')).not.toBeNull()
+    act(() => { vi.advanceTimersByTime(FADE_OUT_MS + 10) })
+    expect(slot()).toBeNull()
+  })
+
+  it('the exiting slot keeps the LAST child even when children collapse to null', () => {
+    render(true)
+    render(false, null) // the flag and its backing value clear together
+    expect(container.querySelector('[data-testid="chip"]')).not.toBeNull()
+  })
+
+  it('re-showing during the exit cancels the unmount', () => {
+    render(true)
+    render(false)
+    act(() => { vi.advanceTimersByTime(FADE_OUT_MS / 2) })
+    render(true)
+    act(() => { vi.advanceTimersByTime(FADE_OUT_MS * 2) })
+    expect(slot()?.getAttribute('data-phase')).toBe('in')
+    expect(container.querySelector('[data-testid="chip"]')).not.toBeNull()
+  })
+})

--- a/tests/unit/renderer/sleep-indicator.test.tsx
+++ b/tests/unit/renderer/sleep-indicator.test.tsx
@@ -99,6 +99,22 @@ describe('sleep store — snapshot application', () => {
     useSleepStore.getState().applyWatchdogSessions([{ sessionId: 'a', silent: true, idleMs: 135_000 }], now + 5_000)
     expect(useSleepStore.getState().silentSince).toBe(before)
   })
+
+  it('a monitor session never records a silentSince, even when silent (RC8)', () => {
+    const now = 500_000
+    useSleepStore.getState().applyWatchdogSessions(
+      [{ sessionId: 'a', silent: true, idleMs: 130_000, hasMonitors: true }], now)
+    expect(useSleepStore.getState().silentSince.a).toBeUndefined()
+  })
+
+  it('monitors appearing on a tracked silent session clear its moon (RC8)', () => {
+    const now = 500_000
+    useSleepStore.getState().applyWatchdogSessions([{ sessionId: 'a', silent: true, idleMs: 130_000 }], now)
+    expect(useSleepStore.getState().silentSince.a).toBeDefined()
+    useSleepStore.getState().applyWatchdogSessions(
+      [{ sessionId: 'a', silent: true, idleMs: 190_000, hasMonitors: true }], now + 60_000)
+    expect(useSleepStore.getState().silentSince.a).toBeUndefined()
+  })
 })
 
 describe('sleep store — dismiss grace timer', () => {


### PR DESCRIPTION
Three related fixes to the session sleep moon and working pill (the RC8 batch, owner-requested as one PR). Closes nothing directly; batch was specced from the 2026-08-27 session.

## 1. Clicking a sleeping session no longer wakes it (and no longer inconsistently)
**Root cause (confirmed empirically with a node-pty probe against claude CLI):** Claude Code's TUI enables focus reporting (DECSET 1004), so every pane focus change makes xterm write `\x1b[I`/`\x1b[O` to the PTY and the TUI answers with a small redraw (~31 bytes measured); a changed-geometry resize additionally makes ConPTY repaint (~2.6 KB measured). Any chunk cleared the silence latch — so a click *sometimes* woke the moon (geometry changed / TUI responded) and sometimes didn't. 

**Fix — activation grace, no new IPC:** both trigger signals already cross existing channels. `writePty` exact-matches the standalone focus-report chunks and `noteResize` covers resizes; each arms a 1 s per-session grace in the Watchdog. Output inside the grace neither clears a latched silence nor resets the idle clock (so a click can't silently push an impending moon back either); the pane still ingests every byte, so detection is never blinded. Genuine work streams past the grace and wakes ≤1 s late. The renderer `activeStore` mirrors the same grace for the working pill (armed from the same focus-report writes in `term.onData` + the resize path), covering **both sides of a session switch** — the leaving pane's focus-out response no longer flashes its pill (the multi-session case).

## 2. Monitor sessions are no longer tagged asleep
A session with active monitors is quiet between triggers by design. The Watchdog now parses the "· N monitors ·" mode footer from its rendered pane — silent sessions only, last 15 rendered lines, two anchors (`⏵⏵` footer form + interpunct segment) — and surfaces `hasMonitors` on `WatchdogSessionMonitor`; `sleepStore` skips the moon for those sessions. Deliberate bias: the regex fails toward *suppressing* a moon (the safe direction) rather than under-matching an unseen footer variant.

## 3. The moon and pill fade instead of popping
`FadeSlot` (Badges.tsx) fades opacity and collapses width on enter/exit (200/220 ms), keeping the exiting chip mounted for its fade (the backing store value clears the same frame as the flag). Reduced motion keeps the instant behaviour.

## Verification
- `npm run typecheck` green (all three tsconfigs); full `npx vitest run` green — 760 files / 8772 tests.
- New/extended tests: `hasActiveMonitors` variants (patterns), grace semantics incl. the not-yet-silent click case (watchdog-manager), focus-report exact-match (pty-manager), monitor skip (sleepStore), grace per-session + drop-on-remove (activeStore), FadeSlot lifecycle.

## Double Review (owner away — done rigorously)
- **Review 1 (independent code review): PASS**, 3 MINOR + 3 NIT, all addressed in follow-up commits (vacuous test assertion tightened, stale comments fixed) or accepted (fade end-snap ~6 px).
- **Review 2 (adversarial, bounded one round, main-process scope): PASS.** Hostile output cannot reach the focus-report write path (renderer→main input path; no answerback collides with the exact 3-byte match); stale `silent`/`lastDataAt` alter **no** watchdog retry/send/give-up decision (the retry engine reads none of them; the send gate is untouched); `noteResize` validation precedes the grace arm; pane-read cost is bounded and non-amplifiable (and deduped to once per push in the last commit). One accepted-by-design note for the owner: **a child process printing a monitors-footer line in its last 15 rendered lines can suppress its own sleep moon** — same "trust the rendered pane" model as every existing detector, cosmetic impact only.

## ADR-009 determination
`src/main/pty*` is in the adversarial path table, so the pass above was run (fail-closed). The named concern class for that path — spawn/argv/shell construction — is untouched: no new IPC channel, no preload change, `ipc-channels.ts` unchanged, no argv construction; the `writePty` addition is a read-only side-call that never alters, blocks, or delays a write. The adversarial round confirmed this determination.

## Owner follow-ups
- VM check on rc.8: click a sleeping session (moon must stay), a monitors session idling (no moon), fade in/out of pill+moon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)