### PR TITLE
fix(rc12): browser close-click precedence and pty test isolation for the re-ship

### DIFF
--- a/src/renderer/components/WebviewButton.tsx
+++ b/src/renderer/components/WebviewButton.tsx
@@ -66,7 +66,13 @@ export default function WebviewButton({ sessionId }: Props) {
   }
 
   const titleParts = [
-    unread ? 'A page is waiting for you — click to view it' : (isOpen ? 'Back to the terminal (closes the browser pane)' : 'Open the browser pane'),
+    // isOpen decides first: while the pane is open the button CLOSES it, so it
+    // must not promise "click to view" — a click here goes back to the
+    // terminal and leaves the pushed page waiting. The pending URL still
+    // surfaces on the line below so the user knows a page is queued.
+    isOpen
+      ? 'Back to the terminal (closes the browser pane)'
+      : (unread ? 'A page is waiting for you — click to view it' : 'Open the browser pane'),
     unread && state?.pendingAgentUrl ? `\n${state.pendingAgentUrl}` : '',
     state?.currentUrl ? `\n${state.currentUrl}` : '',
     isPending && state?.watchUrl ? `\nWatching ${state.watchUrl}…` : '',
@@ -85,11 +91,22 @@ export default function WebviewButton({ sessionId }: Props) {
   return (
     <button
       onClick={() => {
-        // An unread agent push takes priority: answer the pill by loading the
-        // pushed page and opening the pane. This is the user's explicit action,
-        // so it is not a "yank" — the page never loaded on its own. Consume
-        // clears the pill; navigate opens the pane and points it at the page.
-        if (unread) {
+        // Click precedence is deliberate. An unread agent push is answered
+        // ONLY from a CLOSED pane: a click on the shut Browser button
+        // unambiguously means "show me the page the agent left", so consume
+        // the pill, open the pane and point it at that page. This is the
+        // user's explicit action, so it is not a "yank" — the page never
+        // loaded on its own. Consume clears the pill; navigate opens the pane
+        // and points it at the page.
+        //
+        // When the pane is already OPEN this same button is the CLOSE
+        // affordance (it reads "Terminal"), and a click means "put the
+        // terminal back" — it must NOT navigate the open pane to the agent's
+        // URL. Consuming the pill on a close would overload the affordance
+        // into a surprise navigation and break the never-yank promise on the
+        // close gesture. So the pill is left raised for the next time the
+        // pane is opened; only an open-from-closed answers it.
+        if (unread && !isOpen) {
           const url = consumeAgentPush(sessionId)
           if (url) {
             trackUsage('webview.opened')

--- a/tests/unit/pty-buffered-write-ordering.test.ts
+++ b/tests/unit/pty-buffered-write-ordering.test.ts
@@ -125,12 +125,28 @@ describe('a write that lands while the launch line is still queued', () => {
     vi.advanceTimersByTime(400) // launch line lands, hold releases
     vi.advanceTimersByTime(5000) // let the chunked writer drain its interval
 
-    const payloads = writeMock.mock.calls
+    // Select ONLY the paste's own chunk writes. The paste is a run of one
+    // sentinel byte, so every replayed chunk is a PURE run of it (`/^X+$/`) and
+    // nothing else -- while the launch line is always a shell command
+    // (`cd '...' && '...claude...' ...; exit`) that can never be all-X.
+    //
+    // The old `includes('X')` filter was a latent ~9% flake (it surfaced on the
+    // Linux CI runner as `expected 278 to be less than or equal to 256`). The
+    // launch line is a SEPARATE, single un-chunked write -- a command line is not
+    // a multi-KB paste and is deliberately not routed through the chunker -- and
+    // its --plugin-dir/--settings/--mcp-config paths live under the per-worker
+    // temp root `ccc-vitest-<rand>`. `fs.mkdtempSync` fills that random suffix
+    // from [A-Za-z0-9], so ~9% of runs it contains an uppercase 'X'; that launch
+    // line (278-424 B, > 256) then matched `includes('X')` and tripped the <=256
+    // assertion meant only for paste chunks. A pure-run filter is deterministic
+    // (no dependence on the random temp name) and still catches a genuinely
+    // oversized PASTE write -- an un-chunked replay would be one X-run > 256.
+    const pasteChunks = writeMock.mock.calls
       .map((c) => (typeof c[0] === 'string' ? c[0] : ''))
-      .filter((s) => s.includes('X'))
-    expect(payloads.length).toBeGreaterThan(1) // chunked, not one write
-    expect(Math.max(...payloads.map((p) => p.length))).toBeLessThanOrEqual(256)
-    expect(payloads.join('').length).toBe(big.length) // and nothing lost
+      .filter((s) => /^X+$/.test(s))
+    expect(pasteChunks.length).toBeGreaterThan(1) // chunked, not one write
+    expect(Math.max(...pasteChunks.map((p) => p.length))).toBeLessThanOrEqual(256)
+    expect(pasteChunks.join('')).toBe(big) // and nothing lost or reordered
 
     killPty(id)
   })

--- a/tests/unit/renderer/webview-button-agent-pill.test.tsx
+++ b/tests/unit/renderer/webview-button-agent-pill.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 /**
  * The Browser tool's agent-push notification pill (open_in_app_browser). The
- * pill appears when the store carries an unread push; clicking the button
- * consumes it — loads the pushed page and opens the pane — and never yanks a
- * page the user is already viewing (the page loads only on that explicit click).
+ * pill appears when the store carries an unread push. Clicking the button
+ * while the pane is CLOSED consumes it — loads the pushed page and opens the
+ * pane. It never yanks a page the user is already viewing (the push alone
+ * navigates nothing). And a click that CLOSES an already-open pane must NOT
+ * consume the pill or navigate to the agent URL: closing is not "view it".
+ * The pill stays raised so the next open can act on it.
  */
 import React from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -67,17 +70,70 @@ describe('agent-push notification pill', () => {
     expect(trackUsage.mock.calls.filter((c) => c[0] === 'webview.opened')).toHaveLength(1)
   })
 
-  it('does NOT yank an actively-viewed page: the pill waits, the viewed URL is untouched until the click', () => {
+  it('never-yank: pushing a page while one is open does not navigate or open on its own', () => {
     act(() => {
       useWebviewStore.getState().navigate('s1', 'https://user-here.test/')
       useWebviewStore.getState().pushAgentUrl('s1', 'https://agent.test/')
     })
     render()
+    // The push raised the pill but left the viewed page and the open pane
+    // exactly as they were — the page loads only when the user acts on it.
     expect(pill()).not.toBeNull()
-    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBe('https://user-here.test/')
-    // The explicit click is what loads the pushed page — not the push itself.
+    const st = useWebviewStore.getState().bySessionId['s1']
+    expect(st.currentUrl).toBe('https://user-here.test/')
+    expect(st.isOpen).toBe(true)
+    expect(st.pendingAgentUrl).toBe('https://agent.test/')
+    expect(st.unread).toBe(true)
+  })
+
+  it('pane OPEN + unread: a click CLOSES the pane and must NOT navigate to the pushed URL or consume the pill', () => {
+    act(() => {
+      useWebviewStore.getState().navigate('s1', 'https://user-here.test/')  // opens the pane on the user's page
+      useWebviewStore.getState().pushAgentUrl('s1', 'https://agent.test/')  // pill raised, page still the user's
+    })
+    // Spy AFTER setup, BEFORE render, so the button captures the spies. On a
+    // close click neither may fire — that is the whole precedence fix.
+    const navigateSpy = vi.spyOn(useWebviewStore.getState(), 'navigate')
+    const consumeSpy = vi.spyOn(useWebviewStore.getState(), 'consumeAgentPush')
+    render()
+    // While open the button is the CLOSE affordance — its tooltip must not
+    // promise "view it"; a click here goes back to the terminal.
+    expect(btn().title).toContain('terminal')
+    expect(btn().title).not.toContain('click to view it')
+
     act(() => { btn().click() })
-    expect(useWebviewStore.getState().bySessionId['s1'].currentUrl).toBe('https://agent.test/')
+
+    const st = useWebviewStore.getState().bySessionId['s1']
+    // The close never navigates the pane to the agent URL — the key invariant.
+    expect(st.currentUrl).toBe('https://user-here.test/')
+    expect(st.isOpen).toBe(false)                    // the click closed the pane
+    // The pill is untouched: it stays raised for the next open.
+    expect(st.unread).toBe(true)
+    expect(st.pendingAgentUrl).toBe('https://agent.test/')
+    expect(pill()).not.toBeNull()
+    expect(btn().getAttribute('data-agent-unread')).toBe('1')
+    // Mutation-check: reverting the `!isOpen` guard would fire both of these.
+    expect(navigateSpy).not.toHaveBeenCalled()
+    expect(consumeSpy).not.toHaveBeenCalled()
+    navigateSpy.mockRestore()
+    consumeSpy.mockRestore()
+  })
+
+  it('the raised pill stays actionable: after closing, the next click (pane now CLOSED) opens + navigates + consumes', () => {
+    act(() => {
+      useWebviewStore.getState().navigate('s1', 'https://user-here.test/')
+      useWebviewStore.getState().pushAgentUrl('s1', 'https://agent.test/')
+    })
+    render()
+    act(() => { btn().click() })   // pane was OPEN -> this closes it; pill stays raised
+    expect(useWebviewStore.getState().bySessionId['s1'].isOpen).toBe(false)
+    expect(useWebviewStore.getState().bySessionId['s1'].unread).toBe(true)
+    act(() => { btn().click() })   // pane now CLOSED + unread -> open + navigate + consume
+    const st = useWebviewStore.getState().bySessionId['s1']
+    expect(st.currentUrl).toBe('https://agent.test/')
+    expect(st.isOpen).toBe(true)
+    expect(st.unread).toBe(false)
+    expect(st.pendingAgentUrl).toBeNull()
     expect(pill()).toBeNull()
   })
 


### PR DESCRIPTION
Two fixes so rc.12 re-ships complete (with Linux):
- pty-buffered-write test isolated its paste-chunk filter from the launch-line write (the ~9% 'X'-in-temp-dir-name flake that failed the Linux release test step). Product chunker unchanged; test-only.
- in-app browser: a click to CLOSE the pane no longer consumes the agent-push pill (never navigates on a close).
Both Double-Review PASS; full suite 10308 green; typecheck clean.