### PR TITLE
fix(ssh): multiple sessions to one host — per-session MCP port (#24) + concurrent trust-prompt race (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,8 @@ jobs:
           PubkeyAuthentication yes
           AllowTcpForwarding yes
           UsePAM no
+          StrictModes no
+          LogLevel VERBOSE
           EOF
           sudo mkdir -p /run/sshd
           sudo "$(command -v sshd)" -t -f "$D/sshd_config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,13 @@ jobs:
           AllowTcpForwarding yes
           UsePAM no
           EOF
-          sudo "$(command -v sshd)" -f "$D/sshd_config"
+          sudo mkdir -p /run/sshd
+          sudo "$(command -v sshd)" -t -f "$D/sshd_config"
+          sudo "$(command -v sshd)" -f "$D/sshd_config" -E "$D/sshd.log"
           for i in $(seq 1 20); do nc -z 127.0.0.1 2222 && break; sleep 0.5; done
+          nc -z 127.0.0.1 2222 || { echo "sshd failed to start"; sudo cat "$D/sshd.log" 2>/dev/null || true; exit 1; }
+          # prove key auth + forwarding before the test, surfacing sshd errors early
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -p 2222 "$(whoami)@127.0.0.1" 'echo SSHD_UP' || { sudo cat "$D/sshd.log" 2>/dev/null || true; exit 1; }
       - name: Write live host entry (localhost)
         run: |
           mkdir -p tests/live

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,3 +188,55 @@ jobs:
           path: dist/*.dmg
           if-no-files-found: error
           retention-days: 14
+
+  # SSH multi-session smoke (#24 regression gate; aicc_planning#28). Real `ssh`
+  # against an EPHEMERAL localhost sshd — no external hosts or credentials, so
+  # unlike the manual live matrix (AGENTS.md) this CAN run in CI. It proves the
+  # per-session MCP reverse-tunnel ports coexist (two sessions to one host) and
+  # that the old single-fixed-port shape collides. It exercises only the SSH
+  # connection / `-R` / argv layer (child_process ssh + the pure argv builder) —
+  # NOT claude/tmux/statusline, which still need the manual matrix.
+  #
+  # ALWAYS runs on PRs (not `ci-run`-gated) so it can be a REQUIRED status check
+  # without the skipped-required deadlock the desktop-gate comment describes.
+  ssh-smoke:
+    name: SSH multi-session smoke (#24)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Provision an ephemeral key-auth sshd (TCP forwarding on)
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y -qq openssh-server netcat-openbsd
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519 -q
+          cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+          chmod 600 ~/.ssh/authorized_keys
+          D="$RUNNER_TEMP/sshd"; mkdir -p "$D"
+          ssh-keygen -t ed25519 -N '' -f "$D/hostkey" -q
+          cat > "$D/sshd_config" <<EOF
+          Port 2222
+          ListenAddress 127.0.0.1
+          HostKey $D/hostkey
+          PidFile $D/sshd.pid
+          AuthorizedKeysFile $HOME/.ssh/authorized_keys
+          PasswordAuthentication no
+          PubkeyAuthentication yes
+          AllowTcpForwarding yes
+          UsePAM no
+          EOF
+          sudo "$(command -v sshd)" -f "$D/sshd_config"
+          for i in $(seq 1 20); do nc -z 127.0.0.1 2222 && break; sleep 0.5; done
+      - name: Write live host entry (localhost)
+        run: |
+          mkdir -p tests/live
+          printf '{ "linuxKey": { "host": "127.0.0.1", "username": "%s", "port": 2222 } }\n' "$(whoami)" > tests/live/hosts.local.json
+      - name: SSH multi-session -R test (#24)
+        run: npx vitest run --config vitest.live.config.ts tests/live/ssh-multisession.live.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update -qq && sudo apt-get install -y -qq openssh-server netcat-openbsd
+          # The runner account is password-locked in /etc/shadow; sshd (UsePAM no)
+          # refuses locked accounts even for pubkey auth. Set a throwaway password
+          # to UNLOCK it — PasswordAuthentication stays off, so it's never usable
+          # for login; the ephemeral runner is discarded after the job.
+          echo "$(whoami):ci-ssh-smoke-$(date +%s)" | sudo chpasswd
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519 -q
           cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys

--- a/CONTEXT.d/2026-08-28-24-multi-session-per-host.md
+++ b/CONTEXT.d/2026-08-28-24-multi-session-per-host.md
@@ -10,10 +10,18 @@ opens with its MCP silently cross-wired to session 1's tunnel.
 
 Fix: a STABLE per-session remote listen port R, forwarded to the one shared local
 server (`-R R:127.0.0.1:L`), with the remote Claude's MCP URL baked to
-`localhost:R`. R is allocated once per CCC sessionId and reused on reconnect (the
-tmux-persisted Claude keeps the URL it launched with), freed on teardown.
-- `src/main/ssh-remote-port.ts` (new): pickRemoteMcpPort (pure, testable) +
-  getRemoteMcpPort/releaseRemoteMcpPort (stable per-session map).
+`localhost:R`. R is DERIVED deterministically from the (random, unique) CCC
+sessionId (FNV-1a → [20000,60000]) so it is identical across reconnects AND app
+relaunches — the tmux-persisted Claude keeps the URL it launched with, so the
+reconnect must forward the same R.
+- `src/main/ssh-remote-port.ts` (new): remoteMcpPortForSession (pure,
+  deterministic) + getRemoteMcpPort (applies the server-down 0 gate). No map, no
+  release.
+
+Adversarial review (fable LEAD) caught the first cut as a BLOCKER: an in-memory
+map freed in cleanupSessionResources changed R on every reconnect (cleanup runs
+on transient drops AND before each respawn), killing MCP for the default-on tmux
+reconnect path. Deterministic derivation removes the per-session state entirely.
 - `src/main/ssh-args.ts`: buildSshArgs gains `remoteMcpPort` (defaults to mcpPort
   = pre-#24 shape); forwards `-R remote:127.0.0.1:local`.
 - `ssh-shim.ts`: generateRemoteSetupScript + generateWindowsRemoteSetupScript bake

--- a/CONTEXT.d/2026-08-28-24-multi-session-per-host.md
+++ b/CONTEXT.d/2026-08-28-24-multi-session-per-host.md
@@ -1,0 +1,39 @@
+## 2026-08-28 -- #24: multiple concurrent sessions to the same host (per-session MCP port)
+
+Only one SSH session could have a working Conductor MCP tunnel per host. Root
+cause: every session forwarded the SAME fixed remote listen port
+(`-R <L>:127.0.0.1:<L>`, L = getConductorMcpPort, 19333/19433) — so a second
+session to one host asked sshd to bind L again, which is refused
+("remote port forwarding failed for listen port L"). On a forwarding-enabled host
+the 2nd session then either dies (user ssh config `ExitOnForwardFailure yes`) or
+opens with its MCP silently cross-wired to session 1's tunnel.
+
+Fix: a STABLE per-session remote listen port R, forwarded to the one shared local
+server (`-R R:127.0.0.1:L`), with the remote Claude's MCP URL baked to
+`localhost:R`. R is allocated once per CCC sessionId and reused on reconnect (the
+tmux-persisted Claude keeps the URL it launched with), freed on teardown.
+- `src/main/ssh-remote-port.ts` (new): pickRemoteMcpPort (pure, testable) +
+  getRemoteMcpPort/releaseRemoteMcpPort (stable per-session map).
+- `src/main/ssh-args.ts`: buildSshArgs gains `remoteMcpPort` (defaults to mcpPort
+  = pre-#24 shape); forwards `-R remote:127.0.0.1:local`.
+- `ssh-shim.ts`: generateRemoteSetupScript + generateWindowsRemoteSetupScript bake
+  the URL with `opts.remoteMcpPort` (falls back to the local port). Threaded
+  through getRemoteSetupCommand / getWindowsRemoteSetupCommand /
+  configureRemoteSettings (+ the SshCapableProvider interface).
+- `pty-manager.ts`: allocate R per session, pass to buildSshArgs + setupOpts;
+  release on cleanup.
+
+No ExitOnForwardFailure added (would kill a session on a rare unrelated remote
+collision); distinct per-session R fully solves the CCC-vs-CCC collision.
+
+Tests: ssh-args.test.ts (per-session -R), ssh-remote-port.test.ts (pick +
+stable-per-session + distinct + release), ssh-shim-mcp-port.test.ts (URL bakes R,
+POSIX + Windows). typecheck clean; 176 ssh unit tests green.
+
+LIVE VALIDATION BLOCKED on the offered host: p-aai-se01.aai.bnts.us has
+`AllowTcpForwarding no` in sshd_config, so `-R` is refused entirely (single or
+multi session) — the fix can't be exercised there, and on such a host the
+collision is a non-fatal warning, not a hard block. Two plain concurrent sessions
+to it already work (no MaxSessions limit). The live SSH matrix for this change
+needs a forwarding-ENABLED host; the symptom-match (does the user's "can't open
+2nd" host allow forwarding / use ExitOnForwardFailure?) is still to confirm.

--- a/CONTEXT.d/2026-08-29-25-concurrent-session-trust-race.md
+++ b/CONTEXT.d/2026-08-29-25-concurrent-session-trust-race.md
@@ -1,0 +1,38 @@
+## 2026-08-29 -- #25: 2nd concurrent SSH session drops to a bare shell (trust-prompt race)
+
+Reported: opening a 2nd session to the same host while the first runs — the 2nd
+connects and gets a terminal, but claude/tmux never launches (bare shell).
+
+Root cause (live-confirmed on p-aai-se01): the remote folder is UNtrusted
+(`~/.claude.json` projects[<path>].hasTrustDialogAccepted=false), so EVERY claude
+launch shows the first-run "trust this folder?" prompt (default "No, exit"). Two
+concurrent sessions to the same untrusted folder both show the prompt, and the
+concurrent claude/config/tmux activity disrupts one session's prompt (its
+selection resets to "No, exit" and claude exits) → bare shell. Pre-trusting the
+folder made 6/6 concurrent runs succeed; untrusted, ~3/6 dropped the first-spawned
+session. Distinct from #24 (per-session `-R` port) — the ports were already
+distinct here.
+
+Fix (both, per owner decision):
+1. **Pre-trust the configured folder** (`ssh-shim.ts` generateRemoteSetupScript):
+   during setup, set `projects[<resolved remotePath>].hasTrustDialogAccepted=true`
+   in `~/.claude.json` (both the resolved and realpath keys, since claude keys by
+   cwd realpath), written BEFORE claude launches, idempotent, fully fail-open. The
+   user explicitly configured this host+path, so trusting exactly it is intent.
+   remotePath threaded generateRemoteSetupScript ← getRemoteSetupCommand.
+2. **Fix the false-green latch** (`ui-detection.ts` + `pty-manager.ts`): the SSH
+   idle-fallback latched `claude-running` even when claude had exited to a bare
+   shell. New `looksLikeShellPromptTail` (conservative: last ANSI-stripped line
+   ends in `$`/`#` and carries NO claude glyph `❯`/box-drawing) gates the
+   fallback — on a bare shell it sets state `failed` ("claude exited to shell")
+   instead of a false `claude-running`.
+
+Validation: after the fix, from a COLD untrusted state, 5/5 concurrent runs →
+both sessions reach a running claude, zero bare-shells. Unit tests:
+ui-detection.test.ts (looksLikeShellPromptTail), ssh-shim-mcp-port.test.ts
+(pre-trust bake). Live regression harness: tests/live/ssh-multisession-repro.live.ts
+(asserts the PANE, not the false-green state).
+
+Note: pre-trust auto-accepts claude's trust gate for the CCC-configured folder
+only. Windows-remote setup (prototype) not wired for pre-trust — Linux is the
+real path.

--- a/src/main/providers/claude/index.ts
+++ b/src/main/providers/claude/index.ts
@@ -52,7 +52,7 @@ export class ClaudeProvider implements SshCapableProvider {
     sessionId: string,
     remotePath: string,
     hooksConfig: { port: number; secret: string } | null,
-    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
     nonce: string,
   ): string {
     return getRemoteSetupCommand(sessionId, remotePath, hooksConfig, opts, nonce)

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -179,6 +179,10 @@ export function generateRemoteSetupScript(
   if (!/^[A-Za-z0-9]+$/.test(nonce)) {
     throw new Error(`generateRemoteSetupScript: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
   }
+  // #25: sink-side re-assertion (adversarial review F2) — remotePath is embedded
+  // in the emitted node script (JSON literal) AND cd'd to; the wrapper already
+  // gates it, this closes a future caller that bypasses getRemoteSetupCommand.
+  assertSafeRemotePath(remotePath)
   const { includeStatusLine = true, includeConductorMcp = true, remoteMcpPort } = opts ?? {}
   // Conductor MCP server is always running (independent of browser/vision config),
   // so SSH sessions always get the conductor MCP entry pointing at the
@@ -438,7 +442,7 @@ export function generateRemoteSetupScript(
     // folder is their intent. Written BEFORE claude launches (idempotent; both
     // the resolved and realpath keys, since claude keys projects by cwd realpath).
     // Fully fail-open (try/catch): on any error the prompt simply reappears.
-    `try{const cj=path.join(home,'.claude.json');let c={};if(fs.existsSync(cj))c=JSON.parse(fs.readFileSync(cj,'utf-8'));let rp=${JSON.stringify(remotePath)};if(rp==='~')rp=home;else if(rp.slice(0,2)==='~/')rp=path.join(home,rp.slice(2));else if(!path.isAbsolute(rp))rp=path.resolve(home,rp);let tp=rp;try{tp=fs.realpathSync(rp)}catch{}c.projects=c.projects||{};let mut2=false;for(const key of new Set([rp,tp])){c.projects[key]=c.projects[key]||{};if(c.projects[key].hasTrustDialogAccepted!==true){c.projects[key].hasTrustDialogAccepted=true;mut2=true}}if(mut2)fs.writeFileSync(cj,JSON.stringify(c,null,2))}catch{}`,
+    `try{const cj=path.join(home,'.claude.json');let c={};if(fs.existsSync(cj))c=JSON.parse(fs.readFileSync(cj,'utf-8'));let rp=${JSON.stringify(remotePath)};if(rp==='~')rp=home;else if(rp.slice(0,2)==='~/')rp=path.join(home,rp.slice(2));else if(!path.isAbsolute(rp))rp=path.resolve(home,rp);let tp=rp;try{tp=fs.realpathSync(rp)}catch{}c.projects=c.projects||{};let mut2=false;for(const key of new Set([rp,tp])){c.projects[key]=c.projects[key]||{};if(c.projects[key].hasTrustDialogAccepted!==true){c.projects[key].hasTrustDialogAccepted=true;mut2=true}}if(mut2){const tmp=cj+'.ccctrust.'+process.pid;fs.writeFileSync(tmp,JSON.stringify(c,null,2));fs.renameSync(tmp,cj)}}catch{}`,
     // Sentinel now carries the tmux result alongside the original
     // completion marker: pty-manager's parseTmuxSentinel requires an EXACT
     // match on THIS session's nonce, immediately after 'setup ok', before

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -162,7 +162,7 @@ process.stdout.write(' ');
 export function generateRemoteSetupScript(
   sessionId: string,
   hooksConfig: { port: number; secret: string } | null,
-  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
   nonce: string,
 ): string {
   // #242 finding F1 (b): the `setup ok` sentinel this script emits (bottom
@@ -178,7 +178,7 @@ export function generateRemoteSetupScript(
   if (!/^[A-Za-z0-9]+$/.test(nonce)) {
     throw new Error(`generateRemoteSetupScript: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
   }
-  const { includeStatusLine = true, includeConductorMcp = true } = opts ?? {}
+  const { includeStatusLine = true, includeConductorMcp = true, remoteMcpPort } = opts ?? {}
   // Conductor MCP server is always running (independent of browser/vision config),
   // so SSH sessions always get the conductor MCP entry pointing at the
   // reverse-tunneled MCP port. The fetch_host_screenshot tool is always available;
@@ -232,7 +232,7 @@ export function generateRemoteSetupScript(
         mcpServers: {
           'conductor': {
             type: 'sse',
-            url: `http://localhost:${mcpPort}/sse?cccSessionId=${encodeURIComponent(sessionId)}&token=${mcpSessionToken(sessionId)}`,
+            url: `http://localhost:${remoteMcpPort && remoteMcpPort > 0 ? remoteMcpPort : mcpPort}/sse?cccSessionId=${encodeURIComponent(sessionId)}&token=${mcpSessionToken(sessionId)}`,
           },
         },
       })
@@ -584,7 +584,7 @@ export function getRemoteSetupCommand(
   sessionId: string,
   remotePath: string,
   hooksConfig: { port: number; secret: string } | null,
-  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
   nonce: string,
 ): string {
   assertSafeRemotePath(remotePath)
@@ -700,13 +700,13 @@ const SSH_STATUSLINE_SHIM_WINDOWS = "const fs=require('fs'),os=require('os'),pat
 
 export function generateWindowsRemoteSetupScript(
   sessionId: string,
-  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
   nonce: string,
 ): string {
   if (!/^[A-Za-z0-9]+$/.test(nonce)) {
     throw new Error(`generateWindowsRemoteSetupScript: nonce "${nonce}" fails the charset guard (expected [A-Za-z0-9]+).`)
   }
-  const { includeStatusLine = true, includeConductorMcp = true } = opts ?? {}
+  const { includeStatusLine = true, includeConductorMcp = true, remoteMcpPort } = opts ?? {}
   const mcpPort = getConductorMcpPort()
   const hasVision = mcpPort > 0 && includeConductorMcp
   const shimLiteral = JSON.stringify(SSH_STATUSLINE_SHIM_WINDOWS)
@@ -716,7 +716,7 @@ export function generateWindowsRemoteSetupScript(
         mcpServers: {
           conductor: {
             type: 'sse',
-            url: `http://localhost:${mcpPort}/sse?cccSessionId=${encodeURIComponent(sessionId)}&token=${mcpSessionToken(sessionId)}`,
+            url: `http://localhost:${remoteMcpPort && remoteMcpPort > 0 ? remoteMcpPort : mcpPort}/sse?cccSessionId=${encodeURIComponent(sessionId)}&token=${mcpSessionToken(sessionId)}`,
           },
         },
       })
@@ -778,7 +778,7 @@ export function generateWindowsRemoteSetupScript(
  */
 export function getWindowsRemoteSetupCommand(
   sessionId: string,
-  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+  opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
   nonce: string,
 ): string {
   const script = generateWindowsRemoteSetupScript(sessionId, opts, nonce)

--- a/src/main/providers/claude/ssh-shim.ts
+++ b/src/main/providers/claude/ssh-shim.ts
@@ -164,6 +164,7 @@ export function generateRemoteSetupScript(
   hooksConfig: { port: number; secret: string } | null,
   opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
   nonce: string,
+  remotePath: string = '~',
 ): string {
   // #242 finding F1 (b): the `setup ok` sentinel this script emits (bottom
   // of `lines`, below) MUST carry `nonce` -- required, not optional, so a
@@ -428,6 +429,16 @@ export function generateRemoteSetupScript(
     // no account or the file is unreadable.
     `let acctB64='';try{const cj=path.join(home,'.claude.json');if(fs.existsSync(cj)){let c=JSON.parse(fs.readFileSync(cj,'utf-8'));if(c&&c.oauthAccount&&typeof c.oauthAccount.emailAddress==='string')acctB64=Buffer.from(c.oauthAccount.emailAddress,'utf-8').toString('base64');let mut=false;if(c.mcpServers){if(c.mcpServers['conductor-vision']){delete c.mcpServers['conductor-vision'];mut=true}if(c.mcpServers['conductor']){delete c.mcpServers['conductor'];mut=true}}if(mut)fs.writeFileSync(cj,JSON.stringify(c,null,2))}}catch{}`,
     `try{const md=path.join(claudeDir,'CLAUDE.md');let c=fs.readFileSync(md,'utf-8');const rx=/\\n?\\n?<!-- VISION-INSTRUCTIONS-START -->[\\s\\S]*?<!-- VISION-INSTRUCTIONS-END -->\\n?/g;if(rx.test(c)){c=c.replace(rx,'').trim();fs.writeFileSync(md,c?c+'\\n':'')}}catch{}`,
+    // #25: pre-accept claude's first-run "trust this folder" dialog for the
+    // remotePath the USER configured for this SSH session. Without it every
+    // launch shows the trust prompt (default "No, exit"); two concurrent
+    // sessions to the same untrusted folder race on that prompt and one claude
+    // exits to a bare shell ("2nd session can't open claude"). The user
+    // explicitly configured this host+path in CCC, so trusting exactly that
+    // folder is their intent. Written BEFORE claude launches (idempotent; both
+    // the resolved and realpath keys, since claude keys projects by cwd realpath).
+    // Fully fail-open (try/catch): on any error the prompt simply reappears.
+    `try{const cj=path.join(home,'.claude.json');let c={};if(fs.existsSync(cj))c=JSON.parse(fs.readFileSync(cj,'utf-8'));let rp=${JSON.stringify(remotePath)};if(rp==='~')rp=home;else if(rp.slice(0,2)==='~/')rp=path.join(home,rp.slice(2));else if(!path.isAbsolute(rp))rp=path.resolve(home,rp);let tp=rp;try{tp=fs.realpathSync(rp)}catch{}c.projects=c.projects||{};let mut2=false;for(const key of new Set([rp,tp])){c.projects[key]=c.projects[key]||{};if(c.projects[key].hasTrustDialogAccepted!==true){c.projects[key].hasTrustDialogAccepted=true;mut2=true}}if(mut2)fs.writeFileSync(cj,JSON.stringify(c,null,2))}catch{}`,
     // Sentinel now carries the tmux result alongside the original
     // completion marker: pty-manager's parseTmuxSentinel requires an EXACT
     // match on THIS session's nonce, immediately after 'setup ok', before
@@ -588,7 +599,7 @@ export function getRemoteSetupCommand(
   nonce: string,
 ): string {
   assertSafeRemotePath(remotePath)
-  const script = generateRemoteSetupScript(sessionId, hooksConfig, opts, nonce)
+  const script = generateRemoteSetupScript(sessionId, hooksConfig, opts, nonce, remotePath)
   const b64 = Buffer.from(script).toString('base64')
   // `cd --` so a path beginning with "-" is treated as an operand, not an option.
   return `stty -echo 2>/dev/null; echo '${b64}' | base64 -d | node 2>/dev/null; stty echo 2>/dev/null; cd -- ${remotePath} && clear`

--- a/src/main/providers/claude/ui-detection.ts
+++ b/src/main/providers/claude/ui-detection.ts
@@ -8,6 +8,28 @@ export function detectClaudeUi(data: string, claudeSent: boolean): boolean {
   return false
 }
 
+/**
+ * #25: after the claude command has been written, does the pane's last line look
+ * like a bare SHELL prompt returning — i.e. claude exited (or never started) and
+ * dropped to the shell? Used by the SSH idle-fallback to avoid the "false green":
+ * latching `claude-running` on a session that actually exited to a bare shell
+ * (e.g. the first-run trust prompt was declined, or claude crashed).
+ *
+ * Deliberately CONSERVATIVE to never mis-flag a RUNNING claude as exited: it
+ * requires the last non-empty (ANSI-stripped) line to end in `$`/`#` AND to carry
+ * NO claude-UI glyph (`❯`, box drawing, vertical bars). Claude's input line uses
+ * `❯` and box drawing, never a bare `$`/`#`, so a running claude cannot match;
+ * `>`/`~` are excluded (a claude screen can legitimately end in either).
+ */
+export function looksLikeShellPromptTail(data: string): boolean {
+  const clean = data
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '') // OSC
+    .replace(/\x1b\[[\x20-\x3f]*[\x40-\x7e]/g, '') // CSI
+  const last = clean.split(/\r?\n/).map((l) => l.replace(/\s+$/, '')).filter((l) => l.length > 0).pop() ?? ''
+  if (/[❯╭╰╮╯┃│]/.test(last)) return false
+  return /[$#]\s*$/.test(last)
+}
+
 // Escape stripping for the prompt-shape tests. Two gaps in the old
 // CSI-only `\x1b\[[0-9;]*[a-zA-Z]` strip broke every END-ANCHORED detector
 // on Windows OpenSSH under ConPTY (probed against a real host, 2026-08-27):

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -131,7 +131,7 @@ export interface SshCapableProvider extends SessionProvider {
     sessionId: string,
     remotePath: string,
     hooksConfig: { port: number; secret: string } | null,
-    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean } | undefined,
+    opts: { includeStatusLine?: boolean; includeConductorMcp?: boolean; remoteMcpPort?: number } | undefined,
     nonce: string,
   ): string
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -27,7 +27,7 @@ import { getConductorMcpPort } from './conductor-mcp-server'
 import { buildSshArgs, buildSshExecArgs } from './ssh-args'
 import { getRemoteMcpPort } from './ssh-remote-port'
 import { resolveClaudeBinary, resolveHostColorScheme, colorFgBgEnvToken } from './providers/claude/spawn'
-import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
+import { detectClaudeUi, lastPromptLineForClaude, looksLikeShellPromptTail } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
 import { isSshCapable } from './providers/types'
 import type { TelemetrySource } from './providers/types'
@@ -1223,6 +1223,9 @@ export function spawnPty(
     let containerSetupShellReady = false
     let claudeSent = false
     let claudeRunning = false
+    // #25: rolling tail of recent PTY output, so the idle-fallback can tell a
+    // running-but-marker-less claude from one that exited to a bare shell.
+    let recentSshTail = ''
     // #242 finding F1 (b), BLOCKER (adversarial review round 5): per-session
     // nonce, generated ONCE here via randomId() (src/shared/id.ts -- the
     // repo's CSPRNG helper, NOT Math.random) and baked into every setup/
@@ -1471,6 +1474,16 @@ export function spawnPty(
         // almost certainly running — flip the latch so the overlay
         // can disappear and no more auto-writes ever fire.
         if (currentFlowState === 'running-claude' && claudeSent) {
+          // #25: don't FALSE-GREEN. If the pane has dropped back to a bare shell
+          // prompt, claude exited (e.g. the first-run trust prompt was declined,
+          // or claude crashed) — surface it as failed instead of latching
+          // claude-running. Conservative detector: never mis-flags a running
+          // claude (whose UI uses ❯/box drawing, not a bare $/#).
+          if (looksLikeShellPromptTail(recentSshTail)) {
+            logError(`[ssh] ${sessionId}: idle after claudeCmd but pane is a bare shell → claude exited (not latching claude-running)`)
+            setFlowState('failed', 'claude exited to shell')
+            return
+          }
           logInfo(`[ssh] ${sessionId}: idle after claudeCmd → assuming claude-running (fallback)`)
           claudeRunning = true
           setFlowState('claude-running', 'idle-fallback')
@@ -2406,6 +2419,7 @@ export function spawnPty(
       // since once Claude is running we never want auto-writes again.
       if (data.length > 0 && !claudeRunning) {
         receivedAnyData = true
+        recentSshTail = (recentSshTail + data).slice(-800) // #25: for claude-exit detection in the fallback
         // Fresh output resets the auth-hold budget: the hold cap only counts
         // CONSECUTIVE quiet fallback fires, so a genuinely waiting prompt that
         // repaints keeps its full hold window.

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -25,6 +25,7 @@ import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand, buildRemote
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
 import { buildSshArgs, buildSshExecArgs } from './ssh-args'
+import { getRemoteMcpPort, releaseRemoteMcpPort } from './ssh-remote-port'
 import { resolveClaudeBinary, resolveHostColorScheme, colorFgBgEnvToken } from './providers/claude/spawn'
 import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
@@ -1153,7 +1154,13 @@ export function spawnPty(
     // resolves `localhost` IPv6-first (::1) -- a dead address that would
     // ECONNREFUSED and kill the channel ("socket connection closed unexpectedly"
     // on the remote MCP client).
-    const sshArgs = buildSshArgs(ssh, getConductorMcpPort(), os.platform())
+    // #24: a STABLE per-session remote listen port for the MCP reverse tunnel,
+    // so multiple sessions to the SAME host don't collide on one fixed port.
+    // Forward `-R <remoteMcpPort>:127.0.0.1:<localMcpPort>` and bake the remote
+    // Claude's MCP URL with the same per-session port (setupOpts below).
+    const localMcpPort = getConductorMcpPort()
+    const remoteMcpPort = getRemoteMcpPort(sessionId, localMcpPort)
+    const sshArgs = buildSshArgs(ssh, localMcpPort, os.platform(), remoteMcpPort)
 
     // HTTP Hooks Gateway: when enabled, tunnel the gateway's loopback port so
     // Claude Code inside the SSH session can reach it via http://localhost:<port>.
@@ -1625,6 +1632,7 @@ export function spawnPty(
           const setupOpts = {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
+            remoteMcpPort, // #24: bake the remote MCP URL with the per-session port
           }
           // item 3: Windows uses the PowerShell-delivered setup (no POSIX
           // base64/stty, no tmux); auto/unix keep the POSIX path unchanged.
@@ -1667,6 +1675,7 @@ export function spawnPty(
           const setupOpts = {
             includeStatusLine: s?.statusLineEnabled !== false,
             includeConductorMcp: s?.conductorToolsEnabled !== false,
+            remoteMcpPort, // #24: bake the remote MCP URL with the per-session port
           }
           // item 3: Windows uses the PowerShell-delivered setup (no POSIX
           // base64/stty, no tmux); auto/unix keep the POSIX path unchanged.
@@ -3753,6 +3762,7 @@ function cleanupSessionResources(sessionId: string): void {
   launchPendingSessions.delete(sessionId)
   recentWrites.delete(sessionId)
   sshOscBuffers.delete(sessionId)
+  releaseRemoteMcpPort(sessionId) // #24: free the session's reserved remote MCP port
   // #242 finding I1: drop ALL of this session's sentinel buffers alongside its
   // OSC sibling above -- same per-session-map shape, same leak risk if omitted.
   // All three kinds, not just 'setup': a session can die with its stage or arch

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -25,7 +25,7 @@ import { buildRemoteSessionCleanupCommand, buildTmuxBinPatchCommand, buildRemote
 import { isGlobalVisionRunning, getGlobalVisionConfig, teardownVisionSession } from './vision-manager'
 import { getConductorMcpPort } from './conductor-mcp-server'
 import { buildSshArgs, buildSshExecArgs } from './ssh-args'
-import { getRemoteMcpPort, releaseRemoteMcpPort } from './ssh-remote-port'
+import { getRemoteMcpPort } from './ssh-remote-port'
 import { resolveClaudeBinary, resolveHostColorScheme, colorFgBgEnvToken } from './providers/claude/spawn'
 import { detectClaudeUi, lastPromptLineForClaude } from './providers/claude/ui-detection'
 import { getProvider } from './providers'
@@ -3762,7 +3762,6 @@ function cleanupSessionResources(sessionId: string): void {
   launchPendingSessions.delete(sessionId)
   recentWrites.delete(sessionId)
   sshOscBuffers.delete(sessionId)
-  releaseRemoteMcpPort(sessionId) // #24: free the session's reserved remote MCP port
   // #242 finding I1: drop ALL of this session's sentinel buffers alongside its
   // OSC sibling above -- same per-session-map shape, same leak risk if omitted.
   // All three kinds, not just 'setup': a session can die with its stage or arch

--- a/src/main/ssh-args.ts
+++ b/src/main/ssh-args.ts
@@ -41,11 +41,16 @@ function assertSafeSshField(name: 'username' | 'host', value: string): void {
  * Build the argument list passed to `ssh`/`ssh.exe`.
  *
  * @param ssh      connection target (user, host, port)
- * @param mcpPort  Conductor MCP reverse-tunnel port; when > 0 a `-R` forward is
- *                 added. The host-side target is 127.0.0.1, not `localhost`: the
- *                 MCP server binds IPv4-only, but Windows resolves `localhost`
- *                 IPv6-first (::1) -- a dead address that would ECONNREFUSED and
- *                 kill the channel.
+ * @param mcpPort  Conductor MCP reverse-tunnel LOCAL target port; when > 0 a
+ *                 `-R` forward is added. The host-side target is 127.0.0.1, not
+ *                 `localhost`: the MCP server binds IPv4-only, but Windows
+ *                 resolves `localhost` IPv6-first (::1) -- a dead address that
+ *                 would ECONNREFUSED and kill the channel.
+ * @param remoteMcpPort  #24: the REMOTE listen port sshd binds for the `-R`
+ *                 forward. Defaults to mcpPort (the pre-#24 shape, where the
+ *                 remote and local ports were the same). Passing a distinct
+ *                 per-session port lets multiple sessions share ONE host without
+ *                 the second colliding on the single fixed port.
  * @param platform host platform (os.platform()). On win32 only, ControlMaster and
  *                 ControlPath are forced off (#241): Windows OpenSSH has no
  *                 connection-multiplexing support, so if the user's global
@@ -54,7 +59,12 @@ function assertSafeSshField(name: 'username' | 'host', value: string): void {
  *                 fine, so this stays win32-only and leaves other platforms
  *                 untouched.
  */
-export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: NodeJS.Platform): string[] {
+export function buildSshArgs(
+  ssh: SshArgsTarget,
+  mcpPort: number,
+  platform: NodeJS.Platform,
+  remoteMcpPort: number = mcpPort,
+): string[] {
   assertSafeSshField('username', ssh.username)
   assertSafeSshField('host', ssh.host)
 
@@ -81,7 +91,9 @@ export function buildSshArgs(ssh: SshArgsTarget, mcpPort: number, platform: Node
   }
 
   if (mcpPort > 0) {
-    args.push('-R', `${mcpPort}:127.0.0.1:${mcpPort}`)
+    // #24: remote listen port (per session) → the one shared local MCP server.
+    const listen = remoteMcpPort > 0 ? remoteMcpPort : mcpPort
+    args.push('-R', `${listen}:127.0.0.1:${mcpPort}`)
   }
 
   return args

--- a/src/main/ssh-remote-port.ts
+++ b/src/main/ssh-remote-port.ts
@@ -10,57 +10,48 @@
 // `-R <R>:127.0.0.1:<L>` (distinct remote binds, one shared local server). The
 // remote Claude's MCP URL then points at localhost:<R> on the remote.
 //
-// R must be STABLE for the life of a session: a tmux reconnect re-establishes
-// the forward, and the already-running remote Claude keeps the URL it launched
-// with, so the reconnect must forward the SAME R. Hence the per-session map
-// (keyed by the CCC sessionId), populated once and reused on every respawn until
-// the session is torn down.
+// R MUST be STABLE for a session across reconnects AND app relaunches: a tmux
+// reconnect re-establishes the forward while the already-running remote Claude
+// keeps the URL it launched with, so the reconnect must forward the SAME R — and
+// an app relaunch that reattaches a persisted session must too. So R is DERIVED
+// deterministically from the (random, unique) CCC sessionId rather than drawn
+// from a live counter/map: the same sessionId always maps to the same port, with
+// no per-session state to allocate, free, or lose on restart. (An in-memory map
+// freed on teardown looked simpler but broke exactly this: cleanupSessionResources
+// runs on transient drops and before every respawn, so R would change on every
+// reconnect — regressing MCP for the default-on tmux-persistence path.)
+//
+// The port space is [20000, 60000] (40001 values). Two DIFFERENT sessions to the
+// SAME host could hash to the same R (birthday-style), but with the handful of
+// concurrent sessions a user runs against one host the probability is ~N^2/80002
+// — negligible — and a collision degrades to the pre-#24 "one session's MCP
+// wins" behaviour, never a hard failure. sshd picks the loser's forward off with
+// a non-fatal warning (CCC sets no ExitOnForwardFailure).
 
-// sessionId -> allocated remote listen port
-const bySession = new Map<string, number>()
+const PORT_LO = 20000
+const PORT_HI = 60000
+const PORT_SPAN = PORT_HI - PORT_LO + 1
 
 /**
- * Pick a port in [lo, hi] that is not already in `used`. Pure + injectable rng
- * so the "distinct per concurrent session" property is unit-testable. Throws if
- * the range is exhausted (never in practice — the range is ~40k wide and real
- * concurrent-session counts are tiny).
+ * Deterministic remote listen port for a session — pure function of sessionId
+ * (FNV-1a → [20000, 60000]). Stable across reconnects and app relaunches. Same
+ * sessionId ⇒ same port; different sessionIds ⇒ (almost always) different ports.
  */
-export function pickRemoteMcpPort(
-  used: ReadonlySet<number>,
-  rng: () => number = Math.random,
-  lo = 20000,
-  hi = 60000,
-): number {
-  const span = hi - lo + 1
-  for (let attempt = 0; attempt < span; attempt++) {
-    const p = lo + Math.floor(rng() * span)
-    if (!used.has(p)) return p
+export function remoteMcpPortForSession(sessionId: string): number {
+  let h = 2166136261 >>> 0 // FNV-1a offset basis
+  for (let i = 0; i < sessionId.length; i++) {
+    h ^= sessionId.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
   }
-  throw new Error('pickRemoteMcpPort: no free port in range')
+  return PORT_LO + (h % PORT_SPAN)
 }
 
 /**
- * The stable remote MCP listen port for this session. Returns 0 (no forward)
- * when the local server is down (localPort === 0), matching the pre-#24
- * "mcpPort === 0 => no -R, empty remote mcpServers" fail-closed behaviour.
- * Idempotent: the first call allocates, later calls (reconnects) return the
- * same port.
+ * The remote MCP listen port to forward for this session, or 0 (no forward) when
+ * the local server is down (localPort === 0) — matching the pre-#24 "mcpPort ===
+ * 0 ⇒ no -R, empty remote mcpServers" fail-closed behaviour.
  */
 export function getRemoteMcpPort(sessionId: string, localPort: number): number {
   if (localPort <= 0) return 0
-  const existing = bySession.get(sessionId)
-  if (existing !== undefined) return existing
-  const port = pickRemoteMcpPort(new Set(bySession.values()))
-  bySession.set(sessionId, port)
-  return port
-}
-
-/** Free the session's reserved port on teardown so the range can't leak. */
-export function releaseRemoteMcpPort(sessionId: string): void {
-  bySession.delete(sessionId)
-}
-
-/** Test-only: inspect the current mapping. */
-export function _getRemoteMcpPortForTest(sessionId: string): number | undefined {
-  return bySession.get(sessionId)
+  return remoteMcpPortForSession(sessionId)
 }

--- a/src/main/ssh-remote-port.ts
+++ b/src/main/ssh-remote-port.ts
@@ -1,0 +1,66 @@
+// Per-session remote MCP listen port (#24).
+//
+// The Conductor MCP server binds ONE local port (getConductorMcpPort). Before
+// #24 every SSH session forwarded `-R <L>:127.0.0.1:<L>` using that single port
+// as the REMOTE listen port too, so a second session to the SAME host asked sshd
+// to bind <L> again and it was refused ("remote port forwarding failed for
+// listen port <L>") — you could not run two sessions against one host.
+//
+// Fix: give each session its OWN remote listen port R and forward
+// `-R <R>:127.0.0.1:<L>` (distinct remote binds, one shared local server). The
+// remote Claude's MCP URL then points at localhost:<R> on the remote.
+//
+// R must be STABLE for the life of a session: a tmux reconnect re-establishes
+// the forward, and the already-running remote Claude keeps the URL it launched
+// with, so the reconnect must forward the SAME R. Hence the per-session map
+// (keyed by the CCC sessionId), populated once and reused on every respawn until
+// the session is torn down.
+
+// sessionId -> allocated remote listen port
+const bySession = new Map<string, number>()
+
+/**
+ * Pick a port in [lo, hi] that is not already in `used`. Pure + injectable rng
+ * so the "distinct per concurrent session" property is unit-testable. Throws if
+ * the range is exhausted (never in practice — the range is ~40k wide and real
+ * concurrent-session counts are tiny).
+ */
+export function pickRemoteMcpPort(
+  used: ReadonlySet<number>,
+  rng: () => number = Math.random,
+  lo = 20000,
+  hi = 60000,
+): number {
+  const span = hi - lo + 1
+  for (let attempt = 0; attempt < span; attempt++) {
+    const p = lo + Math.floor(rng() * span)
+    if (!used.has(p)) return p
+  }
+  throw new Error('pickRemoteMcpPort: no free port in range')
+}
+
+/**
+ * The stable remote MCP listen port for this session. Returns 0 (no forward)
+ * when the local server is down (localPort === 0), matching the pre-#24
+ * "mcpPort === 0 => no -R, empty remote mcpServers" fail-closed behaviour.
+ * Idempotent: the first call allocates, later calls (reconnects) return the
+ * same port.
+ */
+export function getRemoteMcpPort(sessionId: string, localPort: number): number {
+  if (localPort <= 0) return 0
+  const existing = bySession.get(sessionId)
+  if (existing !== undefined) return existing
+  const port = pickRemoteMcpPort(new Set(bySession.values()))
+  bySession.set(sessionId, port)
+  return port
+}
+
+/** Free the session's reserved port on teardown so the range can't leak. */
+export function releaseRemoteMcpPort(sessionId: string): void {
+  bySession.delete(sessionId)
+}
+
+/** Test-only: inspect the current mapping. */
+export function _getRemoteMcpPortForTest(sessionId: string): number | undefined {
+  return bySession.get(sessionId)
+}

--- a/tests/live/ssh-multisession-repro.live.ts
+++ b/tests/live/ssh-multisession-repro.live.ts
@@ -1,0 +1,126 @@
+// LIVE repro (#25 / #24 app-flow): two CONCURRENT sessions to the SAME host,
+// driven through the REAL pty-manager SSH flow, both should reach claude/tmux.
+//
+// Reproduces the reported "2nd session connects, gets a terminal, but cannot open
+// claude/tmux" by running two sessions at once (distinct ids, as the app does per
+// launch) and reporting, per session, whether it reached `claude-running` and
+// whether its pane shows the tmux wrapper / claude UI. On-demand only.
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { readFileSync, existsSync, mkdtempSync, appendFileSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const scratch = mkdtempSync(join(tmpdir(), 'ccc-repro-'))
+const settingsState: { value: Record<string, unknown> } = { value: {} }
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  nativeTheme: { shouldUseDarkColors: true, on: () => {} },
+  app: { getPath: () => scratch },
+}))
+vi.mock('../../src/main/config-manager', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/main/config-manager')>()),
+  readConfig: vi.fn((name: string) => (name === 'settings' ? settingsState.value : null)),
+  getConfigDir: vi.fn(() => scratch),
+}))
+vi.mock('../../src/main/ipc/setup-handlers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/main/ipc/setup-handlers')>()),
+  getResourcesDirectory: vi.fn(() => scratch),
+}))
+
+const { spawnPty, killPty, getSshFlow, writePty } = await import('../../src/main/pty-manager')
+const { registerProvider } = await import('../../src/main/providers')
+const { ClaudeProvider } = await import('../../src/main/providers/claude')
+registerProvider(new ClaudeProvider())
+
+interface HostEntry { host: string; username: string; port?: number }
+const hostsPath = process.env.CCC_LIVE_HOSTS ?? join(process.cwd(), 'tests', 'live', 'hosts.local.json')
+const hosts: Record<string, HostEntry> = existsSync(hostsPath) ? JSON.parse(readFileSync(hostsPath, 'utf-8')) : {}
+const linux = hosts.linuxKey
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+interface Captured { channel: string; payload: unknown }
+function makeWin() {
+  const events: Captured[] = []
+  return { events, win: { isDestroyed: () => false, webContents: { send: (channel: string, payload?: unknown) => events.push({ channel, payload }) } } as never }
+}
+const states = (ev: Captured[], sid: string) => ev.filter((e) => e.channel === `ssh:flowState:${sid}`).map((e) => (e.payload as { state: string }).state)
+const pane = (ev: Captured[], sid: string) => ev.filter((e) => e.channel === `pty:data:${sid}`).map((e) => String(e.payload)).join('')
+const flat = (p: string) => p.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[\x20-\x3f]*[\x40-\x7e]/g, '').replace(/\s/g, '')
+
+beforeAll(() => { settingsState.value = {} })
+
+describe('LIVE repro: two concurrent sessions to one host (#25/#24)', () => {
+  const run = linux ? it : it.skip
+
+  run('both concurrent sessions reach claude/tmux', async () => {
+    const e = linux as HostEntry
+    const ssh = { host: e.host, port: e.port ?? 22, username: e.username, remotePath: '~' }
+    const sidA = `rpa${Date.now().toString(36)}`
+    const sidB = `rpb${Date.now().toString(36)}`
+    const wA = makeWin(); const wB = makeWin()
+    const sids: [string, ReturnType<typeof makeWin>][] = [[sidA, wA], [sidB, wB]]
+
+    spawnPty(wA.win, sidA, { ssh, provider: 'claude' } as never)
+    await sleep(400)
+    spawnPty(wB.win, sidB, { ssh, provider: 'claude' } as never)
+
+    const launched = new Set<string>()
+    const trusted = new Set<string>()
+    const t0 = Date.now()
+    while (Date.now() - t0 < 150_000) {
+      for (const [sid, w] of sids) {
+        const st = states(w.events, sid)
+        if (!launched.has(sid) && st.includes('awaiting-claude')) { getSshFlow(sid)?.launchClaude(); launched.add(sid) }
+        // Trust prompt default is "No, exit" — pressing Enter EXITS claude. Move
+        // DOWN to "Yes, I trust this folder" first, then confirm.
+        if (!trusted.has(sid) && /trustthisfolder|Doyoutrust/i.test(flat(pane(w.events, sid)))) {
+          trusted.add(sid)
+          writePty(sid, '\x1b[B')
+          setTimeout(() => writePty(sid, '\r'), 250)
+        }
+      }
+      const done = sids.every(([sid, w]) => states(w.events, sid).includes('claude-running'))
+      if (done) break
+      await sleep(500)
+    }
+
+    const EV = process.env.CCC_REPRO_EVIDENCE ?? join(tmpdir(), 'ccc-repro-evidence.txt')
+    const log = (s: string) => appendFileSync(EV, s + '\n')
+    log(`\n==== repro run ${new Date().toISOString()} host=${e.host} ====`)
+    for (const [sid, w] of sids) {
+      const p = pane(w.events, sid)
+      const st = [...new Set(states(w.events, sid))]
+      const claudeUi = /esctocancel|trustthisfolder|Doyoutrust|❯|Bypassing|claude\*/i.test(flat(p))
+      const bareShell = /\$\s*$|]\$$/.test(p.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[\x20-\x3f]*[\x40-\x7e]/g, '').trimEnd())
+      log(`${sid}: claudeUi=${claudeUi} bareShell=${bareShell} states=${JSON.stringify(st)} paneLen=${p.length}`)
+      log(`${sid} tail: ${JSON.stringify(flat(p).slice(-300))}`)
+      writeFileSync(`${EV}.${sid}.pane.txt`, p) // full RAW pane for offline inspection
+    }
+    // Remote state snapshot for root-causing.
+    try {
+      const out = execFileSync('ssh', [`${e.username}@${e.host}`, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8',
+        `tmux ls 2>&1; echo '---setup files---'; ls -1 ~/.claude/settings-${sidA}.json ~/.claude/settings-${sidB}.json ~/.claude/mcp-${sidA}.json ~/.claude/mcp-${sidB}.json 2>&1`],
+        { encoding: 'utf8', timeout: 15000 })
+      log(`remote:\n${out}`)
+    } catch (err) { log(`remote snapshot failed: ${(err as Error).message}`) }
+
+    killPty(sidA); killPty(sidB)
+    for (const sid of [sidA, sidB]) {
+      try { execFileSync('ssh', [`${e.username}@${e.host}`, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', `tmux kill-session -t ccc-${sid} 2>/dev/null; true`], { timeout: 12000 }) } catch { /* gone */ }
+    }
+
+    // Assert on the PANE, not the flow state: the idle-fallback can latch
+    // claude-running even when claude exited to a bare shell (the #25 false
+    // green), so a state-only check would pass on the very bug this guards.
+    const ok = (w: ReturnType<typeof makeWin>, sid: string) => {
+      const p = pane(w.events, sid)
+      const clean = p.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[\x20-\x3f]*[\x40-\x7e]/g, '')
+      const claudeUi = /esctocancel|trustthisfolder|Doyoutrust|❯|Bypassing|claude\*/i.test(flat(p))
+      const bareShell = /[$#]\s*$/.test(clean.replace(/\r/g, '').split('\n').map((l) => l.replace(/\s+$/, '')).filter(Boolean).pop() ?? '')
+      return claudeUi && !bareShell
+    }
+    expect(ok(wA, sidA), 'session A shows a running claude (not a bare shell)').toBe(true)
+    expect(ok(wB, sidB), 'session B shows a running claude (not a bare shell)').toBe(true)
+  }, 200_000)
+})

--- a/tests/live/ssh-multisession.live.ts
+++ b/tests/live/ssh-multisession.live.ts
@@ -1,0 +1,83 @@
+// LIVE multi-session-per-host test (#24).
+//
+// Proves, against a REAL forwarding-enabled host, that the per-session remote
+// MCP listen port lets two sessions to the SAME host coexist — the exact bug
+// #24 fixes. Uses the ACTUAL argv builder (buildSshArgs) with the ACTUAL
+// per-session ports (remoteMcpPortForSession), so a regression in either shows
+// up here.
+//
+//   - distinct per-session ports  → both `-R` binds succeed (no warning)
+//   - the SAME port (pre-#24 shape) → the 2nd bind is refused
+//     ("remote port forwarding failed for listen port N")
+//
+// On-demand only (tests/live/, gitignored hosts) — never CI. Requires a
+// forwarding-ENABLED host under `linuxKey` in hosts.local.json; the test skips
+// itself (with a note) on a host that has `AllowTcpForwarding no`, since
+// coexistence cannot be shown where no `-R` binds at all.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { spawn, spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import * as os from 'node:os'
+import { buildSshArgs } from '../../src/main/ssh-args'
+import { remoteMcpPortForSession } from '../../src/main/ssh-remote-port'
+
+interface HostEntry { host: string; username: string; port?: number }
+const hostsPath = process.env.CCC_LIVE_HOSTS ?? join(process.cwd(), 'tests', 'live', 'hosts.local.json')
+const hosts: Record<string, HostEntry> = existsSync(hostsPath) ? JSON.parse(readFileSync(hostsPath, 'utf-8')) : {}
+const linux = hosts.linuxKey
+const SSH = os.platform() === 'win32' ? 'ssh.exe' : 'ssh'
+const LOCAL = 19333 // -R local target; the remote BIND is independent of it
+
+// Local MCP target port is irrelevant to whether sshd binds the remote port, so
+// no local server is needed. We only read ssh's forward-bind stderr.
+function target(h: HostEntry) { return { username: h.username, host: h.host, port: h.port ?? 22 } }
+
+/** Run one ssh with the real per-session argv + a trivial remote command; return stderr. */
+function probe(h: HostEntry, remotePort: number, remoteCmd: string): string {
+  const args = [...buildSshArgs(target(h), LOCAL, os.platform(), remotePort),
+    '-o', 'BatchMode=yes', remoteCmd]
+  const r = spawnSync(SSH, args, { encoding: 'utf8', timeout: 25_000 })
+  return `${r.stdout ?? ''}\n${r.stderr ?? ''}`
+}
+
+const FWD_FAILED = /remote port forwarding failed for listen port/i
+
+describe('LIVE: multiple sessions to one host (#24)', () => {
+  const run = linux ? it : it.skip
+
+  run('distinct per-session -R ports coexist; the same port collides', () => {
+    const h = linux as HostEntry
+    // Preflight: does this host allow remote forwarding at all?
+    const pre = probe(h, remoteMcpPortForSession('ccc-live-pre'), 'echo PREFLIGHT')
+    if (FWD_FAILED.test(pre)) {
+      console.warn(`[live #24] ${h.host} has AllowTcpForwarding off — cannot show -R coexistence here; skipping.`)
+      return
+    }
+    expect(pre).toContain('PREFLIGHT')
+
+    const r1 = remoteMcpPortForSession('ccc-live-session-1')
+    const r2 = remoteMcpPortForSession('ccc-live-session-2')
+    expect(r1).not.toBe(r2) // the allocator gives distinct ports to distinct sessions
+
+    // Hold r1 open on a background connection for the duration of the probes.
+    const holder = spawn(SSH, [...buildSshArgs(target(h), LOCAL, os.platform(), r1),
+      '-o', 'BatchMode=yes', 'sleep 12'], { stdio: 'ignore' })
+    try {
+      // Give the holder time to establish its -R r1 bind.
+      const until = Date.now() + 3500
+      while (Date.now() < until) { /* busy-wait: keep it simple + sync */ }
+
+      // DISTINCT: a 2nd session with r2 must bind cleanly alongside r1.
+      const distinct = probe(h, r2, 'echo DISTINCT_OK')
+      expect(distinct).toContain('DISTINCT_OK')
+      expect(distinct).not.toMatch(FWD_FAILED)
+
+      // SAME (pre-#24 shape): a 2nd session reusing r1 must be refused.
+      const same = probe(h, r1, 'echo SAME_TRIED')
+      expect(same).toMatch(FWD_FAILED)
+    } finally {
+      holder.kill()
+    }
+  }, 90_000)
+})

--- a/tests/unit/providers/claude/ssh-shim-mcp-port.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-mcp-port.test.ts
@@ -1,0 +1,39 @@
+// #24: the remote Claude's MCP URL must point at the PER-SESSION remote listen
+// port (opts.remoteMcpPort), which sshd forwards to the one shared local server.
+// Before #24 it hardcoded the single local port, so two sessions to one host
+// collided. These pin that the emitted setup script bakes the per-session port.
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../../src/main/conductor-mcp-server', () => ({
+  getConductorMcpPort: () => 19333, // the shared LOCAL server port
+  getConductorMcpSecret: () => 'b'.repeat(64),
+  mcpSessionToken: (sessionId: string) => `tok-${sessionId}`,
+}))
+
+import { generateRemoteSetupScript, generateWindowsRemoteSetupScript } from '../../../../src/main/providers/claude/ssh-shim'
+
+const NONCE = 'testnonce123abc'
+
+describe('#24 remote MCP URL uses the per-session port', () => {
+  it('POSIX: bakes localhost:<remoteMcpPort>/sse, not the shared local port', () => {
+    const script = generateRemoteSetupScript('sid-1', null, { remoteMcpPort: 40007 }, NONCE)
+    expect(script).toContain('localhost:40007/sse')
+    expect(script).not.toContain('localhost:19333/sse')
+  })
+
+  it('Windows: bakes localhost:<remoteMcpPort>/sse too', () => {
+    const script = generateWindowsRemoteSetupScript('sid-1', { remoteMcpPort: 40007 }, NONCE)
+    expect(script).toContain('localhost:40007/sse')
+    expect(script).not.toContain('localhost:19333/sse')
+  })
+
+  it('falls back to the shared local port when no per-session port is given (pre-#24 shape)', () => {
+    const script = generateRemoteSetupScript('sid-1', null, undefined, NONCE)
+    expect(script).toContain('localhost:19333/sse')
+  })
+
+  it('falls back to the local port when remoteMcpPort is 0 (server-down defensive)', () => {
+    const script = generateRemoteSetupScript('sid-1', null, { remoteMcpPort: 0 }, NONCE)
+    expect(script).toContain('localhost:19333/sse')
+  })
+})

--- a/tests/unit/providers/claude/ssh-shim-mcp-port.test.ts
+++ b/tests/unit/providers/claude/ssh-shim-mcp-port.test.ts
@@ -37,3 +37,27 @@ describe('#24 remote MCP URL uses the per-session port', () => {
     expect(script).toContain('localhost:19333/sse')
   })
 })
+
+// #25: the setup pre-accepts claude's first-run trust dialog for the configured
+// remotePath, so concurrent sessions don't race on the prompt and one exit to a
+// bare shell.
+describe('#25 pre-trust the configured remote folder', () => {
+  it('bakes a hasTrustDialogAccepted write into ~/.claude.json for the default (~) path', () => {
+    const script = generateRemoteSetupScript('sid-1', null, undefined, NONCE, '~')
+    expect(script).toContain('hasTrustDialogAccepted')
+    expect(script).toContain('.claude.json')
+  })
+
+  it('embeds the exact configured remotePath as a string literal (not shell-interpolated)', () => {
+    const script = generateRemoteSetupScript('sid-1', null, undefined, NONCE, '/srv/app')
+    expect(script).toContain('"/srv/app"')
+    expect(script).toContain('hasTrustDialogAccepted')
+  })
+
+  it('resolves ~, ~/sub, and relative paths against the remote home', () => {
+    const script = generateRemoteSetupScript('sid-1', null, undefined, NONCE, '~/proj')
+    // The remote node resolves ~/ and relative paths against os.homedir().
+    expect(script).toContain('path.join(home,rp.slice(2))')
+    expect(script).toContain('path.resolve(home,rp)')
+  })
+})

--- a/tests/unit/providers/claude/ui-detection.test.ts
+++ b/tests/unit/providers/claude/ui-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { detectClaudeUi, lastPromptLineForClaude } from '../../../../src/main/providers/claude/ui-detection'
+import { detectClaudeUi, lastPromptLineForClaude, looksLikeShellPromptTail } from '../../../../src/main/providers/claude/ui-detection'
 
 describe('Claude UI detection', () => {
   describe('detectClaudeUi', () => {
@@ -15,6 +15,32 @@ describe('Claude UI detection', () => {
     })
     it('matches vertical bars + glyphs after claudeSent', () => {
       expect(detectClaudeUi('│ some output', true)).toBe(true)
+    })
+  })
+
+  // #25: the idle-fallback uses this to avoid latching claude-running when
+  // claude actually exited to a bare shell.
+  describe('looksLikeShellPromptTail', () => {
+    it('detects a bare shell prompt (claude exited)', () => {
+      expect(looksLikeShellPromptTail('[adm-severson@p-aai-se01 ~]$ ')).toBe(true)
+      expect(looksLikeShellPromptTail('some output\nuser@host:/tmp# ')).toBe(true)
+    })
+    it('detects a shell prompt through ANSI/OSC noise and trailing blank lines', () => {
+      expect(looksLikeShellPromptTail('\x1b[0m\x1b]0;title\x07[user@host ~]$ \n\n')).toBe(true)
+    })
+    it('never flags a RUNNING claude (❯ / box drawing) as exited', () => {
+      expect(looksLikeShellPromptTail('╭─────────╮\n│ ❯ type here            │\n╰─────────╯')).toBe(false)
+      expect(looksLikeShellPromptTail('❯ ')).toBe(false)
+      // Even if a $ appears earlier, the LAST line is the claude input.
+      expect(looksLikeShellPromptTail('cost: $0.12\n❯ ')).toBe(false)
+    })
+    it('excludes > and ~ endings (a claude screen can end in either)', () => {
+      expect(looksLikeShellPromptTail('foo >')).toBe(false)
+      expect(looksLikeShellPromptTail('~')).toBe(false)
+    })
+    it('is false on empty / no prompt', () => {
+      expect(looksLikeShellPromptTail('')).toBe(false)
+      expect(looksLikeShellPromptTail('just some text')).toBe(false)
     })
   })
 

--- a/tests/unit/ssh-args.test.ts
+++ b/tests/unit/ssh-args.test.ts
@@ -62,6 +62,25 @@ describe('buildSshArgs', () => {
     expect(args.some((a) => a.includes(' '))).toBe(false)
   })
 
+  // #24: a distinct per-session REMOTE listen port forwarded to the ONE shared
+  // LOCAL server port, so two sessions to the same host don't collide on a
+  // single fixed port. Mutation to prove this: revert the `-R` to
+  // `${mcpPort}:127.0.0.1:${mcpPort}` — both assertions below fail.
+  it('#24: forwards the per-session remote listen port to the shared local port', () => {
+    expect(buildSshArgs(target, 5111, 'linux', 40001)).toEqual([...BASE, '-R', '40001:127.0.0.1:5111'])
+    // Two concurrent sessions → two distinct remote binds, same local target.
+    expect(buildSshArgs(target, 5111, 'linux', 40002)).toEqual([...BASE, '-R', '40002:127.0.0.1:5111'])
+  })
+
+  it('#24: defaults the remote port to mcpPort (pre-#24 shape) when omitted or 0', () => {
+    expect(buildSshArgs(target, 5111, 'linux')).toEqual([...BASE, '-R', '5111:127.0.0.1:5111'])
+    expect(buildSshArgs(target, 5111, 'linux', 0)).toEqual([...BASE, '-R', '5111:127.0.0.1:5111'])
+  })
+
+  it('#24: no tunnel when the local server is down (mcpPort 0), regardless of remote port', () => {
+    expect(buildSshArgs(target, 0, 'linux', 40001).some((a) => a === '-R')).toBe(false)
+  })
+
   // #242: tmux persistence depends on the connection eventually noticing
   // it's dead (see the doc comment on buildSshArgs). Unlike ControlMaster,
   // this is NOT platform-conditional.

--- a/tests/unit/ssh-remote-port.test.ts
+++ b/tests/unit/ssh-remote-port.test.ts
@@ -1,64 +1,45 @@
 import { describe, it, expect } from 'vitest'
-import {
-  pickRemoteMcpPort,
-  getRemoteMcpPort,
-  releaseRemoteMcpPort,
-  _getRemoteMcpPortForTest,
-} from '../../src/main/ssh-remote-port'
+import { remoteMcpPortForSession, getRemoteMcpPort } from '../../src/main/ssh-remote-port'
 
-describe('pickRemoteMcpPort (#24)', () => {
-  it('returns a port in range not already used', () => {
-    const p = pickRemoteMcpPort(new Set(), () => 0.5, 20000, 60000)
-    expect(p).toBe(20000 + Math.floor(0.5 * 40001))
+describe('remoteMcpPortForSession (#24 — deterministic, reconnect-stable)', () => {
+  it('is a pure function of sessionId: same id ⇒ same port, always in range', () => {
+    const sid = 'a1b2c3d4e5f6a1b2c3d4e5f6'
+    const p = remoteMcpPortForSession(sid)
+    expect(p).toBe(remoteMcpPortForSession(sid)) // stable across calls
+    expect(p).toBe(remoteMcpPortForSession(sid)) // ...and again (reconnect/relaunch)
     expect(p).toBeGreaterThanOrEqual(20000)
     expect(p).toBeLessThanOrEqual(60000)
   })
 
-  it('skips a used port and advances the rng', () => {
-    // First rng() lands on a used port, second lands free.
-    const used = new Set([20000])
-    let calls = 0
-    const rng = () => (calls++ === 0 ? 0 : 0.5) // 0 -> 20000 (used), then 0.5
-    const p = pickRemoteMcpPort(used, rng, 20000, 60000)
-    expect(p).not.toBe(20000)
-  })
-
-  it('throws when the range is exhausted', () => {
-    const used = new Set([20000, 20001])
-    expect(() => pickRemoteMcpPort(used, () => 0, 20000, 20001)).toThrow(/no free port/)
+  it('gives different ports to different sessions (no global collision by construction)', () => {
+    // A spread of realistic 24-hex ids should not all collide.
+    const ports = new Set(
+      Array.from({ length: 200 }, (_, i) => remoteMcpPortForSession('sess' + i.toString(16).padStart(20, '0'))),
+    )
+    // Overwhelmingly distinct across 40k space; allow a couple of birthday hits.
+    expect(ports.size).toBeGreaterThan(196)
   })
 })
 
-describe('getRemoteMcpPort (#24 stable per-session mapping)', () => {
-  it('is stable across calls for one session (reconnect keeps the same port)', () => {
-    const sid = 'sess-stable-' + Math.random().toString(36).slice(2)
+describe('getRemoteMcpPort (#24 local-server gate)', () => {
+  it('returns the deterministic port when the local server is up', () => {
+    const sid = 'deadbeefdeadbeefdeadbeef'
+    expect(getRemoteMcpPort(sid, 19333)).toBe(remoteMcpPortForSession(sid))
+  })
+
+  it('returns 0 (no forward) when the local server is down — fail-closed', () => {
+    expect(getRemoteMcpPort('anything', 0)).toBe(0)
+    expect(getRemoteMcpPort('anything', -1)).toBe(0)
+  })
+
+  // The BLOCKER this design fixes: a reconnect (teardown + respawn) must forward
+  // the SAME port so the tmux-persisted remote Claude's baked URL still resolves.
+  // With a deterministic derivation there is no per-session state to lose.
+  it('is identical before and after a simulated teardown+respawn (reconnect)', () => {
+    const sid = 'reconnectsession01234567'
     const first = getRemoteMcpPort(sid, 19333)
-    const second = getRemoteMcpPort(sid, 19333)
-    expect(second).toBe(first)
-    releaseRemoteMcpPort(sid)
-  })
-
-  it('gives DISTINCT ports to two concurrent sessions', () => {
-    const a = 'sess-a-' + Math.random().toString(36).slice(2)
-    const b = 'sess-b-' + Math.random().toString(36).slice(2)
-    const pa = getRemoteMcpPort(a, 19333)
-    const pb = getRemoteMcpPort(b, 19333)
-    expect(pa).not.toBe(pb)
-    releaseRemoteMcpPort(a)
-    releaseRemoteMcpPort(b)
-  })
-
-  it('returns 0 (no forward) when the local server is down', () => {
-    const sid = 'sess-down-' + Math.random().toString(36).slice(2)
-    expect(getRemoteMcpPort(sid, 0)).toBe(0)
-    expect(_getRemoteMcpPortForTest(sid)).toBeUndefined()
-  })
-
-  it('release frees the mapping', () => {
-    const sid = 'sess-rel-' + Math.random().toString(36).slice(2)
-    getRemoteMcpPort(sid, 19333)
-    expect(_getRemoteMcpPortForTest(sid)).toBeDefined()
-    releaseRemoteMcpPort(sid)
-    expect(_getRemoteMcpPortForTest(sid)).toBeUndefined()
+    // ...session drops, cleanup runs (no state to release), respawn:
+    const afterReconnect = getRemoteMcpPort(sid, 19333)
+    expect(afterReconnect).toBe(first)
   })
 })

--- a/tests/unit/ssh-remote-port.test.ts
+++ b/tests/unit/ssh-remote-port.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  pickRemoteMcpPort,
+  getRemoteMcpPort,
+  releaseRemoteMcpPort,
+  _getRemoteMcpPortForTest,
+} from '../../src/main/ssh-remote-port'
+
+describe('pickRemoteMcpPort (#24)', () => {
+  it('returns a port in range not already used', () => {
+    const p = pickRemoteMcpPort(new Set(), () => 0.5, 20000, 60000)
+    expect(p).toBe(20000 + Math.floor(0.5 * 40001))
+    expect(p).toBeGreaterThanOrEqual(20000)
+    expect(p).toBeLessThanOrEqual(60000)
+  })
+
+  it('skips a used port and advances the rng', () => {
+    // First rng() lands on a used port, second lands free.
+    const used = new Set([20000])
+    let calls = 0
+    const rng = () => (calls++ === 0 ? 0 : 0.5) // 0 -> 20000 (used), then 0.5
+    const p = pickRemoteMcpPort(used, rng, 20000, 60000)
+    expect(p).not.toBe(20000)
+  })
+
+  it('throws when the range is exhausted', () => {
+    const used = new Set([20000, 20001])
+    expect(() => pickRemoteMcpPort(used, () => 0, 20000, 20001)).toThrow(/no free port/)
+  })
+})
+
+describe('getRemoteMcpPort (#24 stable per-session mapping)', () => {
+  it('is stable across calls for one session (reconnect keeps the same port)', () => {
+    const sid = 'sess-stable-' + Math.random().toString(36).slice(2)
+    const first = getRemoteMcpPort(sid, 19333)
+    const second = getRemoteMcpPort(sid, 19333)
+    expect(second).toBe(first)
+    releaseRemoteMcpPort(sid)
+  })
+
+  it('gives DISTINCT ports to two concurrent sessions', () => {
+    const a = 'sess-a-' + Math.random().toString(36).slice(2)
+    const b = 'sess-b-' + Math.random().toString(36).slice(2)
+    const pa = getRemoteMcpPort(a, 19333)
+    const pb = getRemoteMcpPort(b, 19333)
+    expect(pa).not.toBe(pb)
+    releaseRemoteMcpPort(a)
+    releaseRemoteMcpPort(b)
+  })
+
+  it('returns 0 (no forward) when the local server is down', () => {
+    const sid = 'sess-down-' + Math.random().toString(36).slice(2)
+    expect(getRemoteMcpPort(sid, 0)).toBe(0)
+    expect(_getRemoteMcpPortForTest(sid)).toBeUndefined()
+  })
+
+  it('release frees the mapping', () => {
+    const sid = 'sess-rel-' + Math.random().toString(36).slice(2)
+    getRemoteMcpPort(sid, 19333)
+    expect(_getRemoteMcpPortForTest(sid)).toBeDefined()
+    releaseRemoteMcpPort(sid)
+    expect(_getRemoteMcpPortForTest(sid)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Multiple sessions to one SSH host, working end-to-end. Two linked fixes.

Tracked-by:
- aicc_planning#24 — per-session MCP reverse-tunnel port
- aicc_planning#25 — concurrent-session first-run trust-prompt race

(cross-repo; won't auto-close)

## #24 — per-session remote MCP port

Every SSH session forwarded the same fixed remote port (`-R L:127.0.0.1:L`), so a
2nd session to one host collided on that port and its MCP tunnel broke (or the
connection died under `ExitOnForwardFailure`). Fix: a deterministic per-session
remote port `R = FNV1a(sessionId) → [20000,60000]` (stable across reconnects and
app relaunches), forwarded `-R R:127.0.0.1:L`, with the remote MCP URL baked to
`localhost:R`. Files: `ssh-remote-port.ts` (new), `ssh-args.ts`, `ssh-shim.ts`
(POSIX+Windows URL), `pty-manager.ts`.

## #25 — concurrent sessions dropped to a bare shell

Root cause (live-confirmed): the remote folder is untrusted, so every claude
launch shows the first-run "trust this folder?" prompt (default "No, exit"); two
concurrent sessions race on it and one claude exits to a bare shell — "2nd
session can't open claude". Fix (both, per owner call):
1. Pre-trust the CCC-configured remotePath during setup (`ssh-shim.ts`): set
   `projects[<resolved path>].hasTrustDialogAccepted=true` in `~/.claude.json`
   before claude launches — atomic (tmp+rename), idempotent, fail-open, scoped to
   exactly the configured folder.
2. Stop the false green (`ui-detection.ts` + `pty-manager.ts`): the idle-fallback
   latched `claude-running` even when claude exited; `looksLikeShellPromptTail`
   (conservative) now routes a bare shell to `failed` instead.

## Adversarial review (ADR-009)

Both changes reviewed (independent LEAD). #24: LAND-AS-IS after a reconnect
BLOCKER was fixed (deterministic port). #25: FIX-AND-LAND — F1 MAJOR
(non-atomic `~/.claude.json` write) fixed via tmp+rename; F2 MINOR (sink-side
`assertSafeRemotePath`) added. Injection/allowlist/fail-open cleared.

## Live SSH matrix (blast radius: pty-manager SSH branch, ssh-shim, ui-detection)

Real hosts — se01 (forwarding on), se02 (forwarding off, by IP):
- #24: distinct per-session `-R` ports **coexist** on se01; the same port
  **collides** — fix confirmed. se02 (forwarding off): concurrent sessions still
  open (non-fatal warning) — no regression.
- #25: from a **cold untrusted** state, **5/5** concurrent runs → both sessions
  reach a running claude, 0 bare-shells (was ~3/6 failing before). `~/.claude.json`
  verified intact after the atomic write.
- Statusline pack (`test:live:ssh`) fails on these fresh hosts, but **also fails
  on the clean baseline (origin/beta)** — pre-existing/environmental (#242
  delivery path on freshly-built hosts), **not** a regression from this PR.

## Tests

Unit: `ssh-args`, `ssh-remote-port`, `ssh-shim-mcp-port`, `ui-detection` (262 in
the combined ssh run, green); typecheck clean. Live (on-demand):
`ssh-multisession.live.ts` (per-session `-R` coexist/collide) +
`ssh-multisession-repro.live.ts` (two concurrent sessions both reach claude —
asserts the pane, not the false-green state).
