### PR TITLE
build(release): 2.1.0-rc.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.8",
+  "version": "2.1.0-rc.9",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump 2.1.0-rc.8 → 2.1.0-rc.9 (package.json only; the rc.9 changelog entry lands with #550).

Cut after #550 (SSH statusline matrix fixes) merges to beta. Beta-bump RC model: admin-merge this, then `gh workflow run release.yml --ref beta -f channel=beta -f skip_vt=false`.

Milestone 2.1.0-rc.9 is intentionally empty (this RC rolls no tracked issues) — the release gate accepts an empty version-named milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)