### PR TITLE
fix(guard): fence writes to sanctioned locations only — no more stray drive roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ uncommitted work. A `PreToolUse` hook denies writes and mutating git outside the
 worktree you own; `CCC_SESSION_GUARD=off` is the escape hatch. See
 `docs/session-isolation.md` and ADR-012.
 
+**Where files go (enforced by the same hook, #557):** create things ONLY in your
+claimed worktree or the session scratchpad/OS temp. Never invent a new drive
+root — attack harnesses, probe packs, one-off configs, and advisory-fork clones
+all go in one of those two places (a gitignored subdir of the worktree is fine).
+The hook denies writes, `mkdir`, `git clone`/`init`/`worktree add`, and shell
+redirects that land outside the sanctioned roots (worktree, OS temp, the
+checkout's `_RESOURCES` sibling, the worktree base, plus any `CCC_WRITE_ROOTS`
+extras). Beware POSIX paths handed to Windows-native tools: `/tmp/x` with cwd on
+`F:` materialises `F:\tmp\x` — the fence blocks exactly that mangling.
+
 ## Ticket creation & premise review — policy
 
 **Every repo change starts from a GitHub issue, and every issue carries a premise

--- a/CONTEXT.d/2026-08-28-557-write-location-fence.md
+++ b/CONTEXT.d/2026-08-28-557-write-location-fence.md
@@ -1,0 +1,27 @@
+## 2026-08-28 -- #557: session-guard write-location fence
+
+Owner found stray roots on the workspace drive (ccc-attack-*, ccc-probe-scratch-*, an advisory
+clone at a hand-rolled root, plus POSIX-path mangling artifacts \c, \Users, \tmp) and asked for
+the behaviour to be stopped mechanically, not just by convention.
+
+Decision: extend the PreToolUse hook in `scripts/session-guard.mjs` (tooling only -- no app code,
+no release needed). Outside the repo's own worktrees a write is now allowed only under a
+sanctioned root: OS temp (the session scratchpad), the primary checkout's `<name>_RESOURCES`
+sibling, the worktree base (`CCC_WT_ROOT`), plus `CCC_WRITE_ROOTS` extras. Fenced operations:
+Edit/Write/NotebookEdit targets, `mkdir`/`md`/`New-Item`, `git clone`/`init`/`worktree add`
+targets, and `>`/`>>` redirects to resolvable literal paths.
+
+Design points:
+- Ownership is checked BEFORE the sanctioned roots so the worktree base can never launder a
+  write into another session's worktree (caught by the first test run).
+- Existing FOREIGN repos stay writable -- editing another project is a task; a new drive root is
+  clutter.
+- Only statically resolvable literals are denied; tokens with `$`/`%`/backtick expansion pass
+  (fail open), and a guard bug still fails open in cmdHook. `CCC_SESSION_GUARD=off` remains the
+  deliberate-exception hatch.
+- `/tmp/x` and MSYS `/f/x` resolve to the drive paths a Windows-native tool would actually hit,
+  so the drive-mangling class (F:\tmp) is fenced, not just hand-rolled roots.
+
+Tests: `tests/unit/session-guard-write-fence.test.ts` drives the real `hook` subcommand against a
+throwaway repo (18 cases: allow/deny across all fenced operations, env extension, escape hatch,
+mangling, MSYS translation). AGENTS.md gains the "Where files go" rule.

--- a/scripts/session-guard.mjs
+++ b/scripts/session-guard.mjs
@@ -637,6 +637,169 @@ function gitInvocationRisk(inv) {
   return 'allow'
 }
 
+// ---------------------------------------------------- write-location fence
+//
+// Sessions must not scatter files across the machine. Observed strays: hand
+// rolled roots (F:\ccc-attack-*, F:\ccc-sec advisory clones), and POSIX paths
+// mangled onto the cwd's drive (`/tmp/x` handed to a Windows-native tool with
+// cwd on F: materialises F:\tmp\x; same for F:\c and F:\Users). Outside this
+// repo's worktrees a write is allowed only under a sanctioned root; inside
+// them the lease rules decide, as before. An EXISTING foreign repo stays
+// writable -- editing another project is a task, a new drive root is clutter.
+// The fence denies only literal paths it can resolve statically; anything
+// with an expansion passes through (fail open). CCC_SESSION_GUARD=off is the
+// deliberate-exception hatch, as everywhere else in this guard.
+
+/** Case-folded (win/mac) prefix test: p is root or inside it. */
+function isUnderDir(p, root) {
+  const norm = (x) => {
+    let r = path.resolve(x).replace(/[\\/]+$/, '')
+    try {
+      r = fs.realpathSync.native(r)
+    } catch {
+      /* not on disk (yet) -- lexical form */
+    }
+    return process.platform === 'win32' || process.platform === 'darwin' ? r.toLowerCase() : r
+  }
+  const a = norm(p)
+  const b = norm(root)
+  return a === b || a.startsWith(b + path.sep)
+}
+
+/** Where a session may create things OUTSIDE the repo's own worktrees. All
+ *  derived (never personal paths): OS temp (the session scratchpad lives
+ *  there), the primary checkout's `<name>_RESOURCES` sibling, the worktree
+ *  base itself, plus any roots the user lists in CCC_WRITE_ROOTS. */
+function sanctionedWriteRoots(cwd) {
+  const roots = []
+  const add = (p) => {
+    if (!p || typeof p !== 'string' || !p.trim()) return
+    try {
+      roots.push(path.resolve(p.trim()))
+    } catch {
+      /* ignore */
+    }
+  }
+  add(os.tmpdir())
+  add(process.env.TMP)
+  add(process.env.TEMP)
+  add(process.env.TMPDIR)
+  const common = gitSafe(['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd })
+  if (common) {
+    const primary = path.dirname(common)
+    add(`${primary}_RESOURCES`)
+    add(process.env.CCC_WT_ROOT || path.join(path.dirname(primary), 'ccc-wt'))
+  }
+  for (const p of (process.env.CCC_WRITE_ROOTS || '').split(path.delimiter)) add(p)
+  return roots
+}
+
+/**
+ * The absolute path a Windows-native tool would actually touch for a command
+ * token, or null when it cannot be resolved statically. `/f/x` (MSYS) becomes
+ * F:\x; a bare `/tmp/x` resolves against the cwd's DRIVE -- which is exactly
+ * the drive-root mangling this fence exists to stop.
+ */
+function resolveWriteTarget(token, cwd) {
+  if (!token || typeof token !== 'string') return null
+  const t = token.replace(/^["']|["']$/g, '')
+  if (!t || /[$%`]/.test(t)) return null // shell/PS expansion -- fail open
+  const msys = t.match(/^\/([A-Za-z])(\/|$)/)
+  if (msys) return path.resolve(`${msys[1].toUpperCase()}:${t.slice(2) || '/'}`)
+  try {
+    return path.resolve(cwd, t)
+  } catch {
+    return null
+  }
+}
+
+function explainOutsideRoots(target, roots) {
+  return [
+    `session-guard: BLOCKED -- ${target} is outside every sanctioned write location.`,
+    '',
+    'Create files only in your claimed worktree or under one of:',
+    ...roots.map((r) => `  - ${r}`),
+    '',
+    'Stray drive roots (ccc-attack-*, ccc-sec, \\tmp, ...) are what this fence',
+    'stops. Add a root via CCC_WRITE_ROOTS (path-list), or set',
+    'CCC_SESSION_GUARD=off for a deliberate exception.',
+  ].join('\n')
+}
+
+/** null = allowed; string = deny reason. `roots` from sanctionedWriteRoots.
+ *  Ownership is checked FIRST: a sanctioned root (the worktree base
+ *  especially) must never launder a write into another session's worktree. */
+function writeFence(rawTarget, cwd, roots) {
+  const abs = resolveWriteTarget(rawTarget, cwd)
+  if (!abs) return null
+  const o = ownership(abs, cwd)
+  if (o.kind === 'mine') return null
+  if (o.kind === 'not-a-repo') {
+    return roots.some((r) => isUnderDir(abs, r)) ? null : explainOutsideRoots(abs, roots)
+  }
+  // An existing worktree of a DIFFERENT repository: someone else's project,
+  // not our clutter -- leave it to that repo's own rules.
+  if (o.kind === 'unmanaged' && !isRepoWorktree(o.root, cwd)) return null
+  return explain(o, abs)
+}
+
+/** Git invocations that materialise a NEW tree on disk get the fence too. */
+const GIT_VALUE_FLAGS = /^-(b|B|o|u|c|-branch|-origin|-upstream|-depth|-reference|-reference-if-able|-template|-separate-git-dir|-shallow-since|-shallow-exclude|-filter|-jobs|-config)$/
+
+function gitCreationTarget(inv) {
+  const argv = inv.argv
+  let i = argv.indexOf(inv.verb)
+  if (i < 0) return null
+  if (inv.verb === 'worktree') {
+    i = argv.indexOf('add', i + 1)
+    if (i < 0) return null
+  }
+  const rest = []
+  for (let j = i + 1; j < argv.length; j++) {
+    const a = argv[j]
+    if (a.startsWith('-')) {
+      if (GIT_VALUE_FLAGS.test(a)) j++
+      continue
+    }
+    rest.push(a)
+  }
+  if (inv.verb === 'clone') return rest[1] || null // no explicit dir -> lands under cwd
+  if (inv.verb === 'init') return rest[0] || '.'
+  return rest[0] || null // worktree add <path>
+}
+
+/** Creation targets in one shell segment: mkdir/md/New-Item and >/>> redirects. */
+function segmentWriteTargets(seg) {
+  const out = []
+  const toks = seg.match(/"[^"]*"|'[^']*'|\S+/g) || []
+  const bare = toks.map((t) => t.replace(/^["']|["']$/g, ''))
+  const head = bare.findIndex((t) => /^(mkdir|md|new-item)(\.exe)?$/i.test(t))
+  if (head >= 0) {
+    for (let j = head + 1; j < toks.length; j++) {
+      const flag = bare[j]
+      if (flag.startsWith('-')) {
+        if (/^-{1,2}path$/i.test(flag)) continue // its value is a target
+        if (/^-(itemtype|name|value|m|-mode)$/i.test(flag)) j++ // skip the flag's value
+        continue
+      }
+      out.push(toks[j])
+    }
+  }
+  // > target / >> target -- skip fd duplication and the null devices. A `>`
+  // inside a quoted argument can still match; harmless when the token resolves
+  // inside an allowed root, and the escape hatch covers the rest.
+  const re = /(?:^|[^-=<>&|])>{1,2}\s*("[^"]+"|'[^']+'|[^\s&|;]+)/g
+  let m
+  while ((m = re.exec(seg))) {
+    const c = m[1].replace(/^["']|["']$/g, '')
+    if (/^(&\d+|\/dev\/null|nul)$/i.test(c)) continue
+    out.push(m[1])
+  }
+  return out
+}
+
+const SHELL_SPLIT = /\|\||&&|[;|\n]/
+
 function hookDecision(input) {
   const tool = input.tool_name || ''
   const ti = input.tool_input || {}
@@ -648,25 +811,40 @@ function hookDecision(input) {
   const raw = typeof ti.command === 'string' ? ti.command : ''
   if (/session-guard\.mjs/.test(raw)) return null
 
+  // sanctionedWriteRoots shells out to git once -- compute only when needed.
+  let rootsMemo = null
+  const roots = () => (rootsMemo ??= sanctionedWriteRoots(cwd))
+
   if (tool === 'Edit' || tool === 'Write' || tool === 'NotebookEdit' || tool === 'MultiEdit') {
     const f = ti.file_path || ti.notebook_path || ti.path
     if (!f) return null
-    const o = ownership(f, cwd)
-    // Only guard files that live inside this repo's worktrees.
-    if (o.kind === 'not-a-repo' || o.kind === 'mine') return null
-    if (o.kind === 'unmanaged' && !isRepoWorktree(o.root, cwd)) return null
-    return explain(o, f)
+    // mine -> allow; other/stale/unmanaged worktree of this repo -> deny (as
+    // before); outside every repo -> allowed only under a sanctioned root.
+    return writeFence(f, cwd, roots())
   }
 
   if (tool === 'Bash' || tool === 'PowerShell') {
     if (!raw) return null
     for (const inv of parseGitInvocations(raw)) {
+      if (inv.verb === 'clone' || inv.verb === 'init' || (inv.verb === 'worktree' && inv.sub === 'add')) {
+        const base = inv.dashC ? resolveWriteTarget(inv.dashC, cwd) || cwd : cwd
+        const t = gitCreationTarget(inv)
+        const r = t ? writeFence(t, base, roots()) : null
+        if (r) return r
+        continue
+      }
       if (gitInvocationRisk(inv) !== 'mutating') continue
       const target = inv.dashC || cwd
       const o = ownership(target, cwd)
       if (o.kind === 'not-a-repo' || o.kind === 'mine') continue
       if (o.kind === 'unmanaged' && !isRepoWorktree(o.root, cwd)) continue
       return explain(o, target)
+    }
+    for (const seg of raw.split(SHELL_SPLIT)) {
+      for (const t of segmentWriteTargets(seg)) {
+        const r = writeFence(t, cwd, roots())
+        if (r) return r
+      }
     }
   }
   return null

--- a/tests/unit/session-guard-write-fence.test.ts
+++ b/tests/unit/session-guard-write-fence.test.ts
@@ -1,0 +1,187 @@
+// scripts/session-guard.mjs — the PreToolUse write-location fence (#557).
+//
+// Sessions must not scatter files across the machine: outside this repo's
+// worktrees, a write is allowed only under a sanctioned root (OS temp, the
+// primary checkout's `<name>_RESOURCES` sibling, the worktree base,
+// CCC_WRITE_ROOTS extras). Inside the repo's worktrees the lease rules decide,
+// unchanged. Existing FOREIGN repos stay writable. Runs the real script's
+// `hook` subcommand against a throwaway repo.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+const GUARD = path.resolve(__dirname, '..', '..', 'scripts', 'session-guard.mjs')
+
+const CC_ME = '11111111-1111-4111-8111-111111111111'
+const CC_OTHER = '22222222-2222-4222-8222-222222222222'
+
+let root: string // throwaway world
+let repo: string // primary checkout <root>/project
+let wtMine: string // my claimed worktree <root>/ccc-wt/mine
+let wtOther: string // another live session's worktree
+let tmpx: string // the world's "OS temp" (TMP/TEMP/TMPDIR point here)
+let resources: string // <root>/project_RESOURCES
+let foreign: string // an unrelated existing repo
+let stray: (name: string) => string
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+}
+
+/** Run the real hook. Returns '' on allow, or the deny reason. */
+function hook(toolName: string, toolInput: Record<string, unknown>, envOverride: Record<string, string> = {}): string {
+  const merged: Record<string, string> = {}
+  for (const [k, v] of Object.entries(process.env)) if (typeof v === 'string') merged[k] = v
+  delete merged.CCC_SESSION_GUARD
+  delete merged.CCC_WRITE_ROOTS
+  Object.assign(merged, {
+    CLAUDE_CODE_SESSION_ID: CC_ME,
+    TMP: tmpx,
+    TEMP: tmpx,
+    TMPDIR: tmpx,
+    CCC_WT_ROOT: path.join(root, 'ccc-wt'),
+  }, envOverride)
+  const out = execFileSync(process.execPath, [GUARD, 'hook'], {
+    cwd: wtMine,
+    encoding: 'utf8',
+    env: merged,
+    input: JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd: wtMine }),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  if (!out.trim()) return ''
+  return JSON.parse(out).hookSpecificOutput.permissionDecisionReason as string
+}
+
+function writeLease(sessionId: string, worktree: string, branch: string, pid: number) {
+  const dir = path.join(repo, '.git', 'ccc-sessions')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(
+    path.join(dir, `${sessionId}.json`),
+    JSON.stringify({ sessionId, pid, worktree, branch, base: 'main', host: 'test', createdAt: new Date().toISOString(), renewedAt: new Date().toISOString() }),
+  )
+}
+
+beforeAll(() => {
+  root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-fence-')))
+  repo = path.join(root, 'project')
+  tmpx = path.join(root, 'tmpx')
+  resources = path.join(root, 'project_RESOURCES')
+  foreign = path.join(root, 'foreign')
+  for (const d of [repo, tmpx, resources, foreign]) fs.mkdirSync(d, { recursive: true })
+  stray = (name) => path.join(root, name)
+
+  git(['init', '-q', '-b', 'main'], repo)
+  git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '--allow-empty', '-m', 'init'], repo)
+  wtMine = path.join(root, 'ccc-wt', 'mine')
+  wtOther = path.join(root, 'ccc-wt', 'other')
+  git(['worktree', 'add', '-q', '-b', 'session/mine', wtMine, 'main'], repo)
+  git(['worktree', 'add', '-q', '-b', 'session/other', wtOther, 'main'], repo)
+  writeLease(CC_ME, wtMine, 'session/mine', process.pid)
+  writeLease(CC_OTHER, wtOther, 'session/other', process.pid) // "alive": this very process
+
+  git(['init', '-q', '-b', 'main'], foreign)
+  git(['-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-q', '--allow-empty', '-m', 'init'], foreign)
+})
+
+afterAll(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }) } catch { /* best-effort */ }
+})
+
+describe('file-write tools (Write/Edit)', () => {
+  it('allows writes inside my claimed worktree', () => {
+    expect(hook('Write', { file_path: path.join(wtMine, 'src', 'new.ts') })).toBe('')
+  })
+
+  it('still denies writes into another live session worktree', () => {
+    const r = hook('Write', { file_path: path.join(wtOther, 'x.ts') })
+    expect(r).toContain('BLOCKED')
+    expect(r).toContain('do not own')
+  })
+
+  it('still denies writes into the shared primary checkout', () => {
+    const r = hook('Edit', { file_path: path.join(repo, 'src', 'x.ts') })
+    expect(r).toContain('BLOCKED')
+  })
+
+  it('DENIES a write to a stray location outside every sanctioned root', () => {
+    const r = hook('Write', { file_path: path.join(stray('ccc-attack-999'), 'exploit.ts') })
+    expect(r).toContain('outside every sanctioned write location')
+  })
+
+  it('allows writes under OS temp (the session scratchpad)', () => {
+    expect(hook('Write', { file_path: path.join(tmpx, 'scratch', 'a.txt') })).toBe('')
+  })
+
+  it('allows writes under the <primary>_RESOURCES sibling', () => {
+    expect(hook('Write', { file_path: path.join(resources, 'resume.md') })).toBe('')
+  })
+
+  it('allows writes inside an existing foreign repo', () => {
+    expect(hook('Write', { file_path: path.join(foreign, 'their-file.ts') })).toBe('')
+  })
+
+  it('honours CCC_WRITE_ROOTS extras', () => {
+    const extra = stray('extra-root')
+    fs.mkdirSync(extra, { recursive: true })
+    expect(hook('Write', { file_path: path.join(extra, 'ok.txt') }, { CCC_WRITE_ROOTS: extra })).toBe('')
+    expect(hook('Write', { file_path: path.join(extra, 'no.txt') })).toContain('outside every sanctioned')
+  })
+
+  it('is disabled by CCC_SESSION_GUARD=off', () => {
+    expect(hook('Write', { file_path: path.join(stray('ccc-hatch'), 'x.txt') }, { CCC_SESSION_GUARD: 'off' })).toBe('')
+  })
+})
+
+describe('shell creation commands', () => {
+  it('DENIES mkdir of a stray root (bash)', () => {
+    expect(hook('Bash', { command: `mkdir -p "${stray('ccc-probe-x')}"` })).toContain('outside every sanctioned')
+  })
+
+  it('allows mkdir inside the worktree and under temp', () => {
+    expect(hook('Bash', { command: 'mkdir -p sub/dir' })).toBe('')
+    expect(hook('Bash', { command: `mkdir "${path.join(tmpx, 'p')}"` })).toBe('')
+  })
+
+  it('DENIES New-Item directory at a stray root (PowerShell)', () => {
+    expect(hook('PowerShell', { command: `New-Item -ItemType Directory -Path "${stray('ccc-ps-stray')}"` })).toContain('outside every sanctioned')
+  })
+
+  it('DENIES git clone to a stray root, allows clone under temp', () => {
+    expect(hook('Bash', { command: `git clone https://example.invalid/r.git "${stray('ccc-sec-2')}"` })).toContain('outside every sanctioned')
+    expect(hook('Bash', { command: `git clone https://example.invalid/r.git "${path.join(tmpx, 'clone')}"` })).toBe('')
+  })
+
+  it('DENIES git worktree add outside the worktree base, allows inside it', () => {
+    expect(hook('Bash', { command: `git worktree add "${stray('rogue-wt')}" -b rogue` })).toContain('outside every sanctioned')
+    expect(hook('Bash', { command: `git worktree add "${path.join(root, 'ccc-wt', 'wt-next')}" -b next` })).toBe('')
+  })
+
+  it('DENIES a redirect to a stray absolute path, allows redirects in-worktree and to the null device', () => {
+    expect(hook('Bash', { command: `echo hi > "${stray('ccc-log')}.txt"` })).toContain('outside every sanctioned')
+    expect(hook('Bash', { command: 'echo hi > local.txt' })).toBe('')
+    expect(hook('Bash', { command: 'echo hi > /dev/null' })).toBe('')
+    expect(hook('Bash', { command: 'node x.mjs 2>&1' })).toBe('')
+  })
+
+  it('DENIES the POSIX-path drive mangle (`/tmp/...` from a Windows cwd)', () => {
+    // path.resolve maps /tmp/x onto the cwd's drive — F:\tmp\x, the observed stray.
+    const r = hook('Bash', { command: 'echo data > /tmp/ccc-mangle.txt' })
+    if (process.platform === 'win32') expect(r).toContain('outside every sanctioned')
+    else expect(typeof r).toBe('string') // non-Windows: /tmp IS temp-adjacent; no assertion on verdict
+  })
+
+  it('fails open on unresolvable (variable) targets', () => {
+    expect(hook('Bash', { command: 'mkdir "$SOME_DIR"' })).toBe('')
+    expect(hook('Bash', { command: 'echo x > "%TARGET%"' })).toBe('')
+  })
+
+  it('MSYS drive paths are translated before fencing', () => {
+    if (process.platform !== 'win32') return
+    const driveLetter = root[0].toLowerCase()
+    const msys = `/${driveLetter}${root.slice(2).replace(/\\/g, '/')}/ccc-msys-stray`
+    expect(hook('Bash', { command: `mkdir ${msys}` })).toContain('outside every sanctioned')
+  })
+})


### PR DESCRIPTION
Closes #557.

Process/tooling fix only — `scripts/session-guard.mjs` + tests + AGENTS.md. **No app code, no release needed**; takes effect once merged and pulled.

## What the hook now denies
Outside this repo's worktrees, a session may write only under a **sanctioned root**: its claimed worktree, OS temp (the session scratchpad), the checkout's `_RESOURCES` sibling, the worktree base, or `CCC_WRITE_ROOTS` extras. Fenced operations: Edit/Write/NotebookEdit targets; `mkdir`/`md`/`New-Item`; `git clone`/`init`/`worktree add` targets; `>`/`>>` redirects. This is what stops the observed strays (`F:\ccc-attack-*`, `F:\ccc-sec`, and `/tmp`→`F:\tmp` drive-mangling).

## Design
- **Ownership before roots**: the worktree base can never launder a write into another session's worktree.
- **Existing foreign repos stay writable** — editing another project is a task; a new drive root is clutter.
- **Fail open on anything non-literal** (`$`/`%`/backtick), and on guard bugs (existing cmdHook catch). `CCC_SESSION_GUARD=off` unchanged as the deliberate-exception hatch.
- POSIX/MSYS tokens resolve to the drive path a Windows-native tool would actually hit.

## Verification
- 18 new tests drive the real `hook` subcommand against a throwaway repo (`tests/unit/session-guard-write-fence.test.ts`): allow/deny across every fenced op, other-session/primary denials preserved, env extension, escape hatch, mangling + MSYS translation.
- Full suite 8,840 passed; typecheck clean.
- Adversarial review to follow on this PR (the guard gates agent behavior — fail closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)