### PR TITLE
ci(gate): accept runtime-validated on the desktop-test merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,19 @@ jobs:
         run: node scripts/gen-changelog.js --check
 
   # Desktop-test merge gate (#309). Headless CI can pass while the packaged app
-  # fails to run usefully on a real desktop (it has), so "did a human open it?"
-  # is the real acceptance gate — and it should be enforced by the merge button,
-  # not left to a reviewer's memory or a PR-body note.
+  # fails to run usefully on a real desktop (it has), so "was the built app
+  # actually exercised?" is the real acceptance gate — and it should be enforced
+  # by the merge button, not left to a reviewer's memory or a PR-body note.
+  # Two ways to satisfy it (aicc_planning D#20, the Master Test Process):
+  #   - `desktop-tested`    a HUMAN opened and exercised the packaged app
+  #   - `runtime-validated` AUTOMATED runtime validation passed — VM Playwright
+  #                         e2e and/or the live SSH statusline matrix
   #
   # This is the INVERSE of the `ci-run` label below: `ci-run` is opt-in (present
   # => run the matrix); this one is required-to-allow (the check FAILS unless the
-  # PR carries `desktop-tested` or `skip-desktop-test`). Only PRs are gated;
-  # direct pushes to `main` have no label and are exempt by the event guard.
+  # PR carries `desktop-tested`, `runtime-validated`, or `skip-desktop-test`).
+  # Only PRs are gated; direct pushes to `main` have no label and are exempt by
+  # the event guard.
   #
   # The job's only `if` is event-scoped (`pull_request`), and that is the whole
   # design: on every PR it ALWAYS runs, then decides pass/fail from the labels
@@ -53,20 +58,25 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Require desktop-tested (or skip-desktop-test) label
+      - name: Require desktop-tested / runtime-validated (or skip-desktop-test) label
         env:
           HAS_TESTED: ${{ contains(github.event.pull_request.labels.*.name, 'desktop-tested') }}
+          HAS_RUNTIME: ${{ contains(github.event.pull_request.labels.*.name, 'runtime-validated') }}
           HAS_SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-desktop-test') }}
         run: |
           if [ "$HAS_TESTED" = "true" ]; then
-            echo "PR carries 'desktop-tested' — the app was exercised on a real desktop. Gate open."
+            echo "PR carries 'desktop-tested' — a human exercised the packaged app on a real desktop. Gate open."
+            exit 0
+          fi
+          if [ "$HAS_RUNTIME" = "true" ]; then
+            echo "PR carries 'runtime-validated' — automated runtime validation passed (VM Playwright e2e and/or the live SSH statusline matrix). Gate open."
             exit 0
           fi
           if [ "$HAS_SKIP" = "true" ]; then
-            echo "PR carries 'skip-desktop-test' — no desktop test required (docs/deps/CI/changelog-only). Gate open."
+            echo "PR carries 'skip-desktop-test' — no runtime test required (docs/deps/CI/changelog-only). Gate open."
             exit 0
           fi
