### PR TITLE
fix(terminal): stop the link hover flicker (post-#562 residual)

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -4,7 +4,7 @@ import { Terminal, type ILinkProvider } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
-import { decorateTerminalLinks } from './terminal/terminalLinks'
+import { decorateTerminalLinks, createLinkHoverControl, type LinkHoverControl } from './terminal/terminalLinks'
 import { installWebglWithRecovery, createAtlasResync, type WebglHandle } from './terminal/terminalWebgl'
 import { atlasCoordinator } from './terminal/atlasCoordinator'
 import {
@@ -146,10 +146,12 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
   // Whether #145 input diagnostics are on, readable from the init effect's
   // long-lived onData closure.
   const inputDiagRef = useRef(false)
-  // #21: the http/https URI under the cursor, recorded by the link provider's
-  // hover/leave, so the right-click menu can offer "Copy link address" for the
-  // exact link the linkifier matched. null = cursor is not over a link.
-  const hoveredLinkRef = useRef<string | null>(null)
+  // #21: the http/https link under the cursor, owned by a LinkHoverControl
+  // (terminalLinks.ts) rather than xterm's own decorations: xterm clears and
+  // re-asks the hovered link on every viewport re-render, which strobed the
+  // hand cursor at render cadence in a busy Claude session (2026-09-02 fix).
+  // The control debounces the leave, and the context menu reads current().
+  const linkHoverRef = useRef<LinkHoverControl | null>(null)
   // Explicit right-click menu (Copy/Paste). Opened by the contextmenu handler
   // whenever a blind copy-or-paste decision would be unsafe; null = closed.
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; hasSelection: boolean; linkUri?: string } | null>(null)
@@ -568,6 +570,11 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       // underline OFF (kills the flicker), pointer cursor kept, activation routed
       // to the OS browser (the addon's default window.open is denied), and the
       // hovered URI recorded for the context menu. Restored immediately after.
+      // Hand cursor + hovered-URI state live OUTSIDE xterm (hover-flicker fix,
+      // 2026-09-02): xterm's leave/re-hover churn on every viewport re-render
+      // routes through this control, whose debounced leave keeps both stable.
+      const linkHover = createLinkHoverControl(() => term?.element ?? null)
+      linkHoverRef.current = linkHover
       const originalRegister = term.registerLinkProvider.bind(term)
       ;(term as unknown as { registerLinkProvider: (p: ILinkProvider) => { dispose(): void } }).registerLinkProvider = (
         provider: ILinkProvider,
@@ -578,8 +585,8 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
               cb(
                 decorateTerminalLinks(links, {
                   open: (uri) => { void window.electronAPI.shell.openExternal(uri) },
-                  onHover: (uri) => { hoveredLinkRef.current = uri },
-                  onLeave: () => { hoveredLinkRef.current = null },
+                  onHover: (uri) => linkHover.hover(uri),
+                  onLeave: () => linkHover.leave(),
                 }),
               ),
             ),
@@ -1259,7 +1266,7 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         // #21: right-clicking an http/https link with nothing selected opens the
         // menu so "Copy link address" is available (instead of a blind paste).
         // A live selection still copies the selection (action==='copy') and wins.
-        const linkUri = hoveredLinkRef.current
+        const linkUri = linkHoverRef.current?.current() ?? null
         if (linkUri && action !== 'copy') {
           setCtxMenu({ x: e.clientX, y: e.clientY, hasSelection: !!term.getSelection(), linkUri })
           return
@@ -1340,6 +1347,8 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
         try { window.electronAPI.pty.resize(sessionId, lastSentCols, lastSentRows) } catch { /* main gone */ }
       }
       disposeKeybindings?.()
+      linkHoverRef.current?.dispose()
+      linkHoverRef.current = null
       if (handleContextMenu) container.removeEventListener('contextmenu', handleContextMenu, true)
       if (handlePaste) container.removeEventListener('paste', handlePaste, true)
       if (handleWheel) container.removeEventListener('wheel', handleWheel)

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -562,14 +562,16 @@ export default function TerminalView({ sessionId, configId, cwd, shellOnly, elev
       fitAddon = new FitAddon()
       term.loadAddon(fitAddon)
       // #21: WebLinksAddon detects http/https URLs (wrapped-line + wide-char
-      // aware) but registers them with the hover underline ON, which churns the
-      // WebGL underline overlay on every selection-drag mousemove over a link →
-      // high-speed flicker. The addon has no decorations option and its matcher
-      // is not exported, so wrap registerLinkProvider for the duration of
-      // loadAddon and pass each produced link set through decorateTerminalLinks:
-      // underline OFF (kills the flicker), pointer cursor kept, activation routed
-      // to the OS browser (the addon's default window.open is denied), and the
-      // hovered URI recorded for the context menu. Restored immediately after.
+      // aware) but registers them with xterm-owned hover decorations, which
+      // xterm strobes at render cadence (it clears + re-asks the hovered link
+      // on every viewport re-render). The addon has no decorations option and
+      // its matcher is not exported, so wrap registerLinkProvider for the
+      // duration of loadAddon and pass each produced link set through
+      // decorateTerminalLinks: BOTH decorations off (underline: the #562
+      // selection flicker; pointerCursor: the 2026-09-02 hover flicker),
+      // activation routed to the OS browser (the addon's default window.open
+      // is denied), and hover/leave feeding the LinkHoverControl below, which
+      // owns the hand cursor + Copy-link URI. Restored immediately after.
       // Hand cursor + hovered-URI state live OUTSIDE xterm (hover-flicker fix,
       // 2026-09-02): xterm's leave/re-hover churn on every viewport re-render
       // routes through this control, whose debounced leave keeps both stable.

--- a/src/renderer/components/terminal/terminalLinks.ts
+++ b/src/renderer/components/terminal/terminalLinks.ts
@@ -57,11 +57,24 @@ export function decorateTerminalLinks(
 }
 
 /**
+ * The class the hover control toggles for the hand cursor. APP-OWNED, and its
+ * name is load-bearing: it must NEVER contain the substring "xterm-cursor".
+ * Claude sessions carry a full-nuke stylesheet
+ * (`.claude-session [class*="xterm-cursor"]` -> display:none !important,
+ * terminalTheme.ts) that hides Claude's redundant terminal caret — and it
+ * catches xterm's own `xterm-cursor-pointer` link class too. That collision is
+ * what made the pre-fix hover flicker so VISIBLE: xterm strobed its pointer
+ * class on the screen element at render cadence, and each strobe display:noned
+ * the whole screen. terminalTheme.ts pairs this class with the cursor rule.
+ */
+export const LINK_HOVER_CLASS = 'ccc-link-hover'
+
+/**
  * Owns the link-hover UI state OUTSIDE xterm's churn (2026-09-02 flicker fix):
- * the hand cursor (xterm's own `xterm-cursor-pointer` class, on the element
- * xterm would have toggled it on) and the URI the context menu's "Copy link
- * address" reads. `hover` applies both instantly; `leave` only after
- * `delayMs`, so the leave->re-hover cycle xterm fires on every viewport
+ * the hand cursor (LINK_HOVER_CLASS on the terminal root — deliberately NOT
+ * xterm's `xterm-cursor-pointer`, see above) and the URI the context menu's
+ * "Copy link address" reads. `hover` applies both instantly; `leave` only
+ * after `delayMs`, so the leave->re-hover cycle xterm fires on every viewport
  * re-render (spinner/statusline frames) never reaches the screen — a real
  * departure from the link is a single leave with nothing to cancel it, and the
  * cursor reverts after the short delay. The debounced URI also closes a latent
@@ -85,13 +98,13 @@ export function createLinkHoverControl(
   const cancel = () => { if (timer !== null) { clearTimeout(timer); timer = null } }
   const clear = () => {
     uri = null
-    getElement()?.classList.remove('xterm-cursor-pointer')
+    getElement()?.classList.remove(LINK_HOVER_CLASS)
   }
   return {
     hover: (u) => {
       cancel()
       uri = u
-      getElement()?.classList.add('xterm-cursor-pointer')
+      getElement()?.classList.add(LINK_HOVER_CLASS)
     },
     leave: () => {
       cancel()

--- a/src/renderer/components/terminal/terminalLinks.ts
+++ b/src/renderer/components/terminal/terminalLinks.ts
@@ -41,9 +41,63 @@ export function decorateTerminalLinks(
   if (!links) return undefined
   return links.map((link) => ({
     ...link,
-    decorations: { underline: false, pointerCursor: true },
+    // BOTH decorations off (2026-09-02 hover-flicker fix). underline:false was
+    // #562's selection-drag fix; pointerCursor is now false too because xterm's
+    // Linkifier clears + re-asks the hovered link on EVERY rendered-viewport
+    // change that touches its rows (leave -> class off -> async re-provide ->
+    // class on). A Claude session re-renders continuously (spinner, input box,
+    // statusline), so the hand cursor strobed at render cadence. The pointer
+    // cursor is managed by createLinkHoverControl instead, which rides the same
+    // hover/leave callbacks but debounces the leave, so the churn is invisible.
+    decorations: { underline: false, pointerCursor: false },
     activate: (_e: MouseEvent, uri: string) => actions.open(uri),
     hover: (_e: MouseEvent, uri: string) => actions.onHover(uri),
     leave: () => actions.onLeave(),
   }))
+}
+
+/**
+ * Owns the link-hover UI state OUTSIDE xterm's churn (2026-09-02 flicker fix):
+ * the hand cursor (xterm's own `xterm-cursor-pointer` class, on the element
+ * xterm would have toggled it on) and the URI the context menu's "Copy link
+ * address" reads. `hover` applies both instantly; `leave` only after
+ * `delayMs`, so the leave->re-hover cycle xterm fires on every viewport
+ * re-render (spinner/statusline frames) never reaches the screen — a real
+ * departure from the link is a single leave with nothing to cancel it, and the
+ * cursor reverts after the short delay. The debounced URI also closes a latent
+ * race: a right-click landing inside one of those churn gaps read null and
+ * silently dropped the Copy-link menu item.
+ */
+export interface LinkHoverControl {
+  hover: (uri: string) => void
+  leave: () => void
+  /** The URI under the cursor, stable through xterm's re-render churn. */
+  current: () => string | null
+  dispose: () => void
+}
+
+export function createLinkHoverControl(
+  getElement: () => HTMLElement | null,
+  delayMs = 150,
+): LinkHoverControl {
+  let uri: string | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const cancel = () => { if (timer !== null) { clearTimeout(timer); timer = null } }
+  const clear = () => {
+    uri = null
+    getElement()?.classList.remove('xterm-cursor-pointer')
+  }
+  return {
+    hover: (u) => {
+      cancel()
+      uri = u
+      getElement()?.classList.add('xterm-cursor-pointer')
+    },
+    leave: () => {
+      cancel()
+      timer = setTimeout(() => { timer = null; clear() }, delayMs)
+    },
+    current: () => uri,
+    dispose: () => { cancel(); clear() },
+  }
 }

--- a/src/renderer/components/terminal/terminalTheme.ts
+++ b/src/renderer/components/terminal/terminalTheme.ts
@@ -3,6 +3,8 @@
 // Hex literals are kept as the dark-mode fallback for the rare case
 // where computed styles aren't available (e.g. unit tests under jsdom
 // without our `:root` block applied).
+import { LINK_HOVER_CLASS } from './terminalLinks'
+
 const FALLBACK_DARK = {
   background: '#171e27',
   foreground: '#eef2f7',
@@ -147,6 +149,17 @@ const STYLE_TEXT = `
   .claude-session {
     --cursor-color: transparent !important;
     --xterm-cursor-color: transparent !important;
+  }
+
+  /* Link hover hand cursor (2026-09-02 flicker fix). ${LINK_HOVER_CLASS} is
+     the APP-OWNED class LinkHoverControl toggles on the terminal root: it must
+     never be xterm's own xterm-cursor-pointer, because the full-nuke net above
+     ([class*="xterm-cursor"]) display:nones any element wearing that — which is
+     exactly what made xterm's per-render class strobe flicker the whole screen.
+     !important beats xterm.css's own '.xterm { cursor: text }'. */
+  .${LINK_HOVER_CLASS},
+  .${LINK_HOVER_CLASS} .xterm-screen {
+    cursor: pointer !important;
   }
 `
 export function injectGlobalStyles() {

--- a/tests/unit/renderer/terminal-links.test.ts
+++ b/tests/unit/renderer/terminal-links.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import type { ILink } from '@xterm/xterm'
-import { decorateTerminalLinks, createLinkHoverControl } from '../../../src/renderer/components/terminal/terminalLinks'
+import { decorateTerminalLinks, createLinkHoverControl, LINK_HOVER_CLASS } from '../../../src/renderer/components/terminal/terminalLinks'
 
 // The decorator ignores the event arg (handlers key off the URI), so a plain
 // cast avoids needing a DOM environment for MouseEvent.
@@ -70,9 +70,27 @@ describe('createLinkHoverControl (2026-09-02 hover-flicker fix)', () => {
           remove: (c: string) => { classes.delete(c) },
         },
       } as unknown as HTMLElement,
-      has: () => classes.has('xterm-cursor-pointer'),
+      has: () => classes.has(LINK_HOVER_CLASS),
     }
   }
+
+  it('the hover class stays OUT of the claude-session cursor-nuke net (never contains "xterm-cursor")', () => {
+    // terminalTheme.ts hides any element matching [class*="xterm-cursor"]
+    // inside a Claude session (display:none !important) — reusing xterm's own
+    // xterm-cursor-pointer here display:noned the ENTIRE terminal on hover
+    // (review blocker, 2026-09-02), and xterm strobing that class per render
+    // is what made the original flicker so visible. App-owned name only.
+    expect(LINK_HOVER_CLASS).not.toMatch(/xterm-cursor/)
+    // ...and the injected stylesheet actually pairs a cursor rule with it.
+    const fs = require('fs') as typeof import('fs')
+    const path = require('path') as typeof import('path')
+    const theme = fs.readFileSync(
+      path.resolve(__dirname, '../../../src/renderer/components/terminal/terminalTheme.ts'),
+      'utf-8',
+    )
+    expect(theme).toContain('LINK_HOVER_CLASS}')
+    expect(theme).toContain('cursor: pointer !important')
+  })
 
   it('hover applies the hand cursor and records the URI immediately', () => {
     const f = fakeEl()

--- a/tests/unit/renderer/terminal-links.test.ts
+++ b/tests/unit/renderer/terminal-links.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import type { ILink } from '@xterm/xterm'
-import { decorateTerminalLinks } from '../../../src/renderer/components/terminal/terminalLinks'
+import { decorateTerminalLinks, createLinkHoverControl } from '../../../src/renderer/components/terminal/terminalLinks'
 
 // The decorator ignores the event arg (handlers key off the URI), so a plain
 // cast avoids needing a DOM environment for MouseEvent.
@@ -19,10 +19,13 @@ describe('decorateTerminalLinks (#21)', () => {
     expect(decorateTerminalLinks(undefined, { open: () => {}, onHover: () => {}, onLeave: () => {} })).toBeUndefined()
   })
 
-  it('turns the hover underline OFF (the flicker fix) but keeps the pointer cursor', () => {
+  it('turns BOTH hover decorations OFF (underline: #562 selection flicker; pointerCursor: 2026-09-02 hover flicker)', () => {
+    // xterm clears + re-asks the hovered link on every viewport re-render, so
+    // any decoration it owns strobes at render cadence in a busy session. The
+    // hand cursor is managed by createLinkHoverControl instead.
     const [d] = decorateTerminalLinks([fakeLink('https://x.dev')], { open: () => {}, onHover: () => {}, onLeave: () => {} })!
     expect(d.decorations?.underline).toBe(false)
-    expect(d.decorations?.pointerCursor).toBe(true)
+    expect(d.decorations?.pointerCursor).toBe(false)
   })
 
   it('routes activate through open() with the matched URI (both http and https)', () => {
@@ -52,5 +55,95 @@ describe('decorateTerminalLinks (#21)', () => {
     const [d] = decorateTerminalLinks([src], { open: () => {}, onHover: () => {}, onLeave: () => {} })!
     expect(d.text).toBe('https://x.dev/path')
     expect(d.range).toEqual(src.range)
+  })
+})
+
+describe('createLinkHoverControl (2026-09-02 hover-flicker fix)', () => {
+  afterEach(() => { vi.useRealTimers() })
+
+  function fakeEl() {
+    const classes = new Set<string>()
+    return {
+      el: {
+        classList: {
+          add: (c: string) => { classes.add(c) },
+          remove: (c: string) => { classes.delete(c) },
+        },
+      } as unknown as HTMLElement,
+      has: () => classes.has('xterm-cursor-pointer'),
+    }
+  }
+
+  it('hover applies the hand cursor and records the URI immediately', () => {
+    const f = fakeEl()
+    const c = createLinkHoverControl(() => f.el)
+    c.hover('https://x.dev')
+    expect(f.has()).toBe(true)
+    expect(c.current()).toBe('https://x.dev')
+  })
+
+  it("xterm's re-render churn (leave then immediate re-hover) never drops the cursor or the URI", () => {
+    // The bug: xterm clears + re-asks the hovered link on every viewport
+    // re-render, so leave/hover fired at render cadence and the hand cursor
+    // strobed. The debounced leave makes the gap invisible.
+    vi.useFakeTimers()
+    const f = fakeEl()
+    const c = createLinkHoverControl(() => f.el, 150)
+    c.hover('https://x.dev')
+    for (let i = 0; i < 10; i++) {
+      c.leave()
+      vi.advanceTimersByTime(20) // re-provide lands well inside the debounce
+      c.hover('https://x.dev')
+      expect(f.has()).toBe(true)
+      expect(c.current()).toBe('https://x.dev')
+    }
+    // ...and a right-click inside a churn gap still sees the URI (latent race).
+    c.leave()
+    vi.advanceTimersByTime(100)
+    expect(c.current()).toBe('https://x.dev')
+  })
+
+  it('a real departure clears the cursor and the URI after the delay', () => {
+    vi.useFakeTimers()
+    const f = fakeEl()
+    const c = createLinkHoverControl(() => f.el, 150)
+    c.hover('https://x.dev')
+    c.leave()
+    vi.advanceTimersByTime(151)
+    expect(f.has()).toBe(false)
+    expect(c.current()).toBeNull()
+  })
+
+  it('moving between two links keeps the cursor and swaps the URI', () => {
+    vi.useFakeTimers()
+    const f = fakeEl()
+    const c = createLinkHoverControl(() => f.el, 150)
+    c.hover('https://a.dev')
+    c.leave()
+    c.hover('https://b.dev')
+    vi.advanceTimersByTime(500)
+    expect(f.has()).toBe(true)
+    expect(c.current()).toBe('https://b.dev')
+  })
+
+  it('dispose cancels a pending leave and clears state at once', () => {
+    vi.useFakeTimers()
+    const f = fakeEl()
+    const c = createLinkHoverControl(() => f.el, 150)
+    c.hover('https://x.dev')
+    c.leave()
+    c.dispose()
+    expect(f.has()).toBe(false)
+    expect(c.current()).toBeNull()
+    vi.advanceTimersByTime(500) // the cancelled timer must not fire anything
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('tolerates a missing element (terminal not yet opened / already disposed)', () => {
+    const c = createLinkHoverControl(() => null)
+    c.hover('https://x.dev')
+    expect(c.current()).toBe('https://x.dev')
+    c.dispose()
+    expect(c.current()).toBeNull()
   })
 })

--- a/tests/unit/renderer/terminal-links.test.ts
+++ b/tests/unit/renderer/terminal-links.test.ts
@@ -119,6 +119,12 @@ describe('createLinkHoverControl (2026-09-02 hover-flicker fix)', () => {
     c.leave()
     vi.advanceTimersByTime(100)
     expect(c.current()).toBe('https://x.dev')
+    // Run the debounce out (Copilot nit: no pending fake timer left behind) —
+    // which also pins the other half: an UNCANCELLED leave does clear.
+    vi.advanceTimersByTime(51)
+    expect(c.current()).toBeNull()
+    expect(f.has()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('a real departure clears the cursor and the URI after the delay', () => {


### PR DESCRIPTION
Owner + collaborator report: hovering a URL in a terminal flickers -- on every machine, in every build since the feature landed; nobody noticed on quiet terminals.

**Root cause** (read from xterm''s Linkifier source): on every rendered-viewport change that touches the hovered link''s rows, xterm clears the hover (`_clearCurrentLink` -> pointer class removed, `leave` fired) and immediately re-asks via the cached mouse position (class re-added, `hover` re-fired). A Claude session re-renders continuously -- spinner, input-box animation, statusline ticks -- so the hand cursor and hover state strobe at render cadence. #562''s `underline:false` fixed the selection-drag strobing but left this loop; a shell session at rest never re-renders, which is why the desktop "didn''t" reproduce until the right terminal was hovered.

**Fix** (our files only): `pointerCursor: false` too, so xterm touches nothing on hover; the hand cursor (xterm''s own `xterm-cursor-pointer` class) and the hovered-URI state move into `createLinkHoverControl` -- hover applies instantly, leave debounces 150ms, so the leave/re-hover churn never reaches the screen while a genuine departure still reverts the cursor. Also closes a latent race: a right-click landing inside a churn gap read a null URI and silently dropped "Copy link address". Click-to-open behaviour unchanged (and unrelated to `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`, which gates Claude''s in-TUI clickable elements, not terminal links).

Tests: 6 new control tests (fake timers: churn-does-not-drop, real-leave clears, link-to-link move, dispose, missing element) + decoration pin updated; 13 green, typecheck clean. Renderer-only: no ADR-009 surface, no SSH blast-radius files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)