### PR TITLE
build(release): 2.1.0-rc.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.9",
+  "version": "2.1.0-rc.10",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump only — cuts rc.10 from beta after the Agent Canvas rework (#566) landed. Changelog already carries the rc.10 entry (in sync). BETA-BUMP model.