### PR TITLE
build(release): 2.1.0-rc.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.15",
+  "version": "2.1.0-rc.16",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version-only bump to 2.1.0-rc.16 (beta-bump RC model). The rc.16 fixes landed via #600 (all ten rc.15-review findings + the P2 identical-prompt fix). Changelog for rc.16 is already in sync (shipped with #600).