### PR TITLE
build(release): 2.1.0-rc.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.7",
+  "version": "2.1.0-rc.8",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump for the rc.8 prerelease (package.json only; the rc.8 changelog entry landed with #544).

Merge AFTER #544 so the release build carries the sleep/active indicator batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)