### PR TITLE
build(release): 2.1.0-rc.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.11",
+  "version": "2.1.0-rc.12",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump for the 2.1.0-rc.12 cut. Feature work landed in #581 (SSH resume, Multi Spawn, watchdog + pill fixes, in-app browser push) with full CI green, ADR-009 adversarial PASS, Double Review PASS, and a live SSH matrix GREEN on real hosts.