### PR TITLE
fix(terminal): stop link-selection flicker; clickable + copyable http/https links

### DIFF
--- a/CONTEXT.d/2026-08-28-21-terminal-link-flicker.md
+++ b/CONTEXT.d/2026-08-28-21-terminal-link-flicker.md
@@ -1,0 +1,34 @@
+## 2026-08-28 -- #21: terminal link-selection flicker + clickable/copyable links
+
+Selecting a link (or link text) flickered the UI at high speed. Root cause: under
+the WebGL renderer the link hover underline is a separate overlay
+(LinkRenderLayer). `new WebLinksAddon()` (TerminalView.tsx) registered links with
+the underline ON, so during a selection drag over a link xterm's linkifier fired
+hide/show-underline every mousemove and the overlay tore down + redrew each frame,
+fighting the selection-highlight repaint on the same pixels -> flicker. Links were
+also effectively dead: the addon's default `window.open` handler is denied by the
+main window, and there was no "copy link address".
+
+Fix (renderer-only): `src/renderer/components/terminal/terminalLinks.ts`
+(`decorateTerminalLinks`) + a transient wrap of `term.registerLinkProvider` around
+`loadAddon` so each link WebLinksAddon produces is augmented with
+`decorations:{underline:false, pointerCursor:true}` (kills the flicker, keeps the
+hand cursor), `activate` routed to `window.electronAPI.shell.openExternal`, and
+hover/leave recording the URI under the cursor. Right-click over a link (no
+selection) opens the context menu with a new "Copy link address" item
+(TerminalContextMenu.tsx). Reuses the addon's proven wrapped-line/wide-char URL
+matching (its computeLink is not exported).
+
+Scope: opening goes through the existing https-only `safeExternalHttpsHref` gate
+in main (shared with account-web/artifacts -- NOT widened), so https links open;
+http links are detected + copyable but not opened (copy has no scheme gate).
+Works for local + tmux/SSH (linkification is renderer-side text matching).
+
+Not security-sensitive per ADR-009: no IPC/preload/argv/keychain/webPreferences
+change; calls the existing guarded openExternal sink; untrusted URL text is
+double-gated (addon `https?://` regex + main's https-only WHATWG parse).
+
+Tests: tests/unit/renderer/terminal-links.test.ts (decorator) +
+terminal-context-menu.test.tsx (Copy-link item). NOTE: jsdom (.tsx) tests need
+`--pool=threads` locally -- the forks pool fails to spawn workers when the repo
+path contains spaces ("Claude Command Center"); CI paths have none.

--- a/src/renderer/components/TerminalContextMenu.tsx
+++ b/src/renderer/components/TerminalContextMenu.tsx
@@ -12,6 +12,9 @@ interface Props {
   x: number
   y: number
   hasSelection: boolean
+  /** #21: the http/https link under the cursor, if any — enables "Copy link address". */
+  linkUri?: string
+  onCopyLink?: (uri: string) => void
   onCopy: () => void
   onPaste: () => void
   /** Repaint + geometry re-sync (#503) — the rescue for a pane something wrote
@@ -20,7 +23,7 @@ interface Props {
   onClose: () => void
 }
 
-export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPaste, onRepaint, onClose }: Props) {
+export default function TerminalContextMenu({ x, y, hasSelection, linkUri, onCopyLink, onCopy, onPaste, onRepaint, onClose }: Props) {
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Clamp into the viewport after first paint (below-right of the pointer when
@@ -75,6 +78,11 @@ export default function TerminalContextMenu({ x, y, hasSelection, onCopy, onPast
         style={{ left: x, top: y, opacity: 0, background: 'var(--surface-raised)', border: '1px solid var(--border-subtle)' }}
         onMouseDown={(e) => e.stopPropagation()}
       >
+        {linkUri && onCopyLink && (
+          <button type="button" className={itemClass} onClick={() => onCopyLink(linkUri)} title={linkUri}>
+            <span>Copy link address</span>
+          </button>
+        )}
         <button type="button" className={itemClass} onClick={onCopy} disabled={!hasSelection}>
           <span>Copy</span>
           <span style={{ color: 'var(--text-muted)' }}>Ctrl+Shift+C</span>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react'
 import '@xterm/xterm/css/xterm.css'
-import { Terminal } from '@xterm/xterm'
+import { Terminal, type ILinkProvider } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
+import { decorateTerminalLinks } from './terminal/terminalLinks'
 import { installWebglWithRecovery, createAtlasResync, type WebglHandle } from './terminal/terminalWebgl'
 import { atlasCoordinator } from './terminal/atlasCoordinator'
 import {
@@ -144,9 +145,13 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // Whether #145 input diagnostics are on, readable from the init effect's
   // long-lived onData closure.
   const inputDiagRef = useRef(false)
+  // #21: the http/https URI under the cursor, recorded by the link provider's
+  // hover/leave, so the right-click menu can offer "Copy link address" for the
+  // exact link the linkifier matched. null = cursor is not over a link.
+  const hoveredLinkRef = useRef<string | null>(null)
   // Explicit right-click menu (Copy/Paste). Opened by the contextmenu handler
   // whenever a blind copy-or-paste decision would be unsafe; null = closed.
-  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; hasSelection: boolean } | null>(null)
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; hasSelection: boolean; linkUri?: string } | null>(null)
   // Close the menu the instant this tab is deactivated. Every TerminalView stays
   // mounted (App renders inactive ones display:none), and the menu arms a
   // document-level capture Escape listener — a menu left open in a hidden session
@@ -553,7 +558,35 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
 
       fitAddon = new FitAddon()
       term.loadAddon(fitAddon)
+      // #21: WebLinksAddon detects http/https URLs (wrapped-line + wide-char
+      // aware) but registers them with the hover underline ON, which churns the
+      // WebGL underline overlay on every selection-drag mousemove over a link →
+      // high-speed flicker. The addon has no decorations option and its matcher
+      // is not exported, so wrap registerLinkProvider for the duration of
+      // loadAddon and pass each produced link set through decorateTerminalLinks:
+      // underline OFF (kills the flicker), pointer cursor kept, activation routed
+      // to the OS browser (the addon's default window.open is denied), and the
+      // hovered URI recorded for the context menu. Restored immediately after.
+      const originalRegister = term.registerLinkProvider.bind(term)
+      ;(term as unknown as { registerLinkProvider: (p: ILinkProvider) => { dispose(): void } }).registerLinkProvider = (
+        provider: ILinkProvider,
+      ) => {
+        const wrapped: ILinkProvider = {
+          provideLinks: (y, cb) =>
+            provider.provideLinks(y, (links) =>
+              cb(
+                decorateTerminalLinks(links, {
+                  open: (uri) => { void window.electronAPI.shell.openExternal(uri) },
+                  onHover: (uri) => { hoveredLinkRef.current = uri },
+                  onLeave: () => { hoveredLinkRef.current = null },
+                }),
+              ),
+            ),
+        }
+        return originalRegister(wrapped)
+      }
       term.loadAddon(new WebLinksAddon())
+      ;(term as unknown as { registerLinkProvider: typeof originalRegister }).registerLinkProvider = originalRegister
 
       term.open(container)
 
@@ -1222,6 +1255,14 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         if (!term) return
         const classicMode = useSettingsStore.getState().settings.classicTerminalCopyPaste !== false
         const { action, bracketedPaste } = resolveContextMenuIntent(term, classicMode)
+        // #21: right-clicking an http/https link with nothing selected opens the
+        // menu so "Copy link address" is available (instead of a blind paste).
+        // A live selection still copies the selection (action==='copy') and wins.
+        const linkUri = hoveredLinkRef.current
+        if (linkUri && action !== 'copy') {
+          setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!term.getSelection(), linkUri })
+          return
+        }
         if (action === 'copy') {
           const sel = term.getSelection()
           if (sel) {
@@ -1352,6 +1393,17 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
     }
     term?.focus()
   }
+  // #21: copy the http/https link under the cursor to the clipboard. No scheme
+  // gate — copying a URL string is inert (opening it is https-gated in main).
+  const ctxMenuCopyLink = async (uri: string) => {
+    setCtxMenu(null)
+    try {
+      await navigator.clipboard.writeText(uri)
+    } catch {
+      // clipboard write denied (insecure context / not focused)
+    }
+    terminalRef.current?.focus()
+  }
 
   return (
     // data-terminal-session: lets the Ctrl+Alt+R capture handler resolve WHICH
@@ -1414,6 +1466,8 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
           x={ctxMenu.x}
           y={ctxMenu.y}
           hasSelection={ctxMenu.hasSelection}
+          linkUri={ctxMenu.linkUri}
+          onCopyLink={ctxMenuCopyLink}
           onCopy={ctxMenuCopy}
           onPaste={ctxMenuPaste}
           onRepaint={() => {

--- a/src/renderer/components/terminal/terminalLinks.ts
+++ b/src/renderer/components/terminal/terminalLinks.ts
@@ -1,0 +1,49 @@
+import type { ILink } from '@xterm/xterm'
+
+/**
+ * #21: decorate the links produced by WebLinksAddon so they DO NOT draw a hover
+ * underline, then re-route their activation and record the hovered URI.
+ *
+ * Why the underline must go: under the WebGL renderer the link underline is a
+ * separate overlay (LinkRenderLayer). While a selection drag crosses a link
+ * cell, xterm's linkifier fires hide/show-underline on every mousemove and the
+ * overlay tears down + redraws each frame, fighting the selection-highlight
+ * repaint on the same pixels — the high-speed flicker users reported. A link
+ * with `decorations.underline:false` fires no underline event (xterm gates the
+ * event on that flag), so the overlay never churns. `pointerCursor:true` keeps
+ * the hand cursor so links still read as clickable.
+ *
+ * Why wrap rather than reimplement: WebLinksAddon exposes no option for
+ * decorations, and its `computeLink` (wrapped-line + wide-char aware URL
+ * matching) is not exported. So the caller wraps `registerLinkProvider` for the
+ * duration of `loadAddon` and passes each produced link set through here — we
+ * reuse the addon's proven matching and only augment the ILink objects.
+ *
+ * `activate` is replaced so clicking opens via the OS browser (the addon's
+ * default `window.open` is denied by the main window). `hover`/`leave` record
+ * the URI under the cursor so the right-click menu can offer "Copy link
+ * address" for the exact link the linkifier matched (any http/https URI —
+ * copy has no scheme gate; opening is https-gated in main).
+ */
+export interface TerminalLinkActions {
+  /** Open the URI (renderer → shell.openExternal; main re-validates https-only). */
+  open: (uri: string) => void
+  /** Record the URI under the cursor (for the context menu's Copy link item). */
+  onHover: (uri: string) => void
+  /** Clear the recorded hovered URI. */
+  onLeave: () => void
+}
+
+export function decorateTerminalLinks(
+  links: ILink[] | undefined,
+  actions: TerminalLinkActions,
+): ILink[] | undefined {
+  if (!links) return undefined
+  return links.map((link) => ({
+    ...link,
+    decorations: { underline: false, pointerCursor: true },
+    activate: (_e: MouseEvent, uri: string) => actions.open(uri),
+    hover: (_e: MouseEvent, uri: string) => actions.onHover(uri),
+    leave: () => actions.onLeave(),
+  }))
+}

--- a/tests/e2e/terminal-links.spec.ts
+++ b/tests/e2e/terminal-links.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E (#21): terminal http/https link handling in the REAL app + REAL xterm.
+ *
+ * Proves the user-visible behaviour of the fix (the flicker itself — a rapid
+ * WebGL repaint — is not directly assertable, but the link wiring that the same
+ * change adds is):
+ *   1. Clicking an https link routes to shell.openExternal with the URL.
+ *   2. Right-clicking a link offers "Copy link address", which puts the URL on
+ *      the OS clipboard (exercises link detection → hover tracking → the context
+ *      menu → the copy handler).
+ *
+ * Drives a local shell-only PTY (linkification is renderer-side text matching,
+ * so local == tmux/SSH here). Windows-only (uses a powershell terminal config).
+ */
+import { test, expect } from '@playwright/test'
+import { launchIsolatedApp, closeIsolatedApp, IsolatedApp } from './helpers/electron-app'
+
+let ctx: IsolatedApp
+let page: IsolatedApp['page']
+
+const URL = 'https://example.com/ccce2e-21'
+
+test.beforeAll(async () => {
+  ctx = await launchIsolatedApp()
+  page = ctx.page
+})
+test.afterAll(async () => {
+  test.setTimeout(120000)
+  await closeIsolatedApp(ctx)
+})
+
+async function openDialog() {
+  const cancel = page.locator('button:has-text("Cancel")').first()
+  if (await cancel.isVisible().catch(() => false)) await cancel.click()
+  await page.locator('[data-testid="panel-tab-saved"]').click()
+  await page.locator('[data-testid="new-button"]').click()
+  await page.locator('[data-testid="new-menu-config"]').click()
+  await expect(page.locator('text=New saved config')).toBeVisible({ timeout: 10000 })
+}
+
+let sid = ''
+async function ptyWrite(text: string) {
+  await page.evaluate(
+    ([id, t]) => (window as unknown as { electronAPI: any }).electronAPI.pty.write(id, t),
+    [sid, text] as const,
+  )
+}
+
+/** Clear the screen and print the URL at row 0, then return a point on it. */
+async function printUrlAndPoint(): Promise<{ x: number; y: number }> {
+  await ptyWrite(`Clear-Host; Write-Host '${URL}'\r`)
+  await page.waitForTimeout(1200)
+  const screen = page.locator('[data-terminal-active] .xterm-screen').first()
+  await expect(screen).toBeVisible()
+  const box = await screen.boundingBox()
+  if (!box) throw new Error('no .xterm-screen box')
+  // Row 0 (top of the screen after Clear-Host), a few cells into the URL —
+  // x=+30 is inside a 29-char URL for any plausible cell width; y=+6 is row 0.
+  return { x: box.x + 30, y: box.y + 6 }
+}
+
+/** Move onto the link so xterm's linkifier computes it and fires hover. */
+async function hoverLink(p: { x: number; y: number }) {
+  await page.mouse.move(p.x - 20, p.y)
+  await page.mouse.move(p.x, p.y, { steps: 8 })
+  await page.waitForTimeout(500) // linkifier hover debounce
+}
+
+test.describe('#21 terminal link handling (real app, real xterm)', () => {
+  test.skip(process.platform !== 'win32', 'uses a powershell terminal config')
+
+  test.beforeAll(async () => {
+    await openDialog()
+    await page.locator('[role="radiogroup"][aria-label="Provider"] label:has(input[value="terminal"])').click()
+    await page.locator('[role="radiogroup"][aria-label="Where it runs"] label:has(input[value="local"])').click()
+    await expect(page.locator('text=Terminal startup')).toBeVisible({ timeout: 10000 })
+    await page.locator('input[placeholder="npm run dev"]').fill('echo ready')
+    await page.locator('input[placeholder="e.g. App Dev"]').fill('E2E Links')
+    await page.locator('button:has-text("Create config")').click()
+    const term = page.locator('[data-terminal-active]').first()
+    await expect(term).toBeVisible({ timeout: 30000 })
+    sid = (await term.getAttribute('data-terminal-session')) || ''
+    expect(sid).toBeTruthy()
+    await page.waitForTimeout(3000) // shell reaches its prompt
+  })
+
+  test('clicking an https link routes to shell.openExternal with the URL', async () => {
+    test.setTimeout(120000)
+    // electronAPI is a frozen contextBridge object, so intercept in MAIN: swap
+    // the shell:openExternal IPC handler for a recorder. This proves the click
+    // routed the URL through the real renderer→IPC path (safe-url validation is
+    // unit-tested separately).
+    await ctx.app.evaluate(({ ipcMain }) => {
+      ;(globalThis as unknown as { __ext: string[] }).__ext = []
+      ipcMain.removeHandler('shell:openExternal')
+      ipcMain.handle('shell:openExternal', (_e, u: string) => {
+        ;(globalThis as unknown as { __ext: string[] }).__ext.push(u)
+        return true
+      })
+    })
+    const p = await printUrlAndPoint()
+    await hoverLink(p)
+    await page.mouse.click(p.x, p.y)
+    await page.waitForTimeout(400)
+    const opened = await ctx.app.evaluate(() => (globalThis as unknown as { __ext: string[] }).__ext)
+    await page.screenshot({ path: 'test-results/21-link-click.png' }).catch(() => {})
+    expect(opened, `expected shell.openExternal to be called with ${URL}`).toContain(URL)
+  })
+
+  test('right-click a link → "Copy link address" copies the URL to the clipboard', async () => {
+    test.setTimeout(120000)
+    await ctx.app.evaluate(({ clipboard }) => clipboard.writeText(''))
+    const p = await printUrlAndPoint()
+    await hoverLink(p)
+    await page.mouse.click(p.x, p.y, { button: 'right' })
+    const copyLink = page.locator('button:has-text("Copy link address")').first()
+    await expect(copyLink).toBeVisible({ timeout: 5000 })
+    await copyLink.click()
+    await page.waitForTimeout(300)
+    const clip = await ctx.app.evaluate(({ clipboard }) => clipboard.readText())
+    await page.screenshot({ path: 'test-results/21-copy-link.png' }).catch(() => {})
+    expect(clip).toBe(URL)
+  })
+})

--- a/tests/unit/renderer/terminal-context-menu.test.tsx
+++ b/tests/unit/renderer/terminal-context-menu.test.tsx
@@ -95,6 +95,21 @@ describe('TerminalContextMenu', () => {
     r.unmount()
   })
 
+  // #21: "Copy link address" appears only when a link is under the cursor, and
+  // fires onCopyLink with that URI.
+  it('shows "Copy link address" only when linkUri is set, and fires onCopyLink with it', () => {
+    const noLink = renderMenu({ linkUri: undefined })
+    expect(noLink.container.textContent).not.toContain('Copy link address')
+    noLink.unmount()
+
+    const onCopyLink = vi.fn()
+    const r = renderMenu({ linkUri: 'https://example.dev/x', onCopyLink })
+    const item = buttonByText(r.container, 'Copy link address')
+    act(() => { item.click() })
+    expect(onCopyLink).toHaveBeenCalledWith('https://example.dev/x')
+    r.unmount()
+  })
+
   it('closes on backdrop mousedown but NOT on mousedown inside the menu', () => {
     const onClose = vi.fn()
     const r = renderMenu({ onClose })

--- a/tests/unit/renderer/terminal-links.test.ts
+++ b/tests/unit/renderer/terminal-links.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ILink } from '@xterm/xterm'
+import { decorateTerminalLinks } from '../../../src/renderer/components/terminal/terminalLinks'
+
+// The decorator ignores the event arg (handlers key off the URI), so a plain
+// cast avoids needing a DOM environment for MouseEvent.
+const EV = {} as MouseEvent
+
+function fakeLink(text: string): ILink {
+  return {
+    range: { start: { x: 1, y: 1 }, end: { x: text.length, y: 1 } },
+    text,
+    activate: () => { throw new Error('original activate should be replaced') },
+  }
+}
+
+describe('decorateTerminalLinks (#21)', () => {
+  it('returns undefined when given no links', () => {
+    expect(decorateTerminalLinks(undefined, { open: () => {}, onHover: () => {}, onLeave: () => {} })).toBeUndefined()
+  })
+
+  it('turns the hover underline OFF (the flicker fix) but keeps the pointer cursor', () => {
+    const [d] = decorateTerminalLinks([fakeLink('https://x.dev')], { open: () => {}, onHover: () => {}, onLeave: () => {} })!
+    expect(d.decorations?.underline).toBe(false)
+    expect(d.decorations?.pointerCursor).toBe(true)
+  })
+
+  it('routes activate through open() with the matched URI (both http and https)', () => {
+    const open = vi.fn()
+    const links = decorateTerminalLinks(
+      [fakeLink('https://a.dev'), fakeLink('http://b.local')],
+      { open, onHover: () => {}, onLeave: () => {} },
+    )!
+    links[0].activate(EV, 'https://a.dev')
+    links[1].activate(EV, 'http://b.local')
+    expect(open).toHaveBeenNthCalledWith(1, 'https://a.dev')
+    expect(open).toHaveBeenNthCalledWith(2, 'http://b.local')
+  })
+
+  it('records the hovered URI and clears it on leave (for the Copy-link menu item)', () => {
+    const onHover = vi.fn()
+    const onLeave = vi.fn()
+    const [d] = decorateTerminalLinks([fakeLink('https://x.dev')], { open: () => {}, onHover, onLeave })!
+    d.hover!(EV, 'https://x.dev')
+    d.leave!(EV, 'https://x.dev')
+    expect(onHover).toHaveBeenCalledWith('https://x.dev')
+    expect(onLeave).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes range and text through unchanged', () => {
+    const src = fakeLink('https://x.dev/path')
+    const [d] = decorateTerminalLinks([src], { open: () => {}, onHover: () => {}, onLeave: () => {} })!
+    expect(d.text).toBe('https://x.dev/path')
+    expect(d.range).toEqual(src.range)
+  })
+})


### PR DESCRIPTION
Tracked-by: https://github.com/nubbymong/aicc_planning/issues/21 (cross-repo; won't auto-close)

## Problem

Selecting a link (or link text) in a terminal flickered the UI at high speed.
Links were also effectively dead: clicking did nothing and there was no way to
copy a link's address.

## Root cause

Under the WebGL renderer the link hover-underline is a separate overlay
(`LinkRenderLayer`). `new WebLinksAddon()` registered links with the underline
ON, so during a selection drag over a link xterm's linkifier fired
hide/show-underline on every mousemove and the overlay tore down + redrew each
frame, fighting the selection-highlight repaint on the same pixels → flicker.
Clicking was dead because the addon's default `window.open` handler is denied by
the main window.

## Fix (renderer-only)

`src/renderer/components/terminal/terminalLinks.ts` (`decorateTerminalLinks`) +
a transient wrap of `term.registerLinkProvider` around `loadAddon`, so each link
WebLinksAddon produces (its wrapped-line/wide-char matcher is reused — not
reimplemented) is augmented with:
- `decorations: { underline: false, pointerCursor: true }` → **kills the
  flicker**, keeps the hand cursor.
- `activate` → `shell.openExternal` → **clicking opens** in the OS browser.
- `hover`/`leave` → record the URI so the right-click menu offers **"Copy link
  address"** (`TerminalContextMenu.tsx`).

Scope: opening goes through the existing https-only `safeExternalHttpsHref` gate
in main (shared with account-web/artifacts — deliberately **not** widened), so
https links open; http links are detected + copyable (copy has no scheme gate).
Works for local and tmux/SSH (linkification is renderer-side text matching).

## Not security-sensitive (ADR-009)

No IPC/preload/argv/keychain/webPreferences change; calls the existing guarded
`openExternal` sink. Untrusted URL text is double-gated (addon `https?://` regex
+ main's https-only WHATWG parse). Outside the SSH-live-matrix blast radius
(main-process SSH files) — this is renderer-only.

## Tests

- Unit: `tests/unit/renderer/terminal-links.test.ts` (decorator) +
  `terminal-context-menu.test.tsx` (Copy-link item). typecheck clean; 148
  terminal tests + the new files pass.
- E2E (`tests/e2e/terminal-links.spec.ts`, Windows-only): real app + real xterm
  — clicking a URL routes to `shell:openExternal` with the URL, and right-click →
  "Copy link address" lands the URL on the OS clipboard. Both pass.

Note: the flicker itself (a rapid WebGL repaint) isn't directly assertable in
e2e; the link wiring the same change adds is what the e2e covers.
