### PR TITLE
fix(tests): contain test temp in a disposable per-worker root

### DIFF
--- a/CONTEXT.d/2026-08-28-559-test-temp-leak.md
+++ b/CONTEXT.d/2026-08-28-559-test-temp-leak.md
@@ -1,0 +1,28 @@
+## 2026-08-28 -- #559: contain test temp in a disposable per-worker root
+
+A full `npx vitest run` was leaking throwaway temp on every run: ~129 test files
+`fs.mkdtempSync(join(os.tmpdir(),'ccc-...'))` with no teardown (observed ~88 GB of
+`ccc-*` in %TEMP% on a dev box), and the global `getResourcesDirectory` mock
+returned the drive-relative literal `/mock/resources`, so tests writing real fs
+scattered files to `<drive>:\mock\resources` (a real `conductor-secret.json`
+turned up at `C:\mock\...`). Dev/SDLC hygiene only -- not shipped-app behaviour
+(the one runtime temp path, codex-review, already cleans up via try/finally, #487).
+
+Fix (test-side, contained):
+- `tests/helpers/test-tmp.ts` -- creates ONE disposable root per worker under the
+  real `os.tmpdir()`, keyed through `CCC_TEST_TMP_ROOT` so every test file in the
+  worker shares it (single `exit` cleanup, no MaxListeners churn), and redirects
+  `TEMP`/`TMP`/`TMPDIR` to it so every `mkdtemp(os.tmpdir(),...)` lands inside.
+  Exports `MOCK_RESOURCES`/`MOCK_USERDATA` under the root.
+- `tests/unit/setup.ts` -- the global `getResourcesDirectory` and `app.getPath`
+  mocks now return those temp paths instead of `/mock/...`.
+- `tests/global-setup.ts` -- vitest teardown backstop: sweeps orphan
+  `ccc-vitest-*` roots (killed worker) and a stray drive-root `\mock`.
+
+`config-manager.test.ts` keeps its local `/mock/resources` mock: it fully mocks
+`fs`, so it never writes to disk -- inert, and its exact-path assertion stays
+valid. Setup files run before a test file's `vi.mock('fs')` applies, so the helper
+loads with real `fs`.
+
+Verified: full suite 8822 passed (unchanged); a run now adds 0 net `ccc-*` to the
+real temp, leaves 0 `ccc-vitest-*`, and writes no `\mock`.

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,32 @@
+// Vitest global teardown (#559): runs once in the main process after the whole
+// run. Backstop that removes any per-worker `ccc-vitest-*` temp roots a killed
+// worker left behind, plus a stray drive-root `\mock` from any hardcoded mock
+// path, so a test run never leaves litter on the drive.
+import * as os from 'os'
+import * as path from 'path'
+import * as fs from 'fs'
+
+export default function () {
+  return () => {
+    try {
+      const tmp = os.tmpdir()
+      for (const entry of fs.readdirSync(tmp)) {
+        if (entry.startsWith('ccc-vitest-')) {
+          try {
+            fs.rmSync(path.join(tmp, entry), { recursive: true, force: true })
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+    try {
+      const mock = path.resolve('/mock')
+      if (fs.existsSync(mock)) fs.rmSync(mock, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -22,11 +22,19 @@ export default function () {
     } catch {
       /* ignore */
     }
-    try {
-      const mock = path.resolve('/mock')
-      if (fs.existsSync(mock)) fs.rmSync(mock, { recursive: true, force: true })
-    } catch {
-      /* ignore */
+    // A drive-relative `/mock` resolves onto whichever drive is current, so a
+    // suite run from C: scattered to C:\mock and one from F: to F:\mock. Sweep
+    // the roots that can be hit: the cwd drive, the temp drive, and C:.
+    const drives = new Set(
+      [process.cwd(), os.tmpdir(), 'C:\\'].map((p) => path.parse(path.resolve(p)).root),
+    )
+    for (const root of drives) {
+      try {
+        const mock = path.join(root, 'mock')
+        if (fs.existsSync(mock)) fs.rmSync(mock, { recursive: true, force: true })
+      } catch {
+        /* ignore */
+      }
     }
   }
 }

--- a/tests/helpers/test-tmp.ts
+++ b/tests/helpers/test-tmp.ts
@@ -1,0 +1,42 @@
+// One disposable temp root per test worker (#559).
+//
+// Redirecting TEMP/TMP/TMPDIR here means every `fs.mkdtempSync(os.tmpdir(),
+// 'ccc-...')` fixture across the suite lands *inside* this root instead of
+// littering the real %TEMP% (a full run was leaking ~88 GB of `ccc-*` dirs that
+// nothing ever cleaned up). MOCK_RESOURCES / MOCK_USERDATA give the electron
+// mocks a real, writable path under the same root instead of the drive-relative
+// literal '/mock/resources' — which on Windows resolved to `<drive>:\mock` and
+// wrote real files (a conductor-secret.json) to the drive root.
+//
+// The root is created once per worker (keyed through the environment so every
+// test file in the worker shares it) and removed on process exit;
+// tests/global-setup.ts sweeps any orphan left by a killed worker.
+import * as os from 'os'
+import * as path from 'path'
+import * as fs from 'fs'
+
+const KEY = 'CCC_TEST_TMP_ROOT'
+const existing = process.env[KEY]
+
+export const TEST_TMP_ROOT =
+  existing && fs.existsSync(existing) ? existing : fs.mkdtempSync(path.join(os.tmpdir(), 'ccc-vitest-'))
+
+// First importer in this worker owns setup: pin the root in the env, redirect
+// the process temp dir, and register a single exit-time cleanup. Subsequent
+// files reuse it (no duplicate 'exit' listeners -> no MaxListeners warning).
+if (!existing) {
+  process.env[KEY] = TEST_TMP_ROOT
+  process.env.TMPDIR = TEST_TMP_ROOT
+  process.env.TEMP = TEST_TMP_ROOT
+  process.env.TMP = TEST_TMP_ROOT
+  process.once('exit', () => {
+    try {
+      fs.rmSync(TEST_TMP_ROOT, { recursive: true, force: true })
+    } catch {
+      /* best-effort; global-setup teardown is the backstop */
+    }
+  })
+}
+
+export const MOCK_RESOURCES = path.join(TEST_TMP_ROOT, 'resources')
+export const MOCK_USERDATA = path.join(TEST_TMP_ROOT, 'userData')

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -2,11 +2,15 @@
  * Vitest setup — mocks for Electron and window.electronAPI
  */
 import { vi } from 'vitest'
+// Redirects the process temp dir to a disposable per-worker root and provides
+// real writable mock paths (instead of the drive-relative '/mock/...'). Imported
+// for its side effects too — must load before any test creates a temp fixture.
+import { MOCK_RESOURCES, MOCK_USERDATA } from '../helpers/test-tmp'
 
 // Mock electron module for main process tests
 vi.mock('electron', () => ({
   app: {
-    getPath: vi.fn(() => '/mock/userData'),
+    getPath: vi.fn(() => MOCK_USERDATA),
     getAppPath: vi.fn(() => process.cwd()),
     requestSingleInstanceLock: vi.fn(() => true),
     whenReady: vi.fn(() => Promise.resolve()),
@@ -52,7 +56,7 @@ vi.mock('../../src/main/debug-logger', () => ({
 
 // Mock setup-handlers to prevent registry access
 vi.mock('../../src/main/ipc/setup-handlers', () => ({
-  getResourcesDirectory: vi.fn(() => '/mock/resources'),
+  getResourcesDirectory: vi.fn(() => MOCK_RESOURCES),
   registerSetupHandlers: vi.fn(),
 }))
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
     exclude: [...configDefaults.exclude, '**/*.native.test.{ts,tsx}'],
     environment: 'node',
     setupFiles: ['tests/unit/setup.ts'],
+    // Sweeps orphaned per-worker temp roots + a stray drive-root \mock (#559).
+    globalSetup: ['tests/global-setup.ts'],
     // Integration tests (e.g. hooks synthetic path) spin up a real loopback
     // HTTP server and can take longer than a unit-test budget.
     //


### PR DESCRIPTION
Closes #559.

Test-side hygiene fix. Every full `npx vitest run` was leaking throwaway temp: ~129 test files call `fs.mkdtempSync(join(os.tmpdir(),'ccc-...'))` with no teardown (**~88 GB of `ccc-*` seen in %TEMP%**), and the global `getResourcesDirectory` mock returned the drive-relative literal `'/mock/resources'`, which on Windows wrote real files to `<drive>:\mock` (a real `conductor-secret.json` was found at `C:\mock`).

## Fix
- **`tests/helpers/test-tmp.ts`** — one disposable root per worker under the real `os.tmpdir()` (keyed via `CCC_TEST_TMP_ROOT` so all files in a worker share it, single exit cleanup); redirects `TEMP`/`TMP`/`TMPDIR` into it so **every** `mkdtemp(os.tmpdir(),...)` lands inside; exports real `MOCK_RESOURCES`/`MOCK_USERDATA`.
- **`tests/unit/setup.ts`** — global `getResourcesDirectory` / `app.getPath` mocks now return those temp paths instead of `/mock/...`.
- **`tests/global-setup.ts`** — vitest teardown backstop: sweeps orphan `ccc-vitest-*` roots and a stray drive-root `\mock`.

`config-manager.test.ts` keeps its local `/mock/resources` mock — it fully mocks `fs` (never writes to disk), so it's inert and its exact-path assertion stays valid.

## Verification
- Full suite **8822 passed** (unchanged from before).
- Before/after a full run: real-temp `ccc-*` unchanged (**0 net new**), **0** `ccc-vitest-*` left behind, **no** `\mock` created. Previously each run leaked ~130+ dirs.

Not shipped-app behaviour (the one runtime temp path, codex-review, already self-cleans, #487). Docs/test-only + no runtime code → adversarial pass N/A; independent review to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)