### PR TITLE
test(ssh): add Rocky Linux (RHEL) live SSH statusline permutations

### DIFF
--- a/tests/live/hosts.example.json
+++ b/tests/live/hosts.example.json
@@ -2,6 +2,7 @@
   "//": "Copy to hosts.local.json (gitignored) and fill in your own hosts. Every entry is optional — combos whose entry is absent are skipped. password entries are read from this local file only; never commit hosts.local.json.",
   "linuxKey": { "host": "192.0.2.10", "username": "you" },
   "linuxPassword": { "host": "192.0.2.11", "username": "you", "password": "secret" },
+  "linuxRocky": { "host": "192.0.2.14", "username": "you", "password": "secret" },
   "mac": { "host": "192.0.2.12", "username": "you" },
   "windows": { "host": "192.0.2.13", "username": "you", "remoteOs": "windows" }
 }

--- a/tests/live/ssh-statusline.live.ts
+++ b/tests/live/ssh-statusline.live.ts
@@ -16,6 +16,9 @@
 //   password + NO tmux                     [linuxPassword]
 //   mac key + tmux-or-bare (as detected)   [mac]
 //   windows remote (CONOUT$ shim, no tmux) [windows]
+//   rocky password + tmux (staged)         [linuxRocky]
+//   rocky password + NO tmux               [linuxRocky]
+//   rocky password + tmux — reattach       [linuxRocky]
 import { describe, it, expect, vi, beforeAll } from 'vitest'
 import { readFileSync, existsSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
@@ -50,7 +53,7 @@ const { startStatuslineWatcher } = await import('../../src/main/statusline-watch
 registerProvider(new ClaudeProvider())
 
 interface HostEntry { host: string; username: string; password?: string; remoteOs?: 'windows' | 'unix' }
-type Hosts = Partial<Record<'linuxKey' | 'linuxPassword' | 'mac' | 'windows', HostEntry>>
+type Hosts = Partial<Record<'linuxKey' | 'linuxPassword' | 'linuxRocky' | 'mac' | 'windows', HostEntry>>
 // Root-relative (vitest runs with the repo root as cwd); CCC_LIVE_HOSTS
 // overrides for runners whose cwd is elsewhere. __dirname is not reliable
 // under the ESM transform.
@@ -262,4 +265,60 @@ describe('SSH statusline matrix (LIVE, on-demand)', () => {
     killPty(sid)
     expect(updates(w.events).some((u) => u.sessionId === sid)).toBe(true)
   }, 240_000)
+
+  // NB slot numbering: T8 is RESERVED in the shared Master Test Process
+  // (aicc_planning discussion #20) for the auto-tmux-profile host scenario
+  // ([ -z "$TMUX" ] && exec tmux new -A), which is a different host role and
+  // still unfilled. Rocky (RHEL password host, no tmux at all) is a distinct
+  // scenario, so it takes T9–T11 and leaves T8 for that slot.
+  //
+  // Rocky Linux (RHEL-family) over PASSWORD auth with NO tmux on the host — so
+  // T9 exercises the tmux STAGING path (ccc stages its own tmux into
+  // ~/.claude/bin) on a distro the Debian-family Pi does not cover, and holds
+  // the same password-host contract as T4 (product End answers the prompt and
+  // completes; no mis-parsed stage sentinel).
+  itIf(hosts.linuxRocky)('rocky password + tmux (staged): statusline updates', async () => {
+    const e = hosts.linuxRocky!
+    const sid = `lv9${Date.now().toString(36)}`
+    const w = await runSession(sid, e)
+    report('T9 rocky pw+tmux', w, sid)
+    const ended = await endSshRemote(sid) // #572 product End path (password prompt answered)
+    killPty(sid)
+    killRemoteTmux(e, sid)
+    expect(ended).toBe('completed')
+    expect(misParsedStageFail(w.events, sid)).toEqual([])
+    expect(updates(w.events).some((u) => u.sessionId === sid)).toBe(true)
+  }, 240_000)
+
+  itIf(hosts.linuxRocky)('rocky password + NO tmux: statusline via /dev/tty-or-pts', async () => {
+    const e = hosts.linuxRocky!
+    const sid = `lv10${Date.now().toString(36)}`
+    const w = await runSession(sid, e, { detachable: false })
+    report('T10 rocky pw no-tmux', w, sid)
+    await endSshRemote(sid) // no tmux to kill; removes the remote sidecars
+    killPty(sid)
+    expect(updates(w.events).some((u) => u.sessionId === sid)).toBe(true)
+  }, 240_000)
+
+  // The ONLY password-auth reattach in the matrix (T2 is key-auth): drop the
+  // local PTY, let the STAGED remote tmux survive, reconnect — which must
+  // re-answer the password AND reattach to the live tmux — and prove the
+  // statusline resumes with activity through the reattached client tty. Guards
+  // the "SSH under user-owned tmux" reconnection path on RHEL specifically.
+  itIf(hosts.linuxRocky)('rocky password + tmux reattach: statusline still updates after reconnect', async () => {
+    const e = hosts.linuxRocky!
+    const sid = `lv11${Date.now().toString(36)}`
+    const w1 = await runSession(sid, e)
+    report('T11a rocky first connect', w1, sid)
+    const firstOk = updates(w1.events).some((u) => u.sessionId === sid)
+    killPty(sid) // drop the local PTY; the remote staged-tmux session survives
+    await sleep(3000)
+    const w2 = await runSession(sid, e, { win: makeWin(), nudge: true })
+    report('T11b rocky reattach', w2, sid)
+    await endSshRemote(sid) // #572 product End path (password prompt answered)
+    killPty(sid)
+    killRemoteTmux(e, sid)
+    expect(firstOk).toBe(true)
+    expect(updates(w2.events).some((u) => u.sessionId === sid)).toBe(true)
+  }, 480_000)
 })


