### PR TITLE
build(release): 2.1.0-rc.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-conductor",
-  "version": "2.1.0-rc.16",
+  "version": "2.1.0-rc.17",
   "description": "Multi-session Claude Code terminal orchestrator",
   "author": "Nicholas Moger",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Version-only bump for the rc.17 cut. No code change — `package.json` only.

Contents of rc.17 (all merged to `beta` in #606, `9820a4d3`):

- **#605** — Session Watchdog: per-session real-time toggles for the three auto-retry checks, and the checks exposed individually in Settings.
- **#607** — the per-session account picker no longer paints over the Multi Spawn startup page during a restore.
- **#608** — the session context menu stays on screen when opened low in the sidebar; the Switch Account list is reachable.
- **#609** — a boot with saved sessions AND a chained tour no longer renders neither surface and strands the restore.
- **#226** — dev preflight for a missing Electron binary (dev tooling; no user-facing change, so no changelog entry).

Four ADR-009 adversarial rounds, PASS at `c53028fe`. Desktop-tested by the owner on the packaged build before merge.

`skip-desktop-test`: version-only, no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)