### PR TITLE
build(release): 2.1.0-rc.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.14",
+  "version": "2.1.0-rc.15",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version bump only, per the beta-bump RC model. rc.15 content: #598 (rc.14 feedback, stability review Tier A/B/C, adversarial pass, one-surface panes, signed-off resume gate, macOS CI lane). Merge AFTER #598.