### PR DESCRIPTION
## Premise (problem · evidence · still-open · why-now)
- **Problem:** the fleet's RHEL-family graphical+SSH testbed (Rocky Linux) had no slot in the live SSH statusline matrix — only `linuxKey`/`linuxPassword`/`mac`/`windows` existed. The Debian-family Pi was the only Linux password host covered.
- **Evidence:** no `linuxRocky` key anywhere in the pack; the executable matrix stopped at T7.
- **Still-open:** Rocky was never wired in; provisioned this session (claude login + onboarding flags) and confirmed reachable.
- **Why now:** owner wants all-device coverage — Rocky / Hyper-V Windows / macOS are graphical **and** SSH testbeds; Pi / 185 are SSH-only.

## What this adds
A `linuxRocky` host slot with three **password-auth** permutations (mirroring the established patterns):

| Combo | Mirrors | Covers |
|---|---|---|
| **T9** password + tmux (STAGED) | T4 | ccc's tmux staging into `~/.claude/bin` on a distro with **no system tmux** — a path the Pi never exercises |
| **T10** password + NO tmux | T5 | statusline via `/dev/tty`-or-pts on RHEL |
| **T11** password + tmux reattach | T2 (key) | the **only password-auth reattach in the whole matrix** — drop local PTY, staged remote tmux survives, reconnect re-answers the password + reattaches, statusline resumes |

**Slot numbering:** T8 is deliberately skipped — it is **reserved** in the shared Master Test Process (aicc_planning discussion #20) for the auto-tmux-profile host scenario (a different, still-unfilled host role). Rocky (no tmux at all) is a distinct scenario, so it takes T9–T11.

## Evidence — live matrix run (this session)
Rocky Linux 10.2 (Red Quartz), kernel 6.12, claude 2.1.211, OpenSSH 9.9, password auth — each combo run one at a time per the AGENTS.md SSH gate:
- **T9 rocky pw+tmux (staged): PASS** — `updates=1`, `wrapped=true` (tmux staging confirmed), `ended='completed'`, no mis-parsed stage sentinel
- **T10 rocky pw no-tmux: PASS** — `updates=1`, `wrapped=false`
- **T11 rocky pw reattach: PASS** — first connect `updates=1` + reattach `updates=1` (reattached to the staged tmux)

## Scope / gates
- **Test-only.** No blast-radius source touched (`pty-manager.ts`, `ssh-shim.ts`, sentinel parsers, etc. unchanged) → no adversarial review required; the live-matrix evidence above is the runtime proof for the new slots.
- Host entry lives in gitignored `hosts.local.json` (password never committed); `hosts.example.json` documents the new `linuxRocky` key.
- `npm run typecheck` clean; independent Double Review PASS (spec-compliance + code-quality, separate reviewer).
- `skip-desktop-test`: no app UI touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)