-          echo "::error::Desktop-test merge gate: this PR must carry the 'desktop-tested' label (app launched and exercised on a real desktop) or 'skip-desktop-test' (docs/deps/CI/changelog-only) before it can merge. See CONTRIBUTING.md > Desktop-test gate."
+          echo "::error::Desktop-test merge gate: this PR must carry 'desktop-tested' (a human launched and exercised the packaged app), 'runtime-validated' (automated VM e2e and/or the live SSH statusline matrix passed), or 'skip-desktop-test' (docs/deps/CI/changelog-only) before it can merge. See CONTRIBUTING.md > Desktop-test gate."
           exit 1
 
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,22 +182,29 @@ reliable path. Preview locally:
 node scripts/reconcile-issue-dispositions.js --dry-run
 ```
 
-### Desktop-test gate (`desktop-tested` / `skip-desktop-test`)
+### Desktop-test gate (`desktop-tested` / `runtime-validated` / `skip-desktop-test`)
 
 Headless CI (typecheck, unit tests, build) can pass while the packaged app fails
 to run usefully on a real desktop — that has happened. So a PR does not merge on
-green CI alone: **a human must open the app and exercise the change**, and that
-fact is recorded as a label, enforced by the `Desktop test gate` check.
+green CI alone: **the built app must actually be exercised**, and that fact is
+recorded as a label, enforced by the `Desktop test gate` check. There are two
+ways to satisfy it — a human pass or an automated one — plus the skip for
+changes with no runtime surface.
 
-- **`desktop-tested`** — the app was launched and exercised on a real desktop for
-  this change. Apply it once you (or the tester) have actually driven the feature
-  in the running app, not just watched CI go green.
-- **`skip-desktop-test`** — this PR needs no desktop test: docs-, deps-, CI- or
-  changelog-only changes with no runtime surface. Apply it instead of
-  `desktop-tested` for those.
+- **`desktop-tested`** — a **human** launched and exercised the packaged app on a
+  real desktop for this change. Apply it once you (or the tester) have actually
+  driven the feature in the running app, not just watched CI go green.
+- **`runtime-validated`** — **automated** runtime validation passed: VM Playwright
+  E2E and/or the live SSH statusline matrix. This is the automation route (so it
+  no longer borrows `desktop-tested`), and it is strong enough to open the gate on
+  its own — a separate human pass is then optional. See the Master Test Process
+  (aicc_planning discussion #20) for what each automated pack covers.
+- **`skip-desktop-test`** — this PR needs no runtime test: docs-, deps-, CI- or
+  changelog-only changes with no runtime surface. Apply it instead of the two
+  above for those.
 
-The `Desktop test gate` check **fails until one of these two labels is present**,
-so it is the inverse of `ci-run` (which is opt-in — apply it to *run* the matrix;
+The `Desktop test gate` check **fails until one of these labels is present**, so
+it is the inverse of `ci-run` (which is opt-in — apply it to *run* the matrix;
 this one must be present to *allow* the merge). Removing the label turns the check
 red again.
 


### PR DESCRIPTION
## Premise (problem · evidence · still-open · why-now)
- **Problem:** the desktop-test gate (`ci.yml` `desktop-gate` job) opened only on `desktop-tested` or `skip-desktop-test`. Automated runtime validation — VM Playwright e2e and the live SSH statusline matrix — had nowhere to go, so it was being recorded **as** `desktop-tested`, overloading a label the owner has fixed to mean "a **human** opened the app."
- **Evidence:** `ci.yml:56-70` checked exactly two labels; the rc.11 record marked PR #574 "desktop-tested via VM Playwright e2e" — automation borrowing the human label.
- **Still-open:** the owner reserved the label decision in aicc_planning D#20; settled 2026-08-30.
- **Why now:** finalising the test-pack alignment (D#20 v4) — the gate needs to honour the decision, not just the doc.

## What this does
Adds a third accepted label, **`runtime-validated`**, for the automation route. Per the owner's call (D#20, 2026-08-30) it is strong enough to open the gate on its own:

**Gate is now: `desktop-tested` OR `runtime-validated` OR `skip-desktop-test`.**

- `desktop-tested` — a **human** launched and exercised the packaged app
- `runtime-validated` — **automated** VM Playwright e2e and/or the live SSH statusline matrix passed
- `skip-desktop-test` — docs / deps / CI / changelog-only

The job still **always runs** and decides pass/fail from the labels internally — never a label-gated `if:` skip, which would deadlock a required check (unchanged design, see the in-file comment).

## Also in this PR
- **`runtime-validated` repo label created** (colour `006B75`).
- **CONTRIBUTING.md** "Desktop-test gate" section documents all three labels.

## Scope / gates
- **CI config + docs only** — no test or app code touched. Hence `skip-desktop-test` (this PR has no runtime surface of its own).
- YAML validated (`yaml.safe_load` clean); the always-on jobs (changelog, this gate, #24 smoke) and the `ci-run` matrix will run on this PR.
- Spec: implements the label model recorded in aicc_planning discussion #20 (v4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)